### PR TITLE
feat: auto-retarget pause points across hot-reload patch transitions

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -159,25 +159,27 @@ and read the returned value.
 ## Pause point interaction
 
 Both patch shapes discard the original IL and any prior transpiler output on the patched
-method — delegation replaces the body with a forward to the shim. Source pause points
-instrument methods through the same transpiler chain, so the two tools enforce a strict
-contract instead of composing silently:
+method, so armed source pause points cannot survive a patch unchanged. Instead of
+enforcing exclusivity, every patch transition re-targets them:
 
-- A pause point armed **before** a hot reload of the same method stops firing — its
-  instrumentation was part of the discarded IL. The apply response lists the affected
-  marker ids in `Warnings`, and `pause-point-status` reports `SuppressedByHotReload: true`
-  for those markers until the patch is reverted.
-- Enabling a pause point **on a currently patched method is rejected** with
-  `PAUSE_POINT_PATCHED_BY_HOT_RELOAD`. Marker positions and local-variable capture
-  resolve against the pre-patch compiled body, which no longer exists at runtime; there
-  is no line on a patched method where a new marker would be trustworthy.
-- `uloop hot-reload --revert-all` (or any domain reload) restores the original IL;
-  previously armed pause points fire again and their `SuppressedByHotReload` flag clears.
+- Applying a patch re-resolves each armed marker on the edited method against the
+  patched body. A marker whose line still resolves keeps firing at the edited line —
+  the apply response reports those ids in a `Warnings` entry and `pause-point-status`
+  shows `RetargetedToHotReloadPatch: true`. A marker whose line no longer resolves is
+  suppressed instead: the apply response lists it, and status shows
+  `SuppressedByHotReload: true` with the reason in `SuppressedByHotReloadReason`.
+- Enabling a new pause point on a currently patched method resolves against the patched
+  body directly. `PAUSE_POINT_PATCHED_BY_HOT_RELOAD` is returned only when the line
+  cannot be mapped onto it (a stale line map or a superseded generation).
+- `uloop hot-reload --revert-all` (or reverting a method's patch) re-targets armed
+  markers back onto the compiled body; a marker whose line no longer resolves there
+  stays suppressed with a reason until `uloop compile` and a re-enable.
 
-So the workflow is: iterate on behavior with hot reload, and when you need pause-point
-inspection of an edited method, run `uloop compile` to make the edits real (the compile's
-domain reload clears every patch), then enable the marker. Use `--revert-all` instead
-when you want the on-disk build back without recompiling.
+Suppressed markers are never cleared automatically — they keep their identity and fire
+again as soon as a transition restores their line. The practical workflow: iterate with
+hot reload and place pause points on edited lines in either order — enable then patch,
+or patch then enable. `uloop compile` is needed only when a marker stays suppressed
+because its line no longer resolves in any live body.
 
 ## Output
 

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -125,15 +125,13 @@ below) — raising is only expressible inside the declaring type, which a shim i
 ## When a patch reports `Patched` but behavior does not change
 
 `Patched` means the method body was replaced, not that the method ran. Before suspecting
-the patch, confirm the method is actually reached. A currently patched method rejects new
-pause points with `PAUSE_POINT_PATCHED_BY_HOT_RELOAD` (see the pause point interaction
-below), so run `uloop compile` first — it makes the edits real and its domain reload
-clears every patch — then arm `uloop enable-pause-point --mode trace` on the method's
-first line, drive the game, and check the hit count: zero hits means the calling path
-never reached the method, which no patch (or compile) can fix. To chase an early return
-inside the method, arm a second marker on the suspected early-return line. The other
-known cause is JIT inlining of tiny methods, which the response already flags with a
-single aggregated warning listing the at-risk methods.
+the patch, confirm the method is actually reached: arm `uloop enable-pause-point --mode
+trace` on a line inside the edited method body — it resolves against the patched body
+directly (see the pause point interaction below) — drive the game, and check the hit
+count: zero hits means the calling path never reached the method, which no patch (or
+compile) can fix. To chase an early return inside the method, arm a second marker on the
+suspected early-return line. The other known cause is JIT inlining of tiny methods, which
+the response already flags with a single aggregated warning listing the at-risk methods.
 
 ## Convergence and lifecycle
 

--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -174,12 +174,17 @@ If a `simulate-*` command instead returns a failure whose message says PlayMode 
 
 If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first — clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. When `--trigger` was passed, the expired envelope also carries `Error.Details.TriggerResult` (with `Completed: false` and no `Error` field when the trigger's outcome was still unknown at expiry). The countdown freezes while a hit holds the Editor paused; a manual pause without a hit does not stop it.
 
-`PAUSE_POINT_PATCHED_BY_HOT_RELOAD` means the target method's body is currently replaced
-by `uloop hot-reload`, so a new marker cannot be trusted anywhere in that method. Run
-`uloop compile` (or `uloop hot-reload --revert-all`) first, then enable the marker.
-Relatedly, `SuppressedByHotReload: true` on a status response means the marker's method
-was hot-reload patched after arming; the marker will not fire until the patch is
-reverted or compiled for real.
+`enable-pause-point` works on hot-reload patched methods: the marker resolves against
+the patched body, and `RetargetedToHotReloadPatch: true` in the response confirms it is
+armed on the edited code. `PAUSE_POINT_PATCHED_BY_HOT_RELOAD` is returned only when the
+requested line cannot be mapped onto the patched body — the file's line map is stale or
+the patch belongs to a superseded hot-reload generation. Pick a line inside the edited
+method body, run `uloop hot-reload --revert-all`, or run `uloop compile`, then retry.
+`SuppressedByHotReload: true` on a status response means a later hot-reload transition
+(apply, a newer generation, or revert) could not re-target the armed marker; the reason
+is in `SuppressedByHotReloadReason` and surfaced as the status `Warning`. The marker is
+not cleared — it fires again once a transition restores its line, or after
+`uloop compile` and a re-enable.
 
 Use `uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"` only when you need to confirm the marker is armed or inspect the current hit state.
 

--- a/.agents/skills/uloop-pause-point/references/troubleshooting.md
+++ b/.agents/skills/uloop-pause-point/references/troubleshooting.md
@@ -31,6 +31,10 @@ Recovery order:
 
 A method already bound into a delegate or event before `enable-pause-point` may not fire through that delegate: the pre-bound invocation path can bypass the patch. Workarounds: enable the pause point before the delegate is created, recreate the subscribing GameObject, or re-bind the delegate (e.g. via `execute-dynamic-code`) after enabling.
 
+## Hot-Reload Interaction
+
+`uloop hot-reload` transitions (apply, a newer generation, revert) re-target armed source pause points automatically. `SuppressedByHotReload: true` on a status or wait response means the last transition could not re-target that marker — its line no longer resolves in the code now executing. The reason is in `SuppressedByHotReloadReason` (surfaced as the status `Warning`), and the marker stays armed but silent. Recover by reverting the patch (`uloop hot-reload --revert-all`), editing so the line exists again and re-running `uloop hot-reload`, or running `uloop compile` and re-enabling the marker. `RetargetedToHotReloadPatch: true` is not a problem: it confirms the marker follows the patched body and keeps firing at the edited line.
+
 ## Enable Failures
 
 If enable fails with a "No sequence point found" error even for clearly executable lines, that script's assembly lacks debug sequence points and no line in the file can be patched. Move the pause point to a script in an assembly that carries them, such as a script under `Assets/`.

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -159,25 +159,27 @@ and read the returned value.
 ## Pause point interaction
 
 Both patch shapes discard the original IL and any prior transpiler output on the patched
-method — delegation replaces the body with a forward to the shim. Source pause points
-instrument methods through the same transpiler chain, so the two tools enforce a strict
-contract instead of composing silently:
+method, so armed source pause points cannot survive a patch unchanged. Instead of
+enforcing exclusivity, every patch transition re-targets them:
 
-- A pause point armed **before** a hot reload of the same method stops firing — its
-  instrumentation was part of the discarded IL. The apply response lists the affected
-  marker ids in `Warnings`, and `pause-point-status` reports `SuppressedByHotReload: true`
-  for those markers until the patch is reverted.
-- Enabling a pause point **on a currently patched method is rejected** with
-  `PAUSE_POINT_PATCHED_BY_HOT_RELOAD`. Marker positions and local-variable capture
-  resolve against the pre-patch compiled body, which no longer exists at runtime; there
-  is no line on a patched method where a new marker would be trustworthy.
-- `uloop hot-reload --revert-all` (or any domain reload) restores the original IL;
-  previously armed pause points fire again and their `SuppressedByHotReload` flag clears.
+- Applying a patch re-resolves each armed marker on the edited method against the
+  patched body. A marker whose line still resolves keeps firing at the edited line —
+  the apply response reports those ids in a `Warnings` entry and `pause-point-status`
+  shows `RetargetedToHotReloadPatch: true`. A marker whose line no longer resolves is
+  suppressed instead: the apply response lists it, and status shows
+  `SuppressedByHotReload: true` with the reason in `SuppressedByHotReloadReason`.
+- Enabling a new pause point on a currently patched method resolves against the patched
+  body directly. `PAUSE_POINT_PATCHED_BY_HOT_RELOAD` is returned only when the line
+  cannot be mapped onto it (a stale line map or a superseded generation).
+- `uloop hot-reload --revert-all` (or reverting a method's patch) re-targets armed
+  markers back onto the compiled body; a marker whose line no longer resolves there
+  stays suppressed with a reason until `uloop compile` and a re-enable.
 
-So the workflow is: iterate on behavior with hot reload, and when you need pause-point
-inspection of an edited method, run `uloop compile` to make the edits real (the compile's
-domain reload clears every patch), then enable the marker. Use `--revert-all` instead
-when you want the on-disk build back without recompiling.
+Suppressed markers are never cleared automatically — they keep their identity and fire
+again as soon as a transition restores their line. The practical workflow: iterate with
+hot reload and place pause points on edited lines in either order — enable then patch,
+or patch then enable. `uloop compile` is needed only when a marker stays suppressed
+because its line no longer resolves in any live body.
 
 ## Output
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -125,15 +125,13 @@ below) — raising is only expressible inside the declaring type, which a shim i
 ## When a patch reports `Patched` but behavior does not change
 
 `Patched` means the method body was replaced, not that the method ran. Before suspecting
-the patch, confirm the method is actually reached. A currently patched method rejects new
-pause points with `PAUSE_POINT_PATCHED_BY_HOT_RELOAD` (see the pause point interaction
-below), so run `uloop compile` first — it makes the edits real and its domain reload
-clears every patch — then arm `uloop enable-pause-point --mode trace` on the method's
-first line, drive the game, and check the hit count: zero hits means the calling path
-never reached the method, which no patch (or compile) can fix. To chase an early return
-inside the method, arm a second marker on the suspected early-return line. The other
-known cause is JIT inlining of tiny methods, which the response already flags with a
-single aggregated warning listing the at-risk methods.
+the patch, confirm the method is actually reached: arm `uloop enable-pause-point --mode
+trace` on a line inside the edited method body — it resolves against the patched body
+directly (see the pause point interaction below) — drive the game, and check the hit
+count: zero hits means the calling path never reached the method, which no patch (or
+compile) can fix. To chase an early return inside the method, arm a second marker on the
+suspected early-return line. The other known cause is JIT inlining of tiny methods, which
+the response already flags with a single aggregated warning listing the at-risk methods.
 
 ## Convergence and lifecycle
 

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -174,12 +174,17 @@ If a `simulate-*` command instead returns a failure whose message says PlayMode 
 
 If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first — clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. When `--trigger` was passed, the expired envelope also carries `Error.Details.TriggerResult` (with `Completed: false` and no `Error` field when the trigger's outcome was still unknown at expiry). The countdown freezes while a hit holds the Editor paused; a manual pause without a hit does not stop it.
 
-`PAUSE_POINT_PATCHED_BY_HOT_RELOAD` means the target method's body is currently replaced
-by `uloop hot-reload`, so a new marker cannot be trusted anywhere in that method. Run
-`uloop compile` (or `uloop hot-reload --revert-all`) first, then enable the marker.
-Relatedly, `SuppressedByHotReload: true` on a status response means the marker's method
-was hot-reload patched after arming; the marker will not fire until the patch is
-reverted or compiled for real.
+`enable-pause-point` works on hot-reload patched methods: the marker resolves against
+the patched body, and `RetargetedToHotReloadPatch: true` in the response confirms it is
+armed on the edited code. `PAUSE_POINT_PATCHED_BY_HOT_RELOAD` is returned only when the
+requested line cannot be mapped onto the patched body — the file's line map is stale or
+the patch belongs to a superseded hot-reload generation. Pick a line inside the edited
+method body, run `uloop hot-reload --revert-all`, or run `uloop compile`, then retry.
+`SuppressedByHotReload: true` on a status response means a later hot-reload transition
+(apply, a newer generation, or revert) could not re-target the armed marker; the reason
+is in `SuppressedByHotReloadReason` and surfaced as the status `Warning`. The marker is
+not cleared — it fires again once a transition restores its line, or after
+`uloop compile` and a re-enable.
 
 Use `uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"` only when you need to confirm the marker is armed or inspect the current hit state.
 

--- a/.claude/skills/uloop-pause-point/references/troubleshooting.md
+++ b/.claude/skills/uloop-pause-point/references/troubleshooting.md
@@ -31,6 +31,10 @@ Recovery order:
 
 A method already bound into a delegate or event before `enable-pause-point` may not fire through that delegate: the pre-bound invocation path can bypass the patch. Workarounds: enable the pause point before the delegate is created, recreate the subscribing GameObject, or re-bind the delegate (e.g. via `execute-dynamic-code`) after enabling.
 
+## Hot-Reload Interaction
+
+`uloop hot-reload` transitions (apply, a newer generation, revert) re-target armed source pause points automatically. `SuppressedByHotReload: true` on a status or wait response means the last transition could not re-target that marker — its line no longer resolves in the code now executing. The reason is in `SuppressedByHotReloadReason` (surfaced as the status `Warning`), and the marker stays armed but silent. Recover by reverting the patch (`uloop hot-reload --revert-all`), editing so the line exists again and re-running `uloop hot-reload`, or running `uloop compile` and re-enabling the marker. `RetargetedToHotReloadPatch: true` is not a problem: it confirms the marker follows the patched body and keeps firing at the edited line.
+
 ## Enable Failures
 
 If enable fails with a "No sequence point found" error even for clearly executable lines, that script's assembly lacks debug sequence points and no line in the file can be patched. Move the pause point to a script in an assembly that carries them, such as a script under `Assets/`.

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
@@ -155,6 +155,73 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a SingleShot marker that already hit (disarmed) is not retargeted or suppressed
+        /// by a later hot-reload of the same method.
+        /// </summary>
+        [Test]
+        public async Task HotReload_AfterSingleShotHit_DoesNotTouchDisarmedMarker()
+        {
+            string onDisk = File.ReadAllText(ResolveFixtureAbsolutePath());
+            int enableLine = FindLineNumber(onDisk, "return _secret + delta;");
+            Assert.That(enableLine, Is.GreaterThan(0));
+
+            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.SingleShot
+            });
+            Assert.That(enable.Success, Is.True, enable.Message);
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(fixture.SecretForAssert + 5));
+            UloopPausePointSnapshot afterHit = UloopPausePointRegistry.GetStatus(enable.Id);
+            Assert.That(afterHit.IsHit, Is.True);
+            Assert.That(afterHit.IsEnabled, Is.False);
+
+            await HotReloadFromEditedSourceAsync(
+                BuildEditedComputePlusHundred(onDisk),
+                "ContractSingleShotDisarmed.cs");
+
+            UloopPausePointSnapshot afterPatch = UloopPausePointRegistry.GetStatus(enable.Id);
+            Assert.That(afterPatch.RetargetedToHotReloadPatch, Is.False);
+            Assert.That(afterPatch.SuppressedByHotReload, Is.False);
+        }
+
+        /// <summary>
+        /// What: RevertAll after enable on a shim-only line cannot restore instrumentation and
+        /// records RestoreAfterHotReloadRevertFailedReason exactly.
+        /// </summary>
+        [Test]
+        public async Task RevertAll_AfterEnableOnShimOnlyLine_SuppressesWithRestoreReason()
+        {
+            string boostedEdit = BuildEditedComputeWithBoostedLocal();
+            int enableLine = FindLineNumber(boostedEdit, "return boosted;");
+            Assert.That(enableLine, Is.GreaterThan(0));
+            await HotReloadFromEditedSourceAsync(boostedEdit, "ContractRestoreFailGen1.cs");
+
+            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(enable.Success, Is.True, enable.Message);
+            Assert.That(enable.RetargetedToHotReloadPatch, Is.True);
+
+            HotReloadPatcher.RevertAll();
+
+            UloopPausePointSnapshot status = UloopPausePointRegistry.GetStatus(enable.Id);
+            Assert.That(status.SuppressedByHotReload, Is.True);
+            Assert.That(status.RetargetedToHotReloadPatch, Is.False);
+            Assert.That(
+                status.SuppressedByHotReloadReason,
+                Is.EqualTo(SourcePausePointConstants.RestoreAfterHotReloadRevertFailedReason));
+        }
+
+        /// <summary>
         /// What: after enable on a patched body, a second hot-reload generation keeps the marker
         /// firing with the newer edited behavior (generation follow).
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
@@ -123,104 +123,109 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a transplant-enabled marker becomes SuppressedByHotReload after RevertAll and
-        /// does not hit (honest display until PR-4 auto-retarget).
+        /// What: arm → transplant hot-reload auto-retargets (not suppress) and hits the edited body.
         /// </summary>
         [Test]
-        public async Task RevertAll_AfterTransplantEnable_SetsSuppressedAndDoesNotHit()
-        {
-            string editedSource = BuildEditedComputeWithBoostedLocal();
-            int enableLine = FindLineNumber(editedSource, "return boosted;");
-            Assert.That(enableLine, Is.GreaterThan(0));
-            await HotReloadFromEditedSourceAsync(editedSource, "ContractTransplantSuppressOnRevert.cs");
-
-            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
-            {
-                File = FixtureProjectRelativePath,
-                Line = enableLine,
-                TimeoutSeconds = 30,
-                Mode = UloopPausePointCaptureMode.Continuous
-            });
-            Assert.That(enable.Success, Is.True, enable.Message);
-
-            HotReloadPatcher.RevertAll();
-            Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).SuppressedByHotReload, Is.True);
-
-            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
-            fixture.ComputeWithPrivate(5);
-            Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).IsHit, Is.False);
-        }
-
-        /// <summary>
-        /// What: a ShimDirect (delegation) marker is suppressed when a newer hot-reload generation
-        /// replaces the file's shim registration.
-        /// </summary>
-        [Test]
-        public async Task ReApply_AfterDelegationEnable_SetsSuppressed()
-        {
-            string firstEdit = BuildEditedLambdaPrivateDelegation();
-            int enableLine = FindLineNumber(firstEdit, "return pred(threshold) ? 7 : 0;");
-            Assert.That(enableLine, Is.GreaterThan(0));
-            await HotReloadFromEditedSourceAsync(firstEdit, "ContractDelegationSuppressGen1.cs");
-
-            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
-            {
-                File = FixtureProjectRelativePath,
-                Line = enableLine,
-                TimeoutSeconds = 30,
-                Mode = UloopPausePointCaptureMode.Continuous
-            });
-            Assert.That(enable.Success, Is.True, enable.Message);
-
-            string secondEdit = firstEdit.Replace(
-                "return pred(threshold) ? 7 : 0;",
-                "return pred(threshold) ? 8 : 0;",
-                StringComparison.Ordinal);
-            await HotReloadFromEditedSourceAsync(secondEdit, "ContractDelegationSuppressGen2.cs");
-            Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).SuppressedByHotReload, Is.True);
-        }
-
-        /// <summary>
-        /// What: re-enabling the same file:line after hot-reload replaces a stale OriginalBody
-        /// injection and the marker hits on the edited body.
-        /// </summary>
-        [Test]
-        public async Task ReEnable_SameFileLine_AfterHotReload_HitsEditedBody()
+        public async Task ArmThenHotReload_AutoRetargetsAndHitsEditedBody()
         {
             string onDisk = File.ReadAllText(ResolveFixtureAbsolutePath());
             int enableLine = FindLineNumber(onDisk, "return _secret + delta;");
             Assert.That(enableLine, Is.GreaterThan(0));
 
-            PausePointResponse firstEnable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
             {
                 File = FixtureProjectRelativePath,
                 Line = enableLine,
                 TimeoutSeconds = 30,
                 Mode = UloopPausePointCaptureMode.Continuous
             });
-            Assert.That(firstEnable.Success, Is.True, firstEnable.Message);
+            Assert.That(enable.Success, Is.True, enable.Message);
 
-            string editedSource = onDisk.Replace(
-                "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
-                "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }",
-                StringComparison.Ordinal);
-            Assert.That(editedSource, Is.Not.EqualTo(onDisk));
-            await HotReloadFromEditedSourceAsync(editedSource, "ContractReEnableSameLine.cs");
+            string editedSource = BuildEditedComputePlusHundred(onDisk);
+            await HotReloadFromEditedSourceAsync(editedSource, "ContractArmThenPatch.cs");
 
-            PausePointResponse reEnable = new PausePointUseCase().Enable(new EnablePausePointSchema
-            {
-                File = FixtureProjectRelativePath,
-                Line = enableLine,
-                TimeoutSeconds = 30,
-                Mode = UloopPausePointCaptureMode.Continuous
-            });
-            Assert.That(reEnable.Success, Is.True, reEnable.Message + " / " + reEnable.RecommendedNextAction);
+            UloopPausePointSnapshot afterPatch = UloopPausePointRegistry.GetStatus(enable.Id);
+            Assert.That(afterPatch.SuppressedByHotReload, Is.False);
+            Assert.That(afterPatch.RetargetedToHotReloadPatch, Is.True);
 
             HotReloadE2EFixture fixture = new HotReloadE2EFixture();
             int result = fixture.ComputeWithPrivate(5);
             Assert.That(result, Is.EqualTo(fixture.SecretForAssert + 5 + 100));
-            Assert.That(UloopPausePointRegistry.GetStatus(reEnable.Id).IsHit, Is.True);
-            Assert.That(UloopPausePointRegistry.GetStatus(reEnable.Id).SuppressedByHotReload, Is.False);
+            Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).IsHit, Is.True);
+        }
+
+        /// <summary>
+        /// What: after enable on a patched body, a second hot-reload generation keeps the marker
+        /// firing with the newer edited behavior (generation follow).
+        /// </summary>
+        [Test]
+        public async Task ReApply_AfterEnable_FollowsNewGenerationAndHits()
+        {
+            string firstEdit = BuildEditedLambdaPrivateDelegation();
+            int enableLine = FindLineNumber(firstEdit, "return pred(threshold) ? 7 : 0;");
+            Assert.That(enableLine, Is.GreaterThan(0));
+            await HotReloadFromEditedSourceAsync(firstEdit, "ContractDelegationFollowGen1.cs");
+
+            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(enable.Success, Is.True, enable.Message);
+            Assert.That(enable.RetargetedToHotReloadPatch, Is.True);
+
+            string secondEdit = firstEdit.Replace(
+                "return pred(threshold) ? 7 : 0;",
+                "return pred(threshold) ? 8 : 0;",
+                StringComparison.Ordinal);
+            await HotReloadFromEditedSourceAsync(secondEdit, "ContractDelegationFollowGen2.cs");
+
+            UloopPausePointSnapshot afterSecond = UloopPausePointRegistry.GetStatus(enable.Id);
+            Assert.That(afterSecond.SuppressedByHotReload, Is.False);
+            Assert.That(afterSecond.RetargetedToHotReloadPatch, Is.True);
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.LambdaPrivate(0), Is.EqualTo(8));
+            Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).IsHit, Is.True);
+        }
+
+        /// <summary>
+        /// What: shrinking the patched method so the armed line falls outside the shim range
+        /// suppresses with a non-empty reason mirrored on status Warning.
+        /// </summary>
+        [Test]
+        public async Task HotReload_ArmedLineOutsidePatchedMethod_SuppressesWithReason()
+        {
+            string boostedEdit = BuildEditedComputeWithBoostedLocal();
+            int enableLine = FindLineNumber(boostedEdit, "return boosted;");
+            Assert.That(enableLine, Is.GreaterThan(0));
+            await HotReloadFromEditedSourceAsync(boostedEdit, "ContractRetargetFailGen1.cs");
+
+            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(enable.Success, Is.True, enable.Message);
+
+            // Why shrink: enableLine sits deep in the boosted body; the short +100 body ends
+            // earlier, so shim resolve reports NotInPatchedMethod and retarget suppresses.
+            string onDisk = File.ReadAllText(ResolveFixtureAbsolutePath());
+            string shortEdit = BuildEditedComputePlusHundred(onDisk);
+            Assert.That(
+                FindLineNumber(shortEdit, "return _secret + delta + 100;"),
+                Is.LessThan(enableLine));
+            await HotReloadFromEditedSourceAsync(shortEdit, "ContractRetargetFailGen2.cs");
+
+            UloopPausePointSnapshot status = UloopPausePointRegistry.GetStatus(enable.Id);
+            Assert.That(status.SuppressedByHotReload, Is.True);
+            Assert.That(status.SuppressedByHotReloadReason, Is.Not.Null.And.Not.Empty);
+            Assert.That(status.RetargetedToHotReloadPatch, Is.False);
+            // Warning mirroring of the reason is covered by PausePointStatusResponseContractTests.
         }
 
         /// <summary>
@@ -356,37 +361,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: Applying a hot-reload patch to a method with an armed marker sets
-        /// SuppressedByHotReload, and RevertAll clears the flag.
-        /// </summary>
-        [Test]
-        public void Apply_MethodWithArmedMarker_SetsAndClearsSuppressedFlag()
-        {
-            const string id = "contract-suppress-flag";
-            MethodInfo original = AccessTools.Method(
-                typeof(HotReloadPausePointContractFixture),
-                nameof(HotReloadPausePointContractFixture.ReplaceableCompute));
-            MethodInfo shim = AccessTools.Method(
-                typeof(HotReloadPausePointContractShims),
-                nameof(HotReloadPausePointContractShims.ReplaceableCompute__shim0));
-
-            UloopPausePointRegistry.Enable(id, 30);
-            Assert.That(
-                SourcePausePointPatcher.Patch(id, BuildSyntheticResolution(original, instructionIndex: 0)).Success,
-                Is.True);
-
-            Assert.That(
-                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
-                Is.True);
-            Assert.That(UloopPausePointRegistry.GetStatus(id).SuppressedByHotReload, Is.True);
-
-            HotReloadPatcher.RevertAll();
-            Assert.That(UloopPausePointRegistry.GetStatus(id).SuppressedByHotReload, Is.False);
-        }
-
-        /// <summary>
-        /// What: An armed deep marker does not make a subsequent hot-reload Apply fail, and
-        /// the marker is reported as SuppressedByHotReload after Apply succeeds.
+        /// What: a synthetic Apply without shim registration cannot retarget, so Apply still
+        /// succeeds and the armed marker is reported SuppressedByHotReload.
         /// </summary>
         [Test]
         public void Apply_MethodWithDeepArmedMarker_SucceedsAndSuppresses()
@@ -408,74 +384,85 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 original, shim, HotReloadPatchShape.Delegation);
             Assert.That(applyResult.Success, Is.True, applyResult.ErrorMessage);
             Assert.That(UloopPausePointRegistry.GetStatus(id).SuppressedByHotReload, Is.True);
+            Assert.That(
+                UloopPausePointRegistry.GetStatus(id).SuppressedByHotReloadReason,
+                Is.Not.Null.And.Not.Empty);
         }
 
         /// <summary>
-        /// What: Unpatching one of two armed markers while the method is hot-reload patched
-        /// does not re-instrument the surviving marker into the shim stream (and does not throw).
+        /// What: after two markers are retargeted onto a shim body, unpatching one sibling leaves
+        /// the survivor firing on the edited body.
         /// </summary>
         [Test]
-        public void Unpatch_SiblingMarker_WhileHotReloadPatched_DoesNotReinstrumentSurvivors()
+        public async Task Unpatch_SiblingMarker_WhileHotReloadPatched_SurvivorStillHits()
         {
-            const string id1 = "contract-sibling-unpatch-a";
-            const string id2 = "contract-sibling-unpatch-b";
-            MethodInfo original = AccessTools.Method(
-                typeof(HotReloadPausePointDeepFixture),
-                nameof(HotReloadPausePointDeepFixture.DeepStatements));
-            MethodInfo shim = AccessTools.Method(
-                typeof(HotReloadPausePointContractShims),
-                nameof(HotReloadPausePointContractShims.DeepStatements__shim0));
+            string editedSource = BuildEditedComputeWithBoostedLocal();
+            int lineBoosted = FindLineNumber(editedSource, "int boosted = _secret + delta + 100;");
+            int lineReturn = FindLineNumber(editedSource, "return boosted;");
+            Assert.That(lineBoosted, Is.GreaterThan(0));
+            Assert.That(lineReturn, Is.GreaterThan(lineBoosted));
+            await HotReloadFromEditedSourceAsync(editedSource, "ContractSiblingSurvivor.cs");
 
-            UloopPausePointRegistry.Enable(id1, 30);
-            Assert.That(
-                SourcePausePointPatcher.Patch(id1, BuildSyntheticResolution(original, instructionIndex: 0)).Success,
-                Is.True);
-            UloopPausePointRegistry.Enable(id2, 30);
-            Assert.That(
-                SourcePausePointPatcher.Patch(id2, BuildSyntheticResolution(original, instructionIndex: 10)).Success,
-                Is.True);
+            PausePointResponse enableBoosted = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = lineBoosted,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            PausePointResponse enableReturn = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = lineReturn,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(enableBoosted.Success, Is.True, enableBoosted.Message);
+            Assert.That(enableReturn.Success, Is.True, enableReturn.Message);
 
-            Assert.That(
-                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Delegation).Success,
-                Is.True);
+            Assert.DoesNotThrow(() => SourcePausePointPatcher.Unpatch(enableBoosted.Id));
 
-            Assert.DoesNotThrow(() => SourcePausePointPatcher.Unpatch(id1));
-
-            HotReloadPausePointDeepFixture fixture = new HotReloadPausePointDeepFixture();
-            Assert.That(fixture.DeepStatements(), Is.EqualTo(99));
-            Assert.That(UloopPausePointRegistry.GetStatus(id2).IsHit, Is.False);
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            int result = fixture.ComputeWithPrivate(5);
+            Assert.That(result, Is.EqualTo(fixture.SecretForAssert + 5 + 100));
+            Assert.That(UloopPausePointRegistry.GetStatus(enableReturn.Id).IsHit, Is.True);
+            Assert.That(UloopPausePointRegistry.GetStatus(enableBoosted.Id).IsHit, Is.False);
         }
 
         /// <summary>
-        /// What: RevertAll restores armed-marker instrumentation so invoking the fixture
-        /// records a hit again (regression for ledger-clear-before-UnpatchAll ordering).
+        /// What: RevertAll restores instrumentation onto the compiled body, clears retargeted,
+        /// and the marker hits with the original (non-edited) return value.
         /// </summary>
         [Test]
-        public void RevertAll_RestoresArmedMarkerInstrumentation()
+        public async Task RevertAll_RestoresArmedMarkerInstrumentation()
         {
-            const string id = "contract-restore-hit";
-            MethodInfo original = AccessTools.Method(
-                typeof(HotReloadPausePointContractFixture),
-                nameof(HotReloadPausePointContractFixture.ReplaceableCompute));
-            MethodInfo shim = AccessTools.Method(
-                typeof(HotReloadPausePointContractShims),
-                nameof(HotReloadPausePointContractShims.ReplaceableCompute__shim0));
+            string onDisk = File.ReadAllText(ResolveFixtureAbsolutePath());
+            int enableLine = FindLineNumber(onDisk, "return _secret + delta;");
+            Assert.That(enableLine, Is.GreaterThan(0));
 
-            UloopPausePointRegistry.Enable(id, 30);
-            Assert.That(
-                SourcePausePointPatcher.Patch(id, BuildSyntheticResolution(original, instructionIndex: 0)).Success,
-                Is.True);
+            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(enable.Success, Is.True, enable.Message);
 
-            Assert.That(
-                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
-                Is.True);
+            await HotReloadFromEditedSourceAsync(
+                BuildEditedComputePlusHundred(onDisk),
+                "ContractRestoreAfterRevert.cs");
+            Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).RetargetedToHotReloadPatch, Is.True);
+
             HotReloadPatcher.RevertAll();
 
-            HotReloadPausePointContractFixture fixture = new HotReloadPausePointContractFixture();
-            int result = fixture.ReplaceableCompute(5);
-            Assert.That(result, Is.EqualTo(-5));
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            int result = fixture.ComputeWithPrivate(5);
+            Assert.That(result, Is.EqualTo(fixture.SecretForAssert + 5));
 
-            UloopPausePointSnapshot status = UloopPausePointRegistry.GetStatus(id);
+            UloopPausePointSnapshot status = UloopPausePointRegistry.GetStatus(enable.Id);
+            Assert.That(status.SuppressedByHotReload, Is.False);
+            Assert.That(status.RetargetedToHotReloadPatch, Is.False);
             Assert.That(status.IsHit, Is.True);
             Assert.That(status.HitCount, Is.EqualTo(1));
         }
@@ -496,6 +483,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 1,
                 Array.Empty<SourcePausePointLocalVariable>(),
                 Array.Empty<SourcePausePointParameter>());
+        }
+
+        private static string BuildEditedComputePlusHundred(string onDisk)
+        {
+            string edited = onDisk.Replace(
+                "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            return edited;
         }
 
         private static string BuildEditedComputeWithBoostedLocal()

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
@@ -335,6 +335,52 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: RevertAll after enable on a hot-reloaded async body restores instrumentation
+        /// onto the compiled MoveNext and hits with the original (non-edited) return value.
+        /// </summary>
+        [Test]
+        public async Task RevertAll_AfterEnableOnHotReloadedAsyncBody_RestoresAndHitsOriginal()
+        {
+            string onDisk = File.ReadAllText(ResolveFixtureAbsolutePath());
+            string editedSource = onDisk.Replace(
+                "public async Task<int> AsyncPrivateFieldAndMethod(int delta)\n        {\n"
+                + "            await Task.Yield();\n"
+                + "            return _secret + delta;\n"
+                + "        }",
+                "public async Task<int> AsyncPrivateFieldAndMethod(int delta)\n        {\n"
+                + "            await Task.Yield();\n"
+                + "            return _secret + delta + 100;\n"
+                + "        }",
+                StringComparison.Ordinal);
+            Assert.That(editedSource, Is.Not.EqualTo(onDisk));
+            int enableLine = FindLineNumber(editedSource, "return _secret + delta + 100;");
+            Assert.That(enableLine, Is.GreaterThan(0));
+
+            await HotReloadFromEditedSourceAsync(editedSource, "ContractAsyncRestore.cs");
+
+            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(enable.Success, Is.True, enable.Message + " / " + enable.RecommendedNextAction);
+            Assert.That(enable.RetargetedToHotReloadPatch, Is.True);
+
+            HotReloadPatcher.RevertAll();
+
+            UloopPausePointSnapshot afterRevert = UloopPausePointRegistry.GetStatus(enable.Id);
+            Assert.That(afterRevert.SuppressedByHotReload, Is.False);
+            Assert.That(afterRevert.RetargetedToHotReloadPatch, Is.False);
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            int result = await fixture.AsyncPrivateFieldAndMethod(5);
+            Assert.That(result, Is.EqualTo(fixture.SecretForAssert + 5));
+            Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).IsHit, Is.True);
+        }
+
+        /// <summary>
         /// What: Patching via synthetic resolution onto a hot-reload patched method still
         /// returns MethodPatchedByHotReload and mentions the requested line in the message.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -75,10 +75,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(response.Methods[0].Kind, Is.EqualTo("Failed"));
         }
 
+        /// <summary>
+        /// What: BuildApplyResponse does not emit pause-point warnings when no markers
+        /// were retargeted or suppressed, even if PatchedTotal &gt; 0.
+        /// </summary>
         [Test]
-        public void BuildApplyResponse_AddsPausePointWarningOnlyWhenPatched()
+        public void BuildApplyResponse_WithoutPausePointTransitions_AddsNoPausePointWarning()
         {
-            // Verifies the pause-point interaction warning appears iff PatchedTotal > 0.
             HotReloadOrchestratorResult patched = new HotReloadOrchestratorResult(
                 new List<HotReloadMethodOutcome>
                 {
@@ -87,24 +90,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 new List<string>(),
                 patchedTotal: 1,
                 activePatchTotal: 1);
-            HotReloadOrchestratorResult skippedOnly = new HotReloadOrchestratorResult(
-                new List<HotReloadMethodOutcome>
-                {
-                    HotReloadMethodOutcome.Skipped("Type.Other", "partial type", "Assets/A.cs")
-                },
-                new List<string>(),
-                patchedTotal: 0,
-                activePatchTotal: 0);
 
             HotReloadResponse patchedResponse = HotReloadTool.BuildApplyResponse(patched);
-            HotReloadResponse skippedResponse = HotReloadTool.BuildApplyResponse(skippedOnly);
 
             Assert.That(
-                patchedResponse.Warnings,
-                Does.Contain(HotReloadConstants.PausePointInteractionWarning));
-            Assert.That(
-                skippedResponse.Warnings,
-                Does.Not.Contain(HotReloadConstants.PausePointInteractionWarning));
+                string.Join(" | ", patchedResponse.Warnings),
+                Does.Not.Contain("pause points").IgnoreCase);
         }
 
         /// <summary>
@@ -133,7 +124,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 response.Warnings,
                 Does.Contain(
-                    "Armed pause points on the patched methods will not fire until the patch is reverted or compiled for real: Assets/Scripts/A.cs:10, Assets/Scripts/B.cs:20"));
+                    "Armed pause points could not be re-targeted and will not fire until the patch "
+                    + "is reverted or compiled for real: Assets/Scripts/A.cs:10, Assets/Scripts/B.cs:20"));
+        }
+
+        /// <summary>
+        /// What: BuildApplyResponse lists retargeted pause-point marker ids in Warnings
+        /// when auto-retarget kept markers firing on patched bodies.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_WithRetargetedPausePointIds_AddsAggregatedWarning()
+        {
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>
+                {
+                    HotReloadMethodOutcome.Patched("Type.Method", "Assets/A.cs")
+                },
+                new List<string>(),
+                patchedTotal: 1,
+                activePatchTotal: 1,
+                retargetedPausePointIds: new List<string>
+                {
+                    "Assets/Scripts/A.cs:10"
+                });
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+            Assert.That(
+                response.Warnings,
+                Does.Contain(
+                    "Armed pause points were re-targeted onto the hot-reload patched bodies and keep "
+                    + "firing at the edited lines: Assets/Scripts/A.cs:10"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
+++ b/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
@@ -5,6 +6,7 @@ using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
@@ -84,7 +86,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 ClearedReason = "",
                 StatusBeforeClear = "",
                 LateHitDiscardedAfterClear = false,
-                SuppressedByHotReload = false
+                SuppressedByHotReload = false,
+                RetargetedToHotReloadPatch = false
             };
             string json = JsonConvert.SerializeObject(
                 response,
@@ -93,6 +96,48 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             JObject actual = NormalizeFieldShape(JObject.Parse(json));
 
             Assert.That(JToken.DeepEquals(actual, expected), Is.True, $"Expected {expected} but got {actual}");
+        }
+
+        /// <summary>
+        /// What: status Warning carries SuppressedByHotReloadReason when the marker is suppressed.
+        /// </summary>
+        [Test]
+        public void FromSnapshot_WhenSuppressed_WarningEqualsReason()
+        {
+            UloopPausePointRegistry.ConfigureForTests(new FakePauseController(), () => DateTime.UtcNow);
+            try
+            {
+                const string id = "status-warning-reason";
+                const string reason = "The marker's line no longer resolves inside the hot-reload patched body.";
+                UloopPausePointRegistry.Enable(id, 30);
+                UloopPausePointRegistry.SetSuppressedByHotReload(id, true, reason);
+                UloopPausePointRegistry.SetRetargetedToHotReloadPatch(id, false);
+
+                PausePointStatusResponse response =
+                    PausePointStatusResponse.FromSnapshot(UloopPausePointRegistry.GetStatus(id));
+
+                Assert.That(response.SuppressedByHotReload, Is.True);
+                Assert.That(response.SuppressedByHotReloadReason, Is.EqualTo(reason));
+                Assert.That(response.Warning, Is.EqualTo(reason));
+                Assert.That(response.RetargetedToHotReloadPatch, Is.False);
+            }
+            finally
+            {
+                UloopPausePointRegistry.ResetForTests();
+            }
+        }
+
+        private sealed class FakePauseController : IUloopPausePointPauseController
+        {
+            public bool IsPlaying => true;
+            public bool IsPaused => false;
+            public void Pause()
+            {
+            }
+
+            public void Resume()
+            {
+            }
         }
 
         private static JObject ReadSharedContractFieldShape()

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -174,12 +174,17 @@ If a `simulate-*` command instead returns a failure whose message says PlayMode 
 
 If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first — clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. When `--trigger` was passed, the expired envelope also carries `Error.Details.TriggerResult` (with `Completed: false` and no `Error` field when the trigger's outcome was still unknown at expiry). The countdown freezes while a hit holds the Editor paused; a manual pause without a hit does not stop it.
 
-`PAUSE_POINT_PATCHED_BY_HOT_RELOAD` means the target method's body is currently replaced
-by `uloop hot-reload`, so a new marker cannot be trusted anywhere in that method. Run
-`uloop compile` (or `uloop hot-reload --revert-all`) first, then enable the marker.
-Relatedly, `SuppressedByHotReload: true` on a status response means the marker's method
-was hot-reload patched after arming; the marker will not fire until the patch is
-reverted or compiled for real.
+`enable-pause-point` works on hot-reload patched methods: the marker resolves against
+the patched body, and `RetargetedToHotReloadPatch: true` in the response confirms it is
+armed on the edited code. `PAUSE_POINT_PATCHED_BY_HOT_RELOAD` is returned only when the
+requested line cannot be mapped onto the patched body — the file's line map is stale or
+the patch belongs to a superseded hot-reload generation. Pick a line inside the edited
+method body, run `uloop hot-reload --revert-all`, or run `uloop compile`, then retry.
+`SuppressedByHotReload: true` on a status response means a later hot-reload transition
+(apply, a newer generation, or revert) could not re-target the armed marker; the reason
+is in `SuppressedByHotReloadReason` and surfaced as the status `Warning`. The marker is
+not cleared — it fires again once a transition restores its line, or after
+`uloop compile` and a re-enable.
 
 Use `uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"` only when you need to confirm the marker is armed or inspect the current hit state.
 

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/references/troubleshooting.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/references/troubleshooting.md
@@ -31,6 +31,10 @@ Recovery order:
 
 A method already bound into a delegate or event before `enable-pause-point` may not fire through that delegate: the pre-bound invocation path can bypass the patch. Workarounds: enable the pause point before the delegate is created, recreate the subscribing GameObject, or re-bind the delegate (e.g. via `execute-dynamic-code`) after enabling.
 
+## Hot-Reload Interaction
+
+`uloop hot-reload` transitions (apply, a newer generation, revert) re-target armed source pause points automatically. `SuppressedByHotReload: true` on a status or wait response means the last transition could not re-target that marker — its line no longer resolves in the code now executing. The reason is in `SuppressedByHotReloadReason` (surfaced as the status `Warning`), and the marker stays armed but silent. Recover by reverting the patch (`uloop hot-reload --revert-all`), editing so the line exists again and re-running `uloop hot-reload`, or running `uloop compile` and re-enabling the marker. `RetargetedToHotReloadPatch: true` is not a problem: it confirms the marker follows the patched body and keeps firing at the edited line.
+
 ## Enable Failures
 
 If enable fails with a "No sequence point found" error even for clearly executable lines, that script's assembly lacks debug sequence points and no line in the file can be patched. Move the pause point to a script in an assembly that carries them, such as a script under `Assets/`.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -96,15 +96,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             "The target assembly is not currently loaded in this AppDomain. Ensure the code path "
             + "that loads it has run, then retry.";
 
-        // Both patch shapes discard the original IL and any prior transpiler output on that
-        // method (delegation replaces the body with a forward to the shim), so a source pause
-        // point on a hot-reloaded method stops firing until domain reload (or until the method
-        // is reverted and re-armed).
-        public const string PausePointInteractionWarning =
-            "A hot-reload patch replaces the method body and discards other transpilers on "
-            + "that method; a pause point on a hot-reloaded method will not fire until the patch "
-            + "is reverted or a domain reload restores the original IL.";
-
         // Format: file name, assembly name. Emitted per file when PDB-validated snapshot is absent.
         public const string NoVerifiedSourceSnapshotWarningFormat =
             "No verified source snapshot for {0} (assembly {1}); patching all methods. "

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -42,6 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
             List<string> warnings = new List<string>();
             List<string> suppressedPausePointIds = new List<string>();
+            List<string> retargetedPausePointIds = new List<string>();
             List<string> inlineRiskMethodLabels = new List<string>();
             int patchedTotal = 0;
             int unchangedTotal = 0;
@@ -67,6 +68,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 outcomes.AddRange(fileResult.Outcomes);
                 warnings.AddRange(fileResult.Warnings);
                 AppendDistinct(suppressedPausePointIds, fileResult.SuppressedPausePointIds);
+                AppendDistinct(retargetedPausePointIds, fileResult.RetargetedPausePointIds);
                 AppendDistinct(inlineRiskMethodLabels, fileResult.InlineRiskMethodLabels);
                 patchedTotal += fileResult.PatchedCount;
                 unchangedTotal += fileResult.UnchangedMethodCount;
@@ -88,7 +90,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 patchedTotal,
                 HotReloadPatcher.ActivePatchCount,
                 suppressedPausePointIds,
-                unchangedTotal);
+                unchangedTotal,
+                retargetedPausePointIds);
         }
 
         private static async Task<HotReloadFileProcessResult> ProcessFileAsync(
@@ -99,6 +102,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
             List<string> warnings = new List<string>();
             List<string> suppressedPausePointIds = new List<string>();
+            List<string> retargetedPausePointIds = new List<string>();
 
             // CompilationPipeline / Application.dataPath require the Unity main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -287,7 +291,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         0,
                         suppressedPausePointIds,
                         new List<string>(),
-                        unchangedMethodCount);
+                        unchangedMethodCount,
+                        retargetedPausePointIds);
                 }
 
                 entriesToPatch = isolation.RetryEntries;
@@ -318,7 +323,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     assemblyResolvePath,
                     projectRelativePath,
                     inlineRiskMethodLabels,
-                    suppressedPausePointIds);
+                    suppressedPausePointIds,
+                    retargetedPausePointIds);
                 outcomes.Add(outcome);
                 if (outcome.Kind == HotReloadMethodOutcomeKind.Patched)
                 {
@@ -332,7 +338,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 patchedCount,
                 suppressedPausePointIds,
                 inlineRiskMethodLabels,
-                unchangedMethodCount);
+                unchangedMethodCount,
+                retargetedPausePointIds);
         }
 
         // Peels leftover Harmony patches when the source again matches the verified baseline.
@@ -377,7 +384,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string filePath,
             string projectRelativePath,
             List<string> inlineRiskMethodLabels,
-            List<string> suppressedPausePointIds)
+            List<string> suppressedPausePointIds,
+            List<string> retargetedPausePointIds)
         {
             string methodLabel = entry.typeMetadataName + "." + entry.methodName;
 
@@ -452,7 +460,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return HotReloadMethodOutcome.Failed(methodLabel, patchResult.ErrorMessage, filePath);
             }
 
-            AppendSuppressedPausePointIds(matchResult.Method, suppressedPausePointIds);
+            AppendPausePointTransitionIds(
+                matchResult.Method,
+                suppressedPausePointIds,
+                retargetedPausePointIds);
 
             // Inline risk is flagged per method but reported as one aggregated warning so
             // Warnings stay readable when many tiny methods are patched together.
@@ -492,10 +503,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        // What: records armed pause-point marker ids on a method just patched by hot reload.
-        private static void AppendSuppressedPausePointIds(
+        // What: after Apply (+ retarget handler), splits armed markers into retargeted vs suppressed.
+        private static void AppendPausePointTransitionIds(
             MethodBase method,
-            List<string> suppressedPausePointIds)
+            List<string> suppressedPausePointIds,
+            List<string> retargetedPausePointIds)
         {
             IReadOnlyList<string> armedIds =
                 HotReloadPausePointCoordination.GetArmedMarkerIdsOnMethod?.Invoke(method);
@@ -504,13 +516,34 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return;
             }
 
+            IReadOnlyList<string> suppressedIds =
+                HotReloadPausePointCoordination.GetSuppressedMarkerIdsOnMethod?.Invoke(method)
+                ?? Array.Empty<string>();
+
             // The same method can be patched twice in one run (duplicate file inputs,
             // re-applied edits); the aggregated warning must list each marker id once.
             foreach (string armedId in armedIds)
             {
-                if (!suppressedPausePointIds.Contains(armedId))
+                bool suppressed = false;
+                for (int index = 0; index < suppressedIds.Count; index++)
                 {
-                    suppressedPausePointIds.Add(armedId);
+                    if (suppressedIds[index] == armedId)
+                    {
+                        suppressed = true;
+                        break;
+                    }
+                }
+
+                if (suppressed)
+                {
+                    if (!suppressedPausePointIds.Contains(armedId))
+                    {
+                        suppressedPausePointIds.Add(armedId);
+                    }
+                }
+                else if (!retargetedPausePointIds.Contains(armedId))
+                {
+                    retargetedPausePointIds.Add(armedId);
                 }
             }
         }
@@ -1026,6 +1059,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public List<string> Warnings { get; }
             public int PatchedCount { get; }
             public List<string> SuppressedPausePointIds { get; }
+            public List<string> RetargetedPausePointIds { get; }
             public List<string> InlineRiskMethodLabels { get; }
             public int UnchangedMethodCount { get; }
 
@@ -1035,7 +1069,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 int patchedCount,
                 List<string> suppressedPausePointIds = null,
                 List<string> inlineRiskMethodLabels = null,
-                int unchangedMethodCount = 0)
+                int unchangedMethodCount = 0,
+                List<string> retargetedPausePointIds = null)
             {
                 Outcomes = outcomes;
                 Warnings = warnings;
@@ -1043,6 +1078,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 SuppressedPausePointIds = suppressedPausePointIds ?? new List<string>();
                 InlineRiskMethodLabels = inlineRiskMethodLabels ?? new List<string>();
                 UnchangedMethodCount = unchangedMethodCount;
+                RetargetedPausePointIds = retargetedPausePointIds ?? new List<string>();
             }
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
@@ -13,6 +13,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public int PatchedTotal { get; }
         public int ActivePatchTotal { get; }
         public IReadOnlyList<string> SuppressedPausePointIds { get; }
+        public IReadOnlyList<string> RetargetedPausePointIds { get; }
         public int UnchangedTotal { get; }
 
         public HotReloadOrchestratorResult(
@@ -21,7 +22,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int patchedTotal,
             int activePatchTotal,
             IReadOnlyList<string> suppressedPausePointIds = null,
-            int unchangedTotal = 0)
+            int unchangedTotal = 0,
+            IReadOnlyList<string> retargetedPausePointIds = null)
         {
             Methods = methods;
             Warnings = warnings;
@@ -29,6 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ActivePatchTotal = activePatchTotal;
             SuppressedPausePointIds = suppressedPausePointIds ?? Array.Empty<string>();
             UnchangedTotal = unchangedTotal;
+            RetargetedPausePointIds = retargetedPausePointIds ?? Array.Empty<string>();
         }
     }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -108,15 +108,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (ShimByMethod.ContainsKey(method))
             {
-                // A second hot reload of the same method must replace the previous patch;
-                // leaving it in place would stack transpilers and run discarded IL chains.
-                HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
+                // Why ledger before Unpatch: same as Revert — during Unpatch Harmony rebuilds
+                // the method and pause-point ChainJoin must see GetActiveShimForMethod == null,
+                // or it injects donor instruction indexes into the restored original IL stream.
+                // Do not RemoveMethod from the shim registry here: ApplyEntry already registered
+                // this method into the new generation before calling Apply.
                 ShimByMethod.Remove(method);
                 TransplantLocalsByMethod.Remove(method);
-                // Mirror the ledger removal immediately: if the re-Patch below fails, its
-                // contained Unpatch rebuilds the method with markers re-instrumented (the
-                // ledger no longer lists it), and RevertAll can never reach this method
-                // again — leaving the flag stuck at true would make status lie forever.
+                HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
+                // Mirror the ledger removal: if the re-Patch below fails, its contained Unpatch
+                // rebuilds with markers restored (ledger empty), and RevertAll can never reach
+                // this method again — leaving suppress stuck true would make status lie forever.
                 HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
             }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -152,6 +152,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // suppress that re-instrumentation (regression vs the old ContainsKey probe).
                 _pendingShimMethod = null;
                 _pendingOriginalMethod = null;
+                // Why Remove before Unpatch: Invoke(true) may have written ShimByMethod before
+                // a later failure; rebuild must not see an active shim (same as re-apply path).
+                ShimByMethod.Remove(method);
                 // User-approved exception to the no-try-catch policy: Harmony emit/JIT
                 // failures cannot be pre-validated (the IL shape is only known inside
                 // Harmony), and an escaping exception would abort the whole run while
@@ -161,6 +164,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // wrapper, restoring the original body (verified by the extern-shim test).
                 HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
                 TransplantLocalsByMethod.Remove(method);
+                // Why after Unpatch: retarget may have already replaced markers onto the shim;
+                // restore them onto the original body now that GetActiveShim is null.
+                HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
                 Exception rootCause = exception;
                 while (rootCause.InnerException != null)
                 {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -190,17 +190,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             List<string> warnings = new List<string>(result.Warnings);
-            if (result.PatchedTotal > 0)
+            if (result.RetargetedPausePointIds != null && result.RetargetedPausePointIds.Count > 0)
             {
-                // Always surface the pause-point interaction when any patch was applied.
-                warnings.Add(HotReloadConstants.PausePointInteractionWarning);
+                string ids = string.Join(", ", result.RetargetedPausePointIds);
+                warnings.Add(
+                    "Armed pause points were re-targeted onto the hot-reload patched bodies and keep "
+                    + $"firing at the edited lines: {ids}");
             }
 
             if (result.SuppressedPausePointIds != null && result.SuppressedPausePointIds.Count > 0)
             {
                 string ids = string.Join(", ", result.SuppressedPausePointIds);
                 warnings.Add(
-                    $"Armed pause points on the patched methods will not fire until the patch is reverted or compiled for real: {ids}");
+                    "Armed pause points could not be re-targeted and will not fire until the patch "
+                    + $"is reverted or compiled for real: {ids}");
             }
 
             return new HotReloadResponse

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -159,25 +159,27 @@ and read the returned value.
 ## Pause point interaction
 
 Both patch shapes discard the original IL and any prior transpiler output on the patched
-method — delegation replaces the body with a forward to the shim. Source pause points
-instrument methods through the same transpiler chain, so the two tools enforce a strict
-contract instead of composing silently:
+method, so armed source pause points cannot survive a patch unchanged. Instead of
+enforcing exclusivity, every patch transition re-targets them:
 
-- A pause point armed **before** a hot reload of the same method stops firing — its
-  instrumentation was part of the discarded IL. The apply response lists the affected
-  marker ids in `Warnings`, and `pause-point-status` reports `SuppressedByHotReload: true`
-  for those markers until the patch is reverted.
-- Enabling a pause point **on a currently patched method is rejected** with
-  `PAUSE_POINT_PATCHED_BY_HOT_RELOAD`. Marker positions and local-variable capture
-  resolve against the pre-patch compiled body, which no longer exists at runtime; there
-  is no line on a patched method where a new marker would be trustworthy.
-- `uloop hot-reload --revert-all` (or any domain reload) restores the original IL;
-  previously armed pause points fire again and their `SuppressedByHotReload` flag clears.
+- Applying a patch re-resolves each armed marker on the edited method against the
+  patched body. A marker whose line still resolves keeps firing at the edited line —
+  the apply response reports those ids in a `Warnings` entry and `pause-point-status`
+  shows `RetargetedToHotReloadPatch: true`. A marker whose line no longer resolves is
+  suppressed instead: the apply response lists it, and status shows
+  `SuppressedByHotReload: true` with the reason in `SuppressedByHotReloadReason`.
+- Enabling a new pause point on a currently patched method resolves against the patched
+  body directly. `PAUSE_POINT_PATCHED_BY_HOT_RELOAD` is returned only when the line
+  cannot be mapped onto it (a stale line map or a superseded generation).
+- `uloop hot-reload --revert-all` (or reverting a method's patch) re-targets armed
+  markers back onto the compiled body; a marker whose line no longer resolves there
+  stays suppressed with a reason until `uloop compile` and a re-enable.
 
-So the workflow is: iterate on behavior with hot reload, and when you need pause-point
-inspection of an edited method, run `uloop compile` to make the edits real (the compile's
-domain reload clears every patch), then enable the marker. Use `--revert-all` instead
-when you want the on-disk build back without recompiling.
+Suppressed markers are never cleared automatically — they keep their identity and fire
+again as soon as a transition restores their line. The practical workflow: iterate with
+hot reload and place pause points on edited lines in either order — enable then patch,
+or patch then enable. `uloop compile` is needed only when a marker stays suppressed
+because its line no longer resolves in any live body.
 
 ## Output
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -125,15 +125,13 @@ below) — raising is only expressible inside the declaring type, which a shim i
 ## When a patch reports `Patched` but behavior does not change
 
 `Patched` means the method body was replaced, not that the method ran. Before suspecting
-the patch, confirm the method is actually reached. A currently patched method rejects new
-pause points with `PAUSE_POINT_PATCHED_BY_HOT_RELOAD` (see the pause point interaction
-below), so run `uloop compile` first — it makes the edits real and its domain reload
-clears every patch — then arm `uloop enable-pause-point --mode trace` on the method's
-first line, drive the game, and check the hit count: zero hits means the calling path
-never reached the method, which no patch (or compile) can fix. To chase an early return
-inside the method, arm a second marker on the suspected early-return line. The other
-known cause is JIT inlining of tiny methods, which the response already flags with a
-single aggregated warning listing the at-risk methods.
+the patch, confirm the method is actually reached: arm `uloop enable-pause-point --mode
+trace` on a line inside the edited method body — it resolves against the patched body
+directly (see the pause point interaction below) — drive the game, and check the hit
+count: zero hits means the calling path never reached the method, which no patch (or
+compile) can fix. To chase an early return inside the method, arm a second marker on the
+suspected early-return line. The other known cause is JIT inlining of tiny methods, which
+the response already flags with a single aggregated warning listing the at-risk methods.
 
 ## Convergence and lifecycle
 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using UnityEditor;
 using UnityEditor.Compilation;
 using UnityEngine;
@@ -86,6 +87,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool LateHitDiscardedAfterClear { get; set; }
         public bool SuppressedByHotReload { get; set; }
         public bool RetargetedToHotReloadPatch { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string SuppressedByHotReloadReason { get; set; }
 
         internal static PausePointResponse FromSnapshot(UloopPausePointSnapshot snapshot)

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -85,6 +85,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string StatusBeforeClear { get; set; } = string.Empty;
         public bool LateHitDiscardedAfterClear { get; set; }
         public bool SuppressedByHotReload { get; set; }
+        public bool RetargetedToHotReloadPatch { get; set; }
+        public string SuppressedByHotReloadReason { get; set; }
 
         internal static PausePointResponse FromSnapshot(UloopPausePointSnapshot snapshot)
         {
@@ -123,7 +125,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ClearedReason = snapshot.ClearedReason,
                 StatusBeforeClear = snapshot.StatusBeforeClear,
                 LateHitDiscardedAfterClear = snapshot.LateHitDiscardedAfterClear,
-                SuppressedByHotReload = snapshot.SuppressedByHotReload
+                SuppressedByHotReload = snapshot.SuppressedByHotReload,
+                RetargetedToHotReloadPatch = snapshot.RetargetedToHotReloadPatch,
+                SuppressedByHotReloadReason = snapshot.SuppressedByHotReloadReason
             };
         }
 
@@ -495,7 +499,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         parameters,
                         shimResolution.ResolvedLine,
                         shimResolution.MethodDisplayName,
-                        shimPatchResult);
+                        shimPatchResult,
+                        retargetedToHotReloadPatch: true);
                 }
 
                 if (shimResolution.Kind == SourcePausePointShimResolveKind.NoStatementInPatchedMethod)
@@ -544,7 +549,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameters,
                 resolveResult.Resolution.ResolvedLine,
                 resolveResult.Resolution.MethodDisplayName,
-                patchResult);
+                patchResult,
+                retargetedToHotReloadPatch: false);
         }
 
         private static PausePointResponse FinishEnableBySourceLocation(
@@ -552,7 +558,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             EnablePausePointSchema parameters,
             int resolvedLine,
             string resolvedMethod,
-            SourcePausePointPatchResult patchResult)
+            SourcePausePointPatchResult patchResult,
+            bool retargetedToHotReloadPatch)
         {
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(
                 id,
@@ -560,6 +567,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameters.Mode,
                 parameters.MaxHistory,
                 parameters.MaxPreviewElements);
+            if (retargetedToHotReloadPatch)
+            {
+                UloopPausePointRegistry.SetRetargetedToHotReloadPatch(id, true);
+                snapshot = UloopPausePointRegistry.GetStatus(id);
+            }
+
             PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
             response.ResolvedLine = resolvedLine;
             response.ResolvedLineText = ReadResolvedLineText(parameters.File, resolvedLine);

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -165,5 +165,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             + "and that --line is on or after an executable statement inside a method body. After a code edit "
             + "or a Code Optimization switch, run uloop compile and retry. See the pause-point skill's "
             + "troubleshooting reference for specific failure patterns.";
+
+        // Auto-retarget failure reasons surfaced on status Warning / SuppressedByHotReloadReason.
+        public const string RetargetOntoHotReloadFailedReason =
+            "The marker's line no longer resolves inside the hot-reload patched body; it will not fire "
+            + "until the patch is reverted, the line exists again, or 'uloop compile' runs.";
+
+        public const string RestoreAfterHotReloadRevertFailedReason =
+            "Instrumentation could not be restored after the hot-reload patch was reverted; the line "
+            + "no longer resolves in the compiled assembly. Re-enable the marker after 'uloop compile'.";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
 
 using HarmonyLib;
 using UnityEngine;
@@ -150,22 +151,31 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 UnpatchInstrumentationOnly(id);
-                SourcePausePointPatchResult patchResult = PatchShimTarget(
-                    id,
-                    shimResolution,
-                    request.NormalizedFile,
-                    request.Line);
-                if (!patchResult.Success)
+                // Why try-finally (not catch): Fail Fast on Harmony emit failures, but keep
+                // LogicalOwner/Request and suppress flags honest when CommitPatch rolls back.
+                bool committed = false;
+                try
                 {
-                    // Why re-anchor: Unpatch cleared ledgers; without LogicalOwner later transitions
-                    // cannot see this armed registry marker.
-                    ReanchorMarkerWithoutInjection(id, logicalOwner, request);
-                    SuppressMarkerRetargetFailed(id);
-                    continue;
+                    SourcePausePointPatchResult patchResult = PatchShimTarget(
+                        id,
+                        shimResolution,
+                        request.NormalizedFile,
+                        request.Line);
+                    committed = patchResult.Success;
+                    if (committed)
+                    {
+                        UloopPausePointRegistry.SetSuppressedByHotReload(id, false, null);
+                        UloopPausePointRegistry.SetRetargetedToHotReloadPatch(id, true);
+                    }
                 }
-
-                UloopPausePointRegistry.SetSuppressedByHotReload(id, false, null);
-                UloopPausePointRegistry.SetRetargetedToHotReloadPatch(id, true);
+                finally
+                {
+                    if (!committed)
+                    {
+                        ReanchorMarkerWithoutInjection(id, logicalOwner, request);
+                        SuppressMarkerRetargetFailed(id);
+                    }
+                }
             }
         }
 
@@ -190,28 +200,59 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 SourcePausePointPatchResult methodResolve =
                     TryResolveMethod(resolveResult.Resolution, out MethodBase restoredMethod);
-                if (!methodResolve.Success || restoredMethod == null || !restoredMethod.Equals(logicalOwner))
+                if (!methodResolve.Success
+                    || restoredMethod == null
+                    || !IsSameLogicalMethodOrItsStateMachine(restoredMethod, logicalOwner))
                 {
                     SuppressMarkerRestoreFailed(id);
                     continue;
                 }
 
                 UnpatchInstrumentationOnly(id);
-                SourcePausePointPatchResult patchResult = Patch(
-                    id,
-                    resolveResult.Resolution,
-                    request.NormalizedFile,
-                    request.Line);
-                if (!patchResult.Success)
+                bool committed = false;
+                try
                 {
-                    ReanchorMarkerWithoutInjection(id, logicalOwner, request);
-                    SuppressMarkerRestoreFailed(id);
-                    continue;
+                    // Why logicalOwner override: async/iterator PDB resolve returns MoveNext, but
+                    // hot-reload keys and later transitions use the compiled wrapper as owner.
+                    SourcePausePointPatchResult patchResult = Patch(
+                        id,
+                        resolveResult.Resolution,
+                        request.NormalizedFile,
+                        request.Line,
+                        logicalOwner);
+                    committed = patchResult.Success;
+                    if (committed)
+                    {
+                        UloopPausePointRegistry.SetSuppressedByHotReload(id, false, null);
+                        UloopPausePointRegistry.SetRetargetedToHotReloadPatch(id, false);
+                    }
                 }
-
-                UloopPausePointRegistry.SetSuppressedByHotReload(id, false, null);
-                UloopPausePointRegistry.SetRetargetedToHotReloadPatch(id, false);
+                finally
+                {
+                    if (!committed)
+                    {
+                        ReanchorMarkerWithoutInjection(id, logicalOwner, request);
+                        SuppressMarkerRestoreFailed(id);
+                    }
+                }
             }
+        }
+
+        // Why StateMachineAttribute: async/iterator hot-reload events key the compiled wrapper,
+        // while compiled PDB resolve returns MoveNext on the state-machine type.
+        private static bool IsSameLogicalMethodOrItsStateMachine(
+            MethodBase restoredMethod,
+            MethodBase logicalOwner)
+        {
+            if (restoredMethod.Equals(logicalOwner))
+            {
+                return true;
+            }
+
+            StateMachineAttribute attribute = logicalOwner.GetCustomAttribute<StateMachineAttribute>();
+            return attribute != null
+                && attribute.StateMachineType != null
+                && attribute.StateMachineType == restoredMethod.DeclaringType;
         }
 
         private static void ReanchorMarkerWithoutInjection(
@@ -245,7 +286,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string id,
             SourcePausePointResolution resolution,
             string normalizedFile = "",
-            int requestedLine = 0)
+            int requestedLine = 0,
+            MethodBase logicalOwnerOverride = null)
         {
             Debug.Assert(!string.IsNullOrEmpty(id), "id must not be null or empty.");
             Debug.Assert(resolution != null, "resolution must not be null.");
@@ -277,6 +319,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     + "restore compiled bodies, or run 'uloop compile' to realign line numbers.");
             }
 
+            MethodBase logicalOwner = logicalOwnerOverride ?? method;
+
             // Why conditional no-op: ShouldInject can leave a prior injection inert (e.g. stale
             // OriginalBody under an active shim). Re-enable must replace mismatched ledger state
             // instead of reporting success while the call site never fires.
@@ -287,6 +331,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     donorShim: null))
             {
                 RememberRequest(id, normalizedFile, requestedLine);
+                LogicalOwnerById[id] = logicalOwner;
                 return SourcePausePointPatchResult.SuccessResult();
             }
 
@@ -299,7 +344,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 resolution.Locals,
                 SourcePausePointPatchInjectionTargetKind.OriginalBody);
 
-            return CommitPatch(id, method, method, injection, normalizedFile, requestedLine);
+            return CommitPatch(id, method, logicalOwner, injection, normalizedFile, requestedLine);
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -33,6 +33,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static readonly Dictionary<MethodBase, List<SourcePausePointPatchInjection>> InjectionsByMethod = new();
         private static readonly Dictionary<string, MethodBase> MethodById = new();
         private static readonly Dictionary<string, MethodBase> LogicalOwnerById = new();
+        // Why store file:line separately: auto-retarget must re-resolve with the original enable
+        // request, and parsing the id string would couple us to id formatting.
+        private static readonly Dictionary<string, (string NormalizedFile, int Line)> RequestById = new();
 
         // The registry lives in a Runtime assembly this Editor-only tool assembly may depend on,
         // but not the reverse (patching is an outer/implementation concern the registry's inner
@@ -44,6 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             UloopPausePointRegistry.OnCleared = Unpatch;
             UloopPausePointRegistry.OnClearedAll = UnpatchAll;
             HotReloadPausePointCoordination.GetArmedMarkerIdsOnMethod = GetArmedMarkerIds;
+            HotReloadPausePointCoordination.GetSuppressedMarkerIdsOnMethod = GetSuppressedMarkerIds;
             HotReloadPausePointCoordination.OnHotReloadPatchStateChanged = HandleHotReloadPatchStateChanged;
         }
 
@@ -63,43 +67,174 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return ids;
         }
 
-        // What: mirrors hot-reload patch state onto markers by logical owner so ShimDirect
-        // (physical key = shim-side method) still receives suppress updates.
-        private static void HandleHotReloadPatchStateChanged(MethodBase method, bool isPatched)
+        // What: ids that stayed armed on the logical owner but could not be re-targeted.
+        private static IReadOnlyList<string> GetSuppressedMarkerIds(MethodBase method)
         {
-            foreach (KeyValuePair<string, MethodBase> ownerPair in LogicalOwnerById)
+            List<string> ids = new List<string>();
+            foreach (KeyValuePair<string, MethodBase> pair in LogicalOwnerById)
             {
-                if (!ownerPair.Value.Equals(method))
+                if (!pair.Value.Equals(method))
                 {
                     continue;
                 }
 
-                string id = ownerPair.Key;
-                if (!MethodById.TryGetValue(id, out MethodBase physicalMethod)
-                    || !InjectionsByMethod.TryGetValue(physicalMethod, out List<SourcePausePointPatchInjection> injections))
+                if (UloopPausePointRegistry.GetStatus(pair.Key).SuppressedByHotReload)
                 {
-                    continue;
-                }
-
-                SourcePausePointPatchInjection injection = FindInjectionById(injections, id);
-                if (injection == null)
-                {
-                    continue;
-                }
-
-                // Why kind-specific: OriginalBody indexes are valid again after revert (isPatched
-                // false). TransplantChainJoin / ShimDirect were resolved against a specific shim
-                // generation — apply and revert both invalidate that generation until PR-4
-                // auto-retarget replaces the injection, so status must stay suppressed=true.
-                if (injection.TargetKind == SourcePausePointPatchInjectionTargetKind.OriginalBody)
-                {
-                    UloopPausePointRegistry.SetSuppressedByHotReload(id, isPatched);
-                }
-                else
-                {
-                    UloopPausePointRegistry.SetSuppressedByHotReload(id, true);
+                    ids.Add(pair.Key);
                 }
             }
+
+            return ids;
+        }
+
+        // What: re-targets or restores armed markers when a logical owner's hot-reload patch
+        // state changes. Succeeds before mutating registry flags; never clears the marker.
+        private static void HandleHotReloadPatchStateChanged(MethodBase method, bool isPatched)
+        {
+            List<string> markerIds = CollectMarkerIdsForLogicalOwner(method);
+            if (isPatched)
+            {
+                RetargetMarkersOntoHotReloadPatch(markerIds, method);
+                return;
+            }
+
+            RestoreMarkersAfterHotReloadRevert(markerIds, method);
+        }
+
+        private static List<string> CollectMarkerIdsForLogicalOwner(MethodBase method)
+        {
+            List<string> ids = new List<string>();
+            foreach (KeyValuePair<string, MethodBase> ownerPair in LogicalOwnerById)
+            {
+                if (ownerPair.Value.Equals(method))
+                {
+                    ids.Add(ownerPair.Key);
+                }
+            }
+
+            return ids;
+        }
+
+        private static void RetargetMarkersOntoHotReloadPatch(List<string> markerIds, MethodBase logicalOwner)
+        {
+            for (int index = 0; index < markerIds.Count; index++)
+            {
+                string id = markerIds[index];
+                if (!RequestById.TryGetValue(id, out (string NormalizedFile, int Line) request))
+                {
+                    SuppressMarkerRetargetFailed(id);
+                    continue;
+                }
+
+                HotReloadShimFileLookup lookup =
+                    HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(request.NormalizedFile);
+                if (lookup == null)
+                {
+                    SuppressMarkerRetargetFailed(id);
+                    continue;
+                }
+
+                SourcePausePointShimResolution shimResolution = SourcePausePointShimResolver.Resolve(
+                    lookup,
+                    request.NormalizedFile,
+                    request.Line);
+                if (shimResolution.Kind != SourcePausePointShimResolveKind.TransplantChainJoin
+                    && shimResolution.Kind != SourcePausePointShimResolveKind.ShimDirect)
+                {
+                    SuppressMarkerRetargetFailed(id);
+                    continue;
+                }
+
+                UnpatchInstrumentationOnly(id);
+                SourcePausePointPatchResult patchResult = PatchShimTarget(
+                    id,
+                    shimResolution,
+                    request.NormalizedFile,
+                    request.Line);
+                if (!patchResult.Success)
+                {
+                    // Why re-anchor: Unpatch cleared ledgers; without LogicalOwner later transitions
+                    // cannot see this armed registry marker.
+                    ReanchorMarkerWithoutInjection(id, logicalOwner, request);
+                    SuppressMarkerRetargetFailed(id);
+                    continue;
+                }
+
+                UloopPausePointRegistry.SetSuppressedByHotReload(id, false, null);
+                UloopPausePointRegistry.SetRetargetedToHotReloadPatch(id, true);
+            }
+        }
+
+        private static void RestoreMarkersAfterHotReloadRevert(List<string> markerIds, MethodBase logicalOwner)
+        {
+            for (int index = 0; index < markerIds.Count; index++)
+            {
+                string id = markerIds[index];
+                if (!RequestById.TryGetValue(id, out (string NormalizedFile, int Line) request))
+                {
+                    SuppressMarkerRestoreFailed(id);
+                    continue;
+                }
+
+                SourcePausePointResolveResult resolveResult =
+                    SourcePausePointResolver.Resolve(request.NormalizedFile, request.Line);
+                if (!resolveResult.Success)
+                {
+                    SuppressMarkerRestoreFailed(id);
+                    continue;
+                }
+
+                SourcePausePointPatchResult methodResolve =
+                    TryResolveMethod(resolveResult.Resolution, out MethodBase restoredMethod);
+                if (!methodResolve.Success || restoredMethod == null || !restoredMethod.Equals(logicalOwner))
+                {
+                    SuppressMarkerRestoreFailed(id);
+                    continue;
+                }
+
+                UnpatchInstrumentationOnly(id);
+                SourcePausePointPatchResult patchResult = Patch(
+                    id,
+                    resolveResult.Resolution,
+                    request.NormalizedFile,
+                    request.Line);
+                if (!patchResult.Success)
+                {
+                    ReanchorMarkerWithoutInjection(id, logicalOwner, request);
+                    SuppressMarkerRestoreFailed(id);
+                    continue;
+                }
+
+                UloopPausePointRegistry.SetSuppressedByHotReload(id, false, null);
+                UloopPausePointRegistry.SetRetargetedToHotReloadPatch(id, false);
+            }
+        }
+
+        private static void ReanchorMarkerWithoutInjection(
+            string id,
+            MethodBase logicalOwner,
+            (string NormalizedFile, int Line) request)
+        {
+            LogicalOwnerById[id] = logicalOwner;
+            RememberRequest(id, request.NormalizedFile, request.Line);
+        }
+
+        private static void SuppressMarkerRetargetFailed(string id)
+        {
+            UloopPausePointRegistry.SetSuppressedByHotReload(
+                id,
+                true,
+                SourcePausePointConstants.RetargetOntoHotReloadFailedReason);
+            UloopPausePointRegistry.SetRetargetedToHotReloadPatch(id, false);
+        }
+
+        private static void SuppressMarkerRestoreFailed(string id)
+        {
+            UloopPausePointRegistry.SetSuppressedByHotReload(
+                id,
+                true,
+                SourcePausePointConstants.RestoreAfterHotReloadRevertFailedReason);
+            UloopPausePointRegistry.SetRetargetedToHotReloadPatch(id, false);
         }
 
         public static SourcePausePointPatchResult Patch(
@@ -147,6 +282,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     method,
                     donorShim: null))
             {
+                RememberRequest(id, normalizedFile, requestedLine);
                 return SourcePausePointPatchResult.SuccessResult();
             }
 
@@ -159,7 +295,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 resolution.Locals,
                 SourcePausePointPatchInjectionTargetKind.OriginalBody);
 
-            return CommitPatch(id, method, method, injection);
+            return CommitPatch(id, method, method, injection, normalizedFile, requestedLine);
         }
 
         /// <summary>
@@ -196,6 +332,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (TryReuseExistingPatch(id, targetKind, method, shim.DonorShim))
             {
+                RememberRequest(id, normalizedFile, requestedLine);
                 return SourcePausePointPatchResult.SuccessResult();
             }
 
@@ -217,7 +354,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 shim.DonorShim,
                 shim.InstanceFromFirstArgument);
 
-            return CommitPatch(id, method, shim.LogicalOwner, injection);
+            return CommitPatch(id, method, shim.LogicalOwner, injection, normalizedFile, requestedLine);
         }
 
         private static bool TryReuseExistingPatch(
@@ -247,7 +384,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return true;
             }
 
-            Unpatch(id);
+            UnpatchInstrumentationOnly(id);
             return false;
         }
 
@@ -266,11 +403,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return null;
         }
 
+        private static void RememberRequest(string id, string normalizedFile, int requestedLine)
+        {
+            RequestById[id] = (normalizedFile, requestedLine);
+        }
+
         private static SourcePausePointPatchResult CommitPatch(
             string id,
             MethodBase method,
             MethodBase logicalOwner,
-            SourcePausePointPatchInjection injection)
+            SourcePausePointPatchInjection injection,
+            string normalizedFile,
+            int requestedLine)
         {
             bool methodAlreadyPatched = InjectionsByMethod.TryGetValue(method, out List<SourcePausePointPatchInjection> injections);
             if (!methodAlreadyPatched)
@@ -282,6 +426,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             injections.Add(injection);
             MethodById[id] = method;
             LogicalOwnerById[id] = logicalOwner;
+            RememberRequest(id, normalizedFile, requestedLine);
 
             // The ledger above is written before Harmony actually rebuilds the method. If
             // Unpatch/Patch throws (e.g. a byref-like `this` produces invalid IL at JIT time), a
@@ -314,6 +459,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     }
                     MethodById.Remove(id);
                     LogicalOwnerById.Remove(id);
+                    RequestById.Remove(id);
                 }
             }
 
@@ -321,7 +467,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return SourcePausePointPatchResult.SuccessResult(warning, method.DeclaringType, hasPhysicsCallbackWarning);
         }
 
+        // What: removes Harmony instrumentation and patcher ledgers for one id without touching
+        // the runtime registry. Used by auto-retarget (keep armed/hit) and by registry clear.
+        // Why keep Unpatch as the OnCleared hook name: the registry wires OnCleared = Unpatch.
         public static void Unpatch(string id)
+        {
+            UnpatchInstrumentationOnly(id);
+        }
+
+        public static void UnpatchInstrumentationOnly(string id)
         {
             Debug.Assert(!string.IsNullOrEmpty(id), "id must not be null or empty.");
 
@@ -331,6 +485,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
             MethodById.Remove(id);
             LogicalOwnerById.Remove(id);
+            RequestById.Remove(id);
 
             List<SourcePausePointPatchInjection> injections = InjectionsByMethod[method];
             injections.RemoveAll(injection => injection.Id == id);
@@ -360,6 +515,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     {
                         MethodById.Remove(remainingId);
                         LogicalOwnerById.Remove(remainingId);
+                        RequestById.Remove(remainingId);
                     }
                     InjectionsByMethod.Remove(method);
                 }
@@ -372,6 +528,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             InjectionsByMethod.Clear();
             MethodById.Clear();
             LogicalOwnerById.Clear();
+            RequestById.Clear();
         }
 
         private static SourcePausePointPatchResult TryResolveMethod(SourcePausePointResolution resolution, out MethodBase method)

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -53,12 +53,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         // What: lets the hot-reload tool list marker ids by logical owner (user method),
         // including markers whose physical injection lives on a shim-side MoveNext/closure.
+        // Why IsArmed: hit/expired SingleShot markers keep instrumentation until clear, but
+        // transitions and apply warnings must track only currently armed markers.
         private static IReadOnlyList<string> GetArmedMarkerIds(MethodBase method)
         {
             List<string> ids = new List<string>();
             foreach (KeyValuePair<string, MethodBase> pair in LogicalOwnerById)
             {
-                if (pair.Value.Equals(method))
+                if (pair.Value.Equals(method) && UloopPausePointRegistry.IsArmed(pair.Key))
                 {
                     ids.Add(pair.Key);
                 }
@@ -73,7 +75,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> ids = new List<string>();
             foreach (KeyValuePair<string, MethodBase> pair in LogicalOwnerById)
             {
-                if (!pair.Value.Equals(method))
+                if (!pair.Value.Equals(method) || !UloopPausePointRegistry.IsArmed(pair.Key))
                 {
                     continue;
                 }
@@ -106,7 +108,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> ids = new List<string>();
             foreach (KeyValuePair<string, MethodBase> ownerPair in LogicalOwnerById)
             {
-                if (ownerPair.Value.Equals(method))
+                // Why IsArmed: hit/expired instrumentation remains until clear, but retarget /
+                // restore must not rewrite disarmed markers back to RetargetedToHotReloadPatch.
+                if (ownerPair.Value.Equals(method) && UloopPausePointRegistry.IsArmed(ownerPair.Key))
                 {
                     ids.Add(ownerPair.Key);
                 }
@@ -479,13 +483,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(!string.IsNullOrEmpty(id), "id must not be null or empty.");
 
+            // Why before MethodById guard: ReanchorMarkerWithoutInjection leaves MethodById
+            // empty while LogicalOwnerById/RequestById still hold the id; clear must scrub
+            // those ledgers so a later transition cannot revive a cleared marker's request.
+            LogicalOwnerById.Remove(id);
+            RequestById.Remove(id);
+
             if (!MethodById.TryGetValue(id, out MethodBase method))
             {
                 return;
             }
             MethodById.Remove(id);
-            LogicalOwnerById.Remove(id);
-            RequestById.Remove(id);
 
             List<SourcePausePointPatchInjection> injections = InjectionsByMethod[method];
             injections.RemoveAll(injection => injection.Id == id);

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -139,6 +139,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public string StatusBeforeClear { get; set; } = string.Empty;
         public bool LateHitDiscardedAfterClear { get; set; }
         public bool SuppressedByHotReload { get; set; }
+        public bool RetargetedToHotReloadPatch { get; set; }
+        // Null when unset so the status contract omits the field (matches Go omitempty).
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string SuppressedByHotReloadReason { get; set; }
         // Null when unset so the status contract omits Warning (matches Go omitempty).
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Warning { get; set; }
@@ -187,9 +191,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 StatusBeforeClear = snapshot.StatusBeforeClear,
                 LateHitDiscardedAfterClear = snapshot.LateHitDiscardedAfterClear,
                 SuppressedByHotReload = snapshot.SuppressedByHotReload,
-                Warning = snapshot.SuppressedByHotReload
-                    ? "This method is currently hot-reload patched; the marker's instrumentation was discarded and it will not fire until 'uloop hot-reload --revert-all' or 'uloop compile'."
-                    : null
+                RetargetedToHotReloadPatch = snapshot.RetargetedToHotReloadPatch,
+                SuppressedByHotReloadReason = snapshot.SuppressedByHotReloadReason,
+                // Why reason as Warning: agents already read Warning; suppressed=false clears both.
+                Warning = snapshot.SuppressedByHotReload ? snapshot.SuppressedByHotReloadReason : null
             };
         }
     }

--- a/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
+++ b/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
@@ -44,6 +44,10 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         // into the method (empty when none).
         public static Func<MethodBase, IReadOnlyList<string>> GetArmedMarkerIdsOnMethod { get; set; }
 
+        // Set by SourcePausePointPatcher. Returns marker ids whose logical owner is the
+        // method and whose registry entry is currently SuppressedByHotReload.
+        public static Func<MethodBase, IReadOnlyList<string>> GetSuppressedMarkerIdsOnMethod { get; set; }
+
         // Set by SourcePausePointPatcher. Invoked by HotReloadPatcher after a
         // method's patch state changes (true = patched, false = reverted).
         public static Action<MethodBase, bool> OnHotReloadPatchStateChanged { get; set; }

--- a/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
@@ -62,6 +62,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public string StatusBeforeClear { get; private set; } = string.Empty;
         public bool LateHitDiscardedAfterClear { get; private set; }
         public bool SuppressedByHotReload { get; set; }
+        public string SuppressedByHotReloadReason { get; set; }
+        public bool RetargetedToHotReloadPatch { get; set; }
 
         public bool ExpireIfNeeded(DateTime nowUtc)
         {
@@ -269,7 +271,9 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 ClearedReason,
                 StatusBeforeClear,
                 LateHitDiscardedAfterClear,
-                SuppressedByHotReload);
+                SuppressedByHotReload,
+                SuppressedByHotReloadReason,
+                RetargetedToHotReloadPatch);
         }
 
         private long CalculateRemainingMilliseconds(DateTime nowUtc)

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -194,17 +194,33 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
 
         /// <summary>
-        /// Marks whether an armed marker's instrumentation was discarded by a hot-reload patch.
+        /// Marks whether an armed marker could not stay live across a hot-reload patch transition.
+        /// When <paramref name="suppressed"/> is false, <paramref name="reason"/> is cleared to null.
         /// No-op when the id is unknown.
         /// </summary>
-        public static void SetSuppressedByHotReload(string id, bool value)
+        public static void SetSuppressedByHotReload(string id, bool suppressed, string reason)
         {
             if (!Entries.TryGetValue(id, out UloopPausePointEntry entry))
             {
                 return;
             }
 
-            entry.SuppressedByHotReload = value;
+            entry.SuppressedByHotReload = suppressed;
+            entry.SuppressedByHotReloadReason = suppressed ? reason : null;
+        }
+
+        /// <summary>
+        /// Marks whether the marker's instrumentation currently targets a hot-reload shim body.
+        /// No-op when the id is unknown.
+        /// </summary>
+        public static void SetRetargetedToHotReloadPatch(string id, bool value)
+        {
+            if (!Entries.TryGetValue(id, out UloopPausePointEntry entry))
+            {
+                return;
+            }
+
+            entry.RetargetedToHotReloadPatch = value;
         }
 
         /// <summary>

--- a/Packages/src/Runtime/PausePoints/UloopPausePointSnapshot.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointSnapshot.cs
@@ -42,7 +42,9 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             string clearedReason,
             string statusBeforeClear,
             bool lateHitDiscardedAfterClear,
-            bool suppressedByHotReload)
+            bool suppressedByHotReload,
+            string suppressedByHotReloadReason,
+            bool retargetedToHotReloadPatch)
         {
             Debug.Assert(editorState != null, "editorState must not be null");
 
@@ -77,6 +79,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             StatusBeforeClear = statusBeforeClear ?? string.Empty;
             LateHitDiscardedAfterClear = lateHitDiscardedAfterClear;
             SuppressedByHotReload = suppressedByHotReload;
+            SuppressedByHotReloadReason = suppressedByHotReloadReason;
+            RetargetedToHotReloadPatch = retargetedToHotReloadPatch;
         }
 
         public string Id { get; }
@@ -110,6 +114,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public string StatusBeforeClear { get; }
         public bool LateHitDiscardedAfterClear { get; }
         public bool SuppressedByHotReload { get; }
+        public string SuppressedByHotReloadReason { get; }
+        public bool RetargetedToHotReloadPatch { get; }
 
         public static UloopPausePointSnapshot NotEnabled(string id, IUloopPausePointPauseController pauseController)
         {
@@ -148,6 +154,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 string.Empty,
                 string.Empty,
                 false,
+                false,
+                null,
                 false);
         }
     }

--- a/cli/project-runner/internal/projectrunner/pause_point_errors.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors.go
@@ -129,14 +129,23 @@ const (
 
 	// pausePointHintSuppressedByHotReload short-circuits every other timeout diagnosis:
 	// a suppressed marker cannot fire no matter what the caller does in PlayMode.
-	pausePointHintSuppressedByHotReload = "The marker's method is currently hot-reload patched: the patch discarded the marker's instrumentation, so it cannot fire no matter how often the code path runs. Run `uloop hot-reload --revert-all` (or `uloop compile`) to restore it, then trigger the code path and wait again."
+	pausePointHintSuppressedByHotReload = "The marker's method is hot-reload patched and the marker could not be re-targeted onto the patched body. Revert the patch with 'uloop hot-reload --revert-all' or run 'uloop compile', then re-enable the marker."
 )
+
+// pausePointSuppressedByHotReloadHint prepends Unity's reason when present so agents see
+// both the specific failure and the shared recovery steps.
+func pausePointSuppressedByHotReloadHint(response pausePointStatusResponse) string {
+	if response.SuppressedByHotReloadReason != "" {
+		return response.SuppressedByHotReloadReason + " " + pausePointHintSuppressedByHotReload
+	}
+	return pausePointHintSuppressedByHotReload
+}
 
 // pausePointTimeoutHint maps the final probed status to a deterministic diagnosis,
 // because timeouts are where agents struggle to tell a missed code path from Editor state.
 func pausePointTimeoutHint(response pausePointStatusResponse, hasNewHitBaseline bool) string {
 	if response.SuppressedByHotReload {
-		return pausePointHintSuppressedByHotReload
+		return pausePointSuppressedByHotReloadHint(response)
 	}
 	if hasNewHitBaseline {
 		return pausePointHintAlreadyHitWaitingForNew
@@ -162,7 +171,7 @@ func pausePointTimeoutHint(response pausePointStatusResponse, hasNewHitBaseline 
 // of a timeout and would otherwise carry no hint at all.
 func pausePointExpiredHint(response pausePointStatusResponse) string {
 	if response.SuppressedByHotReload {
-		return pausePointHintSuppressedByHotReload
+		return pausePointSuppressedByHotReloadHint(response)
 	}
 	if !response.EditorState.IsPlaying {
 		return pausePointHintPlayModeNotRunning

--- a/cli/project-runner/internal/projectrunner/pause_point_errors.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors.go
@@ -132,11 +132,13 @@ const (
 	pausePointHintSuppressedByHotReload = "The marker's method is hot-reload patched and the marker could not be re-targeted onto the patched body. Revert the patch with 'uloop hot-reload --revert-all' or run 'uloop compile', then re-enable the marker."
 )
 
-// pausePointSuppressedByHotReloadHint prepends Unity's reason when present so agents see
-// both the specific failure and the shared recovery steps.
+// pausePointSuppressedByHotReloadHint returns Unity's reason alone when present: both
+// retarget/restore reason strings already include recovery steps, and concatenating the
+// fixed "currently patched / revert-all" fallback after a restore-failure reason contradicts
+// itself (the patch was already reverted).
 func pausePointSuppressedByHotReloadHint(response pausePointStatusResponse) string {
 	if response.SuppressedByHotReloadReason != "" {
-		return response.SuppressedByHotReloadReason + " " + pausePointHintSuppressedByHotReload
+		return response.SuppressedByHotReloadReason
 	}
 	return pausePointHintSuppressedByHotReload
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_errors_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors_test.go
@@ -21,13 +21,14 @@ func TestPausePointTimeoutHint_SuppressedByHotReload_WinsOverOtherBranches(t *te
 	}
 }
 
-// Verifies a non-empty Unity reason is prepended to the shared suppressed recovery hint.
-func TestPausePointTimeoutHint_SuppressedByHotReload_PrependsReason(t *testing.T) {
+// Verifies a non-empty Unity reason is returned as-is (no fixed-hint concatenation).
+func TestPausePointTimeoutHint_SuppressedByHotReload_ReturnsReasonOnly(t *testing.T) {
+	const reason = "Line no longer resolves inside the patched body."
 	response := pausePointStatusResponse{
 		Status:                      pausePointStatusEnabled,
 		HitCount:                    0,
 		SuppressedByHotReload:       true,
-		SuppressedByHotReloadReason: "Line no longer resolves inside the patched body.",
+		SuppressedByHotReloadReason: reason,
 		EditorState: pausePointEditorState{
 			IsPlaying: true,
 			IsPaused:  false,
@@ -35,9 +36,27 @@ func TestPausePointTimeoutHint_SuppressedByHotReload_PrependsReason(t *testing.T
 	}
 
 	hint := pausePointTimeoutHint(response, false)
-	want := "Line no longer resolves inside the patched body. " + pausePointHintSuppressedByHotReload
-	if hint != want {
-		t.Fatalf("expected %q, got %q", want, hint)
+	if hint != reason {
+		t.Fatalf("expected reason-only hint %q, got %q", reason, hint)
+	}
+}
+
+// Verifies the fixed suppressed hint is used only when Unity omitted a reason.
+func TestPausePointTimeoutHint_SuppressedByHotReload_EmptyReasonUsesFallback(t *testing.T) {
+	response := pausePointStatusResponse{
+		Status:                      pausePointStatusEnabled,
+		HitCount:                    0,
+		SuppressedByHotReload:       true,
+		SuppressedByHotReloadReason: "",
+		EditorState: pausePointEditorState{
+			IsPlaying: true,
+			IsPaused:  false,
+		},
+	}
+
+	hint := pausePointTimeoutHint(response, false)
+	if hint != pausePointHintSuppressedByHotReload {
+		t.Fatalf("expected fallback suppressed hint, got %q", hint)
 	}
 }
 

--- a/cli/project-runner/internal/projectrunner/pause_point_errors_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors_test.go
@@ -21,6 +21,26 @@ func TestPausePointTimeoutHint_SuppressedByHotReload_WinsOverOtherBranches(t *te
 	}
 }
 
+// Verifies a non-empty Unity reason is prepended to the shared suppressed recovery hint.
+func TestPausePointTimeoutHint_SuppressedByHotReload_PrependsReason(t *testing.T) {
+	response := pausePointStatusResponse{
+		Status:                      pausePointStatusEnabled,
+		HitCount:                    0,
+		SuppressedByHotReload:       true,
+		SuppressedByHotReloadReason: "Line no longer resolves inside the patched body.",
+		EditorState: pausePointEditorState{
+			IsPlaying: true,
+			IsPaused:  false,
+		},
+	}
+
+	hint := pausePointTimeoutHint(response, false)
+	want := "Line no longer resolves inside the patched body. " + pausePointHintSuppressedByHotReload
+	if hint != want {
+		t.Fatalf("expected %q, got %q", want, hint)
+	}
+}
+
 // Verifies the enabled-but-never-hit timeout hint still wins when suppression is false,
 // so inserting the suppressed short-circuit does not reorder the remaining branches.
 func TestPausePointTimeoutHint_NotSuppressed_ReturnsEnabledNeverHitHint(t *testing.T) {

--- a/cli/project-runner/internal/projectrunner/pause_point_types.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_types.go
@@ -33,10 +33,12 @@ type pausePointStatusResponse struct {
 	StatusBeforeClear               string                           `json:"StatusBeforeClear"`
 	LateHitDiscardedAfterClear      bool                             `json:"LateHitDiscardedAfterClear"`
 	SuppressedByHotReload           bool                             `json:"SuppressedByHotReload"`
+	RetargetedToHotReloadPatch      bool                             `json:"RetargetedToHotReloadPatch"`
+	SuppressedByHotReloadReason     string                           `json:"SuppressedByHotReloadReason,omitempty"`
 
 	// Warning is set by Unity on enable/clear tool responses when this shared type decodes those
-	// envelopes. The status bridge sets it only when SuppressedByHotReload is true. On
-	// enable-pause-point --await hits, that enable response text is exposed as EnableTimeWarning
+	// envelopes. The status bridge sets it to SuppressedByHotReloadReason when suppressed.
+	// On enable-pause-point --await hits, that enable response text is exposed as EnableTimeWarning
 	// on the wait payload, not as hit-time Warning.
 	Warning string `json:"Warning,omitempty"`
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -159,6 +159,27 @@ instance method, the shim is a static method whose first parameter is the origin
 instance (`__uloopInstance`) so IL argument slots match the original method and the body can be
 transplanted without rewriting call/load slots. Prefix wrappers are not generated.
 
+### Shim registration
+
+The per-file record hot reload publishes after a successful apply so pause points can
+resolve against the patched code: the shim assembly and portable-PDB bytes plus, for
+each patched method, its shim `MethodBase`, source line range, and whether the patch is
+a delegation (`HotReloadShimRegistry`, exposed through
+`HotReloadPausePointCoordination`). A file's registration is replaced by the next
+hot-reload generation, and a method's entry is removed when its patch is reverted;
+consumers treat a missing entry as "cannot re-target", never as an error.
+
+### Re-target
+
+Moving an armed source pause point's instrumentation to follow a hot-reload patch
+transition without changing the marker's identity or registry state. On apply, the
+marker's requested file and line are re-resolved against the new shim registration and
+the capture call is re-injected into the patched body; on revert, the same request is
+re-resolved against the compiled assembly. A marker that re-targets onto a patched body
+reports `RetargetedToHotReloadPatch: true`; one that cannot be re-targeted is suppressed
+(`SuppressedByHotReload: true`, with a reason) until a later transition or
+`uloop compile` makes its line resolvable again.
+
 ### Publicized reference
 
 A Cecil-rewritten copy of a project assembly under `Library/UloopHotReload/PublicizedRefs/fmt2/`

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -212,11 +212,15 @@ Wire details:
 - In-flight async methods and coroutines keep running the old code until re-entered.
 - Callers whose call sites were JIT-inlined may not observe the detour (`IsLikelyJitInlined`
   heuristic produces a warning, as with pause points).
-- A pause point armed before a hot reload of the same method stops firing. The apply
-  response lists the affected marker ids, `pause-point-status` reports
-  `SuppressedByHotReload: true`, and enabling a new marker on a currently patched
-  method is rejected with `PAUSE_POINT_PATCHED_BY_HOT_RELOAD`. Reverting the patch
-  restores armed markers and clears the flag.
+- Pause points on a hot-reload patched method follow the patch instead of being
+  rejected: applying a patch re-targets armed markers onto the patched body
+  (`RetargetedToHotReloadPatch: true`) and reverting re-targets them back onto the
+  compiled body. The residual limit is a marker whose requested line no longer
+  resolves in the code now executing — it is suppressed (`SuppressedByHotReload: true`,
+  reason in `SuppressedByHotReloadReason`) rather than cleared, and stays silent until
+  a later patch transition restores the line or `uloop compile` runs. Enabling a new
+  marker on a patched method is rejected with `PAUSE_POINT_PATCHED_BY_HOT_RELOAD` only
+  when the line cannot be mapped onto the patched body.
 
 ## Open Questions Tracked for Implementation
 

--- a/tests/contracts/pause_point_status_response_contract.json
+++ b/tests/contracts/pause_point_status_response_contract.json
@@ -55,5 +55,6 @@
   "ClearedReason": "",
   "StatusBeforeClear": "",
   "LateHitDiscardedAfterClear": false,
-  "SuppressedByHotReload": false
+  "SuppressedByHotReload": false,
+  "RetargetedToHotReloadPatch": false
 }


### PR DESCRIPTION
## Summary
- Auto-retarget armed source pause points across hot-reload apply / generation change / revert, keeping marker identity and recording `RetargetedToHotReloadPatch` / `SuppressedByHotReloadReason`.
- Replace the blanket hot-reload × pause-point exclusivity warning with conditional apply warnings for retargeted vs suppressed marker ids; clear ledger before re-Apply Unpatch so ChainJoin injections stay inert during rebuild.
- Document the coexistence semantics with advisor-authored English SKILL/docs prose (generated skill copies refreshed; tool catalog unchanged).

## Test plan
- [x] `dist/darwin-arm64/uloop compile` → Error 0 / Warning 0
- [x] `uloop run-tests --test-mode EditMode --filter-type regex --filter-value HotReload` → 129/129
- [x] `uloop run-tests --test-mode EditMode --filter-type regex --filter-value PausePoint` → 283/283
- [x] `scripts/check-go-cli.sh` pass
- [x] `go run ./cmd/sync-tool-docs --check -repository-root ../..` (from `cli/release-automation`) → catalog matches


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

