### PR TITLE
fix: report the full error count in diagnostics summaries

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionResponseFactoryTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionResponseFactoryTests.cs
@@ -88,6 +88,43 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
+        /// Verifies the diagnostics summary reports the pre-deduplication error count as the total.
+        /// </summary>
+        [Test]
+        public void ConvertExecutionResultToResponse_WhenDuplicateErrorsCollapse_SummaryKeepsPreDeduplicationTotal()
+        {
+            DynamicCodeExecutionResponseFactory factory = new();
+            ExecutionResult result = new()
+            {
+                Success = false,
+                ErrorMessage = "Compilation error occurred",
+                UpdatedCode = "return MissingType.Value;",
+                CompilationErrors = new List<CompilationError>
+                {
+                    new CompilationError
+                    {
+                        ErrorCode = "CS0246",
+                        Message = "The type or namespace name 'MissingType' could not be found",
+                        Line = 1,
+                        Column = 8
+                    },
+                    new CompilationError
+                    {
+                        ErrorCode = "CS0246",
+                        Message = "The type or namespace name 'MissingType' could not be found",
+                        Line = 1,
+                        Column = 8
+                    }
+                }
+            };
+
+            ExecuteDynamicCodeResponse response = factory.ConvertExecutionResultToResponse(result);
+
+            Assert.That(response.Diagnostics, Has.Count.EqualTo(1));
+            Assert.That(response.DiagnosticsSummary, Does.StartWith("Errors: 1 unique (2 total)."));
+        }
+
+        /// <summary>
         /// Verifies wrapped UpdatedCode diagnostics render context from the user snippet region.
         /// </summary>
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
@@ -146,18 +146,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 originalUserSnippet,
                 result.AmbiguousTypeCandidates);
             response.CompilationErrors = response.Diagnostics;
-            response.DiagnosticsSummary = CreateDiagnosticsSummary(response.Diagnostics);
+            response.DiagnosticsSummary = CreateDiagnosticsSummary(
+                response.Diagnostics,
+                result.CompilationErrors.Count);
             response.Logs.Add(response.DiagnosticsSummary);
         }
 
-        private static string CreateDiagnosticsSummary(List<CompilationErrorDto> diagnostics)
+        // Why totalBeforeDeduplication is a parameter: BuildDiagnostics already deduplicated the
+        // list, so counting it here can only ever reproduce the unique count — the raw total must
+        // come from the pre-deduplication source.
+        private static string CreateDiagnosticsSummary(
+            List<CompilationErrorDto> diagnostics,
+            int totalBeforeDeduplication)
         {
-            int total = diagnostics.Count;
-            int unique = diagnostics
-                .GroupBy(error => new { error.Line, error.Column, error.ErrorCode, error.Message })
-                .Count();
+            int unique = diagnostics.Count;
             CompilationErrorDto first = diagnostics.First();
-            return $"Errors: {unique} unique ({total} total). First at L{first.Line}: {first.ErrorCode} {first.Message}";
+            return $"Errors: {unique} unique ({totalBeforeDeduplication} total). First at L{first.Line}: {first.ErrorCode} {first.Message}";
         }
 
         private static void ApplyExceptionResponseDetails(


### PR DESCRIPTION
## Summary

- Report both unique and total compiler error counts in dynamic-code diagnostics summaries.

## User Impact

- When duplicate compiler diagnostics are collapsed, the summary now preserves the original total instead of showing the unique count twice.

## Changes

- Pass the pre-deduplication compilation error count to the diagnostics summary.
- Add a regression test covering duplicate diagnostics.

## Verification

- Unity compilation completed with 0 errors and 0 warnings.
- All 2,427 applicable EditMode tests passed; 7 platform-specific tests were skipped.
- `DynamicCodeExecutionResponseFactoryTests`: 12/12 passed.
