### PR TITLE
chore: release v3-beta

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "Packages/src": "3.0.0-beta.72",
+  "Packages/src": "3.0.0-beta.73",
   "cli/dispatcher": "3.0.0-beta.31",
   "cli/project-runner": "3.0.0-beta.66"
 }

--- a/Packages/src/CHANGELOG.md
+++ b/Packages/src/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [3.0.0-beta.72](https://github.com/hatayama/unity-cli-loop/compare/v3.0.0-beta.71...v3.0.0-beta.72) (2026-08-11)
+## [3.0.0-beta.73](https://github.com/hatayama/unity-cli-loop/compare/v3.0.0-beta.71...v3.0.0-beta.73) (2026-08-11)
 
 
 ### Bug Fixes

--- a/Packages/src/package.json
+++ b/Packages/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io.github.hatayama.uloopmcp",
-  "version": "3.0.0-beta.72",
+  "version": "3.0.0-beta.73",
   "displayName": "Unity CLI Loop",
   "description": "AI-driven development loop for Unity via CLI.",
   "unity": "2022.3",


### PR DESCRIPTION
Prepares Unity package 3.0.0-beta.73.

- updates the package metadata to 3.0.0-beta.73
- carries forward the existing changelog entries
- keeps the native CLI pins aligned with the published prereleases