### PR TITLE
feat: retain shim binaries and publish a hot-reload shim registration

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadShimRegistryTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShimRegistryTests.cs
@@ -32,7 +32,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: after a successful orchestrated apply, GetShimLookupForFile returns the
-        /// patched method for the fixture's project-relative path.
+        /// patched method for the fixture path (relative and absolute), with PDB bytes and
+        /// transplant (non-delegation) shape for ComputeWithPrivate.
         /// </summary>
         [Test]
         public async Task Apply_ThenGetShimLookupForFile_ReturnsPatchedMethods()
@@ -43,8 +44,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
             Assert.That(lookup, Is.Not.Null);
             Assert.That(lookup.AssemblyBytes, Is.Not.Null.And.Not.Empty);
+            Assert.That(lookup.PdbBytes, Is.Not.Null.And.Not.Empty);
             Assert.That(lookup.LoadedAssembly, Is.Not.Null);
             Assert.That(lookup.Methods, Is.Not.Empty);
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string absoluteFixturePath = Path.GetFullPath(
+                Path.Combine(projectRoot, FixtureProjectRelativePath));
+            HotReloadShimFileLookup absoluteLookup =
+                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(absoluteFixturePath);
+            Assert.That(
+                absoluteLookup,
+                Is.Not.Null,
+                "Absolute --file-style paths must resolve via PathsReferToSameFile linear scan.");
 
             bool foundCompute = false;
             foreach (HotReloadShimMethodLookup method in lookup.Methods)
@@ -54,6 +66,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 {
                     foundCompute = true;
                     Assert.That(method.ShimMethod, Is.Not.Null);
+                    Assert.That(method.IsDelegation, Is.False);
                     Assert.That(method.SourceStartLine, Is.GreaterThan(0));
                     Assert.That(method.SourceEndLine, Is.GreaterThanOrEqualTo(method.SourceStartLine));
                 }
@@ -63,8 +76,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: reverting a patched method removes it from GetShimLookupForFile (lookup becomes
-        /// null when it was the last registered method for that file).
+        /// What: reverting ComputeWithPrivate removes only that method from GetShimLookupForFile
+        /// while sibling methods that shared the edited statement remain registered.
         /// </summary>
         [Test]
         public async Task Revert_RemovesMethodFromShimLookup()
@@ -75,18 +88,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 BindingFlags.Instance | BindingFlags.Public);
             Assert.That(computeMethod, Is.Not.Null);
 
+            HotReloadShimFileLookup beforeLookup =
+                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+            Assert.That(beforeLookup, Is.Not.Null);
+            Assert.That(
+                beforeLookup.Methods.Count,
+                Is.GreaterThanOrEqualTo(2),
+                "Precondition: Replace of `return _secret + delta;` must patch ComputeWithPrivate " +
+                "plus at least one sibling so revert cannot clear the whole file lookup.");
+
             bool reverted = HotReloadPatcher.Revert(computeMethod);
             Assert.That(reverted, Is.True);
 
             HotReloadShimFileLookup lookup =
                 HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
-            if (lookup == null)
-            {
-                return;
-            }
+            Assert.That(lookup, Is.Not.Null);
+            Assert.That(lookup.Methods, Is.Not.Empty);
 
-            // Why allow non-null lookup: editing `return _secret + delta;` can also touch sibling
-            // methods that share that statement text; only ComputeWithPrivate must disappear.
             foreach (HotReloadShimMethodLookup method in lookup.Methods)
             {
                 Assert.That(
@@ -132,7 +150,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: GetTransplantLocals returns a non-null list for a method patched via transplant.
+        /// What: GetTransplantLocals returns a list whose length matches the shim method's
+        /// LocalVariables count for a transplant-patched method.
         /// </summary>
         [Test]
         public async Task Apply_Transplant_ExposesTransplantLocals()
@@ -143,9 +162,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 BindingFlags.Instance | BindingFlags.Public);
             Assert.That(computeMethod, Is.Not.Null);
 
+            HotReloadShimFileLookup lookup =
+                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+            Assert.That(lookup, Is.Not.Null);
+
+            MethodBase shimMethod = null;
+            foreach (HotReloadShimMethodLookup method in lookup.Methods)
+            {
+                if (method.OriginalMethod != null
+                    && method.OriginalMethod.Name == nameof(HotReloadE2EFixture.ComputeWithPrivate))
+                {
+                    shimMethod = method.ShimMethod;
+                    break;
+                }
+            }
+
+            Assert.That(shimMethod, Is.Not.Null);
+            MethodBody shimBody = shimMethod.GetMethodBody();
+            Assert.That(shimBody, Is.Not.Null);
+
             IReadOnlyList<LocalBuilder> locals =
                 HotReloadPausePointCoordination.GetTransplantLocals?.Invoke(computeMethod);
             Assert.That(locals, Is.Not.Null);
+            Assert.That(locals.Count, Is.EqualTo(shimBody.LocalVariables.Count));
         }
 
         private static async Task PatchComputeWithPrivateAsync(int extraDelta = 100)

--- a/Assets/Tests/Editor/HotReload/HotReloadShimRegistryTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShimRegistryTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for shim registration exposed through hot-reload / pause-point
+    /// coordination after orchestrated apply / revert.
+    /// </summary>
+    public class HotReloadShimRegistryTests
+    {
+        private const string FixtureProjectRelativePath =
+            "Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs";
+
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadPatcher.RevertAll();
+        }
+
+        /// <summary>
+        /// What: after a successful orchestrated apply, GetShimLookupForFile returns the
+        /// patched method for the fixture's project-relative path.
+        /// </summary>
+        [Test]
+        public async Task Apply_ThenGetShimLookupForFile_ReturnsPatchedMethods()
+        {
+            await PatchComputeWithPrivateAsync();
+
+            HotReloadShimFileLookup lookup =
+                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+            Assert.That(lookup, Is.Not.Null);
+            Assert.That(lookup.AssemblyBytes, Is.Not.Null.And.Not.Empty);
+            Assert.That(lookup.LoadedAssembly, Is.Not.Null);
+            Assert.That(lookup.Methods, Is.Not.Empty);
+
+            bool foundCompute = false;
+            foreach (HotReloadShimMethodLookup method in lookup.Methods)
+            {
+                if (method.OriginalMethod != null
+                    && method.OriginalMethod.Name == nameof(HotReloadE2EFixture.ComputeWithPrivate))
+                {
+                    foundCompute = true;
+                    Assert.That(method.ShimMethod, Is.Not.Null);
+                    Assert.That(method.SourceStartLine, Is.GreaterThan(0));
+                    Assert.That(method.SourceEndLine, Is.GreaterThanOrEqualTo(method.SourceStartLine));
+                }
+            }
+
+            Assert.That(foundCompute, Is.True, "ComputeWithPrivate missing from shim lookup Methods.");
+        }
+
+        /// <summary>
+        /// What: reverting a patched method removes it from GetShimLookupForFile (lookup becomes
+        /// null when it was the last registered method for that file).
+        /// </summary>
+        [Test]
+        public async Task Revert_RemovesMethodFromShimLookup()
+        {
+            await PatchComputeWithPrivateAsync();
+            MethodInfo computeMethod = typeof(HotReloadE2EFixture).GetMethod(
+                nameof(HotReloadE2EFixture.ComputeWithPrivate),
+                BindingFlags.Instance | BindingFlags.Public);
+            Assert.That(computeMethod, Is.Not.Null);
+
+            bool reverted = HotReloadPatcher.Revert(computeMethod);
+            Assert.That(reverted, Is.True);
+
+            HotReloadShimFileLookup lookup =
+                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+            if (lookup == null)
+            {
+                return;
+            }
+
+            // Why allow non-null lookup: editing `return _secret + delta;` can also touch sibling
+            // methods that share that statement text; only ComputeWithPrivate must disappear.
+            foreach (HotReloadShimMethodLookup method in lookup.Methods)
+            {
+                Assert.That(
+                    method.OriginalMethod.Name,
+                    Is.Not.EqualTo(nameof(HotReloadE2EFixture.ComputeWithPrivate)));
+            }
+        }
+
+        /// <summary>
+        /// What: RevertAll clears every shim registration so GetShimLookupForFile returns null.
+        /// </summary>
+        [Test]
+        public async Task RevertAll_ClearsShimLookup()
+        {
+            await PatchComputeWithPrivateAsync();
+            HotReloadPatcher.RevertAll();
+
+            HotReloadShimFileLookup lookup =
+                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+            Assert.That(lookup, Is.Null);
+        }
+
+        /// <summary>
+        /// What: re-applying a newer edit replaces the LoadedAssembly identity for that file.
+        /// </summary>
+        [Test]
+        public async Task ReApply_ReplacesLoadedAssembly()
+        {
+            await PatchComputeWithPrivateAsync(extraDelta: 100);
+            HotReloadShimFileLookup firstLookup =
+                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+            Assert.That(firstLookup, Is.Not.Null);
+            Assembly firstAssembly = firstLookup.LoadedAssembly;
+
+            await PatchComputeWithPrivateAsync(extraDelta: 200);
+            HotReloadShimFileLookup secondLookup =
+                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+            Assert.That(secondLookup, Is.Not.Null);
+            Assert.That(
+                ReferenceEquals(secondLookup.LoadedAssembly, firstAssembly),
+                Is.False,
+                "Re-apply must load a new shim assembly generation.");
+        }
+
+        /// <summary>
+        /// What: GetTransplantLocals returns a non-null list for a method patched via transplant.
+        /// </summary>
+        [Test]
+        public async Task Apply_Transplant_ExposesTransplantLocals()
+        {
+            await PatchComputeWithPrivateAsync();
+            MethodInfo computeMethod = typeof(HotReloadE2EFixture).GetMethod(
+                nameof(HotReloadE2EFixture.ComputeWithPrivate),
+                BindingFlags.Instance | BindingFlags.Public);
+            Assert.That(computeMethod, Is.Not.Null);
+
+            IReadOnlyList<LocalBuilder> locals =
+                HotReloadPausePointCoordination.GetTransplantLocals?.Invoke(computeMethod);
+            Assert.That(locals, Is.Not.Null);
+        }
+
+        private static async Task PatchComputeWithPrivateAsync(int extraDelta = 100)
+        {
+            string fixturePath = Path.GetFullPath(
+                Path.Combine(
+                    Application.dataPath,
+                    "Tests",
+                    "Editor",
+                    "HotReload",
+                    "HotReloadE2EFixtures.cs"));
+            Assert.That(File.Exists(fixturePath), Is.True);
+
+            string onDisk = File.ReadAllText(fixturePath);
+            string editedSource = onDisk.Replace(
+                "return _secret + delta;",
+                "return _secret + delta + " + extraDelta + ";",
+                StringComparison.Ordinal);
+            Assert.That(
+                editedSource,
+                Is.Not.EqualTo(onDisk),
+                "Precondition: ComputeWithPrivate body must differ from on-disk fixture.");
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(
+                projectRoot,
+                HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string editedPath = Path.Combine(directory, "ShimRegistryCompute_" + extraDelta + ".cs");
+            File.WriteAllText(editedPath, editedSource);
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            bool foundPatched = false;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Patched
+                    && outcome.Method.Contains(nameof(HotReloadE2EFixture.ComputeWithPrivate)))
+                {
+                    foundPatched = true;
+                }
+            }
+
+            Assert.That(
+                foundPatched,
+                Is.True,
+                "Expected ComputeWithPrivate to patch.\n" + FormatOutcomes(result));
+        }
+
+        private static string FormatOutcomes(HotReloadOrchestratorResult result)
+        {
+            List<string> lines = new List<string>();
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                lines.Add(outcome.Kind + " " + outcome.Method + " :: " + outcome.Reason);
+            }
+
+            return string.Join("\n", lines);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadShimRegistryTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadShimRegistryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4cf8fc23138e04d8d8582e34f9d1273d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -296,6 +296,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // Harmony Patch/Unpatch and method resolution against loaded modules require main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
+            // Why before ApplyEntry: OnHotReloadPatchStateChanged(true) runs inside Apply and
+            // pause-point retarget reads the shim registration — it must already see this
+            // generation's bytes/methods.
+            HotReloadShimRegistry.BeginFileGeneration(
+                projectRelativePath,
+                compileResult.AssemblyBytes,
+                compileResult.PdbBytes,
+                compileResult.Assembly);
             Dictionary<string, string> bindFailureReasonByShimTypeName =
                 BindShimAccessors(compileResult.Assembly);
             List<string> inlineRiskMethodLabels = new List<string>();
@@ -308,6 +316,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     compileResult.Assembly,
                     bindFailureReasonByShimTypeName,
                     assemblyResolvePath,
+                    projectRelativePath,
                     inlineRiskMethodLabels,
                     suppressedPausePointIds);
                 outcomes.Add(outcome);
@@ -366,6 +375,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Assembly shimAssembly,
             IReadOnlyDictionary<string, string> bindFailureReasonByShimTypeName,
             string filePath,
+            string projectRelativePath,
             List<string> inlineRiskMethodLabels,
             List<string> suppressedPausePointIds)
         {
@@ -425,9 +435,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     filePath);
             }
 
+            // Why before Apply: Apply notifies OnHotReloadPatchStateChanged(true) after the
+            // ledger write; registration must already expose this method's shim for retarget.
+            HotReloadShimRegistry.RegisterMethod(
+                projectRelativePath,
+                matchResult.Method,
+                new HotReloadShimRegistry.MethodEntry(
+                    shimMethod,
+                    patchShape == HotReloadPatchShape.Delegation,
+                    entry.sourceStartLine,
+                    entry.sourceEndLine));
             HotReloadPatchResult patchResult = HotReloadPatcher.Apply(matchResult.Method, shimMethod, patchShape);
             if (!patchResult.Success)
             {
+                HotReloadShimRegistry.RemoveMethod(matchResult.Method);
                 return HotReloadMethodOutcome.Failed(methodLabel, patchResult.ErrorMessage, filePath);
             }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -56,7 +56,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return shimMethod;
                 }
 
-                if (_pendingShimMethod != null && ReferenceEquals(method, _pendingOriginalMethod))
+                // Why Equals (not ReferenceEquals): match MethodBase equality used by
+                // ShimByMethod.TryGetValue rather than Harmony's instance identity.
+                if (_pendingShimMethod != null
+                    && _pendingOriginalMethod != null
+                    && method != null
+                    && method.Equals(_pendingOriginalMethod))
                 {
                     return _pendingShimMethod;
                 }
@@ -67,8 +72,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 TransplantLocalsByMethod.TryGetValue(method, out IReadOnlyList<LocalBuilder> locals)
                     ? locals
                     : null;
-            // Touch the registry type so GetShimLookupForFile is wired in this domain.
-            HotReloadShimRegistry.Clear();
         }
 
         /// <summary>
@@ -141,6 +144,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
             catch (Exception exception)
             {
+                // Why clear pending before Unpatch: cleanup rebuild must see "not patched"
+                // so pause-point markers re-instrument the restored original body. Leaving
+                // pending set would make GetActiveShimForMethod return the failed shim and
+                // suppress that re-instrumentation (regression vs the old ContainsKey probe).
+                _pendingShimMethod = null;
+                _pendingOriginalMethod = null;
                 // User-approved exception to the no-try-catch policy: Harmony emit/JIT
                 // failures cannot be pre-validated (the IL shape is only known inside
                 // Harmony), and an escaping exception would abort the whole run while

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -33,16 +33,42 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static readonly Dictionary<MethodBase, MethodInfo> ShimByMethod =
             new Dictionary<MethodBase, MethodInfo>();
 
+        // Transplant LocalBuilders (shim slot order) from the latest rebuild of each original.
+        private static readonly Dictionary<MethodBase, IReadOnlyList<LocalBuilder>> TransplantLocalsByMethod =
+            new Dictionary<MethodBase, IReadOnlyList<LocalBuilder>>();
+
         // Harmony resolves transpilers as static methods, so the shim cannot be a parameter.
         // Production looks up the target method in the ledger; the apply path also stashes the
         // pending shim here so the first Patch call can read it before the ledger entry
         // exists (Patch invokes the transpiler synchronously on the main thread).
         private static MethodInfo _pendingShimMethod;
+        private static MethodBase _pendingOriginalMethod;
 
         static HotReloadPatcher()
         {
-            HotReloadPausePointCoordination.IsMethodPatchedByHotReload = method =>
-                ShimByMethod.ContainsKey(method);
+            // Why also expose _pending*: with Priority.First, hot-reload runs before pause-point
+            // during Apply. The ledger is written only after Patch returns, so without the pending
+            // shim pause-point would try to inject original-body indexes into the shim stream.
+            HotReloadPausePointCoordination.GetActiveShimForMethod = method =>
+            {
+                if (ShimByMethod.TryGetValue(method, out MethodInfo shimMethod))
+                {
+                    return shimMethod;
+                }
+
+                if (_pendingShimMethod != null && ReferenceEquals(method, _pendingOriginalMethod))
+                {
+                    return _pendingShimMethod;
+                }
+
+                return null;
+            };
+            HotReloadPausePointCoordination.GetTransplantLocals = method =>
+                TransplantLocalsByMethod.TryGetValue(method, out IReadOnlyList<LocalBuilder> locals)
+                    ? locals
+                    : null;
+            // Touch the registry type so GetShimLookupForFile is wired in this domain.
+            HotReloadShimRegistry.Clear();
         }
 
         /// <summary>
@@ -83,6 +109,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // leaving it in place would stack transpilers and run discarded IL chains.
                 HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
                 ShimByMethod.Remove(method);
+                TransplantLocalsByMethod.Remove(method);
                 // Mirror the ledger removal immediately: if the re-Patch below fails, its
                 // contained Unpatch rebuilds the method with markers re-instrumented (the
                 // ledger no longer lists it), and RevertAll can never reach this method
@@ -97,11 +124,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Ledger is updated after Patch succeeds. During Patch the transpiler reads the
             // pending shim because Harmony resolves transpilers statically (no MethodInfo arg).
             _pendingShimMethod = shimMethodInfo;
+            _pendingOriginalMethod = method;
             try
             {
+                // Why Priority.First: same numeric priority sorts by registration index, and
+                // Unpatch does not reindex — Patch/Unpatch cycles make same-priority order
+                // unstable. pause-point must run after hot-reload so it sees the shim stream.
                 HarmonyInstance.Patch(
                     method,
-                    transpiler: new HarmonyMethod(transpilerMethodInfo));
+                    transpiler: new HarmonyMethod(transpilerMethodInfo)
+                    {
+                        priority = Priority.First
+                    });
                 ShimByMethod[method] = shimMethodInfo;
                 HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, true);
             }
@@ -115,6 +149,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // the transpiler this call registered before failing and rebuilds the
                 // wrapper, restoring the original body (verified by the extern-shim test).
                 HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
+                TransplantLocalsByMethod.Remove(method);
                 Exception rootCause = exception;
                 while (rootCause.InnerException != null)
                 {
@@ -133,6 +168,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             finally
             {
                 _pendingShimMethod = null;
+                _pendingOriginalMethod = null;
             }
 
             return HotReloadPatchResult.SuccessResult(IsLikelyJitInlined(method));
@@ -146,10 +182,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Snapshot and clear the ledger BEFORE UnpatchAll: Harmony rebuilds every
             // patched method during UnpatchAll, and the pause-point transpiler guard
             // must see those methods as unpatched so armed markers are re-instrumented
-            // into the restored original IL.
+            // into the restored original IL. Shim registration clears in the same window
+            // so GetActiveShimForMethod / GetShimLookupForFile agree during rebuild.
             List<MethodBase> revertedMethods = new List<MethodBase>(ShimByMethod.Keys);
             ShimByMethod.Clear();
+            HotReloadShimRegistry.Clear();
+            TransplantLocalsByMethod.Clear();
             _pendingShimMethod = null;
+            _pendingOriginalMethod = null;
             HarmonyInstance.UnpatchAll(HotReloadConstants.HarmonyId);
             foreach (MethodBase revertedMethod in revertedMethods)
             {
@@ -171,8 +211,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             // Why Remove before Unpatch: Harmony rebuilds the method during Unpatch, and the
-            // pause-point transpiler guard reads IsMethodPatchedByHotReload — the ledger must
-            // already show unpatched so armed markers are re-instrumented into the restored IL.
+            // pause-point guard sees GetActiveShimForMethod == null so surviving markers are
+            // re-instrumented into the restored original IL. Registry removal stays in the same
+            // pre-Unpatch window so lookup and ledger never disagree mid-rebuild.
+            HotReloadShimRegistry.RemoveMethod(method);
+            TransplantLocalsByMethod.Remove(method);
             HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
             HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
             return true;
@@ -216,7 +259,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Labels need the same treatment: see RebindLabels below.
             List<CodeInstruction> transplanted =
                 new List<CodeInstruction>(PatchProcessor.GetOriginalInstructions(shimMethod));
-            RebindShortFormLocals(shimMethod, generator, transplanted);
+            IReadOnlyList<LocalBuilder> transplantLocals =
+                RebindShortFormLocals(shimMethod, generator, transplanted);
+            TransplantLocalsByMethod[original] = transplantLocals;
             RebindLabels(generator, transplanted);
             return transplanted;
         }
@@ -328,7 +373,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return HotReloadPatchResult.SuccessResult();
         }
 
-        private static void RebindShortFormLocals(
+        private static IReadOnlyList<LocalBuilder> RebindShortFormLocals(
             MethodInfo shimMethod,
             ILGenerator generator,
             List<CodeInstruction> instructions)
@@ -340,7 +385,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             MethodBody methodBody = shimMethod.GetMethodBody();
             if (methodBody == null || methodBody.LocalVariables.Count == 0)
             {
-                return;
+                return Array.Empty<LocalBuilder>();
             }
 
             LocalBuilder[] locals = new LocalBuilder[methodBody.LocalVariables.Count];
@@ -374,6 +419,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     blocks = instruction.blocks
                 };
             }
+
+            return locals;
         }
 
         // Labels read from the shim without this patch's ILGenerator belong to a throwaway

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
@@ -103,7 +103,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         "Shim assembly compiled but failed to load: " + dllPath);
                 }
 
-                return HotReloadShimCompileResult.SuccessResult(loadResult.CompiledAssembly);
+                return HotReloadShimCompileResult.SuccessResult(
+                    loadResult.CompiledAssembly,
+                    assemblyBytes,
+                    pdbBytes);
             }
             finally
             {
@@ -229,7 +232,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     }
 
     /// <summary>
-    /// Outcome of compiling and loading a hot-reload shim assembly.
+    /// Outcome of compiling and loading a hot-reload shim assembly. Successful results keep the
+    /// dll/pdb bytes so pause-point can resolve sequence points against the shim PDB after the
+    /// compile work directory is deleted.
     /// </summary>
     internal sealed class HotReloadShimCompileResult
     {
@@ -238,6 +243,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public bool Success { get; }
         public Assembly Assembly { get; }
+        public byte[] AssemblyBytes { get; }
+        public byte[] PdbBytes { get; }
         public string ErrorMessage { get; }
         public IReadOnlyList<HotReloadShimCompileError> Errors { get; }
 
@@ -245,17 +252,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool success,
             Assembly assembly,
             string errorMessage,
-            IReadOnlyList<HotReloadShimCompileError> errors)
+            IReadOnlyList<HotReloadShimCompileError> errors,
+            byte[] assemblyBytes,
+            byte[] pdbBytes)
         {
             Success = success;
             Assembly = assembly;
             ErrorMessage = errorMessage;
             Errors = errors;
+            AssemblyBytes = assemblyBytes;
+            PdbBytes = pdbBytes;
         }
 
-        public static HotReloadShimCompileResult SuccessResult(Assembly assembly)
+        public static HotReloadShimCompileResult SuccessResult(
+            Assembly assembly,
+            byte[] assemblyBytes,
+            byte[] pdbBytes)
         {
-            return new HotReloadShimCompileResult(true, assembly, string.Empty, EmptyErrors);
+            return new HotReloadShimCompileResult(
+                true,
+                assembly,
+                string.Empty,
+                EmptyErrors,
+                assemblyBytes,
+                pdbBytes);
         }
 
         // errors stays empty for failures that never reached the compiler (e.g. missing external
@@ -263,7 +283,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public static HotReloadShimCompileResult Failure(
             string errorMessage, IReadOnlyList<HotReloadShimCompileError> errors = null)
         {
-            return new HotReloadShimCompileResult(false, null, errorMessage, errors ?? EmptyErrors);
+            return new HotReloadShimCompileResult(
+                false,
+                null,
+                errorMessage,
+                errors ?? EmptyErrors,
+                null,
+                null);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimRegistry.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimRegistry.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+using Assembly = System.Reflection.Assembly;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Per-file hot-reload shim generation ledger (bytes + loaded assembly + method map).
+    /// Pause-point resolves markers against the active generation via coordination delegates.
+    /// </summary>
+    internal static class HotReloadShimRegistry
+    {
+        private static readonly Dictionary<string, FileGeneration> GenerationsByPath =
+            new Dictionary<string, FileGeneration>(StringComparer.Ordinal);
+
+        static HotReloadShimRegistry()
+        {
+            HotReloadPausePointCoordination.GetShimLookupForFile = LookupForFile;
+        }
+
+        /// <summary>
+        /// Replaces any prior generation for <paramref name="projectRelativePath"/> with a new
+        /// empty method map backed by the compiled shim bytes.
+        /// </summary>
+        public static void BeginFileGeneration(
+            string projectRelativePath,
+            byte[] assemblyBytes,
+            byte[] pdbBytes,
+            Assembly loadedAssembly)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+            Debug.Assert(assemblyBytes != null && assemblyBytes.Length > 0, "assemblyBytes must not be empty.");
+            Debug.Assert(loadedAssembly != null, "loadedAssembly must not be null.");
+
+            GenerationsByPath[projectRelativePath] = new FileGeneration(
+                assemblyBytes,
+                pdbBytes,
+                loadedAssembly);
+        }
+
+        public static void RegisterMethod(
+            string projectRelativePath,
+            MethodBase originalMethod,
+            MethodEntry entry)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+            Debug.Assert(originalMethod != null, "originalMethod must not be null.");
+            Debug.Assert(entry != null, "entry must not be null.");
+            Debug.Assert(
+                GenerationsByPath.ContainsKey(projectRelativePath),
+                "BeginFileGeneration must run before RegisterMethod for this path.");
+
+            GenerationsByPath[projectRelativePath].Methods[originalMethod] = entry;
+        }
+
+        /// <summary>
+        /// Removes <paramref name="originalMethod"/> from every file generation; deletes empty
+        /// generations. Safe when the method is not registered.
+        /// </summary>
+        public static void RemoveMethod(MethodBase originalMethod)
+        {
+            Debug.Assert(originalMethod != null, "originalMethod must not be null.");
+
+            List<string> emptyPaths = null;
+            foreach (KeyValuePair<string, FileGeneration> pair in GenerationsByPath)
+            {
+                if (!pair.Value.Methods.Remove(originalMethod))
+                {
+                    continue;
+                }
+
+                if (pair.Value.Methods.Count == 0)
+                {
+                    emptyPaths ??= new List<string>();
+                    emptyPaths.Add(pair.Key);
+                }
+            }
+
+            if (emptyPaths == null)
+            {
+                return;
+            }
+
+            for (int index = 0; index < emptyPaths.Count; index++)
+            {
+                GenerationsByPath.Remove(emptyPaths[index]);
+            }
+        }
+
+        public static void Clear()
+        {
+            GenerationsByPath.Clear();
+        }
+
+        private static HotReloadShimFileLookup LookupForFile(string requestedPath)
+        {
+            if (string.IsNullOrEmpty(requestedPath))
+            {
+                return null;
+            }
+
+            // Why linear scan (not Dictionary key equality): request paths may be absolute while
+            // registration keys are project-relative, and Windows needs OrdinalIgnoreCase —
+            // HotReloadSourcePathNormalizer already encodes both rules.
+            FileGeneration matchedGeneration = null;
+            foreach (KeyValuePair<string, FileGeneration> pair in GenerationsByPath)
+            {
+                if (HotReloadSourcePathNormalizer.PathsReferToSameFile(requestedPath, pair.Key))
+                {
+                    matchedGeneration = pair.Value;
+                    break;
+                }
+            }
+
+            if (matchedGeneration == null)
+            {
+                return null;
+            }
+
+            List<HotReloadShimMethodLookup> methods = new List<HotReloadShimMethodLookup>();
+            foreach (KeyValuePair<MethodBase, MethodEntry> methodPair in matchedGeneration.Methods)
+            {
+                // Why filter by active shim ledger: BeginFileGeneration can outlive a Revert of
+                // individual methods; pause-point must only see methods still patched.
+                MethodBase activeShim =
+                    HotReloadPausePointCoordination.GetActiveShimForMethod?.Invoke(methodPair.Key);
+                if (activeShim == null)
+                {
+                    continue;
+                }
+
+                MethodEntry entry = methodPair.Value;
+                methods.Add(
+                    new HotReloadShimMethodLookup(
+                        methodPair.Key,
+                        entry.ShimMethod,
+                        entry.IsDelegation,
+                        entry.SourceStartLine,
+                        entry.SourceEndLine));
+            }
+
+            if (methods.Count == 0)
+            {
+                return null;
+            }
+
+            return new HotReloadShimFileLookup(
+                matchedGeneration.AssemblyBytes,
+                matchedGeneration.PdbBytes,
+                matchedGeneration.LoadedAssembly,
+                methods);
+        }
+
+        internal sealed class MethodEntry
+        {
+            public MethodBase ShimMethod { get; }
+            public bool IsDelegation { get; }
+            public int SourceStartLine { get; }
+            public int SourceEndLine { get; }
+
+            public MethodEntry(
+                MethodBase shimMethod,
+                bool isDelegation,
+                int sourceStartLine,
+                int sourceEndLine)
+            {
+                ShimMethod = shimMethod;
+                IsDelegation = isDelegation;
+                SourceStartLine = sourceStartLine;
+                SourceEndLine = sourceEndLine;
+            }
+        }
+
+        private sealed class FileGeneration
+        {
+            public byte[] AssemblyBytes { get; }
+            public byte[] PdbBytes { get; }
+            public Assembly LoadedAssembly { get; }
+            public Dictionary<MethodBase, MethodEntry> Methods { get; }
+
+            public FileGeneration(byte[] assemblyBytes, byte[] pdbBytes, Assembly loadedAssembly)
+            {
+                AssemblyBytes = assemblyBytes;
+                PdbBytes = pdbBytes;
+                LoadedAssembly = loadedAssembly;
+                Methods = new Dictionary<MethodBase, MethodEntry>();
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimRegistry.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimRegistry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 
 using UnityEngine;
@@ -60,36 +61,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
-        /// Removes <paramref name="originalMethod"/> from every file generation; deletes empty
-        /// generations. Safe when the method is not registered.
+        /// Removes <paramref name="originalMethod"/> from every file generation. Empty
+        /// generations stay so a later RegisterMethod in the same Apply run still finds the
+        /// file key (per-method Apply failure must not abort sibling registration).
         /// </summary>
         public static void RemoveMethod(MethodBase originalMethod)
         {
             Debug.Assert(originalMethod != null, "originalMethod must not be null.");
 
-            List<string> emptyPaths = null;
             foreach (KeyValuePair<string, FileGeneration> pair in GenerationsByPath)
             {
-                if (!pair.Value.Methods.Remove(originalMethod))
-                {
-                    continue;
-                }
-
-                if (pair.Value.Methods.Count == 0)
-                {
-                    emptyPaths ??= new List<string>();
-                    emptyPaths.Add(pair.Key);
-                }
-            }
-
-            if (emptyPaths == null)
-            {
-                return;
-            }
-
-            for (int index = 0; index < emptyPaths.Count; index++)
-            {
-                GenerationsByPath.Remove(emptyPaths[index]);
+                pair.Value.Methods.Remove(originalMethod);
             }
         }
 
@@ -105,19 +87,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return null;
             }
 
-            // Why linear scan (not Dictionary key equality): request paths may be absolute while
-            // registration keys are project-relative, and Windows needs OrdinalIgnoreCase —
-            // HotReloadSourcePathNormalizer already encodes both rules.
-            FileGeneration matchedGeneration = null;
-            foreach (KeyValuePair<string, FileGeneration> pair in GenerationsByPath)
-            {
-                if (HotReloadSourcePathNormalizer.PathsReferToSameFile(requestedPath, pair.Key))
-                {
-                    matchedGeneration = pair.Value;
-                    break;
-                }
-            }
-
+            FileGeneration matchedGeneration = FindGenerationForPath(requestedPath);
             if (matchedGeneration == null)
             {
                 return null;
@@ -155,6 +125,46 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 matchedGeneration.PdbBytes,
                 matchedGeneration.LoadedAssembly,
                 methods);
+        }
+
+        private static FileGeneration FindGenerationForPath(string requestedPath)
+        {
+            string normalizedRequest = HotReloadSourcePathNormalizer.ToForwardSlashes(requestedPath);
+            StringComparison comparison = Path.DirectorySeparatorChar == '\\'
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            // Why exact-first: Dictionary enumeration order is non-deterministic; prefer a
+            // unique Ordinal(/IgnoreCase) key match before any suffix match.
+            foreach (KeyValuePair<string, FileGeneration> pair in GenerationsByPath)
+            {
+                string normalizedKey = HotReloadSourcePathNormalizer.ToForwardSlashes(pair.Key);
+                if (string.Equals(normalizedRequest, normalizedKey, comparison))
+                {
+                    return pair.Value;
+                }
+            }
+
+            FileGeneration suffixMatch = null;
+            int suffixMatchCount = 0;
+            foreach (KeyValuePair<string, FileGeneration> pair in GenerationsByPath)
+            {
+                if (!HotReloadSourcePathNormalizer.PathsReferToSameFile(requestedPath, pair.Key))
+                {
+                    continue;
+                }
+
+                suffixMatchCount++;
+                suffixMatch = pair.Value;
+                if (suffixMatchCount > 1)
+                {
+                    // Why null on ambiguity: same fail-closed rule as FindEntryForError —
+                    // guessing among multiple suffix hits is worse than no lookup.
+                    return null;
+                }
+            }
+
+            return suffixMatchCount == 1 ? suffixMatch : null;
         }
 
         internal sealed class MethodEntry

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimRegistry.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7d6907f2db3f4663939d3545cc17b57
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -95,7 +95,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             bool patchedByHotReload =
-                HotReloadPausePointCoordination.IsMethodPatchedByHotReload?.Invoke(method) ?? false;
+                HotReloadPausePointCoordination.GetActiveShimForMethod?.Invoke(method) != null;
             if (patchedByHotReload)
             {
                 return SourcePausePointPatchResult.Failure(
@@ -367,7 +367,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             bool patchedByHotReload =
-                HotReloadPausePointCoordination.IsMethodPatchedByHotReload?.Invoke(original) ?? false;
+                HotReloadPausePointCoordination.GetActiveShimForMethod?.Invoke(original) != null;
             if (patchedByHotReload)
             {
                 // Injections resolve instruction indexes and local slots against the

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -377,9 +377,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // covers Unpatch of a sibling marker while the method is hot-reload
                 // patched: re-Patching the survivors registers a new transpiler that runs
                 // after the hot-reload one and therefore receives the shim stream. During
-                // the hot-reload apply itself the guard is inert (the ledger is written
-                // after Patch succeeds), which is fine — the hot-reload transpiler
-                // discards prior transpiler output anyway.
+                // the hot-reload apply itself the pending-shim exposure keeps this guard
+                // active, and Priority.First guarantees the hot-reload transpiler has
+                // already produced the shim stream this transpiler receives.
                 return list;
             }
 

--- a/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
+++ b/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Reflection.Emit;
 
 namespace io.github.hatayama.UnityCliLoop.ToolContracts
 {
@@ -11,13 +12,22 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
     /// wired in its own static constructor (the same pattern as
     /// UloopPausePointRegistry's OnCleared wiring). A null delegate means the owning
     /// side has not initialized in this domain, which also means it has no state
-    /// worth querying; callers treat null as "no patches" / "no markers".
+    /// worth querying; callers treat null as "no patches" / "no markers" /
+    /// "no shim lookup".
     /// </summary>
     public static class HotReloadPausePointCoordination
     {
-        // Set by HotReloadPatcher. True while the method's body is replaced by a
-        // hot-reload patch.
-        public static Func<MethodBase, bool> IsMethodPatchedByHotReload { get; set; }
+        // Set by HotReloadPatcher. Returns the active shim MethodBase for a patched
+        // original method, or null when the method is not hot-reload patched.
+        public static Func<MethodBase, MethodBase> GetActiveShimForMethod { get; set; }
+
+        // Set by HotReloadShimRegistry. Argument is a forward-slash path (absolute or
+        // project-relative); returns null when that file has no active shim generation.
+        public static Func<string, HotReloadShimFileLookup> GetShimLookupForFile { get; set; }
+
+        // Set by HotReloadPatcher. Returns the LocalBuilder array (shim slot order) from
+        // the latest transplant rebuild of the original method, or null when none.
+        public static Func<MethodBase, IReadOnlyList<LocalBuilder>> GetTransplantLocals { get; set; }
 
         // Set by SourcePausePointPatcher. Returns the marker ids currently injected
         // into the method (empty when none).
@@ -26,5 +36,55 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         // Set by SourcePausePointPatcher. Invoked by HotReloadPatcher after a
         // method's patch state changes (true = patched, false = reverted).
         public static Action<MethodBase, bool> OnHotReloadPatchStateChanged { get; set; }
+    }
+
+    /// <summary>
+    /// One method registered in an active hot-reload shim generation for a file.
+    /// BCL types only so PausePoint can consume it without referencing HotReload.
+    /// </summary>
+    public sealed class HotReloadShimMethodLookup
+    {
+        public MethodBase OriginalMethod { get; }
+        public MethodBase ShimMethod { get; }
+        public bool IsDelegation { get; }
+        public int SourceStartLine { get; }
+        public int SourceEndLine { get; }
+
+        public HotReloadShimMethodLookup(
+            MethodBase originalMethod,
+            MethodBase shimMethod,
+            bool isDelegation,
+            int sourceStartLine,
+            int sourceEndLine)
+        {
+            OriginalMethod = originalMethod;
+            ShimMethod = shimMethod;
+            IsDelegation = isDelegation;
+            SourceStartLine = sourceStartLine;
+            SourceEndLine = sourceEndLine;
+        }
+    }
+
+    /// <summary>
+    /// Active shim assembly bytes and per-method lookups for one edited source file.
+    /// </summary>
+    public sealed class HotReloadShimFileLookup
+    {
+        public byte[] AssemblyBytes { get; }
+        public byte[] PdbBytes { get; }
+        public Assembly LoadedAssembly { get; }
+        public IReadOnlyList<HotReloadShimMethodLookup> Methods { get; }
+
+        public HotReloadShimFileLookup(
+            byte[] assemblyBytes,
+            byte[] pdbBytes,
+            Assembly loadedAssembly,
+            IReadOnlyList<HotReloadShimMethodLookup> methods)
+        {
+            AssemblyBytes = assemblyBytes;
+            PdbBytes = pdbBytes;
+            LoadedAssembly = loadedAssembly;
+            Methods = methods;
+        }
     }
 }

--- a/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
+++ b/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
@@ -21,12 +21,23 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         // original method, or null when the method is not hot-reload patched.
         public static Func<MethodBase, MethodBase> GetActiveShimForMethod { get; set; }
 
-        // Set by HotReloadShimRegistry. Argument is a forward-slash path (absolute or
-        // project-relative); returns null when that file has no active shim generation.
+        /// <summary>
+        /// Set by HotReloadShimRegistry. Argument is a forward-slash path (absolute or
+        /// project-relative); returns null when that file has no active shim generation.
+        /// A method may still report an active shim via <see cref="GetActiveShimForMethod"/>
+        /// while missing from this file lookup (a newer generation replaced the file and
+        /// the method was skipped, bind-failed, or isolation-excluded). Consumers must treat
+        /// that combination as retarget-impossible (suppress the marker).
+        /// </summary>
         public static Func<string, HotReloadShimFileLookup> GetShimLookupForFile { get; set; }
 
-        // Set by HotReloadPatcher. Returns the LocalBuilder array (shim slot order) from
-        // the latest transplant rebuild of the original method, or null when none.
+        /// <summary>
+        /// Set by HotReloadPatcher. Returns the LocalBuilder array (shim slot order) from
+        /// the latest transplant rebuild of the original method, or null when none.
+        /// Returned LocalBuilders are tied to the ILGenerator of that rebuild and are valid
+        /// only inside the same rebuild (the pause-point transpiler that runs after the
+        /// hot-reload transpiler). Do not retain or use them outside that rebuild.
+        /// </summary>
         public static Func<MethodBase, IReadOnlyList<LocalBuilder>> GetTransplantLocals { get; set; }
 
         // Set by SourcePausePointPatcher. Returns the marker ids currently injected


### PR DESCRIPTION
## Summary
- Hot-reload now keeps the compiled shim assembly/PDB bytes and publishes a file-scoped shim registration that pause-point can query.
- Coordination no longer uses a boolean “is patched” probe; callers receive the active shim method (or null) plus transplant locals for later marker retargeting.

## User Impact
- No end-user-facing pause-point retargeting yet (that lands in follow-up PRs).
- This change is the registration foundation so a later PR can place markers on hot-reload-patched method bodies without forcing `uloop compile`.

## Changes
- Keep `AssemblyBytes` / `PdbBytes` on successful shim compile results.
- Add `HotReloadShimRegistry` with generation/method registration and path-tolerant file lookup.
- Replace `IsMethodPatchedByHotReload` with `GetActiveShimForMethod`; add `GetShimLookupForFile` and `GetTransplantLocals` DTOs on the coordination contract.
- Wire orchestrator to `BeginFileGeneration` before Apply and `RegisterMethod` / `RemoveMethod` around Apply.
- Run hot-reload Harmony transpilers at `Priority.First` so pause-point always sees the shim stream.
- Cover registry lifecycle with `HotReloadShimRegistryTests`.

## Verification
- `dist/darwin-arm64/uloop compile` — ErrorCount 0
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value HotReload` — 122 passed
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value PausePoint` — 275 passed

## Notes
- Covers plan To-Dos 6–9 (shim binary retention, coordination expansion, registry + priority, orchestrator wiring).
- CI may not run against base `feature/hot-reload`; local EditMode evidence above is the merge gate for this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

