### PR TITLE
fix: Stop screenshot rendering mode from returning all-black PNGs

### DIFF
--- a/Assets/Tests/Editor/UniformColorDetectorTests.cs
+++ b/Assets/Tests/Editor/UniformColorDetectorTests.cs
@@ -1,0 +1,62 @@
+#nullable enable
+using NUnit.Framework;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies UniformColorDetector pixel uniformity checks used by screenshot capture retries.
+    /// </summary>
+    public class UniformColorDetectorTests
+    {
+        /// <summary>
+        /// Verifies that an all-black pixel buffer returns that black color.
+        /// </summary>
+        [Test]
+        public void DetectUniformColor_WhenAllPixelsBlack_ReturnsBlack()
+        {
+            Color32[] pixels = new Color32[16];
+            for (int i = 0; i < pixels.Length; i++)
+            {
+                pixels[i] = new Color32(0, 0, 0, 255);
+            }
+
+            Color32? result = UniformColorDetector.DetectUniformColor(pixels);
+
+            Assert.That(result, Is.EqualTo(new Color32?(new Color32(0, 0, 0, 255))));
+        }
+
+        /// <summary>
+        /// Verifies that a single non-matching trailing pixel makes the buffer non-uniform.
+        /// </summary>
+        [Test]
+        public void DetectUniformColor_WhenLastPixelDiffers_ReturnsNull()
+        {
+            Color32[] pixels = new Color32[16];
+            for (int i = 0; i < pixels.Length; i++)
+            {
+                pixels[i] = new Color32(0, 0, 0, 255);
+            }
+            pixels[pixels.Length - 1] = new Color32(255, 255, 255, 255);
+
+            Color32? result = UniformColorDetector.DetectUniformColor(pixels);
+
+            Assert.That(result, Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies that an empty pixel buffer is treated as non-uniform.
+        /// </summary>
+        [Test]
+        public void DetectUniformColor_WhenEmpty_ReturnsNull()
+        {
+            Color32[] pixels = System.Array.Empty<Color32>();
+
+            Color32? result = UniformColorDetector.DetectUniformColor(pixels);
+
+            Assert.That(result, Is.Null);
+        }
+    }
+}

--- a/Assets/Tests/Editor/UniformColorDetectorTests.cs.meta
+++ b/Assets/Tests/Editor/UniformColorDetectorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f38d7d68bc5b4726899fe4b9988dc5f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/EditorWindowCaptureUtility.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/EditorWindowCaptureUtility.cs
@@ -17,6 +17,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public static class EditorWindowCaptureUtility
     {
+        private const int UNIFORM_COLOR_CAPTURE_ATTEMPTS = 3;
+        private const int WINDOW_UNIFORM_RETRY_WAIT_FRAMES = 2;
+
         /// <summary>
         /// Find all EditorWindows matching the given name (title bar text).
         /// </summary>
@@ -89,7 +92,51 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
-            return (CaptureWindowInternal(window, resolutionScale), false);
+
+            Texture2D? texture = null;
+            Color32? uniformColor = null;
+            for (int attempt = 1; attempt <= UNIFORM_COLOR_CAPTURE_ATTEMPTS; attempt++)
+            {
+                texture = CaptureWindowInternal(window, resolutionScale);
+                if (texture == null)
+                {
+                    return (null, false);
+                }
+
+                uniformColor = UniformColorDetector.DetectUniformColor(texture.GetPixels32());
+                if (!uniformColor.HasValue)
+                {
+                    return (texture, false);
+                }
+
+                if (attempt == UNIFORM_COLOR_CAPTURE_ATTEMPTS)
+                {
+                    break;
+                }
+
+                // Why destroy before retry: keep only the final texture if retries exhaust.
+                UnityEngine.Object.DestroyImmediate(texture);
+                texture = null;
+                window.Repaint();
+                bool retryReady = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
+                    WINDOW_UNIFORM_RETRY_WAIT_FRAMES,
+                    frameWaitTimeoutMilliseconds,
+                    ct).ConfigureAwait(false);
+                if (!retryReady)
+                {
+                    return (null, true);
+                }
+
+                await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+            }
+
+            Debug.Assert(texture != null, "Window capture retry loop must leave a texture when exhausted.");
+            Debug.Assert(uniformColor.HasValue, "Exhausted window retries must have observed a uniform color.");
+            Color32 color = uniformColor.GetValueOrDefault();
+            VibeLogger.LogWarning(
+                "screenshot_uniform_color_after_retries",
+                $"Window capture remained uniform color RGBA({color.r},{color.g},{color.b},{color.a}) after {UNIFORM_COLOR_CAPTURE_ATTEMPTS} attempts.");
+            return (texture, false);
         }
 
         /// <summary>
@@ -175,37 +222,96 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             SynchronizationContext editorContext =
                 CapturedEditorSynchronizationContext.RequireCurrent("rendering screenshot capture");
-            // Wait for the game camera to complete at least one full render cycle after any state change
-            bool framesReady = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
-                2,
-                frameWaitTimeoutMilliseconds,
-                ct).ConfigureAwait(false);
-            if (!framesReady)
+            // Why render-wait: editor update ticks can advance without redrawing the Play Mode RT.
+            PlayModeViewRenderWaitResult renderWaitResult =
+                await PlayModeViewRenderWaiter.WaitForRenderedFrameAsync(
+                    frameWaitTimeoutMilliseconds,
+                    ct).ConfigureAwait(false);
+            if (renderWaitResult == PlayModeViewRenderWaitResult.TicksStalled)
             {
                 return (null, default, true);
             }
 
-            await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
-
-            RenderTexture rt = GameViewBridge.GetRenderTexture();
-            if (rt == null)
+            if (renderWaitResult == PlayModeViewRenderWaitResult.NotRendered)
             {
-                Debug.LogWarning("[EditorWindowCaptureUtility] Play Mode view RenderTexture is not available");
-                GameRenderingImageInfo unavailableInfo = renderingImageInfo ??
-                    CreateUnavailableGameRenderingImageInfo(Handles.GetMainGameViewSize());
-                return (null, unavailableInfo, false);
+                VibeLogger.LogWarning(
+                    "screenshot_render_wait_not_confirmed",
+                    "Timed out waiting for a Game camera render before reading the Play Mode view RenderTexture; continuing capture.");
             }
 
-            // Play Mode view RenderTexture can be shorter than the full input area, so raw image Y needs this offset.
-            GameRenderingImageInfo captureInfo = renderingImageInfo ??
-                CreateGameRenderingImageInfo(Handles.GetMainGameViewSize(), rt.width, rt.height);
+            await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
 
-            // RenderTexture uses bottom-left origin; flip vertically for standard top-left image format
+            Texture2D? texture = null;
+            Color32? uniformColor = null;
+            GameRenderingImageInfo captureInfo = default;
+            for (int attempt = 1; attempt <= UNIFORM_COLOR_CAPTURE_ATTEMPTS; attempt++)
+            {
+                RenderTexture rt = GameViewBridge.GetRenderTexture();
+                if (rt == null)
+                {
+                    Debug.LogWarning("[EditorWindowCaptureUtility] Play Mode view RenderTexture is not available");
+                    GameRenderingImageInfo unavailableInfo = renderingImageInfo ??
+                        CreateUnavailableGameRenderingImageInfo(Handles.GetMainGameViewSize());
+                    return (null, unavailableInfo, false);
+                }
+
+                // Play Mode view RenderTexture can be shorter than the full input area, so raw image Y needs this offset.
+                captureInfo = renderingImageInfo ??
+                    CreateGameRenderingImageInfo(Handles.GetMainGameViewSize(), rt.width, rt.height);
+
+                texture = ReadPlayModeViewTexture(rt, resolutionScale);
+                uniformColor = UniformColorDetector.DetectUniformColor(texture.GetPixels32());
+                if (!uniformColor.HasValue)
+                {
+                    return (texture, captureInfo, false);
+                }
+
+                if (attempt == UNIFORM_COLOR_CAPTURE_ATTEMPTS)
+                {
+                    break;
+                }
+
+                // Why destroy before retry: keep only the final texture if retries exhaust.
+                UnityEngine.Object.DestroyImmediate(texture);
+                texture = null;
+
+                PlayModeViewRenderWaitResult retryWaitResult =
+                    await PlayModeViewRenderWaiter.WaitForRenderedFrameAsync(
+                        frameWaitTimeoutMilliseconds,
+                        ct).ConfigureAwait(false);
+                if (retryWaitResult == PlayModeViewRenderWaitResult.TicksStalled)
+                {
+                    return (null, default, true);
+                }
+
+                if (retryWaitResult == PlayModeViewRenderWaitResult.NotRendered)
+                {
+                    VibeLogger.LogWarning(
+                        "screenshot_render_wait_not_confirmed",
+                        "Timed out waiting for a Game camera render before uniform-color capture retry; continuing capture.");
+                }
+
+                await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+            }
+
+            Debug.Assert(texture != null, "Rendering capture retry loop must leave a texture when exhausted.");
+            Debug.Assert(uniformColor.HasValue, "Exhausted rendering retries must have observed a uniform color.");
+            Color32 color = uniformColor.GetValueOrDefault();
+            VibeLogger.LogWarning(
+                "screenshot_uniform_color_after_retries",
+                $"Rendering capture remained uniform color RGBA({color.r},{color.g},{color.b},{color.a}) after {UNIFORM_COLOR_CAPTURE_ATTEMPTS} attempts.");
+            return (texture, captureInfo, false);
+        }
+
+        // Reads and vertically flips the Play Mode view RT into a Texture2D (top-left origin).
+        private static Texture2D ReadPlayModeViewTexture(RenderTexture rt, float resolutionScale)
+        {
             RenderTextureDescriptor flipDescriptor = new(rt.width, rt.height, rt.format, 0);
             if (QualitySettings.activeColorSpace == ColorSpace.Linear)
             {
                 flipDescriptor.sRGB = false;
             }
+
             // Capture the caller's active target before Blit: Blit leaves the destination
             // assigned to RenderTexture.active, so saving afterwards would "restore" the
             // temporary itself and releasing it would warn about an active render texture.
@@ -233,7 +339,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 texture = ApplyResolutionScaling(texture, resolutionScale);
             }
 
-            return (texture, captureInfo, false);
+            return texture;
         }
 
         // Raycast-grid annotations must use the same settled RenderTexture geometry as the PNG capture path.

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/PlayModeViewRenderWaiter.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/PlayModeViewRenderWaiter.cs
@@ -94,6 +94,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             try
             {
                 System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
+                // Why sawTick: the inner wait's timeout is the remaining overall budget, so false
+                // usually means that budget expired — not that editor ticks are stalled. Only treat
+                // the first wait failure (no successful tick yet) as TicksStalled.
+                bool sawTick = false;
                 while (stopwatch.ElapsedMilliseconds < timeoutMilliseconds)
                 {
                     // Why SwitchTo: WaitFramesOrTimeoutAsync continuations leave the main thread,
@@ -117,9 +121,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         ct).ConfigureAwait(false);
                     if (!tick)
                     {
-                        return PlayModeViewRenderWaitResult.TicksStalled;
+                        return sawTick
+                            ? PlayModeViewRenderWaitResult.NotRendered
+                            : PlayModeViewRenderWaitResult.TicksStalled;
                     }
 
+                    sawTick = true;
                     if (gameCameraRendered)
                     {
                         return PlayModeViewRenderWaitResult.Rendered;
@@ -149,9 +156,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         /// <summary>
         /// True when at least one eligible Game camera exists in Camera.allCameras.
-        /// Must use the same predicate as the render subscriptions.
+        /// Must use the same predicate as the render subscriptions and the overlay-hide clear guard.
         /// </summary>
-        private static bool HasEligibleGameCamera()
+        internal static bool HasEligibleGameCamera()
         {
             Camera[] cameras = Camera.allCameras;
             for (int i = 0; i < cameras.Length; i++)

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/PlayModeViewRenderWaiter.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/PlayModeViewRenderWaiter.cs
@@ -16,13 +16,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal enum PlayModeViewRenderWaitResult
     {
-        /// <summary>A Game camera rendered after wait started.</summary>
+        /// <summary>An eligible Game camera rendered after wait started.</summary>
         Rendered,
 
-        /// <summary>No cameras; only editor ticks were waited.</summary>
+        /// <summary>
+        /// No eligible Game camera that can drive a display render; only editor ticks were waited.
+        /// </summary>
         NoCamera,
 
-        /// <summary>Editor ticks advanced but no Game camera render was observed.</summary>
+        /// <summary>Editor ticks advanced but no eligible Game camera render was observed.</summary>
         NotRendered,
 
         /// <summary>Editor ticks themselves stalled (legacy timeout).</summary>
@@ -30,14 +32,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     }
 
     /// <summary>
-    /// Waits until a Game camera actually renders, instead of counting editor update ticks.
+    /// Waits until an eligible Game camera actually renders, instead of counting editor update ticks.
     /// Why not Time.renderedFrameCount: when the Editor is unfocused it can advance with
     /// Time.frameCount even though the Play Mode view RT was not redrawn.
     /// </summary>
     internal static class PlayModeViewRenderWaiter
     {
         /// <summary>
-        /// Waits for a CameraType.Game render within the timeout, or reports why it did not.
+        /// Waits for an eligible Game-camera render within the timeout, or reports why it did not.
         /// Must start on the editor main thread.
         /// </summary>
         internal static async Task<PlayModeViewRenderWaitResult> WaitForRenderedFrameAsync(
@@ -50,9 +52,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             SynchronizationContext editorContext =
                 CapturedEditorSynchronizationContext.RequireCurrent("PlayModeViewRenderWaiter");
 
-            if (Camera.allCamerasCount == 0)
+            if (!HasEligibleGameCamera())
             {
-                // Why tick-only: with no cameras a Game render will never arrive.
+                // Why tick-only: without an eligible Game camera a subscribed render will never arrive.
                 bool ready = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(2, timeoutMilliseconds, ct)
                     .ConfigureAwait(false);
                 return ready
@@ -64,7 +66,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             void OnPostRender(Camera camera)
             {
-                if (camera != null && camera.cameraType == CameraType.Game)
+                if (IsEligibleGameCamera(camera))
                 {
                     gameCameraRendered = true;
                 }
@@ -79,8 +81,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 for (int i = 0; i < cameras.Count; i++)
                 {
-                    Camera camera = cameras[i];
-                    if (camera != null && camera.cameraType == CameraType.Game)
+                    if (IsEligibleGameCamera(cameras[i]))
                     {
                         gameCameraRendered = true;
                         return;
@@ -132,6 +133,36 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Camera.onPostRender -= OnPostRender;
                 RenderPipelineManager.endContextRendering -= OnEndContextRendering;
             }
+        }
+
+        /// <summary>
+        /// True for a display-bound Game camera (not SceneView / Preview / offscreen RT cameras).
+        /// Why exclude targetTexture: those cameras never refresh the Play Mode view RT, so counting
+        /// them would falsely complete the wait while the screenshot RT stays stale/black.
+        /// </summary>
+        private static bool IsEligibleGameCamera(Camera camera)
+        {
+            return camera != null
+                && camera.cameraType == CameraType.Game
+                && camera.targetTexture == null;
+        }
+
+        /// <summary>
+        /// True when at least one eligible Game camera exists in Camera.allCameras.
+        /// Must use the same predicate as the render subscriptions.
+        /// </summary>
+        private static bool HasEligibleGameCamera()
+        {
+            Camera[] cameras = Camera.allCameras;
+            for (int i = 0; i < cameras.Length; i++)
+            {
+                if (IsEligibleGameCamera(cameras[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/PlayModeViewRenderWaiter.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/PlayModeViewRenderWaiter.cs
@@ -1,0 +1,137 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+using io.github.hatayama.UnityCliLoop.InternalAPIBridge;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Outcome of waiting for a Play Mode view Game-camera render to land.
+    /// </summary>
+    internal enum PlayModeViewRenderWaitResult
+    {
+        /// <summary>A Game camera rendered after wait started.</summary>
+        Rendered,
+
+        /// <summary>No cameras; only editor ticks were waited.</summary>
+        NoCamera,
+
+        /// <summary>Editor ticks advanced but no Game camera render was observed.</summary>
+        NotRendered,
+
+        /// <summary>Editor ticks themselves stalled (legacy timeout).</summary>
+        TicksStalled,
+    }
+
+    /// <summary>
+    /// Waits until a Game camera actually renders, instead of counting editor update ticks.
+    /// Why not Time.renderedFrameCount: when the Editor is unfocused it can advance with
+    /// Time.frameCount even though the Play Mode view RT was not redrawn.
+    /// </summary>
+    internal static class PlayModeViewRenderWaiter
+    {
+        /// <summary>
+        /// Waits for a CameraType.Game render within the timeout, or reports why it did not.
+        /// Must start on the editor main thread.
+        /// </summary>
+        internal static async Task<PlayModeViewRenderWaitResult> WaitForRenderedFrameAsync(
+            int timeoutMilliseconds,
+            CancellationToken ct)
+        {
+            Debug.Assert(timeoutMilliseconds > 0, "timeoutMilliseconds must be positive");
+            ct.ThrowIfCancellationRequested();
+
+            SynchronizationContext editorContext =
+                CapturedEditorSynchronizationContext.RequireCurrent("PlayModeViewRenderWaiter");
+
+            if (Camera.allCamerasCount == 0)
+            {
+                // Why tick-only: with no cameras a Game render will never arrive.
+                bool ready = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(2, timeoutMilliseconds, ct)
+                    .ConfigureAwait(false);
+                return ready
+                    ? PlayModeViewRenderWaitResult.NoCamera
+                    : PlayModeViewRenderWaitResult.TicksStalled;
+            }
+
+            bool gameCameraRendered = false;
+
+            void OnPostRender(Camera camera)
+            {
+                if (camera != null && camera.cameraType == CameraType.Game)
+                {
+                    gameCameraRendered = true;
+                }
+            }
+
+            void OnEndContextRendering(ScriptableRenderContext context, List<Camera> cameras)
+            {
+                if (cameras == null)
+                {
+                    return;
+                }
+
+                for (int i = 0; i < cameras.Count; i++)
+                {
+                    Camera camera = cameras[i];
+                    if (camera != null && camera.cameraType == CameraType.Game)
+                    {
+                        gameCameraRendered = true;
+                        return;
+                    }
+                }
+            }
+
+            Camera.onPostRender += OnPostRender;
+            RenderPipelineManager.endContextRendering += OnEndContextRendering;
+            try
+            {
+                System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
+                while (stopwatch.ElapsedMilliseconds < timeoutMilliseconds)
+                {
+                    // Why SwitchTo: WaitFramesOrTimeoutAsync continuations leave the main thread,
+                    // but RepaintMainPlayModeView / QueuePlayerLoopUpdate require it.
+                    await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+                    GameViewBridge.RepaintMainPlayModeView();
+                    EditorApplication.QueuePlayerLoopUpdate();
+
+                    long remainingLong = timeoutMilliseconds - stopwatch.ElapsedMilliseconds;
+                    if (remainingLong <= 0)
+                    {
+                        break;
+                    }
+
+                    int remainingMilliseconds = remainingLong > int.MaxValue
+                        ? int.MaxValue
+                        : (int)remainingLong;
+                    bool tick = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
+                        1,
+                        remainingMilliseconds,
+                        ct).ConfigureAwait(false);
+                    if (!tick)
+                    {
+                        return PlayModeViewRenderWaitResult.TicksStalled;
+                    }
+
+                    if (gameCameraRendered)
+                    {
+                        return PlayModeViewRenderWaitResult.Rendered;
+                    }
+                }
+
+                return PlayModeViewRenderWaitResult.NotRendered;
+            }
+            finally
+            {
+                Camera.onPostRender -= OnPostRender;
+                RenderPipelineManager.endContextRendering -= OnEndContextRendering;
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/PlayModeViewRenderWaiter.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/PlayModeViewRenderWaiter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a5b536c1b65a4a74b75775bfe40a966
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -153,16 +153,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // on CLI disconnect; finally must still restore the overlay.
                 if (inputVisualizationWasActive)
                 {
-                    bool hideFramesReady = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
-                        ANNOTATION_OVERLAY_RENDER_WAIT_FRAMES,
-                        UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
-                        ct).ConfigureAwait(false);
-                    if (!hideFramesReady)
+                    PlayModeViewRenderWaitResult hideWaitResult =
+                        await PlayModeViewRenderWaiter.WaitForRenderedFrameAsync(
+                            UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
+                            ct).ConfigureAwait(false);
+                    if (hideWaitResult == PlayModeViewRenderWaitResult.TicksStalled)
                     {
                         return CreateTimedOutResult(
                             "input visualization overlay hide",
                             correlationId,
                             new List<ScreenshotInfo>());
+                    }
+
+                    if (hideWaitResult == PlayModeViewRenderWaitResult.NotRendered)
+                    {
+                        VibeLogger.LogWarning(
+                            "screenshot_render_wait_not_confirmed",
+                            "Timed out waiting for a Game camera render after hiding the input visualization overlay; continuing capture.",
+                            correlationId: correlationId);
                     }
 
                     await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
@@ -179,16 +187,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                             request.ResolutionScale);
                         Canvas.ForceUpdateCanvases();
                         // Chained CLI calls can read the previous GameView RT before overlay rendering catches up.
-                        bool overlayFramesReady = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
-                            ANNOTATION_OVERLAY_RENDER_WAIT_FRAMES,
-                            UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
-                            ct).ConfigureAwait(false);
-                        if (!overlayFramesReady)
+                        PlayModeViewRenderWaitResult overlayWaitResult =
+                            await PlayModeViewRenderWaiter.WaitForRenderedFrameAsync(
+                                UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
+                                ct).ConfigureAwait(false);
+                        if (overlayWaitResult == PlayModeViewRenderWaitResult.TicksStalled)
                         {
                             return CreateTimedOutResult(
                                 "annotation overlay render",
                                 correlationId,
                                 new List<ScreenshotInfo>());
+                        }
+
+                        if (overlayWaitResult == PlayModeViewRenderWaitResult.NotRendered)
+                        {
+                            VibeLogger.LogWarning(
+                                "screenshot_render_wait_not_confirmed",
+                                "Timed out waiting for a Game camera render after showing the annotation overlay; continuing capture.",
+                                correlationId: correlationId);
                         }
 
                         await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
@@ -482,10 +498,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             Canvas.ForceUpdateCanvases();
-            // Why clear: with no camera the Play Mode RT never rewrites itself after a Screen Space
-            // Overlay is hidden, so the last badge composite would stay forever. With cameras, the
-            // caller's frame wait redraws the scene without the overlay.
-            GameViewBridge.ClearMainPlayModeViewRenderTexture();
+            // Why clear only with no cameras: Screen Space Overlay can leave a permanent badge
+            // composite on the Play Mode RT when nothing rewrites it. With cameras present, the
+            // next Game view redraw overwrites the RT — clearing to black would destroy a valid
+            // frame and yield an all-black PNG if capture runs before that redraw.
+            if (Camera.allCamerasCount == 0)
+            {
+                GameViewBridge.ClearMainPlayModeViewRenderTexture();
+            }
             GameViewBridge.RepaintMainPlayModeView();
             return (overlay, true);
         }

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -498,11 +498,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             Canvas.ForceUpdateCanvases();
-            // Why clear only with no cameras: Screen Space Overlay can leave a permanent badge
-            // composite on the Play Mode RT when nothing rewrites it. With cameras present, the
-            // next Game view redraw overwrites the RT — clearing to black would destroy a valid
-            // frame and yield an all-black PNG if capture runs before that redraw.
-            if (Camera.allCamerasCount == 0)
+            // Why clear only without eligible Game cameras: an eligible camera will overwrite the
+            // Play Mode RT on the next redraw, so clearing to black would destroy a valid frame.
+            // With no eligible camera (including offscreen-only setups), hide the overlay's leftover
+            // badge composite by clearing — same predicate as PlayModeViewRenderWaiter.
+            if (!PlayModeViewRenderWaiter.HasEligibleGameCamera())
             {
                 GameViewBridge.ClearMainPlayModeViewRenderTexture();
             }

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/UniformColorDetector.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/UniformColorDetector.cs
@@ -1,0 +1,37 @@
+#nullable enable
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Detects whether every pixel in a buffer shares one Color32 value.
+    /// </summary>
+    internal static class UniformColorDetector
+    {
+        /// <summary>
+        /// Returns the shared color when all pixels match; otherwise null.
+        /// Empty input is treated as non-uniform.
+        /// Why full scan (no sampling): sparse non-black pixels must not be missed when deciding
+        /// whether a capture retry is warranted.
+        /// </summary>
+        internal static Color32? DetectUniformColor(Color32[] pixels)
+        {
+            if (pixels.Length == 0)
+            {
+                return null;
+            }
+
+            Color32 first = pixels[0];
+            for (int i = 1; i < pixels.Length; i++)
+            {
+                Color32 pixel = pixels[i];
+                if (pixel.r != first.r || pixel.g != first.g || pixel.b != first.b || pixel.a != first.a)
+                {
+                    return null;
+                }
+            }
+
+            return first;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/UniformColorDetector.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/UniformColorDetector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f3e42ec436764c9c9a8e3441c67e12b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- Fixes all-black PNGs from `uloop screenshot --capture-mode rendering` that still reported `Success: true` (issue #2106).
- Stops the input-visualization overlay hide path from clearing the Play Mode view RenderTexture when an eligible Game camera will redraw it.
- Replaces editor update-tick waits on the rendering path with a wait for a real display-bound `CameraType.Game` render, and retries uniform-color captures a bounded number of times.

Fixes #2106

## Root cause

1. `HideInputVisualizationOverlay()` cleared the Play Mode view RT to black (`GL.Clear`) whenever the input-visualization overlay was active (common after simulate-mouse / simulate-keyboard).
2. The follow-up wait used `EditorFrameWaiter` on `EditorApplication.update` ticks only. Those ticks can keep advancing while the Editor is unfocused even when the Play Mode view RT is not redrawn. (`EditorApplication.tick` / SignalTick is a separate channel and is not what this waiter uses.)
3. `CaptureGameRenderingAsync` then read the still-black RT and returned a well-formed black PNG with `Success: true`.

## Fix

1. Clear the RT only when `!PlayModeViewRenderWaiter.HasEligibleGameCamera()` (no display-bound Game camera will rewrite it — includes camera-less and offscreen-only scenes). Always keep `RepaintMainPlayModeView()`.
2. Add `PlayModeViewRenderWaiter` that subscribes to both `Camera.onPostRender` and `RenderPipelineManager.endContextRendering`, counting only eligible Game cameras (`cameraType == Game` and `targetTexture == null`), and use it on the three rendering-path wait sites. The no-eligible-camera guard and the overlay-hide clear use the same predicate. Inner wait budget expiry after at least one successful tick maps to `NotRendered` (warning + continue), not `TicksStalled` (hard timeout). Unsubscribe in `finally`.
3. After capture, detect fully uniform pixel buffers and retry (rendering: wait for a Game render; window: `Repaint` + tick wait) up to 3 attempts. Exhaustion logs a warning and still returns the last texture (legitimately uniform scenes exist).

Public contracts (`IEditorWindowCaptureService` / ToolContracts facade / `(texture, yOffset, timedOut)` tuple shape) are unchanged.

## Render-wait strategy choice

**Fallback hooks** (`Camera.onPostRender` + `RenderPipelineManager.endContextRendering`), not `Time.renderedFrameCount`.

Measured on 2026-08-04 with SimulateMouseDemoScene in Play Mode:

| Condition | sample (frameCount, renderedFrameCount) |
|---|---|
| Unfocused, ~2.5s apart | 564/564 → 716/716 → 869/869 |
| Focused, ~2.5s apart | 1113/1113 → 1262/1262 → 1415/1415 |

`renderedFrameCount` tracked `frameCount` equally while unfocused, so it cannot detect a missing Play Mode view redraw.

## Measurement evidence

Scene: `Assets/Scenes/SimulateMouseDemoScene.unity`, Play Mode, Editor kept unfocused (Terminal activated). Natural repro = one `simulate-mouse-input` click, then `screenshot --capture-mode rendering` ×10.

| Stage | Natural black rate | Notes |
|---|---|---|
| Pre-fix (baseline) | **5/10** | Production path (overlay hide → clear → tick wait → read) |
| Forced Clear→screenshot ×5 | 0/5 | Discarded as a fault model: Clear works (immediate ReadPixels all-black), but without an active overlay the 2-tick wait recovers the RT |
| After Fix 1 only (checkpoint) | **0/10** | Confirms the self-clear was the black source |
| After Fixes 1–3 | **0/10** | Main acceptance check |
| After eligible-camera predicate follow-up | **0/10** | Shared `IsEligibleGameCamera` / `HasEligibleGameCamera` |
| After final-review fixes (`sawTick` + clear-guard align) | **0/10** | Budget expiry → `NotRendered`; clear uses `HasEligibleGameCamera()`; compile 0 errors |
| Annotate + window (post-fix) | both non-uniform | `--annotate-elements` and `--capture-mode window --window-name Game` |
| Visual check | pass | Scene UI visible; no input-visualization badge in the PNG |

## Test plan

- [x] `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "UniformColorDetectorTests"` → 3/3 passed
- [x] `dist/darwin-arm64/uloop compile` → 0 errors / 0 warnings
- [x] EditMode full suite: FailedCount 0 on green runs; one unrelated flaky (`MouseUiPointerTargetResolverTests.ResolvePressablePointerTargets_WithoutRaycastHit_ReturnsEmpty`) fails only in full-suite order and passes in isolation
- [x] Natural repro E2E before/after as in the table above
