### PR TITLE
feat: diff edited methods against a source snapshot in the worker

### DIFF
--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -292,7 +292,146 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + reasonFragment + "'.");
         }
 
-        private static async Task<TransformWorkerClientResult> RunWorkerOnE2EFixtureAsync()
+        /// <summary>
+        /// What: with a snapshot whose ComputeWithPrivate body differs, the worker emits only that edited method and reports a positive unchangedMethodCount for the rest.
+        /// </summary>
+        [Test]
+        public async Task Run_WithSnapshotDifferingOnlyInOneMethod_EmitsOnlyEditedMethod()
+        {
+            string onDisk = File.ReadAllText(ResolveE2EFixturePath());
+            string snapshotSource = onDisk.Replace(
+                "return _secret + delta;",
+                "return _secret + delta + 999;",
+                StringComparison.Ordinal);
+            Assert.That(snapshotSource, Is.Not.EqualTo(onDisk), "Precondition: snapshot must differ.");
+
+            TransformWorkerClientResult result = await RunWorkerOnE2EFixtureAsync(snapshotSource);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.unchangedMethodCount, Is.GreaterThan(0));
+
+            bool foundCompute = false;
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                Assert.That(
+                    entry.methodName,
+                    Is.Not.EqualTo(nameof(HotReloadE2EFixture.QueryPrivate)),
+                    "Unedited QueryPrivate must not appear in entries.");
+                if (entry.methodName == nameof(HotReloadE2EFixture.ComputeWithPrivate))
+                {
+                    foundCompute = true;
+                }
+            }
+
+            Assert.That(foundCompute, Is.True, "Edited ComputeWithPrivate must appear in entries.");
+
+            if (result.Output.skipped != null)
+            {
+                foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+                {
+                    Assert.That(
+                        skipped.method,
+                        Does.Not.Contain(nameof(HotReloadE2EFixture.QueryPrivate)),
+                        "Unedited QueryPrivate must not appear in skipped.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// What: a snapshot that differs only by EOL (LF↔CRLF) treats every method as unchanged — Windows guardrail for line-ending noise.
+        /// </summary>
+        [Test]
+        public async Task Run_WithSnapshotDifferingOnlyByEol_TreatsAllMethodsUnchanged()
+        {
+            string onDisk = File.ReadAllText(ResolveE2EFixturePath());
+            string normalizedLf = onDisk.Replace("\r\n", "\n", StringComparison.Ordinal);
+            string snapshotSource = normalizedLf.Contains('\n')
+                ? normalizedLf.Replace("\n", "\r\n", StringComparison.Ordinal)
+                : normalizedLf + "\r\n";
+            Assert.That(snapshotSource, Is.Not.EqualTo(onDisk), "Precondition: EOL-swapped snapshot must differ as raw text.");
+
+            TransformWorkerClientResult result = await RunWorkerOnE2EFixtureAsync(snapshotSource);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.entries, Is.Empty);
+            Assert.That(result.Output.unchangedMethodCount, Is.GreaterThan(0));
+        }
+
+        /// <summary>
+        /// What: a snapshot that changes only a field initializer emits the outside-method-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Run_WithSnapshotFieldInitializerChanged_EmitsOutsideMethodBodyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveE2EFixturePath());
+            string snapshotSource = onDisk.Replace(
+                "private int _secret = 10;",
+                "private int _secret = 11;",
+                StringComparison.Ordinal);
+            Assert.That(snapshotSource, Is.Not.EqualTo(onDisk));
+
+            TransformWorkerClientResult result = await RunWorkerOnE2EFixtureAsync(snapshotSource);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.declarationDriftWarnings, Is.Not.Null);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.Some.Contain("Edits outside method bodies in HotReloadE2EFixtures.cs"));
+        }
+
+        /// <summary>
+        /// What: a snapshot that duplicates a method key falls back to no-baseline behavior (same entries as a null snapshot, unchangedMethodCount 0).
+        /// </summary>
+        [Test]
+        public async Task Run_WithSnapshotDuplicateMethodKey_FallsBackToNoBaseline()
+        {
+            string onDisk = File.ReadAllText(ResolveE2EFixturePath());
+            const string queryPrivateBlock =
+                @"        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int QueryPrivate()
+        {
+            int[] values = { 1, 2, 3 };
+            return (from value in values where value < _secret select value).Count();
+        }
+";
+            Assert.That(onDisk, Does.Contain("public int QueryPrivate()"));
+            // Duplicate the method inside HotReloadE2EFixture so BuildSyntaxMethodKey collides.
+            const string classCloseMarker =
+                "            return token.N;\n        }\n    }\n\n    /// <summary>\n    /// Internal type used only by";
+            int markerIndex = onDisk.IndexOf(classCloseMarker, StringComparison.Ordinal);
+            Assert.That(markerIndex, Is.GreaterThan(0), "Could not locate HotReloadE2EFixture class close for duplicate insert.");
+            int insertAt = onDisk.IndexOf("\n    }\n\n    /// <summary>", markerIndex, StringComparison.Ordinal);
+            Assert.That(insertAt, Is.GreaterThan(0));
+            string snapshotSource = onDisk.Insert(insertAt + 1, queryPrivateBlock);
+
+            TransformWorkerClientResult baseline = await RunWorkerOnE2EFixtureAsync();
+            TransformWorkerClientResult withCollision = await RunWorkerOnE2EFixtureAsync(snapshotSource);
+            Assert.That(baseline.Success, Is.True, baseline.ErrorMessage);
+            Assert.That(withCollision.Success, Is.True, withCollision.ErrorMessage);
+            Assert.That(withCollision.Output.unchangedMethodCount, Is.EqualTo(0));
+
+            HashSet<string> baselineKeys = CollectEntryKeys(baseline.Output.entries);
+            HashSet<string> collisionKeys = CollectEntryKeys(withCollision.Output.entries);
+            Assert.That(collisionKeys, Is.EquivalentTo(baselineKeys));
+        }
+
+        private static HashSet<string> CollectEntryKeys(TransformWorkerEntryDto[] entries)
+        {
+            HashSet<string> keys = new HashSet<string>();
+            if (entries == null)
+            {
+                return keys;
+            }
+
+            foreach (TransformWorkerEntryDto entry in entries)
+            {
+                keys.Add(
+                    entry.typeMetadataName + "::" + entry.methodName + "("
+                    + string.Join(",", entry.parameterTypeFullNames ?? Array.Empty<string>()) + ")");
+            }
+
+            return keys;
+        }
+
+        private static async Task<TransformWorkerClientResult> RunWorkerOnE2EFixtureAsync(
+            string snapshotSource = null)
         {
             string fixturePath = ResolveE2EFixturePath();
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
@@ -320,7 +459,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 sourcePath = fixturePath,
                 defines = compilationAssembly.defines ?? System.Array.Empty<string>(),
                 referencePaths = compilationAssembly.allReferences,
-                targetTypesAssemblyPath = targetDllPath
+                targetTypesAssemblyPath = targetDllPath,
+                snapshotSource = snapshotSource
             };
 
             return await TransformWorkerClient.RunAsync(input, CancellationToken.None);

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -308,6 +308,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             TransformWorkerClientResult result = await RunWorkerOnE2EFixtureAsync(snapshotSource);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(result.Output.unchangedMethodCount, Is.GreaterThan(0));
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.None.Contain("Edits outside method bodies"),
+                "Method-body-only edits must not emit the outside-method-body drift warning.");
 
             bool foundCompute = false;
             foreach (TransformWorkerEntryDto entry in result.Output.entries)
@@ -344,15 +348,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             string onDisk = File.ReadAllText(ResolveE2EFixturePath());
             string normalizedLf = onDisk.Replace("\r\n", "\n", StringComparison.Ordinal);
-            string snapshotSource = normalizedLf.Contains('\n')
-                ? normalizedLf.Replace("\n", "\r\n", StringComparison.Ordinal)
-                : normalizedLf + "\r\n";
+            // Opposite EOL of the on-disk bytes so the precondition holds for both LF and CRLF checkouts.
+            string snapshotSource = onDisk.Contains("\r\n", StringComparison.Ordinal)
+                ? normalizedLf
+                : normalizedLf.Replace("\n", "\r\n", StringComparison.Ordinal);
             Assert.That(snapshotSource, Is.Not.EqualTo(onDisk), "Precondition: EOL-swapped snapshot must differ as raw text.");
 
             TransformWorkerClientResult result = await RunWorkerOnE2EFixtureAsync(snapshotSource);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(result.Output.entries, Is.Empty);
             Assert.That(result.Output.unchangedMethodCount, Is.GreaterThan(0));
+            Assert.That(result.Output.skipped, Is.Empty);
+            Assert.That(result.Output.declarationDriftWarnings, Is.Empty);
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -16,6 +16,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Method keys (see HotReloadOrchestrator.BuildMethodKey) already reported Failed from a
         // first compile round; the retry worker run drops these methods entirely.
         public string[] excludedMethodKeys;
+
+        // Verified snapshot text for edited-method detection. Null = no baseline, patch all methods.
+        // Why pass text (not a path): avoids an IO race between orchestrator verification and worker
+        // read that would crash the whole file under the no-try-catch policy.
+        public string snapshotSource;
     }
 
     /// <summary>
@@ -29,6 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public TransformWorkerSkippedDto[] skipped;
         public string[] parseErrors;
         public string[] declarationDriftWarnings;
+        public int unchangedMethodCount;
     }
 
     [Serializable]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -212,11 +212,41 @@ public static class TransformWorkerProgram
             semanticModel,
             targetTypesAssemblySymbol);
 
+        // Syntax-key maps for edited-method detection. Distinct from BuildMethodKey (Cecil names):
+        // same-file old/new comparison only needs syntax keys to stay consistent with each other.
+        bool hasBaseline = false;
+        Dictionary<string, MethodDeclarationSyntax> snapshotMethodMap = null;
+        Dictionary<string, PropertyDeclarationSyntax> snapshotPropertyMap = null;
+        Dictionary<string, IndexerDeclarationSyntax> snapshotIndexerMap = null;
+        if (!string.IsNullOrEmpty(input.SnapshotSource))
+        {
+            CompilationUnitSyntax snapshotRoot = CSharpSyntaxTree.ParseText(
+                    SourceText.From(input.SnapshotSource, Encoding.UTF8),
+                    parseOptions)
+                .GetCompilationUnitRoot();
+            if (TryBuildSyntaxMethodMap(snapshotRoot, out Dictionary<string, MethodDeclarationSyntax> snapMethods)
+                && TryBuildSyntaxMethodMap(root, out Dictionary<string, MethodDeclarationSyntax> _))
+            {
+                // Why both maps: a duplicate key on either side makes AreEquivalent matching
+                // ambiguous, so fail closed to no-baseline (patch all) instead of guessing.
+                hasBaseline = true;
+                snapshotMethodMap = snapMethods;
+                TryBuildSyntaxPropertyMap(snapshotRoot, out snapshotPropertyMap);
+                TryBuildSyntaxIndexerMap(snapshotRoot, out snapshotIndexerMap);
+                AppendOutsideMethodBodyDriftWarningIfNeeded(
+                    snapshotRoot,
+                    root,
+                    Path.GetFileName(input.SourcePath),
+                    declarationDriftWarnings);
+            }
+        }
+
         List<WorkerEntry> entries = new List<WorkerEntry>();
         List<WorkerSkipped> skipped = new List<WorkerSkipped>();
         List<ShimTypeBuilder> shimTypes = new List<ShimTypeBuilder>();
         int globalShimMethodCounter = 0;
         int shimTypeCounter = 0;
+        int unchangedMethodCount = 0;
 
         foreach (TypeDeclarationSyntax typeDeclaration in EnumerateTypeDeclarations(root))
         {
@@ -228,7 +258,12 @@ public static class TransformWorkerProgram
 
             // Accessors are never patched in v1; report each explicit-body accessor as Skipped
             // so an edited getter/setter never disappears from the response silently.
-            AppendExplicitAccessorSkips(typeDeclaration, semanticModel, skipped);
+            AppendExplicitAccessorSkips(
+                typeDeclaration,
+                semanticModel,
+                skipped,
+                hasBaseline ? snapshotPropertyMap : null,
+                hasBaseline ? snapshotIndexerMap : null);
 
             List<MethodDeclarationSyntax> methods = typeDeclaration.Members
                 .OfType<MethodDeclarationSyntax>()
@@ -238,6 +273,7 @@ public static class TransformWorkerProgram
                 continue;
             }
 
+            string typeMetadataNameFromSyntax = BuildTypeMetadataNameFromSyntax(typeDeclaration);
             ShimTypeBuilder currentShimType = null;
             foreach (MethodDeclarationSyntax methodDeclaration in methods)
             {
@@ -258,6 +294,20 @@ public static class TransformWorkerProgram
                 if (input.ExcludedMethodKeys.Contains(methodKey))
                 {
                     continue;
+                }
+
+                // Why after ExcludedMethodKeys: exclusion means "already Failed on first round", so
+                // it must win. Unchanged methods add no per-method signal — skipping them cuts
+                // response noise and avoids pause-point collateral on untouched methods.
+                if (hasBaseline)
+                {
+                    string syntaxMethodKey = BuildSyntaxMethodKey(typeMetadataNameFromSyntax, methodDeclaration);
+                    if (snapshotMethodMap.TryGetValue(syntaxMethodKey, out MethodDeclarationSyntax snapshotDecl)
+                        && SyntaxFactory.AreEquivalent(snapshotDecl, methodDeclaration, topLevel: false))
+                    {
+                        unchangedMethodCount++;
+                        continue;
+                    }
                 }
 
                 MethodTransformDecision decision = DecideMethodTransform(
@@ -327,7 +377,8 @@ public static class TransformWorkerProgram
             Entries = entries.ToArray(),
             Skipped = skipped.ToArray(),
             DeclarationDriftWarnings = declarationDriftWarnings.ToArray(),
-            ParseErrors = parseErrors.ToArray()
+            ParseErrors = parseErrors.ToArray(),
+            UnchangedMethodCount = unchangedMethodCount
         };
     }
 
@@ -490,17 +541,240 @@ public static class TransformWorkerProgram
     private const string ExplicitAccessorSkipReason =
         "Property and indexer accessors are out of scope for v1; run 'uloop compile' to apply accessor edits.";
 
+    private const string OutsideMethodBodyDriftWarningFormat =
+        "Edits outside method bodies in {0} (fields, initializers, attributes, or added/removed members) are not applied by hot reload; run uloop compile to pick them up.";
+
+    // Syntax-based method key for same-file snapshot vs current comparison. Do not mix with
+    // BuildMethodKey (Cecil/metadata names used by the orchestrator exclusion path).
+    private static string BuildSyntaxMethodKey(string typeMetadataName, MethodDeclarationSyntax methodDeclaration)
+    {
+        List<string> parameterKeys = new List<string>();
+        if (methodDeclaration.ParameterList != null)
+        {
+            foreach (ParameterSyntax parameter in methodDeclaration.ParameterList.Parameters)
+            {
+                parameterKeys.Add(BuildSyntaxParameterTypeKey(parameter));
+            }
+        }
+
+        return typeMetadataName + "::" + methodDeclaration.Identifier.Text + "("
+            + string.Join(",", parameterKeys) + ")";
+    }
+
+    private static string BuildSyntaxParameterTypeKey(ParameterSyntax parameter)
+    {
+        string typeText = parameter.Type != null ? parameter.Type.ToString() : string.Empty;
+        if (parameter.Modifiers.Any(SyntaxKind.RefKeyword)
+            || parameter.Modifiers.Any(SyntaxKind.OutKeyword)
+            || parameter.Modifiers.Any(SyntaxKind.InKeyword))
+        {
+            typeText += "&";
+        }
+
+        return typeText;
+    }
+
+    private static string BuildTypeMetadataNameFromSyntax(TypeDeclarationSyntax typeDeclaration)
+    {
+        List<string> nestedNames = new List<string>();
+        TypeDeclarationSyntax current = typeDeclaration;
+        while (current != null)
+        {
+            string simpleName = current.Identifier.Text;
+            if (current.TypeParameterList != null && current.TypeParameterList.Parameters.Count > 0)
+            {
+                simpleName += "`" + current.TypeParameterList.Parameters.Count.ToString(CultureInfo.InvariantCulture);
+            }
+
+            nestedNames.Add(simpleName);
+            current = current.Parent as TypeDeclarationSyntax;
+        }
+
+        nestedNames.Reverse();
+        string typeMetadataName = string.Join("+", nestedNames);
+
+        string namespaceName = GetContainingNamespaceName(typeDeclaration);
+        if (string.IsNullOrEmpty(namespaceName))
+        {
+            return typeMetadataName;
+        }
+
+        return namespaceName + "." + typeMetadataName;
+    }
+
+    private static string GetContainingNamespaceName(SyntaxNode node)
+    {
+        SyntaxNode current = node.Parent;
+        while (current != null)
+        {
+            if (current is NamespaceDeclarationSyntax namespaceDeclaration)
+            {
+                return namespaceDeclaration.Name.ToString();
+            }
+
+            if (current is FileScopedNamespaceDeclarationSyntax fileScopedNamespace)
+            {
+                return fileScopedNamespace.Name.ToString();
+            }
+
+            current = current.Parent;
+        }
+
+        return string.Empty;
+    }
+
+    private static string BuildSyntaxPropertyKey(PropertyDeclarationSyntax propertyDeclaration)
+    {
+        string name = propertyDeclaration.Identifier.Text;
+        if (propertyDeclaration.ExplicitInterfaceSpecifier != null)
+        {
+            return propertyDeclaration.ExplicitInterfaceSpecifier.Name + "." + name;
+        }
+
+        return name;
+    }
+
+    private static string BuildSyntaxIndexerKey(IndexerDeclarationSyntax indexerDeclaration)
+    {
+        List<string> parameterKeys = new List<string>();
+        if (indexerDeclaration.ParameterList != null)
+        {
+            foreach (ParameterSyntax parameter in indexerDeclaration.ParameterList.Parameters)
+            {
+                parameterKeys.Add(BuildSyntaxParameterTypeKey(parameter));
+            }
+        }
+
+        return "this(" + string.Join(",", parameterKeys) + ")";
+    }
+
+    private static bool TryBuildSyntaxMethodMap(
+        CompilationUnitSyntax root,
+        out Dictionary<string, MethodDeclarationSyntax> map)
+    {
+        map = new Dictionary<string, MethodDeclarationSyntax>();
+        foreach (TypeDeclarationSyntax typeDeclaration in EnumerateTypeDeclarations(root))
+        {
+            string typeMetadataName = BuildTypeMetadataNameFromSyntax(typeDeclaration);
+            foreach (MethodDeclarationSyntax methodDeclaration in typeDeclaration.Members.OfType<MethodDeclarationSyntax>())
+            {
+                string key = BuildSyntaxMethodKey(typeMetadataName, methodDeclaration);
+                if (map.ContainsKey(key))
+                {
+                    map = null;
+                    return false;
+                }
+
+                map[key] = methodDeclaration;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryBuildSyntaxPropertyMap(
+        CompilationUnitSyntax root,
+        out Dictionary<string, PropertyDeclarationSyntax> map)
+    {
+        map = new Dictionary<string, PropertyDeclarationSyntax>();
+        foreach (TypeDeclarationSyntax typeDeclaration in EnumerateTypeDeclarations(root))
+        {
+            foreach (PropertyDeclarationSyntax propertyDeclaration in typeDeclaration.Members.OfType<PropertyDeclarationSyntax>())
+            {
+                string key = BuildSyntaxPropertyKey(propertyDeclaration);
+                if (map.ContainsKey(key))
+                {
+                    map = null;
+                    return false;
+                }
+
+                map[key] = propertyDeclaration;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryBuildSyntaxIndexerMap(
+        CompilationUnitSyntax root,
+        out Dictionary<string, IndexerDeclarationSyntax> map)
+    {
+        map = new Dictionary<string, IndexerDeclarationSyntax>();
+        foreach (TypeDeclarationSyntax typeDeclaration in EnumerateTypeDeclarations(root))
+        {
+            foreach (IndexerDeclarationSyntax indexerDeclaration in typeDeclaration.Members.OfType<IndexerDeclarationSyntax>())
+            {
+                string key = BuildSyntaxIndexerKey(indexerDeclaration);
+                if (map.ContainsKey(key))
+                {
+                    map = null;
+                    return false;
+                }
+
+                map[key] = indexerDeclaration;
+            }
+        }
+
+        return true;
+    }
+
+    private static void AppendOutsideMethodBodyDriftWarningIfNeeded(
+        CompilationUnitSyntax snapshotRoot,
+        CompilationUnitSyntax currentRoot,
+        string fileName,
+        List<string> declarationDriftWarnings)
+    {
+        StripMethodBodiesRewriter rewriter = new StripMethodBodiesRewriter();
+        SyntaxNode strippedSnapshot = rewriter.Visit(snapshotRoot);
+        SyntaxNode strippedCurrent = rewriter.Visit(currentRoot);
+        if (!SyntaxFactory.AreEquivalent(strippedSnapshot, strippedCurrent, topLevel: false))
+        {
+            declarationDriftWarnings.Add(
+                string.Format(CultureInfo.InvariantCulture, OutsideMethodBodyDriftWarningFormat, fileName));
+        }
+    }
+
+    private sealed class StripMethodBodiesRewriter : CSharpSyntaxRewriter
+    {
+        public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            MethodDeclarationSyntax visited = (MethodDeclarationSyntax)base.VisitMethodDeclaration(node);
+            if (visited.Body == null && visited.ExpressionBody == null)
+            {
+                return visited;
+            }
+
+            return visited
+                .WithExpressionBody(null)
+                .WithSemicolonToken(default(SyntaxToken))
+                .WithBody(SyntaxFactory.Block());
+        }
+    }
+
     // What: reports each property/indexer accessor that has an explicit body as Skipped.
     // Auto-properties ({ get; set; }) have no body and are not listed.
+    // When a verified snapshot declares an equivalent property/indexer, skip rows are omitted
+    // (unchanged accessors must not appear as Skipped noise).
     private static void AppendExplicitAccessorSkips(
         TypeDeclarationSyntax typeDeclaration,
         SemanticModel semanticModel,
-        List<WorkerSkipped> skipped)
+        List<WorkerSkipped> skipped,
+        Dictionary<string, PropertyDeclarationSyntax> snapshotPropertyMap,
+        Dictionary<string, IndexerDeclarationSyntax> snapshotIndexerMap)
     {
         foreach (MemberDeclarationSyntax member in typeDeclaration.Members)
         {
             if (member is PropertyDeclarationSyntax propertyDeclaration)
             {
+                if (snapshotPropertyMap != null
+                    && snapshotPropertyMap.TryGetValue(
+                        BuildSyntaxPropertyKey(propertyDeclaration),
+                        out PropertyDeclarationSyntax snapshotProperty)
+                    && SyntaxFactory.AreEquivalent(snapshotProperty, propertyDeclaration, topLevel: false))
+                {
+                    continue;
+                }
+
                 AppendExplicitAccessorSkipsForProperty(
                     propertyDeclaration,
                     semanticModel.GetDeclaredSymbol(propertyDeclaration),
@@ -510,6 +784,15 @@ public static class TransformWorkerProgram
 
             if (member is IndexerDeclarationSyntax indexerDeclaration)
             {
+                if (snapshotIndexerMap != null
+                    && snapshotIndexerMap.TryGetValue(
+                        BuildSyntaxIndexerKey(indexerDeclaration),
+                        out IndexerDeclarationSyntax snapshotIndexer)
+                    && SyntaxFactory.AreEquivalent(snapshotIndexer, indexerDeclaration, topLevel: false))
+                {
+                    continue;
+                }
+
                 AppendExplicitAccessorSkipsForProperty(
                     indexerDeclaration,
                     semanticModel.GetDeclaredSymbol(indexerDeclaration),
@@ -3132,6 +3415,11 @@ internal sealed class WorkerInput
     // reported Failed from a first compile round; the retry excludes them so it does not fail
     // on the same error again.
     public string[] ExcludedMethodKeys { get; set; }
+
+    // Verified snapshot text for edited-method detection. Null = no baseline, patch all methods.
+    // Why pass text (not a path): avoids an IO race between orchestrator verification and worker
+    // read that would crash the whole file under the no-try-catch policy.
+    public string SnapshotSource { get; set; }
 }
 
 internal sealed class WorkerOutput
@@ -3145,6 +3433,8 @@ internal sealed class WorkerOutput
     public string[] DeclarationDriftWarnings { get; set; }
 
     public string[] ParseErrors { get; set; }
+
+    public int UnchangedMethodCount { get; set; }
 }
 
 internal sealed class WorkerEntry

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -218,21 +218,25 @@ public static class TransformWorkerProgram
         Dictionary<string, MethodDeclarationSyntax> snapshotMethodMap = null;
         Dictionary<string, PropertyDeclarationSyntax> snapshotPropertyMap = null;
         Dictionary<string, IndexerDeclarationSyntax> snapshotIndexerMap = null;
-        if (!string.IsNullOrEmpty(input.SnapshotSource))
+        // Null disables comparison; empty string is a real (empty) baseline text.
+        if (input.SnapshotSource != null)
         {
             CompilationUnitSyntax snapshotRoot = CSharpSyntaxTree.ParseText(
                     SourceText.From(input.SnapshotSource, Encoding.UTF8),
                     parseOptions)
                 .GetCompilationUnitRoot();
-            if (TryBuildSyntaxMethodMap(snapshotRoot, out Dictionary<string, MethodDeclarationSyntax> snapMethods)
-                && TryBuildSyntaxMethodMap(root, out Dictionary<string, MethodDeclarationSyntax> _))
+            Dictionary<string, MethodDeclarationSyntax> snapMethods = BuildSyntaxMethodMapOrNull(snapshotRoot);
+            Dictionary<string, MethodDeclarationSyntax> currentMethods = BuildSyntaxMethodMapOrNull(root);
+            if (snapMethods != null && currentMethods != null)
             {
                 // Why both maps: a duplicate key on either side makes AreEquivalent matching
                 // ambiguous, so fail closed to no-baseline (patch all) instead of guessing.
                 hasBaseline = true;
                 snapshotMethodMap = snapMethods;
-                TryBuildSyntaxPropertyMap(snapshotRoot, out snapshotPropertyMap);
-                TryBuildSyntaxIndexerMap(snapshotRoot, out snapshotIndexerMap);
+                // Why null is kept as-is: a colliding property/indexer key only disables accessor
+                // gating for this file; method-level baseline matching still applies.
+                snapshotPropertyMap = BuildSyntaxPropertyMapOrNull(snapshotRoot);
+                snapshotIndexerMap = BuildSyntaxIndexerMapOrNull(snapshotRoot);
                 AppendOutsideMethodBodyDriftWarningIfNeeded(
                     snapshotRoot,
                     root,
@@ -256,10 +260,13 @@ public static class TransformWorkerProgram
                 continue;
             }
 
+            string typeMetadataNameFromSyntax = BuildTypeMetadataNameFromSyntax(typeDeclaration);
+
             // Accessors are never patched in v1; report each explicit-body accessor as Skipped
             // so an edited getter/setter never disappears from the response silently.
             AppendExplicitAccessorSkips(
                 typeDeclaration,
+                typeMetadataNameFromSyntax,
                 semanticModel,
                 skipped,
                 hasBaseline ? snapshotPropertyMap : null,
@@ -273,7 +280,6 @@ public static class TransformWorkerProgram
                 continue;
             }
 
-            string typeMetadataNameFromSyntax = BuildTypeMetadataNameFromSyntax(typeDeclaration);
             ShimTypeBuilder currentShimType = null;
             foreach (MethodDeclarationSyntax methodDeclaration in methods)
             {
@@ -623,18 +629,22 @@ public static class TransformWorkerProgram
         return string.Empty;
     }
 
-    private static string BuildSyntaxPropertyKey(PropertyDeclarationSyntax propertyDeclaration)
+    private static string BuildSyntaxPropertyKey(
+        string typeMetadataName,
+        PropertyDeclarationSyntax propertyDeclaration)
     {
         string name = propertyDeclaration.Identifier.Text;
         if (propertyDeclaration.ExplicitInterfaceSpecifier != null)
         {
-            return propertyDeclaration.ExplicitInterfaceSpecifier.Name + "." + name;
+            name = propertyDeclaration.ExplicitInterfaceSpecifier.Name + "." + name;
         }
 
-        return name;
+        return typeMetadataName + "::" + name;
     }
 
-    private static string BuildSyntaxIndexerKey(IndexerDeclarationSyntax indexerDeclaration)
+    private static string BuildSyntaxIndexerKey(
+        string typeMetadataName,
+        IndexerDeclarationSyntax indexerDeclaration)
     {
         List<string> parameterKeys = new List<string>();
         if (indexerDeclaration.ParameterList != null)
@@ -645,14 +655,13 @@ public static class TransformWorkerProgram
             }
         }
 
-        return "this(" + string.Join(",", parameterKeys) + ")";
+        return typeMetadataName + "::this(" + string.Join(",", parameterKeys) + ")";
     }
 
-    private static bool TryBuildSyntaxMethodMap(
-        CompilationUnitSyntax root,
-        out Dictionary<string, MethodDeclarationSyntax> map)
+    private static Dictionary<string, MethodDeclarationSyntax> BuildSyntaxMethodMapOrNull(
+        CompilationUnitSyntax root)
     {
-        map = new Dictionary<string, MethodDeclarationSyntax>();
+        Dictionary<string, MethodDeclarationSyntax> map = new Dictionary<string, MethodDeclarationSyntax>();
         foreach (TypeDeclarationSyntax typeDeclaration in EnumerateTypeDeclarations(root))
         {
             string typeMetadataName = BuildTypeMetadataNameFromSyntax(typeDeclaration);
@@ -661,61 +670,58 @@ public static class TransformWorkerProgram
                 string key = BuildSyntaxMethodKey(typeMetadataName, methodDeclaration);
                 if (map.ContainsKey(key))
                 {
-                    map = null;
-                    return false;
+                    return null;
                 }
 
                 map[key] = methodDeclaration;
             }
         }
 
-        return true;
+        return map;
     }
 
-    private static bool TryBuildSyntaxPropertyMap(
-        CompilationUnitSyntax root,
-        out Dictionary<string, PropertyDeclarationSyntax> map)
+    private static Dictionary<string, PropertyDeclarationSyntax> BuildSyntaxPropertyMapOrNull(
+        CompilationUnitSyntax root)
     {
-        map = new Dictionary<string, PropertyDeclarationSyntax>();
+        Dictionary<string, PropertyDeclarationSyntax> map = new Dictionary<string, PropertyDeclarationSyntax>();
         foreach (TypeDeclarationSyntax typeDeclaration in EnumerateTypeDeclarations(root))
         {
+            string typeMetadataName = BuildTypeMetadataNameFromSyntax(typeDeclaration);
             foreach (PropertyDeclarationSyntax propertyDeclaration in typeDeclaration.Members.OfType<PropertyDeclarationSyntax>())
             {
-                string key = BuildSyntaxPropertyKey(propertyDeclaration);
+                string key = BuildSyntaxPropertyKey(typeMetadataName, propertyDeclaration);
                 if (map.ContainsKey(key))
                 {
-                    map = null;
-                    return false;
+                    return null;
                 }
 
                 map[key] = propertyDeclaration;
             }
         }
 
-        return true;
+        return map;
     }
 
-    private static bool TryBuildSyntaxIndexerMap(
-        CompilationUnitSyntax root,
-        out Dictionary<string, IndexerDeclarationSyntax> map)
+    private static Dictionary<string, IndexerDeclarationSyntax> BuildSyntaxIndexerMapOrNull(
+        CompilationUnitSyntax root)
     {
-        map = new Dictionary<string, IndexerDeclarationSyntax>();
+        Dictionary<string, IndexerDeclarationSyntax> map = new Dictionary<string, IndexerDeclarationSyntax>();
         foreach (TypeDeclarationSyntax typeDeclaration in EnumerateTypeDeclarations(root))
         {
+            string typeMetadataName = BuildTypeMetadataNameFromSyntax(typeDeclaration);
             foreach (IndexerDeclarationSyntax indexerDeclaration in typeDeclaration.Members.OfType<IndexerDeclarationSyntax>())
             {
-                string key = BuildSyntaxIndexerKey(indexerDeclaration);
+                string key = BuildSyntaxIndexerKey(typeMetadataName, indexerDeclaration);
                 if (map.ContainsKey(key))
                 {
-                    map = null;
-                    return false;
+                    return null;
                 }
 
                 map[key] = indexerDeclaration;
             }
         }
 
-        return true;
+        return map;
     }
 
     private static void AppendOutsideMethodBodyDriftWarningIfNeeded(
@@ -757,6 +763,7 @@ public static class TransformWorkerProgram
     // (unchanged accessors must not appear as Skipped noise).
     private static void AppendExplicitAccessorSkips(
         TypeDeclarationSyntax typeDeclaration,
+        string typeMetadataNameFromSyntax,
         SemanticModel semanticModel,
         List<WorkerSkipped> skipped,
         Dictionary<string, PropertyDeclarationSyntax> snapshotPropertyMap,
@@ -768,7 +775,7 @@ public static class TransformWorkerProgram
             {
                 if (snapshotPropertyMap != null
                     && snapshotPropertyMap.TryGetValue(
-                        BuildSyntaxPropertyKey(propertyDeclaration),
+                        BuildSyntaxPropertyKey(typeMetadataNameFromSyntax, propertyDeclaration),
                         out PropertyDeclarationSyntax snapshotProperty)
                     && SyntaxFactory.AreEquivalent(snapshotProperty, propertyDeclaration, topLevel: false))
                 {
@@ -786,7 +793,7 @@ public static class TransformWorkerProgram
             {
                 if (snapshotIndexerMap != null
                     && snapshotIndexerMap.TryGetValue(
-                        BuildSyntaxIndexerKey(indexerDeclaration),
+                        BuildSyntaxIndexerKey(typeMetadataNameFromSyntax, indexerDeclaration),
                         out IndexerDeclarationSyntax snapshotIndexer)
                     && SyntaxFactory.AreEquivalent(snapshotIndexer, indexerDeclaration, topLevel: false))
                 {


### PR DESCRIPTION
## Summary
- The out-of-process hot-reload transform worker can now compare an edited file against a verified source snapshot and emit only methods whose syntax actually changed.
- **Unity does not send `snapshotSource` yet**, so runtime behavior is unchanged until the orchestrator wiring PR.

## User Impact
- No end-user facing change in this PR.
- Enables the follow-up wiring that stops patching (and pause-point-colliding with) untouched methods once the Editor passes a verified snapshot.

## Changes
- Worker input/output: `snapshotSource` (verified text; null = patch all) and `unchangedMethodCount`.
- Matching uses syntax keys (metadata-style type name + method + parameter types, with `ref`/`out`/`in` as `&`). Duplicate keys on either side fall back to no-baseline.
- Unchanged methods are skipped after `ExcludedMethodKeys` checks; equivalent properties/indexers omit accessor skip rows; outside-method-body edits add a declaration-drift warning.
- EditMode coverage: single-method edit, EOL-only snapshot, field-initializer drift warning, duplicate-key fallback.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → ErrorCount=0, WarningCount=0
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value HotReload` → TestCount=109, PassedCount=109, FailedCount=0


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

