### PR TITLE
feat: refuse uloop update for Homebrew-managed installs

### DIFF
--- a/cli/dispatcher/internal/dispatcher/dispatcher_bootstrap_routing_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_bootstrap_routing_test.go
@@ -68,11 +68,13 @@ func TestRunDispatcherUpdateRunsInDispatcherProcess(t *testing.T) {
 	previousReader := dispatcherReadInstalledVersion
 	previousResolver := resolveUpdateTargetVersionFunc
 	previousManifest := fetchAttestationSubjectManifestFunc
+	previousExecutablePath := resolveUpdateExecutablePathFunc
 	defer func() {
 		updateRunCommand = previousRun
 		dispatcherReadInstalledVersion = previousReader
 		resolveUpdateTargetVersionFunc = previousResolver
 		fetchAttestationSubjectManifestFunc = previousManifest
+		resolveUpdateExecutablePathFunc = previousExecutablePath
 	}()
 	updateExecuted := false
 	updateRunCommand = func(context.Context, update.Command, io.Writer, io.Writer) error {
@@ -90,6 +92,11 @@ func TestRunDispatcherUpdateRunsInDispatcherProcess(t *testing.T) {
 	}
 	fetchAttestationSubjectManifestFunc = func(ctx context.Context, tag string) (string, error) {
 		return "deadbeef  install.sh\n", nil
+	}
+	// Why: keep this routing test off os.Executable so a Cellar-hosted binary cannot
+	// trip the Homebrew guard and hide a real dispatcher-process regression.
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return "/Users/someone/.local/bin/uloop", nil
 	}
 
 	var stdout bytes.Buffer

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -445,8 +445,9 @@ func TestEnforceDispatcherFreshnessRequiresBrewUpgradeWhenHomebrewManagedAndUpda
 	if !handled || code != 1 {
 		t.Fatalf("freshness result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
 	}
-	if !bytes.Contains(stderr.Bytes(), []byte("brew upgrade uloop")) {
-		t.Fatalf("expected brew upgrade guidance in stderr, got: %s", stderr.String())
+	expectedNextAction := "Run `brew upgrade uloop` and retry the command."
+	if !bytes.Contains(stderr.Bytes(), []byte(expectedNextAction)) {
+		t.Fatalf("expected NextActions brew upgrade guidance in stderr, got: %s", stderr.String())
 	}
 	if !bytes.Contains(stderr.Bytes(), []byte(clierrors.ErrorCodeCLIUpdateRequired)) {
 		t.Fatalf("freshness output mismatch: %s", stderr.String())

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -420,6 +420,70 @@ func TestEnforceDispatcherFreshnessRequiresManualUpdateWhenSelfUpdateDisabled(t 
 	}
 }
 
+func TestEnforceDispatcherFreshnessRequiresBrewUpgradeWhenHomebrewManagedAndUpdateRequired(t *testing.T) {
+	// Verifies Homebrew-managed installs block required auto-update and point at brew upgrade.
+	previousResolver := resolveUpdateExecutablePathFunc
+	defer func() {
+		resolveUpdateExecutablePathFunc = previousResolver
+	}()
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return "/opt/homebrew/Cellar/uloop/3.0.0/bin/uloop", nil
+	}
+	deps := defaultDispatcherRunDeps()
+	deps.runUpdate = func(context.Context) error {
+		t.Fatal("runUpdate must not run for Homebrew-managed required freshness")
+		return nil
+	}
+
+	var stderr bytes.Buffer
+	handled, code := enforceDispatcherFreshnessWithDeps(
+		context.Background(),
+		dispatcherPin{MinimumDispatcherVersion: "999.0.0"},
+		&stderr,
+		deps)
+
+	if !handled || code != 1 {
+		t.Fatalf("freshness result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("brew upgrade uloop")) {
+		t.Fatalf("expected brew upgrade guidance in stderr, got: %s", stderr.String())
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte(clierrors.ErrorCodeCLIUpdateRequired)) {
+		t.Fatalf("freshness output mismatch: %s", stderr.String())
+	}
+}
+
+func TestEnforceDispatcherFreshnessSkipsOptionalUpdateWhenHomebrewManaged(t *testing.T) {
+	// Verifies Homebrew-managed installs skip optional auto-update without running the installer.
+	t.Setenv(nativepath.CacheDirEnvName, t.TempDir())
+	previousResolver := resolveUpdateExecutablePathFunc
+	defer func() {
+		resolveUpdateExecutablePathFunc = previousResolver
+	}()
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return "/opt/homebrew/Cellar/uloop/3.0.0/bin/uloop", nil
+	}
+	deps := defaultDispatcherRunDeps()
+	deps.runUpdate = func(context.Context) error {
+		t.Fatal("runUpdate must not run for Homebrew-managed optional freshness")
+		return nil
+	}
+
+	var stderr bytes.Buffer
+	handled, code := enforceDispatcherFreshnessWithDeps(
+		context.Background(),
+		dispatcherPin{MinimumDispatcherVersion: dispatcherVersion},
+		&stderr,
+		deps)
+
+	if handled || code != 0 {
+		t.Fatalf("freshness result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no optional update output for Homebrew installs, got: %s", stderr.String())
+	}
+}
+
 func TestEnforceDispatcherFreshnessMarksFailedOptionalUpdateChecked(t *testing.T) {
 	// Verifies transient optional update failures are throttled until the next check interval.
 	cacheRoot := t.TempDir()
@@ -545,7 +609,9 @@ func TestDecideDispatcherFreshnessPlansUpdatePaths(t *testing.T) {
 		selfUpdateDisabled bool
 		hasSiblingRealCLI  bool
 		updateDue          bool
+		homebrewManaged    bool
 		expectedAction     dispatcherFreshnessAction
+		expectedReason     string
 	}{
 		{
 			name:           "no minimum",
@@ -559,6 +625,16 @@ func TestDecideDispatcherFreshnessPlansUpdatePaths(t *testing.T) {
 			selfUpdateDisabled: true,
 			updateDue:          true,
 			expectedAction:     dispatcherFreshnessManualUpdateRequired,
+			expectedReason:     dispatcherFreshnessReasonSelfUpdateDisabled,
+		},
+		{
+			name:            "required update homebrew managed",
+			minimumVersion:  "999.0.0",
+			currentVersion:  dispatcherVersion,
+			homebrewManaged: true,
+			updateDue:       true,
+			expectedAction:  dispatcherFreshnessManualUpdateRequired,
+			expectedReason:  dispatcherFreshnessReasonHomebrewManaged,
 		},
 		{
 			name:           "required update runs immediately",
@@ -573,6 +649,14 @@ func TestDecideDispatcherFreshnessPlansUpdatePaths(t *testing.T) {
 			hasSiblingRealCLI: true,
 			updateDue:         true,
 			expectedAction:    dispatcherFreshnessNoop,
+		},
+		{
+			name:            "optional homebrew skip",
+			minimumVersion:  dispatcherVersion,
+			currentVersion:  dispatcherVersion,
+			homebrewManaged: true,
+			updateDue:       true,
+			expectedAction:  dispatcherFreshnessNoop,
 		},
 		{
 			name:           "optional due",
@@ -597,6 +681,7 @@ func TestDecideDispatcherFreshnessPlansUpdatePaths(t *testing.T) {
 				SelfUpdateDisabled: tt.selfUpdateDisabled,
 				HasSiblingRealCLI:  tt.hasSiblingRealCLI,
 				UpdateDue:          tt.updateDue,
+				HomebrewManaged:    tt.homebrewManaged,
 			})
 
 			if plan.Action != tt.expectedAction {
@@ -605,6 +690,9 @@ func TestDecideDispatcherFreshnessPlansUpdatePaths(t *testing.T) {
 			if plan.MinimumVersion != strings.TrimSpace(tt.minimumVersion) {
 				t.Fatalf("minimum version mismatch: %s", plan.MinimumVersion)
 			}
+			if plan.Reason != tt.expectedReason {
+				t.Fatalf("reason mismatch: %q", plan.Reason)
+			}
 		})
 	}
 }
@@ -612,6 +700,7 @@ func TestDecideDispatcherFreshnessPlansUpdatePaths(t *testing.T) {
 func stubDispatcherUpdateHooks(t *testing.T, updatedVersion string) (dispatcherRunDeps, func()) {
 	t.Helper()
 	previousReader := dispatcherReadInstalledVersion
+	previousExecutablePath := resolveUpdateExecutablePathFunc
 	deps := defaultDispatcherRunDeps()
 	deps.runUpdate = func(context.Context) error {
 		return nil
@@ -619,8 +708,14 @@ func stubDispatcherUpdateHooks(t *testing.T, updatedVersion string) (dispatcherR
 	dispatcherReadInstalledVersion = func(context.Context) (string, error) {
 		return updatedVersion, nil
 	}
+	// Why: keep freshness update tests off os.Executable so a Cellar-hosted binary cannot
+	// trip the Homebrew guard and hide a real auto-update regression.
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return "/Users/someone/.local/bin/uloop", nil
+	}
 	return deps, func() {
 		dispatcherReadInstalledVersion = previousReader
+		resolveUpdateExecutablePathFunc = previousExecutablePath
 	}
 }
 

--- a/cli/dispatcher/internal/dispatcher/run_dispatcher.go
+++ b/cli/dispatcher/internal/dispatcher/run_dispatcher.go
@@ -244,12 +244,20 @@ type dispatcherFreshnessInputs struct {
 	SelfUpdateDisabled bool
 	HasSiblingRealCLI  bool
 	UpdateDue          bool
+	HomebrewManaged    bool
 }
 
 type dispatcherFreshnessPlan struct {
 	Action         dispatcherFreshnessAction
 	MinimumVersion string
+	Reason         string
 }
+
+const (
+	dispatcherFreshnessReasonSelfUpdateDisabled = "Automatic update is disabled."
+	// Why: Homebrew installs must not run the curl installer; brew upgrade is the only safe path.
+	dispatcherFreshnessReasonHomebrewManaged = "This uloop install is managed by Homebrew. Run `brew upgrade uloop` to update."
+)
 
 func enforceDispatcherFreshnessWithDeps(ctx context.Context, pin dispatcherPin, stderr io.Writer, deps dispatcherRunDeps) (bool, int) {
 	minimumVersion := strings.TrimSpace(pin.MinimumDispatcherVersion)
@@ -271,8 +279,20 @@ func enforceDispatcherFreshnessWithDeps(ctx context.Context, pin dispatcherPin, 
 		SelfUpdateDisabled: selfUpdateDisabled,
 		HasSiblingRealCLI:  hasSiblingRealCLI,
 		UpdateDue:          updateDue,
+		HomebrewManaged:    isHomebrewManagedDispatcherInstall(),
 	})
 	return executeDispatcherFreshnessPlan(ctx, plan, stderr, deps)
+}
+
+// isHomebrewManagedDispatcherInstall reports whether this dispatcher binary lives under Homebrew.
+// Why: freshness is best-effort background work — path resolution failures stay false here so
+// ordinary commands keep running; explicit `uloop update` is what surfaces resolution errors.
+func isHomebrewManagedDispatcherInstall() bool {
+	executablePath, err := resolveUpdateExecutablePathFunc()
+	if err != nil {
+		return false
+	}
+	return sharedupdate.IsHomebrewManagedPath(executablePath)
 }
 
 func decideDispatcherFreshness(inputs dispatcherFreshnessInputs) dispatcherFreshnessPlan {
@@ -281,13 +301,24 @@ func decideDispatcherFreshness(inputs dispatcherFreshnessInputs) dispatcherFresh
 		return dispatcherFreshnessPlan{Action: dispatcherFreshnessNoop}
 	}
 	updateRequired := sharedversion.IsLessThan(inputs.CurrentVersion, minimumVersion)
+	if updateRequired && inputs.HomebrewManaged {
+		return dispatcherFreshnessPlan{
+			Action:         dispatcherFreshnessManualUpdateRequired,
+			MinimumVersion: minimumVersion,
+			Reason:         dispatcherFreshnessReasonHomebrewManaged,
+		}
+	}
 	if updateRequired && inputs.SelfUpdateDisabled {
-		return dispatcherFreshnessPlan{Action: dispatcherFreshnessManualUpdateRequired, MinimumVersion: minimumVersion}
+		return dispatcherFreshnessPlan{
+			Action:         dispatcherFreshnessManualUpdateRequired,
+			MinimumVersion: minimumVersion,
+			Reason:         dispatcherFreshnessReasonSelfUpdateDisabled,
+		}
 	}
 	if updateRequired {
 		return dispatcherFreshnessPlan{Action: dispatcherFreshnessRunRequiredUpdate, MinimumVersion: minimumVersion}
 	}
-	if inputs.HasSiblingRealCLI || !inputs.UpdateDue {
+	if inputs.HomebrewManaged || inputs.HasSiblingRealCLI || !inputs.UpdateDue {
 		return dispatcherFreshnessPlan{Action: dispatcherFreshnessNoop, MinimumVersion: minimumVersion}
 	}
 	return dispatcherFreshnessPlan{Action: dispatcherFreshnessRunOptionalUpdate, MinimumVersion: minimumVersion}
@@ -298,7 +329,11 @@ func executeDispatcherFreshnessPlan(ctx context.Context, plan dispatcherFreshnes
 	case dispatcherFreshnessNoop:
 		return false, 0
 	case dispatcherFreshnessManualUpdateRequired:
-		writeDispatcherManualUpdateRequiredError(stderr, plan.MinimumVersion, "Automatic update is disabled.")
+		reason := plan.Reason
+		if reason == "" {
+			reason = dispatcherFreshnessReasonSelfUpdateDisabled
+		}
+		writeDispatcherManualUpdateRequiredError(stderr, plan.MinimumVersion, reason)
 		return true, 1
 	case dispatcherFreshnessRunRequiredUpdate, dispatcherFreshnessRunOptionalUpdate:
 		return runDispatcherFreshnessUpdate(ctx, plan, stderr, deps)
@@ -359,13 +394,18 @@ func writeDispatcherSelfUpdateRequiredError(stderr io.Writer, updatedVersion str
 }
 
 func writeDispatcherManualUpdateRequiredError(stderr io.Writer, minimumVersion string, reason string) {
+	nextActions := []string{"Run `uloop update` and retry the command."}
+	if reason == dispatcherFreshnessReasonHomebrewManaged {
+		// Why: uloop update refuses Homebrew installs; brew upgrade is the only safe next step.
+		nextActions = []string{"Run `brew upgrade uloop` and retry the command."}
+	}
 	clierrors.WriteErrorEnvelope(stderr, clierrors.CLIError{
 		ErrorCode:   clierrors.ErrorCodeCLIUpdateRequired,
 		Phase:       clierrors.ErrorPhaseExecution,
 		Message:     "This project requires uloop dispatcher >= " + minimumVersion + ". " + reason,
 		Retryable:   true,
 		SafeToRetry: true,
-		NextActions: []string{"Run `uloop update` and retry the command."},
+		NextActions: nextActions,
 		Details: map[string]any{
 			"CurrentDispatcherVersion": dispatcherVersion,
 			"MinimumDispatcherVersion": minimumVersion,

--- a/cli/dispatcher/internal/dispatcher/run_dispatcher.go
+++ b/cli/dispatcher/internal/dispatcher/run_dispatcher.go
@@ -329,11 +329,7 @@ func executeDispatcherFreshnessPlan(ctx context.Context, plan dispatcherFreshnes
 	case dispatcherFreshnessNoop:
 		return false, 0
 	case dispatcherFreshnessManualUpdateRequired:
-		reason := plan.Reason
-		if reason == "" {
-			reason = dispatcherFreshnessReasonSelfUpdateDisabled
-		}
-		writeDispatcherManualUpdateRequiredError(stderr, plan.MinimumVersion, reason)
+		writeDispatcherManualUpdateRequiredError(stderr, plan.MinimumVersion, plan.Reason)
 		return true, 1
 	case dispatcherFreshnessRunRequiredUpdate, dispatcherFreshnessRunOptionalUpdate:
 		return runDispatcherFreshnessUpdate(ctx, plan, stderr, deps)

--- a/cli/dispatcher/internal/dispatcher/update.go
+++ b/cli/dispatcher/internal/dispatcher/update.go
@@ -19,7 +19,10 @@ const (
 	updateToVersionFlagName    = "to-version"
 )
 
-var updateRunCommand = runUpdateCommand
+var (
+	updateRunCommand                = runUpdateCommand
+	resolveUpdateExecutablePathFunc = resolveUpdateExecutablePath
+)
 
 type updateOptions struct {
 	targetVersion string
@@ -32,6 +35,19 @@ func tryHandleUpdateRequest(ctx context.Context, args []string, stdout io.Writer
 	if clicore.ContainsHelpRequest(args[1:]) {
 		printUpdateHelp(stdout)
 		return true, 0
+	}
+	executablePath, err := resolveUpdateExecutablePathFunc()
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{Command: clicore.UpdateCommandName})
+		return true, 1
+	}
+	if update.IsHomebrewManagedPath(executablePath) {
+		clierrors.WriteErrorEnvelope(stderr, invalidArgumentExecutionError(
+			"uloop is managed by Homebrew ("+executablePath+"); self-update would create a second install in ~/.local/bin",
+			clierrors.ErrorContext{Command: clicore.UpdateCommandName},
+			[]string{"Run `brew upgrade uloop` to update."},
+		))
+		return true, 1
 	}
 	options, err := parseUpdateOptions(args[1:])
 	if err != nil {
@@ -149,6 +165,17 @@ func updateExecutionArgs(updateCommand update.Command, installerPath string) []s
 func printUpdateHelp(stdout io.Writer) {
 	clicore.WriteLine(stdout, "Usage:")
 	clicore.WriteLine(stdout, "  uloop update [--to-version <version>]")
+}
+
+// resolveUpdateExecutablePath returns the on-disk path of this dispatcher binary.
+// Why: Homebrew installs link <prefix>/bin/uloop to Cellar; EvalSymlinks is required
+// so IsHomebrewManagedPath sees the Cellar segment instead of the shim path.
+func resolveUpdateExecutablePath() (string, error) {
+	executablePath, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(executablePath)
 }
 
 func parseUpdateOptions(args []string) (updateOptions, error) {

--- a/cli/dispatcher/internal/dispatcher/update_test.go
+++ b/cli/dispatcher/internal/dispatcher/update_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -367,6 +368,60 @@ func TestTryHandleUpdateRequestReportsAlreadyCurrentVersion(t *testing.T) {
 	}
 }
 
+func TestUpdateRefusesHomebrewManagedExecutable(t *testing.T) {
+	// Verifies Homebrew-managed installs refuse self-update and point users at brew upgrade.
+	previousResolver := resolveUpdateExecutablePathFunc
+	previousRunner := updateRunCommand
+	defer func() {
+		resolveUpdateExecutablePathFunc = previousResolver
+		updateRunCommand = previousRunner
+	}()
+	homebrewPath := "/opt/homebrew/Cellar/uloop/3.0.0/bin/uloop"
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return homebrewPath, nil
+	}
+	updateRunCommand = func(context.Context, update.Command, io.Writer, io.Writer) error {
+		t.Fatal("updateRunCommand must not run for Homebrew-managed installs")
+		return nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	handled, code := tryHandleUpdateRequest(context.Background(), []string{clicore.UpdateCommandName}, &stdout, &stderr)
+
+	if !handled || code != 1 {
+		t.Fatalf("update result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "brew upgrade uloop") {
+		t.Fatalf("expected brew upgrade guidance in stderr, got: %s", stderr.String())
+	}
+}
+
+func TestUpdateFailsWhenExecutablePathResolutionFails(t *testing.T) {
+	// Verifies update aborts when the dispatcher executable path cannot be resolved.
+	previousResolver := resolveUpdateExecutablePathFunc
+	previousRunner := updateRunCommand
+	defer func() {
+		resolveUpdateExecutablePathFunc = previousResolver
+		updateRunCommand = previousRunner
+	}()
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return "", errors.New("executable path unavailable")
+	}
+	updateRunCommand = func(context.Context, update.Command, io.Writer, io.Writer) error {
+		t.Fatal("updateRunCommand must not run when executable path resolution fails")
+		return nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	handled, code := tryHandleUpdateRequest(context.Background(), []string{clicore.UpdateCommandName}, &stdout, &stderr)
+
+	if !handled || code != 1 {
+		t.Fatalf("update result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
+	}
+}
+
 func TestUpdateCommandForLinuxIsUnsupported(t *testing.T) {
 	// Verifies Linux update fails before trying to run a platform-specific update.
 	_, _, err := updateCommandForOS("linux")
@@ -400,6 +455,7 @@ func stubManualUpdateHooks(t *testing.T, updatedVersion string) func() {
 	previousReader := dispatcherReadInstalledVersion
 	previousResolver := resolveUpdateTargetVersionFunc
 	previousManifest := fetchAttestationSubjectManifestFunc
+	previousExecutablePath := resolveUpdateExecutablePathFunc
 	updateRunCommand = func(context.Context, update.Command, io.Writer, io.Writer) error {
 		return nil
 	}
@@ -415,11 +471,17 @@ func stubManualUpdateHooks(t *testing.T, updatedVersion string) func() {
 	fetchAttestationSubjectManifestFunc = func(ctx context.Context, tag string) (string, error) {
 		return "deadbeef  install.sh\n", nil
 	}
+	// Why: keep existing update tests off os.Executable so a Cellar-hosted test binary
+	// cannot trip the Homebrew guard and change their assertions.
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return "/Users/someone/.local/bin/uloop", nil
+	}
 	return func() {
 		updateRunCommand = previousRunner
 		dispatcherReadInstalledVersion = previousReader
 		resolveUpdateTargetVersionFunc = previousResolver
 		fetchAttestationSubjectManifestFunc = previousManifest
+		resolveUpdateExecutablePathFunc = previousExecutablePath
 	}
 }
 

--- a/cli/dispatcher/internal/dispatcher/update_test.go
+++ b/cli/dispatcher/internal/dispatcher/update_test.go
@@ -420,6 +420,9 @@ func TestUpdateFailsWhenExecutablePathResolutionFails(t *testing.T) {
 	if !handled || code != 1 {
 		t.Fatalf("update result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
 	}
+	if !strings.Contains(stderr.String(), "executable path unavailable") {
+		t.Fatalf("expected resolution error in stderr, got: %s", stderr.String())
+	}
 }
 
 func TestUpdateCommandForLinuxIsUnsupported(t *testing.T) {

--- a/cli/dispatcher/internal/update/homebrew.go
+++ b/cli/dispatcher/internal/update/homebrew.go
@@ -1,0 +1,20 @@
+package update
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// IsHomebrewManagedPath reports whether executablePath is under Homebrew's Cellar.
+// Why: brew expands binaries under a Cellar segment for every prefix (/opt/homebrew,
+// /usr/local, linuxbrew) and symlinks them from <prefix>/bin, so a resolved path
+// containing an exact Cellar path segment is the brew-managed install signal.
+func IsHomebrewManagedPath(executablePath string) bool {
+	normalized := filepath.ToSlash(executablePath)
+	for _, segment := range strings.Split(normalized, "/") {
+		if segment == "Cellar" {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/dispatcher/internal/update/homebrew_test.go
+++ b/cli/dispatcher/internal/update/homebrew_test.go
@@ -1,0 +1,58 @@
+package update
+
+import "testing"
+
+// TestIsHomebrewManagedPath verifies Cellar path-segment detection across Homebrew
+// prefixes and rejects substring false positives, including Windows-style paths.
+func TestIsHomebrewManagedPath(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "apple silicon cellar",
+			path: "/opt/homebrew/Cellar/uloop/3.0.0/bin/uloop",
+			want: true,
+		},
+		{
+			name: "intel mac cellar",
+			path: "/usr/local/Cellar/uloop/3.0.0-beta.30/bin/uloop",
+			want: true,
+		},
+		{
+			name: "linuxbrew cellar",
+			path: "/home/linuxbrew/.linuxbrew/Cellar/uloop/3.0.0/bin/uloop",
+			want: true,
+		},
+		{
+			name: "curl install location",
+			path: "/Users/someone/.local/bin/uloop",
+			want: false,
+		},
+		{
+			name: "cellar substring segment only",
+			path: "/Users/someone/MyCellarTools/uloop",
+			want: false,
+		},
+		{
+			name: "windows path with backslashes",
+			path: `C:\Users\someone\AppData\Local\uloop\uloop.exe`,
+			want: false,
+		},
+		{
+			name: "empty path",
+			path: "",
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsHomebrewManagedPath(tc.path)
+			if got != tc.want {
+				t.Fatalf("IsHomebrewManagedPath(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Homebrew-installed `uloop` now refuses self-update on both the explicit `uloop update` command and the background dispatcher freshness path, and steers users to `brew upgrade uloop` instead of writing a second copy under `~/.local/bin`.

## User Impact
- Before: a brew-managed binary could still self-update into `~/.local/bin` via `uloop update` or via automatic required/optional freshness updates, leaving two installs and an ambiguous PATH winner.
- After:
  - `uloop update` exits with a clear error and the correct upgrade command.
  - When the pin requires a newer dispatcher, Homebrew installs get a manual-update-required error that points at `brew upgrade uloop` (NextActions included) instead of running the curl installer.
  - Optional 24h freshness updates are skipped for Homebrew installs so they never silently create a second binary.

## Changes
- Detect Homebrew Cellar path segments after symlink resolution.
- Short-circuit `uloop update` for those installs with an invalid-argument envelope pointing at `brew upgrade uloop`.
- Extend dispatcher freshness planning with `HomebrewManaged`: required updates become `manual-update-required` with brew upgrade guidance; optional updates become noop.
- Cover path detection, explicit update refusal, freshness brew routing, and resolution-error stderr content with unit tests; keep existing update/freshness stubs off `os.Executable`.

## Verification
- `cd cli/dispatcher && go test ./...`
- `scripts/check-go-cli.sh` (pass)
- Repository CI does not run against `feature/package-manager-distribution`; full workflow verification is deferred to the final PR into `v3-beta`.
