### PR TITLE
feat: report hot-reload patch invocation counts and lifecycle notes

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -184,7 +184,7 @@ because its line no longer resolves in any live body.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`
 - `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough (or marked `[AggressiveInlining]`) to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `UnchangedTotal` (number): Methods left untouched because their bodies match the source baseline from the last compile; `0` when no baseline was available

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -184,7 +184,7 @@ because its line no longer resolves in any live body.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`
 - `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough (or marked `[AggressiveInlining]`) to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `UnchangedTotal` (number): Methods left untouched because their bodies match the source baseline from the last compile; `0` when no baseline was available

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -343,6 +343,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: worker-shaped FormatMethodKeyParts matches FormatMethodKey(MethodBase) so apply
+        /// Methods[].Method and --status Active rows use the same label (including '()' and
+        /// Cecil '/' → reflection '+' nested separators).
+        /// </summary>
+        [Test]
+        public void FormatMethodKeyParts_MatchesFormatMethodKey_IncludingNestedCecilSeparators()
+        {
+            MethodInfo original = AccessTools.Method(
+                typeof(HotReloadCoreFixture), nameof(HotReloadCoreFixture.ReplaceableCompute));
+            string fromMethod = HotReloadPatcher.FormatMethodKey(original);
+            string fromParts = HotReloadPatcher.FormatMethodKeyParts(
+                typeof(HotReloadCoreFixture).FullName,
+                nameof(HotReloadCoreFixture.ReplaceableCompute),
+                new[] { typeof(int).FullName },
+                genericArity: 0);
+
+            Assert.That(fromParts, Is.EqualTo(fromMethod));
+            Assert.That(fromParts, Does.EndWith("(System.Int32)"));
+
+            MethodInfo nested = AccessTools.Method(
+                typeof(HotReloadNestedKeyFixture.Inner),
+                nameof(HotReloadNestedKeyFixture.Inner.Ping));
+            string nestedFromMethod = HotReloadPatcher.FormatMethodKey(nested);
+            string cecilStyleTypeName = typeof(HotReloadNestedKeyFixture.Inner).FullName.Replace('+', '/');
+            string nestedFromParts = HotReloadPatcher.FormatMethodKeyParts(
+                cecilStyleTypeName,
+                nameof(HotReloadNestedKeyFixture.Inner.Ping),
+                System.Array.Empty<string>(),
+                genericArity: 0);
+
+            Assert.That(nestedFromParts, Is.EqualTo(nestedFromMethod));
+            Assert.That(nestedFromParts, Does.Contain("+Inner.Ping()"));
+            Assert.That(nestedFromParts, Does.Not.Contain("/Inner"));
+        }
+
+        /// <summary>
         /// What: Revert(method) clears that method's invocation count (RevertAll is not required).
         /// </summary>
         [Test]
@@ -391,6 +427,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public int Compute(string label)
         {
             return label == null ? 0 : label.Length;
+        }
+    }
+
+    /// <summary>
+    /// Nested type used only to assert Cecil '/' labels normalize to reflection '+'.
+    /// </summary>
+    public sealed class HotReloadNestedKeyFixture
+    {
+        public sealed class Inner
+        {
+            public int Ping()
+            {
+                return 1;
+            }
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -2,12 +2,16 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 using HarmonyLib;
 using NUnit.Framework;
 
+using Newtonsoft.Json.Linq;
+
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
@@ -235,6 +239,83 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             HotReloadCoreFixture fixture = new HotReloadCoreFixture();
             Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(-5), "Original body must survive.");
+        }
+
+        /// <summary>
+        /// What: each call into a transplanted body increments the invocation registry, --status
+        /// reports that count, and RevertAll clears it (removing the IL Increment would leave 0).
+        /// </summary>
+        [Test]
+        public async Task Apply_ThenInvoke_IncrementsStatusCount_AndRevertAllClears()
+        {
+            MethodInfo original = AccessTools.Method(
+                typeof(HotReloadCoreFixture), nameof(HotReloadCoreFixture.ReplaceableCompute));
+            MethodInfo shim = AccessTools.Method(
+                typeof(HotReloadHandwrittenShims), nameof(HotReloadHandwrittenShims.ReplaceableCompute__shim0));
+            string methodKey = HotReloadPatcher.FormatMethodKey(original);
+
+            Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(0L));
+            Assert.That(
+                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
+                Is.True);
+            Assert.That(
+                HotReloadInvocationRegistry.GetCount(methodKey),
+                Is.EqualTo(0L),
+                "Count must stay 0 until the patched body actually runs.");
+
+            HotReloadCoreFixture fixture = new HotReloadCoreFixture();
+            Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(47));
+            Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(47));
+            Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(2L));
+
+            HotReloadTool tool = new HotReloadTool();
+            UnityCliLoopToolResponse baseResponse = await tool.ExecuteAsync(
+                new JObject { ["Status"] = true },
+                CancellationToken.None);
+            HotReloadResponse status = baseResponse as HotReloadResponse;
+            Assert.That(status, Is.Not.Null);
+            Assert.That(status.Success, Is.True);
+            Assert.That(status.Methods.Count, Is.EqualTo(1));
+            Assert.That(status.Methods[0].Method, Is.EqualTo(methodKey));
+            Assert.That(status.Methods[0].InvocationCount, Is.EqualTo(2L));
+
+            HotReloadPatcher.RevertAll();
+            Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(0L));
+            Assert.That(HotReloadPatcher.DescribeActivePatches(), Is.Empty);
+        }
+
+        /// <summary>
+        /// What: re-applying a patch removes the previous invocation count so status does not
+        /// keep pre-reapply totals.
+        /// </summary>
+        [Test]
+        public void Apply_Twice_ResetsInvocationCount()
+        {
+            MethodInfo original = AccessTools.Method(
+                typeof(HotReloadCoreFixture), nameof(HotReloadCoreFixture.ReplaceableCompute));
+            MethodInfo shim0 = AccessTools.Method(
+                typeof(HotReloadHandwrittenShims), nameof(HotReloadHandwrittenShims.ReplaceableCompute__shim0));
+            MethodInfo shim1 = AccessTools.Method(
+                typeof(HotReloadHandwrittenShims), nameof(HotReloadHandwrittenShims.ReplaceableCompute__shim1));
+            string methodKey = HotReloadPatcher.FormatMethodKey(original);
+
+            HotReloadCoreFixture fixture = new HotReloadCoreFixture();
+            Assert.That(
+                HotReloadPatcher.Apply(original, shim0, HotReloadPatchShape.Transplant).Success,
+                Is.True);
+            Assert.That(fixture.ReplaceableCompute(1), Is.EqualTo(43));
+            Assert.That(fixture.ReplaceableCompute(1), Is.EqualTo(43));
+            Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(2L));
+
+            Assert.That(
+                HotReloadPatcher.Apply(original, shim1, HotReloadPatchShape.Transplant).Success,
+                Is.True);
+            Assert.That(
+                HotReloadInvocationRegistry.GetCount(methodKey),
+                Is.EqualTo(0L),
+                "Re-apply must drop the prior generation's count.");
+            Assert.That(fixture.ReplaceableCompute(1), Is.EqualTo(100));
+            Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(1L));
         }
     }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -317,6 +317,54 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(fixture.ReplaceableCompute(1), Is.EqualTo(100));
             Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(1L));
         }
+
+        /// <summary>
+        /// What: FormatMethodKey includes parameter FullNames so overloads do not share a counter
+        /// key (name-only keys would merge counts across Compute(int) and Compute(string)).
+        /// </summary>
+        [Test]
+        public void FormatMethodKey_DistinguishesOverloadsByParameterTypes()
+        {
+            MethodInfo intOverload = AccessTools.Method(
+                typeof(HotReloadOverloadKeyFixture),
+                nameof(HotReloadOverloadKeyFixture.Compute),
+                new[] { typeof(int) });
+            MethodInfo stringOverload = AccessTools.Method(
+                typeof(HotReloadOverloadKeyFixture),
+                nameof(HotReloadOverloadKeyFixture.Compute),
+                new[] { typeof(string) });
+
+            string intKey = HotReloadPatcher.FormatMethodKey(intOverload);
+            string stringKey = HotReloadPatcher.FormatMethodKey(stringOverload);
+
+            Assert.That(intKey, Is.Not.EqualTo(stringKey));
+            Assert.That(intKey, Does.Contain("System.Int32"));
+            Assert.That(stringKey, Does.Contain("System.String"));
+        }
+
+        /// <summary>
+        /// What: Revert(method) clears that method's invocation count (RevertAll is not required).
+        /// </summary>
+        [Test]
+        public void Revert_ClearsInvocationCountForThatMethod()
+        {
+            MethodInfo original = AccessTools.Method(
+                typeof(HotReloadCoreFixture), nameof(HotReloadCoreFixture.ReplaceableCompute));
+            MethodInfo shim = AccessTools.Method(
+                typeof(HotReloadHandwrittenShims), nameof(HotReloadHandwrittenShims.ReplaceableCompute__shim0));
+            string methodKey = HotReloadPatcher.FormatMethodKey(original);
+
+            HotReloadCoreFixture fixture = new HotReloadCoreFixture();
+            Assert.That(
+                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
+                Is.True);
+            Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(47));
+            Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(1L));
+
+            Assert.That(HotReloadPatcher.Revert(original), Is.True);
+            Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(0L));
+            Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(-5));
+        }
     }
 
     /// <summary>
@@ -327,6 +375,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public int Compute(int delta)
         {
             return delta;
+        }
+    }
+
+    /// <summary>
+    /// Overload pair used only to assert FormatMethodKey distinguishes parameter types.
+    /// </summary>
+    public sealed class HotReloadOverloadKeyFixture
+    {
+        public int Compute(int delta)
+        {
+            return delta;
+        }
+
+        public int Compute(string label)
+        {
+            return label == null ? 0 : label.Length;
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -319,8 +319,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: FormatMethodKey includes parameter FullNames so overloads do not share a counter
-        /// key (name-only keys would merge counts across Compute(int) and Compute(string)).
+        /// What: FormatMethodKey includes parameter type strings so overloads do not share a
+        /// counter key (name-only keys would merge counts across Compute(int) and Compute(string)).
         /// </summary>
         [Test]
         public void FormatMethodKey_DistinguishesOverloadsByParameterTypes()
@@ -343,6 +343,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: constructed generic parameters use Type.ToString (List`1[System.Int32]), not
+        /// assembly-qualified FullName (FullName would embed Version/PublicKeyToken).
+        /// </summary>
+        [Test]
+        public void FormatMethodKey_ConstructedGenericParameter_OmitsAssemblyQualification()
+        {
+            MethodInfo take = AccessTools.Method(
+                typeof(HotReloadGenericKeyFixture),
+                nameof(HotReloadGenericKeyFixture.Take));
+            string key = HotReloadPatcher.FormatMethodKey(take);
+
+            Assert.That(key, Does.Contain("System.Collections.Generic.List`1[System.Int32]"));
+            Assert.That(key, Does.Contain("System.Collections.Generic.Dictionary`2[System.String,System.Int32]"));
+            Assert.That(key, Does.Not.Contain("Version="));
+            Assert.That(key, Does.Not.Contain("PublicKeyToken="));
+            Assert.That(key, Does.Not.Contain("mscorlib"));
+            Assert.That(key, Does.Not.Contain("[["));
+        }
+
+        /// <summary>
         /// What: worker-shaped FormatMethodKeyParts matches FormatMethodKey(MethodBase) so apply
         /// Methods[].Method and --status Active rows use the same label (including '()' and
         /// Cecil '/' → reflection '+' nested separators).
@@ -356,7 +376,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string fromParts = HotReloadPatcher.FormatMethodKeyParts(
                 typeof(HotReloadCoreFixture).FullName,
                 nameof(HotReloadCoreFixture.ReplaceableCompute),
-                new[] { typeof(int).FullName },
+                new[] { typeof(int).ToString() },
                 genericArity: 0);
 
             Assert.That(fromParts, Is.EqualTo(fromMethod));
@@ -441,6 +461,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             {
                 return 1;
             }
+        }
+    }
+
+    /// <summary>
+    /// Constructed-generic parameters used only to assert FormatMethodKey omits assembly quals.
+    /// </summary>
+    public sealed class HotReloadGenericKeyFixture
+    {
+        public void Take(
+            System.Collections.Generic.List<int> values,
+            System.Collections.Generic.Dictionary<string, int> byName)
+        {
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -331,29 +331,39 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: BuildApplyResponse copies lifecycleNote onto Methods and appends it to Message.
+        /// What: BuildApplyResponse keeps LifecycleNote on Methods and aggregates a count into
+        /// Message instead of concatenating every note (two notes must not paste both paragraphs).
         /// </summary>
         [Test]
-        public void BuildApplyResponse_WithLifecycleNote_ExposesNoteOnMethodsAndMessage()
+        public void BuildApplyResponse_WithLifecycleNotes_ExposesPerMethodAndAggregatesMessage()
         {
-            const string note =
-                "BuildPlayer is only called from Awake (one-shot lifecycle methods); "
-                + "the patched body may not run again for objects that are already initialized.";
+            const string noteA =
+                "Awake is a one-shot lifecycle method; objects that already ran it will not run the "
+                + "patched body. It takes effect only for newly created objects.";
+            const string noteB =
+                "Start is a one-shot lifecycle method; objects that already ran it will not run the "
+                + "patched body. It takes effect only for newly created objects.";
             HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
                 new List<HotReloadMethodOutcome>
                 {
-                    HotReloadMethodOutcome.Patched("Type.BuildPlayer", "Assets/A.cs", note)
+                    HotReloadMethodOutcome.Patched("Type.Awake", "Assets/A.cs", noteA),
+                    HotReloadMethodOutcome.Patched("Type.Start", "Assets/A.cs", noteB)
                 },
                 new List<string>(),
-                patchedTotal: 1,
-                activePatchTotal: 1);
+                patchedTotal: 2,
+                activePatchTotal: 2);
 
             HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
 
-            Assert.That(response.Methods.Count, Is.EqualTo(1));
-            Assert.That(response.Methods[0].LifecycleNote, Is.EqualTo(note));
-            Assert.That(response.Methods[0].Kind, Is.EqualTo("Patched"));
-            Assert.That(response.Message, Does.Contain(note));
+            Assert.That(response.Methods.Count, Is.EqualTo(2));
+            Assert.That(response.Methods[0].LifecycleNote, Is.EqualTo(noteA));
+            Assert.That(response.Methods[1].LifecycleNote, Is.EqualTo(noteB));
+            Assert.That(
+                response.Message,
+                Does.Contain("2 patched method(s) have one-shot lifecycle notes"));
+            Assert.That(response.Message, Does.Contain("Methods[].LifecycleNote"));
+            Assert.That(response.Message, Does.Not.Contain(noteA));
+            Assert.That(response.Message, Does.Not.Contain(noteB));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -331,6 +331,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: BuildApplyResponse copies lifecycleNote onto Methods and appends it to Message.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_WithLifecycleNote_ExposesNoteOnMethodsAndMessage()
+        {
+            const string note =
+                "BuildPlayer is only called from Awake (one-shot lifecycle methods); "
+                + "the patched body may not run again for objects that are already initialized.";
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>
+                {
+                    HotReloadMethodOutcome.Patched("Type.BuildPlayer", "Assets/A.cs", note)
+                },
+                new List<string>(),
+                patchedTotal: 1,
+                activePatchTotal: 1);
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+            Assert.That(response.Methods.Count, Is.EqualTo(1));
+            Assert.That(response.Methods[0].LifecycleNote, Is.EqualTo(note));
+            Assert.That(response.Methods[0].Kind, Is.EqualTo("Patched"));
+            Assert.That(response.Message, Does.Contain(note));
+        }
+
+        /// <summary>
         /// What: a skipped-only run keeps the existing "See Methods for Skipped reasons." message.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -791,61 +791,82 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a method only called from Awake gets an indirect lifecycleNote; the same method
-        /// also called from Update does not (removing ComputeLifecycleNote would leave both null).
+        /// What: private void Start on MonoBehaviour gets a direct lifecycleNote; POCO Start and
+        /// public/parameterized Start on MonoBehaviour do not (name-only notes would flag all).
         /// </summary>
         [Test]
-        public async Task Run_WithAwakeOnlyCallee_EmitsIndirectLifecycleNote_UpdateCallerDoesNot()
+        public async Task Run_WithStartLifecycleGates_EmitsNoteOnlyForPrivateVoidMonoBehaviour()
         {
-            string awakeOnlySource =
+            string monoPrivateSource =
                 "using UnityEngine;\n"
-                + "public class HotReloadLifecycleAwakeOnlyFixture : MonoBehaviour\n"
+                + "public class HotReloadLifecycleMonoPrivateStartFixture : MonoBehaviour\n"
                 + "{\n"
-                + "    private void Awake()\n"
-                + "    {\n"
-                + "        BuildPlayer();\n"
-                + "    }\n"
-                + "\n"
-                + "    private void BuildPlayer()\n"
+                + "    private void Start()\n"
                 + "    {\n"
                 + "        int x = 1;\n"
                 + "        x += 1;\n"
                 + "    }\n"
                 + "}\n";
-            string updateAlsoSource =
-                "using UnityEngine;\n"
-                + "public class HotReloadLifecycleUpdateAlsoFixture : MonoBehaviour\n"
+            string pocoSource =
+                "public class HotReloadLifecyclePocoStartFixture\n"
                 + "{\n"
-                + "    private void Awake()\n"
-                + "    {\n"
-                + "        BuildPlayer();\n"
-                + "    }\n"
-                + "\n"
-                + "    private void Update()\n"
-                + "    {\n"
-                + "        BuildPlayer();\n"
-                + "    }\n"
-                + "\n"
-                + "    private void BuildPlayer()\n"
+                + "    private void Start()\n"
                 + "    {\n"
                 + "        int x = 1;\n"
                 + "        x += 1;\n"
                 + "    }\n"
                 + "}\n";
+            string monoPublicSource =
+                "using UnityEngine;\n"
+                + "public class HotReloadLifecycleMonoPublicStartFixture : MonoBehaviour\n"
+                + "{\n"
+                + "    public void Start()\n"
+                + "    {\n"
+                + "        int x = 1;\n"
+                + "        x += 1;\n"
+                + "    }\n"
+                + "}\n";
+            string monoParameterizedSource =
+                "using UnityEngine;\n"
+                + "public class HotReloadLifecycleMonoParamStartFixture : MonoBehaviour\n"
+                + "{\n"
+                + "    private void Start(int delay)\n"
+                + "    {\n"
+                + "        int x = delay;\n"
+                + "        x += 1;\n"
+                + "    }\n"
+                + "}\n";
 
-            TransformWorkerEntryDto awakeOnlyEntry =
-                await RunWorkerAndFindEntryAsync(awakeOnlySource, "LifecycleAwakeOnly.cs", "BuildPlayer");
-            Assert.That(awakeOnlyEntry.lifecycleNote, Is.Not.Null.And.Not.Empty);
-            Assert.That(awakeOnlyEntry.lifecycleNote, Does.Contain("BuildPlayer"));
-            Assert.That(awakeOnlyEntry.lifecycleNote, Does.Contain("Awake"));
-            Assert.That(awakeOnlyEntry.lifecycleNote, Does.Contain("one-shot lifecycle"));
-
-            TransformWorkerEntryDto updateAlsoEntry =
-                await RunWorkerAndFindEntryAsync(updateAlsoSource, "LifecycleUpdateAlso.cs", "BuildPlayer");
+            TransformWorkerEntryDto monoPrivateEntry =
+                await RunWorkerAndFindEntryAsync(
+                    monoPrivateSource, "LifecycleMonoPrivateStart.cs", "Start");
+            Assert.That(monoPrivateEntry.lifecycleNote, Is.Not.Null.And.Not.Empty);
             Assert.That(
-                updateAlsoEntry.lifecycleNote,
+                monoPrivateEntry.lifecycleNote,
+                Does.Contain("Start is a one-shot lifecycle method"));
+
+            TransformWorkerEntryDto pocoEntry =
+                await RunWorkerAndFindEntryAsync(pocoSource, "LifecyclePocoStart.cs", "Start");
+            Assert.That(
+                pocoEntry.lifecycleNote,
                 Is.Null.Or.Empty,
-                "A method also called from Update must not get a lifecycle note.");
+                "POCO Start must not get a lifecycle note.");
+
+            TransformWorkerEntryDto monoPublicEntry =
+                await RunWorkerAndFindEntryAsync(
+                    monoPublicSource, "LifecycleMonoPublicStart.cs", "Start");
+            Assert.That(
+                monoPublicEntry.lifecycleNote,
+                Is.Null.Or.Empty,
+                "public void Start on MonoBehaviour must not get a lifecycle note.");
+
+            TransformWorkerEntryDto monoParameterizedEntry =
+                await RunWorkerAndFindEntryAsync(
+                    monoParameterizedSource, "LifecycleMonoParamStart.cs", "Start");
+            Assert.That(
+                monoParameterizedEntry.lifecycleNote,
+                Is.Null.Or.Empty,
+                "private void Start(int) must not get a lifecycle note.");
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -790,6 +790,120 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Both IA.Run and IB.Run must appear in unchangedMethods after key qualification.");
         }
 
+        /// <summary>
+        /// What: a method only called from Awake gets an indirect lifecycleNote; the same method
+        /// also called from Update does not (removing ComputeLifecycleNote would leave both null).
+        /// </summary>
+        [Test]
+        public async Task Run_WithAwakeOnlyCallee_EmitsIndirectLifecycleNote_UpdateCallerDoesNot()
+        {
+            string awakeOnlySource =
+                "using UnityEngine;\n"
+                + "public class HotReloadLifecycleAwakeOnlyFixture : MonoBehaviour\n"
+                + "{\n"
+                + "    private void Awake()\n"
+                + "    {\n"
+                + "        BuildPlayer();\n"
+                + "    }\n"
+                + "\n"
+                + "    private void BuildPlayer()\n"
+                + "    {\n"
+                + "        int x = 1;\n"
+                + "        x += 1;\n"
+                + "    }\n"
+                + "}\n";
+            string updateAlsoSource =
+                "using UnityEngine;\n"
+                + "public class HotReloadLifecycleUpdateAlsoFixture : MonoBehaviour\n"
+                + "{\n"
+                + "    private void Awake()\n"
+                + "    {\n"
+                + "        BuildPlayer();\n"
+                + "    }\n"
+                + "\n"
+                + "    private void Update()\n"
+                + "    {\n"
+                + "        BuildPlayer();\n"
+                + "    }\n"
+                + "\n"
+                + "    private void BuildPlayer()\n"
+                + "    {\n"
+                + "        int x = 1;\n"
+                + "        x += 1;\n"
+                + "    }\n"
+                + "}\n";
+
+            TransformWorkerEntryDto awakeOnlyEntry =
+                await RunWorkerAndFindEntryAsync(awakeOnlySource, "LifecycleAwakeOnly.cs", "BuildPlayer");
+            Assert.That(awakeOnlyEntry.lifecycleNote, Is.Not.Null.And.Not.Empty);
+            Assert.That(awakeOnlyEntry.lifecycleNote, Does.Contain("BuildPlayer"));
+            Assert.That(awakeOnlyEntry.lifecycleNote, Does.Contain("Awake"));
+            Assert.That(awakeOnlyEntry.lifecycleNote, Does.Contain("one-shot lifecycle"));
+
+            TransformWorkerEntryDto updateAlsoEntry =
+                await RunWorkerAndFindEntryAsync(updateAlsoSource, "LifecycleUpdateAlso.cs", "BuildPlayer");
+            Assert.That(
+                updateAlsoEntry.lifecycleNote,
+                Is.Null.Or.Empty,
+                "A method also called from Update must not get a lifecycle note.");
+        }
+
+        /// <summary>
+        /// What: patching Awake itself emits the direct one-shot lifecycle note.
+        /// </summary>
+        [Test]
+        public async Task Run_WithAwakeMethod_EmitsDirectLifecycleNote()
+        {
+            string source =
+                "using UnityEngine;\n"
+                + "public class HotReloadLifecycleAwakeFixture : MonoBehaviour\n"
+                + "{\n"
+                + "    private void Awake()\n"
+                + "    {\n"
+                + "        int x = 1;\n"
+                + "        x += 1;\n"
+                + "    }\n"
+                + "}\n";
+
+            TransformWorkerEntryDto awakeEntry =
+                await RunWorkerAndFindEntryAsync(source, "LifecycleAwake.cs", "Awake");
+            Assert.That(awakeEntry.lifecycleNote, Is.Not.Null.And.Not.Empty);
+            Assert.That(
+                awakeEntry.lifecycleNote,
+                Does.Contain("Awake is a one-shot lifecycle method"));
+        }
+
+        private static async Task<TransformWorkerEntryDto> RunWorkerAndFindEntryAsync(
+            string source,
+            string fileName,
+            string methodName)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string sourcePath = Path.Combine(directory, fileName);
+            File.WriteAllText(sourcePath, source);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HotReloadConstants.TestSourcesRelativeDirectory.Replace('\\', '/') + "/" + fileName);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.entries, Is.Not.Null);
+
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                if (entry.methodName == methodName)
+                {
+                    return entry;
+                }
+            }
+
+            Assert.Fail(
+                "Expected entry for " + methodName + "; got: "
+                + FormatEntryMethodNames(result.Output.entries));
+            return null;
+        }
+
         private static HashSet<string> CollectEntryKeys(TransformWorkerEntryDto[] entries)
         {
             HashSet<string> keys = new HashSet<string>();

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -123,24 +123,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string RetargetedPausePointIdDetailFormat =
             "{0} (now line {1}: {2})";
 
-        // Keep in sync with TransformWorker LifecycleNotes (worker cannot reference this type).
-        public static readonly string[] OneShotLifecycleMethodNames =
-        {
-            "Awake",
-            "Start",
-            "OnEnable",
-            "OnDisable",
-            "OnDestroy"
-        };
-
-        // Format: method name.
-        public const string DirectLifecycleNoteFormat =
-            "{0} is a one-shot lifecycle method; objects that already ran it will not run the "
-            + "patched body. It takes effect only for newly created objects.";
-
-        // Format: method name, comma-separated caller names.
-        public const string IndirectLifecycleNoteFormat =
-            "Within this file, {0} is only called from {1} (one-shot lifecycle methods); the "
-            + "patched body may not run again for objects that are already initialized.";
+        // Format: count of Methods entries that carry a LifecycleNote.
+        public const string LifecycleNotesAggregatedMessageFormat =
+            "{0} patched method(s) have one-shot lifecycle notes; see Methods[].LifecycleNote.";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -122,5 +122,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Format: id, resolved line number, resolved line text.
         public const string RetargetedPausePointIdDetailFormat =
             "{0} (now line {1}: {2})";
+
+        // Keep in sync with TransformWorker LifecycleNotes (worker cannot reference this type).
+        public static readonly string[] OneShotLifecycleMethodNames =
+        {
+            "Awake",
+            "Start",
+            "OnEnable",
+            "OnDisable",
+            "OnDestroy"
+        };
+
+        // Format: method name.
+        public const string DirectLifecycleNoteFormat =
+            "{0} is a one-shot lifecycle method; objects that already ran it will not run the "
+            + "patched body. It takes effect only for newly created objects.";
+
+        // Format: method name, comma-separated caller names.
+        public const string IndirectLifecycleNoteFormat =
+            "Within this file, {0} is only called from {1} (one-shot lifecycle methods); the "
+            + "patched body may not run again for objects that are already initialized.";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadInvocationRegistry.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadInvocationRegistry.cs
@@ -1,0 +1,74 @@
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Counts how many times each hot-reload patched method body has run since it was applied.
+    /// Keys match <see cref="HotReloadPatcher"/> status labels so --status can report counts.
+    /// </summary>
+    internal static class HotReloadInvocationRegistry
+    {
+        private sealed class Counter
+        {
+            public long Value;
+        }
+
+        private static readonly ConcurrentDictionary<string, Counter> CountsByMethodKey =
+            new ConcurrentDictionary<string, Counter>();
+
+        /// <summary>
+        /// Increments the counter for <paramref name="methodKey"/>. Called from patched IL on
+        /// every invocation; Interlocked keeps the hot path safe under concurrent callers.
+        /// </summary>
+        public static void Increment(string methodKey)
+        {
+            if (string.IsNullOrEmpty(methodKey))
+            {
+                return;
+            }
+
+            Counter counter = CountsByMethodKey.GetOrAdd(methodKey, _ => new Counter());
+            Interlocked.Increment(ref counter.Value);
+        }
+
+        /// <summary>
+        /// Returns the invocation count for <paramref name="methodKey"/>, or 0 when unknown.
+        /// </summary>
+        public static long GetCount(string methodKey)
+        {
+            if (string.IsNullOrEmpty(methodKey))
+            {
+                return 0L;
+            }
+
+            if (!CountsByMethodKey.TryGetValue(methodKey, out Counter counter))
+            {
+                return 0L;
+            }
+
+            return Interlocked.Read(ref counter.Value);
+        }
+
+        /// <summary>
+        /// Drops the counter for one method key (unpatch / re-apply of that method).
+        /// </summary>
+        public static void Remove(string methodKey)
+        {
+            if (string.IsNullOrEmpty(methodKey))
+            {
+                return;
+            }
+
+            CountsByMethodKey.TryRemove(methodKey, out _);
+        }
+
+        /// <summary>
+        /// Clears every counter (--revert-all / domain teardown of all patches).
+        /// </summary>
+        public static void Clear()
+        {
+            CountsByMethodKey.Clear();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadInvocationRegistry.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadInvocationRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98e65f549f66c46bdbdb019ef37c5b07
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -403,7 +403,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             string[] parameterTypeFullNames = entry.parameterTypeFullNames ?? Array.Empty<string>();
             // Pre-Resolve label: same shape as --status (params + nested '+' normalization).
-            // After Resolve, prefer FormatMethodKey(MethodBase) so reflection FullNames win.
+            // After Resolve, prefer FormatMethodKey(MethodBase) so reflection ToString() wins.
+            // Why genericArity 0: TransformWorkerEntryDto has no arity field; open generics are
+            // rare here, and Resolve replaces this label with FormatMethodKey(MethodBase).
             string methodLabel = HotReloadPatcher.FormatMethodKeyParts(
                 entry.typeMetadataName,
                 entry.methodName,
@@ -860,6 +862,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<HotReloadMethodOutcome> failedMethodOutcomes = new List<HotReloadMethodOutcome>();
             foreach (TransformWorkerEntryDto failedEntry in attribution.FailedEntries)
             {
+                // Why genericArity 0: TransformWorkerEntryDto has no arity field (see ApplyEntry).
                 string methodLabel = HotReloadPatcher.FormatMethodKeyParts(
                     failedEntry.typeMetadataName,
                     failedEntry.methodName,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -486,7 +486,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 inlineRiskMethodLabels.Add(methodLabel);
             }
 
-            return HotReloadMethodOutcome.Patched(methodLabel, filePath);
+            return HotReloadMethodOutcome.Patched(methodLabel, filePath, entry.lifecycleNote);
         }
 
         private static string FormatInlineRiskAggregatedWarning(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -401,7 +401,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> suppressedPausePointIds,
             List<string> retargetedPausePointIds)
         {
-            string methodLabel = entry.typeMetadataName + "." + entry.methodName;
+            string[] parameterTypeFullNames = entry.parameterTypeFullNames ?? Array.Empty<string>();
+            // Pre-Resolve label: same shape as --status (params + nested '+' normalization).
+            // After Resolve, prefer FormatMethodKey(MethodBase) so reflection FullNames win.
+            string methodLabel = HotReloadPatcher.FormatMethodKeyParts(
+                entry.typeMetadataName,
+                entry.methodName,
+                parameterTypeFullNames,
+                genericArity: 0);
 
             // Only "delegation" selects the forwarding patch; null/empty/anything else is transplant.
             HotReloadPatchShape patchShape = entry.patchKind == HotReloadConstants.PatchKindDelegation
@@ -416,8 +423,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return HotReloadMethodOutcome.Failed(methodLabel, bindFailureReason, filePath);
             }
 
-            string[] parameterTypeFullNames = entry.parameterTypeFullNames ?? Array.Empty<string>();
-
             HotReloadMethodMatchResult matchResult = HotReloadMethodMatcher.Resolve(
                 assemblyName,
                 entry.typeMetadataName,
@@ -427,6 +432,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 return HotReloadMethodOutcome.Failed(methodLabel, matchResult.ErrorMessage, filePath);
             }
+
+            methodLabel = HotReloadPatcher.FormatMethodKey(matchResult.Method);
 
             Type shimType = FindShimType(shimAssembly, entry.shimTypeName);
             if (shimType == null)
@@ -853,7 +860,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<HotReloadMethodOutcome> failedMethodOutcomes = new List<HotReloadMethodOutcome>();
             foreach (TransformWorkerEntryDto failedEntry in attribution.FailedEntries)
             {
-                string methodLabel = failedEntry.typeMetadataName + "." + failedEntry.methodName;
+                string methodLabel = HotReloadPatcher.FormatMethodKeyParts(
+                    failedEntry.typeMetadataName,
+                    failedEntry.methodName,
+                    failedEntry.parameterTypeFullNames ?? Array.Empty<string>(),
+                    genericArity: 0);
                 List<string> entryErrorMessages = attribution.ErrorMessagesByEntry[failedEntry];
                 failedMethodOutcomes.Add(
                     HotReloadMethodOutcome.Failed(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
@@ -44,26 +44,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string Method { get; }
         public string Reason { get; }
         public string FilePath { get; }
+        public string LifecycleNote { get; }
 
         private HotReloadMethodOutcome(
             HotReloadMethodOutcomeKind kind,
             string method,
             string reason,
-            string filePath)
+            string filePath,
+            string lifecycleNote)
         {
             Kind = kind;
             Method = method;
             Reason = reason;
             FilePath = filePath;
+            LifecycleNote = lifecycleNote ?? string.Empty;
         }
 
-        public static HotReloadMethodOutcome Patched(string method, string filePath)
+        public static HotReloadMethodOutcome Patched(
+            string method,
+            string filePath,
+            string lifecycleNote = null)
         {
             return new HotReloadMethodOutcome(
                 HotReloadMethodOutcomeKind.Patched,
                 method,
                 string.Empty,
-                filePath);
+                filePath,
+                lifecycleNote);
         }
 
         public static HotReloadMethodOutcome Skipped(string method, string reason, string filePath)
@@ -72,7 +79,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadMethodOutcomeKind.Skipped,
                 method,
                 reason,
-                filePath);
+                filePath,
+                string.Empty);
         }
 
         public static HotReloadMethodOutcome Failed(string method, string reason, string filePath)
@@ -81,7 +89,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadMethodOutcomeKind.Failed,
                 method,
                 reason,
-                filePath);
+                filePath,
+                string.Empty);
         }
     }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -28,6 +28,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             typeof(HotReloadPatcher).GetMethod(
                 nameof(ReplaceWithDelegationTranspiler),
                 BindingFlags.NonPublic | BindingFlags.Static);
+        private static readonly MethodInfo IncrementInvocationMethodInfo =
+            typeof(HotReloadInvocationRegistry).GetMethod(
+                nameof(HotReloadInvocationRegistry.Increment),
+                BindingFlags.Public | BindingFlags.Static,
+                null,
+                new[] { typeof(string) },
+                null);
 
         // Ledger: key = patched original method, value = the shim whose call replaced it.
         private static readonly Dictionary<MethodBase, MethodInfo> ShimByMethod =
@@ -115,6 +122,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // this method into the new generation before calling Apply.
                 ShimByMethod.Remove(method);
                 TransplantLocalsByMethod.Remove(method);
+                HotReloadInvocationRegistry.Remove(FormatMethodKey(method));
                 HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
                 // Mirror the ledger removal: if the re-Patch below fails, its contained Unpatch
                 // rebuilds with markers restored (ledger empty), and RevertAll can never reach
@@ -155,6 +163,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Why Remove before Unpatch: Invoke(true) may have written ShimByMethod before
                 // a later failure; rebuild must not see an active shim (same as re-apply path).
                 ShimByMethod.Remove(method);
+                HotReloadInvocationRegistry.Remove(FormatMethodKey(method));
                 // User-approved exception to the no-try-catch policy: Harmony emit/JIT
                 // failures cannot be pre-validated (the IL shape is only known inside
                 // Harmony), and an escaping exception would abort the whole run while
@@ -205,6 +214,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ShimByMethod.Clear();
             HotReloadShimRegistry.Clear();
             TransplantLocalsByMethod.Clear();
+            HotReloadInvocationRegistry.Clear();
             _pendingShimMethod = null;
             _pendingOriginalMethod = null;
             HarmonyInstance.UnpatchAll(HotReloadConstants.HarmonyId);
@@ -233,6 +243,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // pre-Unpatch window so lookup and ledger never disagree mid-rebuild.
             HotReloadShimRegistry.RemoveMethod(method);
             TransplantLocalsByMethod.Remove(method);
+            HotReloadInvocationRegistry.Remove(FormatMethodKey(method));
             HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
             HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
             return true;
@@ -252,12 +263,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> labels = new List<string>(ShimByMethod.Count);
             foreach (MethodBase method in ShimByMethod.Keys)
             {
-                Debug.Assert(method.DeclaringType != null, "Patched methods must have a declaring type.");
-                labels.Add(method.DeclaringType.FullName + "." + method.Name);
+                labels.Add(FormatMethodKey(method));
             }
 
             labels.Sort(StringComparer.Ordinal);
             return labels;
+        }
+
+        // What: status label shared by DescribeActivePatches and the IL-injected counter key.
+        internal static string FormatMethodKey(MethodBase method)
+        {
+            Debug.Assert(method != null, "method must not be null.");
+            Debug.Assert(method.DeclaringType != null, "Patched methods must have a declaring type.");
+            return method.DeclaringType.FullName + "." + method.Name;
         }
 
         private static IEnumerable<CodeInstruction> ReplaceWithTransplantSourceTranspiler(
@@ -280,6 +298,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 RebindShortFormLocals(shimMethod, generator, transplanted);
             TransplantLocalsByMethod[original] = transplantLocals;
             RebindLabels(generator, transplanted);
+            PrependInvocationCountIncrement(transplanted, original);
             return transplanted;
         }
 
@@ -299,7 +318,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 argumentSlotCount == shimMethod.GetParameters().Length,
                 "Shim parameter count must equal the original's argument slots (instance receiver included).");
 
-            List<CodeInstruction> forwarding = new List<CodeInstruction>(argumentSlotCount + 2);
+            List<CodeInstruction> forwarding = new List<CodeInstruction>(argumentSlotCount + 4);
+            PrependInvocationCountIncrement(forwarding, original);
             for (int slot = 0; slot < argumentSlotCount; slot++)
             {
                 forwarding.Add(CreateLoadArgumentInstruction(slot));
@@ -308,6 +328,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             forwarding.Add(new CodeInstruction(OpCodes.Call, shimMethod));
             forwarding.Add(new CodeInstruction(OpCodes.Ret));
             return forwarding;
+        }
+
+        // What: records one invocation before the patched body runs (transplant or delegation).
+        // Why move entry labels onto Ldstr: branches targeting the old first instruction must
+        // still hit the counter when that instruction is no longer at offset 0.
+        private static void PrependInvocationCountIncrement(
+            List<CodeInstruction> instructions,
+            MethodBase original)
+        {
+            Debug.Assert(IncrementInvocationMethodInfo != null, "Increment method must resolve.");
+            CodeInstruction loadKey = new CodeInstruction(OpCodes.Ldstr, FormatMethodKey(original));
+            CodeInstruction increment = new CodeInstruction(OpCodes.Call, IncrementInvocationMethodInfo);
+            if (instructions.Count > 0 && instructions[0].labels.Count > 0)
+            {
+                loadKey.labels.AddRange(instructions[0].labels);
+                instructions[0].labels.Clear();
+            }
+
+            instructions.Insert(0, increment);
+            instructions.Insert(0, loadKey);
         }
 
         private static CodeInstruction CreateLoadArgumentInstruction(int slot)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -275,9 +275,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         // What: status / counter key from a resolved MethodBase (apply outcomes use the same
         // helper after Resolve so --status rows match Patched Methods[].Method).
-        // Why parameter FullNames (+ generic arity): MethodBase ledger entries distinguish
+        // Why parameter ToString (+ generic arity): MethodBase ledger entries distinguish
         // overloads, so a name-only key would merge counts and let Revert of one overload
-        // zero the other's counter.
+        // zero the other's counter. FullName embeds assembly Version/PublicKeyToken for
+        // constructed generics (List`1[[Int32, mscorlib, ...]]), which bloated labels.
         internal static string FormatMethodKey(MethodBase method)
         {
             Debug.Assert(method != null, "method must not be null.");
@@ -288,8 +289,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string[] parameterTypeFullNames = new string[parameters.Length];
             for (int index = 0; index < parameters.Length; index++)
             {
-                Type parameterType = parameters[index].ParameterType;
-                parameterTypeFullNames[index] = parameterType.FullName ?? parameterType.Name;
+                parameterTypeFullNames[index] = parameters[index].ParameterType.ToString();
             }
 
             int genericArity = 0;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -10,6 +10,8 @@ using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
+using ReflectionParameterInfo = System.Reflection.ParameterInfo;
+
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
@@ -271,7 +273,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return labels;
         }
 
-        // What: status label shared by DescribeActivePatches and the IL-injected counter key.
+        // What: status / counter key from a resolved MethodBase (apply outcomes use the same
+        // helper after Resolve so --status rows match Patched Methods[].Method).
         // Why parameter FullNames (+ generic arity): MethodBase ledger entries distinguish
         // overloads, so a name-only key would merge counts and let Revert of one overload
         // zero the other's counter.
@@ -280,31 +283,74 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(method != null, "method must not be null.");
             Debug.Assert(method.DeclaringType != null, "Patched methods must have a declaring type.");
 
-            StringBuilder builder = new StringBuilder();
-            builder.Append(method.DeclaringType.FullName);
-            builder.Append('.');
-            builder.Append(method.Name);
+            // Why alias: ToolContracts.ParameterInfo also exists in this file's usings.
+            ReflectionParameterInfo[] parameters = method.GetParameters();
+            string[] parameterTypeFullNames = new string[parameters.Length];
+            for (int index = 0; index < parameters.Length; index++)
+            {
+                Type parameterType = parameters[index].ParameterType;
+                parameterTypeFullNames[index] = parameterType.FullName ?? parameterType.Name;
+            }
+
+            int genericArity = 0;
             if (method.IsGenericMethodDefinition || method.IsGenericMethod)
             {
+                genericArity = method.GetGenericArguments().Length;
+            }
+
+            return FormatMethodKeyParts(
+                method.DeclaringType.FullName,
+                method.Name,
+                parameterTypeFullNames,
+                genericArity);
+        }
+
+        // What: Method label from worker DTO fields (pre-Resolve failures) using the same shape
+        // as FormatMethodKey. Cecil nested separators ('/') are normalized to reflection ('+').
+        internal static string FormatMethodKeyParts(
+            string typeMetadataName,
+            string methodName,
+            string[] parameterTypeFullNames,
+            int genericArity)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(typeMetadataName), "typeMetadataName must not be null or empty.");
+            Debug.Assert(!string.IsNullOrEmpty(methodName), "methodName must not be null or empty.");
+            Debug.Assert(parameterTypeFullNames != null, "parameterTypeFullNames must not be null.");
+            Debug.Assert(genericArity >= 0, "genericArity must not be negative.");
+
+            StringBuilder builder = new StringBuilder();
+            builder.Append(NormalizeNestedTypeSeparators(typeMetadataName));
+            builder.Append('.');
+            builder.Append(methodName);
+            if (genericArity > 0)
+            {
                 builder.Append('`');
-                builder.Append(method.GetGenericArguments().Length);
+                builder.Append(genericArity);
             }
 
             builder.Append('(');
-            System.Reflection.ParameterInfo[] parameters = method.GetParameters();
-            for (int index = 0; index < parameters.Length; index++)
+            for (int index = 0; index < parameterTypeFullNames.Length; index++)
             {
                 if (index > 0)
                 {
                     builder.Append(',');
                 }
 
-                Type parameterType = parameters[index].ParameterType;
-                builder.Append(parameterType.FullName ?? parameterType.Name);
+                string parameterTypeFullName = parameterTypeFullNames[index];
+                Debug.Assert(
+                    !string.IsNullOrEmpty(parameterTypeFullName),
+                    "parameterTypeFullNames entries must not be null or empty.");
+                builder.Append(NormalizeNestedTypeSeparators(parameterTypeFullName));
             }
 
             builder.Append(')');
             return builder.ToString();
+        }
+
+        // Why: Cecil metadata names use '/' for nested types; Type.FullName uses '+'.
+        private static string NormalizeNestedTypeSeparators(string metadataName)
+        {
+            return metadataName.Replace('/', '+');
         }
 
         private static IEnumerable<CodeInstruction> ReplaceWithTransplantSourceTranspiler(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Text;
 
 using HarmonyLib;
 
@@ -271,11 +272,39 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         // What: status label shared by DescribeActivePatches and the IL-injected counter key.
+        // Why parameter FullNames (+ generic arity): MethodBase ledger entries distinguish
+        // overloads, so a name-only key would merge counts and let Revert of one overload
+        // zero the other's counter.
         internal static string FormatMethodKey(MethodBase method)
         {
             Debug.Assert(method != null, "method must not be null.");
             Debug.Assert(method.DeclaringType != null, "Patched methods must have a declaring type.");
-            return method.DeclaringType.FullName + "." + method.Name;
+
+            StringBuilder builder = new StringBuilder();
+            builder.Append(method.DeclaringType.FullName);
+            builder.Append('.');
+            builder.Append(method.Name);
+            if (method.IsGenericMethodDefinition || method.IsGenericMethod)
+            {
+                builder.Append('`');
+                builder.Append(method.GetGenericArguments().Length);
+            }
+
+            builder.Append('(');
+            System.Reflection.ParameterInfo[] parameters = method.GetParameters();
+            for (int index = 0; index < parameters.Length; index++)
+            {
+                if (index > 0)
+                {
+                    builder.Append(',');
+                }
+
+                Type parameterType = parameters[index].ParameterType;
+                builder.Append(parameterType.FullName ?? parameterType.Name);
+            }
+
+            builder.Append(')');
+            return builder.ToString();
         }
 
         private static IEnumerable<CodeInstruction> ReplaceWithTransplantSourceTranspiler(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -328,19 +328,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 message += " " + result.UnchangedTotal + " unchanged methods were left untouched.";
             }
 
-            List<string> lifecycleNotes = new List<string>();
+            int lifecycleNoteCount = 0;
             for (int index = 0; index < result.Methods.Count; index++)
             {
-                string note = result.Methods[index].LifecycleNote;
-                if (!string.IsNullOrEmpty(note))
+                if (!string.IsNullOrEmpty(result.Methods[index].LifecycleNote))
                 {
-                    lifecycleNotes.Add(note);
+                    lifecycleNoteCount++;
                 }
             }
 
-            if (lifecycleNotes.Count > 0)
+            if (lifecycleNoteCount > 0)
             {
-                message += " " + string.Join(" ", lifecycleNotes);
+                // Why aggregate: per-method text already lives on Methods[].LifecycleNote;
+                // dumping every note into Message repeats nearly identical paragraphs.
+                message += " " + string.Format(
+                    HotReloadConstants.LifecycleNotesAggregatedMessageFormat,
+                    lifecycleNoteCount);
             }
 
             return message;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -40,6 +40,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string Method { get; set; } = string.Empty;
         public string Reason { get; set; } = string.Empty;
         public string FilePath { get; set; } = string.Empty;
+
+        /// <summary>
+        /// How many times this patched method body has run since the current patch was applied.
+        /// Populated on --status; 0 for apply/revert outcomes.
+        /// </summary>
+        public long InvocationCount { get; set; }
     }
 
     /// <summary>
@@ -129,11 +135,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<HotReloadMethodResult> methods = new List<HotReloadMethodResult>(active.Count);
             for (int index = 0; index < active.Count; index++)
             {
+                string methodKey = active[index];
                 methods.Add(
                     new HotReloadMethodResult
                     {
                         Kind = "Active",
-                        Method = active[index]
+                        Method = methodKey,
+                        InvocationCount = HotReloadInvocationRegistry.GetCount(methodKey)
                     });
             }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -46,6 +46,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Populated on --status; 0 for apply/revert outcomes.
         /// </summary>
         public long InvocationCount { get; set; }
+
+        /// <summary>
+        /// Optional note when the patched method is (or is only reached from) a one-shot lifecycle
+        /// method. Empty when not applicable; does not change Kind.
+        /// </summary>
+        public string LifecycleNote { get; set; } = string.Empty;
     }
 
     /// <summary>
@@ -194,7 +200,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         Kind = outcome.Kind.ToString(),
                         Method = outcome.Method,
                         Reason = outcome.Reason ?? string.Empty,
-                        FilePath = outcome.FilePath ?? string.Empty
+                        FilePath = outcome.FilePath ?? string.Empty,
+                        LifecycleNote = outcome.LifecycleNote ?? string.Empty
                     });
             }
 
@@ -319,6 +326,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (result.UnchangedTotal > 0)
             {
                 message += " " + result.UnchangedTotal + " unchanged methods were left untouched.";
+            }
+
+            List<string> lifecycleNotes = new List<string>();
+            for (int index = 0; index < result.Methods.Count; index++)
+            {
+                string note = result.Methods[index].LifecycleNote;
+                if (!string.IsNullOrEmpty(note))
+                {
+                    lifecycleNotes.Add(note);
+                }
+            }
+
+            if (lifecycleNotes.Count > 0)
+            {
+                message += " " + string.Join(" ", lifecycleNotes);
             }
 
             return message;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -184,7 +184,7 @@ because its line no longer resolves in any live body.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`
 - `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough (or marked `[AggressiveInlining]`) to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `UnchangedTotal` (number): Methods left untouched because their bodies match the source baseline from the last compile; `0` when no baseline was available

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -72,6 +72,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Used to attribute shim compile errors whose #line-mapped locations fall in this method.
         public int sourceStartLine;
         public int sourceEndLine;
+
+        // Null/empty when the method is not a one-shot lifecycle method and is not only called
+        // from them inside this file.
+        public string lifecycleNote;
     }
 
     [Serializable]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -439,7 +439,10 @@ public static class TransformWorkerProgram
                     ShimMethodName = shimMethodName,
                     PatchKind = decision.PatchKind,
                     SourceStartLine = sourceStartLine,
-                    SourceEndLine = sourceEndLine
+                    SourceEndLine = sourceEndLine,
+                    // Why annotated root: methodDeclaration comes from this tree, so caller
+                    // identity checks stay reference-equal (plainRoot would never match).
+                    LifecycleNote = ComputeLifecycleNote(methodDeclaration, root)
                 });
             }
         }
@@ -461,6 +464,87 @@ public static class TransformWorkerProgram
     /// Attaches original-source 1-based line annotations to every method and statement in the
     /// parsed tree. Must run before compilation so the SemanticModel binds the annotated tree.
     /// </summary>
+    // What: optional note when a patched method is (or is only reached from) a one-shot lifecycle.
+    private static string ComputeLifecycleNote(
+        MethodDeclarationSyntax methodDeclaration,
+        CompilationUnitSyntax root)
+    {
+        string methodName = methodDeclaration.Identifier.Text;
+        if (IsOneShotLifecycleMethodName(methodName))
+        {
+            return string.Format(LifecycleNotes.DirectFormat, methodName);
+        }
+
+        List<string> callerNames = new List<string>();
+        foreach (InvocationExpressionSyntax invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (!InvocationTargetsMethodName(invocation, methodName))
+            {
+                continue;
+            }
+
+            MethodDeclarationSyntax caller = invocation.Ancestors()
+                .OfType<MethodDeclarationSyntax>()
+                .FirstOrDefault();
+            if (caller == null || ReferenceEquals(caller, methodDeclaration))
+            {
+                continue;
+            }
+
+            string callerName = caller.Identifier.Text;
+            if (!IsOneShotLifecycleMethodName(callerName))
+            {
+                return null;
+            }
+
+            if (!callerNames.Contains(callerName))
+            {
+                callerNames.Add(callerName);
+            }
+        }
+
+        if (callerNames.Count == 0)
+        {
+            return null;
+        }
+
+        return string.Format(
+            LifecycleNotes.IndirectFormat,
+            methodName,
+            string.Join(", ", callerNames));
+    }
+
+    private static bool IsOneShotLifecycleMethodName(string methodName)
+    {
+        for (int index = 0; index < LifecycleNotes.OneShotLifecycleMethodNames.Length; index++)
+        {
+            if (LifecycleNotes.OneShotLifecycleMethodNames[index] == methodName)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool InvocationTargetsMethodName(
+        InvocationExpressionSyntax invocation,
+        string methodName)
+    {
+        if (invocation.Expression is IdentifierNameSyntax identifier)
+        {
+            return identifier.Identifier.Text == methodName;
+        }
+
+        if (invocation.Expression is MemberAccessExpressionSyntax memberAccess
+            && memberAccess.Name is IdentifierNameSyntax memberName)
+        {
+            return memberName.Identifier.Text == methodName;
+        }
+
+        return false;
+    }
+
     private static CompilationUnitSyntax AnnotateOriginalSourceLines(CompilationUnitSyntax root)
     {
         List<SyntaxNode> nodesToAnnotate = new List<SyntaxNode>();
@@ -3664,6 +3748,30 @@ internal sealed class WorkerEntry
     public int SourceStartLine { get; set; }
 
     public int SourceEndLine { get; set; }
+
+    // Null when the method is not a one-shot lifecycle method and is not only called from them.
+    public string LifecycleNote { get; set; }
+}
+
+internal static class LifecycleNotes
+{
+    // Keep in sync with HotReloadConstants one-shot lifecycle names / formats.
+    public static readonly string[] OneShotLifecycleMethodNames =
+    {
+        "Awake",
+        "Start",
+        "OnEnable",
+        "OnDisable",
+        "OnDestroy"
+    };
+
+    public const string DirectFormat =
+        "{0} is a one-shot lifecycle method; objects that already ran it will not run the "
+        + "patched body. It takes effect only for newly created objects.";
+
+    public const string IndirectFormat =
+        "Within this file, {0} is only called from {1} (one-shot lifecycle methods); the "
+        + "patched body may not run again for objects that are already initialized.";
 }
 
 internal static class PatchKinds

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -440,9 +440,7 @@ public static class TransformWorkerProgram
                     PatchKind = decision.PatchKind,
                     SourceStartLine = sourceStartLine,
                     SourceEndLine = sourceEndLine,
-                    // Why annotated root: methodDeclaration comes from this tree, so caller
-                    // identity checks stay reference-equal (plainRoot would never match).
-                    LifecycleNote = ComputeLifecycleNote(methodDeclaration, root)
+                    LifecycleNote = ComputeLifecycleNote(methodDeclaration, methodSymbol, typeSymbol)
                 });
             }
         }
@@ -464,54 +462,36 @@ public static class TransformWorkerProgram
     /// Attaches original-source 1-based line annotations to every method and statement in the
     /// parsed tree. Must run before compilation so the SemanticModel binds the annotated tree.
     /// </summary>
-    // What: optional note when a patched method is (or is only reached from) a one-shot lifecycle.
+    // What: direct one-shot Unity lifecycle note only. Indirect "only called from Awake"
+    // notes were dropped — syntax-only caller walks cannot prove that claim (ctors,
+    // accessors, lambdas, other types in the same file).
     private static string ComputeLifecycleNote(
         MethodDeclarationSyntax methodDeclaration,
-        CompilationUnitSyntax root)
+        IMethodSymbol methodSymbol,
+        INamedTypeSymbol typeSymbol)
     {
         string methodName = methodDeclaration.Identifier.Text;
-        if (IsOneShotLifecycleMethodName(methodName))
-        {
-            return string.Format(LifecycleNotes.DirectFormat, methodName);
-        }
-
-        List<string> callerNames = new List<string>();
-        foreach (InvocationExpressionSyntax invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
-        {
-            if (!InvocationTargetsMethodName(invocation, methodName))
-            {
-                continue;
-            }
-
-            MethodDeclarationSyntax caller = invocation.Ancestors()
-                .OfType<MethodDeclarationSyntax>()
-                .FirstOrDefault();
-            if (caller == null || ReferenceEquals(caller, methodDeclaration))
-            {
-                continue;
-            }
-
-            string callerName = caller.Identifier.Text;
-            if (!IsOneShotLifecycleMethodName(callerName))
-            {
-                return null;
-            }
-
-            if (!callerNames.Contains(callerName))
-            {
-                callerNames.Add(callerName);
-            }
-        }
-
-        if (callerNames.Count == 0)
+        if (!IsOneShotLifecycleMethodName(methodName))
         {
             return null;
         }
 
-        return string.Format(
-            LifecycleNotes.IndirectFormat,
-            methodName,
-            string.Join(", ", callerNames));
+        if (!IsUnityEngineMonoBehaviourDerived(typeSymbol))
+        {
+            return null;
+        }
+
+        // Why private void (): Unity message methods are instance void with no parameters;
+        // public/static/parameterized Start() on a MonoBehaviour is not the lifecycle hook.
+        if (methodSymbol.DeclaredAccessibility != Accessibility.Private
+            || methodSymbol.IsStatic
+            || !methodSymbol.ReturnsVoid
+            || methodSymbol.Parameters.Length != 0)
+        {
+            return null;
+        }
+
+        return string.Format(LifecycleNotes.DirectFormat, methodName);
     }
 
     private static bool IsOneShotLifecycleMethodName(string methodName)
@@ -527,19 +507,19 @@ public static class TransformWorkerProgram
         return false;
     }
 
-    private static bool InvocationTargetsMethodName(
-        InvocationExpressionSyntax invocation,
-        string methodName)
+    private static bool IsUnityEngineMonoBehaviourDerived(INamedTypeSymbol typeSymbol)
     {
-        if (invocation.Expression is IdentifierNameSyntax identifier)
+        INamedTypeSymbol current = typeSymbol;
+        while (current != null)
         {
-            return identifier.Identifier.Text == methodName;
-        }
+            if (current.Name == "MonoBehaviour"
+                && current.ContainingNamespace != null
+                && current.ContainingNamespace.ToDisplayString() == "UnityEngine")
+            {
+                return true;
+            }
 
-        if (invocation.Expression is MemberAccessExpressionSyntax memberAccess
-            && memberAccess.Name is IdentifierNameSyntax memberName)
-        {
-            return memberName.Identifier.Text == methodName;
+            current = current.BaseType;
         }
 
         return false;
@@ -3755,7 +3735,6 @@ internal sealed class WorkerEntry
 
 internal static class LifecycleNotes
 {
-    // Keep in sync with HotReloadConstants one-shot lifecycle names / formats.
     public static readonly string[] OneShotLifecycleMethodNames =
     {
         "Awake",
@@ -3768,10 +3747,6 @@ internal static class LifecycleNotes
     public const string DirectFormat =
         "{0} is a one-shot lifecycle method; objects that already ran it will not run the "
         + "patched body. It takes effect only for newly created objects.";
-
-    public const string IndirectFormat =
-        "Within this file, {0} is only called from {1} (one-shot lifecycle methods); the "
-        + "patched body may not run again for objects that are already initialized.";
 }
 
 internal static class PatchKinds


### PR DESCRIPTION
## Summary
- `--status` now reports how many times each hot-reload patched method body has run since apply (`InvocationCount`).
- Apply responses note when a patched method is a one-shot lifecycle method (or is only reached from those methods in the same file), without changing `Patched` Kind.

## User Impact
- **Before:** A successful `Patched` result gave no signal that `Awake`/`Start`-style methods (or helpers only called from them) would not re-run for already-initialized objects, and no way to see whether a patch had executed at all.
- **After:** Agents can read `InvocationCount` from `--status` after exercise, and see `LifecycleNote` on Methods / Message when a one-shot lifecycle pattern is detected from syntax alone.

## Changes
- Inject per-method invocation counters into transplant and delegation IL; clear on unpatch / re-apply / `--revert-all` (domain reload clears static state after compile).
- Worker emits optional `lifecycleNote` for direct lifecycle names and for callees only invoked from those names in-file; orchestrator and `HotReloadTools` forward it to Methods and Message.
- Tests cover counter increments / clear / re-apply reset, and Awake-only vs Update-also lifecycle note discriminability.

## Verification
- `dist/darwin-arm64/uloop compile` → 0 errors
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "HotReload|TransformWorker|PausePoint"` → **419/419 Passed**

## Notes
- Base is `feature/hot-reload` (repo CI that only targets `main` / `v3-beta` will not run). Local suite above is the gate.
- Addresses FB S1-3 / S3-1 (invocation visibility and one-shot lifecycle hints).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

