### PR TITLE
feat: add --status to uloop hot-reload

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -28,16 +28,17 @@ consume exactly one value token.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when `--revert-all` is not set |
+| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when neither `--revert-all` nor `--status` is set |
 | `--revert-all` | flag | - | Remove every active hot-reload patch and clear the patch ledger. When set, `--files` is ignored |
 | `--status` | flag | - | Lists the currently patched methods without applying or reverting anything. |
 
 ## Checking what is currently patched
 
 `uloop hot-reload --status` lists the methods whose bodies are currently replaced,
-without applying or reverting anything. Patches are static Editor state, so the answer
-is authoritative: after a domain reload it reports zero patched methods, which is
-exactly when an `ActivePatchTotal` remembered from an earlier response has gone stale.
+without applying or reverting anything. It cannot be combined with `--files` or
+`--revert-all`. Patches are static Editor state, so the answer is authoritative: after
+a domain reload it reports zero patched methods, which is exactly when an
+`ActivePatchTotal` remembered from an earlier response has gone stale.
 
 ## How it works
 
@@ -138,7 +139,7 @@ when you want the on-disk build back without recompiling.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed`
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply/revert runs, or `Active` on `--status` runs
 - `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -139,7 +139,7 @@ when you want the on-disk build back without recompiling.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply/revert runs, or `Active` on `--status` runs
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
 - `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -30,6 +30,14 @@ consume exactly one value token.
 |-----------|------|---------|-------------|
 | `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when `--revert-all` is not set |
 | `--revert-all` | flag | - | Remove every active hot-reload patch and clear the patch ledger. When set, `--files` is ignored |
+| `--status` | flag | - | Lists the currently patched methods without applying or reverting anything. |
+
+## Checking what is currently patched
+
+`uloop hot-reload --status` lists the methods whose bodies are currently replaced,
+without applying or reverting anything. Patches are static Editor state, so the answer
+is authoritative: after a domain reload it reports zero patched methods, which is
+exactly when an `ActivePatchTotal` remembered from an earlier response has gone stale.
 
 ## How it works
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -28,16 +28,17 @@ consume exactly one value token.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when `--revert-all` is not set |
+| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when neither `--revert-all` nor `--status` is set |
 | `--revert-all` | flag | - | Remove every active hot-reload patch and clear the patch ledger. When set, `--files` is ignored |
 | `--status` | flag | - | Lists the currently patched methods without applying or reverting anything. |
 
 ## Checking what is currently patched
 
 `uloop hot-reload --status` lists the methods whose bodies are currently replaced,
-without applying or reverting anything. Patches are static Editor state, so the answer
-is authoritative: after a domain reload it reports zero patched methods, which is
-exactly when an `ActivePatchTotal` remembered from an earlier response has gone stale.
+without applying or reverting anything. It cannot be combined with `--files` or
+`--revert-all`. Patches are static Editor state, so the answer is authoritative: after
+a domain reload it reports zero patched methods, which is exactly when an
+`ActivePatchTotal` remembered from an earlier response has gone stale.
 
 ## How it works
 
@@ -138,7 +139,7 @@ when you want the on-disk build back without recompiling.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed`
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply/revert runs, or `Active` on `--status` runs
 - `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -139,7 +139,7 @@ when you want the on-disk build back without recompiling.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply/revert runs, or `Active` on `--status` runs
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
 - `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -30,6 +30,14 @@ consume exactly one value token.
 |-----------|------|---------|-------------|
 | `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when `--revert-all` is not set |
 | `--revert-all` | flag | - | Remove every active hot-reload patch and clear the patch ledger. When set, `--files` is ignored |
+| `--status` | flag | - | Lists the currently patched methods without applying or reverting anything. |
+
+## Checking what is currently patched
+
+`uloop hot-reload --status` lists the methods whose bodies are currently replaced,
+without applying or reverting anything. Patches are static Editor state, so the answer
+is authoritative: after a domain reload it reports zero patched methods, which is
+exactly when an `ActivePatchTotal` remembered from an earlier response has gone stale.
 
 ## How it works
 

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -101,6 +102,33 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadPatcher.RevertAll();
             Assert.That(HotReloadPatcher.ActivePatchCount, Is.EqualTo(0));
             Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(-5));
+        }
+
+        /// <summary>
+        /// What: DescribeActivePatches lists the patched fixture method after Apply and is empty
+        /// after RevertAll.
+        /// </summary>
+        [Test]
+        public void DescribeActivePatches_AfterApply_ListsFixture_AndClearsAfterRevertAll()
+        {
+            MethodInfo original = AccessTools.Method(
+                typeof(HotReloadCoreFixture), nameof(HotReloadCoreFixture.ReplaceableCompute));
+            MethodInfo shim = AccessTools.Method(
+                typeof(HotReloadHandwrittenShims), nameof(HotReloadHandwrittenShims.ReplaceableCompute__shim0));
+
+            Assert.That(
+                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
+                Is.True);
+
+            IReadOnlyList<string> afterApply = HotReloadPatcher.DescribeActivePatches();
+            Assert.That(afterApply.Count, Is.EqualTo(1));
+            Assert.That(
+                afterApply[0],
+                Does.Contain(nameof(HotReloadCoreFixture)).And.Contain(nameof(HotReloadCoreFixture.ReplaceableCompute)));
+
+            HotReloadPatcher.RevertAll();
+            IReadOnlyList<string> afterRevert = HotReloadPatcher.DescribeActivePatches();
+            Assert.That(afterRevert, Is.Empty);
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -165,6 +165,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         public static int ActivePatchCount => ShimByMethod.Count;
 
+        /// <summary>
+        /// Returns a sorted list of labels for every method currently recorded in the
+        /// patch ledger, for status reporting without applying or reverting patches.
+        /// </summary>
+        public static IReadOnlyList<string> DescribeActivePatches()
+        {
+            List<string> labels = new List<string>(ShimByMethod.Count);
+            foreach (MethodBase method in ShimByMethod.Keys)
+            {
+                Debug.Assert(method.DeclaringType != null, "Patched methods must have a declaring type.");
+                labels.Add(method.DeclaringType.FullName + "." + method.Name);
+            }
+
+            labels.Sort(StringComparer.Ordinal);
+            return labels;
+        }
+
         private static IEnumerable<CodeInstruction> ReplaceWithTransplantSourceTranspiler(
             IEnumerable<CodeInstruction> instructions,
             ILGenerator generator,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -149,7 +149,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             if (parameters.Files == null || parameters.Files.Length == 0)
             {
-                return "Files is required when --revert-all is not set.";
+                return "Files is required unless --revert-all or --status is set.";
             }
 
             for (int index = 0; index < parameters.Files.Length; index++)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -23,6 +23,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// When true, removes every active hot-reload transplant and ignores Files.
         /// </summary>
         public bool RevertAll { get; set; }
+
+        /// <summary>
+        /// When true, lists the currently patched methods without applying or reverting anything.
+        /// </summary>
+        public bool Status { get; set; }
     }
 
     /// <summary>
@@ -70,6 +75,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ct.ThrowIfCancellationRequested();
             Debug.Assert(parameters != null, "parameters must not be null.");
 
+            if (parameters.Status)
+            {
+                if (parameters.RevertAll
+                    || (parameters.Files != null && parameters.Files.Length > 0))
+                {
+                    return CreateValidationFailure(
+                        "--status cannot be combined with --files or --revert-all.");
+                }
+
+                return ExecuteStatus();
+            }
+
             if (parameters.RevertAll)
             {
                 return ExecuteRevertAll();
@@ -100,6 +117,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Message = clearedCount == 0
                     ? "No active hot-reload patches to revert."
                     : "Reverted all active hot-reload patches."
+            };
+        }
+
+        private static HotReloadResponse ExecuteStatus()
+        {
+            IReadOnlyList<string> active = HotReloadPatcher.DescribeActivePatches();
+            List<HotReloadMethodResult> methods = new List<HotReloadMethodResult>(active.Count);
+            for (int index = 0; index < active.Count; index++)
+            {
+                methods.Add(
+                    new HotReloadMethodResult
+                    {
+                        Kind = "Active",
+                        Method = active[index]
+                    });
+            }
+
+            int count = active.Count;
+            return new HotReloadResponse
+            {
+                Success = true,
+                Methods = methods,
+                ActivePatchTotal = count,
+                Message = $"{count} method(s) currently patched."
             };
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -28,16 +28,17 @@ consume exactly one value token.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when `--revert-all` is not set |
+| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when neither `--revert-all` nor `--status` is set |
 | `--revert-all` | flag | - | Remove every active hot-reload patch and clear the patch ledger. When set, `--files` is ignored |
 | `--status` | flag | - | Lists the currently patched methods without applying or reverting anything. |
 
 ## Checking what is currently patched
 
 `uloop hot-reload --status` lists the methods whose bodies are currently replaced,
-without applying or reverting anything. Patches are static Editor state, so the answer
-is authoritative: after a domain reload it reports zero patched methods, which is
-exactly when an `ActivePatchTotal` remembered from an earlier response has gone stale.
+without applying or reverting anything. It cannot be combined with `--files` or
+`--revert-all`. Patches are static Editor state, so the answer is authoritative: after
+a domain reload it reports zero patched methods, which is exactly when an
+`ActivePatchTotal` remembered from an earlier response has gone stale.
 
 ## How it works
 
@@ -138,7 +139,7 @@ when you want the on-disk build back without recompiling.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed`
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply/revert runs, or `Active` on `--status` runs
 - `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -139,7 +139,7 @@ when you want the on-disk build back without recompiling.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply/revert runs, or `Active` on `--status` runs
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
 - `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -30,6 +30,14 @@ consume exactly one value token.
 |-----------|------|---------|-------------|
 | `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when `--revert-all` is not set |
 | `--revert-all` | flag | - | Remove every active hot-reload patch and clear the patch ledger. When set, `--files` is ignored |
+| `--status` | flag | - | Lists the currently patched methods without applying or reverting anything. |
+
+## Checking what is currently patched
+
+`uloop hot-reload --status` lists the methods whose bodies are currently replaced,
+without applying or reverting anything. Patches are static Editor state, so the answer
+is authoritative: after a domain reload it reports zero patched methods, which is
+exactly when an `ActivePatchTotal` remembered from an earlier response has gone stale.
 
 ## How it works
 

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -750,7 +750,7 @@
         "properties": {
           "Files": {
             "type": "array",
-            "description": "Project-relative .cs paths whose method bodies should be hot-reloaded. Required when --revert-all is not set",
+            "description": "Project-relative .cs paths whose method bodies should be hot-reloaded. Required when neither --revert-all nor --status is set",
             "items": {
               "type": "string"
             }

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -758,6 +758,10 @@
           "RevertAll": {
             "type": "boolean",
             "description": "Remove every active hot-reload patch and clear the patch ledger. When set, --files is ignored"
+          },
+          "Status": {
+            "type": "boolean",
+            "description": "Lists the currently patched methods without applying or reverting anything."
           }
         }
       }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "e4df659b90c264e6076a50d42d6a00f37d3e0ea0"
+  "sharedInputsHash": "e439229e446c71d5b31a7eb0c893c8e7fdaa2d03"
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "e439229e446c71d5b31a7eb0c893c8e7fdaa2d03"
+  "sharedInputsHash": "2fc9c96b3a32ec851cf8f24aaaf0e6b72117d949"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "29f2a6233d6c747af0b22d4987e4657faf55b189"
+  "sharedInputsHash": "429aa8a40472d9d8b46a9d65a1cc8e8fe42b1a28"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "429aa8a40472d9d8b46a9d65a1cc8e8fe42b1a28"
+  "sharedInputsHash": "85db5be8acbb6dafb3e4df5c3eeaf65676b8981e"
 }


### PR DESCRIPTION
## Summary

- Add `uloop hot-reload --status` so agents can list methods currently replaced by the in-memory patch ledger without applying or reverting.
- Patches are static Editor state; after a domain reload the ledger is empty, which is exactly when an earlier `ActivePatchTotal` has gone stale.
- Document `--status` in the skill (parameter table + guidance), regenerate skill copies, and sync `default-tools.json` with release-input stamps.

## User Impact

Agents can ask what is currently hot-reloaded and get an authoritative answer (`ActivePatchTotal` and `Kind: Active` method entries) without guessing from a previous apply response.

## Test plan

- [x] `uloop compile` → 0/0
- [x] EditMode `HotReload|PausePoint` → 0 failed (includes `DescribeActivePatches_AfterApply_ListsFixture_AndClearsAfterRevertAll`)
- [x] `uloop hot-reload --status` → `ActivePatchTotal: 0` and `Message: "0 method(s) currently patched."`
- [x] `scripts/sync-tool-docs.sh` / `--check` clean; skill copies byte-identical to source
- [x] `scripts/check-go-cli.sh` clean


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

