### PR TITLE
fix: attribute single-entry shim compile failures to the edited method

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -131,7 +131,7 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Loaded assembly differs from the one on disk (pending compile) | Run `uloop compile` first, then retry |
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
-| Shim compile error (e.g. the body calls a member that does not exist yet) | Failing methods are isolated: each reports `Failed` with its own compiler errors (plus the `uloop compile` hint when they indicate a missing member) while the remaining methods still patch. When errors cannot be attributed per method, the whole file reports one `(shim-compile)` entry |
+| Shim compile error (e.g. the body calls a member that does not exist yet) | Failing methods are isolated: each reports `Failed` with its own compiler errors (plus the `uloop compile` hint when they indicate a missing member) while the remaining methods still patch. When errors cannot be attributed per method, the whole file reports one `(shim-compile)` entry; if only one method was edited, the failure is attributed to that method's name instead |
 | Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error; other methods in the run still apply |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -131,7 +131,7 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Loaded assembly differs from the one on disk (pending compile) | Run `uloop compile` first, then retry |
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
-| Shim compile error (e.g. the body calls a member that does not exist yet) | Failing methods are isolated: each reports `Failed` with its own compiler errors (plus the `uloop compile` hint when they indicate a missing member) while the remaining methods still patch. When errors cannot be attributed per method, the whole file reports one `(shim-compile)` entry |
+| Shim compile error (e.g. the body calls a member that does not exist yet) | Failing methods are isolated: each reports `Failed` with its own compiler errors (plus the `uloop compile` hint when they indicate a missing member) while the remaining methods still patch. When errors cannot be attributed per method, the whole file reports one `(shim-compile)` entry; if only one method was edited, the failure is attributed to that method's name instead |
 | Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error; other methods in the run still apply |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1295,12 +1295,57 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: when the only edited method fails shim compile, isolation is skipped
-        /// (FailedEntries.Count == entries.Length) and the whole-file (shim-compile) Failed
-        /// Reason still carries the original-file "(line N)" from #line-mapped diagnostics.
+        /// What: when every edited method fails shim compile, isolation is skipped and the
+        /// Failed Reason keeps both CS0103 messages in full (no in-uloop truncation).
         /// </summary>
         [Test]
-        public async Task Run_SingleEditedMethodFailingShimCompile_WholeFileFailureIncludesOriginalLine()
+        public async Task Run_AllEditedMethodsFailingShimCompile_ReasonKeepsBothDiagnosticsInFull()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedSource = BuildFixtureSource(
+                computeWithPrivateMethod:
+                "public int ComputeWithPrivate(int delta)\n        {\n            return MissingAlphaHelper(delta);\n        }",
+                callsMissingHelperMethod:
+                "public int CallsMissingHelper(int value)\n        {\n            return MissingBetaHelper(value);\n        }");
+            string editedPath = WriteEditedSource("AllEntriesShimFailure.cs", editedSource);
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            HotReloadMethodOutcome failed = null;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed)
+                {
+                    failed = outcome;
+                    break;
+                }
+            }
+
+            Assert.That(failed, Is.Not.Null, FormatOutcomes(result));
+            Assert.That(failed.Reason, Does.Contain("MissingAlphaHelper"));
+            Assert.That(failed.Reason, Does.Contain("MissingBetaHelper"));
+            Assert.That(failed.Reason, Does.Contain("CS0103"));
+            Assert.That(
+                failed.Reason,
+                Does.Contain(HotReloadConstants.NewMemberCompileHint),
+                "Reason must keep the full joined diagnostics plus new-member hint.\n" + failed.Reason);
+            Assert.That(
+                failed.Reason.Contains(" ... (truncated)"),
+                Is.False,
+                "uloop must not truncate shim-compile Reason.\n" + failed.Reason);
+        }
+
+        /// <summary>
+        /// What: when the only edited method fails shim compile, isolation is skipped
+        /// (FailedEntries.Count == entries.Length) and Failed.Method uses that method's
+        /// FormatMethodKeyParts label (not "(shim-compile)"), while Reason still carries the
+        /// original-file "(line N)" from #line-mapped diagnostics.
+        /// </summary>
+        [Test]
+        public async Task Run_SingleEditedMethodFailingShimCompile_AttributesFailureToThatMethod()
         {
             string fixturePath = ResolveE2EFixturePath();
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
@@ -1310,7 +1355,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "UnityCLILoop.Tests.Editor.HotReload"
                 + HotReloadConstants.CompiledAssemblyExtension);
             // Why require a snapshot: without it every method becomes an entry and isolation
-            // succeeds — this test pins the whole-file path that only fires when the sole entry fails.
+            // succeeds — this test pins the single-entry path that only fires when the sole entry fails.
             Assert.That(
                 HotReloadSourceBaseline.LoadVerifiedSnapshotSource(
                     "Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs",
@@ -1327,29 +1372,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             int expectedOriginalLine = FindLineNumberContaining(editedSource, "MissingHelperAddedByEdit");
             Assert.That(expectedOriginalLine, Is.GreaterThan(0));
+            string expectedMethodLabel = HotReloadPatcher.FormatMethodKeyParts(
+                typeof(HotReloadE2EFixture).FullName,
+                nameof(HotReloadE2EFixture.CallsMissingHelper),
+                new[] { typeof(int).FullName },
+                genericArity: 0);
 
             HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
                 new[] { fixturePath },
                 editedPath,
                 CancellationToken.None);
 
-            bool foundWholeFileFailure = false;
+            bool foundAttributedFailure = false;
             foreach (HotReloadMethodOutcome outcome in result.Methods)
             {
                 if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
-                    && outcome.Method == "(shim-compile)"
+                    && outcome.Method == expectedMethodLabel
                     && outcome.Reason.Contains(HotReloadConstants.NewMemberCompileHint)
                     && outcome.Reason.Contains("(line " + expectedOriginalLine + ")"))
                 {
-                    foundWholeFileFailure = true;
+                    foundAttributedFailure = true;
                 }
             }
 
             Assert.That(
-                foundWholeFileFailure,
+                foundAttributedFailure,
                 Is.True,
-                "Single-entry shim compile failure must report (shim-compile) with original-file line "
-                + expectedOriginalLine + ".\n" + FormatOutcomes(result));
+                "Single-entry shim compile failure must report Method=" + expectedMethodLabel
+                + " with original-file line " + expectedOriginalLine + ".\n" + FormatOutcomes(result));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1325,6 +1325,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             Assert.That(failed, Is.Not.Null, FormatOutcomes(result));
+            Assert.That(
+                failed.Method,
+                Is.EqualTo("(shim-compile)"),
+                "Multi-entry unattributable failures must keep the file-level label.\n"
+                + FormatOutcomes(result));
             Assert.That(failed.Reason, Does.Contain("MissingAlphaHelper"));
             Assert.That(failed.Reason, Does.Contain("MissingBetaHelper"));
             Assert.That(failed.Reason, Does.Contain("CS0103"));

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -287,9 +287,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     // Why: CompileAndLoadAsync appends "(line N)" only for diagnostics whose
                     // #line-mapped file matches projectRelativePath — scaffold-only errors stay
                     // bare. Single-entry failures skip isolation and always take this path.
+                    // Why attribute single-entry failures: "(shim-compile)" hides which method
+                    // body failed when the agent edited only one method.
+                    string failureMethodLabel = "(shim-compile)";
+                    if (entriesToPatch.Length == 1)
+                    {
+                        TransformWorkerEntryDto soleEntry = entriesToPatch[0];
+                        failureMethodLabel = HotReloadPatcher.FormatMethodKeyParts(
+                            soleEntry.typeMetadataName,
+                            soleEntry.methodName,
+                            soleEntry.parameterTypeFullNames ?? Array.Empty<string>(),
+                            genericArity: 0);
+                    }
+
                     outcomes.Add(
                         HotReloadMethodOutcome.Failed(
-                            "(shim-compile)",
+                            failureMethodLabel,
                             compileResult.ErrorMessage,
                             assemblyResolvePath));
                     return new HotReloadFileProcessResult(
@@ -753,7 +766,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// be attributed to them, so the rest of the file's methods can still patch. Returns null
         /// when isolation is not possible (unattributable errors, all/none of the entries failing,
         /// the retry worker run failing, or the retry compile failing) — the caller then falls back
-        /// to today's whole-file "(shim-compile)" Failed.
+        /// to a single Failed outcome (method-attributed when only one entry remains).
         /// </summary>
         private static async Task<HotReloadShimIsolationResult> TryIsolateShimCompileFailureAsync(
             TransformWorkerInputDto workerInput,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -131,7 +131,7 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Loaded assembly differs from the one on disk (pending compile) | Run `uloop compile` first, then retry |
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | New, renamed, or re-signatured members need `uloop compile` |
-| Shim compile error (e.g. the body calls a member that does not exist yet) | Failing methods are isolated: each reports `Failed` with its own compiler errors (plus the `uloop compile` hint when they indicate a missing member) while the remaining methods still patch. When errors cannot be attributed per method, the whole file reports one `(shim-compile)` entry |
+| Shim compile error (e.g. the body calls a member that does not exist yet) | Failing methods are isolated: each reports `Failed` with its own compiler errors (plus the `uloop compile` hint when they indicate a missing member) while the remaining methods still patch. When errors cannot be attributed per method, the whole file reports one `(shim-compile)` entry; if only one method was edited, the failure is attributed to that method's name instead |
 | Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error; other methods in the run still apply |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 


### PR DESCRIPTION
## Summary
- When a single edited method fails shim compile (isolation skipped), Failed `Method` now uses that method's `FormatMethodKeyParts` label instead of `(shim-compile)`.
- Multi-entry unattributable failures still report `(shim-compile)`.
- Adds coverage for the attributed single-entry path and for full multi-diagnostic `Reason` text.

## User Impact
A clear method name appears on single-method shim compile failures, so agents no longer have to guess which edited body caused `(shim-compile)`.

## Reason truncation investigation (To-Do 9)
- **Branch (b)**: no truncation inside uloop.
- C# evidence: `Run_AllEditedMethodsFailingShimCompile_ReasonKeepsBothDiagnosticsInFull` asserts both `MissingAlphaHelper` / `MissingBetaHelper` CS0103 lines plus the new-member hint, and rejects ` ... (truncated)`.
- CLI evidence: `uloop hot-reload --files Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs` with two missing helpers returned both diagnostics in full (`ReasonLen=297`, both probe names present). Fixture restored afterward.
- Conclusion: FB truncation was outside uloop (terminal/UI). No code change for truncation.

## Test plan
- [x] Red→Green: single-entry failure attributed to `CallsMissingHelper(System.Int32)`
- [x] Multi-error Reason fullness test Passed
- [x] Filter suite `HotReload|TransformWorker|PausePoint`: 430 Passed / 0 Failed
- [x] `uloop compile` errors 0


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

