### PR TITLE
docs: fix stale statements in glossary and code-complexity docs

### DIFF
--- a/docs/code-complexity.md
+++ b/docs/code-complexity.md
@@ -35,9 +35,10 @@ dotnet run --project tools/UnityCliLoop.CodeComplexity -- --root . --max-complex
 
 ## Operating Policy
 
-The repository-wide maximum cyclomatic complexity is 15. It is declared in two places that must
-stay in step: `MAX_COMPLEXITY` in `scripts/check-code-complexity.sh` and `cyclop.max-complexity`
-in `cli/.golangci-complexity.yml`. The `Code Complexity` workflow runs on every pull request that
+The repository-wide maximum cyclomatic complexity is 15. It is declared in three places that must
+stay in step: `MAX_COMPLEXITY` in `scripts/check-code-complexity.sh`, `cyclop.max-complexity`
+in `cli/.golangci-complexity.yml`, and `--max-complexity` in the artifact step of
+`.github/workflows/code-complexity.yml`. The `Code Complexity` workflow runs on every pull request that
 touches `cli/**/*.go` or `Packages/src/**/*.cs`, reports findings, and uploads per-module JSON
 artifacts — it never fails the build.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -18,9 +18,9 @@ match the current glossary:
 - `UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT` and
   `UnityCliLoopConstants.COMMAND_NAME_PAUSE_POINT_STATUS` are used as tool catalog names,
   not internal bridge commands.
-- The skill target types `SkillsTarget`, `SkillSetupTargetInfo`,
-  `ToolSkillSynchronizer.SkillTargetDefinition`, and `ToolSkillSynchronizer.SkillTargetInfo`
-  describe related concepts at different layers, but they remain public package identifiers.
+- The skill target types `SkillsTarget`, `SkillSetupTargetInfo`, and
+  `ToolSkillSynchronizer.SkillTargetInfo` describe related concepts at different layers,
+  but they remain public package identifiers.
 - Several first-party tool UseCases implement `IUnityCliLoop*Service` interfaces. The names
   are preserved because renaming public identifiers is outside terminology cleanup; removing
   the pass-through interfaces would be a separate structural refactor.
@@ -100,7 +100,7 @@ else.
 ### Skill target
 
 A destination agent environment into which skills are installed (for example Claude Code,
-Cursor). Each target defines where its skill copies live and which folder layout it uses.
+Codex CLI). Each target defines where its skill copies live and which folder layout it uses.
 
 ### UseCase
 


### PR DESCRIPTION
## Summary

- Correct stale glossary statements.
- Align the code-complexity documentation with the current implementation.

## Changes

- Use an existing CLI target in the glossary example.
- Remove an obsolete identifier from the naming-debt list.
- Document every location that declares the complexity threshold.
