### PR TITLE
feat: report property accessor edits as skipped in hot reload

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -43,11 +43,13 @@ ledger across runs.
 
 ## Scope and limits
 
-Only ordinary method declarations are scanned. Property and indexer accessors, constructors,
-finalizers, operators, and event accessors are never scanned: edits to them produce **no
-per-method entry at all** and are silently not applied — use `uloop compile` for those.
+Only ordinary method declarations are patched. Constructors, finalizers, operators, and
+event accessors are never scanned: edits to them produce **no per-method entry at all**
+and are silently not applied — use `uloop compile` for those.
 
 Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Changed `const` values (including enum member values) are detected and reported as a `Warnings` entry naming the constant and both values; other outside-body edits stay silent. Use `uloop compile` for such edits.
+Property and indexer accessors with explicit bodies are reported per-accessor as
+`Skipped`, so an edited getter never disappears from the response silently.
 
 ### Skipped — reported per method, never flips `Success`
 

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -43,11 +43,13 @@ ledger across runs.
 
 ## Scope and limits
 
-Only ordinary method declarations are patched. Constructors, finalizers, operators, and
-event accessors are never scanned: edits to them produce **no per-method entry at all**
-and are silently not applied — use `uloop compile` for those.
+Only ordinary method declarations are patched. Constructors, finalizers, operators, event
+accessors, and `interface` members (including default interface implementations) are never
+scanned: edits to them produce **no per-method entry at all** and are silently not applied —
+use `uloop compile` for those.
 
 Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Changed `const` values (including enum member values) are detected and reported as a `Warnings` entry naming the constant and both values; other outside-body edits stay silent. Use `uloop compile` for such edits.
+
 Property and indexer accessors with explicit bodies are reported per-accessor as
 `Skipped`, so an edited getter never disappears from the response silently.
 
@@ -63,6 +65,7 @@ Property and indexer accessors with explicit bodies are reported per-accessor as
 | Body contains a `base.` call | `base` cannot be expressed from outside the type |
 | Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
+| Property or indexer accessor with an explicit body | Accessor patching is out of scope for v1; `uloop compile` applies accessor edits |
 
 ### Failed — flips `Success` to `false`
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -43,11 +43,13 @@ ledger across runs.
 
 ## Scope and limits
 
-Only ordinary method declarations are scanned. Property and indexer accessors, constructors,
-finalizers, operators, and event accessors are never scanned: edits to them produce **no
-per-method entry at all** and are silently not applied — use `uloop compile` for those.
+Only ordinary method declarations are patched. Constructors, finalizers, operators, and
+event accessors are never scanned: edits to them produce **no per-method entry at all**
+and are silently not applied — use `uloop compile` for those.
 
 Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Changed `const` values (including enum member values) are detected and reported as a `Warnings` entry naming the constant and both values; other outside-body edits stay silent. Use `uloop compile` for such edits.
+Property and indexer accessors with explicit bodies are reported per-accessor as
+`Skipped`, so an edited getter never disappears from the response silently.
 
 ### Skipped — reported per method, never flips `Success`
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -43,11 +43,13 @@ ledger across runs.
 
 ## Scope and limits
 
-Only ordinary method declarations are patched. Constructors, finalizers, operators, and
-event accessors are never scanned: edits to them produce **no per-method entry at all**
-and are silently not applied — use `uloop compile` for those.
+Only ordinary method declarations are patched. Constructors, finalizers, operators, event
+accessors, and `interface` members (including default interface implementations) are never
+scanned: edits to them produce **no per-method entry at all** and are silently not applied —
+use `uloop compile` for those.
 
 Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Changed `const` values (including enum member values) are detected and reported as a `Warnings` entry naming the constant and both values; other outside-body edits stay silent. Use `uloop compile` for such edits.
+
 Property and indexer accessors with explicit bodies are reported per-accessor as
 `Skipped`, so an edited getter never disappears from the response silently.
 
@@ -63,6 +65,7 @@ Property and indexer accessors with explicit bodies are reported per-accessor as
 | Body contains a `base.` call | `base` cannot be expressed from outside the type |
 | Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
+| Property or indexer accessor with an explicit body | Accessor patching is out of scope for v1; `uloop compile` applies accessor edits |
 
 ### Failed — flips `Success` to `false`
 

--- a/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
@@ -61,6 +61,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         public int SecretForAssert => _secret;
 
+        // Explicit-body getter — worker must report get_ExplicitBodyGetter as Skipped (not silent).
+        public int ExplicitBodyGetter
+        {
+            get { return _secret; }
+        }
+
         public int Counter;
 
         public HotReloadE2EFixture Next;

--- a/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
@@ -67,6 +67,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             get { return _secret; }
         }
 
+        // Explicit-body setter — worker must report set_ExplicitBodySetter as Skipped (not silent).
+        public int ExplicitBodySetter
+        {
+            set { _secret = value; }
+        }
+
         public int Counter;
 
         public HotReloadE2EFixture Next;

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -239,9 +239,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: one orchestrator run over the fixture reports the explicit-body property getter
-        /// and the expression-bodied indexer getter as Skipped with the v1 accessor reason, while
-        /// auto-property accessors stay unlisted.
+        /// What: one orchestrator run over the fixture reports the explicit-body property getter,
+        /// the explicit-body property setter, and the expression-bodied indexer getter as Skipped
+        /// with the v1 accessor reason, while auto-property accessors stay unlisted.
         /// </summary>
         [Test]
         public async Task Run_ExplicitAccessorsSkipped_AutoPropertyAccessorsUnlisted()
@@ -266,6 +266,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Property and indexer accessors are out of scope for v1; run 'uloop compile' to apply accessor edits.";
             bool foundPropertyGetter = false;
             bool foundIndexerGetter = false;
+            bool foundPropertySetter = false;
             bool foundAutoPropertyAccessor = false;
             foreach (HotReloadMethodOutcome outcome in result.Methods)
             {
@@ -279,6 +280,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 if (skippedWithAccessorReason && outcome.Method.Contains("get_Item"))
                 {
                     foundIndexerGetter = true;
+                }
+
+                if (skippedWithAccessorReason && outcome.Method.Contains("set_ExplicitBodySetter"))
+                {
+                    foundPropertySetter = true;
                 }
 
                 if (outcome.Method.Contains("get_HiddenScore") || outcome.Method.Contains("set_HiddenScore"))
@@ -295,6 +301,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 foundIndexerGetter,
                 Is.True,
                 "Expected the expression-bodied indexer getter (get_Item) to be Skipped with the accessor out-of-scope reason.");
+            Assert.That(
+                foundPropertySetter,
+                Is.True,
+                "Expected the explicit-body setter (set_ExplicitBodySetter) to be Skipped with the accessor out-of-scope reason.");
             Assert.That(
                 foundAutoPropertyAccessor,
                 Is.False,
@@ -928,6 +938,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public int ExplicitBodyGetter
         {
             get { return _secret; }
+        }
+
+        // Explicit-body setter — worker must report set_ExplicitBodySetter as Skipped (not silent).
+        public int ExplicitBodySetter
+        {
+            set { _secret = value; }
         }
 
         public int Counter;

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -239,6 +239,48 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: an explicit-body property getter is reported as Skipped with the v1 accessor
+        /// reason, so an edited getter never disappears from the response silently.
+        /// </summary>
+        [Test]
+        public async Task Run_ExplicitBodyPropertyGetter_IsSkippedWithAccessorReason()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "ExplicitBodyGetter.cs",
+                BuildFixtureSource(
+                    "public int ComputeWithPrivate(int delta)\n"
+                    + "        {\n"
+                    + "            return _secret + delta;\n"
+                    + "        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                contentPathOverride: editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+
+            const string expectedReason =
+                "Property and indexer accessors are out of scope for v1; run 'uloop compile' to apply accessor edits.";
+            bool found = false;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Skipped
+                    && outcome.Method.Contains("get_ExplicitBodyGetter")
+                    && outcome.Reason == expectedReason)
+                {
+                    found = true;
+                }
+            }
+
+            Assert.That(
+                found,
+                Is.True,
+                "Expected get_ExplicitBodyGetter to be Skipped with the accessor out-of-scope reason.");
+        }
+
+        /// <summary>
         /// What: a mixed transplant+delegation fixture patches both the sync private-access
         /// method (transplant) and the LINQ private-access method (delegation).
         /// </summary>
@@ -860,6 +902,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         " + tuningConst + @"
 
         public int SecretForAssert => _secret;
+
+        // Explicit-body getter — worker must report get_ExplicitBodyGetter as Skipped (not silent).
+        public int ExplicitBodyGetter
+        {
+            get { return _secret; }
+        }
 
         public int Counter;
 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -239,11 +239,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: an explicit-body property getter is reported as Skipped with the v1 accessor
-        /// reason, so an edited getter never disappears from the response silently.
+        /// What: one orchestrator run over the fixture reports the explicit-body property getter
+        /// and the expression-bodied indexer getter as Skipped with the v1 accessor reason, while
+        /// auto-property accessors stay unlisted.
         /// </summary>
         [Test]
-        public async Task Run_ExplicitBodyPropertyGetter_IsSkippedWithAccessorReason()
+        public async Task Run_ExplicitAccessorsSkipped_AutoPropertyAccessorsUnlisted()
         {
             string fixturePath = ResolveE2EFixturePath();
             string editedPath = WriteEditedSource(
@@ -263,21 +264,41 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             const string expectedReason =
                 "Property and indexer accessors are out of scope for v1; run 'uloop compile' to apply accessor edits.";
-            bool found = false;
+            bool foundPropertyGetter = false;
+            bool foundIndexerGetter = false;
+            bool foundAutoPropertyAccessor = false;
             foreach (HotReloadMethodOutcome outcome in result.Methods)
             {
-                if (outcome.Kind == HotReloadMethodOutcomeKind.Skipped
-                    && outcome.Method.Contains("get_ExplicitBodyGetter")
-                    && outcome.Reason == expectedReason)
+                bool skippedWithAccessorReason = outcome.Kind == HotReloadMethodOutcomeKind.Skipped
+                    && outcome.Reason == expectedReason;
+                if (skippedWithAccessorReason && outcome.Method.Contains("get_ExplicitBodyGetter"))
                 {
-                    found = true;
+                    foundPropertyGetter = true;
+                }
+
+                if (skippedWithAccessorReason && outcome.Method.Contains("get_Item"))
+                {
+                    foundIndexerGetter = true;
+                }
+
+                if (outcome.Method.Contains("get_HiddenScore") || outcome.Method.Contains("set_HiddenScore"))
+                {
+                    foundAutoPropertyAccessor = true;
                 }
             }
 
             Assert.That(
-                found,
+                foundPropertyGetter,
                 Is.True,
                 "Expected get_ExplicitBodyGetter to be Skipped with the accessor out-of-scope reason.");
+            Assert.That(
+                foundIndexerGetter,
+                Is.True,
+                "Expected the expression-bodied indexer getter (get_Item) to be Skipped with the accessor out-of-scope reason.");
+            Assert.That(
+                foundAutoPropertyAccessor,
+                Is.False,
+                "Auto-property accessors must not be listed; only explicit-body accessors are reported.");
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -43,11 +43,13 @@ ledger across runs.
 
 ## Scope and limits
 
-Only ordinary method declarations are scanned. Property and indexer accessors, constructors,
-finalizers, operators, and event accessors are never scanned: edits to them produce **no
-per-method entry at all** and are silently not applied — use `uloop compile` for those.
+Only ordinary method declarations are patched. Constructors, finalizers, operators, and
+event accessors are never scanned: edits to them produce **no per-method entry at all**
+and are silently not applied — use `uloop compile` for those.
 
 Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Changed `const` values (including enum member values) are detected and reported as a `Warnings` entry naming the constant and both values; other outside-body edits stay silent. Use `uloop compile` for such edits.
+Property and indexer accessors with explicit bodies are reported per-accessor as
+`Skipped`, so an edited getter never disappears from the response silently.
 
 ### Skipped — reported per method, never flips `Success`
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -43,11 +43,13 @@ ledger across runs.
 
 ## Scope and limits
 
-Only ordinary method declarations are patched. Constructors, finalizers, operators, and
-event accessors are never scanned: edits to them produce **no per-method entry at all**
-and are silently not applied — use `uloop compile` for those.
+Only ordinary method declarations are patched. Constructors, finalizers, operators, event
+accessors, and `interface` members (including default interface implementations) are never
+scanned: edits to them produce **no per-method entry at all** and are silently not applied —
+use `uloop compile` for those.
 
 Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Changed `const` values (including enum member values) are detected and reported as a `Warnings` entry naming the constant and both values; other outside-body edits stay silent. Use `uloop compile` for such edits.
+
 Property and indexer accessors with explicit bodies are reported per-accessor as
 `Skipped`, so an edited getter never disappears from the response silently.
 
@@ -63,6 +65,7 @@ Property and indexer accessors with explicit bodies are reported per-accessor as
 | Body contains a `base.` call | `base` cannot be expressed from outside the type |
 | Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
+| Property or indexer accessor with an explicit body | Accessor patching is out of scope for v1; `uloop compile` applies accessor edits |
 
 ### Failed — flips `Success` to `false`
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -219,6 +219,10 @@ public static class TransformWorkerProgram
                 continue;
             }
 
+            // Accessors are never patched in v1; report each explicit-body accessor as Skipped
+            // so an edited getter/setter never disappears from the response silently.
+            AppendExplicitAccessorSkips(typeDeclaration, semanticModel, skipped);
+
             List<MethodDeclarationSyntax> methods = typeDeclaration.Members
                 .OfType<MethodDeclarationSyntax>()
                 .ToList();
@@ -436,6 +440,112 @@ public static class TransformWorkerProgram
         }
 
         return Convert.ToString(value, CultureInfo.InvariantCulture);
+    }
+
+    private const string ExplicitAccessorSkipReason =
+        "Property and indexer accessors are out of scope for v1; run 'uloop compile' to apply accessor edits.";
+
+    // What: reports each property/indexer accessor that has an explicit body as Skipped.
+    // Auto-properties ({ get; set; }) have no body and are not listed.
+    private static void AppendExplicitAccessorSkips(
+        TypeDeclarationSyntax typeDeclaration,
+        SemanticModel semanticModel,
+        List<WorkerSkipped> skipped)
+    {
+        foreach (MemberDeclarationSyntax member in typeDeclaration.Members)
+        {
+            if (member is PropertyDeclarationSyntax propertyDeclaration)
+            {
+                AppendExplicitAccessorSkipsForProperty(
+                    propertyDeclaration,
+                    semanticModel.GetDeclaredSymbol(propertyDeclaration),
+                    skipped);
+                continue;
+            }
+
+            if (member is IndexerDeclarationSyntax indexerDeclaration)
+            {
+                AppendExplicitAccessorSkipsForProperty(
+                    indexerDeclaration,
+                    semanticModel.GetDeclaredSymbol(indexerDeclaration),
+                    skipped);
+            }
+        }
+    }
+
+    private static void AppendExplicitAccessorSkipsForProperty(
+        BasePropertyDeclarationSyntax propertyDeclaration,
+        IPropertySymbol propertySymbol,
+        List<WorkerSkipped> skipped)
+    {
+        if (propertySymbol == null)
+        {
+            return;
+        }
+
+        // Expression-bodied property/indexer (`=> expr`) is the getter body.
+        bool hasExpressionBody =
+            (propertyDeclaration is PropertyDeclarationSyntax propertyWithExpression
+                && propertyWithExpression.ExpressionBody != null)
+            || (propertyDeclaration is IndexerDeclarationSyntax indexerWithExpression
+                && indexerWithExpression.ExpressionBody != null);
+        if (hasExpressionBody)
+        {
+            if (propertySymbol.GetMethod != null)
+            {
+                skipped.Add(new WorkerSkipped
+                {
+                    Method = FormatMethodLabel(propertySymbol.GetMethod),
+                    Reason = ExplicitAccessorSkipReason
+                });
+            }
+
+            return;
+        }
+
+        if (propertyDeclaration.AccessorList == null)
+        {
+            return;
+        }
+
+        foreach (AccessorDeclarationSyntax accessor in propertyDeclaration.AccessorList.Accessors)
+        {
+            // Auto-properties emit accessors with neither Body nor ExpressionBody.
+            if (accessor.Body == null && accessor.ExpressionBody == null)
+            {
+                continue;
+            }
+
+            IMethodSymbol accessorMethod = ResolveAccessorMethodSymbol(propertySymbol, accessor.Kind());
+            if (accessorMethod == null)
+            {
+                continue;
+            }
+
+            skipped.Add(new WorkerSkipped
+            {
+                Method = FormatMethodLabel(accessorMethod),
+                Reason = ExplicitAccessorSkipReason
+            });
+        }
+    }
+
+    private static IMethodSymbol ResolveAccessorMethodSymbol(
+        IPropertySymbol propertySymbol,
+        SyntaxKind accessorKind)
+    {
+        if (accessorKind == SyntaxKind.GetAccessorDeclaration)
+        {
+            return propertySymbol.GetMethod;
+        }
+
+        if (accessorKind == SyntaxKind.SetAccessorDeclaration
+            || accessorKind == SyntaxKind.InitAccessorDeclaration)
+        {
+            return propertySymbol.SetMethod;
+        }
+
+        return null;
     }
 
     private static IEnumerable<TypeDeclarationSyntax> EnumerateTypeDeclarations(CompilationUnitSyntax root)


### PR DESCRIPTION
## Summary

- Explicit-body property and indexer accessors are now reported as `Skipped` in hot-reload responses instead of disappearing silently.
- Auto-properties (`{ get; set; }`) remain unlisted; only accessors with a real body are enumerated.

## User Impact

Editing a getter or indexer no longer looks like a successful no-op. The response names the accessor (e.g. `get_PropertyName`) and tells the agent to run `uloop compile` to apply the edit.

## Test plan

- [x] TDD: `Run_ExplicitBodyPropertyGetter_IsSkippedWithAccessorReason` went Red, then Green after the TransformWorker change
- [x] `dist/darwin-arm64/uloop compile` → 0/0
- [x] `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value "HotReload|PausePoint"` → 348 passed / 0 failed
- [x] `uloop skills install --claude --agents` + `cmp` byte-identical for hot-reload SKILL copies
- [x] `scripts/sync-tool-docs.sh` → no catalog diff (parameter table untouched)
- [ ] Base is `feature/hot-reload`; repository CI may not run — local verification is the gate


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

