### PR TITLE
feat: map shim sources to original files with #line directives

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1129,19 +1129,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// <summary>
         /// What: a shim compile error in one method no longer kills the file — the failing method
         /// reports Failed with its own compiler error (and the new-member hint) while the other
-        /// methods still patch and take effect.
+        /// methods still patch and take effect. Attribution uses original-file line numbers from
+        /// #line-mapped diagnostics.
         /// </summary>
         [Test]
         public async Task Run_OneMethodFailingShimCompile_IsolatesFailureAndPatchesRest()
         {
             string fixturePath = ResolveE2EFixturePath();
-            string editedPath = WriteEditedSource(
-                "IsolatedShimFailure.cs",
-                BuildFixtureSource(
-                    computeWithPrivateMethod:
-                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }",
-                    callsMissingHelperMethod:
-                    "public int CallsMissingHelper(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }"));
+            string editedSource = BuildFixtureSource(
+                computeWithPrivateMethod:
+                "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }",
+                callsMissingHelperMethod:
+                "public int CallsMissingHelper(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }");
+            string editedPath = WriteEditedSource("IsolatedShimFailure.cs", editedSource);
+
+            int expectedOriginalLine = FindLineNumberContaining(editedSource, "MissingHelperAddedByEdit");
+            Assert.That(expectedOriginalLine, Is.GreaterThan(0));
 
             HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
                 new[] { fixturePath },
@@ -1156,17 +1159,33 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             {
                 if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
                     && outcome.Method.Contains(nameof(HotReloadE2EFixture.CallsMissingHelper))
-                    && outcome.Reason.Contains(HotReloadConstants.NewMemberCompileHint))
+                    && outcome.Reason.Contains(HotReloadConstants.NewMemberCompileHint)
+                    && outcome.Reason.Contains("(line " + expectedOriginalLine + ")"))
                 {
                     missingHelperFailed = true;
                 }
             }
 
             Assert.That(missingHelperFailed, Is.True,
-                "CallsMissingHelper must fail per-method with its own compiler error.\n" + FormatOutcomes(result));
+                "CallsMissingHelper must fail per-method with its own compiler error and original-file line "
+                + expectedOriginalLine + ".\n" + FormatOutcomes(result));
 
             HotReloadE2EFixture fixture = new HotReloadE2EFixture();
             Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(115));
+        }
+
+        private static int FindLineNumberContaining(string source, string fragment)
+        {
+            string[] lines = source.Replace("\r\n", "\n").Split('\n');
+            for (int index = 0; index < lines.Length; index++)
+            {
+                if (lines[index].Contains(fragment))
+                {
+                    return index + 1;
+                }
+            }
+
+            return -1;
         }
 
         private static void AssertNoFileLevelFailure(HotReloadOrchestratorResult result)

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1127,6 +1127,64 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: when the only edited method fails shim compile, isolation is skipped
+        /// (FailedEntries.Count == entries.Length) and the whole-file (shim-compile) Failed
+        /// Reason still carries the original-file "(line N)" from #line-mapped diagnostics.
+        /// </summary>
+        [Test]
+        public async Task Run_SingleEditedMethodFailingShimCompile_WholeFileFailureIncludesOriginalLine()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string targetDllPath = Path.Combine(
+                projectRoot,
+                HotReloadConstants.ScriptAssembliesRelativeDirectory,
+                "UnityCLILoop.Tests.Editor.HotReload"
+                + HotReloadConstants.CompiledAssemblyExtension);
+            // Why require a snapshot: without it every method becomes an entry and isolation
+            // succeeds — this test pins the whole-file path that only fires when the sole entry fails.
+            Assert.That(
+                HotReloadSourceBaseline.LoadVerifiedSnapshotSource(
+                    "Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs",
+                    targetDllPath),
+                Is.Not.Null,
+                "Verified snapshot must resolve so only the edited failing method is an entry.");
+
+            string editedSource = BuildFixtureSource(
+                computeWithPrivateMethod:
+                "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                callsMissingHelperMethod:
+                "public int CallsMissingHelper(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }");
+            string editedPath = WriteEditedSource("WholeFileShimFailure.cs", editedSource);
+
+            int expectedOriginalLine = FindLineNumberContaining(editedSource, "MissingHelperAddedByEdit");
+            Assert.That(expectedOriginalLine, Is.GreaterThan(0));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            bool foundWholeFileFailure = false;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
+                    && outcome.Method == "(shim-compile)"
+                    && outcome.Reason.Contains(HotReloadConstants.NewMemberCompileHint)
+                    && outcome.Reason.Contains("(line " + expectedOriginalLine + ")"))
+                {
+                    foundWholeFileFailure = true;
+                }
+            }
+
+            Assert.That(
+                foundWholeFileFailure,
+                Is.True,
+                "Single-entry shim compile failure must report (shim-compile) with original-file line "
+                + expectedOriginalLine + ".\n" + FormatOutcomes(result));
+        }
+
+        /// <summary>
         /// What: a shim compile error in one method no longer kills the file — the failing method
         /// reports Failed with its own compiler error (and the new-member hint) while the other
         /// methods still patch and take effect. Attribution uses original-file line numbers from

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -304,47 +304,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private static string SliceShimMethod(string shimSource, string shimMethodName)
         {
             Assert.That(shimMethodName, Is.Not.Null.And.Not.Empty);
-            int nameIndex = shimSource.IndexOf(shimMethodName, StringComparison.Ordinal);
+            (bool found, int declarationStart, int closeBraceIndex) =
+                FindShimMethodSpan(shimSource, shimMethodName);
             Assert.That(
-                nameIndex,
-                Is.GreaterThanOrEqualTo(0),
-                "shimMethodName not found in shimSource: " + shimMethodName);
-
-            int declarationStart = shimSource.LastIndexOf(
-                "public static",
-                nameIndex,
-                StringComparison.Ordinal);
-            Assert.That(
-                declarationStart,
-                Is.GreaterThanOrEqualTo(0),
-                "shim method declaration start not found for: " + shimMethodName);
-
-            int openBrace = shimSource.IndexOf('{', nameIndex);
-            Assert.That(
-                openBrace,
-                Is.GreaterThanOrEqualTo(0),
-                "shim method body not found for: " + shimMethodName);
-
-            int depth = 0;
-            for (int index = openBrace; index < shimSource.Length; index++)
-            {
-                char character = shimSource[index];
-                if (character == '{')
-                {
-                    depth++;
-                }
-                else if (character == '}')
-                {
-                    depth--;
-                    if (depth == 0)
-                    {
-                        return shimSource.Substring(declarationStart, index - declarationStart + 1);
-                    }
-                }
-            }
-
-            Assert.Fail("Unbalanced braces while slicing shim method: " + shimMethodName);
-            return null;
+                found,
+                Is.True,
+                "Could not locate a balanced shim method span for: " + shimMethodName);
+            return shimSource.Substring(declarationStart, closeBraceIndex - declarationStart + 1);
         }
 
         /// <summary>
@@ -353,20 +319,55 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// </summary>
         private static bool TextAfterShimMethodContainsLineDefault(string shimSource, string shimMethodName)
         {
+            (bool found, int _, int closeBraceIndex) = FindShimMethodSpan(shimSource, shimMethodName);
+            if (!found)
+            {
+                return false;
+            }
+
+            int gapStart = closeBraceIndex + 1;
+            int nextMethod = shimSource.IndexOf("public static", gapStart, StringComparison.Ordinal);
+            string gap = nextMethod < 0
+                ? shimSource.Substring(gapStart)
+                : shimSource.Substring(gapStart, nextMethod - gapStart);
+            return gap.Contains("#line default", StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// What: finds a shim method's <c>public static</c> declaration start and the index of its
+        /// balanced closing brace so slice and post-method gap checks share one scan.
+        /// </summary>
+        private static (bool Found, int DeclarationStart, int CloseBraceIndex) FindShimMethodSpan(
+            string shimSource,
+            string shimMethodName)
+        {
+            if (string.IsNullOrEmpty(shimSource) || string.IsNullOrEmpty(shimMethodName))
+            {
+                return (false, -1, -1);
+            }
+
             int nameIndex = shimSource.IndexOf(shimMethodName, StringComparison.Ordinal);
             if (nameIndex < 0)
             {
-                return false;
+                return (false, -1, -1);
+            }
+
+            int declarationStart = shimSource.LastIndexOf(
+                "public static",
+                nameIndex,
+                StringComparison.Ordinal);
+            if (declarationStart < 0)
+            {
+                return (false, -1, -1);
             }
 
             int openBrace = shimSource.IndexOf('{', nameIndex);
             if (openBrace < 0)
             {
-                return false;
+                return (false, -1, -1);
             }
 
             int depth = 0;
-            int closeBrace = -1;
             for (int index = openBrace; index < shimSource.Length; index++)
             {
                 char character = shimSource[index];
@@ -379,23 +380,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     depth--;
                     if (depth == 0)
                     {
-                        closeBrace = index;
-                        break;
+                        return (true, declarationStart, index);
                     }
                 }
             }
 
-            if (closeBrace < 0)
-            {
-                return false;
-            }
-
-            int gapStart = closeBrace + 1;
-            int nextMethod = shimSource.IndexOf("public static", gapStart, StringComparison.Ordinal);
-            string gap = nextMethod < 0
-                ? shimSource.Substring(gapStart)
-                : shimSource.Substring(gapStart, nextMethod - gapStart);
-            return gap.Contains("#line default", StringComparison.Ordinal);
+            return (false, -1, -1);
         }
 
         private static void AssertHasSkip(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -158,35 +158,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: every worker entry carries a 1-based shim source line range so the orchestrator
-        /// can attribute compile errors per method (end within the emitted source; ranges do not
-        /// overlap).
+        /// What: every worker entry carries a 1-based original-source line range (start &gt;= 1,
+        /// start &lt;= end) and those ranges do not overlap within the fixture file.
         /// </summary>
         [Test]
-        public async Task BootstrapAndRun_OnE2EFixture_EveryEntryHasAValidShimSourceLineRange()
+        public async Task BootstrapAndRun_OnE2EFixture_EveryEntryHasAValidOriginalSourceLineRange()
         {
             TransformWorkerClientResult result = await RunWorkerOnE2EFixtureAsync();
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(result.Output.entries, Is.Not.Empty);
 
-            int shimSourceLineCount = CountLines(result.Output.shimSource);
             List<(int Start, int End, string MethodName)> ranges =
                 new List<(int Start, int End, string MethodName)>();
             foreach (TransformWorkerEntryDto entry in result.Output.entries)
             {
                 Assert.That(
-                    entry.shimSourceStartLine,
+                    entry.sourceStartLine,
                     Is.GreaterThanOrEqualTo(1),
-                    "Entry missing a 1-based shim source start line: " + entry.methodName);
+                    "Entry missing a 1-based original source start line: " + entry.methodName);
                 Assert.That(
-                    entry.shimSourceStartLine,
-                    Is.LessThanOrEqualTo(entry.shimSourceEndLine),
-                    "Entry shim source start line must not be after its end line: " + entry.methodName);
-                Assert.That(
-                    entry.shimSourceEndLine,
-                    Is.LessThanOrEqualTo(shimSourceLineCount),
-                    "Entry shim source end line exceeds shimSource line count: " + entry.methodName);
-                ranges.Add((entry.shimSourceStartLine, entry.shimSourceEndLine, entry.methodName));
+                    entry.sourceStartLine,
+                    Is.LessThanOrEqualTo(entry.sourceEndLine),
+                    "Entry source start line must not be after its end line: " + entry.methodName);
+                ranges.Add((entry.sourceStartLine, entry.sourceEndLine, entry.methodName));
             }
 
             ranges.Sort((left, right) => left.Start.CompareTo(right.Start));
@@ -195,30 +189,98 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Assert.That(
                     ranges[index].Start,
                     Is.GreaterThan(ranges[index - 1].End),
-                    "Shim source line ranges overlap between "
+                    "Original source line ranges overlap between "
                     + ranges[index - 1].MethodName
                     + " and "
                     + ranges[index].MethodName);
             }
         }
 
-        private static int CountLines(string text)
+        /// <summary>
+        /// What: emitted shimSource contains #line directives that name the project-relative path
+        /// before methods/statements and #line default after each shim method.
+        /// </summary>
+        [Test]
+        public async Task BootstrapAndRun_OnE2EFixture_ShimSourceContainsLineDirectives()
         {
-            if (string.IsNullOrEmpty(text))
-            {
-                return 0;
-            }
+            TransformWorkerClientResult result = await RunWorkerOnE2EFixtureAsync();
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.shimSource, Is.Not.Null.And.Not.Empty);
 
-            int lineCount = 1;
-            for (int index = 0; index < text.Length; index++)
+            string expectedDirectivePrefix = "#line ";
+            string expectedPathLiteral = "\"" + ResolveE2EFixtureProjectRelativePath() + "\"";
+            Assert.That(result.Output.shimSource, Does.Contain(expectedDirectivePrefix));
+            Assert.That(result.Output.shimSource, Does.Contain(expectedPathLiteral));
+            Assert.That(result.Output.shimSource, Does.Contain("#line default"));
+
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
             {
-                if (text[index] == '\n')
+                string slice = SliceShimMethod(result.Output.shimSource, entry.shimMethodName);
+                Assert.That(
+                    slice,
+                    Does.Contain(expectedDirectivePrefix),
+                    "Shim method must carry at least one #line directive: " + entry.methodName);
+                Assert.That(
+                    slice,
+                    Does.Contain(expectedPathLiteral),
+                    "Shim method #line must name the project-relative path: " + entry.methodName);
+            }
+        }
+
+        /// <summary>
+        /// What: an expression-bodied method maps its #line to the arrow expression's original
+        /// start line (not the declaration keyword line when they differ).
+        /// </summary>
+        [Test]
+        public async Task BootstrapAndRun_ArrowBodyMethod_LineDirectiveUsesArrowExpressionLine()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string tempDirectory = Path.Combine(
+                projectRoot,
+                "Library",
+                "UloopHotReload",
+                "TestSources",
+                "ArrowLineDirective");
+            Directory.CreateDirectory(tempDirectory);
+            string sourcePath = Path.Combine(tempDirectory, "ArrowBodyFixture.cs");
+            // Line 1 blank intentionally so the arrow expression starts on line 7 while the
+            // method keyword is on line 6 — the #line must report 7.
+            // Why a constant body: private-field access would force Delegation against a type that
+            // is not in the compiled test assembly; a literal return keeps Transplant and still
+            // exercises arrow-expression line mapping.
+            const string sourceText =
+                "\nnamespace ArrowLineDirectiveFixture\n{\n    public class ArrowHost\n    {\n"
+                + "        public int Read()\n"
+                + "            => 42;\n"
+                + "    }\n}\n";
+            File.WriteAllText(sourcePath, sourceText);
+
+            string projectRelativePath = "Library/UloopHotReload/TestSources/ArrowLineDirective/ArrowBodyFixture.cs";
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(sourcePath, projectRelativePath);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.entries, Is.Not.Empty);
+
+            TransformWorkerEntryDto arrowEntry = null;
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                if (entry.methodName == "Read")
                 {
-                    lineCount++;
+                    arrowEntry = entry;
+                    break;
                 }
             }
 
-            return lineCount;
+            Assert.That(arrowEntry, Is.Not.Null, "Read entry missing.");
+            // Why not SliceShimMethod: expression-bodied shims have no `{` block to bound a slice.
+            string expectedLineDirective = "#line 7 \"" + projectRelativePath + "\"";
+            Assert.That(
+                result.Output.shimSource,
+                Does.Contain(expectedLineDirective),
+                "Arrow-body #line must point at the expression start line.\n" + result.Output.shimSource);
+            Assert.That(
+                result.Output.shimSource,
+                Does.Contain(arrowEntry.shimMethodName),
+                "Shim method must appear in emitted source.");
         }
 
         /// <summary>
@@ -464,7 +526,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private static async Task<TransformWorkerClientResult> RunWorkerOnE2EFixtureAsync(
             string snapshotSource = null)
         {
-            string fixturePath = ResolveE2EFixturePath();
+            return await RunWorkerOnSourceAsync(
+                ResolveE2EFixturePath(),
+                ResolveE2EFixtureProjectRelativePath(),
+                snapshotSource);
+        }
+
+        private static async Task<TransformWorkerClientResult> RunWorkerOnSourceAsync(
+            string sourcePath,
+            string projectRelativePath,
+            string snapshotSource = null)
+        {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string targetDllPath = Path.Combine(
                 projectRoot,
@@ -487,11 +559,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             TransformWorkerInputDto input = new TransformWorkerInputDto
             {
-                sourcePath = fixturePath,
+                sourcePath = sourcePath,
                 defines = compilationAssembly.defines ?? System.Array.Empty<string>(),
                 referencePaths = compilationAssembly.allReferences,
                 targetTypesAssemblyPath = targetDllPath,
-                snapshotSource = snapshotSource
+                snapshotSource = snapshotSource,
+                projectRelativePath = projectRelativePath
             };
 
             return await TransformWorkerClient.RunAsync(input, CancellationToken.None);
@@ -507,6 +580,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "HotReloadE2EFixtures.cs");
             Assert.That(File.Exists(path), Is.True, "E2E fixture source missing: " + path);
             return Path.GetFullPath(path);
+        }
+
+        private static string ResolveE2EFixtureProjectRelativePath()
+        {
+            return "Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs";
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -224,6 +224,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     slice,
                     Does.Contain(expectedPathLiteral),
                     "Shim method #line must name the project-relative path: " + entry.methodName);
+                // Why outside SliceShimMethod: #line default is trailing trivia after the closing
+                // '}', so the brace-bounded slice cannot see it — assert the reset in the gap
+                // before the next method (or EOF) instead.
+                Assert.That(
+                    TextAfterShimMethodContainsLineDefault(
+                        result.Output.shimSource,
+                        entry.shimMethodName),
+                    Is.True,
+                    "Each shim method must be followed by #line default: " + entry.methodName);
             }
         }
 
@@ -331,6 +340,57 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.Fail("Unbalanced braces while slicing shim method: " + shimMethodName);
             return null;
+        }
+
+        /// <summary>
+        /// What: returns whether <c>#line default</c> appears after a shim method's closing brace
+        /// and before the next <c>public static</c> method declaration (or EOF).
+        /// </summary>
+        private static bool TextAfterShimMethodContainsLineDefault(string shimSource, string shimMethodName)
+        {
+            int nameIndex = shimSource.IndexOf(shimMethodName, StringComparison.Ordinal);
+            if (nameIndex < 0)
+            {
+                return false;
+            }
+
+            int openBrace = shimSource.IndexOf('{', nameIndex);
+            if (openBrace < 0)
+            {
+                return false;
+            }
+
+            int depth = 0;
+            int closeBrace = -1;
+            for (int index = openBrace; index < shimSource.Length; index++)
+            {
+                char character = shimSource[index];
+                if (character == '{')
+                {
+                    depth++;
+                }
+                else if (character == '}')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        closeBrace = index;
+                        break;
+                    }
+                }
+            }
+
+            if (closeBrace < 0)
+            {
+                return false;
+            }
+
+            int gapStart = closeBrace + 1;
+            int nextMethod = shimSource.IndexOf("public static", gapStart, StringComparison.Ordinal);
+            string gap = nextMethod < 0
+                ? shimSource.Substring(gapStart)
+                : shimSource.Substring(gapStart, nextMethod - gapStart);
+            return gap.Contains("#line default", StringComparison.Ordinal);
         }
 
         private static void AssertHasSkip(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -168,6 +168,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(result.Output.entries, Is.Not.Empty);
 
+            int fixtureLineCount = File.ReadAllLines(ResolveE2EFixturePath()).Length;
             List<(int Start, int End, string MethodName)> ranges =
                 new List<(int Start, int End, string MethodName)>();
             foreach (TransformWorkerEntryDto entry in result.Output.entries)
@@ -180,6 +181,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     entry.sourceStartLine,
                     Is.LessThanOrEqualTo(entry.sourceEndLine),
                     "Entry source start line must not be after its end line: " + entry.methodName);
+                Assert.That(
+                    entry.sourceEndLine,
+                    Is.LessThanOrEqualTo(fixtureLineCount),
+                    "Entry source end line exceeds fixture file line count: " + entry.methodName);
                 ranges.Add((entry.sourceStartLine, entry.sourceEndLine, entry.methodName));
             }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -249,6 +249,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 workerOutput.shimSource,
                 shimReferences,
                 defines,
+                projectRelativePath,
                 ct).ConfigureAwait(false);
 
             TransformWorkerEntryDto[] entriesToPatch = workerOutput.entries;
@@ -265,10 +266,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     ct).ConfigureAwait(false);
                 if (isolation == null)
                 {
-                    // Why these line numbers are original-file lines: shim sources emit #line
-                    // directives mapped to the edited user file, and the compile backends report
-                    // GetMappedLineSpan / csc locations — so ErrorMessage lines refer to the
-                    // user's source, not the temp HotReloadShim.cs scaffold.
+                    // Why: CompileAndLoadAsync appends "(line N)" only for diagnostics whose
+                    // #line-mapped file matches projectRelativePath — scaffold-only errors stay
+                    // bare. Single-entry failures skip isolation and always take this path.
                     outcomes.Add(
                         HotReloadMethodOutcome.Failed(
                             "(shim-compile)",
@@ -757,6 +757,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 retryOutput.shimSource,
                 shimReferences,
                 defines,
+                workerInput.projectRelativePath,
                 ct).ConfigureAwait(false);
             if (!retryCompileResult.Success)
             {
@@ -851,16 +852,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return null;
             }
 
+            // Why reject multi-match: original-source ranges can share a line (unlike the old
+            // shim-source ranges, which were structurally disjoint). First-match would exclude the
+            // wrong method on isolation retry — treat ambiguity as unattributable.
+            TransformWorkerEntryDto matchedEntry = null;
+            int matchCount = 0;
             foreach (TransformWorkerEntryDto entry in entries)
             {
                 bool hasKnownRange = entry.sourceStartLine > 0 && entry.sourceEndLine > 0;
                 if (hasKnownRange && error.Line >= entry.sourceStartLine && error.Line <= entry.sourceEndLine)
                 {
-                    return entry;
+                    matchedEntry = entry;
+                    matchCount++;
+                    if (matchCount > 1)
+                    {
+                        return null;
+                    }
                 }
             }
 
-            return null;
+            return matchedEntry;
         }
 
         private sealed class ShimCompileErrorAttribution

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -177,7 +177,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 defines = defines,
                 referencePaths = referencePaths,
                 targetTypesAssemblyPath = Path.GetFullPath(targetDllPath),
-                snapshotSource = snapshotSource
+                snapshotSource = snapshotSource,
+                projectRelativePath = projectRelativePath
             };
 
             TransformWorkerClientResult workerResult =
@@ -264,6 +265,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     ct).ConfigureAwait(false);
                 if (isolation == null)
                 {
+                    // Why these line numbers are original-file lines: shim sources emit #line
+                    // directives mapped to the edited user file, and the compile backends report
+                    // GetMappedLineSpan / csc locations — so ErrorMessage lines refer to the
+                    // user's source, not the temp HotReloadShim.cs scaffold.
                     outcomes.Add(
                         HotReloadMethodOutcome.Failed(
                             "(shim-compile)",
@@ -677,14 +682,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return null;
             }
 
-            ShimCompileErrorAttribution attribution =
-                AttributeErrorsToEntries(workerOutput.entries, compileResult.Errors);
+            ShimCompileErrorAttribution attribution = AttributeErrorsToEntries(
+                workerOutput.entries,
+                compileResult.Errors,
+                workerInput.projectRelativePath);
             if (attribution == null
                 || attribution.FailedEntries.Count == 0
                 || attribution.FailedEntries.Count == workerOutput.entries.Length)
             {
-                // Unattributable errors (header/binder/using-level), or isolating everyone / no one
-                // would not narrow the failure at all.
+                // Unattributable errors (header/binder/using-level / scaffold path), or isolating
+                // everyone / no one would not narrow the failure at all.
                 return null;
             }
 
@@ -720,7 +727,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 excludedMethodKeys = excludedMethodKeys,
                 // Why copy: omitting snapshotSource would make the retry patch unedited methods
                 // again and diverge the retry entries set from the first-pass isolation baseline.
-                snapshotSource = workerInput.snapshotSource
+                snapshotSource = workerInput.snapshotSource,
+                projectRelativePath = workerInput.projectRelativePath
             };
 
             TransformWorkerClientResult retryWorkerResult =
@@ -789,19 +797,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
-        /// Maps each shim compile error to the entry whose [shimSourceStartLine, shimSourceEndLine]
-        /// range contains it. Returns null if any error falls outside every entry's range (a
-        /// header/binder/using-level error, which method isolation cannot fix).
+        /// Maps each shim compile error to the entry whose original-source [sourceStartLine,
+        /// sourceEndLine] contains its #line-mapped location in the same user file. Returns null
+        /// if any error is unattributable (wrong/empty file, scaffold path, or outside every
+        /// entry range) — method isolation cannot fix those.
         /// </summary>
         private static ShimCompileErrorAttribution AttributeErrorsToEntries(
             TransformWorkerEntryDto[] entries,
-            IReadOnlyList<HotReloadShimCompileError> errors)
+            IReadOnlyList<HotReloadShimCompileError> errors,
+            string projectRelativePath)
         {
             Dictionary<TransformWorkerEntryDto, List<string>> errorMessagesByEntry =
                 new Dictionary<TransformWorkerEntryDto, List<string>>();
             foreach (HotReloadShimCompileError error in errors)
             {
-                TransformWorkerEntryDto matchedEntry = FindEntryForLine(entries, error.Line);
+                TransformWorkerEntryDto matchedEntry =
+                    FindEntryForError(entries, error, projectRelativePath);
                 if (matchedEntry == null)
                 {
                     return null;
@@ -813,18 +824,37 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     errorMessagesByEntry[matchedEntry] = messages;
                 }
 
-                messages.Add(error.Message);
+                // Why append the mapped line: ComposeShimCompileFailureMessage must still see the
+                // "CSxxxx:" prefix for hint matching, while Failed outcomes need the original-file
+                // line visible to the caller.
+                messages.Add(error.Message + " (line " + error.Line + ")");
             }
 
             return new ShimCompileErrorAttribution(errorMessagesByEntry);
         }
 
-        private static TransformWorkerEntryDto FindEntryForLine(TransformWorkerEntryDto[] entries, int line)
+        private static TransformWorkerEntryDto FindEntryForError(
+            TransformWorkerEntryDto[] entries,
+            HotReloadShimCompileError error,
+            string projectRelativePath)
         {
+            if (string.IsNullOrEmpty(error.File) || string.IsNullOrEmpty(projectRelativePath))
+            {
+                return null;
+            }
+
+            // Why suffix-tolerant compare (not ordinal equality): the three shim-compile backends
+            // report file as #line literal, absolute path, or temp scaffold path depending on the
+            // fallback stage — HotReloadSourcePathNormalizer already encodes that contract.
+            if (!HotReloadSourcePathNormalizer.PathsReferToSameFile(error.File, projectRelativePath))
+            {
+                return null;
+            }
+
             foreach (TransformWorkerEntryDto entry in entries)
             {
-                bool hasKnownRange = entry.shimSourceStartLine > 0 && entry.shimSourceEndLine > 0;
-                if (hasKnownRange && line >= entry.shimSourceStartLine && line <= entry.shimSourceEndLine)
+                bool hasKnownRange = entry.sourceStartLine > 0 && entry.sourceEndLine > 0;
+                if (hasKnownRange && error.Line >= entry.sourceStartLine && error.Line <= entry.sourceEndLine)
                 {
                     return entry;
                 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
@@ -30,11 +30,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string shimSource,
             IReadOnlyList<string> referencePaths,
             IReadOnlyList<string> defineSymbols,
+            string projectRelativePath,
             CancellationToken ct)
         {
             Debug.Assert(!string.IsNullOrEmpty(shimSource), "shimSource must not be empty.");
             Debug.Assert(referencePaths != null, "referencePaths must not be null.");
             Debug.Assert(defineSymbols != null, "defineSymbols must not be null.");
+            Debug.Assert(projectRelativePath != null, "projectRelativePath must not be null.");
 
             // Resolver and Application.dataPath (CreateWorkDirectory) need the Unity main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -78,7 +80,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     List<string> errorMessages = new List<string>(errors.Count);
                     foreach (HotReloadShimCompileError error in errors)
                     {
-                        errorMessages.Add(error.Message);
+                        // Why only user-file mapped lines: scaffold diagnostics (temp HotReloadShim.cs)
+                        // must not grow a fake "(line N)" that looks like the edited source.
+                        errorMessages.Add(FormatErrorMessageWithMappedLine(error, projectRelativePath));
                     }
 
                     return HotReloadShimCompileResult.Failure(
@@ -123,6 +127,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             "CS1501",
             "CS7036"
         };
+
+        /// <summary>
+        /// Appends " (line N)" only when the diagnostic's #line-mapped file refers to the user's
+        /// project-relative path. Scaffold-path errors keep the bare message.
+        /// </summary>
+        private static string FormatErrorMessageWithMappedLine(
+            HotReloadShimCompileError error,
+            string projectRelativePath)
+        {
+            if (error.Line > 0
+                && !string.IsNullOrEmpty(error.File)
+                && HotReloadSourcePathNormalizer.PathsReferToSameFile(error.File, projectRelativePath))
+            {
+                return error.Message + " (line " + error.Line + ")";
+            }
+
+            return error.Message;
+        }
 
         internal static string ComposeShimCompileFailureMessage(IReadOnlyList<string> errors)
         {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
@@ -159,7 +159,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 if (compilerMessage.type == CompilerMessageType.Error)
                 {
-                    errors.Add(new HotReloadShimCompileError(compilerMessage.line, compilerMessage.message));
+                    // Why keep file: #line-mapped diagnostics point at the user's project-relative
+                    // path (or an absolute form of it); attribution matches via suffix-tolerant
+                    // path compare, not exact equality across the three compile backends.
+                    errors.Add(
+                        new HotReloadShimCompileError(
+                            compilerMessage.file ?? string.Empty,
+                            compilerMessage.line,
+                            compilerMessage.message));
                 }
             }
 
@@ -181,16 +188,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     }
 
     /// <summary>
-    /// One compiler error from a shim compile, with its 1-based line in the shim source
-    /// (0 when the diagnostic carried no location).
+    /// One compiler error from a shim compile. Line/File are #line-mapped when directives are
+    /// present (original user file + 1-based original line); 0 / empty when the diagnostic
+    /// carried no location.
     /// </summary>
     internal sealed class HotReloadShimCompileError
     {
+        public string File { get; }
         public int Line { get; }
         public string Message { get; }
 
-        public HotReloadShimCompileError(int line, string message)
+        public HotReloadShimCompileError(string file, int line, string message)
         {
+            File = file ?? string.Empty;
             Line = line;
             Message = message;
         }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -21,6 +21,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Why pass text (not a path): avoids an IO race between orchestrator verification and worker
         // read that would crash the whole file under the no-try-catch policy.
         public string snapshotSource;
+
+        // Project-relative forward-slash path baked into #line document names so shim compile
+        // diagnostics map back to the user's file (not the temp HotReloadShim.cs path).
+        public string projectRelativePath;
     }
 
     /// <summary>
@@ -60,10 +64,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // "transplant" | "delegation". Null/empty is treated as transplant by the orchestrator.
         public string patchKind;
 
-        // 1-based, both ends inclusive, within TransformWorkerOutputDto.shimSource; 0 when the
-        // shim method declaration could not be located while re-parsing the emitted source.
-        public int shimSourceStartLine;
-        public int shimSourceEndLine;
+        // 1-based, both ends inclusive, within the original edited source file (not shimSource).
+        // Used to attribute shim compile errors whose #line-mapped locations fall in this method.
+        public int sourceStartLine;
+        public int sourceEndLine;
     }
 
     [Serializable]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -22,6 +23,10 @@ using Microsoft.CodeAnalysis.Text;
 public static class TransformWorkerProgram
 {
     private const string RoslynDirectorySidecarFileName = "roslyn-directory.txt";
+
+    // SyntaxAnnotation kind for original-source 1-based lines; survive rewriter + NormalizeWhitespace
+    // so Emit can inject #line directives after formatting.
+    internal const string UloopLineAnnotationKind = "uloop-line";
 
     private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
     {
@@ -150,6 +155,13 @@ public static class TransformWorkerProgram
                 parseErrors.Add(diagnostic.ToString());
             }
         }
+
+        // Why before CSharpCompilation.Create: annotating after GetSemanticModel detaches nodes
+        // from the bound tree and ShimBodyRewriter's GetSymbolInfo throws "Syntax node is not
+        // within syntax tree". Binding the SemanticModel to the annotated tree keeps rewriter
+        // lookups valid while uloop-line annotations ride through to Emit.
+        CompilationUnitSyntax annotatedRoot = AnnotateOriginalSourceLines(syntaxTree.GetCompilationUnitRoot());
+        syntaxTree = syntaxTree.WithRootAndOptions(annotatedRoot, syntaxTree.Options);
 
         string targetTypesFullPath =
             !string.IsNullOrEmpty(input.TargetTypesAssemblyPath) && File.Exists(input.TargetTypesAssemblyPath)
@@ -357,8 +369,13 @@ public static class TransformWorkerProgram
                 string shimMethodName = methodSymbol.Name + "__shim" + globalShimMethodCounter;
                 globalShimMethodCounter++;
 
+                FileLinePositionSpan originalSpan = methodDeclaration.GetLocation().GetLineSpan();
+                int sourceStartLine = originalSpan.StartLinePosition.Line + 1;
+                int sourceEndLine = originalSpan.EndLinePosition.Line + 1;
+
                 // Eligibility uses a disposable plan; the rewriter lazily GetOrAdd-s into the
                 // shim-type-level plan so AllocateName stays unique across methods in the type.
+                // methodDeclaration already carries uloop-line annotations from the parse-time pass.
                 AccessorPlan rewritePlan = decision.UsesDelegation
                     ? currentShimType.AccessorPlan
                     : null;
@@ -377,13 +394,14 @@ public static class TransformWorkerProgram
                     ParameterTypeFullNames = parameterTypeFullNames,
                     ShimTypeName = currentShimType.ShimTypeName,
                     ShimMethodName = shimMethodName,
-                    PatchKind = decision.PatchKind
+                    PatchKind = decision.PatchKind,
+                    SourceStartLine = sourceStartLine,
+                    SourceEndLine = sourceEndLine
                 });
             }
         }
 
-        string shimSource = ShimSourceEmitter.Emit(root, shimTypes);
-        ApplyShimSourceLineRanges(shimSource, entries);
+        string shimSource = ShimSourceEmitter.Emit(root, shimTypes, input.ProjectRelativePath);
         return new WorkerOutput
         {
             ShimSource = shimSource,
@@ -395,30 +413,46 @@ public static class TransformWorkerProgram
         };
     }
 
-    // Shim method names are globally unique within one emitted source (name + global counter),
-    // so re-parsing the exact text csc will compile yields authoritative per-entry line ranges
-    // for error attribution. Members outside the manifest (e.g. __BindAccessors) end up in the
-    // map too but are simply never looked up.
-    private static void ApplyShimSourceLineRanges(string shimSource, List<WorkerEntry> entries)
+    /// <summary>
+    /// Attaches original-source 1-based line annotations to every method and statement in the
+    /// parsed tree. Must run before compilation so the SemanticModel binds the annotated tree.
+    /// </summary>
+    private static CompilationUnitSyntax AnnotateOriginalSourceLines(CompilationUnitSyntax root)
     {
-        SyntaxTree emittedTree = CSharpSyntaxTree.ParseText(shimSource);
-        Dictionary<string, (int Start, int End)> lineSpanByShimMethodName =
-            new Dictionary<string, (int Start, int End)>();
-        foreach (MethodDeclarationSyntax method in emittedTree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>())
+        List<SyntaxNode> nodesToAnnotate = new List<SyntaxNode>();
+        nodesToAnnotate.AddRange(root.DescendantNodes().OfType<MethodDeclarationSyntax>());
+        nodesToAnnotate.AddRange(root.DescendantNodes().OfType<StatementSyntax>());
+        if (nodesToAnnotate.Count == 0)
         {
-            FileLinePositionSpan lineSpan = method.GetLocation().GetLineSpan();
-            lineSpanByShimMethodName[method.Identifier.Text] =
-                (lineSpan.StartLinePosition.Line + 1, lineSpan.EndLinePosition.Line + 1);
+            return root;
         }
 
-        foreach (WorkerEntry entry in entries)
-        {
-            if (lineSpanByShimMethodName.TryGetValue(entry.ShimMethodName, out (int Start, int End) lineSpan))
+        // Why rewritten (not original): ReplaceNodes applies nested replacements first; basing the
+        // parent annotation on original would drop statement annotations already applied inside.
+        return root.ReplaceNodes(
+            nodesToAnnotate,
+            (original, rewritten) =>
             {
-                entry.ShimSourceStartLine = lineSpan.Start;
-                entry.ShimSourceEndLine = lineSpan.End;
-            }
+                int line = ResolveUloopLineAnnotationLine(original);
+                return rewritten.WithAdditionalAnnotations(
+                    new SyntaxAnnotation(
+                        UloopLineAnnotationKind,
+                        line.ToString(CultureInfo.InvariantCulture)));
+            });
+    }
+
+    private static int ResolveUloopLineAnnotationLine(SyntaxNode node)
+    {
+        if (node is MethodDeclarationSyntax methodDeclaration && methodDeclaration.ExpressionBody != null)
+        {
+            // Why arrow expression (not declaration start): NormalizeWhitespace collapses the
+            // method to one line, so mapping to the arrow expression's original start is the only
+            // location that still matches the user's intent for expression-bodied methods.
+            return methodDeclaration.ExpressionBody.Expression.GetLocation()
+                .GetLineSpan().StartLinePosition.Line + 1;
         }
+
+        return node.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
     }
 
     /// <summary>
@@ -3273,12 +3307,22 @@ internal sealed class ShimTypeBuilder
 
 internal static class ShimSourceEmitter
 {
-    public static string Emit(CompilationUnitSyntax originalRoot, List<ShimTypeBuilder> shimTypes)
+    public static string Emit(
+        CompilationUnitSyntax originalRoot,
+        List<ShimTypeBuilder> shimTypes,
+        string projectRelativePath)
     {
         if (shimTypes.Count == 0)
         {
             return string.Empty;
         }
+
+        Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+        // Why assert shape: #line document names are embedded as C# string literals; backslashes
+        // or quotes would break the directive or require escaping we deliberately do not support.
+        Debug.Assert(
+            projectRelativePath.IndexOf('\\') < 0 && projectRelativePath.IndexOf('"') < 0,
+            "projectRelativePath must be forward-slash and quote-free.");
 
         // Emit each shim type in the original type's namespace (and with that type's usings) so
         // unqualified sibling-type references in transplanted bodies still resolve. Manifest
@@ -3313,13 +3357,62 @@ internal static class ShimSourceEmitter
             }
         }
 
+        // Why after NormalizeWhitespace: formatting would otherwise shift #line relative to
+        // statements; annotations survive formatting so we inject directives on the final tree.
         unit = unit.NormalizeWhitespace();
+        unit = InjectLineDirectives(unit, projectRelativePath);
 
         StringBuilder builder = new StringBuilder();
         builder.AppendLine(
             "// Generated shims mirror user method signatures verbatim; repo style rules apply to hand-written code only.");
         builder.Append(unit.ToFullString());
         return builder.ToString();
+    }
+
+    private static CompilationUnitSyntax InjectLineDirectives(
+        CompilationUnitSyntax unit,
+        string projectRelativePath)
+    {
+        List<SyntaxNode> annotatedNodes = unit.GetAnnotatedNodes(TransformWorkerProgram.UloopLineAnnotationKind)
+            .ToList();
+        if (annotatedNodes.Count > 0)
+        {
+            unit = unit.ReplaceNodes(
+                annotatedNodes,
+                (original, rewritten) =>
+                {
+                    SyntaxAnnotation annotation = original
+                        .GetAnnotations(TransformWorkerProgram.UloopLineAnnotationKind)
+                        .First();
+                    // Why leading trivia starts/ends with newline: #line must occupy its own line.
+                    string directiveText =
+                        "\n#line " + annotation.Data + " \"" + projectRelativePath + "\"\n";
+                    SyntaxTriviaList leading = SyntaxFactory.ParseLeadingTrivia(directiveText);
+                    return rewritten.WithLeadingTrivia(leading.AddRange(rewritten.GetLeadingTrivia()));
+                });
+        }
+
+        // Reset mapping after each method so scaffold (__BindAccessors, fields, class braces)
+        // does not inherit the previous method's document/line.
+        List<MethodDeclarationSyntax> methods = unit.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .ToList();
+        if (methods.Count == 0)
+        {
+            return unit;
+        }
+
+        // Why ParseLeadingTrivia into trailing: ParseTrailingTrivia does not reliably produce
+        // LineDirectiveTrivia for "#line default", while ParseLeadingTrivia does — and directive
+        // trivia is legal in a trailing trivia list for ToFullString emission.
+        return unit.ReplaceNodes(
+            methods,
+            (original, rewritten) =>
+            {
+                SyntaxTriviaList defaultDirective = SyntaxFactory.ParseLeadingTrivia("\n#line default\n");
+                return rewritten.WithTrailingTrivia(
+                    rewritten.GetTrailingTrivia().AddRange(defaultDirective));
+            });
     }
 }
 
@@ -3434,6 +3527,9 @@ internal sealed class WorkerInput
     // Why pass text (not a path): avoids an IO race between orchestrator verification and worker
     // read that would crash the whole file under the no-try-catch policy.
     public string SnapshotSource { get; set; }
+
+    // Project-relative forward-slash path embedded in #line document names.
+    public string ProjectRelativePath { get; set; }
 }
 
 internal sealed class WorkerOutput
@@ -3475,11 +3571,10 @@ internal sealed class WorkerEntry
     // "transplant" | "delegation" — see PatchKinds.
     public string PatchKind { get; set; }
 
-    // 1-based, both ends inclusive, within WorkerOutput.ShimSource; 0 when the shim method
-    // declaration could not be located while re-parsing the emitted source.
-    public int ShimSourceStartLine { get; set; }
+    // 1-based, both ends inclusive, within the original edited source file.
+    public int SourceStartLine { get; set; }
 
-    public int ShimSourceEndLine { get; set; }
+    public int SourceEndLine { get; set; }
 }
 
 internal static class PatchKinds

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -123,6 +122,25 @@ public static class TransformWorkerProgram
     private static WorkerOutput TransformFile(WorkerInput input)
     {
         List<string> parseErrors = new List<string>();
+
+        // Why ParseErrors (not Debug.Assert): ProjectRelativePath crosses a process boundary via
+        // JSON, and the worker is built without a DEBUG define so Conditional Asserts are stripped.
+        if (string.IsNullOrEmpty(input.ProjectRelativePath)
+            || input.ProjectRelativePath.IndexOf('\\') >= 0
+            || input.ProjectRelativePath.IndexOf('"') >= 0)
+        {
+            return new WorkerOutput
+            {
+                ShimSource = string.Empty,
+                Entries = Array.Empty<WorkerEntry>(),
+                Skipped = Array.Empty<WorkerSkipped>(),
+                ParseErrors = new[]
+                {
+                    "Invalid projectRelativePath: must be a non-empty forward-slash path without quotes."
+                }
+            };
+        }
+
         string sourceText;
         try
         {
@@ -3317,12 +3335,7 @@ internal static class ShimSourceEmitter
             return string.Empty;
         }
 
-        Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
-        // Why assert shape: #line document names are embedded as C# string literals; backslashes
-        // or quotes would break the directive or require escaping we deliberately do not support.
-        Debug.Assert(
-            projectRelativePath.IndexOf('\\') < 0 && projectRelativePath.IndexOf('"') < 0,
-            "projectRelativePath must be forward-slash and quote-free.");
+        // projectRelativePath shape is validated at TransformFile's input boundary (ParseErrors).
 
         // Emit each shim type in the original type's namespace (and with that type's usings) so
         // unqualified sibling-type references in transplanted bodies still resolve. Manifest


### PR DESCRIPTION
## Summary

- Emit `#line` directives in hot-reload shim sources so compiler diagnostics map to the user's project-relative file and original line numbers (statement-level, with `#line default` after each shim method).
- Attribute shim compile failures by `(file, sourceStartLine..sourceEndLine)` instead of shim-source line ranges, using the existing path normalizer (suffix-tolerant across compile backends).
- Annotate the parsed syntax tree before `CSharpCompilation.Create` so the SemanticModel binds the annotated tree and the rewriter can keep `uloop-line` annotations without detaching nodes.

## To-Do coverage (PR-1)

- To-Do 1: branch `feat/hot-reload-shim-line-directives` from `origin/feature/hot-reload`
- To-Do 2: `projectRelativePath` on worker input; parse-time `uloop-line` annotations; `sourceStartLine`/`sourceEndLine` on entries
- To-Do 3: post-`NormalizeWhitespace` `#line` / `#line default` injection in `ShimSourceEmitter.Emit`
- To-Do 4: `HotReloadShimCompileError.File` + `FindEntryForError` attribution
- To-Do 5: worker/orchestrator test updates for original-line ranges, `#line` emission, arrow-body mapping, and isolation with original-file line in Failed messages

## User Impact

When a hot-reload shim fails to compile, error lines now point at the edited user source (not the temporary shim file), so agents can jump to the real statement that broke.

## Test plan

- [x] `dist/darwin-arm64/uloop compile` → Error 0 / Warning 0
- [x] `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value HotReload` → Failed 0 (116 passed)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

