### PR TITLE
fix: polish hot-reload diagnostics and pause-point error state

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -155,7 +155,7 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
-- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
+- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough (or marked `[AggressiveInlining]`) to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -57,6 +57,10 @@ accessors, and `interface` members (including default interface implementations)
 scanned: edits to them produce **no per-method entry at all** and are silently not applied —
 use `uloop compile` for those.
 
+Hot reload never adds members. A refactor that extracts a new helper method cannot be
+applied piecewise — keep iterating inside existing method bodies, then run
+`uloop compile` once to introduce the new member for real.
+
 Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Changed `const` values (including enum member values) are detected and reported as a `Warnings` entry naming the constant and both values; other outside-body edits stay silent. Use `uloop compile` for such edits.
 
 Property and indexer accessors with explicit bodies are reported per-accessor as
@@ -84,7 +88,7 @@ Property and indexer accessors with explicit bodies are reported per-accessor as
 | Loaded assembly differs from the one on disk (pending compile) | Run `uloop compile` first, then retry |
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
-| Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler error and a hint to run `uloop compile` |
+| Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler errors and, when they indicate a member or type the compiled assembly does not have yet, a hint to run `uloop compile` |
 | Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error; other methods in the run still apply |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 
@@ -110,6 +114,17 @@ single aggregated warning listing the at-risk methods.
   domain reload. There is no persistence and no automatic re-apply.
 - Never reflected by hot reload: new fields, field initializer changes, new types, and
   signature changes. Those always need `uloop compile`.
+- A run with `Failed` outcomes still applies every other patch — outcomes are
+  per-method and there is no run-level rollback. `Methods` is the authoritative
+  record of which bodies changed.
+
+## Editor-code iteration without PlayMode
+
+Hot reload also patches static methods in Editor assemblies. Combined with
+`uloop execute-dynamic-code` invoking the patched method, this gives a
+compile-free loop for editor tooling: edit the method body, run
+`uloop hot-reload --files <file>`, then re-invoke it via `execute-dynamic-code`
+and read the returned value.
 
 ## Pause point interaction
 
@@ -140,7 +155,7 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
-- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
+- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -155,7 +155,7 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
-- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
+- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough (or marked `[AggressiveInlining]`) to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -57,6 +57,10 @@ accessors, and `interface` members (including default interface implementations)
 scanned: edits to them produce **no per-method entry at all** and are silently not applied —
 use `uloop compile` for those.
 
+Hot reload never adds members. A refactor that extracts a new helper method cannot be
+applied piecewise — keep iterating inside existing method bodies, then run
+`uloop compile` once to introduce the new member for real.
+
 Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Changed `const` values (including enum member values) are detected and reported as a `Warnings` entry naming the constant and both values; other outside-body edits stay silent. Use `uloop compile` for such edits.
 
 Property and indexer accessors with explicit bodies are reported per-accessor as
@@ -84,7 +88,7 @@ Property and indexer accessors with explicit bodies are reported per-accessor as
 | Loaded assembly differs from the one on disk (pending compile) | Run `uloop compile` first, then retry |
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
-| Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler error and a hint to run `uloop compile` |
+| Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler errors and, when they indicate a member or type the compiled assembly does not have yet, a hint to run `uloop compile` |
 | Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error; other methods in the run still apply |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 
@@ -110,6 +114,17 @@ single aggregated warning listing the at-risk methods.
   domain reload. There is no persistence and no automatic re-apply.
 - Never reflected by hot reload: new fields, field initializer changes, new types, and
   signature changes. Those always need `uloop compile`.
+- A run with `Failed` outcomes still applies every other patch — outcomes are
+  per-method and there is no run-level rollback. `Methods` is the authoritative
+  record of which bodies changed.
+
+## Editor-code iteration without PlayMode
+
+Hot reload also patches static methods in Editor assemblies. Combined with
+`uloop execute-dynamic-code` invoking the patched method, this gives a
+compile-free loop for editor tooling: edit the method body, run
+`uloop hot-reload --files <file>`, then re-invoke it via `execute-dynamic-code`
+and read the returned value.
 
 ## Pause point interaction
 
@@ -140,7 +155,7 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
-- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
+- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -384,7 +384,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             int aggregatedInlineRiskCount = 0;
             foreach (string warning in result.Warnings)
             {
-                if (warning.Contains("patched methods are small")
+                if (warning.Contains("patched methods had pre-patch bodies")
                     && warning.Contains(nameof(HotReloadE2EFixture.ComputeWithPrivate))
                     && warning.Contains(nameof(HotReloadE2EFixture.CenterOfCell)))
                 {

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -52,6 +52,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: an edited method whose parameter is named "instance" still hot-reloads; the shim
+        /// receiver parameter must not collide with user identifiers (CS0100).
+        /// </summary>
+        [Test]
+        public async Task Run_EditedMethodWithParameterNamedInstance_Patches()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "InstanceParameterName.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int instance)\n        {\n            return _secret + instance + 100;\n        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(10 + 5 + 100));
+        }
+
+        /// <summary>
         /// What: expression-bodied edited methods keep a terminating semicolon in generated shims
         /// and still transplant successfully.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadShimCompilerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShimCompilerTests.cs
@@ -37,5 +37,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(message, Does.Contain(error));
             Assert.That(message, Does.Not.Contain(HotReloadConstants.NewMemberCompileHint));
         }
+
+        /// <summary>
+        /// What: a non-missing-member diagnostic whose text merely mentions CS0103 does not get the hint
+        /// (only a real CS0103: prefix gates the hint).
+        /// </summary>
+        [Test]
+        public void ComposeShimCompileFailureMessage_CodeMentionedInTextOnly_OmitsHint()
+        {
+            string error = "CS0229: Ambiguity between 'A.CS0103' and 'B.CS0103'";
+            string message = HotReloadShimCompiler.ComposeShimCompileFailureMessage(new[] { error });
+
+            Assert.That(message, Does.Contain(error));
+            Assert.That(message, Does.Not.Contain(HotReloadConstants.NewMemberCompileHint));
+        }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadShimCompilerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShimCompilerTests.cs
@@ -1,0 +1,41 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Unit coverage for shim-compile failure message composition (hint gating).
+    /// </summary>
+    public class HotReloadShimCompilerTests
+    {
+        /// <summary>
+        /// What: a missing-member diagnostic (CS0103) appends the new-member compile hint.
+        /// </summary>
+        [Test]
+        public void ComposeShimCompileFailureMessage_MissingMemberDiagnostic_AppendsHint()
+        {
+            string message = HotReloadShimCompiler.ComposeShimCompileFailureMessage(
+                new[]
+                {
+                    "CS0103: The name 'MissingHelperAddedByEdit' does not exist in the current context"
+                });
+
+            Assert.That(message, Does.Contain(HotReloadConstants.NewMemberCompileHint));
+            Assert.That(message, Does.Contain("CS0103"));
+        }
+
+        /// <summary>
+        /// What: a non-missing-member diagnostic (CS0229) does not get the new-member compile hint.
+        /// </summary>
+        [Test]
+        public void ComposeShimCompileFailureMessage_NonMissingMemberDiagnostic_OmitsHint()
+        {
+            string error = "CS0229: Ambiguity between 'A.E' and 'A.E'";
+            string message = HotReloadShimCompiler.ComposeShimCompileFailureMessage(new[] { error });
+
+            Assert.That(message, Does.Contain(error));
+            Assert.That(message, Does.Not.Contain(HotReloadConstants.NewMemberCompileHint));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadShimCompilerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShimCompilerTests.cs
@@ -26,6 +26,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a signature-mismatch diagnostic (CS1501) appends the hint (re-signatured members
+        /// need a real compile).
+        /// </summary>
+        [Test]
+        public void ComposeShimCompileFailureMessage_SignatureMismatchDiagnostic_AppendsHint()
+        {
+            string message = HotReloadShimCompiler.ComposeShimCompileFailureMessage(
+                new[]
+                {
+                    "CS1501: No overload for method 'Helper' takes 2 arguments"
+                });
+
+            Assert.That(message, Does.Contain(HotReloadConstants.NewMemberCompileHint));
+            Assert.That(message, Does.Contain("CS1501"));
+        }
+
+        /// <summary>
         /// What: a non-missing-member diagnostic (CS0229) does not get the new-member compile hint.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/HotReloadShimCompilerTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadShimCompilerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d371d50a4894e4925b0c4290298a6687
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -156,5 +156,69 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(response.ClearedCount, Is.EqualTo(0));
             Assert.That(response.Message, Is.EqualTo("No active hot-reload patches to revert."));
         }
+
+        /// <summary>
+        /// What: an empty Methods list yields the "no patchable method bodies" message (never "See Methods").
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_EmptyMethods_YieldsNoPatchableBodiesMessage()
+        {
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>(),
+                new List<string>(),
+                patchedTotal: 0,
+                activePatchTotal: 0);
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+            Assert.That(
+                response.Message,
+                Does.Contain("Hot reload found no patchable method bodies in the given files"));
+            Assert.That(response.Message, Does.Not.Contain("See Methods"));
+        }
+
+        /// <summary>
+        /// What: a skipped-only run keeps the existing "See Methods for Skipped reasons." message.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_SkippedOnly_KeepsExistingSkippedMessage()
+        {
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>
+                {
+                    HotReloadMethodOutcome.Skipped("T.M", "reason", "file.cs")
+                },
+                new List<string>(),
+                patchedTotal: 0,
+                activePatchTotal: 0);
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+            Assert.That(
+                response.Message,
+                Is.EqualTo("Hot reload finished with no methods patched. See Methods for Skipped reasons."));
+        }
+
+        /// <summary>
+        /// What: a failed run keeps the existing failure message.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_WithFailedOutcome_KeepsExistingFailureMessage()
+        {
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>
+                {
+                    HotReloadMethodOutcome.Failed("T.M", "reason", "file.cs")
+                },
+                new List<string>(),
+                patchedTotal: 0,
+                activePatchTotal: 0);
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+            Assert.That(
+                response.Message,
+                Is.EqualTo("Hot reload finished with one or more Failed method outcomes. See Methods."));
+        }
     }
 }

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -68,7 +68,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     foundCallsBareSiblings = true;
                     Assert.That(entry.patchKind, Is.EqualTo("transplant"));
                     string slice = SliceShimMethod(result.Output.shimSource, entry.shimMethodName);
-                    Assert.That(slice, Does.Contain("instance.VisibleSibling()"));
+                    Assert.That(slice, Does.Contain("__uloopInstance.VisibleSibling()"));
                     Assert.That(slice, Does.Contain(".VisibleStaticSibling()"));
                 }
 
@@ -77,7 +77,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     foundAsyncPrivateAndBareSibling = true;
                     Assert.That(entry.patchKind, Is.EqualTo(HotReloadConstants.PatchKindDelegation));
                     string slice = SliceShimMethod(result.Output.shimSource, entry.shimMethodName);
-                    Assert.That(slice, Does.Contain("instance.VisibleSibling()"));
+                    Assert.That(slice, Does.Contain("__uloopInstance.VisibleSibling()"));
                 }
 
                 if (entry.methodName == nameof(HotReloadE2EFixture.AsyncInvokePrivateDelegate))
@@ -85,7 +85,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     foundAsyncInvokePrivateDelegate = true;
                     Assert.That(entry.patchKind, Is.EqualTo(HotReloadConstants.PatchKindDelegation));
                     string slice = SliceShimMethod(result.Output.shimSource, entry.shimMethodName);
-                    Assert.That(slice, Does.Contain("__F__callback(instance)()"));
+                    Assert.That(slice, Does.Contain("__F__callback(__uloopInstance)()"));
                 }
 
                 if (entry.methodName == nameof(HotReloadE2EFixture.AsyncInvokePrivateDelegateOnThis))
@@ -93,7 +93,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     foundAsyncInvokePrivateDelegateOnThis = true;
                     Assert.That(entry.patchKind, Is.EqualTo(HotReloadConstants.PatchKindDelegation));
                     string slice = SliceShimMethod(result.Output.shimSource, entry.shimMethodName);
-                    Assert.That(slice, Does.Contain("__F__callback(instance)()"));
+                    Assert.That(slice, Does.Contain("__F__callback(__uloopInstance)()"));
                 }
 
                 if (entry.methodName == nameof(HotReloadE2EFixture.AsyncInvokePrivateDelegateOnOther))

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -1273,6 +1273,27 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Is.EquivalentTo(new[] { "left", "right", "sum", "this", "Tag" }));
         }
 
+        /// <summary>
+        /// What: an enable failure response carries the live editor state instead of a
+        /// zero-filled default (IsPlaying/CapturedAt must flow from the registry's pause controller).
+        /// </summary>
+        [Test]
+        public void Enable_UnresolvableFile_CarriesLiveEditorState()
+        {
+            PausePointUseCase useCase = new();
+            PausePointResponse response = useCase.Enable(new EnablePausePointSchema
+            {
+                File = "Assets/UloopNoSuchFileForEditorStateTest.cs",
+                Line = 1
+            });
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.EditorState.CapturedAt, Is.EqualTo(UloopPausePointEditorStateCapturedAt.Current),
+                "Error responses must capture the editor state instead of returning the zero-filled default.");
+            Assert.That(response.EditorState.IsPlaying, Is.True,
+                "SetUp's fake controller pins IsPlaying to true, so a zero-filled default (false) is detectable.");
+        }
+
         [Test]
         public async Task Enable_WhenIdAndFileBothProvided_ReturnsValidationFailureResponse()
         {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -351,7 +351,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(methodLabels.Count == atRiskCount, "methodLabels count must match atRiskCount.");
 
             string methods = string.Join(", ", methodLabels);
-            return $"{atRiskCount} of {patchedTotal} patched methods are small (or marked [AggressiveInlining]) and the Mono JIT may already have inlined them into callers compiled before the patch; those call sites keep the old behavior until a real compile: {methods}";
+            return $"{atRiskCount} of {patchedTotal} patched methods had pre-patch bodies small enough (or marked [AggressiveInlining]) that the Mono JIT may already have inlined them into callers compiled before the patch; those call sites keep the old behavior until a real compile: {methods}";
         }
 
         // Duplicate file inputs process the same source twice, producing duplicates across

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
@@ -105,13 +105,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         // Only these diagnostics indicate a member/type the compiled assembly does not have yet;
         // appending the "run a real compile" hint to unrelated errors (CS0229 ambiguity, syntax
-        // errors) misdirects the caller.
+        // errors) misdirects the caller. CS1501/CS7036 cover calls whose target signature changed
+        // in the edit but not yet in the compiled assembly.
         private static readonly string[] MissingMemberDiagnosticCodes =
         {
             "CS0103",
             "CS0117",
             "CS0246",
-            "CS1061"
+            "CS1061",
+            "CS1501",
+            "CS7036"
         };
 
         internal static string ComposeShimCompileFailureMessage(IReadOnlyList<string> errors)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
@@ -125,7 +125,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 string error = errors[index];
                 for (int codeIndex = 0; codeIndex < MissingMemberDiagnosticCodes.Length; codeIndex++)
                 {
-                    if (error.Contains(MissingMemberDiagnosticCodes[codeIndex]))
+                    // Match the diagnostic-code prefix ("CS0103: …"), not a bare Contains —
+                    // otherwise a message that merely mentions the code text could append the hint.
+                    if (error.StartsWith(MissingMemberDiagnosticCodes[codeIndex] + ":", StringComparison.Ordinal))
                     {
                         return message + "\n" + HotReloadConstants.NewMemberCompileHint;
                     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
@@ -75,9 +75,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 List<string> errors = CollectErrors(backendResult.CompilerMessages);
                 if (errors.Count > 0)
                 {
-                    string message = string.Join("\n", errors);
-                    return HotReloadShimCompileResult.Failure(
-                        message + "\n" + HotReloadConstants.NewMemberCompileHint);
+                    return HotReloadShimCompileResult.Failure(ComposeShimCompileFailureMessage(errors));
                 }
 
                 if (!File.Exists(dllPath))
@@ -103,6 +101,38 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     Directory.Delete(workDirectory, recursive: true);
                 }
             }
+        }
+
+        // Only these diagnostics indicate a member/type the compiled assembly does not have yet;
+        // appending the "run a real compile" hint to unrelated errors (CS0229 ambiguity, syntax
+        // errors) misdirects the caller.
+        private static readonly string[] MissingMemberDiagnosticCodes =
+        {
+            "CS0103",
+            "CS0117",
+            "CS0246",
+            "CS1061"
+        };
+
+        internal static string ComposeShimCompileFailureMessage(IReadOnlyList<string> errors)
+        {
+            Debug.Assert(errors != null, "errors must not be null.");
+            Debug.Assert(errors.Count > 0, "errors must not be empty.");
+
+            string message = string.Join("\n", errors);
+            for (int index = 0; index < errors.Count; index++)
+            {
+                string error = errors[index];
+                for (int codeIndex = 0; codeIndex < MissingMemberDiagnosticCodes.Length; codeIndex++)
+                {
+                    if (error.Contains(MissingMemberDiagnosticCodes[codeIndex]))
+                    {
+                        return message + "\n" + HotReloadConstants.NewMemberCompileHint;
+                    }
+                }
+            }
+
+            return message;
         }
 
         private static List<string> CollectErrors(CompilerMessage[] compilerMessages)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -219,6 +219,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return "Hot reload finished with one or more Failed method outcomes. See Methods.";
             }
 
+            if (result.Methods.Count == 0)
+            {
+                return "Hot reload found no patchable method bodies in the given files; nothing was changed. "
+                    + "Hot reload only replaces existing ordinary method bodies; use uloop compile for other edits.";
+            }
+
             if (result.PatchedTotal == 0)
             {
                 return "Hot reload finished with no methods patched. See Methods for Skipped reasons.";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -57,6 +57,10 @@ accessors, and `interface` members (including default interface implementations)
 scanned: edits to them produce **no per-method entry at all** and are silently not applied —
 use `uloop compile` for those.
 
+Hot reload never adds members. A refactor that extracts a new helper method cannot be
+applied piecewise — keep iterating inside existing method bodies, then run
+`uloop compile` once to introduce the new member for real.
+
 Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Changed `const` values (including enum member values) are detected and reported as a `Warnings` entry naming the constant and both values; other outside-body edits stay silent. Use `uloop compile` for such edits.
 
 Property and indexer accessors with explicit bodies are reported per-accessor as
@@ -84,7 +88,7 @@ Property and indexer accessors with explicit bodies are reported per-accessor as
 | Loaded assembly differs from the one on disk (pending compile) | Run `uloop compile` first, then retry |
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
-| Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler error and a hint to run `uloop compile` |
+| Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler errors and, when they indicate a member or type the compiled assembly does not have yet, a hint to run `uloop compile` |
 | Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error; other methods in the run still apply |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 
@@ -110,6 +114,17 @@ single aggregated warning listing the at-risk methods.
   domain reload. There is no persistence and no automatic re-apply.
 - Never reflected by hot reload: new fields, field initializer changes, new types, and
   signature changes. Those always need `uloop compile`.
+- A run with `Failed` outcomes still applies every other patch — outcomes are
+  per-method and there is no run-level rollback. `Methods` is the authoritative
+  record of which bodies changed.
+
+## Editor-code iteration without PlayMode
+
+Hot reload also patches static methods in Editor assemblies. Combined with
+`uloop execute-dynamic-code` invoking the patched method, this gives a
+compile-free loop for editor tooling: edit the method body, run
+`uloop hot-reload --files <file>`, then re-invoke it via `execute-dynamic-code`
+and read the returned value.
 
 ## Pause point interaction
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -155,7 +155,7 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
-- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
+- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough (or marked `[AggressiveInlining]`) to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -140,7 +140,7 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
-- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
+- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -2634,7 +2634,7 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
     }
 
     // Why not Visit synthetic nodes: GetSymbolInfo requires nodes from the original SemanticModel
-    // tree. Bare-member rewrite invents IdentifierName("instance"), which must not be re-visited.
+    // tree. Bare-member rewrite invents IdentifierName(InstanceParameterName), which must not be re-visited.
     private ExpressionSyntax VisitReceiver(ExpressionSyntax receiver)
     {
         if (receiver.SyntaxTree != _semanticModel.SyntaxTree)
@@ -2742,7 +2742,11 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
 // of string literals scattered across Visit overrides.
 internal static class TransformWorkerProgramMarker
 {
-    public const string InstanceParameterName = "instance";
+    // Why "__uloopInstance": the shim prepends this receiver parameter to the user's own
+    // parameter list verbatim, so a plain name like "instance" collides (CS0100) with any
+    // user parameter or local of that name. The uloop-prefixed name makes collisions
+    // practically impossible.
+    public const string InstanceParameterName = "__uloopInstance";
 }
 
 internal static class ShimMethodFactory

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -482,7 +482,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     Success = false,
                     ErrorCode = errorCode,
                     Message = patchResult.ErrorMessage,
-                    RecommendedNextAction = patchResult.Hint
+                    RecommendedNextAction = patchResult.Hint,
+                    EditorState = PausePointEditorState.FromSnapshot(UloopPausePointRegistry.CaptureEditorState()),
                 };
             }
 
@@ -665,7 +666,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Success = false,
                 Message = message,
                 ErrorCode = errorCode,
-                RecommendedNextAction = recommendedNextAction
+                RecommendedNextAction = recommendedNextAction,
+                EditorState = PausePointEditorState.FromSnapshot(UloopPausePointRegistry.CaptureEditorState()),
             };
         }
 

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -62,6 +62,15 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         // referencing it directly.
         public static Action<string, int, string> OnClearResolved { get; set; }
 
+        // Error responses built outside the registry still need a truthful editor state; this
+        // exposes the same controller-backed capture the snapshot paths use.
+        public static UloopPausePointEditorStateSnapshot CaptureEditorState()
+        {
+            return UloopPausePointEditorStateSnapshot.FromController(
+                _pauseController,
+                UloopPausePointEditorStateCapturedAt.Current);
+        }
+
         public static UloopPausePointSnapshot Enable(
             string id,
             int timeoutSeconds,

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -148,7 +148,7 @@ source behavior.
 
 A generated static method that mirrors an edited user method body for hot reload. For an
 instance method, the shim is a static method whose first parameter is the original
-instance (`instance`) so IL argument slots match the original method and the body can be
+instance (`__uloopInstance`) so IL argument slots match the original method and the body can be
 transplanted without rewriting call/load slots. Prefix wrappers are not generated.
 
 ### Publicized reference

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -22,7 +22,7 @@ edited .cs file
   ▼
 transform worker (external process: Unity-bundled Roslyn on the Unity-bundled .NET host)
   │ (2) parse + semantic analysis; convert each eligible method body into a static shim
-  │     method source (bare member references qualified via `instance.` / `global::Type.`),
+  │     method source (bare member references qualified via `__uloopInstance.` / `global::Type.`),
   │     plus a manifest and per-method skip reasons
   ▼
 shim compilation (existing external csc infrastructure, RoslynCompilerBackend)
@@ -75,7 +75,7 @@ What the spike **proved**:
   inside Harmony's skip-visibility DynamicMethod. Private field write, private method call,
   and internal type access all succeed. The shim method itself is never JIT-compiled; its IL
   is only read as data. Argument slots line up because an instance method `(this, args…)`
-  and its static shim `(instance, args…)` occupy identical slots.
+  and its static shim `(__uloopInstance, args…)` occupy identical slots.
 - **Accessor mechanism (proven; committed as the v2 stage).** Rewriting private accesses to
   Harmony accessor delegate fields keeps the shim IL JIT-legal; this works even inside async
   state machine bodies. Verified for private field access (`AccessTools.FieldRefAccess`
@@ -130,7 +130,7 @@ to collide.
 Why transplant over the accessor rewrite:
 
 - The worker-side transform stays exactly the qualification rewrite stage (2) already needs
-  (`this` → `instance`, bare member references qualified); no per-access-kind accessor
+  (`this` → `__uloopInstance`, bare member references qualified); no per-access-kind accessor
   machinery, whose corner cases (compound assignments, ref arguments, internal types in
   locals and signatures, events, object creation of internal types) would each become a skip
   or a bug.


### PR DESCRIPTION
## Summary
- Hot reload diagnostics no longer mislead on ambiguity/name collisions, empty method lists, or inline-risk timing.
- Pause-point enable failures now return a live `EditorState` instead of a zero-filled default.

## User Impact
- Editing a method whose parameter is named `instance` no longer fails shim compile with CS0100.
- Shim compile errors only suggest `uloop compile` when the diagnostics actually indicate a missing member/type (e.g. CS0103), not for unrelated failures like CS0229.
- A hot-reload run that finds no patchable methods says so clearly, instead of "See Methods for Skipped reasons." with an empty list.
- The inline-risk warning correctly describes pre-patch body size (past tense), not the patched body.
- Pause-point validation/patch failure responses report truthful `IsPlaying` / `CapturedAt` for the current Editor.

## Changes
- Rename the shim receiver parameter to `__uloopInstance`.
- Gate `NewMemberCompileHint` on missing-member diagnostic codes.
- Branch the empty-`Methods` apply message; past-tense the aggregated inline-risk warning.
- Populate error-path `EditorState` from the registry pause controller.
- Document member limits, Failed-outcome semantics, and the editor-assembly iteration loop in the hot-reload skill.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → ErrorCount=0 / WarningCount=0
- `dist/darwin-arm64/uloop run-tests` → FailedCount=0 (EditMode; 7 pre-existing Skipped)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

