### PR TITLE
feat: resolve and patch pause points on hot-reload shims

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
@@ -123,17 +123,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: hot-reload then enable-pause-point (patch→enable order) yields the edited
-        /// return value and a marker hit (Priority.First pin for this PR; arm→patch is PR-4).
+        /// What: a transplant-enabled marker becomes SuppressedByHotReload after RevertAll and
+        /// does not hit (honest display until PR-4 auto-retarget).
         /// </summary>
         [Test]
-        public async Task HotReloadThenEnable_EditedBodyHits()
+        public async Task RevertAll_AfterTransplantEnable_SetsSuppressedAndDoesNotHit()
         {
             string editedSource = BuildEditedComputeWithBoostedLocal();
             int enableLine = FindLineNumber(editedSource, "return boosted;");
-            Assert.That(enableLine, Is.GreaterThan(0));
-
-            await HotReloadFromEditedSourceAsync(editedSource, "ContractOrderPatchThenEnable.cs");
+            await HotReloadFromEditedSourceAsync(editedSource, "ContractTransplantSuppressOnRevert.cs");
 
             PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
             {
@@ -144,9 +142,186 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             });
             Assert.That(enable.Success, Is.True, enable.Message);
 
+            HotReloadPatcher.RevertAll();
+            Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).SuppressedByHotReload, Is.True);
+
             HotReloadE2EFixture fixture = new HotReloadE2EFixture();
-            int result = fixture.ComputeWithPrivate(1);
-            Assert.That(result, Is.EqualTo(fixture.SecretForAssert + 1 + 100));
+            fixture.ComputeWithPrivate(5);
+            Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).IsHit, Is.False);
+        }
+
+        /// <summary>
+        /// What: a ShimDirect (delegation) marker is suppressed when a newer hot-reload generation
+        /// replaces the file's shim registration.
+        /// </summary>
+        [Test]
+        public async Task ReApply_AfterDelegationEnable_SetsSuppressed()
+        {
+            string firstEdit = BuildEditedLambdaPrivateDelegation();
+            int enableLine = FindLineNumber(firstEdit, "return pred(threshold) ? 7 : 0;");
+            await HotReloadFromEditedSourceAsync(firstEdit, "ContractDelegationSuppressGen1.cs");
+
+            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(enable.Success, Is.True, enable.Message);
+
+            string secondEdit = firstEdit.Replace(
+                "return pred(threshold) ? 7 : 0;",
+                "return pred(threshold) ? 8 : 0;",
+                StringComparison.Ordinal);
+            await HotReloadFromEditedSourceAsync(secondEdit, "ContractDelegationSuppressGen2.cs");
+            Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).SuppressedByHotReload, Is.True);
+        }
+
+        /// <summary>
+        /// What: re-enabling the same file:line after hot-reload replaces a stale OriginalBody
+        /// injection and the marker hits on the edited body.
+        /// </summary>
+        [Test]
+        public async Task ReEnable_SameFileLine_AfterHotReload_HitsEditedBody()
+        {
+            string onDisk = File.ReadAllText(ResolveFixtureAbsolutePath());
+            int enableLine = FindLineNumber(onDisk, "return _secret + delta;");
+            Assert.That(enableLine, Is.GreaterThan(0));
+
+            PausePointResponse firstEnable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(firstEnable.Success, Is.True, firstEnable.Message);
+
+            string editedSource = onDisk.Replace(
+                "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }",
+                StringComparison.Ordinal);
+            await HotReloadFromEditedSourceAsync(editedSource, "ContractReEnableSameLine.cs");
+
+            PausePointResponse reEnable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(reEnable.Success, Is.True, reEnable.Message + " / " + reEnable.RecommendedNextAction);
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            int result = fixture.ComputeWithPrivate(5);
+            Assert.That(result, Is.EqualTo(fixture.SecretForAssert + 5 + 100));
+            Assert.That(UloopPausePointRegistry.GetStatus(reEnable.Id).IsHit, Is.True);
+            Assert.That(UloopPausePointRegistry.GetStatus(reEnable.Id).SuppressedByHotReload, Is.False);
+        }
+
+        /// <summary>
+        /// What: enabling on an async hot-reloaded body (struct MoveNext ShimDirect) hits with
+        /// the edited await result.
+        /// </summary>
+        [Test]
+        public async Task Enable_OnHotReloadedAsyncBody_HitsEditedResult()
+        {
+            string onDisk = File.ReadAllText(ResolveFixtureAbsolutePath());
+            string editedSource = onDisk.Replace(
+                "public async Task<int> AsyncPrivateFieldAndMethod(int delta)\n        {\n"
+                + "            await Task.Yield();\n"
+                + "            return _secret + delta;\n"
+                + "        }",
+                "public async Task<int> AsyncPrivateFieldAndMethod(int delta)\n        {\n"
+                + "            await Task.Yield();\n"
+                + "            return _secret + delta + 100;\n"
+                + "        }",
+                StringComparison.Ordinal);
+            Assert.That(editedSource, Is.Not.EqualTo(onDisk));
+            int enableLine = FindLineNumber(editedSource, "return _secret + delta + 100;");
+            Assert.That(enableLine, Is.GreaterThan(0));
+
+            await HotReloadFromEditedSourceAsync(editedSource, "ContractAsyncMoveNext.cs");
+
+            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(enable.Success, Is.True, enable.Message + " / " + enable.RecommendedNextAction);
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            int result = await fixture.AsyncPrivateFieldAndMethod(5);
+            Assert.That(result, Is.EqualTo(fixture.SecretForAssert + 5 + 100));
+            Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).IsHit, Is.True);
+        }
+
+        /// <summary>
+        /// What: Patching via synthetic resolution onto a hot-reload patched method still
+        /// returns MethodPatchedByHotReload and mentions the requested line in the message.
+        /// </summary>
+        [Test]
+        public void Patch_OnHotReloadedMethod_ReturnsMethodPatchedByHotReload()
+        {
+            MethodInfo original = AccessTools.Method(
+                typeof(HotReloadPausePointContractFixture),
+                nameof(HotReloadPausePointContractFixture.ReplaceableCompute));
+            MethodInfo shim = AccessTools.Method(
+                typeof(HotReloadPausePointContractShims),
+                nameof(HotReloadPausePointContractShims.ReplaceableCompute__shim0));
+
+            Assert.That(
+                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
+                Is.True);
+
+            const int requestedLine = 42;
+            SourcePausePointPatchResult result = SourcePausePointPatcher.Patch(
+                "contract-reject-on-patched",
+                BuildSyntheticResolution(original, instructionIndex: 5000),
+                normalizedFile: "Assets/Tests/Editor/HotReload/HotReloadPausePointContractFixture.cs",
+                requestedLine: requestedLine);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(
+                result.FailureReason,
+                Is.EqualTo(SourcePausePointPatchFailureReason.MethodPatchedByHotReload));
+            Assert.That(result.ErrorMessage, Does.Contain("line " + requestedLine));
+            Assert.That(result.Hint, Does.Contain("uloop hot-reload --revert-all"));
+        }
+
+        /// <summary>
+        /// What: enable on an unedited method in a hot-reloaded file still uses the compiled
+        /// resolver (NotInPatchedMethod fallthrough) and hits.
+        /// </summary>
+        [Test]
+        public async Task Enable_UneditedMethod_InHotReloadedFile_FallsThroughAndHits()
+        {
+            string editedSource = BuildEditedComputeWithBoostedLocal();
+            await HotReloadFromEditedSourceAsync(editedSource, "ContractFallthroughUnedited.cs");
+
+            // CallsMissingHelper is never part of the ComputeWithPrivate edit, so shim lookup
+            // must NotInPatchedMethod-fall through to the compiled ScriptAssemblies resolver.
+            string onDisk = File.ReadAllText(ResolveFixtureAbsolutePath());
+            int enableLine = FindLineNumber(onDisk, "return value;");
+            Assert.That(enableLine, Is.GreaterThan(0));
+
+            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(
+                enable.Success,
+                Is.True,
+                enable.ErrorCode + " / " + enable.Message + " / " + enable.RecommendedNextAction);
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.CallsMissingHelper(9), Is.EqualTo(9));
             Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).IsHit, Is.True);
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
@@ -1,21 +1,32 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 using HarmonyLib;
 using NUnit.Framework;
 
+using UnityEngine;
+
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
     /// <summary>
     /// EditMode coverage for the hot-reload / source pause-point contract:
-    /// reject new markers on patched methods, and restore arming after RevertAll.
+    /// shim-path enable after apply, restore arming after RevertAll, and suppress flags.
     /// </summary>
     public class HotReloadPausePointContractTests
     {
+        private const string FixtureProjectRelativePath =
+            "Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs";
+
         [SetUp]
         public void SetUp()
         {
@@ -31,32 +42,112 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: Patching a pause point onto a method that is already hot-reload patched
-        /// returns MethodPatchedByHotReload instead of crashing or silently injecting.
+        /// What: after a transplant hot-reload, enable-pause-point on an edited-body line hits
+        /// and captures an added local (LocalBuilder hand-off) with the edited return value.
         /// </summary>
         [Test]
-        public void Patch_OnHotReloadedMethod_ReturnsMethodPatchedByHotReload()
+        public async Task Enable_OnHotReloadedTransplantBody_HitsAndCapturesAddedLocal()
         {
-            MethodInfo original = AccessTools.Method(
-                typeof(HotReloadPausePointContractFixture),
-                nameof(HotReloadPausePointContractFixture.ReplaceableCompute));
-            MethodInfo shim = AccessTools.Method(
-                typeof(HotReloadPausePointContractShims),
-                nameof(HotReloadPausePointContractShims.ReplaceableCompute__shim0));
+            string editedSource = BuildEditedComputeWithBoostedLocal();
+            // Why return line (not the declaration): sequence points on the declaration can land
+            // before the local enters the PDB scope, so capture would omit `boosted`.
+            int enableLine = FindLineNumber(editedSource, "return boosted;");
+            Assert.That(enableLine, Is.GreaterThan(0));
 
+            await HotReloadFromEditedSourceAsync(editedSource, "ContractTransplantBoosted.cs");
+
+            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(enable.Success, Is.True, enable.Message + " / " + enable.RecommendedNextAction);
+            Assert.That(enable.ResolvedLine, Is.GreaterThan(0));
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            int result = fixture.ComputeWithPrivate(5);
+            Assert.That(result, Is.EqualTo(fixture.SecretForAssert + 5 + 100));
+
+            UloopPausePointSnapshot status = UloopPausePointRegistry.GetStatus(enable.Id);
+            Assert.That(status.IsHit, Is.True);
+            UloopCapturedVariable boosted = status.CapturedVariables.FirstOrDefault(v => v.Name == "boosted");
+            Assert.That(boosted, Is.Not.Null, FormatCaptured(status));
+            Assert.That(boosted.Value, Is.EqualTo(result.ToString()));
+        }
+
+        /// <summary>
+        /// What: after a delegation hot-reload, enable on the shim body hits with synthetic
+        /// "this" and never exposes __uloopInstance as a captured parameter name.
+        /// </summary>
+        [Test]
+        public async Task Enable_OnHotReloadedDelegationBody_HitsWithoutUloopInstanceParameter()
+        {
+            string editedSource = BuildEditedLambdaPrivateDelegation();
+            int enableLine = FindLineNumber(editedSource, "return pred(threshold) ? 7 : 0;");
+            Assert.That(enableLine, Is.GreaterThan(0));
+
+            await HotReloadFromEditedSourceAsync(editedSource, "ContractDelegationLambda.cs");
+            HotReloadShimFileLookup lookup =
+                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+            Assert.That(lookup, Is.Not.Null);
+            HotReloadShimMethodLookup lambdaEntry = lookup.Methods.FirstOrDefault(
+                m => m.OriginalMethod != null
+                     && m.OriginalMethod.Name == nameof(HotReloadE2EFixture.LambdaPrivate));
+            Assert.That(lambdaEntry, Is.Not.Null);
+            Assert.That(lambdaEntry.IsDelegation, Is.True);
+
+            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(enable.Success, Is.True, enable.Message + " / " + enable.RecommendedNextAction);
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.LambdaPrivate(5), Is.EqualTo(7));
+
+            UloopPausePointSnapshot status = UloopPausePointRegistry.GetStatus(enable.Id);
+            Assert.That(status.IsHit, Is.True);
             Assert.That(
-                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
-                Is.True);
-
-            SourcePausePointResolution resolution = BuildSyntheticResolution(original, instructionIndex: 5000);
-            SourcePausePointPatchResult result = SourcePausePointPatcher.Patch(
-                "contract-reject-on-patched",
-                resolution);
-
-            Assert.That(result.Success, Is.False);
+                status.CapturedVariables.Any(v => v.Name == "__uloopInstance"),
+                Is.False,
+                FormatCaptured(status));
             Assert.That(
-                result.FailureReason,
-                Is.EqualTo(SourcePausePointPatchFailureReason.MethodPatchedByHotReload));
+                status.CapturedVariables.Any(v => v.Name == "this"),
+                Is.True,
+                FormatCaptured(status));
+        }
+
+        /// <summary>
+        /// What: hot-reload then enable-pause-point (patch→enable order) yields the edited
+        /// return value and a marker hit (Priority.First pin for this PR; arm→patch is PR-4).
+        /// </summary>
+        [Test]
+        public async Task HotReloadThenEnable_EditedBodyHits()
+        {
+            string editedSource = BuildEditedComputeWithBoostedLocal();
+            int enableLine = FindLineNumber(editedSource, "return boosted;");
+            Assert.That(enableLine, Is.GreaterThan(0));
+
+            await HotReloadFromEditedSourceAsync(editedSource, "ContractOrderPatchThenEnable.cs");
+
+            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(enable.Success, Is.True, enable.Message);
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            int result = fixture.ComputeWithPrivate(1);
+            Assert.That(result, Is.EqualTo(fixture.SecretForAssert + 1 + 100));
+            Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).IsHit, Is.True);
         }
 
         /// <summary>
@@ -227,6 +318,109 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 1,
                 Array.Empty<SourcePausePointLocalVariable>(),
                 Array.Empty<SourcePausePointParameter>());
+        }
+
+        private static string BuildEditedComputeWithBoostedLocal()
+        {
+            string onDisk = File.ReadAllText(ResolveFixtureAbsolutePath());
+            const string original =
+                "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }";
+            // Why the loop: Roslyn can elide a trivial local (`int x = …; return x;`) from both
+            // IL and PDB; the loop keeps `boosted` as a real capturable slot for the LocalBuilder assert.
+            const string replacement =
+                "public int ComputeWithPrivate(int delta)\n        {\n"
+                + "            int boosted = _secret + delta + 100;\n"
+                + "            for (int i = 0; i < 1; i++)\n"
+                + "            {\n"
+                + "                boosted += i;\n"
+                + "            }\n"
+                + "\n"
+                + "            return boosted;\n"
+                + "        }";
+            string edited = onDisk.Replace(original, replacement, StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            return edited;
+        }
+
+        private static string BuildEditedLambdaPrivateDelegation()
+        {
+            string onDisk = File.ReadAllText(ResolveFixtureAbsolutePath());
+            string edited = onDisk.Replace(
+                "Func<int, bool> pred = v => v < _secret;\n            return pred(threshold) ? 1 : 0;",
+                "Func<int, bool> pred = v => v < (_secret + 100);\n            return pred(threshold) ? 7 : 0;",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            return edited;
+        }
+
+        private static async Task HotReloadFromEditedSourceAsync(string editedSource, string fileName)
+        {
+            string fixturePath = ResolveFixtureAbsolutePath();
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string editedPath = Path.Combine(directory, fileName);
+            File.WriteAllText(editedPath, editedSource);
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+            Assert.That(
+                result.Methods.Any(m => m.Kind == HotReloadMethodOutcomeKind.Failed),
+                Is.False,
+                FormatHotReloadOutcomes(result));
+            Assert.That(
+                result.Methods.Any(m => m.Kind == HotReloadMethodOutcomeKind.Patched),
+                Is.True,
+                FormatHotReloadOutcomes(result));
+        }
+
+        private static string ResolveFixtureAbsolutePath()
+        {
+            return Path.GetFullPath(
+                Path.Combine(
+                    Application.dataPath,
+                    "Tests",
+                    "Editor",
+                    "HotReload",
+                    "HotReloadE2EFixtures.cs"));
+        }
+
+        private static int FindLineNumber(string source, string fragment)
+        {
+            string[] lines = source.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+            for (int index = 0; index < lines.Length; index++)
+            {
+                if (lines[index].Contains(fragment, StringComparison.Ordinal))
+                {
+                    return index + 1;
+                }
+            }
+
+            return -1;
+        }
+
+        private static string FormatCaptured(UloopPausePointSnapshot status)
+        {
+            List<string> lines = new List<string>();
+            foreach (UloopCapturedVariable variable in status.CapturedVariables)
+            {
+                lines.Add(variable.Name + "=" + variable.Value);
+            }
+
+            return string.Join(", ", lines);
+        }
+
+        private static string FormatHotReloadOutcomes(HotReloadOrchestratorResult result)
+        {
+            List<string> lines = new List<string>();
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                lines.Add(outcome.Kind + " " + outcome.Method + " :: " + outcome.Reason);
+            }
+
+            return string.Join("\n", lines);
         }
 
         private sealed class FakePausePointPauseController : IUloopPausePointPauseController

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
@@ -131,6 +131,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             string editedSource = BuildEditedComputeWithBoostedLocal();
             int enableLine = FindLineNumber(editedSource, "return boosted;");
+            Assert.That(enableLine, Is.GreaterThan(0));
             await HotReloadFromEditedSourceAsync(editedSource, "ContractTransplantSuppressOnRevert.cs");
 
             PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
@@ -159,6 +160,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             string firstEdit = BuildEditedLambdaPrivateDelegation();
             int enableLine = FindLineNumber(firstEdit, "return pred(threshold) ? 7 : 0;");
+            Assert.That(enableLine, Is.GreaterThan(0));
             await HotReloadFromEditedSourceAsync(firstEdit, "ContractDelegationSuppressGen1.cs");
 
             PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
@@ -202,6 +204,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
                 "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }",
                 StringComparison.Ordinal);
+            Assert.That(editedSource, Is.Not.EqualTo(onDisk));
             await HotReloadFromEditedSourceAsync(editedSource, "ContractReEnableSameLine.cs");
 
             PausePointResponse reEnable = new PausePointUseCase().Enable(new EnablePausePointSchema

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -460,6 +460,55 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     SourcePausePointConstants.ReleaseCodeOptimizationRecommendedNextAction);
             }
 
+            string normalizedFile = SourcePausePointPathNormalizer.ToForwardSlashes(parameters.File);
+            string id = BuildSourcePausePointId(parameters.File, parameters.Line);
+
+            HotReloadShimFileLookup shimLookup =
+                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(normalizedFile);
+            if (shimLookup != null)
+            {
+                SourcePausePointShimResolution shimResolution =
+                    SourcePausePointShimResolver.Resolve(shimLookup, normalizedFile, parameters.Line);
+                if (shimResolution.Kind == SourcePausePointShimResolveKind.TransplantChainJoin
+                    || shimResolution.Kind == SourcePausePointShimResolveKind.ShimDirect)
+                {
+                    SourcePausePointPatchResult shimPatchResult = SourcePausePointPatcher.PatchShimTarget(
+                        id,
+                        shimResolution,
+                        normalizedFile,
+                        parameters.Line);
+                    if (!shimPatchResult.Success)
+                    {
+                        return new PausePointResponse
+                        {
+                            Success = false,
+                            ErrorCode = SourcePausePointConstants.ErrorCodePatchFailed,
+                            Message = shimPatchResult.ErrorMessage,
+                            RecommendedNextAction = shimPatchResult.Hint,
+                            EditorState = PausePointEditorState.FromSnapshot(
+                                UloopPausePointRegistry.CaptureEditorState()),
+                        };
+                    }
+
+                    return FinishEnableBySourceLocation(
+                        id,
+                        parameters,
+                        shimResolution.ResolvedLine,
+                        shimResolution.MethodDisplayName,
+                        shimPatchResult);
+                }
+
+                if (shimResolution.Kind == SourcePausePointShimResolveKind.NoStatementInPatchedMethod)
+                {
+                    return CreateValidationFailure(
+                        shimResolution.ErrorMessage,
+                        SourcePausePointConstants.ErrorCodeResolveFailed,
+                        "Pick a line with an executable statement inside the edited method body.");
+                }
+
+                // NotInPatchedMethod: fall through to the compiled ScriptAssemblies resolver.
+            }
+
             SourcePausePointResolveResult resolveResult = SourcePausePointResolver.Resolve(parameters.File, parameters.Line);
             if (!resolveResult.Success)
             {
@@ -469,8 +518,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     SourcePausePointConstants.ResolveFailedRecommendedNextAction);
             }
 
-            string id = BuildSourcePausePointId(parameters.File, parameters.Line);
-            SourcePausePointPatchResult patchResult = SourcePausePointPatcher.Patch(id, resolveResult.Resolution);
+            SourcePausePointPatchResult patchResult = SourcePausePointPatcher.Patch(
+                id,
+                resolveResult.Resolution,
+                normalizedFile,
+                parameters.Line);
             if (!patchResult.Success)
             {
                 string errorCode =
@@ -487,6 +539,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 };
             }
 
+            return FinishEnableBySourceLocation(
+                id,
+                parameters,
+                resolveResult.Resolution.ResolvedLine,
+                resolveResult.Resolution.MethodDisplayName,
+                patchResult);
+        }
+
+        private static PausePointResponse FinishEnableBySourceLocation(
+            string id,
+            EnablePausePointSchema parameters,
+            int resolvedLine,
+            string resolvedMethod,
+            SourcePausePointPatchResult patchResult)
+        {
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(
                 id,
                 parameters.TimeoutSeconds,
@@ -494,9 +561,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameters.MaxHistory,
                 parameters.MaxPreviewElements);
             PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
-            response.ResolvedLine = resolveResult.Resolution.ResolvedLine;
-            response.ResolvedLineText = ReadResolvedLineText(parameters.File, resolveResult.Resolution.ResolvedLine);
-            response.ResolvedMethod = resolveResult.Resolution.MethodDisplayName;
+            response.ResolvedLine = resolvedLine;
+            response.ResolvedLineText = ReadResolvedLineText(parameters.File, resolvedLine);
+            response.ResolvedMethod = resolvedMethod;
             response.SnapshotTiming = SourcePausePointConstants.PreLineSnapshotTimingNote;
             response.Warning = MergeWarnings(CreateEnableWarning(), patchResult.Warning);
             LogEnable(response.Id, response.ResolvedMethod, $"{parameters.File}:{response.ResolvedLine}", response.Mode, response.Warning);

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatchInjection.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatchInjection.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
@@ -14,6 +15,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool IsDeclaringTypeValueType { get; }
         public IReadOnlyList<SourcePausePointParameter> Parameters { get; }
         public IReadOnlyList<SourcePausePointLocalVariable> Locals { get; }
+        public SourcePausePointPatchInjectionTargetKind TargetKind { get; }
+        public MethodBase DonorShim { get; }
+        public bool InstanceFromFirstArgument { get; }
 
         public SourcePausePointPatchInjection(
             string id,
@@ -21,7 +25,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool isStatic,
             bool isDeclaringTypeValueType,
             IReadOnlyList<SourcePausePointParameter> parameters,
-            IReadOnlyList<SourcePausePointLocalVariable> locals)
+            IReadOnlyList<SourcePausePointLocalVariable> locals,
+            SourcePausePointPatchInjectionTargetKind targetKind =
+                SourcePausePointPatchInjectionTargetKind.OriginalBody,
+            MethodBase donorShim = null,
+            bool instanceFromFirstArgument = false)
         {
             Id = id;
             InstructionIndex = instructionIndex;
@@ -29,6 +37,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             IsDeclaringTypeValueType = isDeclaringTypeValueType;
             Parameters = parameters;
             Locals = locals;
+            TargetKind = targetKind;
+            DonorShim = donorShim;
+            InstanceFromFirstArgument = instanceFromFirstArgument;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatchInjectionTargetKind.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatchInjectionTargetKind.cs
@@ -1,0 +1,12 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Which instruction stream an injection's indexes and local slots were resolved against.
+    /// </summary>
+    internal enum SourcePausePointPatchInjectionTargetKind
+    {
+        OriginalBody,
+        TransplantChainJoin,
+        ShimDirect
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatchInjectionTargetKind.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatchInjectionTargetKind.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 65a19c12ef7834da0825ca4309a8698a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -32,6 +32,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static readonly Dictionary<MethodBase, List<SourcePausePointPatchInjection>> InjectionsByMethod = new();
         private static readonly Dictionary<string, MethodBase> MethodById = new();
+        private static readonly Dictionary<string, MethodBase> LogicalOwnerById = new();
 
         // The registry lives in a Runtime assembly this Editor-only tool assembly may depend on,
         // but not the reverse (patching is an outer/implementation concern the registry's inner
@@ -46,14 +47,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadPausePointCoordination.OnHotReloadPatchStateChanged = HandleHotReloadPatchStateChanged;
         }
 
-        // What: lets the hot-reload tool list the marker ids it is about to suppress.
+        // What: lets the hot-reload tool list marker ids by logical owner (user method),
+        // including markers whose physical injection lives on a shim-side MoveNext/closure.
         private static IReadOnlyList<string> GetArmedMarkerIds(MethodBase method)
         {
-            if (!InjectionsByMethod.TryGetValue(method, out List<SourcePausePointPatchInjection> injections))
+            List<string> ids = new List<string>();
+            foreach (KeyValuePair<string, MethodBase> pair in LogicalOwnerById)
             {
-                return Array.Empty<string>();
+                if (pair.Value.Equals(method))
+                {
+                    ids.Add(pair.Key);
+                }
             }
-            return injections.Select(injection => injection.Id).ToList();
+
+            return ids;
         }
 
         // What: mirrors the hot-reload patch state onto every marker of the method so
@@ -70,7 +77,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        public static SourcePausePointPatchResult Patch(string id, SourcePausePointResolution resolution)
+        public static SourcePausePointPatchResult Patch(
+            string id,
+            SourcePausePointResolution resolution,
+            string normalizedFile = "",
+            int requestedLine = 0)
         {
             Debug.Assert(!string.IsNullOrEmpty(id), "id must not be null or empty.");
             Debug.Assert(resolution != null, "resolution must not be null.");
@@ -98,13 +109,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadPausePointCoordination.GetActiveShimForMethod?.Invoke(method) != null;
             if (patchedByHotReload)
             {
+                string typeName = method.DeclaringType != null ? method.DeclaringType.Name : "?";
                 return SourcePausePointPatchResult.Failure(
                     SourcePausePointPatchFailureReason.MethodPatchedByHotReload,
-                    $"'{method.DeclaringType?.Name}.{method.Name}' is currently hot-reload patched; " +
-                    "pause-point instrumentation resolves instruction positions and local slots " +
-                    "against the pre-patch compiled body, which no longer exists at runtime.",
-                    "Run 'uloop hot-reload --revert-all' or 'uloop compile' first, then enable " +
-                    "the marker.");
+                    $"'{typeName}.{method.Name}' is currently hot-reload patched and line {requestedLine} "
+                    + "does not fall inside any hot-reload patched method's current body, so the marker "
+                    + "cannot be placed reliably.",
+                    "The compiled line map for this file is stale. Pick a line inside the edited method "
+                    + "body, or run 'uloop compile' to realign line numbers.");
             }
 
             SourcePausePointPatchInjection injection = new(
@@ -113,8 +125,77 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 resolution.IsStatic,
                 resolution.IsDeclaringTypeValueType,
                 resolution.Parameters,
-                resolution.Locals);
+                resolution.Locals,
+                SourcePausePointPatchInjectionTargetKind.OriginalBody);
 
+            return CommitPatch(id, method, method, injection);
+        }
+
+        /// <summary>
+        /// Patches a pause point onto a hot-reload shim target (transplant chain-join or
+        /// shim-direct) without AppDomain name/MVID resolution.
+        /// </summary>
+        public static SourcePausePointPatchResult PatchShimTarget(
+            string id,
+            SourcePausePointShimResolution shim,
+            string normalizedFile,
+            int requestedLine)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(id), "id must not be null or empty.");
+            Debug.Assert(shim != null, "shim must not be null.");
+            Debug.Assert(
+                shim.Kind == SourcePausePointShimResolveKind.TransplantChainJoin
+                || shim.Kind == SourcePausePointShimResolveKind.ShimDirect,
+                "PatchShimTarget requires a successful shim resolution.");
+
+            if (MethodById.ContainsKey(id))
+            {
+                return SourcePausePointPatchResult.SuccessResult();
+            }
+
+            // Why skip TryResolveMethod: shim assemblies are all named HotReloadShim across
+            // generations, so name+MVID lookup cannot identify the loaded generation; the
+            // resolver already handed us the MethodBase from that generation's LoadedAssembly.
+            MethodBase method = shim.TargetMethod;
+            SourcePausePointPatchResult patchabilityResult = CheckPatchable(method);
+            if (!patchabilityResult.Success)
+            {
+                return patchabilityResult;
+            }
+
+            SourcePausePointPatchInjectionTargetKind targetKind =
+                shim.Kind == SourcePausePointShimResolveKind.TransplantChainJoin
+                    ? SourcePausePointPatchInjectionTargetKind.TransplantChainJoin
+                    : SourcePausePointPatchInjectionTargetKind.ShimDirect;
+
+            bool isStatic = shim.InstanceFromFirstArgument
+                ? false
+                : method.IsStatic;
+            bool isDeclaringTypeValueType =
+                shim.LogicalOwner != null
+                && shim.LogicalOwner.DeclaringType != null
+                && shim.LogicalOwner.DeclaringType.IsValueType;
+
+            SourcePausePointPatchInjection injection = new(
+                id,
+                shim.InstructionIndex,
+                isStatic,
+                isDeclaringTypeValueType,
+                shim.Parameters,
+                shim.Locals,
+                targetKind,
+                shim.DonorShim,
+                shim.InstanceFromFirstArgument);
+
+            return CommitPatch(id, method, shim.LogicalOwner, injection);
+        }
+
+        private static SourcePausePointPatchResult CommitPatch(
+            string id,
+            MethodBase method,
+            MethodBase logicalOwner,
+            SourcePausePointPatchInjection injection)
+        {
             bool methodAlreadyPatched = InjectionsByMethod.TryGetValue(method, out List<SourcePausePointPatchInjection> injections);
             if (!methodAlreadyPatched)
             {
@@ -124,6 +205,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             injections.Add(injection);
             MethodById[id] = method;
+            LogicalOwnerById[id] = logicalOwner;
 
             // The ledger above is written before Harmony actually rebuilds the method. If
             // Unpatch/Patch throws (e.g. a byref-like `this` produces invalid IL at JIT time), a
@@ -155,6 +237,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         InjectionsByMethod.Remove(method);
                     }
                     MethodById.Remove(id);
+                    LogicalOwnerById.Remove(id);
                 }
             }
 
@@ -171,6 +254,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return;
             }
             MethodById.Remove(id);
+            LogicalOwnerById.Remove(id);
 
             List<SourcePausePointPatchInjection> injections = InjectionsByMethod[method];
             injections.RemoveAll(injection => injection.Id == id);
@@ -199,6 +283,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     foreach (string remainingId in injections.Select(remaining => remaining.Id).ToList())
                     {
                         MethodById.Remove(remainingId);
+                        LogicalOwnerById.Remove(remainingId);
                     }
                     InjectionsByMethod.Remove(method);
                 }
@@ -210,6 +295,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HarmonyInstance.UnpatchAll(SourcePausePointConstants.HarmonyId);
             InjectionsByMethod.Clear();
             MethodById.Clear();
+            LogicalOwnerById.Clear();
         }
 
         private static SourcePausePointPatchResult TryResolveMethod(SourcePausePointResolution resolution, out MethodBase method)
@@ -366,25 +452,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return list;
             }
 
-            bool patchedByHotReload =
-                HotReloadPausePointCoordination.GetActiveShimForMethod?.Invoke(original) != null;
-            if (patchedByHotReload)
-            {
-                // Injections resolve instruction indexes and local slots against the
-                // pre-patch body; on a hot-reload shim stream they would land at a
-                // meaningless offset, read stale local slots, or run past the end of the
-                // list. Enable already rejects new markers on patched methods; this guard
-                // covers Unpatch of a sibling marker while the method is hot-reload
-                // patched: re-Patching the survivors registers a new transpiler that runs
-                // after the hot-reload one and therefore receives the shim stream. During
-                // the hot-reload apply itself the pending-shim exposure keeps this guard
-                // active, and Priority.First guarantees the hot-reload transpiler has
-                // already produced the shim stream this transpiler receives.
-                return list;
-            }
+            MethodBase activeShim =
+                HotReloadPausePointCoordination.GetActiveShimForMethod?.Invoke(original);
 
             foreach (SourcePausePointPatchInjection injection in injections.OrderByDescending(i => i.InstructionIndex))
             {
+                if (!ShouldInject(injection, activeShim))
+                {
+                    continue;
+                }
+
                 Label skip = generator.DefineLabel();
                 List<CodeInstruction> emitted = BuildInjection(injection, original, skip);
 
@@ -410,6 +487,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return list;
         }
 
+        private static bool ShouldInject(SourcePausePointPatchInjection injection, MethodBase activeShim)
+        {
+            switch (injection.TargetKind)
+            {
+                case SourcePausePointPatchInjectionTargetKind.OriginalBody:
+                    // Pre-hot-reload body indexes are only valid when no shim is active.
+                    return activeShim == null;
+                case SourcePausePointPatchInjectionTargetKind.TransplantChainJoin:
+                    // Inject only while the donor shim that produced these indexes is still active.
+                    return activeShim != null && activeShim.Equals(injection.DonorShim);
+                case SourcePausePointPatchInjectionTargetKind.ShimDirect:
+                    // ShimDirect injections live on the shim-side method's InjectionsByMethod entry;
+                    // they never share a ledger key with an original-body method.
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         private static List<CodeInstruction> BuildInjection(SourcePausePointPatchInjection injection, MethodBase method, Label skip)
         {
             // Checking IsArmed before building the parameter/local object array (rather than
@@ -425,15 +521,72 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             AppendInstanceLoad(emitted, injection, method);
 
+            // InstanceFromFirstArgument stores absolute GetParameters() indexes (including the
+            // hole left by skipping __uloopInstance at 0), so argOffset stays 0. Ordinary
+            // instance methods still need +1 to skip the hidden `this` argument.
+            int argOffset = injection.InstanceFromFirstArgument
+                ? 0
+                : (injection.IsStatic ? 0 : 1);
+
             // Fully qualify: ToolContracts also defines ParameterInfo (tool schema DTO).
             System.Reflection.ParameterInfo[] runtimeParameters = method.GetParameters();
-            int argOffset = injection.IsStatic ? 0 : 1;
             AppendNameValueArray(
                 emitted,
                 injection.Parameters,
                 p => CodeInstruction.LoadArgument(p.Index + argOffset, false),
                 p => p.IsValueType ? runtimeParameters[p.Index].ParameterType : null,
                 p => p.Name);
+
+            AppendLocalsLoad(emitted, injection, method);
+
+            emitted.Add(new CodeInstruction(OpCodes.Call, CaptureMethodInfo));
+            return emitted;
+        }
+
+        private static void AppendLocalsLoad(
+            List<CodeInstruction> emitted,
+            SourcePausePointPatchInjection injection,
+            MethodBase method)
+        {
+            if (injection.TargetKind == SourcePausePointPatchInjectionTargetKind.TransplantChainJoin)
+            {
+                IReadOnlyList<LocalBuilder> transplantLocals =
+                    HotReloadPausePointCoordination.GetTransplantLocals?.Invoke(method);
+                MethodBody donorBody = injection.DonorShim != null
+                    ? injection.DonorShim.GetMethodBody()
+                    : null;
+                List<SourcePausePointLocalVariable> capturable = new List<SourcePausePointLocalVariable>();
+                Dictionary<int, Type> boxTypeBySlot = new Dictionary<int, Type>();
+                foreach (SourcePausePointLocalVariable local in injection.Locals)
+                {
+                    if (transplantLocals == null
+                        || local.SlotIndex < 0
+                        || local.SlotIndex >= transplantLocals.Count
+                        || donorBody == null
+                        || local.SlotIndex >= donorBody.LocalVariables.Count)
+                    {
+                        // Why skip (not fail): a missing LocalBuilder mid-rebuild must not abort
+                        // the whole injection; capture the locals that are still addressable.
+                        Debug.Assert(
+                            false,
+                            "Transplant local slot must exist on the donor shim and LocalBuilder list.");
+                        continue;
+                    }
+
+                    capturable.Add(local);
+                    boxTypeBySlot[local.SlotIndex] = local.IsValueType
+                        ? donorBody.LocalVariables[local.SlotIndex].LocalType
+                        : null;
+                }
+
+                AppendNameValueArray(
+                    emitted,
+                    capturable,
+                    l => new CodeInstruction(OpCodes.Ldloc, transplantLocals[l.SlotIndex]),
+                    l => boxTypeBySlot[l.SlotIndex],
+                    l => l.Name);
+                return;
+            }
 
             IList<LocalVariableInfo> runtimeLocals = method.GetMethodBody().LocalVariables;
             foreach (SourcePausePointLocalVariable local in injection.Locals)
@@ -448,13 +601,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 l => CodeInstruction.LoadLocal(l.SlotIndex, false),
                 l => l.IsValueType ? runtimeLocals[l.SlotIndex].LocalType : null,
                 l => l.Name);
-
-            emitted.Add(new CodeInstruction(OpCodes.Call, CaptureMethodInfo));
-            return emitted;
         }
 
         private static void AppendInstanceLoad(List<CodeInstruction> emitted, SourcePausePointPatchInjection injection, MethodBase method)
         {
+            if (injection.InstanceFromFirstArgument)
+            {
+                // Why no box: hot-reload rejects value-type instance methods as UnpatchableValueType,
+                // so a delegation shim's __uloopInstance is always a reference-type receiver here.
+                emitted.Add(CodeInstruction.LoadArgument(0, false));
+                return;
+            }
+
             if (injection.IsStatic)
             {
                 emitted.Add(new CodeInstruction(OpCodes.Ldnull));

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -63,17 +63,42 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return ids;
         }
 
-        // What: mirrors the hot-reload patch state onto every marker of the method so
-        // status responses can explain why an armed marker went silent.
+        // What: mirrors hot-reload patch state onto markers by logical owner so ShimDirect
+        // (physical key = shim-side method) still receives suppress updates.
         private static void HandleHotReloadPatchStateChanged(MethodBase method, bool isPatched)
         {
-            if (!InjectionsByMethod.TryGetValue(method, out List<SourcePausePointPatchInjection> injections))
+            foreach (KeyValuePair<string, MethodBase> ownerPair in LogicalOwnerById)
             {
-                return;
-            }
-            foreach (SourcePausePointPatchInjection injection in injections)
-            {
-                UloopPausePointRegistry.SetSuppressedByHotReload(injection.Id, isPatched);
+                if (!ownerPair.Value.Equals(method))
+                {
+                    continue;
+                }
+
+                string id = ownerPair.Key;
+                if (!MethodById.TryGetValue(id, out MethodBase physicalMethod)
+                    || !InjectionsByMethod.TryGetValue(physicalMethod, out List<SourcePausePointPatchInjection> injections))
+                {
+                    continue;
+                }
+
+                SourcePausePointPatchInjection injection = FindInjectionById(injections, id);
+                if (injection == null)
+                {
+                    continue;
+                }
+
+                // Why kind-specific: OriginalBody indexes are valid again after revert (isPatched
+                // false). TransplantChainJoin / ShimDirect were resolved against a specific shim
+                // generation — apply and revert both invalidate that generation until PR-4
+                // auto-retarget replaces the injection, so status must stay suppressed=true.
+                if (injection.TargetKind == SourcePausePointPatchInjectionTargetKind.OriginalBody)
+                {
+                    UloopPausePointRegistry.SetSuppressedByHotReload(id, isPatched);
+                }
+                else
+                {
+                    UloopPausePointRegistry.SetSuppressedByHotReload(id, true);
+                }
             }
         }
 
@@ -85,13 +110,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(!string.IsNullOrEmpty(id), "id must not be null or empty.");
             Debug.Assert(resolution != null, "resolution must not be null.");
-
-            if (MethodById.ContainsKey(id))
-            {
-                // Re-enabling an id that is already patched is a no-op here: the call site is
-                // already in the IL and always fires, gated only by the registry's armed state.
-                return SourcePausePointPatchResult.SuccessResult();
-            }
 
             SourcePausePointPatchResult resolveResult = TryResolveMethod(resolution, out MethodBase method);
             if (!resolveResult.Success)
@@ -114,9 +132,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     SourcePausePointPatchFailureReason.MethodPatchedByHotReload,
                     $"'{typeName}.{method.Name}' is currently hot-reload patched and line {requestedLine} "
                     + "does not fall inside any hot-reload patched method's current body, so the marker "
-                    + "cannot be placed reliably.",
-                    "The compiled line map for this file is stale. Pick a line inside the edited method "
-                    + "body, or run 'uloop compile' to realign line numbers.");
+                    + "cannot be placed reliably. Either the compiled line map for this file is stale, "
+                    + "or the method's active patch belongs to a superseded hot-reload generation.",
+                    "Pick a line inside the edited method body, run 'uloop hot-reload --revert-all' to "
+                    + "restore compiled bodies, or run 'uloop compile' to realign line numbers.");
+            }
+
+            // Why conditional no-op: ShouldInject can leave a prior injection inert (e.g. stale
+            // OriginalBody under an active shim). Re-enable must replace mismatched ledger state
+            // instead of reporting success while the call site never fires.
+            if (TryReuseExistingPatch(
+                    id,
+                    SourcePausePointPatchInjectionTargetKind.OriginalBody,
+                    method,
+                    donorShim: null))
+            {
+                return SourcePausePointPatchResult.SuccessResult();
             }
 
             SourcePausePointPatchInjection injection = new(
@@ -148,11 +179,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 || shim.Kind == SourcePausePointShimResolveKind.ShimDirect,
                 "PatchShimTarget requires a successful shim resolution.");
 
-            if (MethodById.ContainsKey(id))
-            {
-                return SourcePausePointPatchResult.SuccessResult();
-            }
-
             // Why skip TryResolveMethod: shim assemblies are all named HotReloadShim across
             // generations, so name+MVID lookup cannot identify the loaded generation; the
             // resolver already handed us the MethodBase from that generation's LoadedAssembly.
@@ -168,13 +194,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     ? SourcePausePointPatchInjectionTargetKind.TransplantChainJoin
                     : SourcePausePointPatchInjectionTargetKind.ShimDirect;
 
-            bool isStatic = shim.InstanceFromFirstArgument
-                ? false
-                : method.IsStatic;
+            if (TryReuseExistingPatch(id, targetKind, method, shim.DonorShim))
+            {
+                return SourcePausePointPatchResult.SuccessResult();
+            }
+
+            bool isStatic = !shim.InstanceFromFirstArgument && method.IsStatic;
+            // Why physical DeclaringType: shim compiles with -optimize+, so async MoveNext state
+            // machines are structs even when the user type is a class. Boxing decisions must
+            // follow the method we actually patch, not the logical owner.
             bool isDeclaringTypeValueType =
-                shim.LogicalOwner != null
-                && shim.LogicalOwner.DeclaringType != null
-                && shim.LogicalOwner.DeclaringType.IsValueType;
+                method.DeclaringType != null && method.DeclaringType.IsValueType;
 
             SourcePausePointPatchInjection injection = new(
                 id,
@@ -188,6 +218,52 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 shim.InstanceFromFirstArgument);
 
             return CommitPatch(id, method, shim.LogicalOwner, injection);
+        }
+
+        private static bool TryReuseExistingPatch(
+            string id,
+            SourcePausePointPatchInjectionTargetKind targetKind,
+            MethodBase physicalTarget,
+            MethodBase donorShim)
+        {
+            if (!MethodById.TryGetValue(id, out MethodBase existingPhysical)
+                || !InjectionsByMethod.TryGetValue(existingPhysical, out List<SourcePausePointPatchInjection> injections))
+            {
+                return false;
+            }
+
+            SourcePausePointPatchInjection existing = FindInjectionById(injections, id);
+            if (existing == null)
+            {
+                return false;
+            }
+
+            bool sameKind = existing.TargetKind == targetKind;
+            bool sameTarget = existingPhysical.Equals(physicalTarget);
+            bool sameDonor = targetKind != SourcePausePointPatchInjectionTargetKind.TransplantChainJoin
+                || (existing.DonorShim != null && donorShim != null && existing.DonorShim.Equals(donorShim));
+            if (sameKind && sameTarget && sameDonor)
+            {
+                return true;
+            }
+
+            Unpatch(id);
+            return false;
+        }
+
+        private static SourcePausePointPatchInjection FindInjectionById(
+            List<SourcePausePointPatchInjection> injections,
+            string id)
+        {
+            for (int index = 0; index < injections.Count; index++)
+            {
+                if (injections[index].Id == id)
+                {
+                    return injections[index];
+                }
+            }
+
+            return null;
         }
 
         private static SourcePausePointPatchResult CommitPatch(

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -154,7 +155,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return (bestMethod, bestSequencePoint);
         }
 
-        private static IEnumerable<MethodDefinition> EnumerateMethodsInModule(ModuleDefinition module)
+        // Shared with SourcePausePointShimResolver so shim-assembly sequence-point walks use the
+        // same nested-type enumeration and capturable-local / parameter exclusion rules.
+        internal static IEnumerable<MethodDefinition> EnumerateMethodsInModule(ModuleDefinition module)
         {
             foreach (TypeDefinition type in module.Types)
             {
@@ -181,7 +184,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        private static int FindInstructionIndex(Collection<Instruction> instructions, int offset)
+        internal static int FindInstructionIndex(Collection<Instruction> instructions, int offset)
         {
             for (int i = 0; i < instructions.Count; i++)
             {
@@ -194,7 +197,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return -1;
         }
 
-        private static List<SourcePausePointLocalVariable> CollectCapturableLocals(MethodDefinition method, int offset)
+        internal static List<SourcePausePointLocalVariable> CollectCapturableLocals(
+            MethodDefinition method,
+            int offset)
         {
             List<SourcePausePointLocalVariable> results = new List<SourcePausePointLocalVariable>();
             ScopeDebugInformation rootScope = method.DebugInformation.Scope;
@@ -204,6 +209,48 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return results;
+        }
+
+        /// <summary>
+        /// Collects every named capturable local in the method's debug scopes, ignoring IL offset.
+        /// Used when a shim sequence point lands on Ret (or similar) after local scopes close.
+        /// </summary>
+        internal static List<SourcePausePointLocalVariable> CollectAllCapturableLocals(
+            MethodDefinition method)
+        {
+            List<SourcePausePointLocalVariable> results = new List<SourcePausePointLocalVariable>();
+            ScopeDebugInformation rootScope = method.DebugInformation.Scope;
+            if (rootScope == null)
+            {
+                return results;
+            }
+
+            CollectAllScopeVariables(rootScope, method.Body.Variables, results);
+            return results;
+        }
+
+        private static void CollectAllScopeVariables(
+            ScopeDebugInformation scope,
+            Collection<VariableDefinition> methodVariables,
+            List<SourcePausePointLocalVariable> results)
+        {
+            if (scope.HasVariables)
+            {
+                foreach (VariableDebugInformation variableDebugInformation in scope.Variables)
+                {
+                    AppendLocalIfCapturable(variableDebugInformation, methodVariables, results);
+                }
+            }
+
+            if (!scope.HasScopes)
+            {
+                return;
+            }
+
+            foreach (ScopeDebugInformation childScope in scope.Scopes)
+            {
+                CollectAllScopeVariables(childScope, methodVariables, results);
+            }
         }
 
         private static void CollectInScopeVariables(
@@ -320,7 +367,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return elementType.FullName == "System.Span`1" || elementType.FullName == "System.ReadOnlySpan`1";
         }
 
-        private static List<SourcePausePointParameter> CollectParameters(MethodDefinition method)
+        internal static List<SourcePausePointParameter> CollectParameters(MethodDefinition method)
         {
             List<SourcePausePointParameter> parameters = new List<SourcePausePointParameter>();
             foreach (ParameterDefinition parameter in method.Parameters)
@@ -335,6 +382,66 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return parameters;
+        }
+
+        /// <summary>
+        /// Collects capturable parameters from a reflection MethodBase (transplant chain-join
+        /// uses the original method; shim-direct uses the resolved shim-side method).
+        /// </summary>
+        internal static List<SourcePausePointParameter> CollectParametersFromReflection(
+            MethodBase method,
+            bool skipFirstParameter)
+        {
+            Debug.Assert(method != null, "method must not be null.");
+
+            // Fully qualify: ToolContracts also defines ParameterInfo (tool schema DTO).
+            System.Reflection.ParameterInfo[] runtimeParameters = method.GetParameters();
+            List<SourcePausePointParameter> parameters = new List<SourcePausePointParameter>();
+            int startIndex = skipFirstParameter ? 1 : 0;
+            for (int index = startIndex; index < runtimeParameters.Length; index++)
+            {
+                System.Reflection.ParameterInfo parameter = runtimeParameters[index];
+                Type parameterType = parameter.ParameterType;
+                if (IsCaptureExcludedReflection(parameterType))
+                {
+                    continue;
+                }
+
+                // Keep GetParameters() position so LoadArgument hits the right slot even when
+                // earlier parameters were excluded from capture (same as Cecil Parameter.Index).
+                parameters.Add(
+                    new SourcePausePointParameter(
+                        parameter.Name,
+                        index,
+                        parameterType.FullName,
+                        parameterType.IsValueType));
+            }
+
+            return parameters;
+        }
+
+        private static bool IsCaptureExcludedReflection(Type type)
+        {
+            return type.IsByRef || type.IsPointer || IsByRefLikeTypeReflection(type);
+        }
+
+        private static bool IsByRefLikeTypeReflection(Type type)
+        {
+            Type elementType = type.IsGenericType ? type.GetGenericTypeDefinition() : type;
+            if (elementType.FullName == "System.Span`1" || elementType.FullName == "System.ReadOnlySpan`1")
+            {
+                return true;
+            }
+
+            foreach (object attribute in type.GetCustomAttributes(inherit: false))
+            {
+                if (attribute.GetType().FullName == SourcePausePointConstants.IsByRefLikeAttributeFullName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs
@@ -214,6 +214,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <summary>
         /// Collects every named capturable local in the method's debug scopes, ignoring IL offset.
         /// Used when a shim sequence point lands on Ret (or similar) after local scopes close.
+        /// Keep-first dedupe by slot and by name avoids duplicate capture entries when scopes
+        /// reuse slots or nest identically named locals.
         /// </summary>
         internal static List<SourcePausePointLocalVariable> CollectAllCapturableLocals(
             MethodDefinition method)
@@ -225,20 +227,40 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return results;
             }
 
-            CollectAllScopeVariables(rootScope, method.Body.Variables, results);
+            HashSet<int> seenSlots = new HashSet<int>();
+            HashSet<string> seenNames = new HashSet<string>(StringComparer.Ordinal);
+            CollectAllScopeVariables(rootScope, method.Body.Variables, results, seenSlots, seenNames);
             return results;
         }
 
         private static void CollectAllScopeVariables(
             ScopeDebugInformation scope,
             Collection<VariableDefinition> methodVariables,
-            List<SourcePausePointLocalVariable> results)
+            List<SourcePausePointLocalVariable> results,
+            HashSet<int> seenSlots,
+            HashSet<string> seenNames)
         {
             if (scope.HasVariables)
             {
                 foreach (VariableDebugInformation variableDebugInformation in scope.Variables)
                 {
+                    int beforeCount = results.Count;
                     AppendLocalIfCapturable(variableDebugInformation, methodVariables, results);
+                    if (results.Count == beforeCount)
+                    {
+                        continue;
+                    }
+
+                    SourcePausePointLocalVariable added = results[results.Count - 1];
+                    if (seenSlots.Contains(added.SlotIndex) || seenNames.Contains(added.Name))
+                    {
+                        results.RemoveAt(results.Count - 1);
+                    }
+                    else
+                    {
+                        seenSlots.Add(added.SlotIndex);
+                        seenNames.Add(added.Name);
+                    }
                 }
             }
 
@@ -249,7 +271,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             foreach (ScopeDebugInformation childScope in scope.Scopes)
             {
-                CollectAllScopeVariables(childScope, methodVariables, results);
+                CollectAllScopeVariables(childScope, methodVariables, results, seenSlots, seenNames);
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolution.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolution.cs
@@ -109,7 +109,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public static SourcePausePointShimResolution NoStatementInPatchedMethod(
             MethodBase logicalOwner,
-            int line,
             string errorMessage)
         {
             return new SourcePausePointShimResolution(
@@ -122,7 +121,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 locals: null,
                 parameters: null,
                 instanceFromFirstArgument: false,
-                logicalOwner != null ? logicalOwner.ToString() : null,
+                logicalOwner.ToString(),
                 errorMessage);
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolution.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolution.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Shim-path resolution for enabling a pause point on a hot-reload patched method body.
+    /// </summary>
+    internal sealed class SourcePausePointShimResolution
+    {
+        public SourcePausePointShimResolveKind Kind { get; }
+        public MethodBase TargetMethod { get; }
+        public MethodBase LogicalOwner { get; }
+        public MethodBase DonorShim { get; }
+        public int InstructionIndex { get; }
+        public int ResolvedLine { get; }
+        public IReadOnlyList<SourcePausePointLocalVariable> Locals { get; }
+        public IReadOnlyList<SourcePausePointParameter> Parameters { get; }
+        public bool InstanceFromFirstArgument { get; }
+        public string MethodDisplayName { get; }
+        public string ErrorMessage { get; }
+
+        private SourcePausePointShimResolution(
+            SourcePausePointShimResolveKind kind,
+            MethodBase targetMethod,
+            MethodBase logicalOwner,
+            MethodBase donorShim,
+            int instructionIndex,
+            int resolvedLine,
+            IReadOnlyList<SourcePausePointLocalVariable> locals,
+            IReadOnlyList<SourcePausePointParameter> parameters,
+            bool instanceFromFirstArgument,
+            string methodDisplayName,
+            string errorMessage)
+        {
+            Kind = kind;
+            TargetMethod = targetMethod;
+            LogicalOwner = logicalOwner;
+            DonorShim = donorShim;
+            InstructionIndex = instructionIndex;
+            ResolvedLine = resolvedLine;
+            Locals = locals;
+            Parameters = parameters;
+            InstanceFromFirstArgument = instanceFromFirstArgument;
+            MethodDisplayName = methodDisplayName;
+            ErrorMessage = errorMessage;
+        }
+
+        public static SourcePausePointShimResolution TransplantChainJoin(
+            MethodBase originalMethod,
+            MethodBase donorShim,
+            int instructionIndex,
+            int resolvedLine,
+            IReadOnlyList<SourcePausePointLocalVariable> locals,
+            IReadOnlyList<SourcePausePointParameter> parameters)
+        {
+            return new SourcePausePointShimResolution(
+                SourcePausePointShimResolveKind.TransplantChainJoin,
+                originalMethod,
+                originalMethod,
+                donorShim,
+                instructionIndex,
+                resolvedLine,
+                locals,
+                parameters,
+                instanceFromFirstArgument: false,
+                originalMethod.ToString(),
+                errorMessage: null);
+        }
+
+        public static SourcePausePointShimResolution ShimDirect(
+            MethodBase targetMethod,
+            MethodBase logicalOwner,
+            int instructionIndex,
+            int resolvedLine,
+            IReadOnlyList<SourcePausePointLocalVariable> locals,
+            IReadOnlyList<SourcePausePointParameter> parameters,
+            bool instanceFromFirstArgument)
+        {
+            return new SourcePausePointShimResolution(
+                SourcePausePointShimResolveKind.ShimDirect,
+                targetMethod,
+                logicalOwner,
+                donorShim: null,
+                instructionIndex,
+                resolvedLine,
+                locals,
+                parameters,
+                instanceFromFirstArgument,
+                logicalOwner.ToString(),
+                errorMessage: null);
+        }
+
+        public static SourcePausePointShimResolution NotInPatchedMethod()
+        {
+            return new SourcePausePointShimResolution(
+                SourcePausePointShimResolveKind.NotInPatchedMethod,
+                targetMethod: null,
+                logicalOwner: null,
+                donorShim: null,
+                instructionIndex: -1,
+                resolvedLine: 0,
+                locals: null,
+                parameters: null,
+                instanceFromFirstArgument: false,
+                methodDisplayName: null,
+                errorMessage: null);
+        }
+
+        public static SourcePausePointShimResolution NoStatementInPatchedMethod(
+            MethodBase logicalOwner,
+            int line,
+            string errorMessage)
+        {
+            return new SourcePausePointShimResolution(
+                SourcePausePointShimResolveKind.NoStatementInPatchedMethod,
+                targetMethod: null,
+                logicalOwner,
+                donorShim: null,
+                instructionIndex: -1,
+                resolvedLine: 0,
+                locals: null,
+                parameters: null,
+                instanceFromFirstArgument: false,
+                logicalOwner != null ? logicalOwner.ToString() : null,
+                errorMessage);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolution.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolution.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d275078763cf4a99b6490cf0a131205
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolveKind.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolveKind.cs
@@ -1,0 +1,13 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Outcome of resolving a pause-point file:line against an active hot-reload shim generation.
+    /// </summary>
+    internal enum SourcePausePointShimResolveKind
+    {
+        TransplantChainJoin,
+        ShimDirect,
+        NotInPatchedMethod,
+        NoStatementInPatchedMethod
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolveKind.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolveKind.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0887b2f3b09404334b8f8081b5d7f317
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolver.cs
@@ -1,0 +1,199 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Resolves a file:line against an active hot-reload shim generation (bytes + PDB),
+    /// choosing transplant chain-join vs shim-direct patching.
+    /// </summary>
+    internal static class SourcePausePointShimResolver
+    {
+        public static SourcePausePointShimResolution Resolve(
+            HotReloadShimFileLookup lookup,
+            string normalizedFilePath,
+            int line)
+        {
+            Debug.Assert(lookup != null, "lookup must not be null.");
+            Debug.Assert(!string.IsNullOrEmpty(normalizedFilePath), "normalizedFilePath must not be empty.");
+            Debug.Assert(line > 0, "line must be a positive 1-based line number.");
+
+            HotReloadShimMethodLookup methodEntry = FindMethodEntryForLine(lookup, line);
+            if (methodEntry == null)
+            {
+                return SourcePausePointShimResolution.NotInPatchedMethod();
+            }
+
+            using MemoryStream assemblyStream = new MemoryStream(lookup.AssemblyBytes, writable: false);
+            using MemoryStream pdbStream = new MemoryStream(
+                lookup.PdbBytes ?? System.Array.Empty<byte>(),
+                writable: false);
+
+            ReaderParameters readerParameters = new ReaderParameters
+            {
+                InMemory = true,
+                ReadSymbols = true,
+                SymbolReaderProvider = new PortablePdbReaderProvider(),
+                SymbolStream = pdbStream
+            };
+
+            using AssemblyDefinition assemblyDefinition =
+                AssemblyDefinition.ReadAssembly(assemblyStream, readerParameters);
+
+            (MethodDefinition containingMethod, SequencePoint sequencePoint) =
+                FindClosestSequencePointInMethodRange(
+                    assemblyDefinition.MainModule,
+                    normalizedFilePath,
+                    line,
+                    methodEntry.SourceEndLine);
+
+            if (containingMethod == null)
+            {
+                string displayName = methodEntry.OriginalMethod != null
+                    ? methodEntry.OriginalMethod.DeclaringType?.Name + "." + methodEntry.OriginalMethod.Name
+                    : "unknown";
+                return SourcePausePointShimResolution.NoStatementInPatchedMethod(
+                    methodEntry.OriginalMethod,
+                    line,
+                    "No executable statement at or after line " + line
+                    + " inside the hot-reload patched method '" + displayName
+                    + "'. The patched body was compiled from the current source, so line numbers "
+                    + "match the file on disk.");
+            }
+
+            int instructionIndex = SourcePausePointResolver.FindInstructionIndex(
+                containingMethod.Body.Instructions,
+                sequencePoint.Offset);
+            Debug.Assert(
+                instructionIndex >= 0,
+                "A sequence point's offset must correspond to an instruction in the same method body.");
+
+            List<SourcePausePointLocalVariable> locals =
+                SourcePausePointResolver.CollectCapturableLocals(containingMethod, sequencePoint.Offset);
+            // Why fallback: shim PDBs (especially with #line) can place the return sequence point
+            // at an offset after lexical local scopes close, yielding an empty in-scope set even
+            // though the locals are still live for capture on that statement.
+            if (locals.Count == 0)
+            {
+                locals = SourcePausePointResolver.CollectAllCapturableLocals(containingMethod);
+            }
+
+            int containingToken = containingMethod.MetadataToken.ToInt32();
+            int shimToken = methodEntry.ShimMethod.MetadataToken;
+            bool isShimMethodBody = containingToken == shimToken;
+
+            if (isShimMethodBody && !methodEntry.IsDelegation)
+            {
+                List<SourcePausePointParameter> parameters =
+                    SourcePausePointResolver.CollectParametersFromReflection(
+                        methodEntry.OriginalMethod,
+                        skipFirstParameter: false);
+                return SourcePausePointShimResolution.TransplantChainJoin(
+                    methodEntry.OriginalMethod,
+                    methodEntry.ShimMethod,
+                    instructionIndex,
+                    sequencePoint.StartLine,
+                    locals,
+                    parameters);
+            }
+
+            MethodBase targetMethod =
+                lookup.LoadedAssembly.ManifestModule.ResolveMethod(containingToken);
+            bool instanceFromFirstArgument =
+                isShimMethodBody
+                && methodEntry.IsDelegation
+                && methodEntry.OriginalMethod != null
+                && !methodEntry.OriginalMethod.IsStatic;
+            List<SourcePausePointParameter> shimParameters =
+                SourcePausePointResolver.CollectParametersFromReflection(
+                    targetMethod,
+                    skipFirstParameter: instanceFromFirstArgument);
+
+            return SourcePausePointShimResolution.ShimDirect(
+                targetMethod,
+                methodEntry.OriginalMethod,
+                instructionIndex,
+                sequencePoint.StartLine,
+                locals,
+                shimParameters,
+                instanceFromFirstArgument);
+        }
+
+        private static HotReloadShimMethodLookup FindMethodEntryForLine(
+            HotReloadShimFileLookup lookup,
+            int line)
+        {
+            foreach (HotReloadShimMethodLookup method in lookup.Methods)
+            {
+                if (line >= method.SourceStartLine && line <= method.SourceEndLine)
+                {
+                    return method;
+                }
+            }
+
+            return null;
+        }
+
+        private static (MethodDefinition method, SequencePoint sequencePoint)
+            FindClosestSequencePointInMethodRange(
+                ModuleDefinition module,
+                string normalizedFilePath,
+                int line,
+                int sourceEndLine)
+        {
+            MethodDefinition bestMethod = null;
+            SequencePoint bestSequencePoint = null;
+
+            foreach (MethodDefinition method in SourcePausePointResolver.EnumerateMethodsInModule(module))
+            {
+                if (!method.HasBody)
+                {
+                    continue;
+                }
+
+                MethodDebugInformation debugInformation = method.DebugInformation;
+                if (debugInformation == null || !debugInformation.HasSequencePoints)
+                {
+                    continue;
+                }
+
+                foreach (SequencePoint sequencePoint in debugInformation.SequencePoints)
+                {
+                    if (sequencePoint.IsHidden
+                        || sequencePoint.StartLine < line
+                        || sequencePoint.StartLine > sourceEndLine)
+                    {
+                        continue;
+                    }
+
+                    // Why request-first arg order: shim PDB Document.Url is the #line project-relative
+                    // literal while --file may be absolute; PathsReferToSameFile suffixes the first
+                    // argument, so the absolute request must be first (opposite of ScriptAssemblies).
+                    string documentUrl = SourcePausePointPathNormalizer.ToForwardSlashes(
+                        sequencePoint.Document.Url);
+                    if (!SourcePausePointPathNormalizer.PathsReferToSameFile(
+                            normalizedFilePath,
+                            documentUrl))
+                    {
+                        continue;
+                    }
+
+                    if (bestSequencePoint == null || sequencePoint.StartLine < bestSequencePoint.StartLine)
+                    {
+                        bestMethod = method;
+                        bestSequencePoint = sequencePoint;
+                    }
+                }
+            }
+
+            return (bestMethod, bestSequencePoint);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolver.cs
@@ -31,10 +31,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return SourcePausePointShimResolution.NotInPatchedMethod();
             }
 
+            // Why bail before Cecil: fallback compile backends can omit PDB bytes; ReadSymbols
+            // against an empty stream throws and would abort the whole enable call.
+            if (lookup.PdbBytes == null || lookup.PdbBytes.Length == 0)
+            {
+                return SourcePausePointShimResolution.NotInPatchedMethod();
+            }
+
             using MemoryStream assemblyStream = new MemoryStream(lookup.AssemblyBytes, writable: false);
-            using MemoryStream pdbStream = new MemoryStream(
-                lookup.PdbBytes ?? System.Array.Empty<byte>(),
-                writable: false);
+            using MemoryStream pdbStream = new MemoryStream(lookup.PdbBytes, writable: false);
 
             ReaderParameters readerParameters = new ReaderParameters
             {
@@ -56,12 +61,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (containingMethod == null)
             {
-                string displayName = methodEntry.OriginalMethod != null
-                    ? methodEntry.OriginalMethod.DeclaringType?.Name + "." + methodEntry.OriginalMethod.Name
-                    : "unknown";
+                string displayName =
+                    methodEntry.OriginalMethod.DeclaringType?.Name
+                    + "."
+                    + methodEntry.OriginalMethod.Name;
                 return SourcePausePointShimResolution.NoStatementInPatchedMethod(
                     methodEntry.OriginalMethod,
-                    line,
                     "No executable statement at or after line " + line
                     + " inside the hot-reload patched method '" + displayName
                     + "'. The patched body was compiled from the current source, so line numbers "
@@ -77,9 +82,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             List<SourcePausePointLocalVariable> locals =
                 SourcePausePointResolver.CollectCapturableLocals(containingMethod, sequencePoint.Offset);
-            // Why fallback: shim PDBs (especially with #line) can place the return sequence point
-            // at an offset after lexical local scopes close, yielding an empty in-scope set even
-            // though the locals are still live for capture on that statement.
+            // Why fallback: observed during PR-3 development — shim PDBs with #line can place the
+            // return sequence point after lexical local scopes close, so in-scope collection is
+            // empty while named locals still exist in the method debug info.
             if (locals.Count == 0)
             {
                 locals = SourcePausePointResolver.CollectAllCapturableLocals(containingMethod);
@@ -109,7 +114,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool instanceFromFirstArgument =
                 isShimMethodBody
                 && methodEntry.IsDelegation
-                && methodEntry.OriginalMethod != null
                 && !methodEntry.OriginalMethod.IsStatic;
             List<SourcePausePointParameter> shimParameters =
                 SourcePausePointResolver.CollectParametersFromReflection(

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolver.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d846cc19f15cf49759334a3fc3cae062
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- `enable-pause-point --file --line` can now arm markers on hot-reload patched method bodies (edited source lines) instead of always failing with `PAUSE_POINT_PATCHED_BY_HOT_RELOAD`.
- Transplant and delegation shapes are both covered: chain-join into the hot-reload stream, or direct patch of the live shim-side method.

## User Impact
- After `uloop hot-reload`, you can place a pause point on a line inside the edited method and hit/capture without `uloop compile`.
- Lines outside every active patched method’s current body still fall back to the compiled PDB path (and may still be rejected when that path lands on a patched method).

## Changes
- Add `SourcePausePointShimResolver` over retained shim assembly/PDB bytes (`GetShimLookupForFile`).
- Generation-aware injections (`OriginalBody` / `TransplantChainJoin` / `ShimDirect`) plus `PatchShimTarget` and logical-owner tracking.
- `EnableBySourceLocation` tries the shim path before ScriptAssemblies resolve.
- Hot-reload state sync is logical-owner based: shim-path markers stay `SuppressedByHotReload=true` across revert/generation change until PR-4 retarget; re-enable replaces stale injections.
- Contract tests: transplant local capture, delegation without `__uloopInstance`, suppress-on-revert/re-apply, re-enable recovery, async MoveNext, rejection message, unedited fallthrough.

## Known gap (follow-up)
- After revert or a newer hot-reload generation, shim-path markers show `SuppressedByHotReload=true` (honest inactive status from this PR) but are not automatically retargeted onto the restored/new body — PR-4’s auto-retarget closes that recovery path.
- Silent direct-patch markers across a later hot-reload generation without that suppress honesty were the prior gap; suppress sync is fixed here, retarget remains PR-4.

## Verification
- `dist/darwin-arm64/uloop compile` — ErrorCount 0
- `run-tests --filter-type regex --filter-value HotReload` — see latest push comment
- `run-tests --filter-type regex --filter-value PausePoint` — see latest push comment
