### PR TITLE
feat: isolate shim compile failures to the failing methods

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -93,7 +93,7 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Loaded assembly differs from the one on disk (pending compile) | Run `uloop compile` first, then retry |
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
-| Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler errors and, when they indicate a member or type the compiled assembly does not have yet, a hint to run `uloop compile` |
+| Shim compile error (e.g. the body calls a member that does not exist yet) | Failing methods are isolated: each reports `Failed` with its own compiler errors (plus the `uloop compile` hint when they indicate a missing member) while the remaining methods still patch. When errors cannot be attributed per method, the whole file reports one `(shim-compile)` entry |
 | Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error; other methods in the run still apply |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -93,7 +93,7 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Loaded assembly differs from the one on disk (pending compile) | Run `uloop compile` first, then retry |
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
-| Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler errors and, when they indicate a member or type the compiled assembly does not have yet, a hint to run `uloop compile` |
+| Shim compile error (e.g. the body calls a member that does not exist yet) | Failing methods are isolated: each reports `Failed` with its own compiler errors (plus the `uloop compile` hint when they indicate a missing member) while the remaining methods still patch. When errors cannot be attributed per method, the whole file reports one `(shim-compile)` entry |
 | Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error; other methods in the run still apply |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -963,6 +963,49 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(fixture.HandledCount, Is.EqualTo(10));
         }
 
+        /// <summary>
+        /// What: a shim compile error in one method no longer kills the file — the failing method
+        /// reports Failed with its own compiler error (and the new-member hint) while the other
+        /// methods still patch and take effect.
+        /// </summary>
+        [Test]
+        public async Task Run_OneMethodFailingShimCompile_IsolatesFailureAndPatchesRest()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "IsolatedShimFailure.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }",
+                    callsMissingHelperMethod:
+                    "public int CallsMissingHelper(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+
+            bool missingHelperFailed = false;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
+                    && outcome.Method.Contains(nameof(HotReloadE2EFixture.CallsMissingHelper))
+                    && outcome.Reason.Contains(HotReloadConstants.NewMemberCompileHint))
+                {
+                    missingHelperFailed = true;
+                }
+            }
+
+            Assert.That(missingHelperFailed, Is.True,
+                "CallsMissingHelper must fail per-method with its own compiler error.\n" + FormatOutcomes(result));
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(115));
+        }
+
         private static void AssertNoFileLevelFailure(HotReloadOrchestratorResult result)
         {
             foreach (HotReloadMethodOutcome outcome in result.Methods)

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -158,7 +159,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: every worker entry carries a 1-based shim source line range so the orchestrator
-        /// can attribute compile errors per method.
+        /// can attribute compile errors per method (end within the emitted source; ranges do not
+        /// overlap).
         /// </summary>
         [Test]
         public async Task BootstrapAndRun_OnE2EFixture_EveryEntryHasAValidShimSourceLineRange()
@@ -167,6 +169,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(result.Output.entries, Is.Not.Empty);
 
+            int shimSourceLineCount = CountLines(result.Output.shimSource);
+            List<(int Start, int End, string MethodName)> ranges =
+                new List<(int Start, int End, string MethodName)>();
             foreach (TransformWorkerEntryDto entry in result.Output.entries)
             {
                 Assert.That(
@@ -177,7 +182,43 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     entry.shimSourceStartLine,
                     Is.LessThanOrEqualTo(entry.shimSourceEndLine),
                     "Entry shim source start line must not be after its end line: " + entry.methodName);
+                Assert.That(
+                    entry.shimSourceEndLine,
+                    Is.LessThanOrEqualTo(shimSourceLineCount),
+                    "Entry shim source end line exceeds shimSource line count: " + entry.methodName);
+                ranges.Add((entry.shimSourceStartLine, entry.shimSourceEndLine, entry.methodName));
             }
+
+            ranges.Sort((left, right) => left.Start.CompareTo(right.Start));
+            for (int index = 1; index < ranges.Count; index++)
+            {
+                Assert.That(
+                    ranges[index].Start,
+                    Is.GreaterThan(ranges[index - 1].End),
+                    "Shim source line ranges overlap between "
+                    + ranges[index - 1].MethodName
+                    + " and "
+                    + ranges[index].MethodName);
+            }
+        }
+
+        private static int CountLines(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return 0;
+            }
+
+            int lineCount = 1;
+            for (int index = 0; index < text.Length; index++)
+            {
+                if (text[index] == '\n')
+                {
+                    lineCount++;
+                }
+            }
+
+            return lineCount;
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -157,6 +157,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: every worker entry carries a 1-based shim source line range so the orchestrator
+        /// can attribute compile errors per method.
+        /// </summary>
+        [Test]
+        public async Task BootstrapAndRun_OnE2EFixture_EveryEntryHasAValidShimSourceLineRange()
+        {
+            TransformWorkerClientResult result = await RunWorkerOnE2EFixtureAsync();
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.entries, Is.Not.Empty);
+
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                Assert.That(
+                    entry.shimSourceStartLine,
+                    Is.GreaterThanOrEqualTo(1),
+                    "Entry missing a 1-based shim source start line: " + entry.methodName);
+                Assert.That(
+                    entry.shimSourceStartLine,
+                    Is.LessThanOrEqualTo(entry.shimSourceEndLine),
+                    "Entry shim source start line must not be after its end line: " + entry.methodName);
+            }
+        }
+
+        /// <summary>
         /// What: extracts one shim method declaration from the aggregated shimSource so Contains
         /// asserts cannot pass via text belonging to a different entry.
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -221,14 +221,37 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 defines,
                 ct).ConfigureAwait(false);
 
+            TransformWorkerEntryDto[] entriesToPatch = workerOutput.entries;
             if (!compileResult.Success)
             {
-                outcomes.Add(
-                    HotReloadMethodOutcome.Failed(
-                        "(shim-compile)",
-                        compileResult.ErrorMessage,
-                        assemblyResolvePath));
-                return new HotReloadFileProcessResult(outcomes, warnings, 0);
+                HotReloadShimIsolationResult isolation = await TryIsolateShimCompileFailureAsync(
+                    workerInput,
+                    workerOutput,
+                    compileResult,
+                    compilationAssembly,
+                    targetDllPath,
+                    defines,
+                    assemblyResolvePath,
+                    ct).ConfigureAwait(false);
+                if (isolation == null)
+                {
+                    outcomes.Add(
+                        HotReloadMethodOutcome.Failed(
+                            "(shim-compile)",
+                            compileResult.ErrorMessage,
+                            assemblyResolvePath));
+                    return new HotReloadFileProcessResult(outcomes, warnings, 0);
+                }
+
+                outcomes.AddRange(isolation.FailedMethodOutcomes);
+                if (isolation.RetryEntries.Length == 0)
+                {
+                    return new HotReloadFileProcessResult(
+                        outcomes, warnings, 0, suppressedPausePointIds, new List<string>());
+                }
+
+                entriesToPatch = isolation.RetryEntries;
+                compileResult = isolation.RetryCompileResult;
             }
 
             // Harmony Patch/Unpatch and method resolution against loaded modules require main thread.
@@ -237,7 +260,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 BindShimAccessors(compileResult.Assembly);
             List<string> inlineRiskMethodLabels = new List<string>();
             int patchedCount = 0;
-            foreach (TransformWorkerEntryDto entry in workerOutput.entries)
+            foreach (TransformWorkerEntryDto entry in entriesToPatch)
             {
                 HotReloadMethodOutcome outcome = ApplyEntry(
                     entry,
@@ -549,6 +572,222 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return false;
+        }
+
+        // Keep in sync with TransformWorkerProgram.BuildMethodKey (out-of-process worker side).
+        private static string BuildMethodKey(TransformWorkerEntryDto entry)
+        {
+            return entry.typeMetadataName + "::" + entry.methodName + "("
+                + string.Join(",", entry.parameterTypeFullNames ?? Array.Empty<string>()) + ")";
+        }
+
+        /// <summary>
+        /// Retries the failed shim compile once, excluding the method(s) whose compiler errors can
+        /// be attributed to them, so the rest of the file's methods can still patch. Returns null
+        /// when isolation is not possible (unattributable errors, all/none of the entries failing,
+        /// the retry worker run failing, or the retry compile failing) — the caller then falls back
+        /// to today's whole-file "(shim-compile)" Failed.
+        /// </summary>
+        private static async Task<HotReloadShimIsolationResult> TryIsolateShimCompileFailureAsync(
+            TransformWorkerInputDto workerInput,
+            TransformWorkerOutputDto workerOutput,
+            HotReloadShimCompileResult compileResult,
+            UnityCompilationAssembly compilationAssembly,
+            string targetDllPath,
+            string[] defines,
+            string assemblyResolvePath,
+            CancellationToken ct)
+        {
+            if (compileResult.Errors.Count == 0)
+            {
+                return null;
+            }
+
+            ShimCompileErrorAttribution attribution =
+                AttributeErrorsToEntries(workerOutput.entries, compileResult.Errors);
+            if (attribution == null
+                || attribution.FailedEntries.Count == 0
+                || attribution.FailedEntries.Count == workerOutput.entries.Length)
+            {
+                // Unattributable errors (header/binder/using-level), or isolating everyone / no one
+                // would not narrow the failure at all.
+                return null;
+            }
+
+            List<HotReloadMethodOutcome> failedMethodOutcomes =
+                BuildFailedMethodOutcomes(attribution, assemblyResolvePath);
+            string[] excludedMethodKeys = BuildExcludedMethodKeys(attribution.FailedEntries);
+
+            return await RunIsolationRetryAsync(
+                workerInput,
+                excludedMethodKeys,
+                failedMethodOutcomes,
+                compilationAssembly,
+                targetDllPath,
+                defines,
+                ct).ConfigureAwait(false);
+        }
+
+        private static async Task<HotReloadShimIsolationResult> RunIsolationRetryAsync(
+            TransformWorkerInputDto workerInput,
+            string[] excludedMethodKeys,
+            List<HotReloadMethodOutcome> failedMethodOutcomes,
+            UnityCompilationAssembly compilationAssembly,
+            string targetDllPath,
+            string[] defines,
+            CancellationToken ct)
+        {
+            TransformWorkerInputDto retryInput = new TransformWorkerInputDto
+            {
+                sourcePath = workerInput.sourcePath,
+                defines = workerInput.defines,
+                referencePaths = workerInput.referencePaths,
+                targetTypesAssemblyPath = workerInput.targetTypesAssemblyPath,
+                excludedMethodKeys = excludedMethodKeys
+            };
+
+            TransformWorkerClientResult retryWorkerResult =
+                await TransformWorkerClient.RunAsync(retryInput, ct).ConfigureAwait(false);
+            if (!retryWorkerResult.Success)
+            {
+                return null;
+            }
+
+            // The first run already surfaced parseErrors / skipped / drift warnings; consuming
+            // them again would duplicate every per-file report.
+            TransformWorkerOutputDto retryOutput = retryWorkerResult.Output;
+            if (string.IsNullOrEmpty(retryOutput.shimSource) || retryOutput.entries.Length == 0)
+            {
+                return new HotReloadShimIsolationResult(
+                    failedMethodOutcomes, Array.Empty<TransformWorkerEntryDto>(), null);
+            }
+
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+            bool includeHarmonyReference = HasDelegationEntry(retryOutput.entries);
+            List<string> shimReferences = BuildShimReferencePaths(
+                compilationAssembly,
+                targetDllPath,
+                includeHarmonyReference);
+            HotReloadShimCompileResult retryCompileResult = await HotReloadShimCompiler.CompileAndLoadAsync(
+                retryOutput.shimSource,
+                shimReferences,
+                defines,
+                ct).ConfigureAwait(false);
+            if (!retryCompileResult.Success)
+            {
+                return null;
+            }
+
+            return new HotReloadShimIsolationResult(failedMethodOutcomes, retryOutput.entries, retryCompileResult);
+        }
+
+        private static List<HotReloadMethodOutcome> BuildFailedMethodOutcomes(
+            ShimCompileErrorAttribution attribution,
+            string assemblyResolvePath)
+        {
+            List<HotReloadMethodOutcome> failedMethodOutcomes = new List<HotReloadMethodOutcome>();
+            foreach (TransformWorkerEntryDto failedEntry in attribution.FailedEntries)
+            {
+                string methodLabel = failedEntry.typeMetadataName + "." + failedEntry.methodName;
+                List<string> entryErrorMessages = attribution.ErrorMessagesByEntry[failedEntry];
+                failedMethodOutcomes.Add(
+                    HotReloadMethodOutcome.Failed(
+                        methodLabel,
+                        HotReloadShimCompiler.ComposeShimCompileFailureMessage(entryErrorMessages),
+                        assemblyResolvePath));
+            }
+
+            return failedMethodOutcomes;
+        }
+
+        private static string[] BuildExcludedMethodKeys(IReadOnlyList<TransformWorkerEntryDto> failedEntries)
+        {
+            string[] excludedMethodKeys = new string[failedEntries.Count];
+            for (int index = 0; index < failedEntries.Count; index++)
+            {
+                excludedMethodKeys[index] = BuildMethodKey(failedEntries[index]);
+            }
+
+            return excludedMethodKeys;
+        }
+
+        /// <summary>
+        /// Maps each shim compile error to the entry whose [shimSourceStartLine, shimSourceEndLine]
+        /// range contains it. Returns null if any error falls outside every entry's range (a
+        /// header/binder/using-level error, which method isolation cannot fix).
+        /// </summary>
+        private static ShimCompileErrorAttribution AttributeErrorsToEntries(
+            TransformWorkerEntryDto[] entries,
+            IReadOnlyList<HotReloadShimCompileError> errors)
+        {
+            Dictionary<TransformWorkerEntryDto, List<string>> errorMessagesByEntry =
+                new Dictionary<TransformWorkerEntryDto, List<string>>();
+            foreach (HotReloadShimCompileError error in errors)
+            {
+                TransformWorkerEntryDto matchedEntry = FindEntryForLine(entries, error.Line);
+                if (matchedEntry == null)
+                {
+                    return null;
+                }
+
+                if (!errorMessagesByEntry.TryGetValue(matchedEntry, out List<string> messages))
+                {
+                    messages = new List<string>();
+                    errorMessagesByEntry[matchedEntry] = messages;
+                }
+
+                messages.Add(error.Message);
+            }
+
+            return new ShimCompileErrorAttribution(errorMessagesByEntry);
+        }
+
+        private static TransformWorkerEntryDto FindEntryForLine(TransformWorkerEntryDto[] entries, int line)
+        {
+            foreach (TransformWorkerEntryDto entry in entries)
+            {
+                bool hasKnownRange = entry.shimSourceStartLine > 0 && entry.shimSourceEndLine > 0;
+                if (hasKnownRange && line >= entry.shimSourceStartLine && line <= entry.shimSourceEndLine)
+                {
+                    return entry;
+                }
+            }
+
+            return null;
+        }
+
+        private sealed class ShimCompileErrorAttribution
+        {
+            public IReadOnlyDictionary<TransformWorkerEntryDto, List<string>> ErrorMessagesByEntry { get; }
+            public IReadOnlyList<TransformWorkerEntryDto> FailedEntries { get; }
+
+            public ShimCompileErrorAttribution(Dictionary<TransformWorkerEntryDto, List<string>> errorMessagesByEntry)
+            {
+                ErrorMessagesByEntry = errorMessagesByEntry;
+                FailedEntries = new List<TransformWorkerEntryDto>(errorMessagesByEntry.Keys);
+            }
+        }
+
+        /// <summary>
+        /// Outcome of <see cref="TryIsolateShimCompileFailureAsync"/>. <see cref="RetryEntries"/>
+        /// empty means the retry worker run produced nothing to patch (still a valid, non-null
+        /// isolation — only <see cref="FailedMethodOutcomes"/> apply).
+        /// </summary>
+        private sealed class HotReloadShimIsolationResult
+        {
+            public List<HotReloadMethodOutcome> FailedMethodOutcomes { get; }
+            public TransformWorkerEntryDto[] RetryEntries { get; }
+            public HotReloadShimCompileResult RetryCompileResult { get; }
+
+            public HotReloadShimIsolationResult(
+                List<HotReloadMethodOutcome> failedMethodOutcomes,
+                TransformWorkerEntryDto[] retryEntries,
+                HotReloadShimCompileResult retryCompileResult)
+            {
+                FailedMethodOutcomes = failedMethodOutcomes;
+                RetryEntries = retryEntries;
+                RetryCompileResult = retryCompileResult;
+            }
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
@@ -72,10 +72,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     markBuildFinished: static () => { },
                     incrementBuildCount: static () => { }).ConfigureAwait(false);
 
-                List<string> errors = CollectErrors(backendResult.CompilerMessages);
+                List<HotReloadShimCompileError> errors = CollectErrors(backendResult.CompilerMessages);
                 if (errors.Count > 0)
                 {
-                    return HotReloadShimCompileResult.Failure(ComposeShimCompileFailureMessage(errors));
+                    List<string> errorMessages = new List<string>(errors.Count);
+                    foreach (HotReloadShimCompileError error in errors)
+                    {
+                        errorMessages.Add(error.Message);
+                    }
+
+                    return HotReloadShimCompileResult.Failure(
+                        ComposeShimCompileFailureMessage(errorMessages), errors);
                 }
 
                 if (!File.Exists(dllPath))
@@ -140,9 +147,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return message;
         }
 
-        private static List<string> CollectErrors(CompilerMessage[] compilerMessages)
+        private static List<HotReloadShimCompileError> CollectErrors(CompilerMessage[] compilerMessages)
         {
-            List<string> errors = new List<string>();
+            List<HotReloadShimCompileError> errors = new List<HotReloadShimCompileError>();
             if (compilerMessages == null)
             {
                 return errors;
@@ -152,7 +159,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 if (compilerMessage.type == CompilerMessageType.Error)
                 {
-                    errors.Add(compilerMessage.message);
+                    errors.Add(new HotReloadShimCompileError(compilerMessage.line, compilerMessage.message));
                 }
             }
 
@@ -174,29 +181,57 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     }
 
     /// <summary>
+    /// One compiler error from a shim compile, with its 1-based line in the shim source
+    /// (0 when the diagnostic carried no location).
+    /// </summary>
+    internal sealed class HotReloadShimCompileError
+    {
+        public int Line { get; }
+        public string Message { get; }
+
+        public HotReloadShimCompileError(int line, string message)
+        {
+            Line = line;
+            Message = message;
+        }
+    }
+
+    /// <summary>
     /// Outcome of compiling and loading a hot-reload shim assembly.
     /// </summary>
     internal sealed class HotReloadShimCompileResult
     {
+        private static readonly IReadOnlyList<HotReloadShimCompileError> EmptyErrors =
+            Array.Empty<HotReloadShimCompileError>();
+
         public bool Success { get; }
         public Assembly Assembly { get; }
         public string ErrorMessage { get; }
+        public IReadOnlyList<HotReloadShimCompileError> Errors { get; }
 
-        private HotReloadShimCompileResult(bool success, Assembly assembly, string errorMessage)
+        private HotReloadShimCompileResult(
+            bool success,
+            Assembly assembly,
+            string errorMessage,
+            IReadOnlyList<HotReloadShimCompileError> errors)
         {
             Success = success;
             Assembly = assembly;
             ErrorMessage = errorMessage;
+            Errors = errors;
         }
 
         public static HotReloadShimCompileResult SuccessResult(Assembly assembly)
         {
-            return new HotReloadShimCompileResult(true, assembly, string.Empty);
+            return new HotReloadShimCompileResult(true, assembly, string.Empty, EmptyErrors);
         }
 
-        public static HotReloadShimCompileResult Failure(string errorMessage)
+        // errors stays empty for failures that never reached the compiler (e.g. missing external
+        // compiler paths, a dll that failed to load) — only an actual compile failure has any.
+        public static HotReloadShimCompileResult Failure(
+            string errorMessage, IReadOnlyList<HotReloadShimCompileError> errors = null)
         {
-            return new HotReloadShimCompileResult(false, null, errorMessage);
+            return new HotReloadShimCompileResult(false, null, errorMessage, errors ?? EmptyErrors);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -93,7 +93,7 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Loaded assembly differs from the one on disk (pending compile) | Run `uloop compile` first, then retry |
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
-| Shim compile error (e.g. the body calls a member that does not exist yet) | Response carries the compiler errors and, when they indicate a member or type the compiled assembly does not have yet, a hint to run `uloop compile` |
+| Shim compile error (e.g. the body calls a member that does not exist yet) | Failing methods are isolated: each reports `Failed` with its own compiler errors (plus the `uloop compile` hint when they indicate a missing member) while the remaining methods still patch. When errors cannot be attributed per method, the whole file reports one `(shim-compile)` entry |
 | Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error; other methods in the run still apply |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -12,6 +12,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string[] defines;
         public string[] referencePaths;
         public string targetTypesAssemblyPath;
+
+        // Method keys (see HotReloadOrchestrator.BuildMethodKey) already reported Failed from a
+        // first compile round; the retry worker run drops these methods entirely.
+        public string[] excludedMethodKeys;
     }
 
     /// <summary>
@@ -38,6 +42,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         // "transplant" | "delegation". Null/empty is treated as transplant by the orchestrator.
         public string patchKind;
+
+        // 1-based, both ends inclusive, within TransformWorkerOutputDto.shimSource; 0 when the
+        // shim method declaration could not be located while re-parsing the emitted source.
+        public int shimSourceStartLine;
+        public int shimSourceEndLine;
     }
 
     [Serializable]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -99,6 +99,7 @@ public static class TransformWorkerProgram
 
         input.Defines ??= Array.Empty<string>();
         input.ReferencePaths ??= Array.Empty<string>();
+        input.ExcludedMethodKeys ??= Array.Empty<string>();
         return input;
     }
 
@@ -106,6 +107,12 @@ public static class TransformWorkerProgram
     {
         byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(output, JsonOptions);
         File.WriteAllBytes(outputJsonPath, bytes);
+    }
+
+    // Keep in sync with HotReloadOrchestrator.BuildMethodKey (Unity package side).
+    private static string BuildMethodKey(string typeMetadataName, string methodName, string[] parameterTypeFullNames)
+    {
+        return typeMetadataName + "::" + methodName + "(" + string.Join(",", parameterTypeFullNames ?? Array.Empty<string>()) + ")";
     }
 
     private static WorkerOutput TransformFile(WorkerInput input)
@@ -240,6 +247,19 @@ public static class TransformWorkerProgram
                     continue;
                 }
 
+                string[] parameterTypeFullNames = methodSymbol.Parameters
+                    .Select(CecilTypeNames.ToParameterTypeFullName)
+                    .ToArray();
+
+                // The orchestrator already reported this method as Failed from the first compile
+                // round; re-emitting it would fail the retry compile again.
+                string methodKey = BuildMethodKey(
+                    CecilTypeNames.ToMetadataName(typeSymbol), methodSymbol.Name, parameterTypeFullNames);
+                if (input.ExcludedMethodKeys.Contains(methodKey))
+                {
+                    continue;
+                }
+
                 MethodTransformDecision decision = DecideMethodTransform(
                     typeDeclaration,
                     typeSymbol,
@@ -291,9 +311,7 @@ public static class TransformWorkerProgram
                 {
                     TypeMetadataName = CecilTypeNames.ToMetadataName(typeSymbol),
                     MethodName = methodSymbol.Name,
-                    ParameterTypeFullNames = methodSymbol.Parameters
-                        .Select(CecilTypeNames.ToParameterTypeFullName)
-                        .ToArray(),
+                    ParameterTypeFullNames = parameterTypeFullNames,
                     ShimTypeName = currentShimType.ShimTypeName,
                     ShimMethodName = shimMethodName,
                     PatchKind = decision.PatchKind
@@ -302,6 +320,7 @@ public static class TransformWorkerProgram
         }
 
         string shimSource = ShimSourceEmitter.Emit(root, shimTypes);
+        ApplyShimSourceLineRanges(shimSource, entries);
         return new WorkerOutput
         {
             ShimSource = shimSource,
@@ -310,6 +329,32 @@ public static class TransformWorkerProgram
             DeclarationDriftWarnings = declarationDriftWarnings.ToArray(),
             ParseErrors = parseErrors.ToArray()
         };
+    }
+
+    // Shim method names are globally unique within one emitted source (name + global counter),
+    // so re-parsing the exact text csc will compile yields authoritative per-entry line ranges
+    // for error attribution. Members outside the manifest (e.g. __BindAccessors) end up in the
+    // map too but are simply never looked up.
+    private static void ApplyShimSourceLineRanges(string shimSource, List<WorkerEntry> entries)
+    {
+        SyntaxTree emittedTree = CSharpSyntaxTree.ParseText(shimSource);
+        Dictionary<string, (int Start, int End)> lineSpanByShimMethodName =
+            new Dictionary<string, (int Start, int End)>();
+        foreach (MethodDeclarationSyntax method in emittedTree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>())
+        {
+            FileLinePositionSpan lineSpan = method.GetLocation().GetLineSpan();
+            lineSpanByShimMethodName[method.Identifier.Text] =
+                (lineSpan.StartLinePosition.Line + 1, lineSpan.EndLinePosition.Line + 1);
+        }
+
+        foreach (WorkerEntry entry in entries)
+        {
+            if (lineSpanByShimMethodName.TryGetValue(entry.ShimMethodName, out (int Start, int End) lineSpan))
+            {
+                entry.ShimSourceStartLine = lineSpan.Start;
+                entry.ShimSourceEndLine = lineSpan.End;
+            }
+        }
     }
 
     /// <summary>
@@ -3082,6 +3127,11 @@ internal sealed class WorkerInput
     public string[] ReferencePaths { get; set; }
 
     public string TargetTypesAssemblyPath { get; set; }
+
+    // Method keys (see TransformWorkerProgram.BuildMethodKey) that the orchestrator already
+    // reported Failed from a first compile round; the retry excludes them so it does not fail
+    // on the same error again.
+    public string[] ExcludedMethodKeys { get; set; }
 }
 
 internal sealed class WorkerOutput
@@ -3111,6 +3161,12 @@ internal sealed class WorkerEntry
 
     // "transplant" | "delegation" — see PatchKinds.
     public string PatchKind { get; set; }
+
+    // 1-based, both ends inclusive, within WorkerOutput.ShimSource; 0 when the shim method
+    // declaration could not be located while re-parsing the emitted source.
+    public int ShimSourceStartLine { get; set; }
+
+    public int ShimSourceEndLine { get; set; }
 }
 
 internal static class PatchKinds


### PR DESCRIPTION
## Summary
- A shim compile error in one method no longer kills every method in the file.
- Failing methods report per-method `Failed` (with the new-member hint when appropriate); the rest still patch.

## User Impact
- Before: one bad shim method produced a single `(shim-compile)` failure for the whole file, so unrelated edited methods were lost.
- After: the orchestrator attributes compiler errors to shim line ranges, excludes the failing methods, retries once, and applies the remaining patches. When attribution is impossible, behavior falls back to the previous whole-file `(shim-compile)` Failed.

## Changes
- Worker emits 1-based `shimSourceStartLine`/`shimSourceEndLine` per entry and accepts `excludedMethodKeys` for retry runs.
- Shim compiler surfaces structured errors (line + message); orchestrator isolates failures via one worker+compile retry.
- E2E coverage for isolation; worker client test pins line ranges; skill table updated.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → ErrorCount=0 / WarningCount=0
- `dist/darwin-arm64/uloop run-tests` → FailedCount=0 (EditMode; pre-existing Skipped remain)
- Existing `Run_EditedBodyCallingMissingHelper_FailsShimCompileWithHint` still passes unchanged
- Note: base is `feature/hot-reload`, so repository CI (`pull_request.branches: main/v3-beta`) does not run on this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

