### PR TITLE
chore: simplify release-please configuration

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,5 @@
 {
   "pull-request-header": "Release components:\n\n- `unity-package`: Unity Package Manager/OpenUPM package (`v<version>` tags).\n- `uloop-project-runner`: native project runner binaries (`uloop-project-runner-v<version>` tags).\n- `dispatcher`: native dispatcher binaries (`dispatcher-v<version>` tags).",
-  "last-release-sha": "a76ef4bfd09530e332dbba9b51acb9b54d5a73b0",
   "packages": {
     "Packages/src": {
       "component": "unity-package",


### PR DESCRIPTION
Removes the explicit commit boundary so release-please uses the current component releases.