### PR TITLE
feat: patch property getter bodies via hot reload

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -52,10 +52,10 @@ ledger across runs.
 
 ## Scope and limits
 
-Only ordinary method declarations are patched. Constructors, finalizers, operators, event
-accessors, and `interface` members (including default interface implementations) are never
-scanned: edits to them produce **no per-method entry at all** and are silently not applied —
-use `uloop compile` for those.
+Only ordinary method declarations and property getters with a body are patched.
+Constructors, finalizers, operators, event accessors, and `interface` members
+(including default interface implementations) are never scanned: edits to them produce
+**no per-method entry at all** and are silently not applied — use `uloop compile` for those.
 
 Hot reload never adds members. A refactor that extracts a new helper method cannot be
 applied piecewise — keep iterating inside existing method bodies, then run
@@ -72,6 +72,18 @@ initializers, attributes, added or removed members — is reported as a `Warning
 entry as well; without a baseline it stays silent. Either way, use `uloop compile`
 for such edits.
 
+### Tunable values: prefer a getter over a const
+
+`const` edits never take effect through hot reload: C# bakes const values into every
+call site at compile time. When you expect to tune a value while Play Mode is running
+(speeds, amplitudes, sensitivities), expose it as a static property getter instead:
+
+    public static float HeightAmplitude => 5f;
+
+A getter body is an ordinary patchable method body, so editing the literal and running
+`uloop hot-reload` updates every consumer on its next call — across all files, without
+restarting Play Mode. Keep `const` for values you never tune at runtime.
+
 Each `uloop compile` also establishes a per-assembly source baseline: a snapshot of
 the sources exactly as they were compiled, captured after the compile's domain reload
 and adopted only once it verifies against the compiled assembly's PDB checksums. With
@@ -87,9 +99,10 @@ the first compile after installing or updating the package — every editable me
 the file is patched and a `Warnings` line reports the fallback; run `uloop compile`
 to establish the baseline.
 
-Property and indexer accessors with explicit bodies are reported per-accessor as
-`Skipped`, so an edited getter never disappears from the response silently; with a
-verified baseline, accessors unchanged from it produce no row.
+Property getters with a body (including expression-bodied properties) are patched
+like ordinary methods. Setter, init, and indexer accessors with explicit bodies are
+reported per-accessor as `Skipped`, so an edited accessor never disappears from the
+response silently; with a verified baseline, accessors unchanged from it produce no row.
 
 Subscribing to or unsubscribing from a field-like event (`+=`/`-=`) inside an edited
 body works. Methods that raise the event are reported as `Skipped` (see the table
@@ -107,7 +120,7 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Body contains a `base.` call | `base` cannot be expressed from outside the type |
 | Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
-| Property or indexer accessor with an explicit body | Accessor patching is out of scope for v1; `uloop compile` applies accessor edits |
+| Property setter, init, or indexer accessor with an explicit body | Accessor patching covers getters only; `uloop compile` applies setter/init/indexer edits |
 | Method raises, invokes, or reads a field-like event (anything beyond `+=`/`-=`) | C# only allows `+=`/`-=` on an event outside its declaring type, so the raising body cannot compile from the shim assembly |
 
 ### Failed — flips `Success` to `false`

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -52,10 +52,10 @@ ledger across runs.
 
 ## Scope and limits
 
-Only ordinary method declarations are patched. Constructors, finalizers, operators, event
-accessors, and `interface` members (including default interface implementations) are never
-scanned: edits to them produce **no per-method entry at all** and are silently not applied —
-use `uloop compile` for those.
+Only ordinary method declarations and property getters with a body are patched.
+Constructors, finalizers, operators, event accessors, and `interface` members
+(including default interface implementations) are never scanned: edits to them produce
+**no per-method entry at all** and are silently not applied — use `uloop compile` for those.
 
 Hot reload never adds members. A refactor that extracts a new helper method cannot be
 applied piecewise — keep iterating inside existing method bodies, then run
@@ -72,6 +72,18 @@ initializers, attributes, added or removed members — is reported as a `Warning
 entry as well; without a baseline it stays silent. Either way, use `uloop compile`
 for such edits.
 
+### Tunable values: prefer a getter over a const
+
+`const` edits never take effect through hot reload: C# bakes const values into every
+call site at compile time. When you expect to tune a value while Play Mode is running
+(speeds, amplitudes, sensitivities), expose it as a static property getter instead:
+
+    public static float HeightAmplitude => 5f;
+
+A getter body is an ordinary patchable method body, so editing the literal and running
+`uloop hot-reload` updates every consumer on its next call — across all files, without
+restarting Play Mode. Keep `const` for values you never tune at runtime.
+
 Each `uloop compile` also establishes a per-assembly source baseline: a snapshot of
 the sources exactly as they were compiled, captured after the compile's domain reload
 and adopted only once it verifies against the compiled assembly's PDB checksums. With
@@ -87,9 +99,10 @@ the first compile after installing or updating the package — every editable me
 the file is patched and a `Warnings` line reports the fallback; run `uloop compile`
 to establish the baseline.
 
-Property and indexer accessors with explicit bodies are reported per-accessor as
-`Skipped`, so an edited getter never disappears from the response silently; with a
-verified baseline, accessors unchanged from it produce no row.
+Property getters with a body (including expression-bodied properties) are patched
+like ordinary methods. Setter, init, and indexer accessors with explicit bodies are
+reported per-accessor as `Skipped`, so an edited accessor never disappears from the
+response silently; with a verified baseline, accessors unchanged from it produce no row.
 
 Subscribing to or unsubscribing from a field-like event (`+=`/`-=`) inside an edited
 body works. Methods that raise the event are reported as `Skipped` (see the table
@@ -107,7 +120,7 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Body contains a `base.` call | `base` cannot be expressed from outside the type |
 | Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
-| Property or indexer accessor with an explicit body | Accessor patching is out of scope for v1; `uloop compile` applies accessor edits |
+| Property setter, init, or indexer accessor with an explicit body | Accessor patching covers getters only; `uloop compile` applies setter/init/indexer edits |
 | Method raises, invokes, or reads a field-like event (anything beyond `+=`/`-=`) | C# only allows `+=`/`-=` on an event outside its declaring type, so the raising body cannot compile from the shim assembly |
 
 ### Failed — flips `Success` to `false`

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -7,9 +7,12 @@ using System.Threading.Tasks;
 
 using NUnit.Framework;
 
+using Newtonsoft.Json.Linq;
+
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
@@ -385,6 +388,85 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 foundAutoPropertyAccessor,
                 Is.False,
                 "Auto-property accessors must not be listed; only explicit-body accessors are reported.");
+        }
+
+        /// <summary>
+        /// What: editing a static expression-bodied property getter patches runtime reads,
+        /// --status lists the Active get_ row, and RevertAll restores the compiled literal.
+        /// </summary>
+        [Test]
+        public async Task Run_EditedPropertyGetter_ApplyStatusRevert_UpdatesRuntimeValue()
+        {
+            string fixturePath = ResolveShapeFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string editedSource = onDisk.Replace(
+                "public static float HeightAmplitude => 5f;",
+                "public static float HeightAmplitude => 6f;",
+                StringComparison.Ordinal);
+            Assert.That(editedSource, Is.Not.EqualTo(onDisk), "Precondition: getter body must differ.");
+
+            string editedPath = WriteEditedSource("PropertyGetterHeightAmplitude.cs", editedSource);
+
+            Assert.That(HotReloadPropertyGetterFixture.HeightAmplitude, Is.EqualTo(5f));
+
+            HotReloadOrchestratorResult patched = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(patched);
+            AssertHasPatched(patched, "get_HeightAmplitude");
+            Assert.That(patched.ActivePatchTotal, Is.GreaterThanOrEqualTo(1));
+            // Why exact label: Skill docs and --status must share FormatMethodKey shape with apply.
+            const string expectedGetterLabel =
+                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                + ".HotReloadPropertyGetterFixture.get_HeightAmplitude()";
+            string applyMethodLabel = null;
+            foreach (HotReloadMethodOutcome outcome in patched.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Patched
+                    && outcome.Method.Contains("get_HeightAmplitude"))
+                {
+                    applyMethodLabel = outcome.Method;
+                    break;
+                }
+            }
+
+            Assert.That(applyMethodLabel, Is.EqualTo(expectedGetterLabel));
+            Assert.That(
+                HotReloadPropertyGetterFixture.HeightAmplitude,
+                Is.EqualTo(6f),
+                "Patched getter must return the edited literal.");
+
+            HotReloadTool tool = new HotReloadTool();
+            UnityCliLoopToolResponse baseResponse = await tool.ExecuteAsync(
+                new JObject { ["Status"] = true },
+                CancellationToken.None);
+            HotReloadResponse status = baseResponse as HotReloadResponse;
+            Assert.That(status, Is.Not.Null);
+            Assert.That(status.Success, Is.True);
+
+            bool foundActiveGetter = false;
+            foreach (HotReloadMethodResult method in status.Methods)
+            {
+                if (method.Kind == "Active" && method.Method == expectedGetterLabel)
+                {
+                    foundActiveGetter = true;
+                    Assert.That(method.InvocationCount, Is.GreaterThanOrEqualTo(1L));
+                }
+            }
+
+            Assert.That(
+                foundActiveGetter,
+                Is.True,
+                "Status must list Active get_HeightAmplitude after apply with the same Method label.");
+
+            HotReloadPatcher.RevertAll();
+            Assert.That(HotReloadPatcher.DescribeActivePatches(), Is.Empty);
+            Assert.That(
+                HotReloadPropertyGetterFixture.HeightAmplitude,
+                Is.EqualTo(5f),
+                "RevertAll must restore the compiled getter body.");
         }
 
         /// <summary>
@@ -1379,6 +1461,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "HotReload",
                 "HotReloadE2EFixtures.cs");
             Assert.That(File.Exists(path), Is.True, "E2E fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string ResolveShapeFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadShapeFixtures.cs");
+            Assert.That(File.Exists(path), Is.True, "Shape fixture source missing: " + path);
             return Path.GetFullPath(path);
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -417,6 +417,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertNoFileLevelFailure(patched);
             AssertHasPatched(patched, "get_HeightAmplitude");
             Assert.That(patched.ActivePatchTotal, Is.GreaterThanOrEqualTo(1));
+            Assert.That(
+                patched.Warnings,
+                Has.None.Contain("Edits outside method bodies"),
+                "Getter-only edits must not warn that outside-body edits were not applied.");
             // Why exact label: Skill docs and --status must share FormatMethodKey shape with apply.
             const string expectedGetterLabel =
                 "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -297,12 +297,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: one orchestrator run over the fixture reports the explicit-body property getter,
-        /// the explicit-body property setter, and the expression-bodied indexer getter as Skipped
-        /// with the v1 accessor reason, while auto-property accessors stay unlisted.
+        /// What: property getters with bodies are Patched; property setters and indexer getters
+        /// with bodies stay Skipped with the accessor reason; auto-property accessors stay unlisted.
         /// </summary>
         [Test]
-        public async Task Run_ExplicitAccessorsSkipped_AutoPropertyAccessorsUnlisted()
+        public async Task Run_PropertyGettersPatched_SetterAndIndexerAccessorsSkipped()
         {
             string fixturePath = ResolveE2EFixturePath();
             string editedPath = WriteEditedSource(
@@ -314,13 +313,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     + "            return _secret + delta;\n"
                     + "        }",
                     explicitAccessorsBlock:
-                    "// Explicit-body getter — worker must report get_ExplicitBodyGetter as Skipped (not silent).\n"
+                    "// Explicit-body getter — worker must patch get_ExplicitBodyGetter.\n"
                     + "        public int ExplicitBodyGetter\n"
                     + "        {\n"
                     + "            get { return _secret + 1; }\n"
                     + "        }\n"
                     + "\n"
-                    + "        // Explicit-body setter — worker must report set_ExplicitBodySetter as Skipped (not silent).\n"
+                    + "        // Explicit-body setter — worker must report set_ExplicitBodySetter as Skipped.\n"
                     + "        public int ExplicitBodySetter\n"
                     + "        {\n"
                     + "            set { _secret = value + 1; }\n"
@@ -338,20 +337,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertNoFileLevelFailure(result);
 
             const string expectedReason =
-                "Property and indexer accessors are out of scope for v1; run 'uloop compile' to apply accessor edits.";
-            bool foundPropertyGetter = false;
+                "Property setter, init, or indexer accessors are out of scope for v1; "
+                + "run 'uloop compile' to apply accessor edits.";
+            bool foundPropertyGetterPatched = false;
             bool foundIndexerGetter = false;
             bool foundPropertySetter = false;
             bool foundAutoPropertyAccessor = false;
             foreach (HotReloadMethodOutcome outcome in result.Methods)
             {
-                bool skippedWithAccessorReason = outcome.Kind == HotReloadMethodOutcomeKind.Skipped
-                    && outcome.Reason == expectedReason;
-                if (skippedWithAccessorReason && outcome.Method.Contains("get_ExplicitBodyGetter"))
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Patched
+                    && outcome.Method.Contains("get_ExplicitBodyGetter"))
                 {
-                    foundPropertyGetter = true;
+                    foundPropertyGetterPatched = true;
                 }
 
+                bool skippedWithAccessorReason = outcome.Kind == HotReloadMethodOutcomeKind.Skipped
+                    && outcome.Reason == expectedReason;
                 if (skippedWithAccessorReason && outcome.Method.Contains("get_Item"))
                 {
                     foundIndexerGetter = true;
@@ -369,9 +370,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             Assert.That(
-                foundPropertyGetter,
+                foundPropertyGetterPatched,
                 Is.True,
-                "Expected get_ExplicitBodyGetter to be Skipped with the accessor out-of-scope reason.");
+                "Expected get_ExplicitBodyGetter to be Patched; got: " + FormatOutcomes(result));
             Assert.That(
                 foundIndexerGetter,
                 Is.True,

--- a/Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs
@@ -94,4 +94,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return 2;
         }
     }
+
+    /// <summary>
+    /// Property getters for hot-reload property-patch coverage: static expression-bodied and
+    /// instance block get. Auto-properties are intentionally absent (not patch candidates).
+    /// </summary>
+    internal class HotReloadPropertyGetterFixture
+    {
+        public static float HeightAmplitude => 5f;
+
+        private int _score;
+
+        public int Score
+        {
+            get
+            {
+                return _score;
+            }
+        }
+    }
 }

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -335,7 +335,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: finds a shim method's <c>public static</c> declaration start and the index of its
-        /// balanced closing brace so slice and post-method gap checks share one scan.
+        /// end token (balanced <c>}</c>, or terminating <c>;</c> for expression-bodied shims) so
+        /// slice and post-method gap checks share one scan.
         /// </summary>
         private static (bool Found, int DeclarationStart, int CloseBraceIndex) FindShimMethodSpan(
             string shimSource,
@@ -361,7 +362,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 return (false, -1, -1);
             }
 
+            int arrowIndex = shimSource.IndexOf("=>", nameIndex, StringComparison.Ordinal);
             int openBrace = shimSource.IndexOf('{', nameIndex);
+            // Why arrow-before-brace: expression-bodied shims have no '{'; IndexOf('{') would
+            // otherwise latch onto the next method and falsely include its #line directives.
+            if (arrowIndex >= 0 && (openBrace < 0 || arrowIndex < openBrace))
+            {
+                int semicolonIndex = FindExpressionBodiedShimSemicolon(shimSource, arrowIndex);
+                if (semicolonIndex < 0)
+                {
+                    return (false, -1, -1);
+                }
+
+                return (true, declarationStart, semicolonIndex);
+            }
+
             if (openBrace < 0)
             {
                 return (false, -1, -1);
@@ -386,6 +401,53 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             return (false, -1, -1);
+        }
+
+        /// <summary>
+        /// What: locates the terminating semicolon of an expression-bodied shim after its <c>=&gt;</c>.
+        /// </summary>
+        private static int FindExpressionBodiedShimSemicolon(string shimSource, int arrowIndex)
+        {
+            int parenDepth = 0;
+            int bracketDepth = 0;
+            int braceDepth = 0;
+            for (int index = arrowIndex + 2; index < shimSource.Length; index++)
+            {
+                char character = shimSource[index];
+                if (character == '(')
+                {
+                    parenDepth++;
+                }
+                else if (character == ')')
+                {
+                    parenDepth--;
+                }
+                else if (character == '[')
+                {
+                    bracketDepth++;
+                }
+                else if (character == ']')
+                {
+                    bracketDepth--;
+                }
+                else if (character == '{')
+                {
+                    braceDepth++;
+                }
+                else if (character == '}')
+                {
+                    braceDepth--;
+                }
+                else if (character == ';'
+                    && parenDepth == 0
+                    && bracketDepth == 0
+                    && braceDepth == 0)
+                {
+                    return index;
+                }
+            }
+
+            return -1;
         }
 
         private static void AssertHasSkip(
@@ -953,6 +1015,120 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + FormatEntryMethodNames(result.Output.entries)
                 + "; skipped="
                 + FormatSkippedMethodNames(result.Output.skipped));
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.None.Contain("Edits outside method bodies"),
+                "Getter-body-only edits must not emit the outside-method-body drift warning.");
+        }
+
+        /// <summary>
+        /// What: editing only an instance block getter emits get_Score with a successful shim
+        /// compile (covers __instance injection + private field rewrite + BlockSyntax path).
+        /// </summary>
+        [Test]
+        public async Task Run_WithSnapshotDifferingOnlyInBlockGetter_EmitsGetScoreEntry()
+        {
+            string sourcePath = ResolveShapeFixturePath();
+            string onDisk = File.ReadAllText(sourcePath);
+            string snapshotSource = onDisk.Replace(
+                "return _score;",
+                "return _score + 1;",
+                StringComparison.Ordinal);
+            Assert.That(snapshotSource, Is.Not.EqualTo(onDisk), "Precondition: snapshot must differ.");
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                ResolveShapeFixtureProjectRelativePath(),
+                snapshotSource: snapshotSource);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.None.Contain("Edits outside method bodies"),
+                "Block getter-body-only edits must not emit outside-method-body drift.");
+
+            bool foundGetter = false;
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                if (entry.methodName == "get_Score")
+                {
+                    foundGetter = true;
+                }
+            }
+
+            Assert.That(
+                foundGetter,
+                Is.True,
+                "Edited get_Score must appear in entries; got: "
+                + FormatEntryMethodNames(result.Output.entries));
+        }
+
+        /// <summary>
+        /// What: when only a property setter body differs from the snapshot, the unchanged getter
+        /// stays out of entries (baseline compare is getter-scoped, not whole-property).
+        /// </summary>
+        [Test]
+        public async Task Run_WithSnapshotDifferingOnlyInSetter_DoesNotEmitUnchangedGetter()
+        {
+            const string source =
+                "namespace GetterBaselineScope\n"
+                + "{\n"
+                + "    public class Host\n"
+                + "    {\n"
+                + "        private int _value;\n"
+                + "        public int Value\n"
+                + "        {\n"
+                + "            get { return _value; }\n"
+                + "            set { _value = value; }\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+            string snapshotSource = source.Replace(
+                "set { _value = value; }",
+                "set { _value = value + 1; }",
+                StringComparison.Ordinal);
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(
+                projectRoot,
+                HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string sourcePath = Path.Combine(directory, "SetterOnlyBaseline.cs");
+            File.WriteAllText(sourcePath, source);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                "Library/UloopHotReload/TestSources/SetterOnlyBaseline.cs",
+                snapshotSource: snapshotSource);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            if (result.Output.entries != null)
+            {
+                foreach (TransformWorkerEntryDto entry in result.Output.entries)
+                {
+                    Assert.That(
+                        entry.methodName,
+                        Is.Not.EqualTo("get_Value"),
+                        "Setter-only edits must not emit Patched get_Value.");
+                }
+            }
+
+            bool foundUnchangedGetter = false;
+            if (result.Output.unchangedMethods != null)
+            {
+                foreach (TransformWorkerUnchangedMethodDto unchanged in result.Output.unchangedMethods)
+                {
+                    if (unchanged.methodName == "get_Value")
+                    {
+                        foundUnchangedGetter = true;
+                    }
+                }
+            }
+
+            Assert.That(
+                foundUnchangedGetter,
+                Is.True,
+                "Unedited get_Value must appear in unchangedMethods after a setter-only edit.");
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -870,6 +870,92 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: with an identical snapshot, property getters with bodies are listed in
+        /// unchangedMethods as get_&lt;Name&gt; (Skipped-only accessors would leave them out).
+        /// </summary>
+        [Test]
+        public async Task Run_WithIdenticalSnapshotOnPropertyGetterFixture_ListsGettersUnchanged()
+        {
+            string sourcePath = ResolveShapeFixturePath();
+            string onDisk = File.ReadAllText(sourcePath);
+            Assert.That(onDisk, Does.Contain(nameof(HotReloadPropertyGetterFixture)));
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                ResolveShapeFixtureProjectRelativePath(),
+                snapshotSource: onDisk);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.unchangedMethods, Is.Not.Null);
+
+            HashSet<string> unchangedNames = new HashSet<string>();
+            foreach (TransformWorkerUnchangedMethodDto unchanged in result.Output.unchangedMethods)
+            {
+                if (unchanged.typeMetadataName != null
+                    && unchanged.typeMetadataName.Contains(nameof(HotReloadPropertyGetterFixture)))
+                {
+                    unchangedNames.Add(unchanged.methodName);
+                }
+            }
+
+            Assert.That(
+                unchangedNames,
+                Does.Contain("get_HeightAmplitude"),
+                "Unedited expression-bodied getter must appear in unchangedMethods; got: "
+                + string.Join(", ", unchangedNames));
+            Assert.That(
+                unchangedNames,
+                Does.Contain("get_Score"),
+                "Unedited block getter must appear in unchangedMethods; got: "
+                + string.Join(", ", unchangedNames));
+        }
+
+        /// <summary>
+        /// What: when only a property getter body differs from the snapshot, the worker emits a
+        /// get_&lt;Name&gt; entry (Skipped for accessors would leave entries empty for that edit).
+        /// </summary>
+        [Test]
+        public async Task Run_WithSnapshotDifferingOnlyInGetter_EmitsGetAccessorEntry()
+        {
+            string sourcePath = ResolveShapeFixturePath();
+            string onDisk = File.ReadAllText(sourcePath);
+            string snapshotSource = onDisk.Replace(
+                "public static float HeightAmplitude => 5f;",
+                "public static float HeightAmplitude => 6f;",
+                StringComparison.Ordinal);
+            Assert.That(snapshotSource, Is.Not.EqualTo(onDisk), "Precondition: snapshot must differ.");
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                ResolveShapeFixtureProjectRelativePath(),
+                snapshotSource: snapshotSource);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.entries, Is.Not.Null);
+
+            bool foundGetter = false;
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                if (entry.methodName == "get_HeightAmplitude")
+                {
+                    foundGetter = true;
+                    Assert.That(
+                        entry.parameterTypeFullNames == null
+                        || entry.parameterTypeFullNames.Length == 0,
+                        "Getter entries must have zero parameters.");
+                }
+            }
+
+            Assert.That(
+                foundGetter,
+                Is.True,
+                "Edited get_HeightAmplitude must appear in entries; got: "
+                + FormatEntryMethodNames(result.Output.entries)
+                + "; skipped="
+                + FormatSkippedMethodNames(result.Output.skipped));
+        }
+
+        /// <summary>
         /// What: patching Awake itself emits the direct one-shot lifecycle note.
         /// </summary>
         [Test]
@@ -1079,6 +1165,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             foreach (TransformWorkerEntryDto entry in entries)
             {
                 names.Add(entry.methodName);
+            }
+
+            return string.Join(", ", names);
+        }
+
+        private static string FormatSkippedMethodNames(TransformWorkerSkippedDto[] skipped)
+        {
+            if (skipped == null || skipped.Length == 0)
+            {
+                return "(none)";
+            }
+
+            List<string> names = new List<string>(skipped.Length);
+            foreach (TransformWorkerSkippedDto entry in skipped)
+            {
+                names.Add(entry.method);
             }
 
             return string.Join(", ", names);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -52,10 +52,10 @@ ledger across runs.
 
 ## Scope and limits
 
-Only ordinary method declarations are patched. Constructors, finalizers, operators, event
-accessors, and `interface` members (including default interface implementations) are never
-scanned: edits to them produce **no per-method entry at all** and are silently not applied —
-use `uloop compile` for those.
+Only ordinary method declarations and property getters with a body are patched.
+Constructors, finalizers, operators, event accessors, and `interface` members
+(including default interface implementations) are never scanned: edits to them produce
+**no per-method entry at all** and are silently not applied — use `uloop compile` for those.
 
 Hot reload never adds members. A refactor that extracts a new helper method cannot be
 applied piecewise — keep iterating inside existing method bodies, then run
@@ -72,6 +72,18 @@ initializers, attributes, added or removed members — is reported as a `Warning
 entry as well; without a baseline it stays silent. Either way, use `uloop compile`
 for such edits.
 
+### Tunable values: prefer a getter over a const
+
+`const` edits never take effect through hot reload: C# bakes const values into every
+call site at compile time. When you expect to tune a value while Play Mode is running
+(speeds, amplitudes, sensitivities), expose it as a static property getter instead:
+
+    public static float HeightAmplitude => 5f;
+
+A getter body is an ordinary patchable method body, so editing the literal and running
+`uloop hot-reload` updates every consumer on its next call — across all files, without
+restarting Play Mode. Keep `const` for values you never tune at runtime.
+
 Each `uloop compile` also establishes a per-assembly source baseline: a snapshot of
 the sources exactly as they were compiled, captured after the compile's domain reload
 and adopted only once it verifies against the compiled assembly's PDB checksums. With
@@ -87,9 +99,10 @@ the first compile after installing or updating the package — every editable me
 the file is patched and a `Warnings` line reports the fallback; run `uloop compile`
 to establish the baseline.
 
-Property and indexer accessors with explicit bodies are reported per-accessor as
-`Skipped`, so an edited getter never disappears from the response silently; with a
-verified baseline, accessors unchanged from it produce no row.
+Property getters with a body (including expression-bodied properties) are patched
+like ordinary methods. Setter, init, and indexer accessors with explicit bodies are
+reported per-accessor as `Skipped`, so an edited accessor never disappears from the
+response silently; with a verified baseline, accessors unchanged from it produce no row.
 
 Subscribing to or unsubscribing from a field-like event (`+=`/`-=`) inside an edited
 body works. Methods that raise the event are reported as `Skipped` (see the table
@@ -107,7 +120,7 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Body contains a `base.` call | `base` cannot be expressed from outside the type |
 | Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
-| Property or indexer accessor with an explicit body | Accessor patching is out of scope for v1; `uloop compile` applies accessor edits |
+| Property setter, init, or indexer accessor with an explicit body | Accessor patching covers getters only; `uloop compile` applies setter/init/indexer edits |
 | Method raises, invokes, or reads a field-like event (anything beyond `+=`/`-=`) | C# only allows `+=`/`-=` on an event outside its declaring type, so the raising body cannot compile from the shim assembly |
 
 ### Failed — flips `Success` to `false`

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -556,6 +556,26 @@ public static class TransformWorkerProgram
         List<SyntaxNode> nodesToAnnotate = new List<SyntaxNode>();
         nodesToAnnotate.AddRange(root.DescendantNodes().OfType<MethodDeclarationSyntax>());
         nodesToAnnotate.AddRange(root.DescendantNodes().OfType<StatementSyntax>());
+        // Why property/accessor arrows: expression-bodied getters are rewritten into synthetic
+        // MethodDeclarations that would otherwise carry no #line annotations into the shim.
+        foreach (PropertyDeclarationSyntax propertyDeclaration in root.DescendantNodes()
+            .OfType<PropertyDeclarationSyntax>())
+        {
+            if (propertyDeclaration.ExpressionBody != null)
+            {
+                nodesToAnnotate.Add(propertyDeclaration.ExpressionBody);
+            }
+        }
+
+        foreach (AccessorDeclarationSyntax accessor in root.DescendantNodes()
+            .OfType<AccessorDeclarationSyntax>())
+        {
+            if (accessor.IsKind(SyntaxKind.GetAccessorDeclaration) && accessor.ExpressionBody != null)
+            {
+                nodesToAnnotate.Add(accessor.ExpressionBody);
+            }
+        }
+
         if (nodesToAnnotate.Count == 0)
         {
             return root;
@@ -583,6 +603,12 @@ public static class TransformWorkerProgram
             // method to one line, so mapping to the arrow expression's original start is the only
             // location that still matches the user's intent for expression-bodied methods.
             return methodDeclaration.ExpressionBody.Expression.GetLocation()
+                .GetLineSpan().StartLinePosition.Line + 1;
+        }
+
+        if (node is ArrowExpressionClauseSyntax arrowExpressionClause)
+        {
+            return arrowExpressionClause.Expression.GetLocation()
                 .GetLineSpan().StartLinePosition.Line + 1;
         }
 
@@ -965,6 +991,50 @@ public static class TransformWorkerProgram
                 .WithSemicolonToken(default(SyntaxToken))
                 .WithBody(SyntaxFactory.Block());
         }
+
+        // Why strip getters only: patched getter edits must not look like outside-body drift.
+        // Setter/init/indexer bodies stay so those still-unapplied edits keep the warning.
+        public override SyntaxNode VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+        {
+            PropertyDeclarationSyntax visited = (PropertyDeclarationSyntax)base.VisitPropertyDeclaration(node);
+            if (visited.ExpressionBody != null)
+            {
+                return visited
+                    .WithExpressionBody(null)
+                    .WithSemicolonToken(default(SyntaxToken))
+                    .WithAccessorList(
+                        SyntaxFactory.AccessorList(
+                            SyntaxFactory.SingletonList(
+                                SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                                    .WithBody(SyntaxFactory.Block()))));
+            }
+
+            if (visited.AccessorList == null)
+            {
+                return visited;
+            }
+
+            List<AccessorDeclarationSyntax> accessors = new List<AccessorDeclarationSyntax>();
+            foreach (AccessorDeclarationSyntax accessor in visited.AccessorList.Accessors)
+            {
+                if (accessor.IsKind(SyntaxKind.GetAccessorDeclaration)
+                    && (accessor.Body != null || accessor.ExpressionBody != null))
+                {
+                    accessors.Add(
+                        accessor
+                            .WithExpressionBody(null)
+                            .WithSemicolonToken(default(SyntaxToken))
+                            .WithBody(SyntaxFactory.Block()));
+                }
+                else
+                {
+                    accessors.Add(accessor);
+                }
+            }
+
+            return visited.WithAccessorList(
+                SyntaxFactory.AccessorList(SyntaxFactory.List(accessors)));
+        }
     }
 
     // What: reports each property/indexer accessor that has an explicit body as Skipped.
@@ -1198,7 +1268,7 @@ public static class TransformWorkerProgram
             string propertyKey = BuildSyntaxPropertyKey(typeMetadataNameFromSyntax, propertyDeclaration);
             if (snapshotPropertyMap.TryGetValue(propertyKey, out PropertyDeclarationSyntax snapshotProperty)
                 && plainCurrentPropertyMap.TryGetValue(propertyKey, out PropertyDeclarationSyntax plainProperty)
-                && SyntaxFactory.AreEquivalent(snapshotProperty, plainProperty, topLevel: false))
+                && ArePropertyGettersEquivalent(snapshotProperty, plainProperty))
             {
                 unchangedMethods.Add(new WorkerUnchangedMethod
                 {
@@ -1323,6 +1393,44 @@ public static class TransformWorkerProgram
         return (false, null);
     }
 
+    // Why getter-only: whole-property AreEquivalent treats setter edits as getter changes and
+    // would emit a useless Patched get_ row beside Skipped set_.
+    private static bool ArePropertyGettersEquivalent(
+        PropertyDeclarationSyntax snapshotProperty,
+        PropertyDeclarationSyntax currentProperty)
+    {
+        return SyntaxFactory.AreEquivalent(
+            NormalizePropertyToGetterShape(snapshotProperty),
+            NormalizePropertyToGetterShape(currentProperty),
+            topLevel: false);
+    }
+
+    private static PropertyDeclarationSyntax NormalizePropertyToGetterShape(
+        PropertyDeclarationSyntax propertyDeclaration)
+    {
+        if (propertyDeclaration.ExpressionBody != null)
+        {
+            return propertyDeclaration.WithAccessorList(null);
+        }
+
+        if (propertyDeclaration.AccessorList == null)
+        {
+            return propertyDeclaration;
+        }
+
+        List<AccessorDeclarationSyntax> getAccessors = new List<AccessorDeclarationSyntax>();
+        foreach (AccessorDeclarationSyntax accessor in propertyDeclaration.AccessorList.Accessors)
+        {
+            if (accessor.IsKind(SyntaxKind.GetAccessorDeclaration))
+            {
+                getAccessors.Add(accessor);
+            }
+        }
+
+        return propertyDeclaration.WithAccessorList(
+            SyntaxFactory.AccessorList(SyntaxFactory.List(getAccessors)));
+    }
+
     // What: rewrite a getter body while it is still in the bound tree, then wrap as a shim method.
     private static MethodDeclarationSyntax RewritePropertyGetterBody(
         PropertyDeclarationSyntax propertyDeclaration,
@@ -1334,6 +1442,8 @@ public static class TransformWorkerProgram
     {
         ShimBodyRewriter rewriter = new ShimBodyRewriter(semanticModel, targetType, accessorPlan);
         SyntaxNode rewrittenBody = rewriter.Visit(getterBodyNode);
+        // Why transfer: Visit may rebuild ArrowExpressionClause nodes and drop #line annotations.
+        rewrittenBody = TransferUloopLineAnnotations(getterBodyNode, rewrittenBody);
 
         TypeSyntax returnType = propertyDeclaration.Type.WithoutTrivia();
         // ToShimMethod forces public static and injects __instance for instance getters.
@@ -1359,13 +1469,33 @@ public static class TransformWorkerProgram
         else
         {
             // get => expr rewritten to a bare expression: wrap as arrow.
+            ArrowExpressionClauseSyntax wrappedArrow = SyntaxFactory.ArrowExpressionClause(
+                (ExpressionSyntax)rewrittenBody);
+            wrappedArrow = (ArrowExpressionClauseSyntax)TransferUloopLineAnnotations(
+                getterBodyNode,
+                wrappedArrow);
             method = method
-                .WithExpressionBody(
-                    SyntaxFactory.ArrowExpressionClause((ExpressionSyntax)rewrittenBody))
+                .WithExpressionBody(wrappedArrow)
                 .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
         }
 
         return ShimMethodFactory.ToShimMethod(method, getterSymbol);
+    }
+
+    private static SyntaxNode TransferUloopLineAnnotations(SyntaxNode source, SyntaxNode target)
+    {
+        if (source == null || target == null)
+        {
+            return target;
+        }
+
+        SyntaxNode result = target;
+        foreach (SyntaxAnnotation annotation in source.GetAnnotations(UloopLineAnnotationKind))
+        {
+            result = result.WithAdditionalAnnotations(annotation);
+        }
+
+        return result;
     }
 
     private static IEnumerable<TypeDeclarationSyntax> EnumerateTypeDeclarations(CompilationUnitSyntax root)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -312,8 +312,8 @@ public static class TransformWorkerProgram
 
             string typeMetadataNameFromSyntax = BuildTypeMetadataNameFromSyntax(typeDeclaration);
 
-            // Accessors are never patched in v1; report each explicit-body accessor as Skipped
-            // so an edited getter/setter never disappears from the response silently.
+            // Property setters/init and all indexer accessors with bodies stay Skipped.
+            // Property getters are patched below (not reported here).
             AppendExplicitAccessorSkips(
                 typeDeclaration,
                 typeMetadataNameFromSyntax,
@@ -327,10 +327,6 @@ public static class TransformWorkerProgram
             List<MethodDeclarationSyntax> methods = typeDeclaration.Members
                 .OfType<MethodDeclarationSyntax>()
                 .ToList();
-            if (methods.Count == 0)
-            {
-                continue;
-            }
 
             ShimTypeBuilder currentShimType = null;
             foreach (MethodDeclarationSyntax methodDeclaration in methods)
@@ -378,11 +374,14 @@ public static class TransformWorkerProgram
                     }
                 }
 
+                SyntaxNode methodBodyNode =
+                    (SyntaxNode)methodDeclaration.Body ?? methodDeclaration.ExpressionBody;
                 MethodTransformDecision decision = DecideMethodTransform(
                     typeDeclaration,
                     typeSymbol,
                     methodDeclaration,
                     methodSymbol,
+                    methodBodyNode,
                     semanticModel);
                 if (decision.SkipReason != null)
                 {
@@ -442,6 +441,33 @@ public static class TransformWorkerProgram
                     SourceEndLine = sourceEndLine,
                     LifecycleNote = ComputeLifecycleNote(methodDeclaration, methodSymbol, typeSymbol)
                 });
+            }
+
+            foreach (PropertyDeclarationSyntax propertyDeclaration in typeDeclaration.Members
+                .OfType<PropertyDeclarationSyntax>())
+            {
+                (ShimTypeBuilder nextShimType, int nextShimTypeCounter, int nextGlobalShimMethodCounter) =
+                    AppendPropertyGetterEntry(
+                        propertyDeclaration,
+                        typeDeclaration,
+                        typeSymbol,
+                        typeMetadataNameFromSyntax,
+                        semanticModel,
+                        root,
+                        input,
+                        hasBaseline,
+                        snapshotPropertyMap,
+                        plainCurrentPropertyMap,
+                        entries,
+                        skipped,
+                        unchangedMethods,
+                        shimTypes,
+                        shimTypeCounter,
+                        globalShimMethodCounter,
+                        currentShimType);
+                currentShimType = nextShimType;
+                shimTypeCounter = nextShimTypeCounter;
+                globalShimMethodCounter = nextGlobalShimMethodCounter;
             }
         }
 
@@ -694,7 +720,8 @@ public static class TransformWorkerProgram
     }
 
     private const string ExplicitAccessorSkipReason =
-        "Property and indexer accessors are out of scope for v1; run 'uloop compile' to apply accessor edits.";
+        "Property setter, init, or indexer accessors are out of scope for v1; "
+        + "run 'uloop compile' to apply accessor edits.";
 
     private const string OutsideMethodBodyDriftWarningFormat =
         "Edits outside method bodies in {0} (fields, initializers, attributes, or added/removed members) are not applied by hot reload; run uloop compile to pick them up.";
@@ -1015,13 +1042,52 @@ public static class TransformWorkerProgram
             return;
         }
 
-        // Expression-bodied property/indexer (`=> expr`) is the getter body.
-        bool hasExpressionBody =
-            (propertyDeclaration is PropertyDeclarationSyntax propertyWithExpression
-                && propertyWithExpression.ExpressionBody != null)
-            || (propertyDeclaration is IndexerDeclarationSyntax indexerWithExpression
-                && indexerWithExpression.ExpressionBody != null);
-        if (hasExpressionBody)
+        // Indexers: keep reporting every explicit-body accessor (including expression-bodied).
+        if (propertyDeclaration is IndexerDeclarationSyntax indexerDeclaration)
+        {
+            AppendIndexerExplicitAccessorSkips(indexerDeclaration, propertySymbol, skipped);
+            return;
+        }
+
+        // Properties: getters are patched elsewhere; only setter/init with bodies are Skipped here.
+        if (propertyDeclaration.AccessorList == null)
+        {
+            return;
+        }
+
+        foreach (AccessorDeclarationSyntax accessor in propertyDeclaration.AccessorList.Accessors)
+        {
+            if (accessor.IsKind(SyntaxKind.GetAccessorDeclaration))
+            {
+                continue;
+            }
+
+            // Auto-properties emit accessors with neither Body nor ExpressionBody.
+            if (accessor.Body == null && accessor.ExpressionBody == null)
+            {
+                continue;
+            }
+
+            IMethodSymbol accessorMethod = ResolveAccessorMethodSymbol(propertySymbol, accessor.Kind());
+            if (accessorMethod == null)
+            {
+                continue;
+            }
+
+            skipped.Add(new WorkerSkipped
+            {
+                Method = FormatMethodLabel(accessorMethod),
+                Reason = ExplicitAccessorSkipReason
+            });
+        }
+    }
+
+    private static void AppendIndexerExplicitAccessorSkips(
+        IndexerDeclarationSyntax indexerDeclaration,
+        IPropertySymbol propertySymbol,
+        List<WorkerSkipped> skipped)
+    {
+        if (indexerDeclaration.ExpressionBody != null)
         {
             if (propertySymbol.GetMethod != null)
             {
@@ -1035,14 +1101,13 @@ public static class TransformWorkerProgram
             return;
         }
 
-        if (propertyDeclaration.AccessorList == null)
+        if (indexerDeclaration.AccessorList == null)
         {
             return;
         }
 
-        foreach (AccessorDeclarationSyntax accessor in propertyDeclaration.AccessorList.Accessors)
+        foreach (AccessorDeclarationSyntax accessor in indexerDeclaration.AccessorList.Accessors)
         {
-            // Auto-properties emit accessors with neither Body nor ExpressionBody.
             if (accessor.Body == null && accessor.ExpressionBody == null)
             {
                 continue;
@@ -1080,6 +1145,229 @@ public static class TransformWorkerProgram
         return null;
     }
 
+    // What: emit a get_<Name> entry / unchanged row / skip for one property with a getter body.
+    private static (ShimTypeBuilder CurrentShimType, int ShimTypeCounter, int GlobalShimMethodCounter)
+        AppendPropertyGetterEntry(
+            PropertyDeclarationSyntax propertyDeclaration,
+            TypeDeclarationSyntax typeDeclaration,
+            INamedTypeSymbol typeSymbol,
+            string typeMetadataNameFromSyntax,
+            SemanticModel semanticModel,
+            CompilationUnitSyntax root,
+            WorkerInput input,
+            bool hasBaseline,
+            Dictionary<string, PropertyDeclarationSyntax> snapshotPropertyMap,
+            Dictionary<string, PropertyDeclarationSyntax> plainCurrentPropertyMap,
+            List<WorkerEntry> entries,
+            List<WorkerSkipped> skipped,
+            List<WorkerUnchangedMethod> unchangedMethods,
+            List<ShimTypeBuilder> shimTypes,
+            int shimTypeCounter,
+            int globalShimMethodCounter,
+            ShimTypeBuilder currentShimType)
+    {
+        IPropertySymbol propertySymbol = semanticModel.GetDeclaredSymbol(propertyDeclaration);
+        if (propertySymbol == null || propertySymbol.GetMethod == null)
+        {
+            return (currentShimType, shimTypeCounter, globalShimMethodCounter);
+        }
+
+        (bool hasGetterBody, AccessorDeclarationSyntax getAccessor) =
+            TryGetPropertyGetterBody(propertyDeclaration);
+        if (!hasGetterBody)
+        {
+            // Auto-property / setter-only: not a patch candidate (no Skipped row either).
+            return (currentShimType, shimTypeCounter, globalShimMethodCounter);
+        }
+
+        IMethodSymbol getterSymbol = propertySymbol.GetMethod;
+        string[] parameterTypeFullNames = Array.Empty<string>();
+        string methodKey = BuildMethodKey(
+            CecilTypeNames.ToMetadataName(typeSymbol),
+            getterSymbol.Name,
+            parameterTypeFullNames);
+        if (input.ExcludedMethodKeys.Contains(methodKey))
+        {
+            return (currentShimType, shimTypeCounter, globalShimMethodCounter);
+        }
+
+        if (hasBaseline
+            && snapshotPropertyMap != null
+            && plainCurrentPropertyMap != null)
+        {
+            string propertyKey = BuildSyntaxPropertyKey(typeMetadataNameFromSyntax, propertyDeclaration);
+            if (snapshotPropertyMap.TryGetValue(propertyKey, out PropertyDeclarationSyntax snapshotProperty)
+                && plainCurrentPropertyMap.TryGetValue(propertyKey, out PropertyDeclarationSyntax plainProperty)
+                && SyntaxFactory.AreEquivalent(snapshotProperty, plainProperty, topLevel: false))
+            {
+                unchangedMethods.Add(new WorkerUnchangedMethod
+                {
+                    TypeMetadataName = CecilTypeNames.ToMetadataName(typeSymbol),
+                    MethodName = getterSymbol.Name,
+                    ParameterTypeFullNames = parameterTypeFullNames
+                });
+                return (currentShimType, shimTypeCounter, globalShimMethodCounter);
+            }
+        }
+
+        if (propertyDeclaration.ExplicitInterfaceSpecifier != null)
+        {
+            skipped.Add(new WorkerSkipped
+            {
+                Method = FormatMethodLabel(getterSymbol),
+                Reason = "Explicit interface implementations are skipped in v1."
+            });
+            return (currentShimType, shimTypeCounter, globalShimMethodCounter);
+        }
+
+        // Why body stays on the property tree: SemanticModel rejects nodes re-parented onto a
+        // synthetic MethodDeclaration ("Syntax node is not within syntax tree").
+        SyntaxNode getterBodyNode = (SyntaxNode)propertyDeclaration.ExpressionBody
+            ?? (SyntaxNode)getAccessor.Body
+            ?? getAccessor.ExpressionBody;
+        MethodTransformDecision decision = DecideMethodTransform(
+            typeDeclaration,
+            typeSymbol,
+            methodDeclaration: null,
+            getterSymbol,
+            getterBodyNode,
+            semanticModel);
+        if (decision.SkipReason != null)
+        {
+            skipped.Add(new WorkerSkipped
+            {
+                Method = FormatMethodLabel(getterSymbol),
+                Reason = decision.SkipReason
+            });
+            return (currentShimType, shimTypeCounter, globalShimMethodCounter);
+        }
+
+        if (currentShimType == null)
+        {
+            string shimTypeName = typeSymbol.Name + "_UloopHotReloadShims_" + shimTypeCounter;
+            shimTypeCounter++;
+            string namespaceName = typeSymbol.ContainingNamespace == null
+                || typeSymbol.ContainingNamespace.IsGlobalNamespace
+                ? string.Empty
+                : typeSymbol.ContainingNamespace.ToDisplayString();
+            currentShimType = new ShimTypeBuilder(
+                shimTypeName,
+                namespaceName,
+                CollectUsingsForType(root, typeDeclaration));
+            shimTypes.Add(currentShimType);
+        }
+
+        string shimMethodName = getterSymbol.Name + "__shim" + globalShimMethodCounter;
+        globalShimMethodCounter++;
+
+        FileLinePositionSpan originalSpan = propertyDeclaration.GetLocation().GetLineSpan();
+        int sourceStartLine = originalSpan.StartLinePosition.Line + 1;
+        int sourceEndLine = originalSpan.EndLinePosition.Line + 1;
+
+        AccessorPlan rewritePlan = decision.UsesDelegation
+            ? currentShimType.AccessorPlan
+            : null;
+        MethodDeclarationSyntax rewrittenMethod = RewritePropertyGetterBody(
+            propertyDeclaration,
+            getterBodyNode,
+            getterSymbol,
+            typeSymbol,
+            semanticModel,
+            rewritePlan);
+        currentShimType.AddMethod(rewrittenMethod, shimMethodName);
+
+        entries.Add(new WorkerEntry
+        {
+            TypeMetadataName = CecilTypeNames.ToMetadataName(typeSymbol),
+            MethodName = getterSymbol.Name,
+            ParameterTypeFullNames = parameterTypeFullNames,
+            ShimTypeName = currentShimType.ShimTypeName,
+            ShimMethodName = shimMethodName,
+            PatchKind = decision.PatchKind,
+            SourceStartLine = sourceStartLine,
+            SourceEndLine = sourceEndLine,
+            LifecycleNote = null
+        });
+
+        return (currentShimType, shimTypeCounter, globalShimMethodCounter);
+    }
+
+    private static (bool HasGetterBody, AccessorDeclarationSyntax GetAccessor) TryGetPropertyGetterBody(
+        PropertyDeclarationSyntax propertyDeclaration)
+    {
+        if (propertyDeclaration.ExpressionBody != null)
+        {
+            return (true, null);
+        }
+
+        if (propertyDeclaration.AccessorList == null)
+        {
+            return (false, null);
+        }
+
+        foreach (AccessorDeclarationSyntax accessor in propertyDeclaration.AccessorList.Accessors)
+        {
+            if (!accessor.IsKind(SyntaxKind.GetAccessorDeclaration))
+            {
+                continue;
+            }
+
+            if (accessor.Body == null && accessor.ExpressionBody == null)
+            {
+                return (false, null);
+            }
+
+            return (true, accessor);
+        }
+
+        return (false, null);
+    }
+
+    // What: rewrite a getter body while it is still in the bound tree, then wrap as a shim method.
+    private static MethodDeclarationSyntax RewritePropertyGetterBody(
+        PropertyDeclarationSyntax propertyDeclaration,
+        SyntaxNode getterBodyNode,
+        IMethodSymbol getterSymbol,
+        INamedTypeSymbol targetType,
+        SemanticModel semanticModel,
+        AccessorPlan accessorPlan)
+    {
+        ShimBodyRewriter rewriter = new ShimBodyRewriter(semanticModel, targetType, accessorPlan);
+        SyntaxNode rewrittenBody = rewriter.Visit(getterBodyNode);
+
+        TypeSyntax returnType = propertyDeclaration.Type.WithoutTrivia();
+        // ToShimMethod forces public static and injects __instance for instance getters.
+        MethodDeclarationSyntax method = SyntaxFactory.MethodDeclaration(
+                returnType,
+                SyntaxFactory.Identifier(getterSymbol.Name))
+            .WithModifiers(
+                SyntaxFactory.TokenList(
+                    SyntaxFactory.Token(SyntaxKind.PublicKeyword),
+                    SyntaxFactory.Token(SyntaxKind.StaticKeyword)))
+            .WithParameterList(SyntaxFactory.ParameterList());
+
+        if (rewrittenBody is ArrowExpressionClauseSyntax arrowBody)
+        {
+            method = method
+                .WithExpressionBody(arrowBody)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+        }
+        else if (rewrittenBody is BlockSyntax blockBody)
+        {
+            method = method.WithBody(blockBody);
+        }
+        else
+        {
+            // get => expr rewritten to a bare expression: wrap as arrow.
+            method = method
+                .WithExpressionBody(
+                    SyntaxFactory.ArrowExpressionClause((ExpressionSyntax)rewrittenBody))
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+        }
+
+        return ShimMethodFactory.ToShimMethod(method, getterSymbol);
+    }
+
     private static IEnumerable<TypeDeclarationSyntax> EnumerateTypeDeclarations(CompilationUnitSyntax root)
     {
         return root.DescendantNodes()
@@ -1090,11 +1378,13 @@ public static class TransformWorkerProgram
                 || typeDeclaration is RecordDeclarationSyntax);
     }
 
+    // methodDeclaration may be null for property getters (bodyNode must still be in the bound tree).
     private static MethodTransformDecision DecideMethodTransform(
         TypeDeclarationSyntax typeDeclaration,
         INamedTypeSymbol typeSymbol,
         MethodDeclarationSyntax methodDeclaration,
         IMethodSymbol methodSymbol,
+        SyntaxNode bodyNode,
         SemanticModel semanticModel)
     {
         string hardSkip = EvaluateHardSkipReason(
@@ -1107,7 +1397,6 @@ public static class TransformWorkerProgram
             return MethodTransformDecision.Skip(hardSkip);
         }
 
-        SyntaxNode bodyNode = (SyntaxNode)methodDeclaration.Body ?? methodDeclaration.ExpressionBody;
         if (bodyNode == null)
         {
             return MethodTransformDecision.Skip("Methods without a body (abstract/extern) are skipped.");
@@ -1145,7 +1434,6 @@ public static class TransformWorkerProgram
 
         if (!AccessorEligibility.TryBuildPlan(
                 semanticModel,
-                methodDeclaration,
                 methodSymbol,
                 typeSymbol,
                 bodyNode,
@@ -1188,8 +1476,8 @@ public static class TransformWorkerProgram
             return "Struct (value type) methods are out of scope for v1; byref instance transplant is unverified.";
         }
 
-        if (typeSymbol.IsGenericType || methodSymbol.IsGenericMethod
-            || methodDeclaration.TypeParameterList != null)
+        bool hasTypeParameters = methodDeclaration != null && methodDeclaration.TypeParameterList != null;
+        if (typeSymbol.IsGenericType || methodSymbol.IsGenericMethod || hasTypeParameters)
         {
             return "Generic methods and methods inside generic types cannot be safely patched with Harmony.";
         }
@@ -1197,7 +1485,7 @@ public static class TransformWorkerProgram
         // Explicit interface implementations have dotted metadata names (e.g. IFoo.Bar) that are
         // not valid C# identifiers for shim method names; sanitizing would also desync the
         // matcher (Cecil MethodDefinition.Name). v1 skips them with an explicit reason.
-        if (methodDeclaration.ExplicitInterfaceSpecifier != null)
+        if (methodDeclaration != null && methodDeclaration.ExplicitInterfaceSpecifier != null)
         {
             return "Explicit interface implementations are skipped in v1.";
         }
@@ -1257,7 +1545,8 @@ public static class TransformWorkerProgram
 
     private static bool IsAsyncOrIterator(MethodDeclarationSyntax methodDeclaration, SyntaxNode bodyNode)
     {
-        if (methodDeclaration.Modifiers.Any(static modifier => modifier.IsKind(SyntaxKind.AsyncKeyword)))
+        if (methodDeclaration != null
+            && methodDeclaration.Modifiers.Any(static modifier => modifier.IsKind(SyntaxKind.AsyncKeyword)))
         {
             return true;
         }
@@ -2135,7 +2424,6 @@ internal static class AccessorEligibility
 {
     public static bool TryBuildPlan(
         SemanticModel semanticModel,
-        MethodDeclarationSyntax methodDeclaration,
         IMethodSymbol methodSymbol,
         INamedTypeSymbol typeSymbol,
         SyntaxNode bodyNode,
@@ -2156,7 +2444,7 @@ internal static class AccessorEligibility
             return false;
         }
 
-        if (!AreBodyTypeUsagesVisible(semanticModel, methodDeclaration, out rejectReason))
+        if (!AreBodyTypeUsagesVisible(semanticModel, bodyNode, out rejectReason))
         {
             return false;
         }
@@ -2223,10 +2511,10 @@ internal static class AccessorEligibility
 
     private static bool AreBodyTypeUsagesVisible(
         SemanticModel semanticModel,
-        MethodDeclarationSyntax methodDeclaration,
+        SyntaxNode bodyNode,
         out string rejectReason)
     {
-        foreach (SyntaxNode node in methodDeclaration.DescendantNodesAndSelf())
+        foreach (SyntaxNode node in bodyNode.DescendantNodesAndSelf())
         {
             if (TransformWorkerProgram.NameofRules.IsInsideNameofArgument(node))
             {


### PR DESCRIPTION
## Summary
- Property getters with a body (expression-bodied or block `get`) can now be hot-reloaded like ordinary methods, so tunable values update on the next call without leaving Play Mode.
- The hot-reload skill documents the recommended pattern: prefer a static property getter over `const` when you expect to tune speeds, amplitudes, or sensitivities at runtime.

## User Impact
- Before: editing a property getter (or a `const` used as a “tunable”) did nothing useful under hot reload — accessors were skipped, and `const` values stay baked into call sites until a full compile.
- After: editing a getter body and running `uloop hot-reload` patches `get_<Name>`; `--status` lists the Active method with the same label; revert restores the compiled body. Setter, init, and indexer accessors remain Skipped and still need `uloop compile`.

This addresses the const-structure feedback from hot-reload usability rounds S1-2 / S2: keep compile-time constants as `const`, and expose values you want to tune through patchable getters.

## Changes
- Transform worker emits and patches `get_<Name>` for property getters with bodies; setter/init/indexer accessors with bodies stay Skipped; auto-properties produce no row.
- EditMode coverage: worker snapshot diffs, orchestrator skip/patch matrix, and apply → `--status` → revert E2E on `HeightAmplitude`.
- Skill + generated `.claude` / `.agents` copies updated (including Scope opening line for getters).

## Verification
- `dist/darwin-arm64/uloop compile` — 0 errors, 0 warnings
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "HotReload|TransformWorker|PausePoint"` — 426/426 Passed
- `scripts/sync-tool-docs.sh` / `go run ./cmd/sync-tool-docs --check` — no drift (skill commit)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

