### PR TITLE
fix: keep event backing fields non-public in publicized references

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -66,6 +66,10 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 Property and indexer accessors with explicit bodies are reported per-accessor as
 `Skipped`, so an edited getter never disappears from the response silently.
 
+Subscribing to or unsubscribing from a field-like event (`+=`/`-=`) inside an edited
+body works. Methods that raise the event are reported as `Skipped` (see the table
+below) — raising is only expressible inside the declaring type, which a shim is not.
+
 ### Skipped — reported per method, never flips `Success`
 
 | Condition | Why |
@@ -79,6 +83,7 @@ Property and indexer accessors with explicit bodies are reported per-accessor as
 | Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
 | Property or indexer accessor with an explicit body | Accessor patching is out of scope for v1; `uloop compile` applies accessor edits |
+| Method raises, invokes, or reads a field-like event (anything beyond `+=`/`-=`) | C# only allows `+=`/`-=` on an event outside its declaring type, so the raising body cannot compile from the shim assembly |
 
 ### Failed — flips `Success` to `false`
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -66,6 +66,10 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 Property and indexer accessors with explicit bodies are reported per-accessor as
 `Skipped`, so an edited getter never disappears from the response silently.
 
+Subscribing to or unsubscribing from a field-like event (`+=`/`-=`) inside an edited
+body works. Methods that raise the event are reported as `Skipped` (see the table
+below) — raising is only expressible inside the declaring type, which a shim is not.
+
 ### Skipped — reported per method, never flips `Success`
 
 | Condition | Why |
@@ -79,6 +83,7 @@ Property and indexer accessors with explicit bodies are reported per-accessor as
 | Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
 | Property or indexer accessor with an explicit body | Accessor patching is out of scope for v1; `uloop compile` applies accessor edits |
+| Method raises, invokes, or reads a field-like event (anything beyond `+=`/`-=`) | C# only allows `+=`/`-=` on an event outside its declaring type, so the raising body cannot compile from the shim assembly |
 
 ### Failed — flips `Success` to `false`
 

--- a/Assets/Tests/Editor/HotReload/HotReloadEventFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadEventFixtures.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled fixture for the field-like event e2e: subscribing must hot-reload while the
+    /// raising method is reported as Skipped. The on-disk source path is passed as files[];
+    /// edited copies live under Library/UloopHotReload/TestSources/.
+    /// </summary>
+    public class HotReloadEventFixture
+    {
+        public event Action ScoreChanged;
+
+        public int HandledCount;
+
+        // Why NoInlining: mirrors HotReloadE2EFixture — assertions must measure the patch
+        // detour, not JIT inlining of tiny bodies.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void EnableCounting()
+        {
+            ScoreChanged += HandleScoreChanged;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void HandleScoreChanged()
+        {
+            HandledCount = HandledCount + 1;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void RaiseScore()
+        {
+            ScoreChanged?.Invoke();
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadEventFixtures.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadEventFixtures.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2625d31a9b37e4d4eb1230f64951122e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -918,6 +918,48 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + string.Join("\n", result.Warnings));
         }
 
+        /// <summary>
+        /// What: a file declaring a field-like event hot-reloads its subscriber/handler methods
+        /// (no CS0229 from the publicized backing field) while the raising method is Skipped
+        /// instead of killing the whole file.
+        /// </summary>
+        [Test]
+        public async Task Run_FieldLikeEventFile_PatchesHandlerAndSkipsRaiser()
+        {
+            string fixturePath = ResolveEventFixturePath();
+            string editedPath = WriteEditedSource(
+                "EventFixtureEdit.cs",
+                BuildEventFixtureSource(
+                    "[MethodImpl(MethodImplOptions.NoInlining)]\n        public void HandleScoreChanged()\n        {\n            HandledCount = HandledCount + 5;\n        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadEventFixture.HandleScoreChanged));
+
+            bool raiserSkipped = false;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Skipped
+                    && outcome.Method.Contains(nameof(HotReloadEventFixture.RaiseScore))
+                    && outcome.Reason.Contains("event"))
+                {
+                    raiserSkipped = true;
+                }
+            }
+
+            Assert.That(raiserSkipped, Is.True,
+                "RaiseScore must be Skipped with the event-use reason.\n" + FormatOutcomes(result));
+
+            HotReloadEventFixture fixture = new HotReloadEventFixture();
+            fixture.EnableCounting();
+            fixture.RaiseScore();
+            Assert.That(fixture.HandledCount, Is.EqualTo(5));
+        }
+
         private static void AssertNoFileLevelFailure(HotReloadOrchestratorResult result)
         {
             foreach (HotReloadMethodOutcome outcome in result.Methods)
@@ -970,6 +1012,45 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "HotReloadE2EFixtures.cs");
             Assert.That(File.Exists(path), Is.True, "E2E fixture source missing: " + path);
             return Path.GetFullPath(path);
+        }
+
+        private static string ResolveEventFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath, "Tests", "Editor", "HotReload", "HotReloadEventFixtures.cs");
+            Assert.That(File.Exists(path), Is.True, "Event fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string BuildEventFixtureSource(string handleScoreChangedMethod)
+        {
+            return @"using System;
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    public class HotReloadEventFixture
+    {
+        public event Action ScoreChanged;
+
+        public int HandledCount;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void EnableCounting()
+        {
+            ScoreChanged += HandleScoreChanged;
+        }
+
+        " + handleScoreChangedMethod + @"
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void RaiseScore()
+        {
+            ScoreChanged?.Invoke();
+        }
+    }
+}
+";
         }
 
         private static string WriteEditedSource(string fileName, string contents)

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -919,8 +919,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a file declaring a field-like event hot-reloads its subscriber/handler methods
-        /// (no CS0229 from the publicized backing field) while the raising method is Skipped
+        /// What: a file declaring a field-like event hot-reloads its subscriber and handler methods
+        /// (no CS0229 from the publicized backing field) — the edited subscriber body (net two
+        /// subscriptions via += / -=) must actually apply (HandledCount == 10, not the original
+        /// body's 5) and EnableCounting must be Patched — while the raising method is Skipped
         /// instead of killing the whole file.
         /// </summary>
         [Test]
@@ -939,6 +941,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             AssertNoFileLevelFailure(result);
             AssertHasPatched(result, nameof(HotReloadEventFixture.HandleScoreChanged));
+            AssertHasPatched(result, nameof(HotReloadEventFixture.EnableCounting));
 
             bool raiserSkipped = false;
             foreach (HotReloadMethodOutcome outcome in result.Methods)
@@ -957,7 +960,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadEventFixture fixture = new HotReloadEventFixture();
             fixture.EnableCounting();
             fixture.RaiseScore();
-            Assert.That(fixture.HandledCount, Is.EqualTo(5));
+            Assert.That(fixture.HandledCount, Is.EqualTo(10));
         }
 
         private static void AssertNoFileLevelFailure(HotReloadOrchestratorResult result)
@@ -1038,7 +1041,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void EnableCounting()
         {
+            // Net two subscriptions: the patched edited body yields HandledCount == 10,
+            // while the original single-subscribe body yields 5, so the assertion can
+            // tell a Patched subscriber from a Skipped one. The -= line additionally
+            // pins the SubtractAssignment exemption in the worker's event gate.
             ScoreChanged += HandleScoreChanged;
+            ScoreChanged += HandleScoreChanged;
+            ScoreChanged += HandleScoreChanged;
+            ScoreChanged -= HandleScoreChanged;
         }
 
         " + handleScoreChangedMethod + @"

--- a/Assets/Tests/Editor/HotReload/ReferencePublicizerTests.cs
+++ b/Assets/Tests/Editor/HotReload/ReferencePublicizerTests.cs
@@ -85,7 +85,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void GetOrCreatePublicizedCopy_DoesNotDeleteHyphenatedSiblingAssemblyCaches()
         {
             string projectRootPath = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
-            string outputDirectory = Path.Combine(projectRootPath, "Library", "UloopHotReload", "PublicizedRefs");
+            string outputDirectory = Path.Combine(projectRootPath, HotReloadConstants.PublicizedRefsRelativeDirectory);
             Directory.CreateDirectory(outputDirectory);
 
             // Force the write+prune path: remove existing exact-mvid caches for this assembly.
@@ -146,6 +146,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
                 foreach (FieldDefinition field in type.Fields)
                 {
+                    bool isEventBackingField = false;
+                    foreach (EventDefinition eventDefinition in type.Events)
+                    {
+                        if (eventDefinition.Name == field.Name)
+                        {
+                            isEventBackingField = true;
+                        }
+                    }
+
+                    if (isEventBackingField)
+                    {
+                        Assert.That(
+                            (field.Attributes & CecilFieldAttributes.FieldAccessMask),
+                            Is.Not.EqualTo(CecilFieldAttributes.Public),
+                            $"Event backing field must stay non-public: {type.FullName}.{field.Name}");
+                        continue;
+                    }
+
                     Assert.That(
                         (field.Attributes & CecilFieldAttributes.FieldAccessMask),
                         Is.EqualTo(CecilFieldAttributes.Public),
@@ -160,6 +178,39 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         $"Method still non-public: {type.FullName}.{method.Name}");
                 }
             }
+        }
+
+        /// <summary>
+        /// What: publicizing keeps a field-like event's backing field non-public while its
+        /// add/remove accessors become public, so shims can subscribe without CS0229.
+        /// </summary>
+        [Test]
+        public void GetOrCreatePublicizedCopy_KeepsEventBackingFieldNonPublic()
+        {
+            string publicizedPath = ReferencePublicizer.GetOrCreatePublicizedCopy(ResolveTestAssemblyDllPath());
+            using AssemblyDefinition publicizedAssembly = AssemblyDefinition.ReadAssembly(publicizedPath);
+
+            const string eventFixtureTypeFullName =
+                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadEventFixture";
+            TypeDefinition fixtureType = publicizedAssembly.MainModule.GetType(eventFixtureTypeFullName);
+            Assert.That(fixtureType, Is.Not.Null, $"Type not found: {eventFixtureTypeFullName}");
+
+            FieldDefinition scoreChangedField = fixtureType.Fields.First(field => field.Name == "ScoreChanged");
+            Assert.That(
+                (scoreChangedField.Attributes & CecilFieldAttributes.FieldAccessMask),
+                Is.Not.EqualTo(CecilFieldAttributes.Public),
+                "Event backing field ScoreChanged must stay non-public.");
+
+            MethodDefinition addAccessor = fixtureType.Methods.First(method => method.Name == "add_ScoreChanged");
+            MethodDefinition removeAccessor = fixtureType.Methods.First(method => method.Name == "remove_ScoreChanged");
+            Assert.That(
+                (addAccessor.Attributes & CecilMethodAttributes.MemberAccessMask),
+                Is.EqualTo(CecilMethodAttributes.Public),
+                "add_ScoreChanged must be public after publicize.");
+            Assert.That(
+                (removeAccessor.Attributes & CecilMethodAttributes.MemberAccessMask),
+                Is.EqualTo(CecilMethodAttributes.Public),
+                "remove_ScoreChanged must be public after publicize.");
         }
 
         private static string ResolveTestAssemblyDllPath()

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -14,7 +14,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         // Publicized reference copies are keyed by assembly name + Mvid so a recompiled assembly
         // never reuses a stale visibility rewrite.
-        public const string PublicizedRefsRelativeDirectory = "Library/UloopHotReload/PublicizedRefs";
+        // "fmt2" = publicize-format generation. The cache key is assembly name + MVID only, so a
+        // rule change (event backing fields stay non-public since fmt2) must move the directory —
+        // otherwise a cache written under the old rule keeps poisoning shim compiles until the
+        // assembly happens to recompile.
+        public const string PublicizedRefsRelativeDirectory = "Library/UloopHotReload/PublicizedRefs/fmt2";
 
         // Worker binaries are keyed by SHA256 of the TransformWorker~/TransformWorker.cs source.
         public const string WorkerCacheRelativeDirectory = "Library/UloopHotReload/Worker";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/ReferencePublicizer.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/ReferencePublicizer.cs
@@ -181,6 +181,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             foreach (FieldDefinition field in type.Fields)
             {
+                // A field-like event's compiler-generated backing field shares the event's name.
+                // Publicizing it makes both the event (via its publicized accessors) and the field
+                // visible, so every shim touching the event fails with CS0229 (ambiguous reference).
+                // The backing field keeps its original accessibility; shims subscribe through the
+                // public add/remove accessors instead.
+                if (HasEventNamed(type, field.Name))
+                {
+                    continue;
+                }
+
                 field.Attributes = (field.Attributes & ~CecilFieldAttributes.FieldAccessMask) | CecilFieldAttributes.Public;
             }
 
@@ -189,6 +199,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 method.Attributes = (method.Attributes & ~CecilMethodAttributes.MemberAccessMask) | CecilMethodAttributes.Public;
             }
+        }
+
+        private static bool HasEventNamed(TypeDefinition type, string fieldName)
+        {
+            foreach (EventDefinition eventDefinition in type.Events)
+            {
+                if (eventDefinition.Name == fieldName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static string NormalizePathForComparison(string path)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -66,6 +66,10 @@ Edits outside method bodies never take effect: changing a `const` value, a field
 Property and indexer accessors with explicit bodies are reported per-accessor as
 `Skipped`, so an edited getter never disappears from the response silently.
 
+Subscribing to or unsubscribing from a field-like event (`+=`/`-=`) inside an edited
+body works. Methods that raise the event are reported as `Skipped` (see the table
+below) — raising is only expressible inside the declaring type, which a shim is not.
+
 ### Skipped — reported per method, never flips `Success`
 
 | Condition | Why |
@@ -79,6 +83,7 @@ Property and indexer accessors with explicit bodies are reported per-accessor as
 | Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
 | Property or indexer accessor with an explicit body | Accessor patching is out of scope for v1; `uloop compile` applies accessor edits |
+| Method raises, invokes, or reads a field-like event (anything beyond `+=`/`-=`) | C# only allows `+=`/`-=` on an event outside its declaring type, so the raising body cannot compile from the shim assembly |
 
 ### Failed — flips `Success` to `false`
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -587,6 +587,12 @@ public static class TransformWorkerProgram
                 "Methods that call base. members are skipped; C# cannot express base calls outside the type.");
         }
 
+        string eventUseReason = EvaluateEventUseSkipReason(bodyNode, semanticModel);
+        if (eventUseReason != null)
+        {
+            return MethodTransformDecision.Skip(eventUseReason);
+        }
+
         bool closureInaccessible = SubtreeHasInaccessibleMemberAccess(
             semanticModel,
             FindClosureBodies(bodyNode));
@@ -662,6 +668,51 @@ public static class TransformWorkerProgram
         if (methodDeclaration.ExplicitInterfaceSpecifier != null)
         {
             return "Explicit interface implementations are skipped in v1.";
+        }
+
+        return null;
+    }
+
+    // Why skip event uses beyond +=/-=: outside the declaring type C# only allows those
+    // assignments, so a shim cannot compile Raise/Invoke/read. nameof(ScoreChanged) and
+    // similar non-runtime references are also skipped — Skip is an honest report and safer
+    // than a compile failure.
+    private static string EvaluateEventUseSkipReason(SyntaxNode bodyNode, SemanticModel semanticModel)
+    {
+        foreach (SyntaxNode node in bodyNode.DescendantNodesAndSelf())
+        {
+            if (node is not IdentifierNameSyntax && node is not MemberAccessExpressionSyntax)
+            {
+                continue;
+            }
+
+            IEventSymbol eventSymbol = semanticModel.GetSymbolInfo(node).Symbol as IEventSymbol;
+            if (eventSymbol == null)
+            {
+                continue;
+            }
+
+            // this.E / instance.E resolve the same event on the IdentifierName and the outer
+            // MemberAccess; judge usage on the outer expression only.
+            SyntaxNode effective = node;
+            if (node.Parent is MemberAccessExpressionSyntax parentAccess && parentAccess.Name == node)
+            {
+                effective = parentAccess;
+            }
+
+            // += / -= on the left-hand side are the only event operations C# allows outside the
+            // declaring type.
+            if (effective.Parent is AssignmentExpressionSyntax assignment
+                && (assignment.IsKind(SyntaxKind.AddAssignmentExpression)
+                    || assignment.IsKind(SyntaxKind.SubtractAssignmentExpression))
+                && assignment.Left == effective)
+            {
+                continue;
+            }
+
+            return "Methods that raise, invoke, or read a field-like event are skipped; "
+                + "C# only allows += / -= on an event outside its declaring type, so the "
+                + "shim cannot compile this body. Use uloop compile.";
         }
 
         return null;

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -153,7 +153,9 @@ transplanted without rewriting call/load slots. Prefix wrappers are not generate
 
 ### Publicized reference
 
-A Cecil-rewritten copy of a project assembly under `Library/UloopHotReload/PublicizedRefs/`
-in which every type and member is public. Hot reload uses these copies only as compile-time
+A Cecil-rewritten copy of a project assembly under `Library/UloopHotReload/PublicizedRefs/fmt2/`
+in which every type and member is public — except field-like event backing fields, which stay
+non-public so shim compilation does not see both the event and its same-named backing field
+(CS0229). Hot reload uses these copies only as compile-time
 references for shim compilation so private/internal member access type-checks; they are
 never loaded into the Editor domain as the runtime identity of the target types.

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -38,7 +38,7 @@ Harmony transpiler transplant  (5) patch the original method with a transpiler t
 ```
 
 Harmony ID: `io.github.hatayama.uloop.hot-reload` (distinct from the pause point's ID).
-Caches: `Library/UloopHotReload/PublicizedRefs/<assemblyName>-<mvid>.dll` and
+Caches: `Library/UloopHotReload/PublicizedRefs/fmt2/<assemblyName>-<mvid>.dll` and
 `Library/UloopHotReload/Worker/<sourceHash>/`.
 
 ## Spike Findings


### PR DESCRIPTION
## Summary
- Files that declare field-like events can hot-reload subscriber/handler methods without CS0229.
- Methods that raise or read those events are reported as `Skipped` instead of failing the whole file.

## User Impact
- Before: publicizing an event's compiler-generated backing field made shim compiles fail with CS0229 (ambiguous event vs field), so one event declaration could kill every method in the file.
- After: shims subscribe through publicized add/remove accessors; raise/invoke/read bodies are skipped with an explicit reason pointing at `uloop compile`.

## Changes
- Skip event-named fields in `ReferencePublicizer` and move the publicized-refs cache to `PublicizedRefs/fmt2`.
- Worker skips method bodies that use a field-like event beyond `+=`/`-=`.
- Add event fixture + E2E coverage; document subscribe vs raise in the hot-reload skill.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → ErrorCount=0 / WarningCount=0
- `dist/darwin-arm64/uloop run-tests` → FailedCount=0 (EditMode; 7 pre-existing Skipped)
- Note: base is `feature/hot-reload`, so repository CI (`pull_request.branches: main/v3-beta`) does not run on this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

