### PR TITLE
fix: enforce the pause point contract on hot-reloaded methods

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -83,10 +83,9 @@ and check the hit count — zero hits means the calling path never reached the m
 which no patch can fix. Arm the marker after the hot-reload run, not before — and if the
 same marker already existed, clear it and enable it again, because re-enabling an
 existing marker re-arms its hit counter without re-injecting the discarded
-instrumentation. Keep it on the first line: on a currently patched method, deeper lines
-and local capture resolve
-against the pre-patch compiled body and are not reliable (see the pause point interaction
-below). To chase an early return inside the method, revert or `uloop compile` first. The
+instrumentation. Note that enabling a pause point on a currently patched method is rejected with
+`PAUSE_POINT_PATCHED_BY_HOT_RELOAD` (see the pause point interaction below); compile or
+revert first. To chase an early return inside the method, revert or `uloop compile` first. The
 other known cause is JIT inlining of tiny methods, which the response already flags with
 a per-method warning.
 
@@ -103,27 +102,25 @@ a per-method warning.
 ## Pause point interaction
 
 Both patch shapes discard the original IL and any prior transpiler output on the patched
-method — delegation replaces the body with a forward to the shim. The interaction with
-source pause points is therefore order-dependent:
+method — delegation replaces the body with a forward to the shim. Source pause points
+instrument methods through the same transpiler chain, so the two tools enforce a strict
+contract instead of composing silently:
 
-- A pause point armed **before** a hot reload of the same method silently stops firing —
-  its instrumentation was part of the discarded IL. `pause-point-status` still reports
-  `Enabled` with nothing hinting at the cause. Apply responses include a `Warnings` entry
-  whenever any method was patched.
-- A pause point enabled fresh **after** the hot reload fires on the method's first
-  line and captures parameters and `this` fields normally. Re-enabling a marker that
-  was already armed before the hot reload does not recover it: the patcher treats a
-  known marker id as a no-op, re-arming the hit counter without re-injecting the
-  discarded instrumentation — clear the marker, then enable it again. Markers on
-  deeper lines — and captured method locals — resolve against the pre-patch compiled
-  body, so they may land on the wrong instruction or read stale slots; treat them as
-  unreliable until the patch is reverted or compiled for real.
-- `--revert-all` (or a domain reload) restores the original IL, and previously armed
-  pause points fire again.
+- A pause point armed **before** a hot reload of the same method stops firing — its
+  instrumentation was part of the discarded IL. The apply response lists the affected
+  marker ids in `Warnings`, and `pause-point-status` reports `SuppressedByHotReload: true`
+  for those markers until the patch is reverted.
+- Enabling a pause point **on a currently patched method is rejected** with
+  `PAUSE_POINT_PATCHED_BY_HOT_RELOAD`. Marker positions and local-variable capture
+  resolve against the pre-patch compiled body, which no longer exists at runtime; there
+  is no line on a patched method where a new marker would be trustworthy.
+- `uloop hot-reload --revert-all` (or any domain reload) restores the original IL;
+  previously armed pause points fire again and their `SuppressedByHotReload` flag clears.
 
-So hot reload and pause points do compose for reachability checks: after each
-`uloop hot-reload` run, clear and re-enable first-line markers on patched methods,
-and defer deeper markers until `--revert-all` or a real `uloop compile`.
+So the workflow is: iterate on behavior with hot reload, and when you need pause-point
+inspection of an edited method, run `uloop compile` to make the edits real (the compile's
+domain reload clears every patch), then enable the marker. Use `--revert-all` instead
+when you want the on-disk build back without recompiling.
 
 ## Output
 

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -77,17 +77,15 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 ## When a patch reports `Patched` but behavior does not change
 
 `Patched` means the method body was replaced, not that the method ran. Before suspecting
-the patch, confirm the method is actually reached: arm
-`uloop enable-pause-point --mode trace` on the method's first line, then drive the game
-and check the hit count — zero hits means the calling path never reached the method,
-which no patch can fix. Arm the marker after the hot-reload run, not before — and if the
-same marker already existed, clear it and enable it again, because re-enabling an
-existing marker re-arms its hit counter without re-injecting the discarded
-instrumentation. Note that enabling a pause point on a currently patched method is rejected with
-`PAUSE_POINT_PATCHED_BY_HOT_RELOAD` (see the pause point interaction below); compile or
-revert first. To chase an early return inside the method, revert or `uloop compile` first. The
-other known cause is JIT inlining of tiny methods, which the response already flags with
-a per-method warning.
+the patch, confirm the method is actually reached. A currently patched method rejects new
+pause points with `PAUSE_POINT_PATCHED_BY_HOT_RELOAD` (see the pause point interaction
+below), so run `uloop compile` first — it makes the edits real and its domain reload
+clears every patch — then arm `uloop enable-pause-point --mode trace` on the method's
+first line, drive the game, and check the hit count: zero hits means the calling path
+never reached the method, which no patch (or compile) can fix. To chase an early return
+inside the method, arm a second marker on the suspected early-return line. The other
+known cause is JIT inlining of tiny methods, which the response already flags with a
+per-method warning.
 
 ## Convergence and lifecycle
 

--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -174,6 +174,13 @@ If a `simulate-*` command instead returns a failure whose message says PlayMode 
 
 If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first — clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. When `--trigger` was passed, the expired envelope also carries `Error.Details.TriggerResult` (with `Completed: false` and no `Error` field when the trigger's outcome was still unknown at expiry). The countdown freezes while a hit holds the Editor paused; a manual pause without a hit does not stop it.
 
+`PAUSE_POINT_PATCHED_BY_HOT_RELOAD` means the target method's body is currently replaced
+by `uloop hot-reload`, so a new marker cannot be trusted anywhere in that method. Run
+`uloop compile` (or `uloop hot-reload --revert-all`) first, then enable the marker.
+Relatedly, `SuppressedByHotReload: true` on a status response means the marker's method
+was hot-reload patched after arming; the marker will not fire until the patch is
+reverted or compiled for real.
+
 Use `uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"` only when you need to confirm the marker is armed or inspect the current hit state.
 
 For the full diagnosis flow — the `Error.Details` status fields, bisecting with a second marker on the method entry, JIT inlining, physics-callback misses, and delegate bypass — read [references/troubleshooting.md](references/troubleshooting.md).

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -83,10 +83,9 @@ and check the hit count — zero hits means the calling path never reached the m
 which no patch can fix. Arm the marker after the hot-reload run, not before — and if the
 same marker already existed, clear it and enable it again, because re-enabling an
 existing marker re-arms its hit counter without re-injecting the discarded
-instrumentation. Keep it on the first line: on a currently patched method, deeper lines
-and local capture resolve
-against the pre-patch compiled body and are not reliable (see the pause point interaction
-below). To chase an early return inside the method, revert or `uloop compile` first. The
+instrumentation. Note that enabling a pause point on a currently patched method is rejected with
+`PAUSE_POINT_PATCHED_BY_HOT_RELOAD` (see the pause point interaction below); compile or
+revert first. To chase an early return inside the method, revert or `uloop compile` first. The
 other known cause is JIT inlining of tiny methods, which the response already flags with
 a per-method warning.
 
@@ -103,27 +102,25 @@ a per-method warning.
 ## Pause point interaction
 
 Both patch shapes discard the original IL and any prior transpiler output on the patched
-method — delegation replaces the body with a forward to the shim. The interaction with
-source pause points is therefore order-dependent:
+method — delegation replaces the body with a forward to the shim. Source pause points
+instrument methods through the same transpiler chain, so the two tools enforce a strict
+contract instead of composing silently:
 
-- A pause point armed **before** a hot reload of the same method silently stops firing —
-  its instrumentation was part of the discarded IL. `pause-point-status` still reports
-  `Enabled` with nothing hinting at the cause. Apply responses include a `Warnings` entry
-  whenever any method was patched.
-- A pause point enabled fresh **after** the hot reload fires on the method's first
-  line and captures parameters and `this` fields normally. Re-enabling a marker that
-  was already armed before the hot reload does not recover it: the patcher treats a
-  known marker id as a no-op, re-arming the hit counter without re-injecting the
-  discarded instrumentation — clear the marker, then enable it again. Markers on
-  deeper lines — and captured method locals — resolve against the pre-patch compiled
-  body, so they may land on the wrong instruction or read stale slots; treat them as
-  unreliable until the patch is reverted or compiled for real.
-- `--revert-all` (or a domain reload) restores the original IL, and previously armed
-  pause points fire again.
+- A pause point armed **before** a hot reload of the same method stops firing — its
+  instrumentation was part of the discarded IL. The apply response lists the affected
+  marker ids in `Warnings`, and `pause-point-status` reports `SuppressedByHotReload: true`
+  for those markers until the patch is reverted.
+- Enabling a pause point **on a currently patched method is rejected** with
+  `PAUSE_POINT_PATCHED_BY_HOT_RELOAD`. Marker positions and local-variable capture
+  resolve against the pre-patch compiled body, which no longer exists at runtime; there
+  is no line on a patched method where a new marker would be trustworthy.
+- `uloop hot-reload --revert-all` (or any domain reload) restores the original IL;
+  previously armed pause points fire again and their `SuppressedByHotReload` flag clears.
 
-So hot reload and pause points do compose for reachability checks: after each
-`uloop hot-reload` run, clear and re-enable first-line markers on patched methods,
-and defer deeper markers until `--revert-all` or a real `uloop compile`.
+So the workflow is: iterate on behavior with hot reload, and when you need pause-point
+inspection of an edited method, run `uloop compile` to make the edits real (the compile's
+domain reload clears every patch), then enable the marker. Use `--revert-all` instead
+when you want the on-disk build back without recompiling.
 
 ## Output
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -77,17 +77,15 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 ## When a patch reports `Patched` but behavior does not change
 
 `Patched` means the method body was replaced, not that the method ran. Before suspecting
-the patch, confirm the method is actually reached: arm
-`uloop enable-pause-point --mode trace` on the method's first line, then drive the game
-and check the hit count — zero hits means the calling path never reached the method,
-which no patch can fix. Arm the marker after the hot-reload run, not before — and if the
-same marker already existed, clear it and enable it again, because re-enabling an
-existing marker re-arms its hit counter without re-injecting the discarded
-instrumentation. Note that enabling a pause point on a currently patched method is rejected with
-`PAUSE_POINT_PATCHED_BY_HOT_RELOAD` (see the pause point interaction below); compile or
-revert first. To chase an early return inside the method, revert or `uloop compile` first. The
-other known cause is JIT inlining of tiny methods, which the response already flags with
-a per-method warning.
+the patch, confirm the method is actually reached. A currently patched method rejects new
+pause points with `PAUSE_POINT_PATCHED_BY_HOT_RELOAD` (see the pause point interaction
+below), so run `uloop compile` first — it makes the edits real and its domain reload
+clears every patch — then arm `uloop enable-pause-point --mode trace` on the method's
+first line, drive the game, and check the hit count: zero hits means the calling path
+never reached the method, which no patch (or compile) can fix. To chase an early return
+inside the method, arm a second marker on the suspected early-return line. The other
+known cause is JIT inlining of tiny methods, which the response already flags with a
+per-method warning.
 
 ## Convergence and lifecycle
 

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -174,6 +174,13 @@ If a `simulate-*` command instead returns a failure whose message says PlayMode 
 
 If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first — clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. When `--trigger` was passed, the expired envelope also carries `Error.Details.TriggerResult` (with `Completed: false` and no `Error` field when the trigger's outcome was still unknown at expiry). The countdown freezes while a hit holds the Editor paused; a manual pause without a hit does not stop it.
 
+`PAUSE_POINT_PATCHED_BY_HOT_RELOAD` means the target method's body is currently replaced
+by `uloop hot-reload`, so a new marker cannot be trusted anywhere in that method. Run
+`uloop compile` (or `uloop hot-reload --revert-all`) first, then enable the marker.
+Relatedly, `SuppressedByHotReload: true` on a status response means the marker's method
+was hot-reload patched after arming; the marker will not fire until the patch is
+reverted or compiled for real.
+
 Use `uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"` only when you need to confirm the marker is armed or inspect the current hit state.
 
 For the full diagnosis flow — the `Error.Details` status fields, bisecting with a second marker on the method entry, JIT inlining, physics-callback misses, and delegate bypass — read [references/troubleshooting.md](references/troubleshooting.md).

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
@@ -142,6 +142,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: Unpatching one of two armed markers while the method is hot-reload patched
+        /// does not re-instrument the surviving marker into the shim stream (and does not throw).
+        /// </summary>
+        [Test]
+        public void Unpatch_SiblingMarker_WhileHotReloadPatched_DoesNotReinstrumentSurvivors()
+        {
+            const string id1 = "contract-sibling-unpatch-a";
+            const string id2 = "contract-sibling-unpatch-b";
+            MethodInfo original = AccessTools.Method(
+                typeof(HotReloadPausePointDeepFixture),
+                nameof(HotReloadPausePointDeepFixture.DeepStatements));
+            MethodInfo shim = AccessTools.Method(
+                typeof(HotReloadPausePointContractShims),
+                nameof(HotReloadPausePointContractShims.DeepStatements__shim0));
+
+            UloopPausePointRegistry.Enable(id1, 30);
+            Assert.That(
+                SourcePausePointPatcher.Patch(id1, BuildSyntheticResolution(original, instructionIndex: 0)).Success,
+                Is.True);
+            UloopPausePointRegistry.Enable(id2, 30);
+            Assert.That(
+                SourcePausePointPatcher.Patch(id2, BuildSyntheticResolution(original, instructionIndex: 10)).Success,
+                Is.True);
+
+            Assert.That(
+                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Delegation).Success,
+                Is.True);
+
+            Assert.DoesNotThrow(() => SourcePausePointPatcher.Unpatch(id1));
+
+            HotReloadPausePointDeepFixture fixture = new HotReloadPausePointDeepFixture();
+            Assert.That(fixture.DeepStatements(), Is.EqualTo(99));
+            Assert.That(UloopPausePointRegistry.GetStatus(id2).IsHit, Is.False);
+        }
+
+        /// <summary>
         /// What: RevertAll restores armed-marker instrumentation so invoking the fixture
         /// records a hit again (regression for ledger-clear-before-UnpatchAll ordering).
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+using HarmonyLib;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Runtime;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for the hot-reload / source pause-point contract:
+    /// reject new markers on patched methods, and restore arming after RevertAll.
+    /// </summary>
+    public class HotReloadPausePointContractTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            UloopPausePointRegistry.ConfigureForTests(new FakePausePointPauseController(), () => DateTime.UtcNow);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadPatcher.RevertAll();
+            SourcePausePointPatcher.UnpatchAll();
+            UloopPausePointRegistry.ResetForTests();
+        }
+
+        /// <summary>
+        /// What: Patching a pause point onto a method that is already hot-reload patched
+        /// returns MethodPatchedByHotReload instead of crashing or silently injecting.
+        /// </summary>
+        [Test]
+        public void Patch_OnHotReloadedMethod_ReturnsMethodPatchedByHotReload()
+        {
+            MethodInfo original = AccessTools.Method(
+                typeof(HotReloadPausePointContractFixture),
+                nameof(HotReloadPausePointContractFixture.ReplaceableCompute));
+            MethodInfo shim = AccessTools.Method(
+                typeof(HotReloadPausePointContractShims),
+                nameof(HotReloadPausePointContractShims.ReplaceableCompute__shim0));
+
+            Assert.That(
+                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
+                Is.True);
+
+            SourcePausePointResolution resolution = BuildSyntheticResolution(original, instructionIndex: 5000);
+            SourcePausePointPatchResult result = SourcePausePointPatcher.Patch(
+                "contract-reject-on-patched",
+                resolution);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(
+                result.FailureReason,
+                Is.EqualTo(SourcePausePointPatchFailureReason.MethodPatchedByHotReload));
+        }
+
+        /// <summary>
+        /// What: After RevertAll, Patching a pause point onto the previously patched method
+        /// succeeds, proving the rejection is not permanent.
+        /// </summary>
+        [Test]
+        public void Patch_AfterRevertAll_Succeeds()
+        {
+            MethodInfo original = AccessTools.Method(
+                typeof(HotReloadPausePointContractFixture),
+                nameof(HotReloadPausePointContractFixture.ReplaceableCompute));
+            MethodInfo shim = AccessTools.Method(
+                typeof(HotReloadPausePointContractShims),
+                nameof(HotReloadPausePointContractShims.ReplaceableCompute__shim0));
+
+            Assert.That(
+                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
+                Is.True);
+            HotReloadPatcher.RevertAll();
+
+            SourcePausePointResolution resolution = BuildSyntheticResolution(original, instructionIndex: 0);
+            SourcePausePointPatchResult result = SourcePausePointPatcher.Patch(
+                "contract-ok-after-revert",
+                resolution);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+        }
+
+        /// <summary>
+        /// What: Applying a hot-reload patch to a method with an armed marker sets
+        /// SuppressedByHotReload, and RevertAll clears the flag.
+        /// </summary>
+        [Test]
+        public void Apply_MethodWithArmedMarker_SetsAndClearsSuppressedFlag()
+        {
+            const string id = "contract-suppress-flag";
+            MethodInfo original = AccessTools.Method(
+                typeof(HotReloadPausePointContractFixture),
+                nameof(HotReloadPausePointContractFixture.ReplaceableCompute));
+            MethodInfo shim = AccessTools.Method(
+                typeof(HotReloadPausePointContractShims),
+                nameof(HotReloadPausePointContractShims.ReplaceableCompute__shim0));
+
+            UloopPausePointRegistry.Enable(id, 30);
+            Assert.That(
+                SourcePausePointPatcher.Patch(id, BuildSyntheticResolution(original, instructionIndex: 0)).Success,
+                Is.True);
+
+            Assert.That(
+                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
+                Is.True);
+            Assert.That(UloopPausePointRegistry.GetStatus(id).SuppressedByHotReload, Is.True);
+
+            HotReloadPatcher.RevertAll();
+            Assert.That(UloopPausePointRegistry.GetStatus(id).SuppressedByHotReload, Is.False);
+        }
+
+        /// <summary>
+        /// What: An armed deep marker does not make a subsequent hot-reload Apply fail, and
+        /// the marker is reported as SuppressedByHotReload after Apply succeeds.
+        /// </summary>
+        [Test]
+        public void Apply_MethodWithDeepArmedMarker_SucceedsAndSuppresses()
+        {
+            const string id = "contract-deep-suppress";
+            MethodInfo original = AccessTools.Method(
+                typeof(HotReloadPausePointDeepFixture),
+                nameof(HotReloadPausePointDeepFixture.DeepStatements));
+            MethodInfo shim = AccessTools.Method(
+                typeof(HotReloadPausePointContractShims),
+                nameof(HotReloadPausePointContractShims.DeepStatements__shim0));
+
+            UloopPausePointRegistry.Enable(id, 30);
+            Assert.That(
+                SourcePausePointPatcher.Patch(id, BuildSyntheticResolution(original, instructionIndex: 10)).Success,
+                Is.True);
+
+            HotReloadPatchResult applyResult = HotReloadPatcher.Apply(
+                original, shim, HotReloadPatchShape.Delegation);
+            Assert.That(applyResult.Success, Is.True, applyResult.ErrorMessage);
+            Assert.That(UloopPausePointRegistry.GetStatus(id).SuppressedByHotReload, Is.True);
+        }
+
+        /// <summary>
+        /// What: RevertAll restores armed-marker instrumentation so invoking the fixture
+        /// records a hit again (regression for ledger-clear-before-UnpatchAll ordering).
+        /// </summary>
+        [Test]
+        public void RevertAll_RestoresArmedMarkerInstrumentation()
+        {
+            const string id = "contract-restore-hit";
+            MethodInfo original = AccessTools.Method(
+                typeof(HotReloadPausePointContractFixture),
+                nameof(HotReloadPausePointContractFixture.ReplaceableCompute));
+            MethodInfo shim = AccessTools.Method(
+                typeof(HotReloadPausePointContractShims),
+                nameof(HotReloadPausePointContractShims.ReplaceableCompute__shim0));
+
+            UloopPausePointRegistry.Enable(id, 30);
+            Assert.That(
+                SourcePausePointPatcher.Patch(id, BuildSyntheticResolution(original, instructionIndex: 0)).Success,
+                Is.True);
+
+            Assert.That(
+                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
+                Is.True);
+            HotReloadPatcher.RevertAll();
+
+            HotReloadPausePointContractFixture fixture = new HotReloadPausePointContractFixture();
+            int result = fixture.ReplaceableCompute(5);
+            Assert.That(result, Is.EqualTo(-5));
+
+            UloopPausePointSnapshot status = UloopPausePointRegistry.GetStatus(id);
+            Assert.That(status.IsHit, Is.True);
+            Assert.That(status.HitCount, Is.EqualTo(1));
+        }
+
+        private static SourcePausePointResolution BuildSyntheticResolution(
+            MethodBase method,
+            int instructionIndex)
+        {
+            return new SourcePausePointResolution(
+                method.Module.Assembly.GetName().Name,
+                method.Module.ModuleVersionId.ToString(),
+                method.MetadataToken,
+                method.ToString(),
+                method.IsStatic,
+                method.DeclaringType.IsValueType,
+                instructionIndex,
+                0,
+                1,
+                Array.Empty<SourcePausePointLocalVariable>(),
+                Array.Empty<SourcePausePointParameter>());
+        }
+
+        private sealed class FakePausePointPauseController : IUloopPausePointPauseController
+        {
+            public int PauseCount { get; private set; }
+            public bool IsPlaying => true;
+            public bool IsPaused => PauseCount > 0;
+
+            public void Pause()
+            {
+                PauseCount++;
+            }
+
+            public void Resume()
+            {
+                PauseCount = 0;
+            }
+        }
+    }
+
+    /// <summary>
+    /// NoInlining fixture used only by the hot-reload / pause-point contract tests.
+    /// </summary>
+    public class HotReloadPausePointContractFixture
+    {
+        // Why NoInlining: patch-target fixtures must not be inlined into the test method
+        // that was JIT-compiled before the patch was applied.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int ReplaceableCompute(int delta)
+        {
+            return -1 * delta;
+        }
+    }
+
+    /// <summary>
+    /// NoInlining fixture with enough independent statements for a deep InstructionIndex arm.
+    /// </summary>
+    public class HotReloadPausePointDeepFixture
+    {
+        // Why NoInlining: patch-target fixtures must not be inlined into the test method
+        // that was JIT-compiled before the patch was applied.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int DeepStatements()
+        {
+            int a = 1;
+            int b = 2;
+            int c = 3;
+            int d = 4;
+            int e = 5;
+            int f = 6;
+            int g = 7;
+            int h = 8;
+            int i = 9;
+            int j = 10;
+            int k = 11;
+            int l = 12;
+            return a + b + c + d + e + f + g + h + i + j + k + l;
+        }
+    }
+
+    /// <summary>
+    /// Hand-written transplant / delegation shims for the contract fixtures.
+    /// </summary>
+    public static class HotReloadPausePointContractShims
+    {
+        public static int ReplaceableCompute__shim0(HotReloadPausePointContractFixture instance, int delta)
+        {
+            return delta + 42;
+        }
+
+        public static int DeepStatements__shim0(HotReloadPausePointDeepFixture instance)
+        {
+            return 99;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d31fa6480fe294f39a21adf0bcb8508b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -107,6 +107,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Does.Not.Contain(HotReloadConstants.PausePointInteractionWarning));
         }
 
+        /// <summary>
+        /// What: BuildApplyResponse lists suppressed pause-point marker ids in Warnings
+        /// when the orchestrator collected any during the apply.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_WithSuppressedPausePointIds_AddsAggregatedWarning()
+        {
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>
+                {
+                    HotReloadMethodOutcome.Patched("Type.Method", "Assets/A.cs")
+                },
+                new List<string>(),
+                patchedTotal: 1,
+                activePatchTotal: 1,
+                suppressedPausePointIds: new List<string>
+                {
+                    "Assets/Scripts/A.cs:10",
+                    "Assets/Scripts/B.cs:20"
+                });
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+            Assert.That(
+                response.Warnings,
+                Does.Contain(
+                    "Armed pause points on the patched methods will not fire until the patch is reverted or compiled for real: Assets/Scripts/A.cs:10, Assets/Scripts/B.cs:20"));
+        }
+
         [Test]
         public async Task ExecuteAsync_RevertAllWithNoActivePatches_ReportsClearedCountZero()
         {

--- a/Assets/Tests/Editor/HotReload/UnityCLILoop.Tests.Editor.HotReload.asmdef
+++ b/Assets/Tests/Editor/HotReload/UnityCLILoop.Tests.Editor.HotReload.asmdef
@@ -6,7 +6,9 @@
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
         "GUID:afe86dd49995e46baa33e099a4d2ee1d",
         "GUID:774ab7841db34070bf18932c90cf9ea6",
-        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b",
+        "GUID:94d8abc693f543a691a4645a5ff42e5c",
+        "GUID:527f26a36b5043c2bd4d4036d04cd76d"
     ],
     "includePlatforms": [
         "Editor"

--- a/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
+++ b/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
@@ -83,7 +83,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 TruncatedVariableCount = 1,
                 ClearedReason = "",
                 StatusBeforeClear = "",
-                LateHitDiscardedAfterClear = false
+                LateHitDiscardedAfterClear = false,
+                SuppressedByHotReload = false
             };
             string json = JsonConvert.SerializeObject(
                 response,

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -174,6 +174,13 @@ If a `simulate-*` command instead returns a failure whose message says PlayMode 
 
 If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first — clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. When `--trigger` was passed, the expired envelope also carries `Error.Details.TriggerResult` (with `Completed: false` and no `Error` field when the trigger's outcome was still unknown at expiry). The countdown freezes while a hit holds the Editor paused; a manual pause without a hit does not stop it.
 
+`PAUSE_POINT_PATCHED_BY_HOT_RELOAD` means the target method's body is currently replaced
+by `uloop hot-reload`, so a new marker cannot be trusted anywhere in that method. Run
+`uloop compile` (or `uloop hot-reload --revert-all`) first, then enable the marker.
+Relatedly, `SuppressedByHotReload: true` on a status response means the marker's method
+was hot-reload patched after arming; the marker will not fire until the patch is
+reverted or compiled for real.
+
 Use `uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"` only when you need to confirm the marker is armed or inspect the current hit state.
 
 For the full diagnosis flow — the `Error.Details` status fields, bisecting with a second marker on the method entry, JIT inlining, physics-callback misses, and delegate bypass — read [references/troubleshooting.md](references/troubleshooting.md).

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -339,7 +339,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return;
             }
 
-            suppressedPausePointIds.AddRange(armedIds);
+            // The same method can be patched twice in one run (duplicate file inputs,
+            // re-applied edits); the aggregated warning must list each marker id once.
+            foreach (string armedId in armedIds)
+            {
+                if (!suppressedPausePointIds.Contains(armedId))
+                {
+                    suppressedPausePointIds.Add(armedId);
+                }
+            }
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -41,6 +41,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
             List<string> warnings = new List<string>();
+            List<string> suppressedPausePointIds = new List<string>();
             int patchedTotal = 0;
 
             for (int index = 0; index < files.Count; index++)
@@ -63,6 +64,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 outcomes.AddRange(fileResult.Outcomes);
                 warnings.AddRange(fileResult.Warnings);
+                suppressedPausePointIds.AddRange(fileResult.SuppressedPausePointIds);
                 patchedTotal += fileResult.PatchedCount;
             }
 
@@ -71,7 +73,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 outcomes,
                 warnings,
                 patchedTotal,
-                HotReloadPatcher.ActivePatchCount);
+                HotReloadPatcher.ActivePatchCount,
+                suppressedPausePointIds);
         }
 
         private static async Task<HotReloadFileProcessResult> ProcessFileAsync(
@@ -81,6 +84,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
             List<string> warnings = new List<string>();
+            List<string> suppressedPausePointIds = new List<string>();
 
             // CompilationPipeline / Application.dataPath require the Unity main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -229,7 +233,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     compileResult.Assembly,
                     bindFailureReasonByShimTypeName,
                     assemblyResolvePath,
-                    warnings);
+                    warnings,
+                    suppressedPausePointIds);
                 outcomes.Add(outcome);
                 if (outcome.Kind == HotReloadMethodOutcomeKind.Patched)
                 {
@@ -237,7 +242,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
             }
 
-            return new HotReloadFileProcessResult(outcomes, warnings, patchedCount);
+            return new HotReloadFileProcessResult(
+                outcomes, warnings, patchedCount, suppressedPausePointIds);
         }
 
         private static HotReloadMethodOutcome ApplyEntry(
@@ -246,7 +252,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Assembly shimAssembly,
             IReadOnlyDictionary<string, string> bindFailureReasonByShimTypeName,
             string filePath,
-            List<string> warnings)
+            List<string> warnings,
+            List<string> suppressedPausePointIds)
         {
             string methodLabel = entry.typeMetadataName + "." + entry.methodName;
 
@@ -310,12 +317,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return HotReloadMethodOutcome.Failed(methodLabel, patchResult.ErrorMessage, filePath);
             }
 
+            AppendSuppressedPausePointIds(matchResult.Method, suppressedPausePointIds);
+
             if (!string.IsNullOrEmpty(patchResult.Warning))
             {
                 warnings.Add(methodLabel + ": " + patchResult.Warning);
             }
 
             return HotReloadMethodOutcome.Patched(methodLabel, filePath, patchResult.Warning);
+        }
+
+        // What: records armed pause-point marker ids on a method just patched by hot reload.
+        private static void AppendSuppressedPausePointIds(
+            MethodBase method,
+            List<string> suppressedPausePointIds)
+        {
+            IReadOnlyList<string> armedIds =
+                HotReloadPausePointCoordination.GetArmedMarkerIdsOnMethod?.Invoke(method);
+            if (armedIds == null || armedIds.Count == 0)
+            {
+                return;
+            }
+
+            suppressedPausePointIds.AddRange(armedIds);
         }
 
         /// <summary>
@@ -573,15 +597,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public List<HotReloadMethodOutcome> Outcomes { get; }
             public List<string> Warnings { get; }
             public int PatchedCount { get; }
+            public List<string> SuppressedPausePointIds { get; }
 
             public HotReloadFileProcessResult(
                 List<HotReloadMethodOutcome> outcomes,
                 List<string> warnings,
-                int patchedCount)
+                int patchedCount,
+                List<string> suppressedPausePointIds = null)
             {
                 Outcomes = outcomes;
                 Warnings = warnings;
                 PatchedCount = patchedCount;
+                SuppressedPausePointIds = suppressedPausePointIds ?? new List<string>();
             }
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -11,17 +12,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public IReadOnlyList<string> Warnings { get; }
         public int PatchedTotal { get; }
         public int ActivePatchTotal { get; }
+        public IReadOnlyList<string> SuppressedPausePointIds { get; }
 
         public HotReloadOrchestratorResult(
             IReadOnlyList<HotReloadMethodOutcome> methods,
             IReadOnlyList<string> warnings,
             int patchedTotal,
-            int activePatchTotal)
+            int activePatchTotal,
+            IReadOnlyList<string> suppressedPausePointIds = null)
         {
             Methods = methods;
             Warnings = warnings;
             PatchedTotal = patchedTotal;
             ActivePatchTotal = activePatchTotal;
+            SuppressedPausePointIds = suppressedPausePointIds ?? Array.Empty<string>();
         }
     }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -83,6 +83,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // leaving it in place would stack transpilers and run discarded IL chains.
                 HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
                 ShimByMethod.Remove(method);
+                // Mirror the ledger removal immediately: if the re-Patch below fails, its
+                // contained Unpatch rebuilds the method with markers re-instrumented (the
+                // ledger no longer lists it), and RevertAll can never reach this method
+                // again — leaving the flag stuck at true would make status lie forever.
+                HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
             }
 
             MethodInfo transpilerMethodInfo = patchShape == HotReloadPatchShape.Delegation

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -7,6 +7,8 @@ using HarmonyLib;
 
 using UnityEngine;
 
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
@@ -36,6 +38,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // pending shim here so the first Patch call can read it before the ledger entry
         // exists (Patch invokes the transpiler synchronously on the main thread).
         private static MethodInfo _pendingShimMethod;
+
+        static HotReloadPatcher()
+        {
+            HotReloadPausePointCoordination.IsMethodPatchedByHotReload = method =>
+                ShimByMethod.ContainsKey(method);
+        }
 
         /// <summary>
         /// Patches <paramref name="method"/> with <paramref name="shimMethodInfo"/> using
@@ -90,6 +98,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     method,
                     transpiler: new HarmonyMethod(transpilerMethodInfo));
                 ShimByMethod[method] = shimMethodInfo;
+                HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, true);
             }
             catch (Exception exception)
             {
@@ -132,9 +141,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         public static void RevertAll()
         {
-            HarmonyInstance.UnpatchAll(HotReloadConstants.HarmonyId);
+            // Snapshot and clear the ledger BEFORE UnpatchAll: Harmony rebuilds every
+            // patched method during UnpatchAll, and the pause-point transpiler guard
+            // must see those methods as unpatched so armed markers are re-instrumented
+            // into the restored original IL.
+            List<MethodBase> revertedMethods = new List<MethodBase>(ShimByMethod.Keys);
             ShimByMethod.Clear();
             _pendingShimMethod = null;
+            HarmonyInstance.UnpatchAll(HotReloadConstants.HarmonyId);
+            foreach (MethodBase revertedMethod in revertedMethods)
+            {
+                HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(revertedMethod, false);
+            }
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -153,6 +153,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 warnings.Add(HotReloadConstants.PausePointInteractionWarning);
             }
 
+            if (result.SuppressedPausePointIds != null && result.SuppressedPausePointIds.Count > 0)
+            {
+                string ids = string.Join(", ", result.SuppressedPausePointIds);
+                warnings.Add(
+                    $"Armed pause points on the patched methods will not fire until the patch is reverted or compiled for real: {ids}");
+            }
+
             return new HotReloadResponse
             {
                 Success = !hasFailure,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -83,10 +83,9 @@ and check the hit count — zero hits means the calling path never reached the m
 which no patch can fix. Arm the marker after the hot-reload run, not before — and if the
 same marker already existed, clear it and enable it again, because re-enabling an
 existing marker re-arms its hit counter without re-injecting the discarded
-instrumentation. Keep it on the first line: on a currently patched method, deeper lines
-and local capture resolve
-against the pre-patch compiled body and are not reliable (see the pause point interaction
-below). To chase an early return inside the method, revert or `uloop compile` first. The
+instrumentation. Note that enabling a pause point on a currently patched method is rejected with
+`PAUSE_POINT_PATCHED_BY_HOT_RELOAD` (see the pause point interaction below); compile or
+revert first. To chase an early return inside the method, revert or `uloop compile` first. The
 other known cause is JIT inlining of tiny methods, which the response already flags with
 a per-method warning.
 
@@ -103,27 +102,25 @@ a per-method warning.
 ## Pause point interaction
 
 Both patch shapes discard the original IL and any prior transpiler output on the patched
-method — delegation replaces the body with a forward to the shim. The interaction with
-source pause points is therefore order-dependent:
+method — delegation replaces the body with a forward to the shim. Source pause points
+instrument methods through the same transpiler chain, so the two tools enforce a strict
+contract instead of composing silently:
 
-- A pause point armed **before** a hot reload of the same method silently stops firing —
-  its instrumentation was part of the discarded IL. `pause-point-status` still reports
-  `Enabled` with nothing hinting at the cause. Apply responses include a `Warnings` entry
-  whenever any method was patched.
-- A pause point enabled fresh **after** the hot reload fires on the method's first
-  line and captures parameters and `this` fields normally. Re-enabling a marker that
-  was already armed before the hot reload does not recover it: the patcher treats a
-  known marker id as a no-op, re-arming the hit counter without re-injecting the
-  discarded instrumentation — clear the marker, then enable it again. Markers on
-  deeper lines — and captured method locals — resolve against the pre-patch compiled
-  body, so they may land on the wrong instruction or read stale slots; treat them as
-  unreliable until the patch is reverted or compiled for real.
-- `--revert-all` (or a domain reload) restores the original IL, and previously armed
-  pause points fire again.
+- A pause point armed **before** a hot reload of the same method stops firing — its
+  instrumentation was part of the discarded IL. The apply response lists the affected
+  marker ids in `Warnings`, and `pause-point-status` reports `SuppressedByHotReload: true`
+  for those markers until the patch is reverted.
+- Enabling a pause point **on a currently patched method is rejected** with
+  `PAUSE_POINT_PATCHED_BY_HOT_RELOAD`. Marker positions and local-variable capture
+  resolve against the pre-patch compiled body, which no longer exists at runtime; there
+  is no line on a patched method where a new marker would be trustworthy.
+- `uloop hot-reload --revert-all` (or any domain reload) restores the original IL;
+  previously armed pause points fire again and their `SuppressedByHotReload` flag clears.
 
-So hot reload and pause points do compose for reachability checks: after each
-`uloop hot-reload` run, clear and re-enable first-line markers on patched methods,
-and defer deeper markers until `--revert-all` or a real `uloop compile`.
+So the workflow is: iterate on behavior with hot reload, and when you need pause-point
+inspection of an edited method, run `uloop compile` to make the edits real (the compile's
+domain reload clears every patch), then enable the marker. Use `--revert-all` instead
+when you want the on-disk build back without recompiling.
 
 ## Output
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -77,17 +77,15 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 ## When a patch reports `Patched` but behavior does not change
 
 `Patched` means the method body was replaced, not that the method ran. Before suspecting
-the patch, confirm the method is actually reached: arm
-`uloop enable-pause-point --mode trace` on the method's first line, then drive the game
-and check the hit count — zero hits means the calling path never reached the method,
-which no patch can fix. Arm the marker after the hot-reload run, not before — and if the
-same marker already existed, clear it and enable it again, because re-enabling an
-existing marker re-arms its hit counter without re-injecting the discarded
-instrumentation. Note that enabling a pause point on a currently patched method is rejected with
-`PAUSE_POINT_PATCHED_BY_HOT_RELOAD` (see the pause point interaction below); compile or
-revert first. To chase an early return inside the method, revert or `uloop compile` first. The
-other known cause is JIT inlining of tiny methods, which the response already flags with
-a per-method warning.
+the patch, confirm the method is actually reached. A currently patched method rejects new
+pause points with `PAUSE_POINT_PATCHED_BY_HOT_RELOAD` (see the pause point interaction
+below), so run `uloop compile` first — it makes the edits real and its domain reload
+clears every patch — then arm `uloop enable-pause-point --mode trace` on the method's
+first line, drive the game, and check the hit count: zero hits means the calling path
+never reached the method, which no patch (or compile) can fix. To chase an early return
+inside the method, arm a second marker on the suspected early-return line. The other
+known cause is JIT inlining of tiny methods, which the response already flags with a
+per-method warning.
 
 ## Convergence and lifecycle
 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/AssemblyInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/AssemblyInfo.cs
@@ -9,3 +9,5 @@ using System.Runtime.CompilerServices;
 // PausePointTests (Tests.Editor) exercises the Resolver/Patcher pipeline end-to-end and needs
 // SourcePausePointPatcher visibility to prove Unpatch actually detaches the ledger entry.
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]
+// The hot-reload contract tests patch a fixture with HotReloadPatcher and then drive SourcePausePointPatcher against it.
+[assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.HotReload")]

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -123,10 +123,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ClearedReason = snapshot.ClearedReason,
                 StatusBeforeClear = snapshot.StatusBeforeClear,
                 LateHitDiscardedAfterClear = snapshot.LateHitDiscardedAfterClear,
-                SuppressedByHotReload = snapshot.SuppressedByHotReload,
-                Warning = snapshot.SuppressedByHotReload
-                    ? "This method is currently hot-reload patched; the marker's instrumentation was discarded and it will not fire until 'uloop hot-reload --revert-all' or 'uloop compile'."
-                    : string.Empty
+                SuppressedByHotReload = snapshot.SuppressedByHotReload
             };
         }
 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -84,6 +84,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string ClearedReason { get; set; } = string.Empty;
         public string StatusBeforeClear { get; set; } = string.Empty;
         public bool LateHitDiscardedAfterClear { get; set; }
+        public bool SuppressedByHotReload { get; set; }
 
         internal static PausePointResponse FromSnapshot(UloopPausePointSnapshot snapshot)
         {
@@ -121,7 +122,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 RecommendedNextAction = snapshot.RecommendedNextAction,
                 ClearedReason = snapshot.ClearedReason,
                 StatusBeforeClear = snapshot.StatusBeforeClear,
-                LateHitDiscardedAfterClear = snapshot.LateHitDiscardedAfterClear
+                LateHitDiscardedAfterClear = snapshot.LateHitDiscardedAfterClear,
+                SuppressedByHotReload = snapshot.SuppressedByHotReload,
+                Warning = snapshot.SuppressedByHotReload
+                    ? "This method is currently hot-reload patched; the marker's instrumentation was discarded and it will not fire until 'uloop hot-reload --revert-all' or 'uloop compile'."
+                    : string.Empty
             };
         }
 
@@ -471,10 +476,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             SourcePausePointPatchResult patchResult = SourcePausePointPatcher.Patch(id, resolveResult.Resolution);
             if (!patchResult.Success)
             {
+                string errorCode =
+                    patchResult.FailureReason == SourcePausePointPatchFailureReason.MethodPatchedByHotReload
+                        ? SourcePausePointConstants.ErrorCodePausePointPatchedByHotReload
+                        : SourcePausePointConstants.ErrorCodePatchFailed;
                 return new PausePointResponse
                 {
                     Success = false,
-                    ErrorCode = SourcePausePointConstants.ErrorCodePatchFailed,
+                    ErrorCode = errorCode,
                     Message = patchResult.ErrorMessage,
                     RecommendedNextAction = patchResult.Hint
                 };

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -146,6 +146,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string ErrorCodeReleaseCodeOptimization = "PAUSE_POINT_RELEASE_CODE_OPTIMIZATION";
         public const string ErrorCodeResolveFailed = "PAUSE_POINT_RESOLVE_FAILED";
         public const string ErrorCodePatchFailed = "PAUSE_POINT_PATCH_FAILED";
+        public const string ErrorCodePausePointPatchedByHotReload = "PAUSE_POINT_PATCHED_BY_HOT_RELOAD";
 
         // Why: Debug mode is lost on every Editor restart (including uloop launch -r), so the
         // recovery steps must remind callers to re-switch after restart rather than only once.

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatchFailureReason.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatchFailureReason.cs
@@ -12,5 +12,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         UnpatchableExtern,
         UnpatchableOpenGeneric,
         UnpatchableBurstCompiled,
+        MethodPatchedByHotReload,
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -373,9 +373,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Injections resolve instruction indexes and local slots against the
                 // pre-patch body; on a hot-reload shim stream they would land at a
                 // meaningless offset, read stale local slots, or run past the end of the
-                // list. Enable already rejects new markers on patched methods; this guards
-                // the re-patch paths (the hot-reload apply itself, and Unpatch of a sibling
-                // marker re-applying the survivors after the hot-reload transpiler).
+                // list. Enable already rejects new markers on patched methods; this guard
+                // covers Unpatch of a sibling marker while the method is hot-reload
+                // patched: re-Patching the survivors registers a new transpiler that runs
+                // after the hot-reload one and therefore receives the shim stream. During
+                // the hot-reload apply itself the guard is inert (the ledger is written
+                // after Patch succeeds), which is fine — the hot-reload transpiler
+                // discards prior transpiler output anyway.
                 return list;
             }
 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -8,6 +8,7 @@ using HarmonyLib;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
@@ -41,6 +42,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             UloopPausePointRegistry.OnCleared = Unpatch;
             UloopPausePointRegistry.OnClearedAll = UnpatchAll;
+            HotReloadPausePointCoordination.GetArmedMarkerIdsOnMethod = GetArmedMarkerIds;
+            HotReloadPausePointCoordination.OnHotReloadPatchStateChanged = HandleHotReloadPatchStateChanged;
+        }
+
+        // What: lets the hot-reload tool list the marker ids it is about to suppress.
+        private static IReadOnlyList<string> GetArmedMarkerIds(MethodBase method)
+        {
+            if (!InjectionsByMethod.TryGetValue(method, out List<SourcePausePointPatchInjection> injections))
+            {
+                return Array.Empty<string>();
+            }
+            return injections.Select(injection => injection.Id).ToList();
+        }
+
+        // What: mirrors the hot-reload patch state onto every marker of the method so
+        // status responses can explain why an armed marker went silent.
+        private static void HandleHotReloadPatchStateChanged(MethodBase method, bool isPatched)
+        {
+            if (!InjectionsByMethod.TryGetValue(method, out List<SourcePausePointPatchInjection> injections))
+            {
+                return;
+            }
+            foreach (SourcePausePointPatchInjection injection in injections)
+            {
+                UloopPausePointRegistry.SetSuppressedByHotReload(injection.Id, isPatched);
+            }
         }
 
         public static SourcePausePointPatchResult Patch(string id, SourcePausePointResolution resolution)
@@ -65,6 +92,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (!patchabilityResult.Success)
             {
                 return patchabilityResult;
+            }
+
+            bool patchedByHotReload =
+                HotReloadPausePointCoordination.IsMethodPatchedByHotReload?.Invoke(method) ?? false;
+            if (patchedByHotReload)
+            {
+                return SourcePausePointPatchResult.Failure(
+                    SourcePausePointPatchFailureReason.MethodPatchedByHotReload,
+                    $"'{method.DeclaringType?.Name}.{method.Name}' is currently hot-reload patched; " +
+                    "pause-point instrumentation resolves instruction positions and local slots " +
+                    "against the pre-patch compiled body, which no longer exists at runtime.",
+                    "Run 'uloop hot-reload --revert-all' or 'uloop compile' first, then enable " +
+                    "the marker.");
             }
 
             SourcePausePointPatchInjection injection = new(
@@ -326,6 +366,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return list;
             }
 
+            bool patchedByHotReload =
+                HotReloadPausePointCoordination.IsMethodPatchedByHotReload?.Invoke(original) ?? false;
+            if (patchedByHotReload)
+            {
+                // Injections resolve instruction indexes and local slots against the
+                // pre-patch body; on a hot-reload shim stream they would land at a
+                // meaningless offset, read stale local slots, or run past the end of the
+                // list. Enable already rejects new markers on patched methods; this guards
+                // the re-patch paths (the hot-reload apply itself, and Unpatch of a sibling
+                // marker re-applying the survivors after the hot-reload transpiler).
+                return list;
+            }
+
             foreach (SourcePausePointPatchInjection injection in injections.OrderByDescending(i => i.InstructionIndex))
             {
                 Label skip = generator.DefineLabel();
@@ -334,6 +387,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // The instruction we insert before may be a branch target or a try/catch/finally
                 // boundary marker; both must move to the new first instruction so control flow and
                 // exception regions still land in the same place, now with our prefix folded in.
+                Debug.Assert(
+                    injection.InstructionIndex < list.Count,
+                    "An injection's index must exist in the current instruction stream.");
                 CodeInstruction displaced = list[injection.InstructionIndex];
                 emitted[0].labels.AddRange(displaced.labels);
                 displaced.labels.Clear();
@@ -365,7 +421,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             AppendInstanceLoad(emitted, injection, method);
 
-            ParameterInfo[] runtimeParameters = method.GetParameters();
+            // Fully qualify: ToolContracts also defines ParameterInfo (tool schema DTO).
+            System.Reflection.ParameterInfo[] runtimeParameters = method.GetParameters();
             int argOffset = injection.IsStatic ? 0 : 1;
             AppendNameValueArray(
                 emitted,

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 using io.github.hatayama.UnityCliLoop.Runtime;
@@ -137,6 +138,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public string ClearedReason { get; set; } = string.Empty;
         public string StatusBeforeClear { get; set; } = string.Empty;
         public bool LateHitDiscardedAfterClear { get; set; }
+        public bool SuppressedByHotReload { get; set; }
+        // Null when unset so the status contract omits Warning (matches Go omitempty).
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string Warning { get; set; }
 
         internal static PausePointStatusResponse FromSnapshot(UloopPausePointSnapshot snapshot)
         {
@@ -180,7 +185,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 TruncatedVariableCount = snapshot.TruncatedVariableCount,
                 ClearedReason = snapshot.ClearedReason,
                 StatusBeforeClear = snapshot.StatusBeforeClear,
-                LateHitDiscardedAfterClear = snapshot.LateHitDiscardedAfterClear
+                LateHitDiscardedAfterClear = snapshot.LateHitDiscardedAfterClear,
+                SuppressedByHotReload = snapshot.SuppressedByHotReload,
+                Warning = snapshot.SuppressedByHotReload
+                    ? "This method is currently hot-reload patched; the marker's instrumentation was discarded and it will not fire until 'uloop hot-reload --revert-all' or 'uloop compile'."
+                    : null
             };
         }
     }

--- a/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
+++ b/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace io.github.hatayama.UnityCliLoop.ToolContracts
+{
+    /// <summary>
+    /// Editor-domain coordination point between the hot-reload tool and the source
+    /// pause-point tool. The two tools live in sibling assemblies that must not
+    /// reference each other, so each side publishes its state through delegates
+    /// wired in its own static constructor (the same pattern as
+    /// UloopPausePointRegistry's OnCleared wiring). A null delegate means the owning
+    /// side has not initialized in this domain, which also means it has no state
+    /// worth querying; callers treat null as "no patches" / "no markers".
+    /// </summary>
+    public static class HotReloadPausePointCoordination
+    {
+        // Set by HotReloadPatcher. True while the method's body is replaced by a
+        // hot-reload patch.
+        public static Func<MethodBase, bool> IsMethodPatchedByHotReload { get; set; }
+
+        // Set by SourcePausePointPatcher. Returns the marker ids currently injected
+        // into the method (empty when none).
+        public static Func<MethodBase, IReadOnlyList<string>> GetArmedMarkerIdsOnMethod { get; set; }
+
+        // Set by SourcePausePointPatcher. Invoked by HotReloadPatcher after a
+        // method's patch state changes (true = patched, false = reverted).
+        public static Action<MethodBase, bool> OnHotReloadPatchStateChanged { get; set; }
+    }
+}

--- a/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs.meta
+++ b/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1bba4875e46904c7badecbe21a23b39f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Runtime/PausePoints/AssemblyInfo.cs
+++ b/Packages/src/Runtime/PausePoints/AssemblyInfo.cs
@@ -13,3 +13,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.PlayMode")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.SourcePausePointCapture")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.SourcePausePointPatcher")]
+// The hot-reload contract tests patch a fixture with HotReloadPatcher and then drive SourcePausePointPatcher against it.
+[assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.HotReload")]

--- a/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
@@ -61,6 +61,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public string ClearedReason { get; private set; } = string.Empty;
         public string StatusBeforeClear { get; private set; } = string.Empty;
         public bool LateHitDiscardedAfterClear { get; private set; }
+        public bool SuppressedByHotReload { get; set; }
 
         public bool ExpireIfNeeded(DateTime nowUtc)
         {
@@ -267,7 +268,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 TruncatedVariableCount,
                 ClearedReason,
                 StatusBeforeClear,
-                LateHitDiscardedAfterClear);
+                LateHitDiscardedAfterClear,
+                SuppressedByHotReload);
         }
 
         private long CalculateRemainingMilliseconds(DateTime nowUtc)

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -185,6 +185,20 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
 
         /// <summary>
+        /// Marks whether an armed marker's instrumentation was discarded by a hot-reload patch.
+        /// No-op when the id is unknown.
+        /// </summary>
+        public static void SetSuppressedByHotReload(string id, bool value)
+        {
+            if (!Entries.TryGetValue(id, out UloopPausePointEntry entry))
+            {
+                return;
+            }
+
+            entry.SuppressedByHotReload = value;
+        }
+
+        /// <summary>
         /// Extends a marker's capture window to at least minimumRemainingSeconds from now, so a
         /// slow multi-step CLI round trip (enable -&gt; seed state -&gt; await) does not let the marker
         /// expire before await-pause-point even starts observing it. Called once when the wait

--- a/Packages/src/Runtime/PausePoints/UloopPausePointSnapshot.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointSnapshot.cs
@@ -41,7 +41,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             int truncatedVariableCount,
             string clearedReason,
             string statusBeforeClear,
-            bool lateHitDiscardedAfterClear)
+            bool lateHitDiscardedAfterClear,
+            bool suppressedByHotReload)
         {
             Debug.Assert(editorState != null, "editorState must not be null");
 
@@ -75,6 +76,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             ClearedReason = clearedReason ?? string.Empty;
             StatusBeforeClear = statusBeforeClear ?? string.Empty;
             LateHitDiscardedAfterClear = lateHitDiscardedAfterClear;
+            SuppressedByHotReload = suppressedByHotReload;
         }
 
         public string Id { get; }
@@ -107,6 +109,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public string ClearedReason { get; }
         public string StatusBeforeClear { get; }
         public bool LateHitDiscardedAfterClear { get; }
+        public bool SuppressedByHotReload { get; }
 
         public static UloopPausePointSnapshot NotEnabled(string id, IUloopPausePointPauseController pauseController)
         {
@@ -144,6 +147,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 0,
                 string.Empty,
                 string.Empty,
+                false,
                 false);
         }
     }

--- a/cli/project-runner/internal/projectrunner/pause_point_errors.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors.go
@@ -126,11 +126,18 @@ const (
 		"(1) the method is a physics/message callback or is called from one on a GameObject that existed before enable — recreate the GameObject or embed UloopPausePoint.Pause; " +
 		"(2) the method was already bound into a delegate/event before enable — the pre-bound invocation path bypasses the patch; " +
 		"(3) the method ran but exited on an earlier branch (for example a guard rejected the action because game state had already moved on) — arm a second marker on the early-return line to see which path ran."
+
+	// pausePointHintSuppressedByHotReload short-circuits every other timeout diagnosis:
+	// a suppressed marker cannot fire no matter what the caller does in PlayMode.
+	pausePointHintSuppressedByHotReload = "The marker's method is currently hot-reload patched: the patch discarded the marker's instrumentation, so it cannot fire no matter how often the code path runs. Run `uloop hot-reload --revert-all` (or `uloop compile`) to restore it, then trigger the code path and wait again."
 )
 
 // pausePointTimeoutHint maps the final probed status to a deterministic diagnosis,
 // because timeouts are where agents struggle to tell a missed code path from Editor state.
 func pausePointTimeoutHint(response pausePointStatusResponse, hasNewHitBaseline bool) string {
+	if response.SuppressedByHotReload {
+		return pausePointHintSuppressedByHotReload
+	}
 	if hasNewHitBaseline {
 		return pausePointHintAlreadyHitWaitingForNew
 	}
@@ -154,6 +161,9 @@ func pausePointTimeoutHint(response pausePointStatusResponse, hasNewHitBaseline 
 // whose enable window ends before the wait deadline surfaces as PAUSE_POINT_EXPIRED instead
 // of a timeout and would otherwise carry no hint at all.
 func pausePointExpiredHint(response pausePointStatusResponse) string {
+	if response.SuppressedByHotReload {
+		return pausePointHintSuppressedByHotReload
+	}
 	if !response.EditorState.IsPlaying {
 		return pausePointHintPlayModeNotRunning
 	}
@@ -202,6 +212,7 @@ func pausePointStateError(
 			"RemainingMilliseconds":           pausePointRemainingMilliseconds(options, response),
 			"MarkerMessage":                   response.Message,
 			"RecommendedNextAction":           response.RecommendedNextAction,
+			"SuppressedByHotReload":           response.SuppressedByHotReload,
 		},
 	}
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_errors_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors_test.go
@@ -1,0 +1,93 @@
+package projectrunner
+
+import "testing"
+
+// Verifies that a suppressed marker short-circuits timeout diagnosis even when the
+// response would otherwise look like an already-hit continuous wait or an enabled-but-never-hit marker.
+func TestPausePointTimeoutHint_SuppressedByHotReload_WinsOverOtherBranches(t *testing.T) {
+	response := pausePointStatusResponse{
+		Status:                pausePointStatusEnabled,
+		HitCount:              0,
+		SuppressedByHotReload: true,
+		EditorState: pausePointEditorState{
+			IsPlaying: true,
+			IsPaused:  false,
+		},
+	}
+
+	hint := pausePointTimeoutHint(response, true)
+	if hint != pausePointHintSuppressedByHotReload {
+		t.Fatalf("expected suppressed hint, got %q", hint)
+	}
+}
+
+// Verifies the enabled-but-never-hit timeout hint still wins when suppression is false,
+// so inserting the suppressed short-circuit does not reorder the remaining branches.
+func TestPausePointTimeoutHint_NotSuppressed_ReturnsEnabledNeverHitHint(t *testing.T) {
+	response := pausePointStatusResponse{
+		Status:                pausePointStatusEnabled,
+		HitCount:              0,
+		SuppressedByHotReload: false,
+		EditorState: pausePointEditorState{
+			IsPlaying: true,
+			IsPaused:  false,
+		},
+	}
+
+	hint := pausePointTimeoutHint(response, false)
+	if hint == pausePointHintSuppressedByHotReload {
+		t.Fatalf("did not expect suppressed hint when SuppressedByHotReload is false")
+	}
+	if hint == "" {
+		t.Fatalf("expected the enabled-but-never-hit hint, got empty")
+	}
+	if hint == pausePointHintPlayModeNotRunning || hint == pausePointHintEditorAlreadyPaused {
+		t.Fatalf("expected the enabled-but-never-hit hint, got %q", hint)
+	}
+}
+
+// Verifies that a suppressed marker short-circuits expired-marker diagnosis as well.
+func TestPausePointExpiredHint_SuppressedByHotReload_ReturnsSuppressedHint(t *testing.T) {
+	response := pausePointStatusResponse{
+		HitCount:              0,
+		SuppressedByHotReload: true,
+		EditorState: pausePointEditorState{
+			IsPlaying: true,
+			IsPaused:  false,
+		},
+	}
+
+	hint := pausePointExpiredHint(response)
+	if hint != pausePointHintSuppressedByHotReload {
+		t.Fatalf("expected suppressed hint, got %q", hint)
+	}
+}
+
+// Verifies pausePointStateError exposes SuppressedByHotReload in Details for await failures.
+func TestPausePointStateError_DetailsIncludeSuppressedByHotReload(t *testing.T) {
+	response := pausePointStatusResponse{
+		Status:                pausePointStatusEnabled,
+		SuppressedByHotReload: true,
+	}
+	options := waitForPausePointOptions{id: "marker", timeoutSeconds: 30}
+
+	err := pausePointStateError(
+		"PAUSE_POINT_WAIT_TIMEOUT",
+		"Pause point was not hit within 30s.",
+		"/tmp/project",
+		options,
+		response,
+		true)
+
+	value, ok := err.Details["SuppressedByHotReload"]
+	if !ok {
+		t.Fatalf("Details missing SuppressedByHotReload")
+	}
+	suppressed, ok := value.(bool)
+	if !ok {
+		t.Fatalf("SuppressedByHotReload Details value has type %T, want bool", value)
+	}
+	if !suppressed {
+		t.Fatalf("expected SuppressedByHotReload Details to be true")
+	}
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_types.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_types.go
@@ -35,8 +35,9 @@ type pausePointStatusResponse struct {
 	SuppressedByHotReload           bool                             `json:"SuppressedByHotReload"`
 
 	// Warning is set by Unity on enable/clear tool responses when this shared type decodes those
-	// envelopes. The status bridge never sets it. On enable-pause-point --await hits, that enable
-	// response text is exposed as EnableTimeWarning on the wait payload, not as hit-time Warning.
+	// envelopes. The status bridge sets it only when SuppressedByHotReload is true. On
+	// enable-pause-point --await hits, that enable response text is exposed as EnableTimeWarning
+	// on the wait payload, not as hit-time Warning.
 	Warning string `json:"Warning,omitempty"`
 
 	// ResolvedLine / ResolvedLineText / ResolvedMethod / SnapshotTiming are copied from the

--- a/cli/project-runner/internal/projectrunner/pause_point_types.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_types.go
@@ -32,6 +32,7 @@ type pausePointStatusResponse struct {
 	ClearedReason                   string                           `json:"ClearedReason"`
 	StatusBeforeClear               string                           `json:"StatusBeforeClear"`
 	LateHitDiscardedAfterClear      bool                             `json:"LateHitDiscardedAfterClear"`
+	SuppressedByHotReload           bool                             `json:"SuppressedByHotReload"`
 
 	// Warning is set by Unity on enable/clear tool responses when this shared type decodes those
 	// envelopes. The status bridge never sets it. On enable-pause-point --await hits, that enable

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -206,8 +206,11 @@ Wire details:
 - In-flight async methods and coroutines keep running the old code until re-entered.
 - Callers whose call sites were JIT-inlined may not observe the detour (`IsLikelyJitInlined`
   heuristic produces a warning, as with pause points).
-- A transplanted method discards other transpilers' output on that method; in particular a
-  pause point on a hot-reloaded method stops firing. The response carries a warning.
+- A pause point armed before a hot reload of the same method stops firing. The apply
+  response lists the affected marker ids, `pause-point-status` reports
+  `SuppressedByHotReload: true`, and enabling a new marker on a currently patched
+  method is rejected with `PAUSE_POINT_PATCHED_BY_HOT_RELOAD`. Reverting the patch
+  restores armed markers and clears the flag.
 
 ## Open Questions Tracked for Implementation
 

--- a/tests/contracts/pause_point_status_response_contract.json
+++ b/tests/contracts/pause_point_status_response_contract.json
@@ -54,5 +54,6 @@
   "TruncatedVariableCount": 1,
   "ClearedReason": "",
   "StatusBeforeClear": "",
-  "LateHitDiscardedAfterClear": false
+  "LateHitDiscardedAfterClear": false,
+  "SuppressedByHotReload": false
 }


### PR DESCRIPTION
## Summary

- Reject enabling a source pause point on a method that is currently hot-reload patched (`PAUSE_POINT_PATCHED_BY_HOT_RELOAD`), and skip re-patch injections on those methods so Harmony cannot crash or inject at a stale index.
- Mark previously armed markers with `SuppressedByHotReload` when their method is hot-reloaded, clear the flag on `--revert-all`, and list affected marker ids in the hot-reload apply `Warnings`.
- Rewrite the hot-reload / pause-point interaction docs so agents no longer treat first-line markers on patched methods as safe.

## User Impact

Agents can no longer get a silent or crashing pause point on a hot-reloaded method. Status shows why an armed marker went quiet, and apply responses name the affected marker ids. After `--revert-all` or a real compile, armed markers fire again.

## Test plan

- [x] `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>` → 0/0
- [x] `scripts/check-go-cli.sh` → clean
- [x] `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value "HotReload|PausePoint" --project-path <PROJECT_ROOT>` → 345 passed / 0 failed
- [x] `sh scripts/regression-harness-hot-reload.sh --project-path <PROJECT_ROOT>` → PASS
- [ ] Note: base is `feature/hot-reload`, so repository CI workflows that filter on `main`/`develop` may not run; local verification above is the gate


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

