### PR TITLE
chore: release v3-beta

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "Packages/src": "3.0.0-beta.71",
+  "Packages/src": "3.0.0-beta.72",
   "cli/dispatcher": "3.0.0-beta.30",
   "cli/project-runner": "3.0.0-beta.65"
 }

--- a/Packages/src/CHANGELOG.md
+++ b/Packages/src/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.0.0-beta.72](https://github.com/hatayama/unity-cli-loop/compare/v3.0.0-beta.71...v3.0.0-beta.72) (2026-08-11)
+
+
+### Bug Fixes
+
+* report the full error count in diagnostics summaries ([#2134](https://github.com/hatayama/unity-cli-loop/issues/2134)) ([12694df](https://github.com/hatayama/unity-cli-loop/commit/12694dff3c63de6e483c276d34900987b63a36bc))
+* Stop screenshot rendering mode from returning all-black PNGs ([#2107](https://github.com/hatayama/unity-cli-loop/issues/2107)) ([ac4cf0a](https://github.com/hatayama/unity-cli-loop/commit/ac4cf0a103f346ccf047c40228aefaec36882184))
+
 ## [3.0.0-beta.71](https://github.com/hatayama/unity-cli-loop/compare/v3.0.0-beta.70...v3.0.0-beta.71) (2026-07-29)
 
 

--- a/Packages/src/package.json
+++ b/Packages/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io.github.hatayama.uloopmcp",
-  "version": "3.0.0-beta.71",
+  "version": "3.0.0-beta.72",
   "displayName": "Unity CLI Loop",
   "description": "AI-driven development loop for Unity via CLI.",
   "unity": "2022.3",


### PR DESCRIPTION
Release components:

- `unity-package`: Unity Package Manager/OpenUPM package (`v<version>` tags).
- `uloop-project-runner`: native project runner binaries (`uloop-project-runner-v<version>` tags).
- `dispatcher`: native dispatcher binaries (`dispatcher-v<version>` tags).
---


<details><summary>3.0.0-beta.72</summary>

## [3.0.0-beta.72](https://github.com/hatayama/unity-cli-loop/compare/v3.0.0-beta.71...v3.0.0-beta.72) (2026-08-11)


### Bug Fixes

* report the full error count in diagnostics summaries ([#2134](https://github.com/hatayama/unity-cli-loop/issues/2134)) ([12694df](https://github.com/hatayama/unity-cli-loop/commit/12694dff3c63de6e483c276d34900987b63a36bc))
* Stop screenshot rendering mode from returning all-black PNGs ([#2107](https://github.com/hatayama/unity-cli-loop/issues/2107)) ([ac4cf0a](https://github.com/hatayama/unity-cli-loop/commit/ac4cf0a103f346ccf047c40228aefaec36882184))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).