### PR TITLE
feat: patch only edited methods using the source snapshot

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -78,7 +78,11 @@ and adopted only once it verifies against the compiled assembly's PDB checksums.
 a baseline, hot reload patches only the methods whose bodies actually changed;
 unchanged methods are left untouched and counted in `UnchangedTotal` (formatting,
 comments, and line-ending differences count as unchanged). A run where every method
-is unchanged succeeds with nothing patched. Without a baseline — for example before
+is unchanged succeeds with nothing patched.
+Convergence works in both directions: a currently patched method whose body matches
+the baseline again is unpatched on that run — the compiled IL comes back,
+`ActivePatchTotal` drops, and its pause-point block lifts.
+Without a baseline — for example before
 the first compile after installing or updating the package — every editable method in
 the file is patched and a `Warnings` line reports the fallback; run `uloop compile`
 to establish the baseline.

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -61,10 +61,31 @@ Hot reload never adds members. A refactor that extracts a new helper method cann
 applied piecewise — keep iterating inside existing method bodies, then run
 `uloop compile` once to introduce the new member for real.
 
-Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Changed `const` values (including enum member values) are detected and reported as a `Warnings` entry naming the constant and both values; other outside-body edits stay silent. Use `uloop compile` for such edits.
+Edits outside method bodies never take effect: changing a `const` value, a field
+initializer, or any declaration other than a method body leaves runtime behavior
+unchanged even though the response reports `Success` — shims resolve those symbols
+against the already-compiled assembly, and C# bakes `const` values into IL at compile
+time. Changed `const` values (including enum member values) are detected and reported
+as a `Warnings` entry naming the constant and both values. When a verified source
+baseline is available (next paragraph), other outside-body drift — fields,
+initializers, attributes, added or removed members — is reported as a `Warnings`
+entry as well; without a baseline it stays silent. Either way, use `uloop compile`
+for such edits.
+
+Each `uloop compile` also establishes a per-assembly source baseline: a snapshot of
+the sources exactly as they were compiled, captured after the compile's domain reload
+and adopted only once it verifies against the compiled assembly's PDB checksums. With
+a baseline, hot reload patches only the methods whose bodies actually changed;
+unchanged methods are left untouched and counted in `UnchangedTotal` (formatting,
+comments, and line-ending differences count as unchanged). A run where every method
+is unchanged succeeds with nothing patched. Without a baseline — for example before
+the first compile after installing or updating the package — every editable method in
+the file is patched and a `Warnings` line reports the fallback; run `uloop compile`
+to establish the baseline.
 
 Property and indexer accessors with explicit bodies are reported per-accessor as
-`Skipped`, so an edited getter never disappears from the response silently.
+`Skipped`, so an edited getter never disappears from the response silently; with a
+verified baseline, accessors unchanged from it produce no row.
 
 Subscribing to or unsubscribing from a field-like event (`+=`/`-=`) inside an edited
 body works. Methods that raise the event are reported as `Skipped` (see the table
@@ -160,8 +181,9 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
-- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough (or marked `[AggressiveInlining]`) to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
+- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough (or marked `[AggressiveInlining]`) to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
+- `UnchangedTotal` (number): Methods left untouched because their bodies match the source baseline from the last compile; `0` when no baseline was available
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)
 - `Message` (string): Short summary

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -78,7 +78,11 @@ and adopted only once it verifies against the compiled assembly's PDB checksums.
 a baseline, hot reload patches only the methods whose bodies actually changed;
 unchanged methods are left untouched and counted in `UnchangedTotal` (formatting,
 comments, and line-ending differences count as unchanged). A run where every method
-is unchanged succeeds with nothing patched. Without a baseline — for example before
+is unchanged succeeds with nothing patched.
+Convergence works in both directions: a currently patched method whose body matches
+the baseline again is unpatched on that run — the compiled IL comes back,
+`ActivePatchTotal` drops, and its pause-point block lifts.
+Without a baseline — for example before
 the first compile after installing or updating the package — every editable method in
 the file is patched and a `Warnings` line reports the fallback; run `uloop compile`
 to establish the baseline.

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -61,10 +61,31 @@ Hot reload never adds members. A refactor that extracts a new helper method cann
 applied piecewise — keep iterating inside existing method bodies, then run
 `uloop compile` once to introduce the new member for real.
 
-Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Changed `const` values (including enum member values) are detected and reported as a `Warnings` entry naming the constant and both values; other outside-body edits stay silent. Use `uloop compile` for such edits.
+Edits outside method bodies never take effect: changing a `const` value, a field
+initializer, or any declaration other than a method body leaves runtime behavior
+unchanged even though the response reports `Success` — shims resolve those symbols
+against the already-compiled assembly, and C# bakes `const` values into IL at compile
+time. Changed `const` values (including enum member values) are detected and reported
+as a `Warnings` entry naming the constant and both values. When a verified source
+baseline is available (next paragraph), other outside-body drift — fields,
+initializers, attributes, added or removed members — is reported as a `Warnings`
+entry as well; without a baseline it stays silent. Either way, use `uloop compile`
+for such edits.
+
+Each `uloop compile` also establishes a per-assembly source baseline: a snapshot of
+the sources exactly as they were compiled, captured after the compile's domain reload
+and adopted only once it verifies against the compiled assembly's PDB checksums. With
+a baseline, hot reload patches only the methods whose bodies actually changed;
+unchanged methods are left untouched and counted in `UnchangedTotal` (formatting,
+comments, and line-ending differences count as unchanged). A run where every method
+is unchanged succeeds with nothing patched. Without a baseline — for example before
+the first compile after installing or updating the package — every editable method in
+the file is patched and a `Warnings` line reports the fallback; run `uloop compile`
+to establish the baseline.
 
 Property and indexer accessors with explicit bodies are reported per-accessor as
-`Skipped`, so an edited getter never disappears from the response silently.
+`Skipped`, so an edited getter never disappears from the response silently; with a
+verified baseline, accessors unchanged from it produce no row.
 
 Subscribing to or unsubscribing from a field-like event (`+=`/`-=`) inside an edited
 body works. Methods that raise the event are reported as `Skipped` (see the table
@@ -160,8 +181,9 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
-- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough (or marked `[AggressiveInlining]`) to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
+- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough (or marked `[AggressiveInlining]`) to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
+- `UnchangedTotal` (number): Methods left untouched because their bodies match the source baseline from the last compile; `0` when no baseline was available
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)
 - `Message` (string): Short summary

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -810,6 +810,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             AssertNoFileLevelFailure(result);
             AssertHasPatched(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+
             bool foundDrift = false;
             foreach (string warning in result.Warnings)
             {
@@ -1031,6 +1032,43 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             fixture.EnableCounting();
             fixture.RaiseScore();
             Assert.That(fixture.HandledCount, Is.EqualTo(10));
+        }
+
+        /// <summary>
+        /// What: after patching an edited method, a later hot-reload against the on-disk baseline
+        /// reverts that patch so runtime behavior and ActivePatchTotal converge to the compiled IL.
+        /// </summary>
+        [Test]
+        public async Task Run_RevertedEditAfterPatch_RestoresOriginalBehaviorAndClearsPatch()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "RevertConvergence.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }"));
+
+            HotReloadOrchestratorResult patched = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(patched);
+            AssertHasPatched(patched, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(115));
+            Assert.That(patched.ActivePatchTotal, Is.EqualTo(1));
+
+            HotReloadOrchestratorResult reverted = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                contentPathOverride: null,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(reverted);
+            Assert.That(reverted.Methods, Is.Empty, FormatOutcomes(reverted));
+            Assert.That(reverted.UnchangedTotal, Is.GreaterThan(0));
+            Assert.That(reverted.ActivePatchTotal, Is.EqualTo(0));
+            Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(15));
         }
 
         /// <summary>
@@ -1294,7 +1332,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + "        }";
             string lambdaPrivate = lambdaPrivateMethod ??
                 "public int LambdaPrivate(int threshold)\n        {\n"
-                + "            System.Func<int, bool> pred = v => v < _secret;\n"
+                + "            Func<int, bool> pred = v => v < _secret;\n"
                 + "            return pred(threshold) ? 1 : 0;\n"
                 + "        }";
             string propertyPrivate = propertyPrivateRoundTripMethod ??
@@ -1337,7 +1375,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + "\n"
                 + "        private int this[int index] => _secret + index;";
 
-            return @"using System.Collections;
+            return @"using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -964,6 +964,61 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: with a verified source snapshot, hot reload patches only the edited method —
+        /// unedited methods appear neither as Patched nor Skipped, and the response carries the
+        /// unchanged count.
+        /// </summary>
+        [Test]
+        public async Task Run_WithVerifiedSnapshot_PatchesOnlyEditedMethod()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string fixtureProjectRelativePath =
+                "Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs";
+            string targetDllPath = Path.Combine(
+                projectRoot,
+                HotReloadConstants.ScriptAssembliesRelativeDirectory,
+                "UnityCLILoop.Tests.Editor.HotReload"
+                + HotReloadConstants.CompiledAssemblyExtension);
+
+            string snapshot = HotReloadSourceBaseline.LoadVerifiedSnapshotSource(
+                fixtureProjectRelativePath,
+                targetDllPath);
+            Assert.That(
+                snapshot,
+                Is.Not.Null,
+                "Verified snapshot must resolve for the E2E fixture; capture regresses otherwise.");
+
+            string editedPath = WriteEditedSource(
+                "OnlyEditedMethod.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                Assert.That(
+                    outcome.Method.Contains(nameof(HotReloadE2EFixture.QueryPrivate)),
+                    Is.False,
+                    "Unedited QueryPrivate must not appear as Patched/Skipped/Failed.\n"
+                    + FormatOutcomes(result));
+            }
+
+            Assert.That(result.UnchangedTotal, Is.GreaterThan(0));
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(115));
+        }
+
+        /// <summary>
         /// What: a shim compile error in one method no longer kills the file — the failing method
         /// reports Failed with its own compiler error (and the new-member hint) while the other
         /// methods still patch and take effect.

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -243,10 +243,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public async Task Run_MethodWithBaseCall_IsSkippedWithReason()
         {
             string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "CallsBaseEdited.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                    callsBaseMethod:
+                    "public int CallsBase()\n        {\n            return base.BaseSeed() + 2;\n        }"));
 
             HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
                 new[] { fixturePath },
-                contentPathOverride: null,
+                contentPathOverride: editedPath,
                 CancellationToken.None);
 
             AssertNoFileLevelFailure(result);
@@ -266,6 +273,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: running hot reload on the on-disk fixture with no edits yields an empty Methods
+        /// list, a positive UnchangedTotal, and the all-unchanged Message wording.
+        /// </summary>
+        [Test]
+        public async Task Run_OnDiskFixtureUnchanged_ReportsEmptyMethodsAndUnchangedTotal()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                contentPathOverride: null,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            Assert.That(result.Methods, Is.Empty, FormatOutcomes(result));
+            Assert.That(result.UnchangedTotal, Is.GreaterThan(0));
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+            Assert.That(
+                response.Message,
+                Does.Contain("methods are unchanged since the last compile; nothing to patch"));
+        }
+
+        /// <summary>
         /// What: one orchestrator run over the fixture reports the explicit-body property getter,
         /// the explicit-body property setter, and the expression-bodied indexer getter as Skipped
         /// with the v1 accessor reason, while auto-property accessors stay unlisted.
@@ -277,10 +308,27 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string editedPath = WriteEditedSource(
                 "ExplicitBodyGetter.cs",
                 BuildFixtureSource(
+                    computeWithPrivateMethod:
                     "public int ComputeWithPrivate(int delta)\n"
                     + "        {\n"
                     + "            return _secret + delta;\n"
-                    + "        }"));
+                    + "        }",
+                    explicitAccessorsBlock:
+                    "// Explicit-body getter — worker must report get_ExplicitBodyGetter as Skipped (not silent).\n"
+                    + "        public int ExplicitBodyGetter\n"
+                    + "        {\n"
+                    + "            get { return _secret + 1; }\n"
+                    + "        }\n"
+                    + "\n"
+                    + "        // Explicit-body setter — worker must report set_ExplicitBodySetter as Skipped (not silent).\n"
+                    + "        public int ExplicitBodySetter\n"
+                    + "        {\n"
+                    + "            set { _secret = value + 1; }\n"
+                    + "        }\n"
+                    + "\n"
+                    + "        public int Counter;\n"
+                    + "\n"
+                    + "        private int this[int index] => _secret + index + 1;"));
 
             HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
                 new[] { fixturePath },
@@ -396,10 +444,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 aggregatedInlineRiskCount,
                 Is.EqualTo(1),
                 "Expected exactly one aggregated inline-risk warning listing the at-risk methods.");
+
+            int declarationDriftCount = CountWarningsContaining(
+                result.Warnings,
+                "Edits outside method bodies");
             Assert.That(
                 result.Warnings,
-                Has.Count.EqualTo(1),
-                "This fixture run must emit only the aggregated inline-risk warning; any extra entry means per-method warning text has come back.");
+                Has.Count.EqualTo(1 + declarationDriftCount),
+                "Expected the aggregated inline-risk warning plus any declaration-drift warning(s).");
         }
 
         /// <summary>
@@ -437,16 +489,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(computeWithPrivatePatchedOperations, Is.EqualTo(2));
 
+            int declarationDriftCount = CountWarningsContaining(
+                result.Warnings,
+                "Edits outside method bodies");
             Assert.That(
                 result.Warnings,
-                Has.Count.EqualTo(1),
-                "This fixture run must emit only the aggregated inline-risk warning.");
+                Has.Count.EqualTo(1 + declarationDriftCount),
+                "Expected the aggregated inline-risk warning plus one declaration-drift warning per duplicate file input.");
 
-            string aggregatedWarning = result.Warnings[0];
+            string aggregatedWarning = null;
+            foreach (string warning in result.Warnings)
+            {
+                if (warning.Contains("patched methods had pre-patch bodies")
+                    && warning.Contains(nameof(HotReloadE2EFixture.ComputeWithPrivate)))
+                {
+                    aggregatedWarning = warning;
+                    break;
+                }
+            }
+
+            Assert.That(aggregatedWarning, Is.Not.Null, "Expected an aggregated inline-risk warning.");
             Assert.That(
                 CountOccurrences(aggregatedWarning, nameof(HotReloadE2EFixture.ComputeWithPrivate)),
                 Is.EqualTo(1),
                 "The aggregated warning must list a re-patched method once, not once per patch operation.");
+            Assert.That(
+                declarationDriftCount,
+                Is.EqualTo(2),
+                "Duplicate file inputs each emit a declaration-drift warning.");
         }
 
         /// <summary>
@@ -729,7 +799,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "ConstDrift.cs",
                 BuildFixtureSource(
                     computeWithPrivateMethod:
-                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }",
                     tuningConstDeclaration:
                     "private const int TuningConst = 4;"));
 
@@ -740,7 +810,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             AssertNoFileLevelFailure(result);
             AssertHasPatched(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
-
             bool foundDrift = false;
             foreach (string warning in result.Warnings)
             {
@@ -922,8 +991,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// What: a file declaring a field-like event hot-reloads its subscriber and handler methods
         /// (no CS0229 from the publicized backing field) — the edited subscriber body (net two
         /// subscriptions via += / -=) must actually apply (HandledCount == 10, not the original
-        /// body's 5) and EnableCounting must be Patched — while the raising method is Skipped
-        /// instead of killing the whole file.
+        /// body's 5) and EnableCounting must be Patched — while the raising method (edited to a
+        /// double Invoke so it is not treated as unchanged) is Skipped instead of killing the
+        /// whole file.
         /// </summary>
         [Test]
         public async Task Run_FieldLikeEventFile_PatchesHandlerAndSkipsRaiser()
@@ -1154,6 +1224,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void RaiseScore()
         {
+            // Double Invoke so the edited template differs from on-disk and stays Skipped
+            // (single Invoke would be unchanged and disappear from Methods after D).
+            ScoreChanged?.Invoke();
             ScoreChanged?.Invoke();
         }
     }
@@ -1173,6 +1246,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return path;
         }
 
+        private static int CountWarningsContaining(IReadOnlyList<string> warnings, string token)
+        {
+            int count = 0;
+            foreach (string warning in warnings)
+            {
+                if (warning.Contains(token))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
         private static string BuildFixtureSource(
             string computeWithPrivateMethod,
             string sumGridMethod = null,
@@ -1185,7 +1272,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string asyncUsesInternalTypeMethod = null,
             string tuningConstDeclaration = null,
             string modeEnumDeclaration = null,
-            string centerOfCellMethod = null)
+            string centerOfCellMethod = null,
+            string callsBaseMethod = null,
+            string explicitAccessorsBlock = null)
         {
             string sumGrid = sumGridMethod ??
                 "public int SumGrid(int[,] grid)\n        {\n            return -1;\n        }";
@@ -1229,6 +1318,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + "        {\n"
                 + "            return Vector3.zero;\n"
                 + "        }";
+            string callsBase = callsBaseMethod ??
+                "public int CallsBase()\n        {\n            return base.BaseSeed() + 1;\n        }";
+            string explicitAccessors = explicitAccessorsBlock ??
+                "// Explicit-body getter — worker must report get_ExplicitBodyGetter as Skipped (not silent).\n"
+                + "        public int ExplicitBodyGetter\n"
+                + "        {\n"
+                + "            get { return _secret; }\n"
+                + "        }\n"
+                + "\n"
+                + "        // Explicit-body setter — worker must report set_ExplicitBodySetter as Skipped (not silent).\n"
+                + "        public int ExplicitBodySetter\n"
+                + "        {\n"
+                + "            set { _secret = value; }\n"
+                + "        }\n"
+                + "\n"
+                + "        public int Counter;\n"
+                + "\n"
+                + "        private int this[int index] => _secret + index;";
 
             return @"using System.Collections;
 using System.Collections.Generic;
@@ -1266,21 +1373,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         public int SecretForAssert => _secret;
 
-        // Explicit-body getter — worker must report get_ExplicitBodyGetter as Skipped (not silent).
-        public int ExplicitBodyGetter
-        {
-            get { return _secret; }
-        }
-
-        // Explicit-body setter — worker must report set_ExplicitBodySetter as Skipped (not silent).
-        public int ExplicitBodySetter
-        {
-            set { _secret = value; }
-        }
-
-        public int Counter;
-
-        private int this[int index] => _secret + index;
+        " + explicitAccessors + @"
 
         private int HiddenScore { get; set; } = 3;
 
@@ -1292,10 +1385,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [MethodImpl(MethodImplOptions.NoInlining)]
         " + computeWithPrivateMethod + @"
 
-        public int CallsBase()
-        {
-            return base.BaseSeed() + 1;
-        }
+        " + callsBase + @"
 
         " + callsMissingHelper + @"
 

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -178,6 +178,54 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: an empty Methods list with UnchangedTotal reports the all-unchanged message
+        /// instead of the generic "no patchable bodies" wording.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_EmptyMethodsWithUnchangedTotal_YieldsAllUnchangedMessage()
+        {
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>(),
+                new List<string>(),
+                patchedTotal: 0,
+                activePatchTotal: 0,
+                unchangedTotal: 8);
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+            Assert.That(
+                response.Message,
+                Is.EqualTo("All 8 methods are unchanged since the last compile; nothing to patch."));
+            Assert.That(response.UnchangedTotal, Is.EqualTo(8));
+        }
+
+        /// <summary>
+        /// What: a patched run with UnchangedTotal appends the untouched-methods suffix.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_WithUnchangedTotal_AppendsUntouchedSuffix()
+        {
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>
+                {
+                    HotReloadMethodOutcome.Patched("Type.Method", "Assets/A.cs")
+                },
+                new List<string>(),
+                patchedTotal: 1,
+                activePatchTotal: 1,
+                unchangedTotal: 7);
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+            Assert.That(
+                response.Message,
+                Is.EqualTo(
+                    "Hot reload applied. PatchedTotal=1, ActivePatchTotal=1. "
+                    + "7 unchanged methods were left untouched."));
+            Assert.That(response.UnchangedTotal, Is.EqualTo(7));
+        }
+
+        /// <summary>
         /// What: a skipped-only run keeps the existing "See Methods for Skipped reasons." message.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -293,7 +293,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: with a snapshot whose ComputeWithPrivate body differs, the worker emits only that edited method and reports a positive unchangedMethodCount for the rest.
+        /// What: with a snapshot whose ComputeWithPrivate body differs, the worker emits only that
+        /// edited method and lists the remaining methods in unchangedMethods.
         /// </summary>
         [Test]
         public async Task Run_WithSnapshotDifferingOnlyInOneMethod_EmitsOnlyEditedMethod()
@@ -307,7 +308,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             TransformWorkerClientResult result = await RunWorkerOnE2EFixtureAsync(snapshotSource);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            Assert.That(result.Output.unchangedMethodCount, Is.GreaterThan(0));
+            Assert.That(result.Output.unchangedMethods, Is.Not.Null);
+            Assert.That(result.Output.unchangedMethods.Length, Is.GreaterThan(0));
             Assert.That(
                 result.Output.declarationDriftWarnings,
                 Has.None.Contain("Edits outside method bodies"),
@@ -341,7 +343,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a snapshot that differs only by EOL (LF↔CRLF) treats every method as unchanged — Windows guardrail for line-ending noise.
+        /// What: a snapshot that differs only by EOL (LF↔CRLF) treats every method as unchanged —
+        /// Windows guardrail for line-ending noise — and lists ComputeWithPrivate in
+        /// unchangedMethods.
         /// </summary>
         [Test]
         public async Task Run_WithSnapshotDifferingOnlyByEol_TreatsAllMethodsUnchanged()
@@ -357,7 +361,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             TransformWorkerClientResult result = await RunWorkerOnE2EFixtureAsync(snapshotSource);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(result.Output.entries, Is.Empty);
-            Assert.That(result.Output.unchangedMethodCount, Is.GreaterThan(0));
+            Assert.That(result.Output.unchangedMethods, Is.Not.Null);
+            Assert.That(result.Output.unchangedMethods.Length, Is.GreaterThan(0));
+            bool foundComputeUnchanged = false;
+            foreach (TransformWorkerUnchangedMethodDto unchanged in result.Output.unchangedMethods)
+            {
+                if (unchanged.methodName == nameof(HotReloadE2EFixture.ComputeWithPrivate))
+                {
+                    foundComputeUnchanged = true;
+                    break;
+                }
+            }
+
+            Assert.That(
+                foundComputeUnchanged,
+                Is.True,
+                "EOL-only snapshot must list ComputeWithPrivate in unchangedMethods.");
             Assert.That(result.Output.skipped, Is.Empty);
             Assert.That(result.Output.declarationDriftWarnings, Is.Empty);
         }
@@ -384,7 +403,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a snapshot that duplicates a method key falls back to no-baseline behavior (same entries as a null snapshot, unchangedMethodCount 0).
+        /// What: a snapshot that duplicates a method key falls back to no-baseline behavior
+        /// (same entries as a null snapshot, empty unchangedMethods).
         /// </summary>
         [Test]
         public async Task Run_WithSnapshotDuplicateMethodKey_FallsBackToNoBaseline()
@@ -412,7 +432,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             TransformWorkerClientResult withCollision = await RunWorkerOnE2EFixtureAsync(snapshotSource);
             Assert.That(baseline.Success, Is.True, baseline.ErrorMessage);
             Assert.That(withCollision.Success, Is.True, withCollision.ErrorMessage);
-            Assert.That(withCollision.Output.unchangedMethodCount, Is.EqualTo(0));
+            Assert.That(
+                withCollision.Output.unchangedMethods == null
+                || withCollision.Output.unchangedMethods.Length == 0,
+                Is.True,
+                "Duplicate-key fallback must not report unchanged methods.");
 
             HashSet<string> baselineKeys = CollectEntryKeys(baseline.Output.entries);
             HashSet<string> collisionKeys = CollectEntryKeys(withCollision.Output.entries);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -104,5 +104,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             "A hot-reload patch replaces the method body and discards other transpilers on "
             + "that method; a pause point on a hot-reloaded method will not fire until the patch "
             + "is reverted or a domain reload restores the original IL.";
+
+        // Format: file name, assembly name. Emitted per file when PDB-validated snapshot is absent.
+        public const string NoVerifiedSourceSnapshotWarningFormat =
+            "No verified source snapshot for {0} (assembly {1}); patching all methods. "
+            + "Run uloop compile to establish a baseline for edited-method detection.";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -156,12 +156,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string[] defines = compilationAssembly.defines ?? Array.Empty<string>();
             string[] referencePaths = BuildWorkerReferencePaths(compilationAssembly, targetDllPath);
 
+            // Why projectRelativePath (not workerSourcePath): contentPathOverride E2E copies live
+            // under Library/UloopHotReload/TestSources/ and are absent from the PDB document list.
+            // Assembly resolution already computed the on-disk Assets/Packages path above.
+            string snapshotSource = HotReloadSourceBaseline.LoadVerifiedSnapshotSource(
+                projectRelativePath,
+                targetDllPath);
+            if (snapshotSource == null)
+            {
+                warnings.Add(
+                    string.Format(
+                        HotReloadConstants.NoVerifiedSourceSnapshotWarningFormat,
+                        Path.GetFileName(projectRelativePath),
+                        assemblyName));
+            }
+
             TransformWorkerInputDto workerInput = new TransformWorkerInputDto
             {
                 sourcePath = Path.GetFullPath(workerSourcePath),
                 defines = defines,
                 referencePaths = referencePaths,
-                targetTypesAssemblyPath = Path.GetFullPath(targetDllPath)
+                targetTypesAssemblyPath = Path.GetFullPath(targetDllPath),
+                snapshotSource = snapshotSource
             };
 
             TransformWorkerClientResult workerResult =
@@ -660,7 +676,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 defines = workerInput.defines,
                 referencePaths = workerInput.referencePaths,
                 targetTypesAssemblyPath = workerInput.targetTypesAssemblyPath,
-                excludedMethodKeys = excludedMethodKeys
+                excludedMethodKeys = excludedMethodKeys,
+                // Why copy: omitting snapshotSource would make the retry patch unedited methods
+                // again and diverge the retry entries set from the first-pass isolation baseline.
+                snapshotSource = workerInput.snapshotSource
             };
 
             TransformWorkerClientResult retryWorkerResult =

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -44,6 +44,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> suppressedPausePointIds = new List<string>();
             List<string> inlineRiskMethodLabels = new List<string>();
             int patchedTotal = 0;
+            int unchangedTotal = 0;
 
             for (int index = 0; index < files.Count; index++)
             {
@@ -68,6 +69,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 AppendDistinct(suppressedPausePointIds, fileResult.SuppressedPausePointIds);
                 AppendDistinct(inlineRiskMethodLabels, fileResult.InlineRiskMethodLabels);
                 patchedTotal += fileResult.PatchedCount;
+                unchangedTotal += fileResult.UnchangedMethodCount;
             }
 
             if (inlineRiskMethodLabels.Count > 0)
@@ -85,7 +87,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 warnings,
                 patchedTotal,
                 HotReloadPatcher.ActivePatchCount,
-                suppressedPausePointIds);
+                suppressedPausePointIds,
+                unchangedTotal);
         }
 
         private static async Task<HotReloadFileProcessResult> ProcessFileAsync(
@@ -201,11 +204,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
             }
 
+            int unchangedMethodCount = workerOutput.unchangedMethodCount;
+
             if (string.IsNullOrEmpty(workerOutput.shimSource)
                 || workerOutput.entries == null
                 || workerOutput.entries.Length == 0)
             {
-                return new HotReloadFileProcessResult(outcomes, warnings, 0);
+                return new HotReloadFileProcessResult(
+                    outcomes, warnings, 0, unchangedMethodCount: unchangedMethodCount);
             }
 
             // BuildShimReferencePaths reads Application.dataPath / platform; stay on main thread.
@@ -240,14 +246,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                             "(shim-compile)",
                             compileResult.ErrorMessage,
                             assemblyResolvePath));
-                    return new HotReloadFileProcessResult(outcomes, warnings, 0);
+                    return new HotReloadFileProcessResult(
+                        outcomes, warnings, 0, unchangedMethodCount: unchangedMethodCount);
                 }
 
                 outcomes.AddRange(isolation.FailedMethodOutcomes);
                 if (isolation.RetryEntries.Length == 0)
                 {
                     return new HotReloadFileProcessResult(
-                        outcomes, warnings, 0, suppressedPausePointIds, new List<string>());
+                        outcomes,
+                        warnings,
+                        0,
+                        suppressedPausePointIds,
+                        new List<string>(),
+                        unchangedMethodCount);
                 }
 
                 entriesToPatch = isolation.RetryEntries;
@@ -278,7 +290,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return new HotReloadFileProcessResult(
-                outcomes, warnings, patchedCount, suppressedPausePointIds, inlineRiskMethodLabels);
+                outcomes,
+                warnings,
+                patchedCount,
+                suppressedPausePointIds,
+                inlineRiskMethodLabels,
+                unchangedMethodCount);
         }
 
         private static HotReloadMethodOutcome ApplyEntry(
@@ -888,19 +905,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public int PatchedCount { get; }
             public List<string> SuppressedPausePointIds { get; }
             public List<string> InlineRiskMethodLabels { get; }
+            public int UnchangedMethodCount { get; }
 
             public HotReloadFileProcessResult(
                 List<HotReloadMethodOutcome> outcomes,
                 List<string> warnings,
                 int patchedCount,
                 List<string> suppressedPausePointIds = null,
-                List<string> inlineRiskMethodLabels = null)
+                List<string> inlineRiskMethodLabels = null,
+                int unchangedMethodCount = 0)
             {
                 Outcomes = outcomes;
                 Warnings = warnings;
                 PatchedCount = patchedCount;
                 SuppressedPausePointIds = suppressedPausePointIds ?? new List<string>();
                 InlineRiskMethodLabels = inlineRiskMethodLabels ?? new List<string>();
+                UnchangedMethodCount = unchangedMethodCount;
             }
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -220,7 +220,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
             }
 
-            int unchangedMethodCount = workerOutput.unchangedMethodCount;
+            TransformWorkerUnchangedMethodDto[] unchangedMethods =
+                workerOutput.unchangedMethods ?? Array.Empty<TransformWorkerUnchangedMethodDto>();
+            int unchangedMethodCount = unchangedMethods.Length;
+
+            // Why before the empty-entries return: all-unchanged runs exit there, and those are
+            // exactly the runs that must peel leftover patches so behavior converges to compiled IL.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+            RevertUnchangedPatches(assemblyName, unchangedMethods);
 
             if (string.IsNullOrEmpty(workerOutput.shimSource)
                 || workerOutput.entries == null
@@ -312,6 +319,40 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 suppressedPausePointIds,
                 inlineRiskMethodLabels,
                 unchangedMethodCount);
+        }
+
+        // Peels leftover Harmony patches when the source again matches the verified baseline.
+        // Resolve failures are silent: unchanged identities already matched compile-time IL.
+        private static void RevertUnchangedPatches(
+            string assemblyName,
+            TransformWorkerUnchangedMethodDto[] unchangedMethods)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
+            Debug.Assert(unchangedMethods != null, "unchangedMethods must not be null.");
+
+            for (int index = 0; index < unchangedMethods.Length; index++)
+            {
+                TransformWorkerUnchangedMethodDto unchanged = unchangedMethods[index];
+                if (unchanged == null
+                    || string.IsNullOrEmpty(unchanged.typeMetadataName)
+                    || string.IsNullOrEmpty(unchanged.methodName)
+                    || unchanged.parameterTypeFullNames == null)
+                {
+                    continue;
+                }
+
+                HotReloadMethodMatchResult matchResult = HotReloadMethodMatcher.Resolve(
+                    assemblyName,
+                    unchanged.typeMetadataName,
+                    unchanged.methodName,
+                    unchanged.parameterTypeFullNames);
+                if (!matchResult.Success)
+                {
+                    continue;
+                }
+
+                HotReloadPatcher.Revert(matchResult.Method);
+            }
         }
 
         private static HotReloadMethodOutcome ApplyEntry(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
@@ -13,19 +13,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public int PatchedTotal { get; }
         public int ActivePatchTotal { get; }
         public IReadOnlyList<string> SuppressedPausePointIds { get; }
+        public int UnchangedTotal { get; }
 
         public HotReloadOrchestratorResult(
             IReadOnlyList<HotReloadMethodOutcome> methods,
             IReadOnlyList<string> warnings,
             int patchedTotal,
             int activePatchTotal,
-            IReadOnlyList<string> suppressedPausePointIds = null)
+            IReadOnlyList<string> suppressedPausePointIds = null,
+            int unchangedTotal = 0)
         {
             Methods = methods;
             Warnings = warnings;
             PatchedTotal = patchedTotal;
             ActivePatchTotal = activePatchTotal;
             SuppressedPausePointIds = suppressedPausePointIds ?? Array.Empty<string>();
+            UnchangedTotal = unchangedTotal;
         }
     }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -158,6 +158,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
+        /// Removes the hot-reload patch on <paramref name="method"/> when one is recorded.
+        /// Returns false when the method was not patched.
+        /// </summary>
+        public static bool Revert(MethodBase method)
+        {
+            Debug.Assert(method != null, "method must not be null.");
+
+            if (!ShimByMethod.Remove(method))
+            {
+                return false;
+            }
+
+            // Why Remove before Unpatch: Harmony rebuilds the method during Unpatch, and the
+            // pause-point transpiler guard reads IsMethodPatchedByHotReload — the ledger must
+            // already show unpatched so armed markers are re-instrumented into the restored IL.
+            HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
+            HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
+            return true;
+        }
+
+        /// <summary>
         /// How many methods currently have an active patch recorded in the ledger.
         /// </summary>
         public static int ActivePatchCount => ShimByMethod.Count;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -55,6 +55,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public int ActivePatchTotal { get; set; }
 
+        public int UnchangedTotal { get; set; }
+
         public int ClearedCount { get; set; }
 
         public string Message { get; set; } = string.Empty;
@@ -208,30 +210,47 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Warnings = warnings,
                 PatchedTotal = result.PatchedTotal,
                 ActivePatchTotal = result.ActivePatchTotal,
+                UnchangedTotal = result.UnchangedTotal,
                 Message = BuildApplyMessage(result, hasFailure)
             };
         }
 
         private static string BuildApplyMessage(HotReloadOrchestratorResult result, bool hasFailure)
         {
+            // Why: when every method was left untouched, the empty Methods list is intentional —
+            // report the unchanged count instead of the generic "no patchable bodies" message.
+            if (!hasFailure && result.Methods.Count == 0 && result.UnchangedTotal > 0)
+            {
+                return "All " + result.UnchangedTotal
+                    + " methods are unchanged since the last compile; nothing to patch.";
+            }
+
+            string message;
             if (hasFailure)
             {
-                return "Hot reload finished with one or more Failed method outcomes. See Methods.";
+                message = "Hot reload finished with one or more Failed method outcomes. See Methods.";
             }
-
-            if (result.Methods.Count == 0)
+            else if (result.Methods.Count == 0)
             {
-                return "Hot reload found no patchable method bodies in the given files; nothing was changed. "
+                message = "Hot reload found no patchable method bodies in the given files; nothing was changed. "
                     + "Hot reload only replaces existing ordinary method bodies; use uloop compile for other edits.";
             }
-
-            if (result.PatchedTotal == 0)
+            else if (result.PatchedTotal == 0)
             {
-                return "Hot reload finished with no methods patched. See Methods for Skipped reasons.";
+                message = "Hot reload finished with no methods patched. See Methods for Skipped reasons.";
+            }
+            else
+            {
+                message = "Hot reload applied. PatchedTotal=" + result.PatchedTotal
+                    + ", ActivePatchTotal=" + result.ActivePatchTotal + ".";
             }
 
-            return "Hot reload applied. PatchedTotal=" + result.PatchedTotal
-                + ", ActivePatchTotal=" + result.ActivePatchTotal + ".";
+            if (result.UnchangedTotal > 0)
+            {
+                message += " " + result.UnchangedTotal + " unchanged methods were left untouched.";
+            }
+
+            return message;
         }
 
         private static HotReloadResponse CreateValidationFailure(string message)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -78,7 +78,11 @@ and adopted only once it verifies against the compiled assembly's PDB checksums.
 a baseline, hot reload patches only the methods whose bodies actually changed;
 unchanged methods are left untouched and counted in `UnchangedTotal` (formatting,
 comments, and line-ending differences count as unchanged). A run where every method
-is unchanged succeeds with nothing patched. Without a baseline — for example before
+is unchanged succeeds with nothing patched.
+Convergence works in both directions: a currently patched method whose body matches
+the baseline again is unpatched on that run — the compiled IL comes back,
+`ActivePatchTotal` drops, and its pause-point block lifts.
+Without a baseline — for example before
 the first compile after installing or updating the package — every editable method in
 the file is patched and a `Warnings` line reports the fallback; run `uloop compile`
 to establish the baseline.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -61,10 +61,31 @@ Hot reload never adds members. A refactor that extracts a new helper method cann
 applied piecewise — keep iterating inside existing method bodies, then run
 `uloop compile` once to introduce the new member for real.
 
-Edits outside method bodies never take effect: changing a `const` value, a field initializer, or any declaration other than a method body leaves runtime behavior unchanged even though the response reports `Success` — shims resolve those symbols against the already-compiled assembly, and C# bakes `const` values into IL at compile time. Changed `const` values (including enum member values) are detected and reported as a `Warnings` entry naming the constant and both values; other outside-body edits stay silent. Use `uloop compile` for such edits.
+Edits outside method bodies never take effect: changing a `const` value, a field
+initializer, or any declaration other than a method body leaves runtime behavior
+unchanged even though the response reports `Success` — shims resolve those symbols
+against the already-compiled assembly, and C# bakes `const` values into IL at compile
+time. Changed `const` values (including enum member values) are detected and reported
+as a `Warnings` entry naming the constant and both values. When a verified source
+baseline is available (next paragraph), other outside-body drift — fields,
+initializers, attributes, added or removed members — is reported as a `Warnings`
+entry as well; without a baseline it stays silent. Either way, use `uloop compile`
+for such edits.
+
+Each `uloop compile` also establishes a per-assembly source baseline: a snapshot of
+the sources exactly as they were compiled, captured after the compile's domain reload
+and adopted only once it verifies against the compiled assembly's PDB checksums. With
+a baseline, hot reload patches only the methods whose bodies actually changed;
+unchanged methods are left untouched and counted in `UnchangedTotal` (formatting,
+comments, and line-ending differences count as unchanged). A run where every method
+is unchanged succeeds with nothing patched. Without a baseline — for example before
+the first compile after installing or updating the package — every editable method in
+the file is patched and a `Warnings` line reports the fallback; run `uloop compile`
+to establish the baseline.
 
 Property and indexer accessors with explicit bodies are reported per-accessor as
-`Skipped`, so an edited getter never disappears from the response silently.
+`Skipped`, so an edited getter never disappears from the response silently; with a
+verified baseline, accessors unchanged from it produce no row.
 
 Subscribing to or unsubscribing from a field-like event (`+=`/`-=`) inside an edited
 body works. Methods that raise the event are reported as `Skipped` (see the table
@@ -160,8 +181,9 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
-- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough (or marked `[AggressiveInlining]`) to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and const drift entries described in "Scope and limits"
+- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough (or marked `[AggressiveInlining]`) to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
+- `UnchangedTotal` (number): Methods left untouched because their bodies match the source baseline from the last compile; `0` when no baseline was available
 - `ActivePatchTotal` (number): Methods still patched after this run
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)
 - `Message` (string): Short summary

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -34,7 +34,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public TransformWorkerSkippedDto[] skipped;
         public string[] parseErrors;
         public string[] declarationDriftWarnings;
-        public int unchangedMethodCount;
+
+        // Identities of methods left untouched because they match the verified snapshot.
+        // Null/empty means none (or no baseline). UnchangedTotal is derived from Length.
+        public TransformWorkerUnchangedMethodDto[] unchangedMethods;
+    }
+
+    [Serializable]
+    internal sealed class TransformWorkerUnchangedMethodDto
+    {
+        public string typeMetadataName;
+        public string methodName;
+        public string[] parameterTypeFullNames;
     }
 
     [Serializable]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -247,10 +247,10 @@ public static class TransformWorkerProgram
 
         List<WorkerEntry> entries = new List<WorkerEntry>();
         List<WorkerSkipped> skipped = new List<WorkerSkipped>();
+        List<WorkerUnchangedMethod> unchangedMethods = new List<WorkerUnchangedMethod>();
         List<ShimTypeBuilder> shimTypes = new List<ShimTypeBuilder>();
         int globalShimMethodCounter = 0;
         int shimTypeCounter = 0;
-        int unchangedMethodCount = 0;
 
         foreach (TypeDeclarationSyntax typeDeclaration in EnumerateTypeDeclarations(root))
         {
@@ -304,14 +304,21 @@ public static class TransformWorkerProgram
 
                 // Why after ExcludedMethodKeys: exclusion means "already Failed on first round", so
                 // it must win. Unchanged methods add no per-method signal — skipping them cuts
-                // response noise and avoids pause-point collateral on untouched methods.
+                // response noise and avoids pause-point collateral on untouched methods. Identities
+                // are returned so the orchestrator can revert a leftover patch when source matches
+                // the baseline again.
                 if (hasBaseline)
                 {
                     string syntaxMethodKey = BuildSyntaxMethodKey(typeMetadataNameFromSyntax, methodDeclaration);
                     if (snapshotMethodMap.TryGetValue(syntaxMethodKey, out MethodDeclarationSyntax snapshotDecl)
                         && SyntaxFactory.AreEquivalent(snapshotDecl, methodDeclaration, topLevel: false))
                     {
-                        unchangedMethodCount++;
+                        unchangedMethods.Add(new WorkerUnchangedMethod
+                        {
+                            TypeMetadataName = CecilTypeNames.ToMetadataName(typeSymbol),
+                            MethodName = methodSymbol.Name,
+                            ParameterTypeFullNames = parameterTypeFullNames
+                        });
                         continue;
                     }
                 }
@@ -384,7 +391,7 @@ public static class TransformWorkerProgram
             Skipped = skipped.ToArray(),
             DeclarationDriftWarnings = declarationDriftWarnings.ToArray(),
             ParseErrors = parseErrors.ToArray(),
-            UnchangedMethodCount = unchangedMethodCount
+            UnchangedMethods = unchangedMethods.ToArray()
         };
     }
 
@@ -3441,7 +3448,16 @@ internal sealed class WorkerOutput
 
     public string[] ParseErrors { get; set; }
 
-    public int UnchangedMethodCount { get; set; }
+    public WorkerUnchangedMethod[] UnchangedMethods { get; set; }
+}
+
+internal sealed class WorkerUnchangedMethod
+{
+    public string TypeMetadataName { get; set; }
+
+    public string MethodName { get; set; }
+
+    public string[] ParameterTypeFullNames { get; set; }
 }
 
 internal sealed class WorkerEntry

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -144,6 +144,14 @@ transpiler (`io.github.hatayama.uloop.hot-reload`). Patches are static Editor st
 disappear on domain reload by design; a later `uloop compile` converges to the same
 source behavior.
 
+### Source snapshot
+
+A per-assembly byte-exact copy of project source files under
+`Library/UloopHotReload/SourceSnapshot/<assemblyName>-<mvid>/`, captured after domain
+reload. Hot reload adopts a snapshot as the edited-method baseline only when its bytes
+match the corresponding portable-PDB document checksum for that source file; otherwise
+the file falls back to patching every editable method.
+
 ### Shim
 
 A generated static method that mirrors an edited user method body for hot reload. For an

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -18,12 +18,15 @@ Editor-only. Players (Mono or IL2CPP) are out of scope.
 
 ```text
 edited .cs file
-  │ (1) resolve owning assembly, defines, and references via CompilationPipeline
+  │ (1) resolve owning assembly, defines, and references via CompilationPipeline;
+  │     load a PDB-checksum-verified source snapshot when one exists for the file
   ▼
 transform worker (external process: Unity-bundled Roslyn on the Unity-bundled .NET host)
-  │ (2) parse + semantic analysis; convert each eligible method body into a static shim
-  │     method source (bare member references qualified via `__uloopInstance.` / `global::Type.`),
-  │     plus a manifest and per-method skip reasons
+  │ (2) parse + semantic analysis; when a verified snapshot is available, diff method
+  │     declarations against it and emit shims only for edited methods (unchanged methods
+  │     are counted, not listed); convert each eligible edited method body into a static
+  │     shim method source (bare member references qualified via `__uloopInstance.` /
+  │     `global::Type.`), plus a manifest and per-method skip reasons
   ▼
 shim compilation (existing external csc infrastructure, RoslynCompilerBackend)
   │ (3) compile the shim source against publicized reference assemblies
@@ -38,8 +41,9 @@ Harmony transpiler transplant  (5) patch the original method with a transpiler t
 ```
 
 Harmony ID: `io.github.hatayama.uloop.hot-reload` (distinct from the pause point's ID).
-Caches: `Library/UloopHotReload/PublicizedRefs/fmt2/<assemblyName>-<mvid>.dll` and
-`Library/UloopHotReload/Worker/<sourceHash>/`.
+Caches: `Library/UloopHotReload/PublicizedRefs/fmt2/<assemblyName>-<mvid>.dll`,
+`Library/UloopHotReload/Worker/<sourceHash>/`, and
+`Library/UloopHotReload/SourceSnapshot/<assemblyName>-<mvid>/`.
 
 ## Spike Findings
 

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -44,6 +44,8 @@ Harmony ID: `io.github.hatayama.uloop.hot-reload` (distinct from the pause point
 Caches: `Library/UloopHotReload/PublicizedRefs/fmt2/<assemblyName>-<mvid>.dll`,
 `Library/UloopHotReload/Worker/<sourceHash>/`, and
 `Library/UloopHotReload/SourceSnapshot/<assemblyName>-<mvid>/`.
+When a verified snapshot marks a currently patched method as unchanged, the
+orchestrator reverts that patch to the compiled IL instead of re-emitting a shim.
 
 ## Spike Findings
 


### PR DESCRIPTION
## Summary
- Hot reload now patches only methods that actually changed since the last compile when a verified source baseline exists.
- Unchanged methods stay out of `Methods`/`Skipped` noise and are reported via `UnchangedTotal`; missing baselines fall back to patching all methods with an explicit warning.
- Restoring a previously patched method to the baseline now reverts its leftover Harmony patch so runtime behavior converges to compiled IL.

## User Impact
- Before: editing one method could report many `Patched`/`Skipped` rows and could block pause points on untouched methods; reverting an edit and hot-reloading again could leave the old patched body running.
- After: with a compile-established baseline, only edited method bodies are patched; restoring source to the baseline clears the patch (`ActivePatchTotal` drops, pause-point block lifts); without a baseline the previous all-methods behavior remains, with a clear warning to run `uloop compile`.

## Changes
- Wire worker unchanged-method identities through orchestrator/tool response and Message wording (all-unchanged + untouched suffix).
- Pass PDB-validated snapshot text into the transform worker from the assembly-resolve project-relative path; copy it into isolation retries; warn when no verified snapshot exists.
- When unchanged identities resolve to currently patched methods, `HotReloadPatcher.Revert` peels those patches before applying new ones (including the all-unchanged early return path).
- Discriminating E2Es for edited-only patching and revert-on-restore convergence.
- Inventory updates: `callsBaseMethod` / `explicitAccessorsBlock` optional template args, warning prefix+counts for declaration drift, event `RaiseScore` double-invoke, on-disk unchanged E2E, const-drift ComputeWithPrivate edit.
- Skill/docs: edited-method detection, bidirectional convergence, `UnchangedTotal`, SourceSnapshot cache path, glossary entry.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → ErrorCount 0, WarningCount 0
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value "HotReload"` → Passed 114 / 114, FailedCount 0
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode` (no filter) → Passed 2542 / 2549, FailedCount 0, Skipped 7
- Base is `feature/hot-reload`, so repository `pull_request` CI does not fire; local compile + full EditMode suite is the gate for this PR.

## Red → Green

### Edited-only patching
- Test: `Run_WithVerifiedSnapshot_PatchesOnlyEditedMethod`
- Red (before snapshot wiring): failed on `QueryPrivate` still appearing as `Patched`; `UnchangedTotal` stayed 0
- Green (after wiring `snapshotSource` from `projectRelativePath`): Passed

### Revert-on-restore convergence
- Test: `Run_RevertedEditAfterPatch_RestoresOriginalBehaviorAndClearsPatch`
- Red (before unchanged-identity revert): Step 2 expected `ActivePatchTotal == 0` but was `1` (old patched body kept returning 115)
- Green (after worker `unchangedMethods` + `HotReloadPatcher.Revert`): Passed — Step 2 returns 15 and `ActivePatchTotal == 0`

## Inventory tests updated
1. `Run_MethodWithBaseCall_IsSkippedWithReason` — edited `CallsBase` body via `callsBaseMethod`
2. `Run_ExplicitAccessorsSkipped_AutoPropertyAccessorsUnlisted` — edited accessors via `explicitAccessorsBlock`
3. `Run_MultipleSmallPatchedMethods_AggregatesInlineRiskWarningOnce` / `Run_DuplicateFileInputs_ListsEachAtRiskMethodOnceInAggregatedWarning` — prefix search + declaration-drift counts
4. `Run_FieldLikeEventFile_PatchesHandlerAndSkipsRaiser` — `RaiseScore` double-invoke in event template
5. Added `Run_OnDiskFixtureUnchanged_ReportsEmptyMethodsAndUnchangedTotal`
6. Added `Run_RevertedEditAfterPatch_RestoresOriginalBehaviorAndClearsPatch`
7. `Run_EditedConstValue_WarnsConstDrift` — keep ComputeWithPrivate edited so Patched assertion survives gating
