### PR TITLE
fix: compare hot-reload baselines on unannotated syntax trees

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1467,6 +1467,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 File.Exists(snapshotPath),
                 Is.True,
                 "Precondition: verified snapshot must exist to hide: " + snapshotPath);
+            // Why LoadVerifiedSnapshotSource (not File.Exists alone): a stale/checksum-invalid
+            // snapshot file already yields null, so hiding it would not change the precondition.
+            Assert.That(
+                HotReloadSourceBaseline.LoadVerifiedSnapshotSource(projectRelativePath, targetDllPath),
+                Is.Not.Null,
+                "Precondition: snapshot must be loadable before hide: " + projectRelativePath);
 
             string hiddenPath = snapshotPath + ".hidden-for-test";
             if (File.Exists(hiddenPath))

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1072,6 +1072,87 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a const-only source with no verified snapshot does not emit the
+        /// "No verified source snapshot" warning (no patch candidates → no noise).
+        /// </summary>
+        [Test]
+        public async Task Run_ConstOnlySourceWithoutSnapshot_DoesNotWarnMissingSnapshot()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            const string projectRelativePath = "Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs";
+            string editedPath = WriteEditedSource(
+                "ConstOnlyNoSnapshot.cs",
+                "namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload\n"
+                + "{\n"
+                + "    internal static class HotReloadConstOnlyProbe\n"
+                + "    {\n"
+                + "        public const int Amp = 5;\n"
+                + "        public const float Speed = 1.5f;\n"
+                + "    }\n"
+                + "}\n");
+
+            using (HideVerifiedSnapshot(projectRelativePath))
+            {
+                HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                    new[] { fixturePath },
+                    editedPath,
+                    CancellationToken.None);
+
+                AssertNoFileLevelFailure(result);
+                foreach (string warning in result.Warnings)
+                {
+                    Assert.That(
+                        warning.Contains("No verified source snapshot"),
+                        Is.False,
+                        "Const-only source must not warn about missing snapshot.\n"
+                        + string.Join("\n", result.Warnings));
+                }
+            }
+        }
+
+        /// <summary>
+        /// What: a method-bearing source with no verified snapshot still emits the
+        /// "No verified source snapshot" warning (patch candidates exist).
+        /// </summary>
+        [Test]
+        public async Task Run_MethodSourceWithoutSnapshot_WarnsMissingSnapshot()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            const string projectRelativePath = "Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs";
+            string editedPath = WriteEditedSource(
+                "MethodNoSnapshot.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }"));
+
+            using (HideVerifiedSnapshot(projectRelativePath))
+            {
+                HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                    new[] { fixturePath },
+                    editedPath,
+                    CancellationToken.None);
+
+                AssertNoFileLevelFailure(result);
+                bool found = false;
+                foreach (string warning in result.Warnings)
+                {
+                    if (warning.Contains("No verified source snapshot")
+                        && warning.Contains("HotReloadE2EFixtures.cs"))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                Assert.That(
+                    found,
+                    Is.True,
+                    "Method-bearing source without snapshot must warn.\n"
+                    + string.Join("\n", result.Warnings));
+            }
+        }
+
+        /// <summary>
         /// What: with a verified source snapshot, hot reload patches only the edited method —
         /// unedited methods appear neither as Patched nor Skipped, and the response carries the
         /// unchanged count.
@@ -1359,6 +1440,74 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string path = Path.Combine(directory, fileName);
             File.WriteAllText(path, contents);
             return path;
+        }
+
+        /// <summary>
+        /// Temporarily moves a verified snapshot aside so LoadVerifiedSnapshotSource returns null.
+        /// Restores the file on dispose.
+        /// </summary>
+        private static IDisposable HideVerifiedSnapshot(string projectRelativePath)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string targetDllPath = Path.Combine(
+                projectRoot,
+                HotReloadConstants.ScriptAssembliesRelativeDirectory,
+                "UnityCLILoop.Tests.Editor.HotReload"
+                + HotReloadConstants.CompiledAssemblyExtension);
+            string mvid = HotReloadSourceSnapshotter.ReadAssemblyMvid(targetDllPath);
+            string snapshotFileName =
+                HotReloadSourceSnapshotter.HashProjectRelativePath(
+                    projectRelativePath.Replace('\\', '/')) + ".cs";
+            string snapshotPath = Path.Combine(
+                projectRoot,
+                HotReloadConstants.SourceSnapshotRelativeDirectory,
+                "UnityCLILoop.Tests.Editor.HotReload-" + mvid,
+                snapshotFileName);
+            Assert.That(
+                File.Exists(snapshotPath),
+                Is.True,
+                "Precondition: verified snapshot must exist to hide: " + snapshotPath);
+
+            string hiddenPath = snapshotPath + ".hidden-for-test";
+            if (File.Exists(hiddenPath))
+            {
+                File.Delete(hiddenPath);
+            }
+
+            File.Move(snapshotPath, hiddenPath);
+            return new SnapshotHideScope(snapshotPath, hiddenPath);
+        }
+
+        private sealed class SnapshotHideScope : IDisposable
+        {
+            private readonly string _snapshotPath;
+            private readonly string _hiddenPath;
+            private bool _disposed;
+
+            public SnapshotHideScope(string snapshotPath, string hiddenPath)
+            {
+                _snapshotPath = snapshotPath;
+                _hiddenPath = hiddenPath;
+            }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                if (File.Exists(_hiddenPath))
+                {
+                    if (File.Exists(_snapshotPath))
+                    {
+                        File.Delete(_snapshotPath);
+                    }
+
+                    File.Move(_hiddenPath, _snapshotPath);
+                }
+            }
         }
 
         private static int CountWarningsContaining(IReadOnlyList<string> warnings, string token)

--- a/Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs
@@ -67,4 +67,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return x + 1;
         }
     }
+
+    internal interface IHotReloadKeyNormA
+    {
+        int Run();
+    }
+
+    internal interface IHotReloadKeyNormB
+    {
+        int Run();
+    }
+
+    /// <summary>
+    /// Why two explicit implementations: syntax keys must distinguish IA.Run vs IB.Run so baseline
+    /// comparison is not silently disabled by a colliding Identifier.Text-only key.
+    /// </summary>
+    internal class HotReloadExplicitInterfaceKeyFixture : IHotReloadKeyNormA, IHotReloadKeyNormB
+    {
+        int IHotReloadKeyNormA.Run()
+        {
+            return 1;
+        }
+
+        int IHotReloadKeyNormB.Run()
+        {
+            return 2;
+        }
+    }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs
@@ -1,0 +1,70 @@
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Pure-computation shapes that reproduce the annotated-vs-plain
+    /// <c>SyntaxFactory.AreEquivalent</c> asymmetry used by the hot-reload baseline compare bug.
+    /// Three shapes historically returned False (long single return / unchecked multi-statement /
+    /// switch); two controls historically returned True (short single / expression-bodied).
+    /// </summary>
+    internal class HotReloadShapeFixture
+    {
+        public int ShortSingle()
+        {
+            return 1;
+        }
+
+        public int ExpressionBodied() => 2;
+
+        // Why >90 chars in one return: Annotation on StatementSyntax makes AreEquivalent return
+        // False for this shape even when the snapshot text is identical.
+        public string LongSingleReturn()
+        {
+            return "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-long-single-return-body-over-ninety-chars";
+        }
+
+        public int UncheckedLongBody(int seed)
+        {
+            unchecked
+            {
+                int a = seed * 17;
+                int b = a + 31;
+                int c = b * 13;
+                int d = c ^ (a << 3);
+                int e = d + b + c;
+                return e ^ (seed + 0x5f3759df);
+            }
+        }
+
+        public string SwitchMessage(int code)
+        {
+            switch (code)
+            {
+                case 0:
+                    return "zero";
+                case 1:
+                    return "one";
+                case 2:
+                    return "two";
+                default:
+                    return "other";
+            }
+        }
+    }
+
+    /// <summary>
+    /// Why overloads here: production code forbids them, but the arity-normalization test needs
+    /// <c>F(int)</c> vs <c>F&lt;T&gt;(int)</c> in one compiled type so the worker binds both symbols.
+    /// </summary>
+    internal class HotReloadKeyNormalizationFixture
+    {
+        public int F(int x)
+        {
+            return x;
+        }
+
+        public int F<T>(int x)
+        {
+            return x + 1;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e8f87bde3f8a4b2f876e2aec6a36881
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -740,6 +740,56 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Both F(int) and F<T>(int) must appear in unchangedMethods after arity normalization.");
         }
 
+        /// <summary>
+        /// What: after including ExplicitInterfaceSpecifier in syntax keys, IA.Run and IB.Run no
+        /// longer collide, so an identical self-snapshot treats both as unchanged.
+        /// </summary>
+        [Test]
+        public async Task Run_WithSelfSnapshotOnExplicitInterfaceMethods_TreatsBothUnchanged()
+        {
+            string sourcePath = ResolveShapeFixturePath();
+            string onDisk = File.ReadAllText(sourcePath);
+            Assert.That(onDisk, Does.Contain("HotReloadExplicitInterfaceKeyFixture"));
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                ResolveShapeFixtureProjectRelativePath(),
+                snapshotSource: onDisk);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.baselineDisabledByDuplicateKeys, Is.False);
+            Assert.That(
+                result.Output.entries,
+                Is.Empty,
+                "Explicit-interface methods must not disable baseline; got entries: "
+                + FormatEntryMethodNames(result.Output.entries));
+
+            int unchangedRunCount = 0;
+            Assert.That(result.Output.unchangedMethods, Is.Not.Null);
+            foreach (TransformWorkerUnchangedMethodDto unchanged in result.Output.unchangedMethods)
+            {
+                // Why EndsWith(".Run"): Roslyn reports explicit-interface methodSymbol.Name as
+                // "IHotReloadKeyNormA.Run" (not bare "Run").
+                bool isExplicitFixture =
+                    unchanged.typeMetadataName != null
+                    && unchanged.typeMetadataName.Contains(
+                        nameof(HotReloadExplicitInterfaceKeyFixture),
+                        StringComparison.Ordinal);
+                bool isRunName =
+                    unchanged.methodName != null
+                    && unchanged.methodName.EndsWith(".Run", StringComparison.Ordinal);
+                if (isExplicitFixture && isRunName)
+                {
+                    unchangedRunCount++;
+                }
+            }
+
+            Assert.That(
+                unchangedRunCount,
+                Is.EqualTo(2),
+                "Both IA.Run and IB.Run must appear in unchangedMethods after key qualification.");
+        }
+
         private static HashSet<string> CollectEntryKeys(TransformWorkerEntryDto[] entries)
         {
             HashSet<string> keys = new HashSet<string>();

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -410,6 +410,137 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a self-snapshot of every .cs file under Assets/Tests/Editor/HotReload/ yields
+        /// Success, empty parseErrors/entries/declarationDriftWarnings, and at least one
+        /// unchanged or skipped method (proves the worker recognized the file). Permanent guard
+        /// that identical source never false-patches after the unannotated-baseline fix.
+        /// </summary>
+        [Test]
+        public async Task Run_WithSelfSnapshotOnHotReloadTestSources_TreatsAllMethodsUnchanged()
+        {
+            string directory = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload");
+            Assert.That(Directory.Exists(directory), Is.True, "HotReload test directory missing.");
+            string[] sourcePaths = Directory.GetFiles(directory, "*.cs", SearchOption.TopDirectoryOnly);
+            Assert.That(sourcePaths.Length, Is.GreaterThan(0), "Expected at least one HotReload test .cs file.");
+
+            List<string> failures = new List<string>();
+            foreach (string sourcePath in sourcePaths)
+            {
+                string fullPath = Path.GetFullPath(sourcePath);
+                string projectRelativePath =
+                    "Assets/Tests/Editor/HotReload/" + Path.GetFileName(fullPath);
+                string onDisk = File.ReadAllText(fullPath);
+                TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                    fullPath,
+                    projectRelativePath,
+                    snapshotSource: onDisk);
+
+                List<string> fileFailures = new List<string>();
+                if (!result.Success)
+                {
+                    fileFailures.Add("Success=false: " + result.ErrorMessage);
+                }
+
+                if (result.Output == null)
+                {
+                    fileFailures.Add("Output is null");
+                    failures.Add(projectRelativePath + " -> " + string.Join("; ", fileFailures));
+                    continue;
+                }
+
+                if (result.Output.parseErrors != null && result.Output.parseErrors.Length > 0)
+                {
+                    fileFailures.Add(
+                        "parseErrors=[" + string.Join(" | ", result.Output.parseErrors) + "]");
+                }
+
+                if (result.Output.entries != null && result.Output.entries.Length > 0)
+                {
+                    fileFailures.Add(
+                        "entries=[" + FormatEntryMethodNames(result.Output.entries) + "]");
+                }
+
+                int unchangedCount =
+                    result.Output.unchangedMethods != null ? result.Output.unchangedMethods.Length : 0;
+                int skippedCount = result.Output.skipped != null ? result.Output.skipped.Length : 0;
+                if (unchangedCount + skippedCount < 1)
+                {
+                    fileFailures.Add(
+                        "unchangedMethods+skipped < 1 (unchanged="
+                        + unchangedCount + ", skipped=" + skippedCount + ")");
+                }
+
+                if (result.Output.declarationDriftWarnings != null
+                    && result.Output.declarationDriftWarnings.Length > 0)
+                {
+                    fileFailures.Add(
+                        "declarationDriftWarnings=["
+                        + string.Join(" | ", result.Output.declarationDriftWarnings) + "]");
+                }
+
+                if (fileFailures.Count > 0)
+                {
+                    failures.Add(projectRelativePath + " -> " + string.Join("; ", fileFailures));
+                }
+            }
+
+            Assert.That(
+                failures,
+                Is.Empty,
+                "Self-snapshot must treat every HotReload test source as unchanged:\n"
+                + string.Join("\n", failures));
+        }
+
+        /// <summary>
+        /// What: an identical self-snapshot of HotReloadShapeFixture treats every method as
+        /// unchanged (empty entries; all five shape methods listed in unchangedMethods). Guards
+        /// the annotated-vs-plain AreEquivalent asymmetry on long-return / unchecked / switch.
+        /// </summary>
+        [Test]
+        public async Task Run_WithIdenticalSnapshotOnShapeFixture_TreatsAllMethodsUnchanged()
+        {
+            string sourcePath = ResolveShapeFixturePath();
+            string onDisk = File.ReadAllText(sourcePath);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                ResolveShapeFixtureProjectRelativePath(),
+                snapshotSource: onDisk);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output, Is.Not.Null);
+            Assert.That(
+                result.Output.entries,
+                Is.Empty,
+                "Identical snapshot must emit no patch entries; got: "
+                + FormatEntryMethodNames(result.Output.entries));
+
+            string[] expectedMethods =
+            {
+                nameof(HotReloadShapeFixture.ShortSingle),
+                nameof(HotReloadShapeFixture.ExpressionBodied),
+                nameof(HotReloadShapeFixture.LongSingleReturn),
+                nameof(HotReloadShapeFixture.UncheckedLongBody),
+                nameof(HotReloadShapeFixture.SwitchMessage),
+            };
+            Assert.That(result.Output.unchangedMethods, Is.Not.Null);
+            HashSet<string> unchangedNames = new HashSet<string>();
+            foreach (TransformWorkerUnchangedMethodDto unchanged in result.Output.unchangedMethods)
+            {
+                unchangedNames.Add(unchanged.methodName);
+            }
+
+            Assert.That(
+                unchangedNames,
+                Is.SupersetOf(expectedMethods),
+                "Identical snapshot must list all five shape methods in unchangedMethods; got: "
+                + string.Join(", ", unchangedNames));
+        }
+
+        /// <summary>
         /// What: with a snapshot whose ComputeWithPrivate body differs, the worker emits only that
         /// edited method and lists the remaining methods in unchangedMethods.
         /// </summary>
@@ -521,7 +652,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: a snapshot that duplicates a method key falls back to no-baseline behavior
-        /// (same entries as a null snapshot, empty unchangedMethods).
+        /// (same entries as a null snapshot, empty unchangedMethods) and sets
+        /// baselineDisabledByDuplicateKeys so the orchestrator can warn.
         /// </summary>
         [Test]
         public async Task Run_WithSnapshotDuplicateMethodKey_FallsBackToNoBaseline()
@@ -554,10 +686,58 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 || withCollision.Output.unchangedMethods.Length == 0,
                 Is.True,
                 "Duplicate-key fallback must not report unchanged methods.");
+            Assert.That(
+                withCollision.Output.baselineDisabledByDuplicateKeys,
+                Is.True,
+                "Duplicate-key fallback must set baselineDisabledByDuplicateKeys.");
 
             HashSet<string> baselineKeys = CollectEntryKeys(baseline.Output.entries);
             HashSet<string> collisionKeys = CollectEntryKeys(withCollision.Output.entries);
             Assert.That(collisionKeys, Is.EquivalentTo(baselineKeys));
+        }
+
+        /// <summary>
+        /// What: after arity normalization, void F(int) and void F&lt;T&gt;(int) no longer share a
+        /// syntax key, so an identical self-snapshot treats both as unchanged (no entries).
+        /// </summary>
+        [Test]
+        public async Task Run_WithSelfSnapshotOnArityDistinctMethods_TreatsBothUnchanged()
+        {
+            string sourcePath = ResolveShapeFixturePath();
+            string onDisk = File.ReadAllText(sourcePath);
+            Assert.That(onDisk, Does.Contain("HotReloadKeyNormalizationFixture"));
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                ResolveShapeFixtureProjectRelativePath(),
+                snapshotSource: onDisk);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.baselineDisabledByDuplicateKeys, Is.False);
+            Assert.That(
+                result.Output.entries,
+                Is.Empty,
+                "Arity-distinct methods must not disable baseline; got entries: "
+                + FormatEntryMethodNames(result.Output.entries));
+
+            int unchangedFCount = 0;
+            Assert.That(result.Output.unchangedMethods, Is.Not.Null);
+            foreach (TransformWorkerUnchangedMethodDto unchanged in result.Output.unchangedMethods)
+            {
+                if (unchanged.methodName == nameof(HotReloadKeyNormalizationFixture.F)
+                    && unchanged.typeMetadataName != null
+                    && unchanged.typeMetadataName.Contains(
+                        nameof(HotReloadKeyNormalizationFixture),
+                        StringComparison.Ordinal))
+                {
+                    unchangedFCount++;
+                }
+            }
+
+            Assert.That(
+                unchangedFCount,
+                Is.EqualTo(2),
+                "Both F(int) and F<T>(int) must appear in unchangedMethods after arity normalization.");
         }
 
         private static HashSet<string> CollectEntryKeys(TransformWorkerEntryDto[] entries)
@@ -612,17 +792,61 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(compilationAssembly, Is.Not.Null, "CompilationPipeline assembly not found.");
 
+            // Why absolute: the worker process cwd is not the Unity project root, so relative
+            // ScriptAssemblies paths from CompilationPipeline become "Reference not found"
+            // parseErrors and poison self-snapshot assertions that require parseErrors empty.
+            string[] referencePaths = BuildAbsoluteReferencePaths(
+                compilationAssembly.allReferences,
+                targetDllPath);
+
             TransformWorkerInputDto input = new TransformWorkerInputDto
             {
                 sourcePath = sourcePath,
                 defines = compilationAssembly.defines ?? System.Array.Empty<string>(),
-                referencePaths = compilationAssembly.allReferences,
+                referencePaths = referencePaths,
                 targetTypesAssemblyPath = targetDllPath,
                 snapshotSource = snapshotSource,
                 projectRelativePath = projectRelativePath
             };
 
             return await TransformWorkerClient.RunAsync(input, CancellationToken.None);
+        }
+
+        private static string[] BuildAbsoluteReferencePaths(
+            string[] allReferences,
+            string targetDllPath)
+        {
+            List<string> paths = new List<string>();
+            if (allReferences != null)
+            {
+                foreach (string reference in allReferences)
+                {
+                    if (string.IsNullOrEmpty(reference) || !File.Exists(reference))
+                    {
+                        continue;
+                    }
+
+                    paths.Add(Path.GetFullPath(reference));
+                }
+            }
+
+            string fullTarget = Path.GetFullPath(targetDllPath);
+            bool hasTarget = false;
+            foreach (string path in paths)
+            {
+                if (string.Equals(path, fullTarget, StringComparison.OrdinalIgnoreCase))
+                {
+                    hasTarget = true;
+                    break;
+                }
+            }
+
+            if (!hasTarget)
+            {
+                paths.Add(fullTarget);
+            }
+
+            return paths.ToArray();
         }
 
         private static string ResolveE2EFixturePath()
@@ -640,6 +864,39 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private static string ResolveE2EFixtureProjectRelativePath()
         {
             return "Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs";
+        }
+
+        private static string ResolveShapeFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadShapeFixtures.cs");
+            Assert.That(File.Exists(path), Is.True, "Shape fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string ResolveShapeFixtureProjectRelativePath()
+        {
+            return "Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs";
+        }
+
+        private static string FormatEntryMethodNames(TransformWorkerEntryDto[] entries)
+        {
+            if (entries == null || entries.Length == 0)
+            {
+                return "(none)";
+            }
+
+            List<string> names = new List<string>(entries.Length);
+            foreach (TransformWorkerEntryDto entry in entries)
+            {
+                names.Add(entry.methodName);
+            }
+
+            return string.Join(", ", names);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -100,5 +100,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string NoVerifiedSourceSnapshotWarningFormat =
             "No verified source snapshot for {0} (assembly {1}); patching all methods. "
             + "Run uloop compile to establish a baseline for edited-method detection.";
+
+        // Format: file name, assembly name. Emitted when syntax-method key collision disables baseline.
+        public const string BaselineDisabledByDuplicateKeysWarningFormat =
+            "Baseline comparison disabled for {0} (assembly {1}): the file contains methods with "
+            + "colliding signature keys; patching all methods.";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -166,14 +166,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string snapshotSource = HotReloadSourceBaseline.LoadVerifiedSnapshotSource(
                 projectRelativePath,
                 targetDllPath);
-            if (snapshotSource == null)
-            {
-                warnings.Add(
-                    string.Format(
-                        HotReloadConstants.NoVerifiedSourceSnapshotWarningFormat,
-                        Path.GetFileName(projectRelativePath),
-                        assemblyName));
-            }
 
             TransformWorkerInputDto workerInput = new TransformWorkerInputDto
             {
@@ -195,6 +187,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             TransformWorkerOutputDto workerOutput = workerResult.Output;
+            // Why after the worker: const-only / empty files have no patch candidates, so the
+            // missing-baseline warning was pure noise (FB E). Emit only when the worker saw at
+            // least one method or accessor row.
+            if (snapshotSource == null
+                && CountPatchCandidateRows(workerOutput) >= 1)
+            {
+                warnings.Add(
+                    string.Format(
+                        HotReloadConstants.NoVerifiedSourceSnapshotWarningFormat,
+                        Path.GetFileName(projectRelativePath),
+                        assemblyName));
+            }
+
+            if (workerOutput.baselineDisabledByDuplicateKeys)
+            {
+                warnings.Add(
+                    string.Format(
+                        HotReloadConstants.BaselineDisabledByDuplicateKeysWarningFormat,
+                        Path.GetFileName(projectRelativePath),
+                        assemblyName));
+            }
+
             if (workerOutput.parseErrors != null)
             {
                 foreach (string parseError in workerOutput.parseErrors)
@@ -657,6 +671,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return HotReloadConstants.AssemblyNotLoadedHint;
+        }
+
+        private static int CountPatchCandidateRows(TransformWorkerOutputDto workerOutput)
+        {
+            int entryCount = workerOutput.entries != null ? workerOutput.entries.Length : 0;
+            int skippedCount = workerOutput.skipped != null ? workerOutput.skipped.Length : 0;
+            int unchangedCount =
+                workerOutput.unchangedMethods != null ? workerOutput.unchangedMethods.Length : 0;
+            return entryCount + skippedCount + unchangedCount;
         }
 
         private static string[] BuildWorkerReferencePaths(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -42,6 +42,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Identities of methods left untouched because they match the verified snapshot.
         // Null/empty means none (or no baseline). UnchangedTotal is derived from Length.
         public TransformWorkerUnchangedMethodDto[] unchangedMethods;
+
+        // True when snapshotSource was provided but a duplicate syntax-method key on either side
+        // disabled baseline comparison (silent patch-all fallback). False when snapshotSource is null.
+        public bool baselineDisabledByDuplicateKeys;
     }
 
     [Serializable]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -174,11 +174,16 @@ public static class TransformWorkerProgram
             }
         }
 
-        // Why before CSharpCompilation.Create: annotating after GetSemanticModel detaches nodes
-        // from the bound tree and ShimBodyRewriter's GetSymbolInfo throws "Syntax node is not
-        // within syntax tree". Binding the SemanticModel to the annotated tree keeps rewriter
-        // lookups valid while uloop-line annotations ride through to Emit.
-        CompilationUnitSyntax annotatedRoot = AnnotateOriginalSourceLines(syntaxTree.GetCompilationUnitRoot());
+        // Why capture plainRoot before annotate: StatementSyntax annotations make
+        // SyntaxFactory.AreEquivalent(topLevel:false) return false for some method shapes
+        // (long single return / unchecked multi-statement / switch) even when the source text
+        // is identical. Baseline comparison must use unannotated nodes on both sides.
+        // Why annotate before CSharpCompilation.Create: annotating after GetSemanticModel
+        // detaches nodes from the bound tree and ShimBodyRewriter's GetSymbolInfo throws
+        // "Syntax node is not within syntax tree". Binding the SemanticModel to the annotated
+        // tree keeps rewriter lookups valid while uloop-line annotations ride through to Emit.
+        CompilationUnitSyntax plainRoot = syntaxTree.GetCompilationUnitRoot();
+        CompilationUnitSyntax annotatedRoot = AnnotateOriginalSourceLines(plainRoot);
         syntaxTree = syntaxTree.WithRootAndOptions(annotatedRoot, syntaxTree.Options);
 
         string targetTypesFullPath =
@@ -245,9 +250,13 @@ public static class TransformWorkerProgram
         // Syntax-key maps for edited-method detection. Distinct from BuildMethodKey (Cecil names):
         // same-file old/new comparison only needs syntax keys to stay consistent with each other.
         bool hasBaseline = false;
+        bool baselineDisabledByDuplicateKeys = false;
         Dictionary<string, MethodDeclarationSyntax> snapshotMethodMap = null;
+        Dictionary<string, MethodDeclarationSyntax> plainCurrentMethodMap = null;
         Dictionary<string, PropertyDeclarationSyntax> snapshotPropertyMap = null;
         Dictionary<string, IndexerDeclarationSyntax> snapshotIndexerMap = null;
+        Dictionary<string, PropertyDeclarationSyntax> plainCurrentPropertyMap = null;
+        Dictionary<string, IndexerDeclarationSyntax> plainCurrentIndexerMap = null;
         // Null disables comparison; empty string is a real (empty) baseline text.
         if (input.SnapshotSource != null)
         {
@@ -256,22 +265,33 @@ public static class TransformWorkerProgram
                     parseOptions)
                 .GetCompilationUnitRoot();
             Dictionary<string, MethodDeclarationSyntax> snapMethods = BuildSyntaxMethodMapOrNull(snapshotRoot);
-            Dictionary<string, MethodDeclarationSyntax> currentMethods = BuildSyntaxMethodMapOrNull(root);
+            // Why plainRoot: annotated current nodes break AreEquivalent for some shapes (see plainRoot above).
+            Dictionary<string, MethodDeclarationSyntax> currentMethods = BuildSyntaxMethodMapOrNull(plainRoot);
             if (snapMethods != null && currentMethods != null)
             {
                 // Why both maps: a duplicate key on either side makes AreEquivalent matching
                 // ambiguous, so fail closed to no-baseline (patch all) instead of guessing.
                 hasBaseline = true;
                 snapshotMethodMap = snapMethods;
+                plainCurrentMethodMap = currentMethods;
                 // Why null is kept as-is: a colliding property/indexer key only disables accessor
                 // gating for this file; method-level baseline matching still applies.
                 snapshotPropertyMap = BuildSyntaxPropertyMapOrNull(snapshotRoot);
                 snapshotIndexerMap = BuildSyntaxIndexerMapOrNull(snapshotRoot);
+                plainCurrentPropertyMap = BuildSyntaxPropertyMapOrNull(plainRoot);
+                plainCurrentIndexerMap = BuildSyntaxIndexerMapOrNull(plainRoot);
+                // Why plainRoot (not annotated root): StripMethodBodiesRewriter only clears method
+                // bodies, so accessor/ctor annotations would otherwise fake outside-body drift.
                 AppendOutsideMethodBodyDriftWarningIfNeeded(
                     snapshotRoot,
-                    root,
+                    plainRoot,
                     Path.GetFileName(input.SourcePath),
                     declarationDriftWarnings);
+            }
+            else
+            {
+                // Why surface: previously a colliding key silently disabled baseline and patched all.
+                baselineDisabledByDuplicateKeys = true;
             }
         }
 
@@ -300,7 +320,9 @@ public static class TransformWorkerProgram
                 semanticModel,
                 skipped,
                 hasBaseline ? snapshotPropertyMap : null,
-                hasBaseline ? snapshotIndexerMap : null);
+                hasBaseline ? snapshotIndexerMap : null,
+                hasBaseline ? plainCurrentPropertyMap : null,
+                hasBaseline ? plainCurrentIndexerMap : null);
 
             List<MethodDeclarationSyntax> methods = typeDeclaration.Members
                 .OfType<MethodDeclarationSyntax>()
@@ -340,8 +362,11 @@ public static class TransformWorkerProgram
                 if (hasBaseline)
                 {
                     string syntaxMethodKey = BuildSyntaxMethodKey(typeMetadataNameFromSyntax, methodDeclaration);
+                    // Why plainDecl: compare unannotated nodes; annotated methodDeclaration breaks
+                    // AreEquivalent for long-return / unchecked / switch shapes (see plainRoot).
                     if (snapshotMethodMap.TryGetValue(syntaxMethodKey, out MethodDeclarationSyntax snapshotDecl)
-                        && SyntaxFactory.AreEquivalent(snapshotDecl, methodDeclaration, topLevel: false))
+                        && plainCurrentMethodMap.TryGetValue(syntaxMethodKey, out MethodDeclarationSyntax plainDecl)
+                        && SyntaxFactory.AreEquivalent(snapshotDecl, plainDecl, topLevel: false))
                     {
                         unchangedMethods.Add(new WorkerUnchangedMethod
                         {
@@ -427,7 +452,8 @@ public static class TransformWorkerProgram
             Skipped = skipped.ToArray(),
             DeclarationDriftWarnings = declarationDriftWarnings.ToArray(),
             ParseErrors = parseErrors.ToArray(),
-            UnchangedMethods = unchangedMethods.ToArray()
+            UnchangedMethods = unchangedMethods.ToArray(),
+            BaselineDisabledByDuplicateKeys = baselineDisabledByDuplicateKeys
         };
     }
 
@@ -611,6 +637,7 @@ public static class TransformWorkerProgram
 
     // Syntax-based method key for same-file snapshot vs current comparison. Do not mix with
     // BuildMethodKey (Cecil/metadata names used by the orchestrator exclusion path).
+    // Used only for in-memory baseline maps — safe to evolve without wire compatibility concerns.
     private static string BuildSyntaxMethodKey(string typeMetadataName, MethodDeclarationSyntax methodDeclaration)
     {
         List<string> parameterKeys = new List<string>();
@@ -622,13 +649,26 @@ public static class TransformWorkerProgram
             }
         }
 
-        return typeMetadataName + "::" + methodDeclaration.Identifier.Text + "("
+        // Why arity suffix: void F(int) and void F<T>(int) must not share a key (was silent
+        // baseline-disable). Arity 0 keeps the bare name so existing non-generic keys stay stable.
+        string methodName = methodDeclaration.Identifier.Text;
+        if (methodDeclaration.TypeParameterList != null
+            && methodDeclaration.TypeParameterList.Parameters.Count > 0)
+        {
+            methodName += "`"
+                + methodDeclaration.TypeParameterList.Parameters.Count.ToString(CultureInfo.InvariantCulture);
+        }
+
+        return typeMetadataName + "::" + methodName + "("
             + string.Join(",", parameterKeys) + ")";
     }
 
     private static string BuildSyntaxParameterTypeKey(ParameterSyntax parameter)
     {
-        string typeText = parameter.Type != null ? parameter.Type.ToString() : string.Empty;
+        // Why NormalizeWhitespace: trivia / spacing differences must not invent distinct keys.
+        string typeText = parameter.Type != null
+            ? parameter.Type.NormalizeWhitespace().ToString()
+            : string.Empty;
         if (parameter.Modifiers.Any(SyntaxKind.RefKeyword)
             || parameter.Modifiers.Any(SyntaxKind.OutKeyword)
             || parameter.Modifiers.Any(SyntaxKind.InKeyword))
@@ -639,6 +679,7 @@ public static class TransformWorkerProgram
         return typeText;
     }
 
+    // What: syntax-only type metadata name for baseline signature keys (not shim naming).
     private static string BuildTypeMetadataNameFromSyntax(TypeDeclarationSyntax typeDeclaration)
     {
         List<string> nestedNames = new List<string>();
@@ -667,25 +708,32 @@ public static class TransformWorkerProgram
         return namespaceName + "." + typeMetadataName;
     }
 
+    // What: dotted namespace path including all ancestor namespaces (not only the innermost).
     private static string GetContainingNamespaceName(SyntaxNode node)
     {
+        List<string> parts = new List<string>();
         SyntaxNode current = node.Parent;
         while (current != null)
         {
             if (current is NamespaceDeclarationSyntax namespaceDeclaration)
             {
-                return namespaceDeclaration.Name.ToString();
+                parts.Add(namespaceDeclaration.Name.ToString());
             }
-
-            if (current is FileScopedNamespaceDeclarationSyntax fileScopedNamespace)
+            else if (current is FileScopedNamespaceDeclarationSyntax fileScopedNamespace)
             {
-                return fileScopedNamespace.Name.ToString();
+                parts.Add(fileScopedNamespace.Name.ToString());
             }
 
             current = current.Parent;
         }
 
-        return string.Empty;
+        if (parts.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        parts.Reverse();
+        return string.Join(".", parts);
     }
 
     private static string BuildSyntaxPropertyKey(
@@ -826,17 +874,26 @@ public static class TransformWorkerProgram
         SemanticModel semanticModel,
         List<WorkerSkipped> skipped,
         Dictionary<string, PropertyDeclarationSyntax> snapshotPropertyMap,
-        Dictionary<string, IndexerDeclarationSyntax> snapshotIndexerMap)
+        Dictionary<string, IndexerDeclarationSyntax> snapshotIndexerMap,
+        Dictionary<string, PropertyDeclarationSyntax> plainCurrentPropertyMap,
+        Dictionary<string, IndexerDeclarationSyntax> plainCurrentIndexerMap)
     {
         foreach (MemberDeclarationSyntax member in typeDeclaration.Members)
         {
             if (member is PropertyDeclarationSyntax propertyDeclaration)
             {
+                string propertyKey = BuildSyntaxPropertyKey(typeMetadataNameFromSyntax, propertyDeclaration);
+                // Why plainCurrentPropertyMap: annotated property nodes break AreEquivalent the
+                // same way annotated method bodies do; compare unannotated peers only.
                 if (snapshotPropertyMap != null
+                    && plainCurrentPropertyMap != null
                     && snapshotPropertyMap.TryGetValue(
-                        BuildSyntaxPropertyKey(typeMetadataNameFromSyntax, propertyDeclaration),
+                        propertyKey,
                         out PropertyDeclarationSyntax snapshotProperty)
-                    && SyntaxFactory.AreEquivalent(snapshotProperty, propertyDeclaration, topLevel: false))
+                    && plainCurrentPropertyMap.TryGetValue(
+                        propertyKey,
+                        out PropertyDeclarationSyntax plainProperty)
+                    && SyntaxFactory.AreEquivalent(snapshotProperty, plainProperty, topLevel: false))
                 {
                     continue;
                 }
@@ -850,11 +907,16 @@ public static class TransformWorkerProgram
 
             if (member is IndexerDeclarationSyntax indexerDeclaration)
             {
+                string indexerKey = BuildSyntaxIndexerKey(typeMetadataNameFromSyntax, indexerDeclaration);
                 if (snapshotIndexerMap != null
+                    && plainCurrentIndexerMap != null
                     && snapshotIndexerMap.TryGetValue(
-                        BuildSyntaxIndexerKey(typeMetadataNameFromSyntax, indexerDeclaration),
+                        indexerKey,
                         out IndexerDeclarationSyntax snapshotIndexer)
-                    && SyntaxFactory.AreEquivalent(snapshotIndexer, indexerDeclaration, topLevel: false))
+                    && plainCurrentIndexerMap.TryGetValue(
+                        indexerKey,
+                        out IndexerDeclarationSyntax plainIndexer)
+                    && SyntaxFactory.AreEquivalent(snapshotIndexer, plainIndexer, topLevel: false))
                 {
                     continue;
                 }
@@ -3558,6 +3620,8 @@ internal sealed class WorkerOutput
     public string[] ParseErrors { get; set; }
 
     public WorkerUnchangedMethod[] UnchangedMethods { get; set; }
+
+    public bool BaselineDisabledByDuplicateKeys { get; set; }
 }
 
 internal sealed class WorkerUnchangedMethod

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -659,6 +659,14 @@ public static class TransformWorkerProgram
                 + methodDeclaration.TypeParameterList.Parameters.Count.ToString(CultureInfo.InvariantCulture);
         }
 
+        // Why explicit-interface qualifier: IA.Run() and IB.Run() must not share a key (same as
+        // BuildSyntaxPropertyKey). Property keys already include ExplicitInterfaceSpecifier.
+        if (methodDeclaration.ExplicitInterfaceSpecifier != null)
+        {
+            methodName = methodDeclaration.ExplicitInterfaceSpecifier.Name.NormalizeWhitespace().ToString()
+                + "." + methodName;
+        }
+
         return typeMetadataName + "::" + methodName + "("
             + string.Join(",", parameterKeys) + ")";
     }
@@ -715,13 +723,14 @@ public static class TransformWorkerProgram
         SyntaxNode current = node.Parent;
         while (current != null)
         {
+            // Why NormalizeWhitespace: trivia in nested namespace names must not invent distinct keys.
             if (current is NamespaceDeclarationSyntax namespaceDeclaration)
             {
-                parts.Add(namespaceDeclaration.Name.ToString());
+                parts.Add(namespaceDeclaration.Name.NormalizeWhitespace().ToString());
             }
             else if (current is FileScopedNamespaceDeclarationSyntax fileScopedNamespace)
             {
-                parts.Add(fileScopedNamespace.Name.ToString());
+                parts.Add(fileScopedNamespace.Name.NormalizeWhitespace().ToString());
             }
 
             current = current.Parent;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -752,7 +752,10 @@ public static class TransformWorkerProgram
         string name = propertyDeclaration.Identifier.Text;
         if (propertyDeclaration.ExplicitInterfaceSpecifier != null)
         {
-            name = propertyDeclaration.ExplicitInterfaceSpecifier.Name + "." + name;
+            // Why NormalizeWhitespace: keep property keys symmetric with BuildSyntaxMethodKey so
+            // trivia in the interface name cannot invent a distinct baseline key.
+            name = propertyDeclaration.ExplicitInterfaceSpecifier.Name.NormalizeWhitespace().ToString()
+                + "." + name;
         }
 
         return typeMetadataName + "::" + name;


### PR DESCRIPTION
## Summary
- Identical sources no longer report unedited methods as `Patched` after hot reload.
- Const-only files no longer emit the noisy "No verified source snapshot" warning.

## User Impact
- Before: re-running hot reload on an unchanged file could keep listing methods as `Patched` (especially long returns, `unchecked` blocks, and `switch` shapes), so agents could not trust `Unchanged` convergence. Const-only tuning files also produced a missing-baseline warning even though there was nothing to patch.
- After: the same source always converges to all-`Unchanged`. Missing-baseline warnings appear only when the file actually has patch candidates. Duplicate signature keys that disable baseline comparison now surface as an explicit warning instead of silently patching everything.

## Changes
- Compare snapshot vs current method/accessor trees on unannotated syntax nodes (pause-point line annotations stay on the compile path only).
- Normalize syntax signature keys (generic arity, nested namespaces, parameter-type whitespace) and report `baselineDisabledByDuplicateKeys` when collisions still force a no-baseline fallback.
- Defer the missing-snapshot warning until after the worker run, and only when entries/skipped/unchanged is non-empty.
- Add shape-fixture, corpus self-snapshot, arity-normalization, and orchestrator warning coverage.

Addresses FB issues S1-1 / S2-1 (false `Patched`) and S1-4 / S2-4 (const-only snapshot warning noise).

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → 0 errors, 0 warnings
- Red confirmed before the fix: `Run_WithIdenticalSnapshotOnShapeFixture_TreatsAllMethodsUnchanged` failed with entries `LongSingleReturn, UncheckedLongBody, SwitchMessage`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --filter-type regex --filter-value "HotReloadOrchestratorTests|TransformWorkerClientTests"` → 43 passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

