### PR TITLE
ci: stop release-please from running on main

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,10 +1,12 @@
 name: release-please
 
 on:
-  push:
-    branches:
-      - main
-  # Enable manual execution via "Run workflow" button in browser
+  # No push trigger on purpose. The v2 series is no longer released, so an automatic
+  # release PR is pure noise: closing it does not stick, because release-please
+  # recreates it on the next push to main (#2095 was closed and came back as #2099).
+  # Removing only the branch entry would leave an empty `branches:`, which matches
+  # every branch, so the whole push trigger goes.
+  # Run this workflow manually (branch=main) if a v2 release becomes necessary again.
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
## Why

The v2 series is no longer released, so the automatic release PR for 2.3.0 is pure noise.

Closing it does not stick. release-please recreates it on the next push to `main` — #2095 was closed and came back as #2099, with identical contents.

## What changes

The `push` trigger is removed from `.github/workflows/release-please.yml` on `main`.

Removing only the `- main` entry would leave an empty `branches:`, which matches **every** branch, so the whole `push` trigger goes instead.

## What still works

- `workflow_dispatch` remains, so a v2 release can still be produced manually (`branch=main`). The job that dispatches `npm-publish.yml` after a successful release is downstream of that, so the chain is intact for manual runs.
- `v3-beta` is unaffected: pushes to that branch are matched by the workflow definition on `v3-beta`, which is a separate file.

## Reverting

Restore the `push:` block. One edit, no state to unwind.

## Follow-up

#2099 will be closed after this merges. Closing it before the merge would let the next push to `main` recreate it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed the automatic `push` trigger for `main` from `.github/workflows/release-please.yml`.
- Retained manual releases through `workflow_dispatch` with `branch=main`.
- Preserved the downstream `npm-publish.yml` dispatch.
- Left the separate `v3-beta` workflow unchanged.
- Release PR `#2099` should be closed after this PR merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->