### PR TITLE
fix: aggregate inline-risk warnings and force English shim diagnostics

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -99,7 +99,7 @@ first line, drive the game, and check the hit count: zero hits means the calling
 never reached the method, which no patch (or compile) can fix. To chase an early return
 inside the method, arm a second marker on the suspected early-return line. The other
 known cause is JIT inlining of tiny methods, which the response already flags with a
-per-method warning.
+single aggregated warning listing the at-risk methods.
 
 ## Convergence and lifecycle
 

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -140,7 +140,7 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
-- `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
+- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -99,7 +99,7 @@ first line, drive the game, and check the hit count: zero hits means the calling
 never reached the method, which no patch (or compile) can fix. To chase an early return
 inside the method, arm a second marker on the suspected early-return line. The other
 known cause is JIT inlining of tiny methods, which the response already flags with a
-per-method warning.
+single aggregated warning listing the at-risk methods.
 
 ## Convergence and lifecycle
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -140,7 +140,7 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
-- `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
+- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)

--- a/Assets/Tests/Editor/DynamicCodeToolTests/RoslynCompilerBackendTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/RoslynCompilerBackendTests.cs
@@ -41,5 +41,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
                 }
             }
         }
+
+        /// <summary>
+        /// What: WriteCompilerResponseFile requests English diagnostics and UTF-8 compiler output.
+        /// </summary>
+        [Test]
+        public void WriteCompilerResponseFile_IncludesEnglishDiagnosticsAndUtf8OutputOptions()
+        {
+            string responseFilePath = Path.Combine(Path.GetTempPath(), "uloop-roslyn-rsp-" + Path.GetRandomFileName());
+            try
+            {
+                RoslynCompilerBackend.WriteCompilerResponseFile(
+                    responseFilePath,
+                    sourcePath: "snippet.cs",
+                    dllPath: "snippet.dll",
+                    references: new List<string>(),
+                    defineSymbols: new List<string>(),
+                    allowUnsafeCode: false);
+
+                string[] lines = File.ReadAllLines(responseFilePath);
+                Assert.That(lines, Does.Contain("-preferreduilang:en-US"));
+                Assert.That(lines, Does.Contain("-utf8output"));
+            }
+            finally
+            {
+                if (File.Exists(responseFilePath))
+                {
+                    File.Delete(responseFilePath);
+                }
+            }
+        }
     }
 }

--- a/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
@@ -617,6 +617,39 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.That(programSource, Does.Contain("DebugInformationFormat.PortablePdb"));
         }
 
+        /// <summary>
+        /// Verifies the worker template forces UTF-8 stdout so diagnostics survive non-UTF-8 default codepages.
+        /// </summary>
+        [Test]
+        public void CreateProgramSource_SetsUtf8ConsoleOutputEncoding()
+        {
+            string programSource = SharedRoslynCompilerWorkerProtocol.CreateProgramSource();
+
+            Assert.That(programSource, Does.Contain("Console.OutputEncoding = Encoding.UTF8;"));
+        }
+
+        /// <summary>
+        /// Verifies the worker start info decodes stdout as UTF-8 to match the worker-side Console.OutputEncoding.
+        /// </summary>
+        [Test]
+        public void CreateWorkerStartInfo_SetsUtf8StandardOutputEncoding()
+        {
+            ExternalCompilerPaths externalCompilerPaths = ExternalCompilerPathResolver.Resolve();
+            Assert.That(externalCompilerPaths, Is.Not.Null, "Unity external compiler layout should be available.");
+            SharedRoslynCompilerWorkerHostProcess.WorkerPaths workerPaths = new(
+                "worker-dir",
+                "worker-dir/RoslynCompilerWorker.cs",
+                "worker-dir/RoslynCompilerWorker.dll",
+                "worker-dir/RoslynCompilerWorker.rsp");
+
+            ProcessStartInfo startInfo = SharedRoslynCompilerWorkerHostProcess.CreateWorkerStartInfo(
+                externalCompilerPaths,
+                workerPaths);
+
+            Assert.That(startInfo.StandardOutputEncoding, Is.EqualTo(Encoding.UTF8));
+            Assert.That(startInfo.StandardErrorEncoding, Is.Null);
+        }
+
         [Test]
         public void CreateProgramSource_WhenRequestPathPrefixHasLeadingGarbage_ShouldDecodeEncodedPath()
         {

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -364,10 +364,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     aggregatedInlineRiskCount++;
                 }
 
-                Assert.That(
-                    warning,
-                    Does.Not.Contain(HotReloadConstants.SmallMethodInliningRiskWarning),
-                    "Per-method SmallMethodInliningRiskWarning text must not appear in Warnings.");
+                if (warning.Contains("[AggressiveInlining]"))
+                {
+                    Assert.That(
+                        warning,
+                        Does.Contain("patched methods are small"),
+                        "Inline-risk text in Warnings must be the aggregated line, not a per-method entry.");
+                }
             }
 
             Assert.That(

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -312,6 +312,71 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: patching multiple small methods emits one aggregated inline-risk warning and
+        /// leaves each Patched outcome's Reason empty.
+        /// </summary>
+        [Test]
+        public async Task Run_MultipleSmallPatchedMethods_AggregatesInlineRiskWarningOnce()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "MultipleSmallInlineRisk.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }",
+                    centerOfCellMethod:
+                    "[MethodImpl(MethodImplOptions.NoInlining)]\n"
+                    + "        public Vector3 CenterOfCell(Vector3Int cell)\n"
+                    + "        {\n"
+                    + "            return new Vector3(cell.x + 0.5f, cell.y + 0.5f, cell.z + 0.5f);\n"
+                    + "        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.CenterOfCell));
+
+            int patchedWithEmptyReason = 0;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind != HotReloadMethodOutcomeKind.Patched)
+                {
+                    continue;
+                }
+
+                Assert.That(outcome.Reason, Is.Empty, "Patched Reason must not carry per-method inline-risk text.");
+                patchedWithEmptyReason++;
+            }
+
+            Assert.That(patchedWithEmptyReason, Is.GreaterThanOrEqualTo(2));
+
+            int aggregatedInlineRiskCount = 0;
+            foreach (string warning in result.Warnings)
+            {
+                if (warning.Contains("patched methods are small")
+                    && warning.Contains(nameof(HotReloadE2EFixture.ComputeWithPrivate))
+                    && warning.Contains(nameof(HotReloadE2EFixture.CenterOfCell)))
+                {
+                    aggregatedInlineRiskCount++;
+                }
+
+                Assert.That(
+                    warning,
+                    Does.Not.Contain(HotReloadConstants.SmallMethodInliningRiskWarning),
+                    "Per-method SmallMethodInliningRiskWarning text must not appear in Warnings.");
+            }
+
+            Assert.That(
+                aggregatedInlineRiskCount,
+                Is.EqualTo(1),
+                "Expected exactly one aggregated inline-risk warning listing the at-risk methods.");
+        }
+
+        /// <summary>
         /// What: a mixed transplant+delegation fixture patches both the sync private-access
         /// method (transplant) and the LINQ private-access method (delegation).
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -363,20 +363,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 {
                     aggregatedInlineRiskCount++;
                 }
-
-                if (warning.Contains("[AggressiveInlining]"))
-                {
-                    Assert.That(
-                        warning,
-                        Does.Contain("patched methods are small"),
-                        "Inline-risk text in Warnings must be the aggregated line, not a per-method entry.");
-                }
             }
 
             Assert.That(
                 aggregatedInlineRiskCount,
                 Is.EqualTo(1),
                 "Expected exactly one aggregated inline-risk warning listing the at-risk methods.");
+            Assert.That(
+                result.Warnings,
+                Has.Count.EqualTo(1),
+                "This fixture run must emit only the aggregated inline-risk warning; any extra entry means per-method warning text has come back.");
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -373,6 +374,53 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 result.Warnings,
                 Has.Count.EqualTo(1),
                 "This fixture run must emit only the aggregated inline-risk warning; any extra entry means per-method warning text has come back.");
+        }
+
+        /// <summary>
+        /// Verifies duplicate file inputs re-patch the same method yet the aggregated warning lists it once.
+        /// </summary>
+        [Test]
+        public async Task Run_DuplicateFileInputs_ListsEachAtRiskMethodOnceInAggregatedWarning()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "DuplicateInputInlineRisk.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath, fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+
+            // Methods and PatchedTotal keep reflecting raw patch operations on purpose:
+            // the duplicated input re-patches every fixture method once per file entry.
+            int computeWithPrivatePatchedOperations = 0;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Patched
+                    && outcome.Method.Contains(nameof(HotReloadE2EFixture.ComputeWithPrivate)))
+                {
+                    computeWithPrivatePatchedOperations++;
+                }
+            }
+
+            Assert.That(computeWithPrivatePatchedOperations, Is.EqualTo(2));
+
+            Assert.That(
+                result.Warnings,
+                Has.Count.EqualTo(1),
+                "This fixture run must emit only the aggregated inline-risk warning.");
+
+            string aggregatedWarning = result.Warnings[0];
+            Assert.That(
+                CountOccurrences(aggregatedWarning, nameof(HotReloadE2EFixture.ComputeWithPrivate)),
+                Is.EqualTo(1),
+                "The aggregated warning must list a re-patched method once, not once per patch operation.");
         }
 
         /// <summary>
@@ -868,6 +916,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             Assert.Fail("Expected Patched outcome for " + methodName + ".\n" + FormatOutcomes(result));
+        }
+
+        private static int CountOccurrences(string text, string token)
+        {
+            return text.Split(new[] { token }, StringSplitOptions.None).Length - 1;
         }
 
         private static string FormatOutcomes(HotReloadOrchestratorResult result)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerBackend.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerBackend.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor.Compilation;
@@ -167,7 +168,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
-                    CreateNoWindow = true
+                    CreateNoWindow = true,
+                    StandardOutputEncoding = Encoding.UTF8,
+                    StandardErrorEncoding = Encoding.UTF8
                 };
 
                 markBuildStarted();
@@ -227,6 +230,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> lines = new()
             {
                 "-nologo",
+                // Diagnostics must be machine-readable by AI agents: English text, UTF-8 bytes.
+                "-preferreduilang:en-US",
+                "-utf8output",
                 "-nostdlib+",
                 "-target:library",
                 "-optimize+",

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHostProcess.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHostProcess.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using UnityEditor.Compilation;
 
@@ -95,6 +96,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = false,
+                // Pairs with Console.OutputEncoding = Encoding.UTF8 in the worker template so
+                // diagnostic text survives non-UTF-8 default codepages on Windows. Stderr is
+                // not redirected, so StandardErrorEncoding must stay unset — Process.Start
+                // rejects it when RedirectStandardError is false.
+                StandardOutputEncoding = Encoding.UTF8,
                 CreateNoWindow = true
             };
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/Templates/SharedRoslynCompilerWorkerProgram.cs.template
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/Templates/SharedRoslynCompilerWorkerProgram.cs.template
@@ -21,6 +21,11 @@ public static class Program
 
     public static int Main()
     {
+        // Diagnostics must reach the host as UTF-8 bytes regardless of the OS default
+        // codepage (Windows defaults to a legacy one); the host pairs this with
+        // ProcessStartInfo.StandardOutputEncoding = Encoding.UTF8.
+        Console.OutputEncoding = Encoding.UTF8;
+
         string requestPath;
         while ((requestPath = Console.ReadLine()) != null)
         {

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/Templates/SharedRoslynCompilerWorkerProgram.cs.template
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/Templates/SharedRoslynCompilerWorkerProgram.cs.template
@@ -196,7 +196,7 @@ public static class Program
                 int column = lineSpan.StartLinePosition.Character + 1;
                 string file = string.IsNullOrEmpty(lineSpan.Path) ? sourcePath : lineSpan.Path;
                 string severity = diagnostic.Severity == DiagnosticSeverity.Warning ? "warning" : "error";
-                diagnosticLines.Add(file + "(" + line + "," + column + "): " + severity + " " + diagnostic.Id + ": " + diagnostic.GetMessage());
+                diagnosticLines.Add(file + "(" + line + "," + column + "): " + severity + " " + diagnostic.Id + ": " + diagnostic.GetMessage(System.Globalization.CultureInfo.InvariantCulture));
             }
 
             return new CompileResponse(exitCode, diagnosticLines);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -78,11 +78,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // in which case a Harmony detour on the original method will not reach existing call sites.
         public const int SmallMethodInliningRiskThresholdBytes = 32;
 
-        public const string SmallMethodInliningRiskWarning =
-            "This method is small enough (or marked [AggressiveInlining]) that the Mono JIT may "
-            + "already have inlined it into callers; those call sites will keep running the old "
-            + "body until they are recompiled.";
-
         public const string StaleAssemblyHint =
             "The loaded assembly no longer matches the compiled assembly on disk (a script compile "
             + "or domain reload may have happened). Hot reload is not needed — use uloop compile, "

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -42,6 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
             List<string> warnings = new List<string>();
             List<string> suppressedPausePointIds = new List<string>();
+            List<string> inlineRiskMethodLabels = new List<string>();
             int patchedTotal = 0;
 
             for (int index = 0; index < files.Count; index++)
@@ -65,7 +66,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 outcomes.AddRange(fileResult.Outcomes);
                 warnings.AddRange(fileResult.Warnings);
                 suppressedPausePointIds.AddRange(fileResult.SuppressedPausePointIds);
+                inlineRiskMethodLabels.AddRange(fileResult.InlineRiskMethodLabels);
                 patchedTotal += fileResult.PatchedCount;
+            }
+
+            if (inlineRiskMethodLabels.Count > 0)
+            {
+                warnings.Add(
+                    FormatInlineRiskAggregatedWarning(
+                        inlineRiskMethodLabels.Count,
+                        patchedTotal,
+                        inlineRiskMethodLabels));
             }
 
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -224,6 +235,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             await MainThreadSwitcher.SwitchToMainThread(ct);
             Dictionary<string, string> bindFailureReasonByShimTypeName =
                 BindShimAccessors(compileResult.Assembly);
+            List<string> inlineRiskMethodLabels = new List<string>();
             int patchedCount = 0;
             foreach (TransformWorkerEntryDto entry in workerOutput.entries)
             {
@@ -233,7 +245,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     compileResult.Assembly,
                     bindFailureReasonByShimTypeName,
                     assemblyResolvePath,
-                    warnings,
+                    inlineRiskMethodLabels,
                     suppressedPausePointIds);
                 outcomes.Add(outcome);
                 if (outcome.Kind == HotReloadMethodOutcomeKind.Patched)
@@ -243,7 +255,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return new HotReloadFileProcessResult(
-                outcomes, warnings, patchedCount, suppressedPausePointIds);
+                outcomes, warnings, patchedCount, suppressedPausePointIds, inlineRiskMethodLabels);
         }
 
         private static HotReloadMethodOutcome ApplyEntry(
@@ -252,7 +264,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Assembly shimAssembly,
             IReadOnlyDictionary<string, string> bindFailureReasonByShimTypeName,
             string filePath,
-            List<string> warnings,
+            List<string> inlineRiskMethodLabels,
             List<string> suppressedPausePointIds)
         {
             string methodLabel = entry.typeMetadataName + "." + entry.methodName;
@@ -319,12 +331,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             AppendSuppressedPausePointIds(matchResult.Method, suppressedPausePointIds);
 
+            // Per-method inline-risk text is aggregated once for the whole run so Warnings
+            // stay readable when many tiny methods are patched together.
             if (!string.IsNullOrEmpty(patchResult.Warning))
             {
-                warnings.Add(methodLabel + ": " + patchResult.Warning);
+                inlineRiskMethodLabels.Add(methodLabel);
             }
 
-            return HotReloadMethodOutcome.Patched(methodLabel, filePath, patchResult.Warning);
+            return HotReloadMethodOutcome.Patched(methodLabel, filePath, string.Empty);
+        }
+
+        private static string FormatInlineRiskAggregatedWarning(
+            int atRiskCount,
+            int patchedTotal,
+            IReadOnlyList<string> methodLabels)
+        {
+            Debug.Assert(atRiskCount > 0, "atRiskCount must be positive.");
+            Debug.Assert(methodLabels != null, "methodLabels must not be null.");
+            Debug.Assert(methodLabels.Count == atRiskCount, "methodLabels count must match atRiskCount.");
+
+            string methods = string.Join(", ", methodLabels);
+            return $"{atRiskCount} of {patchedTotal} patched methods are small (or marked [AggressiveInlining]) and the Mono JIT may already have inlined them into callers compiled before the patch; those call sites keep the old behavior until a real compile: {methods}";
         }
 
         // What: records armed pause-point marker ids on a method just patched by hot reload.
@@ -606,17 +633,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public List<string> Warnings { get; }
             public int PatchedCount { get; }
             public List<string> SuppressedPausePointIds { get; }
+            public List<string> InlineRiskMethodLabels { get; }
 
             public HotReloadFileProcessResult(
                 List<HotReloadMethodOutcome> outcomes,
                 List<string> warnings,
                 int patchedCount,
-                List<string> suppressedPausePointIds = null)
+                List<string> suppressedPausePointIds = null,
+                List<string> inlineRiskMethodLabels = null)
             {
                 Outcomes = outcomes;
                 Warnings = warnings;
                 PatchedCount = patchedCount;
                 SuppressedPausePointIds = suppressedPausePointIds ?? new List<string>();
+                InlineRiskMethodLabels = inlineRiskMethodLabels ?? new List<string>();
             }
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -331,14 +331,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             AppendSuppressedPausePointIds(matchResult.Method, suppressedPausePointIds);
 
-            // Per-method inline-risk text is aggregated once for the whole run so Warnings
-            // stay readable when many tiny methods are patched together.
-            if (!string.IsNullOrEmpty(patchResult.Warning))
+            // Inline risk is flagged per method but reported as one aggregated warning so
+            // Warnings stay readable when many tiny methods are patched together.
+            if (patchResult.InlineRiskDetected)
             {
                 inlineRiskMethodLabels.Add(methodLabel);
             }
 
-            return HotReloadMethodOutcome.Patched(methodLabel, filePath, string.Empty);
+            return HotReloadMethodOutcome.Patched(methodLabel, filePath);
         }
 
         private static string FormatInlineRiskAggregatedWarning(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -65,8 +65,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 outcomes.AddRange(fileResult.Outcomes);
                 warnings.AddRange(fileResult.Warnings);
-                suppressedPausePointIds.AddRange(fileResult.SuppressedPausePointIds);
-                inlineRiskMethodLabels.AddRange(fileResult.InlineRiskMethodLabels);
+                AppendDistinct(suppressedPausePointIds, fileResult.SuppressedPausePointIds);
+                AppendDistinct(inlineRiskMethodLabels, fileResult.InlineRiskMethodLabels);
                 patchedTotal += fileResult.PatchedCount;
             }
 
@@ -352,6 +352,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             string methods = string.Join(", ", methodLabels);
             return $"{atRiskCount} of {patchedTotal} patched methods are small (or marked [AggressiveInlining]) and the Mono JIT may already have inlined them into callers compiled before the patch; those call sites keep the old behavior until a real compile: {methods}";
+        }
+
+        // Duplicate file inputs process the same source twice, producing duplicates across
+        // per-file result lists; aggregated warnings must name each pause-point id / method
+        // label once even then. Methods and PatchedTotal keep reflecting raw patch
+        // operations on purpose.
+        private static void AppendDistinct(List<string> target, IReadOnlyList<string> additions)
+        {
+            foreach (string addition in additions)
+            {
+                if (!target.Contains(addition))
+                {
+                    target.Add(addition);
+                }
+            }
         }
 
         // What: records armed pause-point marker ids on a method just patched by hot reload.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
@@ -51,12 +51,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             FilePath = filePath;
         }
 
-        public static HotReloadMethodOutcome Patched(string method, string filePath, string warning = "")
+        public static HotReloadMethodOutcome Patched(string method, string filePath)
         {
             return new HotReloadMethodOutcome(
                 HotReloadMethodOutcomeKind.Patched,
                 method,
-                warning ?? string.Empty,
+                string.Empty,
                 filePath);
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchResult.cs
@@ -8,28 +8,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool Success { get; }
         public HotReloadPatchFailureReason FailureReason { get; }
         public string ErrorMessage { get; }
-        public string Warning { get; }
+
+        // True when the patched method is small (or marked [AggressiveInlining]) and the
+        // Mono JIT may already have inlined it into existing callers; the orchestrator
+        // aggregates these flags into one response warning.
+        public bool InlineRiskDetected { get; }
 
         private HotReloadPatchResult(
             bool success,
             HotReloadPatchFailureReason failureReason,
             string errorMessage,
-            string warning)
+            bool inlineRiskDetected)
         {
             Success = success;
             FailureReason = failureReason;
             ErrorMessage = errorMessage;
-            Warning = warning;
+            InlineRiskDetected = inlineRiskDetected;
         }
 
-        public static HotReloadPatchResult SuccessResult(string warning = "")
+        public static HotReloadPatchResult SuccessResult(bool inlineRiskDetected = false)
         {
-            return new HotReloadPatchResult(true, HotReloadPatchFailureReason.None, string.Empty, warning ?? string.Empty);
+            return new HotReloadPatchResult(true, HotReloadPatchFailureReason.None, string.Empty, inlineRiskDetected);
         }
 
         public static HotReloadPatchResult Failure(HotReloadPatchFailureReason reason, string errorMessage)
         {
-            return new HotReloadPatchResult(false, reason, errorMessage, string.Empty);
+            return new HotReloadPatchResult(false, reason, errorMessage, false);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -135,10 +135,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 _pendingShimMethod = null;
             }
 
-            string warning = IsLikelyJitInlined(method)
-                ? HotReloadConstants.SmallMethodInliningRiskWarning
-                : string.Empty;
-            return HotReloadPatchResult.SuccessResult(warning);
+            return HotReloadPatchResult.SuccessResult(IsLikelyJitInlined(method));
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -99,7 +99,7 @@ first line, drive the game, and check the hit count: zero hits means the calling
 never reached the method, which no patch (or compile) can fix. To chase an early return
 inside the method, arm a second marker on the suspected early-return line. The other
 known cause is JIT inlining of tiny methods, which the response already flags with a
-per-method warning.
+single aggregated warning listing the at-risk methods.
 
 ## Convergence and lifecycle
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -140,7 +140,7 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
-- `Warnings` (array): Non-fatal notes — a patched method that is small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
+- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)


### PR DESCRIPTION
## Summary

- Aggregate Mono JIT inline-risk notes into a single `Warnings` line listing every at-risk patched method; `Patched` outcomes no longer carry that text in `Reason`.
- Force English, UTF-8 compiler diagnostics on both compiler paths:
  - Shared worker (primary): `GetMessage(InvariantCulture)` for English + worker-side `Console.OutputEncoding = Encoding.UTF8` paired with host-side `StandardOutputEncoding = Encoding.UTF8`. Stderr is not redirected on this path, so `StandardErrorEncoding` stays unset.
  - One-shot csc (fallback): `-preferreduilang:en-US` + `-utf8output` paired with `StandardOutputEncoding`/`StandardErrorEncoding = Encoding.UTF8`.
- Also applies to `execute-dynamic-code` diagnostics (same shared compiler backend).

## User Impact

Hot-reload responses stay readable when many tiny methods are patched, and compile diagnostics stay machine-readable for agents instead of localized or mojibake text.

## Test plan

- [x] To-Do 20: confirmed `HotReloadPatcher.Apply` only signals inline risk (now via `InlineRiskDetected`)
- [x] `uloop compile` → 0/0
- [x] EditMode suite: 0 failed (full run + targeted HotReload/PausePoint/worker tests)
- [x] `uloop execute-dynamic-code --code 'int x = "s";'` → English CS0029
- [x] skills install + `cmp` source/`.claude`/`.agents`