### PR TITLE
feat: persist and expose resolved lines for retargeted pause points

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
@@ -157,13 +157,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: after auto-retarget, apply Warnings include "{id} (now line N: …)" from the
-        /// registry, and both PausePointResponse / PausePointStatusResponse expose
-        /// ResolvedLine / ResolvedLineText. Line-drift wording is covered by HotReloadToolTests
-        /// (contentPathOverride tests cannot rewrite on-disk line text for the reader).
+        /// What: retarget rewrites registry ResolvedLine/Text (not just enable-time values) and
+        /// apply Warnings include the post-retarget detail; a sentinel previous text records
+        /// line-drift through PendingRetargetLineDriftWarnings.
         /// </summary>
         [Test]
-        public async Task ArmThenHotReload_ExposesResolvedLineOnStatusAndApplyWarning()
+        public async Task ArmThenHotReload_RetargetRewritesResolvedLineAndRecordsDrift()
         {
             string onDisk = File.ReadAllText(ResolveFixtureAbsolutePath());
             int enableLine = FindLineNumber(onDisk, "return _secret + delta;");
@@ -178,24 +177,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             });
             Assert.That(enable.Success, Is.True, enable.Message);
             Assert.That(enable.ResolvedLine, Is.GreaterThan(0));
-            Assert.That(enable.ResolvedLineText, Does.Contain("return _secret + delta;"));
+            int enableResolvedLine = enable.ResolvedLine;
+            string enableResolvedText = enable.ResolvedLineText;
+            Assert.That(enableResolvedText, Does.Contain("return _secret + delta;"));
+
+            // Why clear then sentinel: prove retarget wrote the registry (enable alone cannot
+            // satisfy post-patch assertions), and force a drift record against on-disk text.
+            const string sentinelOldText = "SENTINEL_PRE_RETARGET_LINE_TEXT";
+            UloopPausePointRegistry.SetResolvedLine(enable.Id, 0, null);
+            Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).ResolvedLine, Is.EqualTo(0));
+            UloopPausePointRegistry.SetResolvedLine(enable.Id, enableResolvedLine, sentinelOldText);
 
             string editedSource = BuildEditedComputePlusHundred(onDisk);
             HotReloadResponse applyResponse =
                 await HotReloadApplyFromEditedSourceAsync(editedSource, "ContractArmThenPatchResolved.cs");
+
+            UloopPausePointSnapshot afterPatch = UloopPausePointRegistry.GetStatus(enable.Id);
+            Assert.That(afterPatch.RetargetedToHotReloadPatch, Is.True);
+            Assert.That(afterPatch.ResolvedLine, Is.GreaterThan(0));
+            Assert.That(afterPatch.ResolvedLineText, Is.Not.EqualTo(sentinelOldText));
+            Assert.That(afterPatch.ResolvedLineText, Does.Contain("return _secret + delta;"));
 
             string warningsJoined = string.Join(" | ", applyResponse.Warnings);
             Assert.That(
                 warningsJoined,
                 Does.Contain(
                     "Armed pause points were re-targeted onto the hot-reload patched bodies:"));
-            Assert.That(warningsJoined, Does.Contain(enable.Id + " (now line "));
-            Assert.That(warningsJoined, Does.Contain("return _secret + delta;"));
-
-            UloopPausePointSnapshot afterPatch = UloopPausePointRegistry.GetStatus(enable.Id);
-            Assert.That(afterPatch.RetargetedToHotReloadPatch, Is.True);
-            Assert.That(afterPatch.ResolvedLine, Is.GreaterThan(0));
-            Assert.That(afterPatch.ResolvedLineText, Does.Contain("return _secret + delta;"));
+            Assert.That(
+                warningsJoined,
+                Does.Contain(
+                    enable.Id + " (now line " + afterPatch.ResolvedLine + ": "
+                    + afterPatch.ResolvedLineText + ")"));
+            Assert.That(warningsJoined, Does.Contain("now targets a different statement"));
+            Assert.That(warningsJoined, Does.Contain(sentinelOldText));
+            Assert.That(warningsJoined, Does.Contain(afterPatch.ResolvedLineText));
 
             PausePointResponse statusResponse = PausePointResponse.FromSnapshot(afterPatch);
             Assert.That(statusResponse.ResolvedLine, Is.EqualTo(afterPatch.ResolvedLine));
@@ -205,6 +220,90 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 PausePointStatusResponse.FromSnapshot(afterPatch);
             Assert.That(bridgeStatus.ResolvedLine, Is.EqualTo(afterPatch.ResolvedLine));
             Assert.That(bridgeStatus.ResolvedLineText, Is.EqualTo(afterPatch.ResolvedLineText));
+        }
+
+        /// <summary>
+        /// What: an expired armed marker is reported once on the next hot-reload of its owner
+        /// and does not re-warn on a later apply of the same method (pending-drain + detach).
+        /// </summary>
+        [Test]
+        public async Task HotReload_AfterExpire_WarnsOnceAndDoesNotRepeat()
+        {
+            DateTime nowUtc = new DateTime(2026, 8, 12, 12, 0, 0, DateTimeKind.Utc);
+            UloopPausePointRegistry.ConfigureForTests(new FakePausePointPauseController(), () => nowUtc);
+
+            string onDisk = File.ReadAllText(ResolveFixtureAbsolutePath());
+            int enableLine = FindLineNumber(onDisk, "return _secret + delta;");
+            Assert.That(enableLine, Is.GreaterThan(0));
+
+            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 1,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(enable.Success, Is.True, enable.Message);
+
+            nowUtc = nowUtc.AddSeconds(2);
+            UloopPausePointSnapshot expired = UloopPausePointRegistry.GetStatus(enable.Id);
+            Assert.That(expired.Expired, Is.True);
+            Assert.That(expired.Status, Is.EqualTo(UloopPausePointStatus.Expired));
+
+            string editedSource = BuildEditedComputePlusHundred(onDisk);
+            HotReloadResponse firstApply =
+                await HotReloadApplyFromEditedSourceAsync(editedSource, "ContractExpiredWarn1.cs");
+            string firstWarnings = string.Join(" | ", firstApply.Warnings);
+            Assert.That(
+                firstWarnings,
+                Does.Contain(
+                    "Expired pause points were not re-targeted and will not fire: " + enable.Id),
+                firstWarnings);
+
+            HotReloadResponse secondApply =
+                await HotReloadApplyFromEditedSourceAsync(editedSource, "ContractExpiredWarn2.cs");
+            string secondWarnings = string.Join(" | ", secondApply.Warnings);
+            Assert.That(
+                secondWarnings,
+                Does.Not.Contain("Expired pause points were not re-targeted"),
+                secondWarnings);
+        }
+
+        /// <summary>
+        /// What: restore-after-revert rewrites ResolvedLine when re-resolve succeeds, proving
+        /// the restore SetResolvedLine path (not only enable/retarget) updates the registry.
+        /// </summary>
+        [Test]
+        public async Task RevertAll_AfterRetarget_RestoresResolvedLineOnOriginalBody()
+        {
+            string onDisk = File.ReadAllText(ResolveFixtureAbsolutePath());
+            int enableLine = FindLineNumber(onDisk, "return _secret + delta;");
+            Assert.That(enableLine, Is.GreaterThan(0));
+
+            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(enable.Success, Is.True, enable.Message);
+
+            UloopPausePointRegistry.SetResolvedLine(enable.Id, 0, null);
+            await HotReloadFromEditedSourceAsync(
+                BuildEditedComputePlusHundred(onDisk),
+                "ContractRestoreResolvedLine.cs");
+            Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).ResolvedLine, Is.GreaterThan(0));
+            Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).RetargetedToHotReloadPatch, Is.True);
+
+            UloopPausePointRegistry.SetResolvedLine(enable.Id, 0, null);
+            HotReloadPatcher.RevertAll();
+
+            UloopPausePointSnapshot afterRevert = UloopPausePointRegistry.GetStatus(enable.Id);
+            Assert.That(afterRevert.RetargetedToHotReloadPatch, Is.False);
+            Assert.That(afterRevert.SuppressedByHotReload, Is.False);
+            Assert.That(afterRevert.ResolvedLine, Is.GreaterThan(0));
+            Assert.That(afterRevert.ResolvedLineText, Does.Contain("return _secret + delta;"));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
@@ -13,6 +13,7 @@ using NUnit.Framework;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
 using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
@@ -153,6 +154,57 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             int result = fixture.ComputeWithPrivate(5);
             Assert.That(result, Is.EqualTo(fixture.SecretForAssert + 5 + 100));
             Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).IsHit, Is.True);
+        }
+
+        /// <summary>
+        /// What: after auto-retarget, apply Warnings include "{id} (now line N: …)" from the
+        /// registry, and both PausePointResponse / PausePointStatusResponse expose
+        /// ResolvedLine / ResolvedLineText. Line-drift wording is covered by HotReloadToolTests
+        /// (contentPathOverride tests cannot rewrite on-disk line text for the reader).
+        /// </summary>
+        [Test]
+        public async Task ArmThenHotReload_ExposesResolvedLineOnStatusAndApplyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveFixtureAbsolutePath());
+            int enableLine = FindLineNumber(onDisk, "return _secret + delta;");
+            Assert.That(enableLine, Is.GreaterThan(0));
+
+            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(enable.Success, Is.True, enable.Message);
+            Assert.That(enable.ResolvedLine, Is.GreaterThan(0));
+            Assert.That(enable.ResolvedLineText, Does.Contain("return _secret + delta;"));
+
+            string editedSource = BuildEditedComputePlusHundred(onDisk);
+            HotReloadResponse applyResponse =
+                await HotReloadApplyFromEditedSourceAsync(editedSource, "ContractArmThenPatchResolved.cs");
+
+            string warningsJoined = string.Join(" | ", applyResponse.Warnings);
+            Assert.That(
+                warningsJoined,
+                Does.Contain(
+                    "Armed pause points were re-targeted onto the hot-reload patched bodies:"));
+            Assert.That(warningsJoined, Does.Contain(enable.Id + " (now line "));
+            Assert.That(warningsJoined, Does.Contain("return _secret + delta;"));
+
+            UloopPausePointSnapshot afterPatch = UloopPausePointRegistry.GetStatus(enable.Id);
+            Assert.That(afterPatch.RetargetedToHotReloadPatch, Is.True);
+            Assert.That(afterPatch.ResolvedLine, Is.GreaterThan(0));
+            Assert.That(afterPatch.ResolvedLineText, Does.Contain("return _secret + delta;"));
+
+            PausePointResponse statusResponse = PausePointResponse.FromSnapshot(afterPatch);
+            Assert.That(statusResponse.ResolvedLine, Is.EqualTo(afterPatch.ResolvedLine));
+            Assert.That(statusResponse.ResolvedLineText, Is.EqualTo(afterPatch.ResolvedLineText));
+
+            PausePointStatusResponse bridgeStatus =
+                PausePointStatusResponse.FromSnapshot(afterPatch);
+            Assert.That(bridgeStatus.ResolvedLine, Is.EqualTo(afterPatch.ResolvedLine));
+            Assert.That(bridgeStatus.ResolvedLineText, Is.EqualTo(afterPatch.ResolvedLineText));
         }
 
         /// <summary>
@@ -654,6 +706,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private static async Task HotReloadFromEditedSourceAsync(string editedSource, string fileName)
         {
+            await HotReloadApplyFromEditedSourceAsync(editedSource, fileName);
+        }
+
+        private static async Task<HotReloadResponse> HotReloadApplyFromEditedSourceAsync(
+            string editedSource,
+            string fileName)
+        {
             string fixturePath = ResolveFixtureAbsolutePath();
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string directory = Path.Combine(projectRoot, HotReloadConstants.TestSourcesRelativeDirectory);
@@ -673,6 +732,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 result.Methods.Any(m => m.Kind == HotReloadMethodOutcomeKind.Patched),
                 Is.True,
                 FormatHotReloadOutcomes(result));
+            return HotReloadTool.BuildApplyResponse(result);
         }
 
         private static string ResolveFixtureAbsolutePath()

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,6 +8,7 @@ using NUnit.Framework;
 using Newtonsoft.Json.Linq;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
@@ -129,11 +131,87 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: BuildApplyResponse lists retargeted pause-point marker ids in Warnings
-        /// when auto-retarget kept markers firing on patched bodies.
+        /// What: BuildApplyResponse lists retargeted pause-point marker ids with resolved
+        /// line text from the registry (no "keep firing at the edited lines" wording).
         /// </summary>
         [Test]
         public void BuildApplyResponse_WithRetargetedPausePointIds_AddsAggregatedWarning()
+        {
+            UloopPausePointRegistry.ConfigureForTests(new FakePausePointPauseController(), () => DateTime.UtcNow);
+            try
+            {
+                const string id = "Assets/Scripts/A.cs:10";
+                UloopPausePointRegistry.Enable(id, 30);
+                UloopPausePointRegistry.SetResolvedLine(id, 12, "return value;");
+
+                HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                    new List<HotReloadMethodOutcome>
+                    {
+                        HotReloadMethodOutcome.Patched("Type.Method", "Assets/A.cs")
+                    },
+                    new List<string>(),
+                    patchedTotal: 1,
+                    activePatchTotal: 1,
+                    retargetedPausePointIds: new List<string> { id });
+
+                HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+                Assert.That(
+                    response.Warnings,
+                    Does.Contain(
+                        "Armed pause points were re-targeted onto the hot-reload patched bodies: "
+                        + "Assets/Scripts/A.cs:10 (now line 12: return value;)"));
+            }
+            finally
+            {
+                UloopPausePointRegistry.ResetForTests();
+            }
+        }
+
+        /// <summary>
+        /// What: BuildApplyResponse drains retarget line-drift warnings into Warnings.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_WithRetargetLineDrift_AddsDriftWarning()
+        {
+            Func<IReadOnlyList<(string Id, string OldText, string NewText)>> previous =
+                HotReloadPausePointCoordination.ConsumeRetargetLineDriftWarnings;
+            HotReloadPausePointCoordination.ConsumeRetargetLineDriftWarnings = () =>
+                new List<(string, string, string)>
+                {
+                    ("Assets/Scripts/A.cs:10", "return a;", "return a + 1;")
+                };
+            try
+            {
+                HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                    new List<HotReloadMethodOutcome>
+                    {
+                        HotReloadMethodOutcome.Patched("Type.Method", "Assets/A.cs")
+                    },
+                    new List<string>(),
+                    patchedTotal: 1,
+                    activePatchTotal: 1);
+
+                HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+                Assert.That(
+                    response.Warnings,
+                    Does.Contain(
+                        "Pause point Assets/Scripts/A.cs:10 now targets a different statement "
+                        + "(was: \"return a;\", now: \"return a + 1;\"). "
+                        + "Re-enable it at the intended line if this is not what you want."));
+            }
+            finally
+            {
+                HotReloadPausePointCoordination.ConsumeRetargetLineDriftWarnings = previous;
+            }
+        }
+
+        /// <summary>
+        /// What: BuildApplyResponse lists expired pause-point marker ids that were not retargeted.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_WithExpiredPausePointIds_AddsAggregatedWarning()
         {
             HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
                 new List<HotReloadMethodOutcome>
@@ -143,18 +221,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 new List<string>(),
                 patchedTotal: 1,
                 activePatchTotal: 1,
-                retargetedPausePointIds: new List<string>
-                {
-                    "Assets/Scripts/A.cs:10"
-                });
+                expiredPausePointIds: new List<string> { "Assets/Scripts/A.cs:10" });
 
             HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
 
             Assert.That(
                 response.Warnings,
                 Does.Contain(
-                    "Armed pause points were re-targeted onto the hot-reload patched bodies and keep "
-                    + "firing at the edited lines: Assets/Scripts/A.cs:10"));
+                    "Expired pause points were not re-targeted and will not fire: Assets/Scripts/A.cs:10"));
         }
 
         [Test]
@@ -288,6 +362,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 response.Message,
                 Is.EqualTo("Hot reload finished with one or more Failed method outcomes. See Methods."));
+        }
+
+        private sealed class FakePausePointPauseController : IUloopPausePointPauseController
+        {
+            public bool IsPlaying => true;
+            public bool IsPaused => false;
+
+            public void Pause()
+            {
+            }
+
+            public void Resume()
+            {
+            }
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -208,27 +208,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: BuildApplyResponse lists expired pause-point marker ids that were not retargeted.
+        /// What: BuildApplyResponse drains expired-not-retargeted ids into Warnings.
         /// </summary>
         [Test]
-        public void BuildApplyResponse_WithExpiredPausePointIds_AddsAggregatedWarning()
+        public void BuildApplyResponse_WithExpiredNotRetargetedIds_AddsAggregatedWarning()
         {
-            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
-                new List<HotReloadMethodOutcome>
-                {
-                    HotReloadMethodOutcome.Patched("Type.Method", "Assets/A.cs")
-                },
-                new List<string>(),
-                patchedTotal: 1,
-                activePatchTotal: 1,
-                expiredPausePointIds: new List<string> { "Assets/Scripts/A.cs:10" });
+            Func<IReadOnlyList<string>> previous =
+                HotReloadPausePointCoordination.ConsumeExpiredNotRetargetedMarkerIds;
+            HotReloadPausePointCoordination.ConsumeExpiredNotRetargetedMarkerIds = () =>
+                new List<string> { "Assets/Scripts/A.cs:10" };
+            try
+            {
+                HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                    new List<HotReloadMethodOutcome>
+                    {
+                        HotReloadMethodOutcome.Patched("Type.Method", "Assets/A.cs")
+                    },
+                    new List<string>(),
+                    patchedTotal: 1,
+                    activePatchTotal: 1);
 
-            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+                HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
 
-            Assert.That(
-                response.Warnings,
-                Does.Contain(
-                    "Expired pause points were not re-targeted and will not fire: Assets/Scripts/A.cs:10"));
+                Assert.That(
+                    response.Warnings,
+                    Does.Contain(
+                        "Expired pause points were not re-targeted and will not fire: Assets/Scripts/A.cs:10"));
+            }
+            finally
+            {
+                HotReloadPausePointCoordination.ConsumeExpiredNotRetargetedMarkerIds = previous;
+            }
         }
 
         [Test]

--- a/Assets/Tests/Editor/HotReload/UnityCLILoop.Tests.Editor.HotReload.asmdef
+++ b/Assets/Tests/Editor/HotReload/UnityCLILoop.Tests.Editor.HotReload.asmdef
@@ -8,7 +8,8 @@
         "GUID:774ab7841db34070bf18932c90cf9ea6",
         "GUID:fc3fd32eddbee40e39c2d76dc184957b",
         "GUID:94d8abc693f543a691a4645a5ff42e5c",
-        "GUID:527f26a36b5043c2bd4d4036d04cd76d"
+        "GUID:527f26a36b5043c2bd4d4036d04cd76d",
+        "GUID:18e6dd30a99d14f32a045f79a2956f46"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -105,5 +105,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string BaselineDisabledByDuplicateKeysWarningFormat =
             "Baseline comparison disabled for {0} (assembly {1}): the file contains methods with "
             + "colliding signature keys; patching all methods.";
+
+        // Format: comma-separated "{id} (now line {N}: {text})" entries.
+        public const string RetargetedPausePointsMessageFormat =
+            "Armed pause points were re-targeted onto the hot-reload patched bodies: {0}";
+
+        // Format: id, old line text, new line text.
+        public const string RetargetLineDriftWarningFormat =
+            "Pause point {0} now targets a different statement (was: \"{1}\", now: \"{2}\"). "
+            + "Re-enable it at the intended line if this is not what you want.";
+
+        // Format: comma-separated expired marker ids.
+        public const string ExpiredPausePointsNotRetargetedMessageFormat =
+            "Expired pause points were not re-targeted and will not fire: {0}";
+
+        // Format: id, resolved line number, resolved line text.
+        public const string RetargetedPausePointIdDetailFormat =
+            "{0} (now line {1}: {2})";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -43,7 +43,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> warnings = new List<string>();
             List<string> suppressedPausePointIds = new List<string>();
             List<string> retargetedPausePointIds = new List<string>();
-            List<string> expiredPausePointIds = new List<string>();
             List<string> inlineRiskMethodLabels = new List<string>();
             int patchedTotal = 0;
             int unchangedTotal = 0;
@@ -70,7 +69,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 warnings.AddRange(fileResult.Warnings);
                 AppendDistinct(suppressedPausePointIds, fileResult.SuppressedPausePointIds);
                 AppendDistinct(retargetedPausePointIds, fileResult.RetargetedPausePointIds);
-                AppendDistinct(expiredPausePointIds, fileResult.ExpiredPausePointIds);
                 AppendDistinct(inlineRiskMethodLabels, fileResult.InlineRiskMethodLabels);
                 patchedTotal += fileResult.PatchedCount;
                 unchangedTotal += fileResult.UnchangedMethodCount;
@@ -93,8 +91,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadPatcher.ActivePatchCount,
                 suppressedPausePointIds,
                 unchangedTotal,
-                retargetedPausePointIds,
-                expiredPausePointIds);
+                retargetedPausePointIds);
         }
 
         private static async Task<HotReloadFileProcessResult> ProcessFileAsync(
@@ -106,7 +103,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> warnings = new List<string>();
             List<string> suppressedPausePointIds = new List<string>();
             List<string> retargetedPausePointIds = new List<string>();
-            List<string> expiredPausePointIds = new List<string>();
 
             // CompilationPipeline / Application.dataPath require the Unity main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -310,8 +306,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         suppressedPausePointIds,
                         new List<string>(),
                         unchangedMethodCount,
-                        retargetedPausePointIds,
-                        expiredPausePointIds);
+                        retargetedPausePointIds);
                 }
 
                 entriesToPatch = isolation.RetryEntries;
@@ -343,8 +338,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     projectRelativePath,
                     inlineRiskMethodLabels,
                     suppressedPausePointIds,
-                    retargetedPausePointIds,
-                    expiredPausePointIds);
+                    retargetedPausePointIds);
                 outcomes.Add(outcome);
                 if (outcome.Kind == HotReloadMethodOutcomeKind.Patched)
                 {
@@ -359,8 +353,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 suppressedPausePointIds,
                 inlineRiskMethodLabels,
                 unchangedMethodCount,
-                retargetedPausePointIds,
-                expiredPausePointIds);
+                retargetedPausePointIds);
         }
 
         // Peels leftover Harmony patches when the source again matches the verified baseline.
@@ -406,8 +399,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string projectRelativePath,
             List<string> inlineRiskMethodLabels,
             List<string> suppressedPausePointIds,
-            List<string> retargetedPausePointIds,
-            List<string> expiredPausePointIds)
+            List<string> retargetedPausePointIds)
         {
             string methodLabel = entry.typeMetadataName + "." + entry.methodName;
 
@@ -485,8 +477,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             AppendPausePointTransitionIds(
                 matchResult.Method,
                 suppressedPausePointIds,
-                retargetedPausePointIds,
-                expiredPausePointIds);
+                retargetedPausePointIds);
 
             // Inline risk is flagged per method but reported as one aggregated warning so
             // Warnings stay readable when many tiny methods are patched together.
@@ -526,26 +517,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        // What: after Apply (+ retarget handler), splits markers into retargeted / suppressed /
-        // expired (expired are owned by the method but not armed, so they were not re-targeted).
+        // What: after Apply (+ retarget handler), splits armed markers into retargeted vs suppressed.
+        // Expired skips are recorded as a pending-drain event inside SourcePausePointPatcher and
+        // surfaced from HotReloadTools.BuildApplyResponse (same pattern as line-drift warnings).
         private static void AppendPausePointTransitionIds(
             MethodBase method,
             List<string> suppressedPausePointIds,
-            List<string> retargetedPausePointIds,
-            List<string> expiredPausePointIds)
+            List<string> retargetedPausePointIds)
         {
-            IReadOnlyList<string> expiredIds =
-                HotReloadPausePointCoordination.GetExpiredMarkerIdsOnMethod?.Invoke(method)
-                ?? Array.Empty<string>();
-            for (int expiredIndex = 0; expiredIndex < expiredIds.Count; expiredIndex++)
-            {
-                string expiredId = expiredIds[expiredIndex];
-                if (!expiredPausePointIds.Contains(expiredId))
-                {
-                    expiredPausePointIds.Add(expiredId);
-                }
-            }
-
             IReadOnlyList<string> armedIds =
                 HotReloadPausePointCoordination.GetArmedMarkerIdsOnMethod?.Invoke(method);
             if (armedIds == null || armedIds.Count == 0)
@@ -1106,7 +1085,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public int PatchedCount { get; }
             public List<string> SuppressedPausePointIds { get; }
             public List<string> RetargetedPausePointIds { get; }
-            public List<string> ExpiredPausePointIds { get; }
             public List<string> InlineRiskMethodLabels { get; }
             public int UnchangedMethodCount { get; }
 
@@ -1117,8 +1095,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 List<string> suppressedPausePointIds = null,
                 List<string> inlineRiskMethodLabels = null,
                 int unchangedMethodCount = 0,
-                List<string> retargetedPausePointIds = null,
-                List<string> expiredPausePointIds = null)
+                List<string> retargetedPausePointIds = null)
             {
                 Outcomes = outcomes;
                 Warnings = warnings;
@@ -1127,7 +1104,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 InlineRiskMethodLabels = inlineRiskMethodLabels ?? new List<string>();
                 UnchangedMethodCount = unchangedMethodCount;
                 RetargetedPausePointIds = retargetedPausePointIds ?? new List<string>();
-                ExpiredPausePointIds = expiredPausePointIds ?? new List<string>();
             }
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -43,6 +43,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> warnings = new List<string>();
             List<string> suppressedPausePointIds = new List<string>();
             List<string> retargetedPausePointIds = new List<string>();
+            List<string> expiredPausePointIds = new List<string>();
             List<string> inlineRiskMethodLabels = new List<string>();
             int patchedTotal = 0;
             int unchangedTotal = 0;
@@ -69,6 +70,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 warnings.AddRange(fileResult.Warnings);
                 AppendDistinct(suppressedPausePointIds, fileResult.SuppressedPausePointIds);
                 AppendDistinct(retargetedPausePointIds, fileResult.RetargetedPausePointIds);
+                AppendDistinct(expiredPausePointIds, fileResult.ExpiredPausePointIds);
                 AppendDistinct(inlineRiskMethodLabels, fileResult.InlineRiskMethodLabels);
                 patchedTotal += fileResult.PatchedCount;
                 unchangedTotal += fileResult.UnchangedMethodCount;
@@ -91,7 +93,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadPatcher.ActivePatchCount,
                 suppressedPausePointIds,
                 unchangedTotal,
-                retargetedPausePointIds);
+                retargetedPausePointIds,
+                expiredPausePointIds);
         }
 
         private static async Task<HotReloadFileProcessResult> ProcessFileAsync(
@@ -103,6 +106,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> warnings = new List<string>();
             List<string> suppressedPausePointIds = new List<string>();
             List<string> retargetedPausePointIds = new List<string>();
+            List<string> expiredPausePointIds = new List<string>();
 
             // CompilationPipeline / Application.dataPath require the Unity main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -306,7 +310,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         suppressedPausePointIds,
                         new List<string>(),
                         unchangedMethodCount,
-                        retargetedPausePointIds);
+                        retargetedPausePointIds,
+                        expiredPausePointIds);
                 }
 
                 entriesToPatch = isolation.RetryEntries;
@@ -338,7 +343,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     projectRelativePath,
                     inlineRiskMethodLabels,
                     suppressedPausePointIds,
-                    retargetedPausePointIds);
+                    retargetedPausePointIds,
+                    expiredPausePointIds);
                 outcomes.Add(outcome);
                 if (outcome.Kind == HotReloadMethodOutcomeKind.Patched)
                 {
@@ -353,7 +359,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 suppressedPausePointIds,
                 inlineRiskMethodLabels,
                 unchangedMethodCount,
-                retargetedPausePointIds);
+                retargetedPausePointIds,
+                expiredPausePointIds);
         }
 
         // Peels leftover Harmony patches when the source again matches the verified baseline.
@@ -399,7 +406,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string projectRelativePath,
             List<string> inlineRiskMethodLabels,
             List<string> suppressedPausePointIds,
-            List<string> retargetedPausePointIds)
+            List<string> retargetedPausePointIds,
+            List<string> expiredPausePointIds)
         {
             string methodLabel = entry.typeMetadataName + "." + entry.methodName;
 
@@ -477,7 +485,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             AppendPausePointTransitionIds(
                 matchResult.Method,
                 suppressedPausePointIds,
-                retargetedPausePointIds);
+                retargetedPausePointIds,
+                expiredPausePointIds);
 
             // Inline risk is flagged per method but reported as one aggregated warning so
             // Warnings stay readable when many tiny methods are patched together.
@@ -517,12 +526,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        // What: after Apply (+ retarget handler), splits armed markers into retargeted vs suppressed.
+        // What: after Apply (+ retarget handler), splits markers into retargeted / suppressed /
+        // expired (expired are owned by the method but not armed, so they were not re-targeted).
         private static void AppendPausePointTransitionIds(
             MethodBase method,
             List<string> suppressedPausePointIds,
-            List<string> retargetedPausePointIds)
+            List<string> retargetedPausePointIds,
+            List<string> expiredPausePointIds)
         {
+            IReadOnlyList<string> expiredIds =
+                HotReloadPausePointCoordination.GetExpiredMarkerIdsOnMethod?.Invoke(method)
+                ?? Array.Empty<string>();
+            for (int expiredIndex = 0; expiredIndex < expiredIds.Count; expiredIndex++)
+            {
+                string expiredId = expiredIds[expiredIndex];
+                if (!expiredPausePointIds.Contains(expiredId))
+                {
+                    expiredPausePointIds.Add(expiredId);
+                }
+            }
+
             IReadOnlyList<string> armedIds =
                 HotReloadPausePointCoordination.GetArmedMarkerIdsOnMethod?.Invoke(method);
             if (armedIds == null || armedIds.Count == 0)
@@ -1083,6 +1106,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public int PatchedCount { get; }
             public List<string> SuppressedPausePointIds { get; }
             public List<string> RetargetedPausePointIds { get; }
+            public List<string> ExpiredPausePointIds { get; }
             public List<string> InlineRiskMethodLabels { get; }
             public int UnchangedMethodCount { get; }
 
@@ -1093,7 +1117,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 List<string> suppressedPausePointIds = null,
                 List<string> inlineRiskMethodLabels = null,
                 int unchangedMethodCount = 0,
-                List<string> retargetedPausePointIds = null)
+                List<string> retargetedPausePointIds = null,
+                List<string> expiredPausePointIds = null)
             {
                 Outcomes = outcomes;
                 Warnings = warnings;
@@ -1102,6 +1127,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 InlineRiskMethodLabels = inlineRiskMethodLabels ?? new List<string>();
                 UnchangedMethodCount = unchangedMethodCount;
                 RetargetedPausePointIds = retargetedPausePointIds ?? new List<string>();
+                ExpiredPausePointIds = expiredPausePointIds ?? new List<string>();
             }
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
@@ -14,6 +14,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public int ActivePatchTotal { get; }
         public IReadOnlyList<string> SuppressedPausePointIds { get; }
         public IReadOnlyList<string> RetargetedPausePointIds { get; }
+        public IReadOnlyList<string> ExpiredPausePointIds { get; }
         public int UnchangedTotal { get; }
 
         public HotReloadOrchestratorResult(
@@ -23,7 +24,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int activePatchTotal,
             IReadOnlyList<string> suppressedPausePointIds = null,
             int unchangedTotal = 0,
-            IReadOnlyList<string> retargetedPausePointIds = null)
+            IReadOnlyList<string> retargetedPausePointIds = null,
+            IReadOnlyList<string> expiredPausePointIds = null)
         {
             Methods = methods;
             Warnings = warnings;
@@ -32,6 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             SuppressedPausePointIds = suppressedPausePointIds ?? Array.Empty<string>();
             UnchangedTotal = unchangedTotal;
             RetargetedPausePointIds = retargetedPausePointIds ?? Array.Empty<string>();
+            ExpiredPausePointIds = expiredPausePointIds ?? Array.Empty<string>();
         }
     }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
@@ -14,7 +14,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public int ActivePatchTotal { get; }
         public IReadOnlyList<string> SuppressedPausePointIds { get; }
         public IReadOnlyList<string> RetargetedPausePointIds { get; }
-        public IReadOnlyList<string> ExpiredPausePointIds { get; }
         public int UnchangedTotal { get; }
 
         public HotReloadOrchestratorResult(
@@ -24,8 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int activePatchTotal,
             IReadOnlyList<string> suppressedPausePointIds = null,
             int unchangedTotal = 0,
-            IReadOnlyList<string> retargetedPausePointIds = null,
-            IReadOnlyList<string> expiredPausePointIds = null)
+            IReadOnlyList<string> retargetedPausePointIds = null)
         {
             Methods = methods;
             Warnings = warnings;
@@ -34,7 +32,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             SuppressedPausePointIds = suppressedPausePointIds ?? Array.Empty<string>();
             UnchangedTotal = unchangedTotal;
             RetargetedPausePointIds = retargetedPausePointIds ?? Array.Empty<string>();
-            ExpiredPausePointIds = expiredPausePointIds ?? Array.Empty<string>();
         }
     }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -192,6 +192,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             List<string> warnings = new List<string>(result.Warnings);
             AppendRetargetLineDriftWarnings(warnings);
+            AppendExpiredNotRetargetedWarnings(warnings);
 
             if (result.RetargetedPausePointIds != null && result.RetargetedPausePointIds.Count > 0)
             {
@@ -213,14 +214,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 warnings.Add(
                     "Armed pause points could not be re-targeted and will not fire until the patch "
                     + $"is reverted or compiled for real: {ids}");
-            }
-
-            if (result.ExpiredPausePointIds != null && result.ExpiredPausePointIds.Count > 0)
-            {
-                warnings.Add(
-                    string.Format(
-                        HotReloadConstants.ExpiredPausePointsNotRetargetedMessageFormat,
-                        string.Join(", ", result.ExpiredPausePointIds)));
             }
 
             return new HotReloadResponse
@@ -255,6 +248,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         oldText,
                         newText));
             }
+        }
+
+        // What: drains expired-not-retargeted ids recorded during the latest patch transition.
+        private static void AppendExpiredNotRetargetedWarnings(List<string> warnings)
+        {
+            IReadOnlyList<string> expiredIds =
+                HotReloadPausePointCoordination.ConsumeExpiredNotRetargetedMarkerIds?.Invoke();
+            if (expiredIds == null || expiredIds.Count == 0)
+            {
+                return;
+            }
+
+            warnings.Add(
+                string.Format(
+                    HotReloadConstants.ExpiredPausePointsNotRetargetedMessageFormat,
+                    string.Join(", ", expiredIds)));
         }
 
         // What: "{id} (now line {N}: {text})" from the registry values written on retarget/enable.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 
 using UnityEngine;
 
+using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -190,12 +191,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             List<string> warnings = new List<string>(result.Warnings);
+            AppendRetargetLineDriftWarnings(warnings);
+
             if (result.RetargetedPausePointIds != null && result.RetargetedPausePointIds.Count > 0)
             {
-                string ids = string.Join(", ", result.RetargetedPausePointIds);
+                List<string> details = new List<string>(result.RetargetedPausePointIds.Count);
+                for (int index = 0; index < result.RetargetedPausePointIds.Count; index++)
+                {
+                    details.Add(FormatRetargetedPausePointIdDetail(result.RetargetedPausePointIds[index]));
+                }
+
                 warnings.Add(
-                    "Armed pause points were re-targeted onto the hot-reload patched bodies and keep "
-                    + $"firing at the edited lines: {ids}");
+                    string.Format(
+                        HotReloadConstants.RetargetedPausePointsMessageFormat,
+                        string.Join(", ", details)));
             }
 
             if (result.SuppressedPausePointIds != null && result.SuppressedPausePointIds.Count > 0)
@@ -204,6 +213,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 warnings.Add(
                     "Armed pause points could not be re-targeted and will not fire until the patch "
                     + $"is reverted or compiled for real: {ids}");
+            }
+
+            if (result.ExpiredPausePointIds != null && result.ExpiredPausePointIds.Count > 0)
+            {
+                warnings.Add(
+                    string.Format(
+                        HotReloadConstants.ExpiredPausePointsNotRetargetedMessageFormat,
+                        string.Join(", ", result.ExpiredPausePointIds)));
             }
 
             return new HotReloadResponse
@@ -216,6 +233,40 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 UnchangedTotal = result.UnchangedTotal,
                 Message = BuildApplyMessage(result, hasFailure)
             };
+        }
+
+        // What: drains retarget line-drift triples recorded by SourcePausePointPatcher into Warnings.
+        private static void AppendRetargetLineDriftWarnings(List<string> warnings)
+        {
+            IReadOnlyList<(string Id, string OldText, string NewText)> driftWarnings =
+                HotReloadPausePointCoordination.ConsumeRetargetLineDriftWarnings?.Invoke();
+            if (driftWarnings == null || driftWarnings.Count == 0)
+            {
+                return;
+            }
+
+            for (int index = 0; index < driftWarnings.Count; index++)
+            {
+                (string id, string oldText, string newText) = driftWarnings[index];
+                warnings.Add(
+                    string.Format(
+                        HotReloadConstants.RetargetLineDriftWarningFormat,
+                        id,
+                        oldText,
+                        newText));
+            }
+        }
+
+        // What: "{id} (now line {N}: {text})" from the registry values written on retarget/enable.
+        private static string FormatRetargetedPausePointIdDetail(string id)
+        {
+            UloopPausePointSnapshot status = UloopPausePointRegistry.GetStatus(id);
+            string lineText = status.ResolvedLineText ?? string.Empty;
+            return string.Format(
+                HotReloadConstants.RetargetedPausePointIdDetailFormat,
+                id,
+                status.ResolvedLine,
+                lineText);
         }
 
         private static string BuildApplyMessage(HotReloadOrchestratorResult result, bool hasFailure)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/UnityCLILoop.FirstPartyTools.HotReload.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/UnityCLILoop.FirstPartyTools.HotReload.Editor.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
     "references": [
         "GUID:afe86dd49995e46baa33e099a4d2ee1d",
-        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b",
+        "GUID:527f26a36b5043c2bd4d4036d04cd76d"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointLineTextReader.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointLineTextReader.cs
@@ -1,0 +1,25 @@
+using System.IO;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Reads the trimmed source text for a resolved pause-point line so enable and hot-reload
+    /// retarget paths share one helper.
+    /// </summary>
+    internal static class PausePointLineTextReader
+    {
+        public static string ReadResolvedLineText(string requestedFile, int resolvedLine)
+        {
+            if (string.IsNullOrEmpty(requestedFile) || resolvedLine <= 0)
+            {
+                return string.Empty;
+            }
+
+            string normalizedFile = SourcePausePointPathNormalizer.ToForwardSlashes(requestedFile);
+            string absoluteFilePath = Path.Combine(UnityCliLoopPathResolver.GetProjectRoot(), normalizedFile);
+            return SourcePausePointSourceLineReader.ReadLineText(absoluteFilePath, resolvedLine);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointLineTextReader.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointLineTextReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7cca9fb4efd7244ad9961d1de9468ce5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -129,7 +129,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 LateHitDiscardedAfterClear = snapshot.LateHitDiscardedAfterClear,
                 SuppressedByHotReload = snapshot.SuppressedByHotReload,
                 RetargetedToHotReloadPatch = snapshot.RetargetedToHotReloadPatch,
-                SuppressedByHotReloadReason = snapshot.SuppressedByHotReloadReason
+                SuppressedByHotReloadReason = snapshot.SuppressedByHotReloadReason,
+                ResolvedLine = snapshot.ResolvedLine,
+                ResolvedLineText = snapshot.ResolvedLineText ?? string.Empty
             };
         }
 
@@ -575,9 +577,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 snapshot = UloopPausePointRegistry.GetStatus(id);
             }
 
+            string resolvedLineText = PausePointLineTextReader.ReadResolvedLineText(parameters.File, resolvedLine);
+            UloopPausePointRegistry.SetResolvedLine(id, resolvedLine, resolvedLineText);
+
             PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
+            // Why re-read after SetResolvedLine: FromSnapshot above used the pre-write snapshot.
             response.ResolvedLine = resolvedLine;
-            response.ResolvedLineText = ReadResolvedLineText(parameters.File, resolvedLine);
+            response.ResolvedLineText = resolvedLineText;
             response.ResolvedMethod = resolvedMethod;
             response.SnapshotTiming = SourcePausePointConstants.PreLineSnapshotTimingNote;
             response.Warning = MergeWarnings(CreateEnableWarning(), patchResult.Warning);
@@ -640,16 +646,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     InstanceCount = instanceCount,
                     StatusBeforeClear = statusBeforeClear
                 });
-        }
-
-        // The resolved line can be rounded forward from the requested line (the Resolver picks
-        // the closest sequence point on or after it), so returning the actual source text lets
-        // the caller notice a mismatch immediately instead of assuming the requested line hit.
-        private static string ReadResolvedLineText(string requestedFile, int resolvedLine)
-        {
-            string normalizedFile = SourcePausePointPathNormalizer.ToForwardSlashes(requestedFile);
-            string absoluteFilePath = Path.Combine(UnityCliLoopPathResolver.GetProjectRoot(), normalizedFile);
-            return SourcePausePointSourceLineReader.ReadLineText(absoluteFilePath, resolvedLine);
         }
 
         // The derived id must use the originally requested file/line (not the resolved/rounded

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -39,6 +39,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static readonly Dictionary<string, (string NormalizedFile, int Line)> RequestById = new();
         private static readonly List<RetargetLineDriftWarning> PendingRetargetLineDriftWarnings =
             new List<RetargetLineDriftWarning>();
+        private static readonly List<string> PendingExpiredNotRetargetedIds = new List<string>();
 
         // The registry lives in a Runtime assembly this Editor-only tool assembly may depend on,
         // but not the reverse (patching is an outer/implementation concern the registry's inner
@@ -51,7 +52,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             UloopPausePointRegistry.OnClearedAll = UnpatchAll;
             HotReloadPausePointCoordination.GetArmedMarkerIdsOnMethod = GetArmedMarkerIds;
             HotReloadPausePointCoordination.GetSuppressedMarkerIdsOnMethod = GetSuppressedMarkerIds;
-            HotReloadPausePointCoordination.GetExpiredMarkerIdsOnMethod = GetExpiredMarkerIds;
+            HotReloadPausePointCoordination.ConsumeExpiredNotRetargetedMarkerIds =
+                ConsumeExpiredNotRetargetedMarkerIds;
             HotReloadPausePointCoordination.OnHotReloadPatchStateChanged = HandleHotReloadPatchStateChanged;
             HotReloadPausePointCoordination.ConsumeRetargetLineDriftWarnings = ConsumeRetargetLineDriftWarnings;
         }
@@ -75,6 +77,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             PendingRetargetLineDriftWarnings.Clear();
+            return copy;
+        }
+
+        /// <summary>
+        /// Drains expired-marker ids recorded during the latest hot-reload patch transition
+        /// (skipped for retarget because they were not armed).
+        /// </summary>
+        private static IReadOnlyList<string> ConsumeExpiredNotRetargetedMarkerIds()
+        {
+            if (PendingExpiredNotRetargetedIds.Count == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            List<string> copy = new List<string>(PendingExpiredNotRetargetedIds);
+            PendingExpiredNotRetargetedIds.Clear();
             return copy;
         }
 
@@ -130,39 +148,57 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return ids;
         }
 
-        // What: expired markers still owned by the method (not armed, so not re-targeted).
-        private static IReadOnlyList<string> GetExpiredMarkerIds(MethodBase method)
+        // What: re-targets or restores armed markers when a logical owner's hot-reload patch
+        // state changes. Succeeds before mutating registry flags; never clears the marker.
+        private static void HandleHotReloadPatchStateChanged(MethodBase method, bool isPatched)
         {
-            List<string> ids = new List<string>();
+            if (isPatched)
+            {
+                // Why before Collect: expired markers are not armed, so they never enter the
+                // retarget list — record them as a transition event (pending-drain) instead of
+                // scanning residual Expired ledger state on every later apply.
+                EnqueueExpiredNotRetargetedForLogicalOwner(method);
+                List<string> markerIds = CollectMarkerIdsForLogicalOwner(method);
+                RetargetMarkersOntoHotReloadPatch(markerIds, method);
+                return;
+            }
+
+            List<string> restoreIds = CollectMarkerIdsForLogicalOwner(method);
+            RestoreMarkersAfterHotReloadRevert(restoreIds, method);
+        }
+
+        // What: records expired owned markers skipped by this patch transition, then detaches
+        // them from the retarget owner ledger so later hot-reloads do not re-warn forever.
+        // Why keep MethodById/injections: Clear → Unpatch still needs to remove Harmony patches.
+        private static void EnqueueExpiredNotRetargetedForLogicalOwner(MethodBase method)
+        {
+            List<string> expiredIds = new List<string>();
             foreach (KeyValuePair<string, MethodBase> pair in LogicalOwnerById)
             {
-                if (!pair.Value.Equals(method))
+                if (!pair.Value.Equals(method) || UloopPausePointRegistry.IsArmed(pair.Key))
                 {
                     continue;
                 }
 
                 UloopPausePointSnapshot status = UloopPausePointRegistry.GetStatus(pair.Key);
-                if (status.Expired || status.Status == UloopPausePointStatus.Expired)
+                if (!status.Expired && status.Status != UloopPausePointStatus.Expired)
                 {
-                    ids.Add(pair.Key);
+                    continue;
+                }
+
+                expiredIds.Add(pair.Key);
+            }
+
+            for (int index = 0; index < expiredIds.Count; index++)
+            {
+                string id = expiredIds[index];
+                LogicalOwnerById.Remove(id);
+                RequestById.Remove(id);
+                if (!PendingExpiredNotRetargetedIds.Contains(id))
+                {
+                    PendingExpiredNotRetargetedIds.Add(id);
                 }
             }
-
-            return ids;
-        }
-
-        // What: re-targets or restores armed markers when a logical owner's hot-reload patch
-        // state changes. Succeeds before mutating registry flags; never clears the marker.
-        private static void HandleHotReloadPatchStateChanged(MethodBase method, bool isPatched)
-        {
-            List<string> markerIds = CollectMarkerIdsForLogicalOwner(method);
-            if (isPatched)
-            {
-                RetargetMarkersOntoHotReloadPatch(markerIds, method);
-                return;
-            }
-
-            RestoreMarkersAfterHotReloadRevert(markerIds, method);
         }
 
         private static List<string> CollectMarkerIdsForLogicalOwner(MethodBase method)
@@ -671,6 +707,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             MethodById.Clear();
             LogicalOwnerById.Clear();
             RequestById.Clear();
+            PendingExpiredNotRetargetedIds.Clear();
+            PendingRetargetLineDriftWarnings.Clear();
         }
 
         private static SourcePausePointPatchResult TryResolveMethod(SourcePausePointResolution resolution, out MethodBase method)

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -37,6 +37,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Why store file:line separately: auto-retarget must re-resolve with the original enable
         // request, and parsing the id string would couple us to id formatting.
         private static readonly Dictionary<string, (string NormalizedFile, int Line)> RequestById = new();
+        private static readonly List<RetargetLineDriftWarning> PendingRetargetLineDriftWarnings =
+            new List<RetargetLineDriftWarning>();
 
         // The registry lives in a Runtime assembly this Editor-only tool assembly may depend on,
         // but not the reverse (patching is an outer/implementation concern the registry's inner
@@ -49,7 +51,45 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             UloopPausePointRegistry.OnClearedAll = UnpatchAll;
             HotReloadPausePointCoordination.GetArmedMarkerIdsOnMethod = GetArmedMarkerIds;
             HotReloadPausePointCoordination.GetSuppressedMarkerIdsOnMethod = GetSuppressedMarkerIds;
+            HotReloadPausePointCoordination.GetExpiredMarkerIdsOnMethod = GetExpiredMarkerIds;
             HotReloadPausePointCoordination.OnHotReloadPatchStateChanged = HandleHotReloadPatchStateChanged;
+            HotReloadPausePointCoordination.ConsumeRetargetLineDriftWarnings = ConsumeRetargetLineDriftWarnings;
+        }
+
+        /// <summary>
+        /// Drains retarget line-drift warnings recorded during the latest hot-reload patch apply.
+        /// </summary>
+        private static IReadOnlyList<(string Id, string OldText, string NewText)> ConsumeRetargetLineDriftWarnings()
+        {
+            if (PendingRetargetLineDriftWarnings.Count == 0)
+            {
+                return Array.Empty<(string, string, string)>();
+            }
+
+            List<(string Id, string OldText, string NewText)> copy =
+                new List<(string, string, string)>(PendingRetargetLineDriftWarnings.Count);
+            for (int index = 0; index < PendingRetargetLineDriftWarnings.Count; index++)
+            {
+                RetargetLineDriftWarning warning = PendingRetargetLineDriftWarnings[index];
+                copy.Add((warning.Id, warning.OldText, warning.NewText));
+            }
+
+            PendingRetargetLineDriftWarnings.Clear();
+            return copy;
+        }
+
+        private readonly struct RetargetLineDriftWarning
+        {
+            public RetargetLineDriftWarning(string id, string oldText, string newText)
+            {
+                Id = id;
+                OldText = oldText;
+                NewText = newText;
+            }
+
+            public string Id { get; }
+            public string OldText { get; }
+            public string NewText { get; }
         }
 
         // What: lets the hot-reload tool list marker ids by logical owner (user method),
@@ -82,6 +122,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 if (UloopPausePointRegistry.GetStatus(pair.Key).SuppressedByHotReload)
+                {
+                    ids.Add(pair.Key);
+                }
+            }
+
+            return ids;
+        }
+
+        // What: expired markers still owned by the method (not armed, so not re-targeted).
+        private static IReadOnlyList<string> GetExpiredMarkerIds(MethodBase method)
+        {
+            List<string> ids = new List<string>();
+            foreach (KeyValuePair<string, MethodBase> pair in LogicalOwnerById)
+            {
+                if (!pair.Value.Equals(method))
+                {
+                    continue;
+                }
+
+                UloopPausePointSnapshot status = UloopPausePointRegistry.GetStatus(pair.Key);
+                if (status.Expired || status.Status == UloopPausePointStatus.Expired)
                 {
                     ids.Add(pair.Key);
                 }
@@ -164,6 +225,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     committed = patchResult.Success;
                     if (committed)
                     {
+                        string previousLineText = UloopPausePointRegistry.GetStatus(id).ResolvedLineText;
+                        string newLineText = PausePointLineTextReader.ReadResolvedLineText(
+                            request.NormalizedFile,
+                            shimResolution.ResolvedLine);
+                        UloopPausePointRegistry.SetResolvedLine(
+                            id,
+                            shimResolution.ResolvedLine,
+                            newLineText);
+                        if (!string.IsNullOrEmpty(previousLineText)
+                            && !string.Equals(previousLineText, newLineText, StringComparison.Ordinal))
+                        {
+                            PendingRetargetLineDriftWarnings.Add(
+                                new RetargetLineDriftWarning(id, previousLineText, newLineText));
+                        }
+
                         UloopPausePointRegistry.SetSuppressedByHotReload(id, false, null);
                         UloopPausePointRegistry.SetRetargetedToHotReloadPatch(id, true);
                     }
@@ -186,6 +262,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 string id = markerIds[index];
                 if (!RequestById.TryGetValue(id, out (string NormalizedFile, int Line) request))
                 {
+                    UloopPausePointRegistry.SetResolvedLine(id, 0, null);
                     SuppressMarkerRestoreFailed(id);
                     continue;
                 }
@@ -194,6 +271,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     SourcePausePointResolver.Resolve(request.NormalizedFile, request.Line);
                 if (!resolveResult.Success)
                 {
+                    UloopPausePointRegistry.SetResolvedLine(id, 0, null);
                     SuppressMarkerRestoreFailed(id);
                     continue;
                 }
@@ -204,6 +282,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     || restoredMethod == null
                     || !IsSameLogicalMethodOrItsStateMachine(restoredMethod, logicalOwner))
                 {
+                    UloopPausePointRegistry.SetResolvedLine(id, 0, null);
                     SuppressMarkerRestoreFailed(id);
                     continue;
                 }
@@ -223,6 +302,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     committed = patchResult.Success;
                     if (committed)
                     {
+                        // Why update after restore: status must show the line that will fire next.
+                        string restoredLineText = PausePointLineTextReader.ReadResolvedLineText(
+                            request.NormalizedFile,
+                            resolveResult.Resolution.ResolvedLine);
+                        UloopPausePointRegistry.SetResolvedLine(
+                            id,
+                            resolveResult.Resolution.ResolvedLine,
+                            restoredLineText);
                         UloopPausePointRegistry.SetSuppressedByHotReload(id, false, null);
                         UloopPausePointRegistry.SetRetargetedToHotReloadPatch(id, false);
                     }
@@ -231,6 +318,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     if (!committed)
                     {
+                        // Why clear: restore failed, so previously stored shim line is no longer trustworthy.
+                        UloopPausePointRegistry.SetResolvedLine(id, 0, null);
                         ReanchorMarkerWithoutInjection(id, logicalOwner, request);
                         SuppressMarkerRestoreFailed(id);
                     }

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -146,6 +146,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         // Null when unset so the status contract omits Warning (matches Go omitempty).
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Warning { get; set; }
+        // Why DefaultValue/Null ignore: match Go omitempty so unresolved markers omit the fields
+        // from the status contract shape (0 / empty must not appear in the shared JSON fixture).
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int ResolvedLine { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string ResolvedLineText { get; set; }
 
         internal static PausePointStatusResponse FromSnapshot(UloopPausePointSnapshot snapshot)
         {
@@ -194,7 +201,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 RetargetedToHotReloadPatch = snapshot.RetargetedToHotReloadPatch,
                 SuppressedByHotReloadReason = snapshot.SuppressedByHotReloadReason,
                 // Why reason as Warning: agents already read Warning; suppressed=false clears both.
-                Warning = snapshot.SuppressedByHotReload ? snapshot.SuppressedByHotReloadReason : null
+                Warning = snapshot.SuppressedByHotReload ? snapshot.SuppressedByHotReloadReason : null,
+                ResolvedLine = snapshot.ResolvedLine,
+                ResolvedLineText = string.IsNullOrEmpty(snapshot.ResolvedLineText)
+                    ? null
+                    : snapshot.ResolvedLineText
             };
         }
     }

--- a/Packages/src/Editor/Infrastructure/AssemblyInfo.cs
+++ b/Packages/src/Editor/Infrastructure/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]
+[assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.HotReload")]
 [assembly: InternalsVisibleTo("UnityCLILoop.CompositionRoot.Editor")]

--- a/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
+++ b/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
@@ -48,9 +48,10 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         // method and whose registry entry is currently SuppressedByHotReload.
         public static Func<MethodBase, IReadOnlyList<string>> GetSuppressedMarkerIdsOnMethod { get; set; }
 
-        // Set by SourcePausePointPatcher. Returns marker ids whose logical owner is the
-        // method and whose registry entry is already Expired (not re-targeted).
-        public static Func<MethodBase, IReadOnlyList<string>> GetExpiredMarkerIdsOnMethod { get; set; }
+        // Set by SourcePausePointPatcher. Drains marker ids recorded during the latest
+        // hot-reload patch transition that were skipped for retarget because they were
+        // already Expired (not a scan of residual expired ledger state).
+        public static Func<IReadOnlyList<string>> ConsumeExpiredNotRetargetedMarkerIds { get; set; }
 
         // Set by SourcePausePointPatcher. Drains (id, oldText, newText) triples recorded when
         // retarget changed the resolved line text of an armed marker.

--- a/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
+++ b/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
@@ -48,6 +48,15 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         // method and whose registry entry is currently SuppressedByHotReload.
         public static Func<MethodBase, IReadOnlyList<string>> GetSuppressedMarkerIdsOnMethod { get; set; }
 
+        // Set by SourcePausePointPatcher. Returns marker ids whose logical owner is the
+        // method and whose registry entry is already Expired (not re-targeted).
+        public static Func<MethodBase, IReadOnlyList<string>> GetExpiredMarkerIdsOnMethod { get; set; }
+
+        // Set by SourcePausePointPatcher. Drains (id, oldText, newText) triples recorded when
+        // retarget changed the resolved line text of an armed marker.
+        public static Func<IReadOnlyList<(string Id, string OldText, string NewText)>>
+            ConsumeRetargetLineDriftWarnings { get; set; }
+
         // Set by SourcePausePointPatcher. Invoked by HotReloadPatcher after a
         // method's patch state changes (true = patched, false = reverted).
         public static Action<MethodBase, bool> OnHotReloadPatchStateChanged { get; set; }

--- a/Packages/src/Runtime/PausePoints/AssemblyInfo.cs
+++ b/Packages/src/Runtime/PausePoints/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.PausePoint.Editor")]
+// HotReloadTools formats retarget warnings from registry ResolvedLine / ResolvedLineText.
+[assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.HotReload.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.RunTests.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateKeyboard.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateMouseInput.Editor")]

--- a/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
@@ -64,6 +64,9 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public bool SuppressedByHotReload { get; set; }
         public string SuppressedByHotReloadReason { get; set; }
         public bool RetargetedToHotReloadPatch { get; set; }
+        // 0 / null-or-empty means unresolved (not yet written by enable or retarget).
+        public int ResolvedLine { get; set; }
+        public string ResolvedLineText { get; set; }
 
         public bool ExpireIfNeeded(DateTime nowUtc)
         {
@@ -273,7 +276,9 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 LateHitDiscardedAfterClear,
                 SuppressedByHotReload,
                 SuppressedByHotReloadReason,
-                RetargetedToHotReloadPatch);
+                RetargetedToHotReloadPatch,
+                ResolvedLine,
+                ResolvedLineText);
         }
 
         private long CalculateRemainingMilliseconds(DateTime nowUtc)

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -224,6 +224,21 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
 
         /// <summary>
+        /// Stores the currently resolved source line for status / hot-reload retarget visibility.
+        /// Pass 0 / null to clear (unresolved). No-op when the id is unknown.
+        /// </summary>
+        public static void SetResolvedLine(string id, int resolvedLine, string resolvedLineText)
+        {
+            if (!Entries.TryGetValue(id, out UloopPausePointEntry entry))
+            {
+                return;
+            }
+
+            entry.ResolvedLine = resolvedLine;
+            entry.ResolvedLineText = resolvedLineText;
+        }
+
+        /// <summary>
         /// Extends a marker's capture window to at least minimumRemainingSeconds from now, so a
         /// slow multi-step CLI round trip (enable -&gt; seed state -&gt; await) does not let the marker
         /// expire before await-pause-point even starts observing it. Called once when the wait

--- a/Packages/src/Runtime/PausePoints/UloopPausePointSnapshot.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointSnapshot.cs
@@ -44,7 +44,9 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             bool lateHitDiscardedAfterClear,
             bool suppressedByHotReload,
             string suppressedByHotReloadReason,
-            bool retargetedToHotReloadPatch)
+            bool retargetedToHotReloadPatch,
+            int resolvedLine,
+            string resolvedLineText)
         {
             Debug.Assert(editorState != null, "editorState must not be null");
 
@@ -81,6 +83,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             SuppressedByHotReload = suppressedByHotReload;
             SuppressedByHotReloadReason = suppressedByHotReloadReason;
             RetargetedToHotReloadPatch = retargetedToHotReloadPatch;
+            ResolvedLine = resolvedLine;
+            ResolvedLineText = resolvedLineText;
         }
 
         public string Id { get; }
@@ -116,6 +120,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public bool SuppressedByHotReload { get; }
         public string SuppressedByHotReloadReason { get; }
         public bool RetargetedToHotReloadPatch { get; }
+        public int ResolvedLine { get; }
+        public string ResolvedLineText { get; }
 
         public static UloopPausePointSnapshot NotEnabled(string id, IUloopPausePointPauseController pauseController)
         {
@@ -156,7 +162,9 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 false,
                 false,
                 null,
-                false);
+                false,
+                0,
+                null);
         }
     }
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_enable.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable.go
@@ -400,9 +400,16 @@ func runPausePointWaitAfterEnable(
 
 		response.TriggerResult = triggerResult
 		response.ResumePlayResult = resumeResult
-		// Status polls never carry these fields today; always prefer the enable-time values.
-		response.ResolvedLine = enableFields.ResolvedLine
-		response.ResolvedLineText = enableFields.ResolvedLineText
+		// Why prefer status when non-zero/non-empty: hot-reload retarget updates ResolvedLine
+		// / ResolvedLineText on the registry, so a later status poll carries the live target.
+		// Fall back to enable-time values when status still omits them (pre-retarget path).
+		if response.ResolvedLine == 0 {
+			response.ResolvedLine = enableFields.ResolvedLine
+		}
+		if response.ResolvedLineText == "" {
+			response.ResolvedLineText = enableFields.ResolvedLineText
+		}
+		// ResolvedMethod / SnapshotTiming are still enable-only on the status DTO today.
 		response.ResolvedMethod = enableFields.ResolvedMethod
 		response.SnapshotTiming = enableFields.SnapshotTiming
 		response = filterPausePointCapturedVariableHistory(response)

--- a/cli/project-runner/internal/projectrunner/pause_point_enable.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable.go
@@ -400,13 +400,12 @@ func runPausePointWaitAfterEnable(
 
 		response.TriggerResult = triggerResult
 		response.ResumePlayResult = resumeResult
-		// Why prefer status when non-zero/non-empty: hot-reload retarget updates ResolvedLine
-		// / ResolvedLineText on the registry, so a later status poll carries the live target.
-		// Fall back to enable-time values when status still omits them (pre-retarget path).
+		// Why treat ResolvedLine/Text as a pair: Unity SetResolvedLine always writes or clears
+		// both together. Falling back field-by-field can synthesize a line number from status
+		// with enable-time text (or the reverse) when ReadLineText returns empty.
+		// Prefer the status pair when ResolvedLine is non-zero; otherwise keep enable-time.
 		if response.ResolvedLine == 0 {
 			response.ResolvedLine = enableFields.ResolvedLine
-		}
-		if response.ResolvedLineText == "" {
 			response.ResolvedLineText = enableFields.ResolvedLineText
 		}
 		// ResolvedMethod / SnapshotTiming are still enable-only on the status DTO today.

--- a/cli/project-runner/internal/projectrunner/pause_point_enable_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable_test.go
@@ -297,6 +297,96 @@ func TestRunEnablePausePointCommandAwaitPropagatesFileLineResolvedFields(t *test
 	}
 }
 
+// Verifies --await prefers status ResolvedLine / ResolvedLineText when a later status poll
+// carries retarget-updated values that differ from the enable-time fields.
+func TestRunEnablePausePointCommandAwaitPrefersStatusResolvedFieldsOverEnable(t *testing.T) {
+	originalQuery := queryPausePointStatus
+	originalPoll := pausePointStatusPoll
+	originalFetch := fetchMatchingLogs
+	pausePointStatusPoll = time.Millisecond
+	t.Cleanup(func() {
+		queryPausePointStatus = originalQuery
+		pausePointStatusPoll = originalPoll
+		fetchMatchingLogs = originalFetch
+	})
+
+	statusResponses := []pausePointStatusResponse{
+		{Id: "Assets/Foo.cs:42", Status: pausePointStatusEnabled, IsEnabled: true},
+		{
+			Id:               "Assets/Foo.cs:42",
+			Status:           pausePointStatusHit,
+			IsHit:            true,
+			HitCount:         1,
+			ResolvedLine:     55,
+			ResolvedLineText: "    DoJumpRetargeted();",
+		},
+	}
+	statusCallCount := 0
+	queryPausePointStatus = func(ctx context.Context, connection unityipc.Connection, id string) (pausePointStatusResponse, error) {
+		response := statusResponses[statusCallCount]
+		statusCallCount++
+		return response, nil
+	}
+	fetchMatchingLogs = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		searchText string,
+		maxCount int,
+	) (pausePointMatchingLogsResult, error) {
+		return pausePointMatchingLogsResult{SearchText: searchText, Logs: []pausePointMatchingLog{}}, nil
+	}
+
+	listener := newLoopbackIpcListener(t)
+	enableRequests := make(chan map[string]any, 1)
+	serverErr := make(chan error, 1)
+	go serveSingleIPCResponse(
+		listener,
+		pausePointEnableCommandName,
+		enableRequests,
+		serverErr,
+		`{"Success":true,"Id":"Assets/Foo.cs:42","Status":"Enabled","IsEnabled":true,"TimeoutSeconds":30,"ResolvedLine":42,"ResolvedLineText":"    DoJump();","ResolvedMethod":"Player.Update","SnapshotTiming":"OnEnter"}`,
+	)
+
+	connection := unityipc.Connection{
+		Endpoint: unityipc.Endpoint{
+			Network: listener.Addr().Network(),
+			Address: listener.Addr().String(),
+		},
+		ProjectRoot: t.TempDir(),
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runEnablePausePointCommand(
+		context.Background(),
+		connection,
+		[]string{"--file", "Assets/Foo.cs", "--line", "42", "--await"},
+		t.TempDir(),
+		&stdout,
+		&stderr)
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d with stderr %s", code, stderr.String())
+	}
+
+	var response pausePointWaitResult
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode stdout: %v\n%s", err, stdout.String())
+	}
+	if response.ResolvedLine != 55 {
+		t.Fatalf("ResolvedLine should prefer status: %#v", response)
+	}
+	if response.ResolvedLineText != "    DoJumpRetargeted();" {
+		t.Fatalf("ResolvedLineText should prefer status: %#v", response)
+	}
+	if response.ResolvedMethod != "Player.Update" {
+		t.Fatalf("ResolvedMethod mismatch: %#v", response)
+	}
+	if response.SnapshotTiming != "OnEnter" {
+		t.Fatalf("SnapshotTiming mismatch: %#v", response)
+	}
+}
+
 // Verifies method-name enable --await omits ResolvedLine / ResolvedLineText / ResolvedMethod /
 // SnapshotTiming when the enable response did not set them.
 func TestRunEnablePausePointCommandAwaitOmitsResolvedFieldsForMethodArm(t *testing.T) {

--- a/cli/project-runner/internal/projectrunner/pause_point_enable_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable_test.go
@@ -387,6 +387,90 @@ func TestRunEnablePausePointCommandAwaitPrefersStatusResolvedFieldsOverEnable(t 
 	}
 }
 
+// Verifies --await merges ResolvedLine/Text as a pair: a non-zero status line keeps status
+// text even when empty, instead of filling enable-time text onto a status line number.
+func TestRunEnablePausePointCommandAwaitKeepsStatusResolvedPairWhenTextEmpty(t *testing.T) {
+	originalQuery := queryPausePointStatus
+	originalPoll := pausePointStatusPoll
+	originalFetch := fetchMatchingLogs
+	pausePointStatusPoll = time.Millisecond
+	t.Cleanup(func() {
+		queryPausePointStatus = originalQuery
+		pausePointStatusPoll = originalPoll
+		fetchMatchingLogs = originalFetch
+	})
+
+	statusResponses := []pausePointStatusResponse{
+		{Id: "Assets/Foo.cs:42", Status: pausePointStatusEnabled, IsEnabled: true},
+		{
+			Id:               "Assets/Foo.cs:42",
+			Status:           pausePointStatusHit,
+			IsHit:            true,
+			HitCount:         1,
+			ResolvedLine:     55,
+			ResolvedLineText: "",
+		},
+	}
+	statusCallCount := 0
+	queryPausePointStatus = func(ctx context.Context, connection unityipc.Connection, id string) (pausePointStatusResponse, error) {
+		response := statusResponses[statusCallCount]
+		statusCallCount++
+		return response, nil
+	}
+	fetchMatchingLogs = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		searchText string,
+		maxCount int,
+	) (pausePointMatchingLogsResult, error) {
+		return pausePointMatchingLogsResult{SearchText: searchText, Logs: []pausePointMatchingLog{}}, nil
+	}
+
+	listener := newLoopbackIpcListener(t)
+	enableRequests := make(chan map[string]any, 1)
+	serverErr := make(chan error, 1)
+	go serveSingleIPCResponse(
+		listener,
+		pausePointEnableCommandName,
+		enableRequests,
+		serverErr,
+		`{"Success":true,"Id":"Assets/Foo.cs:42","Status":"Enabled","IsEnabled":true,"TimeoutSeconds":30,"ResolvedLine":42,"ResolvedLineText":"    DoJump();","ResolvedMethod":"Player.Update","SnapshotTiming":"OnEnter"}`,
+	)
+
+	connection := unityipc.Connection{
+		Endpoint: unityipc.Endpoint{
+			Network: listener.Addr().Network(),
+			Address: listener.Addr().String(),
+		},
+		ProjectRoot: t.TempDir(),
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runEnablePausePointCommand(
+		context.Background(),
+		connection,
+		[]string{"--file", "Assets/Foo.cs", "--line", "42", "--await"},
+		t.TempDir(),
+		&stdout,
+		&stderr)
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d with stderr %s", code, stderr.String())
+	}
+
+	var response pausePointWaitResult
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode stdout: %v\n%s", err, stdout.String())
+	}
+	if response.ResolvedLine != 55 {
+		t.Fatalf("ResolvedLine should keep status pair: %#v", response)
+	}
+	if response.ResolvedLineText != "" {
+		t.Fatalf("ResolvedLineText must not fall back to enable text when status line is set: %#v", response)
+	}
+}
+
 // Verifies method-name enable --await omits ResolvedLine / ResolvedLineText / ResolvedMethod /
 // SnapshotTiming when the enable response did not set them.
 func TestRunEnablePausePointCommandAwaitOmitsResolvedFieldsForMethodArm(t *testing.T) {

--- a/cli/project-runner/internal/projectrunner/pause_point_types.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_types.go
@@ -42,11 +42,11 @@ type pausePointStatusResponse struct {
 	// on the wait payload, not as hit-time Warning.
 	Warning string `json:"Warning,omitempty"`
 
-	// ResolvedLine / ResolvedLineText may come from a status poll (retarget updates them on the
-	// registry) or, when status omits them, from the enable-pause-point response on the --await
-	// hit path. ResolvedMethod / SnapshotTiming are still enable-only today. Method-name arms
-	// leave them empty on the Unity side, so omitempty keeps the historical await schema
-	// unchanged for those cases.
+	// ResolvedLine / ResolvedLineText are merged as a pair on the --await hit path: when status
+	// carries a non-zero ResolvedLine (retarget-updated), both fields come from status; otherwise
+	// both fall back to the enable-pause-point response. ResolvedMethod / SnapshotTiming are still
+	// enable-only today. Method-name arms leave them empty on the Unity side, so omitempty keeps
+	// the historical await schema unchanged for those cases.
 	ResolvedLine     int    `json:"ResolvedLine,omitempty"`
 	ResolvedLineText string `json:"ResolvedLineText,omitempty"`
 	ResolvedMethod   string `json:"ResolvedMethod,omitempty"`

--- a/cli/project-runner/internal/projectrunner/pause_point_types.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_types.go
@@ -42,10 +42,11 @@ type pausePointStatusResponse struct {
 	// on the wait payload, not as hit-time Warning.
 	Warning string `json:"Warning,omitempty"`
 
-	// ResolvedLine / ResolvedLineText / ResolvedMethod / SnapshotTiming are copied from the
-	// enable-pause-point response on the --await hit path so a single await payload records
-	// both which source line was armed and what was captured. Method-name arms leave them empty
-	// on the Unity side, so omitempty keeps the historical await schema unchanged for those cases.
+	// ResolvedLine / ResolvedLineText may come from a status poll (retarget updates them on the
+	// registry) or, when status omits them, from the enable-pause-point response on the --await
+	// hit path. ResolvedMethod / SnapshotTiming are still enable-only today. Method-name arms
+	// leave them empty on the Unity side, so omitempty keeps the historical await schema
+	// unchanged for those cases.
 	ResolvedLine     int    `json:"ResolvedLine,omitempty"`
 	ResolvedLineText string `json:"ResolvedLineText,omitempty"`
 	ResolvedMethod   string `json:"ResolvedMethod,omitempty"`


### PR DESCRIPTION
## Summary
- After hot-reload retargets a pause point, agents can see which source line it still targets (`ResolvedLine` / `ResolvedLineText` on status and apply warnings).
- Statement drift and expired markers are called out explicitly instead of silently keeping a misleading arm.

## User Impact
- **Before:** Retarget computed a new line but never stored it, so status could not show the live target and apply warnings only listed marker ids (plus the inaccurate "keep firing at the edited lines" wording).
- **After:** Enable and retarget/restore persist the resolved line text; status responses expose it; hot-reload apply warnings include `{id} (now line N: …)`, warn when the statement text changed, and note expired markers that were not retargeted. `enable --await` prefers status values when they carry a newer resolved line.

## Changes
- Registry snapshot/entry gain `ResolvedLine` / `ResolvedLineText`; enable and retarget/restore write them via a shared line-text helper.
- Hot-reload apply response formats retarget/expired/drift warnings from registry + coordination hooks.
- CLI `--await` merge prefers non-zero/non-empty status `ResolvedLine` / `ResolvedLineText` over enable-time fields.

## Verification
- `dist/darwin-arm64/uloop compile` → 0 errors
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "HotReloadPausePoint|HotReloadToolTests|PausePointStatusResponseContractTests"` → 36/36 Passed
- `scripts/check-go-cli.sh` → passed

## Notes
- Base is `feature/hot-reload` (repo CI workflows that only target `main` / `v3-beta` will not run on this PR). Local verification above is the gate for this change.
- Addresses FB S2-2 / S2-3 (retarget visibility and line-drift awareness).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

