### PR TITLE
feat: capture PDB-validated source snapshots for hot reload

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadSourceSnapshotTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSourceSnapshotTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Cecil.Pdb;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for portable-PDB document checksums used by hot-reload source snapshots.
+    /// </summary>
+    public class HotReloadSourceSnapshotTests
+    {
+        private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+        private const string FixtureProjectRelativePath =
+            "Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs";
+
+        /// <summary>
+        /// What: the portable PDB next to a script assembly carries a per-document checksum that matches the hash of the source file bytes, which the snapshot baseline validation relies on.
+        /// </summary>
+        [Test]
+        public void PortablePdb_DocumentChecksum_MatchesSourceFileBytes()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string dllPath = Path.Combine(
+                projectRoot,
+                "Library",
+                "ScriptAssemblies",
+                TestAssemblyName + ".dll");
+            string pdbPath = Path.ChangeExtension(dllPath, ".pdb");
+            string fixtureAbsolutePath = Path.Combine(projectRoot, FixtureProjectRelativePath);
+
+            Assert.That(File.Exists(dllPath), Is.True, "Test assembly DLL must exist at " + dllPath);
+            Assert.That(File.Exists(pdbPath), Is.True, "Portable PDB must exist next to the test assembly DLL.");
+            Assert.That(File.Exists(fixtureAbsolutePath), Is.True, "E2E fixture source must exist.");
+
+            Document document = FindDocumentForProjectRelativePath(dllPath, pdbPath, FixtureProjectRelativePath);
+            Assert.That(document, Is.Not.Null, "PDB must contain a document for " + FixtureProjectRelativePath);
+            Assert.That(document.Hash, Is.Not.Null.And.Not.Empty, "Document.Hash must be non-empty for baseline validation.");
+
+            byte[] sourceBytes = File.ReadAllBytes(fixtureAbsolutePath);
+            byte[] expectedHash = ComputeDocumentHash(document.HashAlgorithm, sourceBytes);
+            Assert.That(
+                expectedHash.SequenceEqual(document.Hash),
+                Is.True,
+                "Document.Hash must equal the hash of the on-disk source bytes (algorithm="
+                + document.HashAlgorithm + ").");
+        }
+
+        private static Document FindDocumentForProjectRelativePath(
+            string dllPath,
+            string pdbPath,
+            string projectRelativePath)
+        {
+            using FileStream dllStream = File.Open(dllPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using FileStream pdbStream = File.Open(pdbPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+
+            ReaderParameters readerParameters = new ReaderParameters
+            {
+                InMemory = true,
+                ReadSymbols = true,
+                SymbolReaderProvider = new PortablePdbReaderProvider(),
+                SymbolStream = pdbStream
+            };
+
+            using AssemblyDefinition assemblyDefinition = AssemblyDefinition.ReadAssembly(dllStream, readerParameters);
+            HashSet<Document> seenDocuments = new HashSet<Document>();
+
+            foreach (TypeDefinition type in assemblyDefinition.MainModule.GetTypes())
+            {
+                foreach (MethodDefinition method in type.Methods)
+                {
+                    if (!method.HasBody)
+                    {
+                        continue;
+                    }
+
+                    MethodDebugInformation debugInformation = method.DebugInformation;
+                    if (debugInformation == null || !debugInformation.HasSequencePoints)
+                    {
+                        continue;
+                    }
+
+                    foreach (SequencePoint sequencePoint in debugInformation.SequencePoints)
+                    {
+                        if (sequencePoint.IsHidden || sequencePoint.Document == null)
+                        {
+                            continue;
+                        }
+
+                        Document document = sequencePoint.Document;
+                        if (!seenDocuments.Add(document))
+                        {
+                            continue;
+                        }
+
+                        if (PathsReferToSameFile(document.Url, projectRelativePath))
+                        {
+                            return document;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        // Same semantics as SourcePausePointPathNormalizer.PathsReferToSameFile; kept local so this
+        // gate test does not depend on HotReload production helpers that land in later commits.
+        private static bool PathsReferToSameFile(string documentUrl, string projectRelativePath)
+        {
+            string normalizedDocumentUrl = documentUrl.Replace('\\', '/');
+            string normalizedRelativePath = projectRelativePath.Replace('\\', '/');
+            StringComparison comparison = Path.DirectorySeparatorChar == '\\'
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            if (string.Equals(normalizedDocumentUrl, normalizedRelativePath, comparison))
+            {
+                return true;
+            }
+
+            return normalizedDocumentUrl.EndsWith("/" + normalizedRelativePath, comparison);
+        }
+
+        private static byte[] ComputeDocumentHash(DocumentHashAlgorithm algorithm, byte[] sourceBytes)
+        {
+            switch (algorithm)
+            {
+                case DocumentHashAlgorithm.SHA1:
+                    using (SHA1 sha1 = SHA1.Create())
+                    {
+                        return sha1.ComputeHash(sourceBytes);
+                    }
+                case DocumentHashAlgorithm.SHA256:
+                    using (SHA256 sha256 = SHA256.Create())
+                    {
+                        return sha256.ComputeHash(sourceBytes);
+                    }
+                default:
+                    Assert.Fail("Unsupported Document.HashAlgorithm: " + algorithm);
+                    return null;
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSourceSnapshotTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSourceSnapshotTests.cs
@@ -188,6 +188,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: on Windows, snapshot filename hashing lowercases the project-relative path so case-only path differences resolve to the same baseline file.
+        /// </summary>
+        [Test]
+        public void HashProjectRelativePath_OnWindows_IgnoresCase()
+        {
+            if (Path.DirectorySeparatorChar != '\\')
+            {
+                Assert.Pass("Case folding applies only on Windows path separators.");
+                return;
+            }
+
+            Assert.That(
+                HotReloadSourceSnapshotter.HashProjectRelativePath("Assets/Foo.cs"),
+                Is.EqualTo(HotReloadSourceSnapshotter.HashProjectRelativePath("assets/foo.cs")));
+        }
+
+        /// <summary>
         /// What: stale MVID snapshot directories for the same assembly name are pruned, while hyphenated sibling assembly names and non-MVID suffixes are kept.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/HotReloadSourceSnapshotTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSourceSnapshotTests.cs
@@ -12,6 +12,8 @@ using NUnit.Framework;
 
 using UnityEngine;
 
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
     /// <summary>
@@ -53,6 +55,132 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.True,
                 "Document.Hash must equal the hash of the on-disk source bytes (algorithm="
                 + document.HashAlgorithm + ").");
+        }
+
+        /// <summary>
+        /// What: LoadVerifiedSnapshotSource returns the on-disk fixture text when a PDB-validated snapshot exists for the test assembly.
+        /// </summary>
+        [Test]
+        public void LoadVerifiedSnapshotSource_ForCapturedFixture_ReturnsOnDiskText()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string dllPath = Path.Combine(
+                projectRoot,
+                HotReloadConstants.ScriptAssembliesRelativeDirectory,
+                TestAssemblyName + HotReloadConstants.CompiledAssemblyExtension);
+            string fixtureAbsolutePath = Path.Combine(projectRoot, FixtureProjectRelativePath);
+
+            string loaded = HotReloadSourceBaseline.LoadVerifiedSnapshotSource(
+                FixtureProjectRelativePath,
+                dllPath);
+            Assert.That(loaded, Is.Not.Null, "Verified snapshot must resolve after domain-reload capture.");
+            Assert.That(loaded, Is.EqualTo(File.ReadAllText(fixtureAbsolutePath)));
+        }
+
+        /// <summary>
+        /// What: a one-byte tamper of the snapshot bytes fails PDB checksum validation and yields null.
+        /// </summary>
+        [Test]
+        public void LoadVerifiedSnapshotSource_WhenSnapshotBytesTampered_ReturnsNull()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string dllPath = Path.Combine(
+                projectRoot,
+                HotReloadConstants.ScriptAssembliesRelativeDirectory,
+                TestAssemblyName + HotReloadConstants.CompiledAssemblyExtension);
+
+            string verified = HotReloadSourceBaseline.LoadVerifiedSnapshotSource(
+                FixtureProjectRelativePath,
+                dllPath);
+            Assert.That(verified, Is.Not.Null, "Precondition: a verified snapshot must exist.");
+
+            string mvid;
+            using (Mono.Cecil.AssemblyDefinition assemblyDefinition =
+                   Mono.Cecil.AssemblyDefinition.ReadAssembly(
+                       dllPath,
+                       new Mono.Cecil.ReaderParameters { InMemory = true }))
+            {
+                mvid = assemblyDefinition.MainModule.Mvid.ToString("N");
+            }
+
+            string slashNormalizedRelativePath = FixtureProjectRelativePath.Replace('\\', '/');
+            string snapshotFileName =
+                HotReloadSourceSnapshotter.HashProjectRelativePath(slashNormalizedRelativePath) + ".cs";
+            string realSnapshotPath = Path.Combine(
+                projectRoot,
+                HotReloadConstants.SourceSnapshotRelativeDirectory,
+                TestAssemblyName + "-" + mvid,
+                snapshotFileName);
+            Assert.That(File.Exists(realSnapshotPath), Is.True);
+
+            string fakeRoot = Path.Combine(Path.GetTempPath(), "uloop-hot-reload-snapshot-tamper-" + Guid.NewGuid().ToString("N"));
+            string fakeSnapshotDir = Path.Combine(
+                fakeRoot,
+                HotReloadConstants.SourceSnapshotRelativeDirectory,
+                TestAssemblyName + "-" + mvid);
+            Directory.CreateDirectory(fakeSnapshotDir);
+            string fakeSnapshotPath = Path.Combine(fakeSnapshotDir, snapshotFileName);
+            byte[] tampered = File.ReadAllBytes(realSnapshotPath);
+            tampered[0] = (byte)(tampered[0] ^ 0xFF);
+            File.WriteAllBytes(fakeSnapshotPath, tampered);
+
+            try
+            {
+                string loaded = HotReloadSourceBaseline.LoadVerifiedSnapshotSourceAt(
+                    fakeRoot,
+                    FixtureProjectRelativePath,
+                    dllPath);
+                Assert.That(loaded, Is.Null);
+            }
+            finally
+            {
+                if (Directory.Exists(fakeRoot))
+                {
+                    Directory.Delete(fakeRoot, recursive: true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// What: path matching tolerates separator differences and absolute-vs-relative document URLs, and on Windows ignores case.
+        /// </summary>
+        [Test]
+        public void PathsReferToSameFile_MatchesRelativeAbsoluteAndSeparatorVariants()
+        {
+            const string relativePath = "Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs";
+
+            Assert.That(
+                HotReloadSourcePathNormalizer.PathsReferToSameFile(relativePath, relativePath),
+                Is.True);
+            Assert.That(
+                HotReloadSourcePathNormalizer.PathsReferToSameFile(
+                    relativePath.Replace('/', '\\'),
+                    relativePath),
+                Is.True);
+            Assert.That(
+                HotReloadSourcePathNormalizer.PathsReferToSameFile(
+                    "/Users/example/project/" + relativePath,
+                    relativePath),
+                Is.True);
+            Assert.That(
+                HotReloadSourcePathNormalizer.PathsReferToSameFile(
+                    "C:/proj/" + relativePath.Replace('/', '\\'),
+                    relativePath),
+                Is.True);
+            Assert.That(
+                HotReloadSourcePathNormalizer.PathsReferToSameFile(
+                    "Assets/Other/File.cs",
+                    relativePath),
+                Is.False);
+
+            if (Path.DirectorySeparatorChar == '\\')
+            {
+                Assert.That(
+                    HotReloadSourcePathNormalizer.PathsReferToSameFile(
+                        relativePath.ToUpperInvariant(),
+                        relativePath),
+                    Is.True);
+            }
         }
 
         private static Document FindDocumentForProjectRelativePath(

--- a/Assets/Tests/Editor/HotReload/HotReloadSourceSnapshotTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSourceSnapshotTests.cs
@@ -10,9 +10,13 @@ using Mono.Cecil.Pdb;
 
 using NUnit.Framework;
 
+using UnityEditor.Compilation;
+
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
@@ -181,6 +185,126 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         relativePath),
                     Is.True);
             }
+        }
+
+        /// <summary>
+        /// What: stale MVID snapshot directories for the same assembly name are pruned, while hyphenated sibling assembly names and non-MVID suffixes are kept.
+        /// </summary>
+        [Test]
+        public void DeleteStaleSnapshotDirectories_RemovesOnlyExactMvidSiblings()
+        {
+            string tempRoot = Path.Combine(
+                Path.GetTempPath(),
+                "uloop-hot-reload-snapshot-prune-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempRoot);
+
+            string mvidA = Guid.NewGuid().ToString("N");
+            string mvidB = Guid.NewGuid().ToString("N");
+            string mvidC = Guid.NewGuid().ToString("N");
+            string currentDir = Path.Combine(tempRoot, "Foo-" + mvidA);
+            string staleDir = Path.Combine(tempRoot, "Foo-" + mvidB);
+            string siblingAssemblyDir = Path.Combine(tempRoot, "Foo-Bar-" + mvidC);
+            string nonMvidDir = Path.Combine(tempRoot, "Foo-notamvid");
+            Directory.CreateDirectory(currentDir);
+            Directory.CreateDirectory(staleDir);
+            Directory.CreateDirectory(siblingAssemblyDir);
+            Directory.CreateDirectory(nonMvidDir);
+
+            try
+            {
+                HotReloadSourceSnapshotter.DeleteStaleSnapshotDirectories(tempRoot, "Foo", currentDir);
+
+                Assert.That(Directory.Exists(currentDir), Is.True);
+                Assert.That(Directory.Exists(staleDir), Is.False);
+                Assert.That(Directory.Exists(siblingAssemblyDir), Is.True);
+                Assert.That(Directory.Exists(nonMvidDir), Is.True);
+            }
+            finally
+            {
+                if (Directory.Exists(tempRoot))
+                {
+                    Directory.Delete(tempRoot, recursive: true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// What: stamp matching accepts only the exact mvid,mtime,length triple and rejects malformed or mismatched stamps.
+        /// </summary>
+        [Test]
+        public void HasMatchingStamp_AcceptsExactTripleAndRejectsMismatchOrMalformed()
+        {
+            string tempRoot = Path.Combine(
+                Path.GetTempPath(),
+                "uloop-hot-reload-snapshot-stamp-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempRoot);
+            string stampPath = Path.Combine(tempRoot, "Foo.stamp");
+            const long mtimeTicks = 123456789L;
+            const long byteLength = 4096L;
+            string mvid = Guid.NewGuid().ToString("N");
+
+            try
+            {
+                File.WriteAllText(stampPath, mvid + "," + mtimeTicks + "," + byteLength);
+                Assert.That(HotReloadSourceSnapshotter.HasMatchingStamp(stampPath, mtimeTicks, byteLength), Is.True);
+                Assert.That(HotReloadSourceSnapshotter.HasMatchingStamp(stampPath, mtimeTicks + 1, byteLength), Is.False);
+                Assert.That(HotReloadSourceSnapshotter.HasMatchingStamp(stampPath, mtimeTicks, byteLength + 1), Is.False);
+
+                File.WriteAllText(stampPath, mvid + "," + mtimeTicks);
+                Assert.That(HotReloadSourceSnapshotter.HasMatchingStamp(stampPath, mtimeTicks, byteLength), Is.False);
+
+                File.WriteAllText(stampPath, "," + mtimeTicks + "," + byteLength);
+                Assert.That(HotReloadSourceSnapshotter.HasMatchingStamp(stampPath, mtimeTicks, byteLength), Is.False);
+            }
+            finally
+            {
+                if (Directory.Exists(tempRoot))
+                {
+                    Directory.Delete(tempRoot, recursive: true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// What: immutable registry package sources are skipped while Assets and embedded package sources are captured.
+        /// </summary>
+        [Test]
+        public void ShouldSkipImmutablePackageSources_SkipsRegistryKeepsAssetsAndEmbedded()
+        {
+            Assert.That(
+                HotReloadSourceSnapshotter.ShouldSkipImmutablePackageSources(
+                    new[] { FixtureProjectRelativePath }),
+                Is.False,
+                "Assets scripts must be captured.");
+
+            string embeddedSourcePath = FindSourceFileForAssembly("UnityCLILoop.FirstPartyTools.HotReload.Editor");
+            Assert.That(
+                HotReloadSourceSnapshotter.ShouldSkipImmutablePackageSources(new[] { embeddedSourcePath }),
+                Is.False,
+                "Embedded package scripts must be captured.");
+
+            string registrySourcePath = FindSourceFileForAssembly("Unity.InputSystem");
+            Assert.That(
+                HotReloadSourceSnapshotter.ShouldSkipImmutablePackageSources(new[] { registrySourcePath }),
+                Is.True,
+                "Registry package scripts must be skipped.");
+        }
+
+        private static string FindSourceFileForAssembly(string assemblyName)
+        {
+            foreach (UnityCompilationAssembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name != assemblyName)
+                {
+                    continue;
+                }
+
+                Assert.That(assembly.sourceFiles, Is.Not.Null.And.Not.Empty);
+                return assembly.sourceFiles[0];
+            }
+
+            Assert.Fail("CompilationPipeline assembly not found: " + assemblyName);
+            return null;
         }
 
         private static Document FindDocumentForProjectRelativePath(

--- a/Assets/Tests/Editor/HotReload/HotReloadSourceSnapshotTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSourceSnapshotTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30827d35c23644cb59f8ceca7d6c7416
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/FirstPartyToolsEditorStartup.cs
+++ b/Packages/src/Editor/FirstPartyTools/FirstPartyToolsEditorStartup.cs
@@ -12,6 +12,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ExternalSceneChangeTracker.Initialize();
             ControlPlayModeEditorStartup.Initialize();
             PausePointEditorStartup.Initialize();
+            HotReloadEditorStartup.Initialize();
             ExecuteDynamicCodeEditorStartup.Initialize();
             GetLogsEditorStartup.Initialize();
             ScreenshotEditorStartup.Initialize();

--- a/Packages/src/Editor/FirstPartyTools/HotReload/AssemblyInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/AssemblyInfo.cs
@@ -3,3 +3,7 @@ using System.Runtime.CompilerServices;
 // Spike / production EditMode tests live in the dedicated HotReload test asmdef and need
 // visibility into the publicizer / matcher / patcher internals.
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.HotReload")]
+
+// Why: CompositionRoot's asmdef does not reference HotReload, so domain-reload snapshot
+// capture is registered through the FirstPartyTools.Editor facade (same pattern as PausePoint).
+[assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Editor")]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -26,6 +26,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // EditMode e2e tests place edited source copies here so AssetDatabase is never provoked.
         public const string TestSourcesRelativeDirectory = "Library/UloopHotReload/TestSources";
 
+        // Per-assembly source snapshots keyed by assembly name + Mvid; file names are SHA256 of
+        // the project-relative source path (slash-normalized) so separators and MAX_PATH never
+        // affect the on-disk layout. Adoption is decided at use time by PDB document checksum.
+        public const string SourceSnapshotRelativeDirectory = "Library/UloopHotReload/SourceSnapshot";
+
         // Package-relative path of the out-of-process transform worker source (tilde dir = Unity-ignored).
         public const string WorkerSourcePackageRelativePath =
             "Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEditorStartup.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEditorStartup.cs
@@ -1,0 +1,25 @@
+using UnityEditor;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    // Keeps hot-reload startup wiring inside the hot-reload assembly so the composition
+    // root only depends on the bundled-tool facade.
+    internal static class HotReloadEditorStartup
+    {
+        public static void Initialize()
+        {
+            // Why not EditorApplication.delayCall: a cold-start session that hits Unity's native
+            // "Scripts have compiler errors" dialog never flushes delayCall again for the rest of
+            // that process's lifetime, even for later registrations — while
+            // EditorApplication.update keeps ticking (see SetupWizardWindow.cs:56-70). Capture is
+            // racy-safe (use-time PDB checksum), so running on the first update tick is fine.
+            void CaptureOnFirstUpdateTick()
+            {
+                EditorApplication.update -= CaptureOnFirstUpdateTick;
+                HotReloadSourceSnapshotter.CaptureAfterDomainReload();
+            }
+
+            EditorApplication.update += CaptureOnFirstUpdateTick;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEditorStartup.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEditorStartup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28f5fd38560724a17a3a8ab561737c11
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourceBaseline.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourceBaseline.cs
@@ -1,0 +1,162 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Cecil.Pdb;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Loads a PDB-checksum-verified source snapshot for edited-method detection.
+    /// </summary>
+    internal static class HotReloadSourceBaseline
+    {
+        /// <summary>
+        /// Returns the verified snapshot text for <paramref name="projectRelativeSourcePath"/>,
+        /// or null when no snapshot passes the portable-PDB document checksum check.
+        /// </summary>
+        public static string LoadVerifiedSnapshotSource(string projectRelativeSourcePath, string targetDllPath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativeSourcePath), "projectRelativeSourcePath must not be null or empty.");
+            Debug.Assert(!string.IsNullOrEmpty(targetDllPath), "targetDllPath must not be null or empty.");
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            return LoadVerifiedSnapshotSourceAt(projectRoot, projectRelativeSourcePath, targetDllPath);
+        }
+
+        // projectRoot is injectable so EditMode tests can point at a tampered snapshot tree
+        // without expanding the public API surface.
+        internal static string LoadVerifiedSnapshotSourceAt(
+            string projectRoot,
+            string projectRelativeSourcePath,
+            string targetDllPath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty.");
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativeSourcePath), "projectRelativeSourcePath must not be null or empty.");
+            Debug.Assert(!string.IsNullOrEmpty(targetDllPath), "targetDllPath must not be null or empty.");
+
+            string pdbPath = Path.ChangeExtension(targetDllPath, ".pdb");
+            if (!File.Exists(targetDllPath) || !File.Exists(pdbPath))
+            {
+                return null;
+            }
+
+            string mvid = ReadAssemblyMvid(targetDllPath);
+            string assemblyName = Path.GetFileNameWithoutExtension(targetDllPath);
+            string slashNormalizedRelativePath = projectRelativeSourcePath.Replace('\\', '/');
+            string snapshotFileName = HotReloadSourceSnapshotter.HashProjectRelativePath(slashNormalizedRelativePath) + ".cs";
+            string snapshotPath = Path.Combine(
+                projectRoot,
+                HotReloadConstants.SourceSnapshotRelativeDirectory,
+                assemblyName + "-" + mvid,
+                snapshotFileName);
+            if (!File.Exists(snapshotPath))
+            {
+                return null;
+            }
+
+            // Why read once: the verified bytes must be the exact payload decoded for the worker —
+            // a second read could race with another writer and diverge from the checksummed content.
+            byte[] snapshotBytes = File.ReadAllBytes(snapshotPath);
+            Document document = FindDocumentForProjectRelativePath(targetDllPath, pdbPath, slashNormalizedRelativePath);
+            if (document == null || document.Hash == null || document.Hash.Length == 0)
+            {
+                return null;
+            }
+
+            byte[] actualHash = ComputeDocumentHash(document.HashAlgorithm, snapshotBytes);
+            if (actualHash == null || !actualHash.SequenceEqual(document.Hash))
+            {
+                return null;
+            }
+
+            using MemoryStream memoryStream = new MemoryStream(snapshotBytes, writable: false);
+            using StreamReader reader = new StreamReader(memoryStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            return reader.ReadToEnd();
+        }
+
+        private static string ReadAssemblyMvid(string dllPath)
+        {
+            ReaderParameters readerParameters = new ReaderParameters { InMemory = true };
+            using AssemblyDefinition assemblyDefinition = AssemblyDefinition.ReadAssembly(dllPath, readerParameters);
+            return assemblyDefinition.MainModule.Mvid.ToString("N");
+        }
+
+        private static Document FindDocumentForProjectRelativePath(
+            string dllPath,
+            string pdbPath,
+            string projectRelativePath)
+        {
+            using FileStream dllStream = File.Open(dllPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using FileStream pdbStream = File.Open(pdbPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+
+            ReaderParameters readerParameters = new ReaderParameters
+            {
+                InMemory = true,
+                ReadSymbols = true,
+                SymbolReaderProvider = new PortablePdbReaderProvider(),
+                SymbolStream = pdbStream
+            };
+
+            using AssemblyDefinition assemblyDefinition = AssemblyDefinition.ReadAssembly(dllStream, readerParameters);
+            foreach (TypeDefinition type in assemblyDefinition.MainModule.GetTypes())
+            {
+                foreach (MethodDefinition method in type.Methods)
+                {
+                    if (!method.HasBody)
+                    {
+                        continue;
+                    }
+
+                    MethodDebugInformation debugInformation = method.DebugInformation;
+                    if (debugInformation == null || !debugInformation.HasSequencePoints)
+                    {
+                        continue;
+                    }
+
+                    foreach (SequencePoint sequencePoint in debugInformation.SequencePoints)
+                    {
+                        if (sequencePoint.IsHidden || sequencePoint.Document == null)
+                        {
+                            continue;
+                        }
+
+                        if (HotReloadSourcePathNormalizer.PathsReferToSameFile(
+                                sequencePoint.Document.Url,
+                                projectRelativePath))
+                        {
+                            return sequencePoint.Document;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static byte[] ComputeDocumentHash(DocumentHashAlgorithm algorithm, byte[] sourceBytes)
+        {
+            switch (algorithm)
+            {
+                case DocumentHashAlgorithm.SHA1:
+                    using (SHA1 sha1 = SHA1.Create())
+                    {
+                        return sha1.ComputeHash(sourceBytes);
+                    }
+                case DocumentHashAlgorithm.SHA256:
+                    using (SHA256 sha256 = SHA256.Create())
+                    {
+                        return sha256.ComputeHash(sourceBytes);
+                    }
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourceBaseline.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourceBaseline.cs
@@ -47,7 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return null;
             }
 
-            string mvid = ReadAssemblyMvid(targetDllPath);
+            string mvid = HotReloadSourceSnapshotter.ReadAssemblyMvid(targetDllPath);
             string assemblyName = Path.GetFileNameWithoutExtension(targetDllPath);
             string slashNormalizedRelativePath = projectRelativeSourcePath.Replace('\\', '/');
             string snapshotFileName = HotReloadSourceSnapshotter.HashProjectRelativePath(slashNormalizedRelativePath) + ".cs";
@@ -79,13 +79,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             using MemoryStream memoryStream = new MemoryStream(snapshotBytes, writable: false);
             using StreamReader reader = new StreamReader(memoryStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
             return reader.ReadToEnd();
-        }
-
-        private static string ReadAssemblyMvid(string dllPath)
-        {
-            ReaderParameters readerParameters = new ReaderParameters { InMemory = true };
-            using AssemblyDefinition assemblyDefinition = AssemblyDefinition.ReadAssembly(dllPath, readerParameters);
-            return assemblyDefinition.MainModule.Mvid.ToString("N");
         }
 
         private static Document FindDocumentForProjectRelativePath(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourceBaseline.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourceBaseline.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 602a634cce8d74df49cb73cfcf2c4d8a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourcePathNormalizer.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourcePathNormalizer.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Compares a PDB document URL against a project-relative script path for snapshot adoption.
+    /// Same semantics as SourcePausePointPathNormalizer; kept local because PausePoint is a
+    /// separate asmdef that HotReload must not reference.
+    /// </summary>
+    internal static class HotReloadSourcePathNormalizer
+    {
+        public static string ToForwardSlashes(string path)
+        {
+            Debug.Assert(path != null, "path must not be null.");
+            return path.Replace('\\', '/');
+        }
+
+        public static bool PathsReferToSameFile(string documentUrl, string projectRelativePath)
+        {
+            Debug.Assert(documentUrl != null, "documentUrl must not be null.");
+            Debug.Assert(projectRelativePath != null, "projectRelativePath must not be null.");
+
+            string normalizedDocumentUrl = ToForwardSlashes(documentUrl);
+            string normalizedRelativePath = ToForwardSlashes(projectRelativePath);
+            StringComparison comparison = Path.DirectorySeparatorChar == '\\'
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            if (string.Equals(normalizedDocumentUrl, normalizedRelativePath, comparison))
+            {
+                return true;
+            }
+
+            return normalizedDocumentUrl.EndsWith("/" + normalizedRelativePath, comparison);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourcePathNormalizer.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourcePathNormalizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd379ecab3f5144b79317f409bcc1d09
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourceSnapshotter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourceSnapshotter.cs
@@ -6,10 +6,12 @@ using System.Text;
 using Mono.Cecil;
 
 using UnityEditor.Compilation;
+using UnityEditor.PackageManager;
 
 using UnityEngine;
 
 using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
+using PackageManagerPackageInfo = UnityEditor.PackageManager.PackageInfo;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
@@ -18,8 +20,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class HotReloadSourceSnapshotter
     {
-        private const string PackageCacheRelativePrefix = "Library/PackageCache/";
         private const string StampFileExtension = ".stamp";
+        private const string IncompleteSnapshotDirectorySuffix = ".tmp";
 
         /// <summary>
         /// Captures snapshots for project assemblies that have adjacent portable PDBs.
@@ -50,7 +52,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return;
             }
 
-            if (AreAllSourcesUnderPackageCache(projectRoot, sourceFiles))
+            if (ShouldSkipImmutablePackageSources(sourceFiles))
             {
                 return;
             }
@@ -73,7 +75,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why stamp short-circuits Cecil: a false stamp (identical mtime+length with different
             // bytes) is vanishingly rare, and even then LoadVerifiedSnapshotSource rejects via PDB
             // checksum — so stamp lies degrade to fallback, never to a wrong method diff.
-            if (TryReadMatchingStamp(stampPath, dllMtimeTicks, dllByteLength, out string stampedMvid))
+            if (HasMatchingStamp(stampPath, dllMtimeTicks, dllByteLength))
             {
                 return;
             }
@@ -82,48 +84,44 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string assemblySnapshotDirectory = Path.Combine(snapshotRoot, assembly.name + "-" + mvid);
             if (!Directory.Exists(assemblySnapshotDirectory))
             {
-                Directory.CreateDirectory(assemblySnapshotDirectory);
-                foreach (string projectRelativeSourcePath in sourceFiles)
-                {
-                    CopySourceFileByteExact(projectRoot, assemblySnapshotDirectory, projectRelativeSourcePath);
-                }
-
+                CaptureAssemblySourcesAtomically(projectRoot, assemblySnapshotDirectory, sourceFiles);
                 DeleteStaleSnapshotDirectories(snapshotRoot, assembly.name, assemblySnapshotDirectory);
             }
 
             WriteStamp(stampPath, mvid, dllMtimeTicks, dllByteLength);
         }
 
-        private static bool AreAllSourcesUnderPackageCache(string projectRoot, string[] sourceFiles)
+        /// <summary>
+        /// Returns whether an assembly's sources belong to an immutable package and must not be
+        /// snapshotted. Uses Package Manager metadata so Windows (where GetFullPath does not
+        /// resolve package junctions) and macOS behave the same.
+        /// </summary>
+        internal static bool ShouldSkipImmutablePackageSources(string[] sourceFiles)
         {
-            // Why resolve to a real path: CompilationPipeline reports package scripts as
-            // Packages/<id>/... virtual paths, which resolve under Library/PackageCache/ on disk.
-            // Matching the virtual prefix alone never skips immutable package assemblies.
-            string packageCacheRoot = Path.GetFullPath(Path.Combine(projectRoot, PackageCacheRelativePrefix.TrimEnd('/')))
-                .Replace('\\', '/');
-            string packageCachePrefix = packageCacheRoot + "/";
+            Debug.Assert(sourceFiles != null, "sourceFiles must not be null.");
+            Debug.Assert(sourceFiles.Length > 0, "sourceFiles must not be empty.");
 
-            foreach (string sourceFile in sourceFiles)
+            // asmdef boundaries keep one assembly inside one package scope, so the first file
+            // is enough to classify the whole assembly.
+            PackageManagerPackageInfo packageInfo = PackageManagerPackageInfo.FindForAssetPath(sourceFiles[0]);
+            if (packageInfo == null)
             {
-                string absolutePath = Path.GetFullPath(
-                        Path.Combine(projectRoot, sourceFile.Replace('/', Path.DirectorySeparatorChar)))
-                    .Replace('\\', '/');
-                if (!absolutePath.StartsWith(packageCachePrefix, StringComparison.Ordinal))
-                {
-                    return false;
-                }
+                // Assets/ (and other non-package) scripts are editable — capture them.
+                return false;
             }
 
+            if (packageInfo.source == PackageSource.Embedded || packageInfo.source == PackageSource.Local)
+            {
+                // Project-owned packages remain editable via hot reload — capture them.
+                return false;
+            }
+
+            // Registry / BuiltIn / Git / LocalTarball are immutable for hot-reload purposes.
             return true;
         }
 
-        private static bool TryReadMatchingStamp(
-            string stampPath,
-            long dllMtimeTicks,
-            long dllByteLength,
-            out string stampedMvid)
+        internal static bool HasMatchingStamp(string stampPath, long dllMtimeTicks, long dllByteLength)
         {
-            stampedMvid = null;
             if (!File.Exists(stampPath))
             {
                 return false;
@@ -136,19 +134,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return false;
             }
 
+            if (string.IsNullOrEmpty(parts[0]))
+            {
+                return false;
+            }
+
             if (!long.TryParse(parts[1], out long stampedMtimeTicks)
                 || !long.TryParse(parts[2], out long stampedByteLength))
             {
                 return false;
             }
 
-            if (stampedMtimeTicks != dllMtimeTicks || stampedByteLength != dllByteLength)
-            {
-                return false;
-            }
-
-            stampedMvid = parts[0];
-            return !string.IsNullOrEmpty(stampedMvid);
+            return stampedMtimeTicks == dllMtimeTicks && stampedByteLength == dllByteLength;
         }
 
         private static void WriteStamp(string stampPath, string mvid, long dllMtimeTicks, long dllByteLength)
@@ -161,6 +158,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ReaderParameters readerParameters = new ReaderParameters { InMemory = true };
             using AssemblyDefinition assemblyDefinition = AssemblyDefinition.ReadAssembly(dllPath, readerParameters);
             return assemblyDefinition.MainModule.Mvid.ToString("N");
+        }
+
+        private static void CaptureAssemblySourcesAtomically(
+            string projectRoot,
+            string assemblySnapshotDirectory,
+            string[] sourceFiles)
+        {
+            // Why temp + Move: Directory.Exists is the "complete" signal. Copying into the final
+            // directory first would leave a partial tree on interrupt that later reloads treat as
+            // done and stamp-short-circuit forever. A sibling .tmp only becomes visible as complete
+            // after Move succeeds.
+            string temporaryDirectory = assemblySnapshotDirectory + IncompleteSnapshotDirectorySuffix;
+            if (Directory.Exists(temporaryDirectory))
+            {
+                Directory.Delete(temporaryDirectory, recursive: true);
+            }
+
+            Directory.CreateDirectory(temporaryDirectory);
+            foreach (string projectRelativeSourcePath in sourceFiles)
+            {
+                CopySourceFileByteExact(projectRoot, temporaryDirectory, projectRelativeSourcePath);
+            }
+
+            Directory.Move(temporaryDirectory, assemblySnapshotDirectory);
         }
 
         private static void CopySourceFileByteExact(
@@ -198,7 +219,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return builder.ToString();
         }
 
-        private static void DeleteStaleSnapshotDirectories(
+        internal static void DeleteStaleSnapshotDirectories(
             string snapshotRoot,
             string assemblyName,
             string currentSnapshotDirectory)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourceSnapshotter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourceSnapshotter.cs
@@ -1,0 +1,236 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+using Mono.Cecil;
+
+using UnityEditor.Compilation;
+
+using UnityEngine;
+
+using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Captures byte-exact source snapshots after domain reload for edited-method detection.
+    /// </summary>
+    internal static class HotReloadSourceSnapshotter
+    {
+        private const string PackageCacheRelativePrefix = "Library/PackageCache/";
+        private const string StampFileExtension = ".stamp";
+
+        /// <summary>
+        /// Captures snapshots for project assemblies that have adjacent portable PDBs.
+        /// Why: adoption is decided at use time by PDB document checksum, so a racy capture
+        /// (edit between compile and this call) can only fail closed into "no baseline" —
+        /// never into a silently wrong method diff.
+        /// </summary>
+        internal static void CaptureAfterDomainReload()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string snapshotRoot = Path.Combine(projectRoot, HotReloadConstants.SourceSnapshotRelativeDirectory);
+            Directory.CreateDirectory(snapshotRoot);
+
+            foreach (UnityCompilationAssembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                CaptureAssemblyIfNeeded(projectRoot, snapshotRoot, assembly);
+            }
+        }
+
+        private static void CaptureAssemblyIfNeeded(
+            string projectRoot,
+            string snapshotRoot,
+            UnityCompilationAssembly assembly)
+        {
+            string[] sourceFiles = assembly.sourceFiles;
+            if (sourceFiles == null || sourceFiles.Length == 0)
+            {
+                return;
+            }
+
+            if (AreAllSourcesUnderPackageCache(projectRoot, sourceFiles))
+            {
+                return;
+            }
+
+            string dllPath = Path.Combine(
+                projectRoot,
+                HotReloadConstants.ScriptAssembliesRelativeDirectory,
+                assembly.name + HotReloadConstants.CompiledAssemblyExtension);
+            string pdbPath = Path.ChangeExtension(dllPath, ".pdb");
+            if (!File.Exists(dllPath) || !File.Exists(pdbPath))
+            {
+                return;
+            }
+
+            FileInfo dllInfo = new FileInfo(dllPath);
+            long dllMtimeTicks = dllInfo.LastWriteTimeUtc.Ticks;
+            long dllByteLength = dllInfo.Length;
+            string stampPath = Path.Combine(snapshotRoot, assembly.name + StampFileExtension);
+
+            // Why stamp short-circuits Cecil: a false stamp (identical mtime+length with different
+            // bytes) is vanishingly rare, and even then LoadVerifiedSnapshotSource rejects via PDB
+            // checksum — so stamp lies degrade to fallback, never to a wrong method diff.
+            if (TryReadMatchingStamp(stampPath, dllMtimeTicks, dllByteLength, out string stampedMvid))
+            {
+                return;
+            }
+
+            string mvid = ReadAssemblyMvid(dllPath);
+            string assemblySnapshotDirectory = Path.Combine(snapshotRoot, assembly.name + "-" + mvid);
+            if (!Directory.Exists(assemblySnapshotDirectory))
+            {
+                Directory.CreateDirectory(assemblySnapshotDirectory);
+                foreach (string projectRelativeSourcePath in sourceFiles)
+                {
+                    CopySourceFileByteExact(projectRoot, assemblySnapshotDirectory, projectRelativeSourcePath);
+                }
+
+                DeleteStaleSnapshotDirectories(snapshotRoot, assembly.name, assemblySnapshotDirectory);
+            }
+
+            WriteStamp(stampPath, mvid, dllMtimeTicks, dllByteLength);
+        }
+
+        private static bool AreAllSourcesUnderPackageCache(string projectRoot, string[] sourceFiles)
+        {
+            // Why resolve to a real path: CompilationPipeline reports package scripts as
+            // Packages/<id>/... virtual paths, which resolve under Library/PackageCache/ on disk.
+            // Matching the virtual prefix alone never skips immutable package assemblies.
+            string packageCacheRoot = Path.GetFullPath(Path.Combine(projectRoot, PackageCacheRelativePrefix.TrimEnd('/')))
+                .Replace('\\', '/');
+            string packageCachePrefix = packageCacheRoot + "/";
+
+            foreach (string sourceFile in sourceFiles)
+            {
+                string absolutePath = Path.GetFullPath(
+                        Path.Combine(projectRoot, sourceFile.Replace('/', Path.DirectorySeparatorChar)))
+                    .Replace('\\', '/');
+                if (!absolutePath.StartsWith(packageCachePrefix, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool TryReadMatchingStamp(
+            string stampPath,
+            long dllMtimeTicks,
+            long dllByteLength,
+            out string stampedMvid)
+        {
+            stampedMvid = null;
+            if (!File.Exists(stampPath))
+            {
+                return false;
+            }
+
+            string stampText = File.ReadAllText(stampPath).Trim();
+            string[] parts = stampText.Split(',');
+            if (parts.Length != 3)
+            {
+                return false;
+            }
+
+            if (!long.TryParse(parts[1], out long stampedMtimeTicks)
+                || !long.TryParse(parts[2], out long stampedByteLength))
+            {
+                return false;
+            }
+
+            if (stampedMtimeTicks != dllMtimeTicks || stampedByteLength != dllByteLength)
+            {
+                return false;
+            }
+
+            stampedMvid = parts[0];
+            return !string.IsNullOrEmpty(stampedMvid);
+        }
+
+        private static void WriteStamp(string stampPath, string mvid, long dllMtimeTicks, long dllByteLength)
+        {
+            File.WriteAllText(stampPath, mvid + "," + dllMtimeTicks + "," + dllByteLength);
+        }
+
+        private static string ReadAssemblyMvid(string dllPath)
+        {
+            ReaderParameters readerParameters = new ReaderParameters { InMemory = true };
+            using AssemblyDefinition assemblyDefinition = AssemblyDefinition.ReadAssembly(dllPath, readerParameters);
+            return assemblyDefinition.MainModule.Mvid.ToString("N");
+        }
+
+        private static void CopySourceFileByteExact(
+            string projectRoot,
+            string assemblySnapshotDirectory,
+            string projectRelativeSourcePath)
+        {
+            string normalizedRelativePath = projectRelativeSourcePath.Replace('\\', '/');
+            string absoluteSourcePath = Path.Combine(projectRoot, normalizedRelativePath.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(absoluteSourcePath))
+            {
+                return;
+            }
+
+            string snapshotFileName = HashProjectRelativePath(normalizedRelativePath) + ".cs";
+            string destinationPath = Path.Combine(assemblySnapshotDirectory, snapshotFileName);
+            byte[] bytes = File.ReadAllBytes(absoluteSourcePath);
+            File.WriteAllBytes(destinationPath, bytes);
+        }
+
+        internal static string HashProjectRelativePath(string slashNormalizedProjectRelativePath)
+        {
+            Debug.Assert(
+                slashNormalizedProjectRelativePath != null,
+                "slashNormalizedProjectRelativePath must not be null.");
+            byte[] utf8 = Encoding.UTF8.GetBytes(slashNormalizedProjectRelativePath);
+            using SHA256 sha256 = SHA256.Create();
+            byte[] hash = sha256.ComputeHash(utf8);
+            StringBuilder builder = new StringBuilder(hash.Length * 2);
+            for (int index = 0; index < hash.Length; index++)
+            {
+                builder.Append(hash[index].ToString("x2"));
+            }
+
+            return builder.ToString();
+        }
+
+        private static void DeleteStaleSnapshotDirectories(
+            string snapshotRoot,
+            string assemblyName,
+            string currentSnapshotDirectory)
+        {
+            string currentFullPath = Path.GetFullPath(currentSnapshotDirectory);
+            string prefix = assemblyName + "-";
+            foreach (string candidateDirectory in Directory.GetDirectories(snapshotRoot, assemblyName + "-*"))
+            {
+                if (string.Equals(
+                        Path.GetFullPath(candidateDirectory),
+                        currentFullPath,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                string directoryName = Path.GetFileName(candidateDirectory);
+                if (directoryName.Length <= prefix.Length)
+                {
+                    continue;
+                }
+
+                // Why: the glob is a prefix match, so hyphenated sibling assembly names also match.
+                // Only delete when the suffix after "<assemblyName>-" is exactly an Mvid in "N" format.
+                string mvidCandidate = directoryName.Substring(prefix.Length);
+                if (!Guid.TryParseExact(mvidCandidate, "N", out Guid _))
+                {
+                    continue;
+                }
+
+                Directory.Delete(candidateDirectory, recursive: true);
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourceSnapshotter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourceSnapshotter.cs
@@ -153,7 +153,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             File.WriteAllText(stampPath, mvid + "," + dllMtimeTicks + "," + dllByteLength);
         }
 
-        private static string ReadAssemblyMvid(string dllPath)
+        internal static string ReadAssemblyMvid(string dllPath)
         {
             ReaderParameters readerParameters = new ReaderParameters { InMemory = true };
             using AssemblyDefinition assemblyDefinition = AssemblyDefinition.ReadAssembly(dllPath, readerParameters);
@@ -207,7 +207,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(
                 slashNormalizedProjectRelativePath != null,
                 "slashNormalizedProjectRelativePath must not be null.");
-            byte[] utf8 = Encoding.UTF8.GetBytes(slashNormalizedProjectRelativePath);
+
+            string hashInput = slashNormalizedProjectRelativePath;
+            // Why lowercase only on Windows: PDB document matching is OrdinalIgnoreCase there, so
+            // a case-only path difference must hash to the same snapshot filename. Unix filesystems
+            // can be case-sensitive, so leave the path bytes unchanged on those platforms.
+            if (Path.DirectorySeparatorChar == '\\')
+            {
+                hashInput = hashInput.ToLowerInvariant();
+            }
+
+            byte[] utf8 = Encoding.UTF8.GetBytes(hashInput);
             using SHA256 sha256 = SHA256.Create();
             byte[] hash = sha256.ComputeHash(utf8);
             StringBuilder builder = new StringBuilder(hash.Length * 2);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourceSnapshotter.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourceSnapshotter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee63f7808c0454de58f3aa9b3806c108
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Adds PDB-validated source snapshots under `Library/UloopHotReload/SourceSnapshot/` so later hot-reload work can detect which methods actually changed.
- **This PR does not change hot-reload behavior yet** — nothing reads the snapshots; capture + verified load only.

## User Impact
- No end-user facing change in this PR.
- Enables the follow-up work that patches only edited methods (instead of every method in a file) once wired in subsequent PRs.

## Changes
- Permanent EditMode gate test: portable PDB document checksum matches on-disk source bytes.
- After domain reload, capture byte-exact sources for editable assemblies (stamp short-circuit; MVID directories; prune stale MVIDs).
- Startup uses a self-unsubscribing `EditorApplication.update` one-shot (same reason as SetupWizardWindow: `delayCall` can stop flushing for the process lifetime after the compiler-errors dialog).
- Immutable package skip uses `PackageInfo.FindForAssetPath` (`Registry` / `BuiltIn` / `Git` / `LocalTarball` skipped; `Embedded` / `Local` / Assets captured) so Windows does not depend on junction resolution.
- Snapshot directories are published atomically (`*.tmp` copy then `Directory.Move`) so a partial capture cannot be stamped as complete.
- `HotReloadSourceBaseline.LoadVerifiedSnapshotSource` adopts a snapshot only when its bytes hash to the PDB document checksum.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → ErrorCount=0, WarningCount=0
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value HotReload` → TestCount=104, PassedCount=104, FailedCount=0
- After reload: `SourceSnapshot` had 52 dirs + 52 stamps; `UnityCLILoop.Tests.Editor.HotReload-<mvid>` + `.stamp` present; registry PackageCache assemblies absent (50 skipped / 52 captured of 102)
