### PR TITLE
feat: warn when an expected pause-point variable is not captured

### DIFF
--- a/cli/project-runner/internal/projectrunner/pause_point_expect.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_expect.go
@@ -93,3 +93,22 @@ func allPausePointExpectationsPassed(results []pausePointExpectationResult) bool
 	}
 	return true
 }
+
+// buildPausePointExpectNotFoundWarning returns a hit-time warning when at least one --expect
+// target was absent from CapturedVariables (Found=false). Empty when every expectation was found.
+func buildPausePointExpectNotFoundWarning(results []pausePointExpectationResult) string {
+	missingNames := make([]string, 0)
+	for _, result := range results {
+		if result.Found {
+			continue
+		}
+		missingNames = append(missingNames, result.Name)
+	}
+	if len(missingNames) == 0 {
+		return ""
+	}
+
+	return "Expected variable(s) not present in CapturedVariables: " +
+		strings.Join(missingNames, ", ") +
+		". This is a not-found result, not a value mismatch — check the variable name, and note that locals can be missing from hot-reload patched bodies compiled before this fix."
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_expect.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_expect.go
@@ -110,5 +110,5 @@ func buildPausePointExpectNotFoundWarning(results []pausePointExpectationResult)
 
 	return "Expected variable(s) not present in CapturedVariables: " +
 		strings.Join(missingNames, ", ") +
-		". This is a not-found result, not a value mismatch — check the variable name, and note that locals can be missing from hot-reload patched bodies compiled before this fix."
+		". This is a not-found result, not a value mismatch — check the variable name; if the method is hot-reload patched, older patches may have dropped locals, so re-apply hot-reload or run uloop compile."
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_expect_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_expect_test.go
@@ -213,7 +213,7 @@ func TestRunWaitForPausePointWarnsWhenExpectedVariableNotFound(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
 		t.Fatalf("stdout parse failed: %v from %s", err, stdout.String())
 	}
-	const wantWarning = "Expected variable(s) not present in CapturedVariables: cells, total. This is a not-found result, not a value mismatch — check the variable name, and note that locals can be missing from hot-reload patched bodies compiled before this fix."
+	const wantWarning = "Expected variable(s) not present in CapturedVariables: cells, total. This is a not-found result, not a value mismatch — check the variable name; if the method is hot-reload patched, older patches may have dropped locals, so re-apply hot-reload or run uloop compile."
 	if result.Warning != wantWarning {
 		t.Fatalf("Warning mismatch:\n got: %q\nwant: %q", result.Warning, wantWarning)
 	}

--- a/cli/project-runner/internal/projectrunner/pause_point_expect_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_expect_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -164,5 +165,107 @@ func TestRunWaitForPausePointEvaluatesExpectations(t *testing.T) {
 	}
 	if result.AllExpectationsPassed == nil || *result.AllExpectationsPassed {
 		t.Fatalf("expected AllExpectationsPassed to be false, got %#v", result.AllExpectationsPassed)
+	}
+}
+
+// Verifies Found=false expectations produce the not-found Warning on a hit.
+func TestRunWaitForPausePointWarnsWhenExpectedVariableNotFound(t *testing.T) {
+	originalQuery := queryPausePointStatus
+	originalFetch := fetchMatchingLogs
+	defer func() {
+		queryPausePointStatus = originalQuery
+		fetchMatchingLogs = originalFetch
+	}()
+
+	queryPausePointStatus = func(ctx context.Context, connection unityipc.Connection, id string) (pausePointStatusResponse, error) {
+		return pausePointStatusResponse{
+			Id:       id,
+			Status:   pausePointStatusHit,
+			IsHit:    true,
+			HitCount: 1,
+			CapturedVariables: []pausePointCapturedVariable{
+				{Name: "health", Scope: "Local", Value: pausePointVariableValue("100")},
+			},
+		}, nil
+	}
+	fetchMatchingLogs = func(ctx context.Context, connection unityipc.Connection, searchText string, maxCount int) (pausePointMatchingLogsResult, error) {
+		return pausePointMatchingLogsResult{SearchText: searchText, Logs: []pausePointMatchingLog{}}, nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runWaitForPausePoint(context.Background(), unityipc.Connection{}, waitForPausePointOptions{
+		id:                   "jump",
+		timeoutSeconds:       1,
+		timeout:              time.Second,
+		matchingLogsMaxCount: pausePointDefaultLogsMaxCount,
+		expectations: []pausePointExpectation{
+			{Name: "cells", Expected: "whatever"},
+			{Name: "total", Expected: "3"},
+		},
+	}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d with stderr %s", code, stderr.String())
+	}
+
+	var result pausePointWaitResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout parse failed: %v from %s", err, stdout.String())
+	}
+	const wantWarning = "Expected variable(s) not present in CapturedVariables: cells, total. This is a not-found result, not a value mismatch — check the variable name, and note that locals can be missing from hot-reload patched bodies compiled before this fix."
+	if result.Warning != wantWarning {
+		t.Fatalf("Warning mismatch:\n got: %q\nwant: %q", result.Warning, wantWarning)
+	}
+}
+
+// Verifies Found=true expectations do not emit the not-found Warning, even on value mismatch.
+func TestRunWaitForPausePointOmitsNotFoundWarningWhenEveryExpectationIsFound(t *testing.T) {
+	originalQuery := queryPausePointStatus
+	originalFetch := fetchMatchingLogs
+	defer func() {
+		queryPausePointStatus = originalQuery
+		fetchMatchingLogs = originalFetch
+	}()
+
+	queryPausePointStatus = func(ctx context.Context, connection unityipc.Connection, id string) (pausePointStatusResponse, error) {
+		return pausePointStatusResponse{
+			Id:       id,
+			Status:   pausePointStatusHit,
+			IsHit:    true,
+			HitCount: 1,
+			CapturedVariables: []pausePointCapturedVariable{
+				{Name: "health", Scope: "Local", Value: pausePointVariableValue("100")},
+				{Name: "speed", Scope: "Local", Value: pausePointVariableValue("4.2")},
+			},
+		}, nil
+	}
+	fetchMatchingLogs = func(ctx context.Context, connection unityipc.Connection, searchText string, maxCount int) (pausePointMatchingLogsResult, error) {
+		return pausePointMatchingLogsResult{SearchText: searchText, Logs: []pausePointMatchingLog{}}, nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runWaitForPausePoint(context.Background(), unityipc.Connection{}, waitForPausePointOptions{
+		id:                   "jump",
+		timeoutSeconds:       1,
+		timeout:              time.Second,
+		matchingLogsMaxCount: pausePointDefaultLogsMaxCount,
+		expectations: []pausePointExpectation{
+			{Name: "health", Expected: "100"},
+			{Name: "speed", Expected: "9.9"},
+		},
+	}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d with stderr %s", code, stderr.String())
+	}
+
+	var result pausePointWaitResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout parse failed: %v from %s", err, stdout.String())
+	}
+	if strings.Contains(result.Warning, "not present in CapturedVariables") {
+		t.Fatalf("not-found warning must be absent when every expectation was Found: %q", result.Warning)
 	}
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_logs.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_logs.go
@@ -94,10 +94,13 @@ func buildPausePointHitPayload(inputs pausePointHitPayloadInputs) any {
 			AllExpectationsPassed *bool                         `json:"AllExpectationsPassed,omitempty"`
 		}{
 			pausePointStatusResponse: response,
-			Warning:                  joinPausePointWarnings(inputs.unityWarning, triggerWarning),
-			EnableTimeWarning:        inputs.enableTimeWarning,
-			Expectations:             inputs.expectations,
-			AllExpectationsPassed:    pausePointAllExpectationsPassedPointer(inputs.expectations),
+			Warning: joinPausePointWarnings(
+				inputs.unityWarning,
+				triggerWarning,
+				buildPausePointExpectNotFoundWarning(inputs.expectations)),
+			EnableTimeWarning:     inputs.enableTimeWarning,
+			Expectations:          inputs.expectations,
+			AllExpectationsPassed: pausePointAllExpectationsPassedPointer(inputs.expectations),
 		}
 	}
 
@@ -107,7 +110,8 @@ func buildPausePointHitPayload(inputs pausePointHitPayloadInputs) any {
 		Warning: joinPausePointWarnings(
 			inputs.unityWarning,
 			buildPausePointWarning(inputs.logs, response.HitCount),
-			triggerWarning),
+			triggerWarning,
+			buildPausePointExpectNotFoundWarning(inputs.expectations)),
 		EnableTimeWarning:     inputs.enableTimeWarning,
 		Expectations:          inputs.expectations,
 		AllExpectationsPassed: pausePointAllExpectationsPassedPointer(inputs.expectations),


### PR DESCRIPTION
## Summary
- When `--expect` targets are absent from `CapturedVariables` (`Found: false`), the hit response `Warning` now names those variables and clarifies this is a not-found result, not a value mismatch.
- Wired through `buildPausePointHitPayload` so both await and enable`--await` hit paths receive the warning.

## User Impact
Agents can tell at a glance that an expected variable was never captured, instead of only noticing `Found: false` buried in the Expectations array.

## Test plan
- [x] `TestRunWaitForPausePointWarnsWhenExpectedVariableNotFound` — Warning lists missing names with the exact planned wording
- [x] `TestRunWaitForPausePointOmitsNotFoundWarningWhenEveryExpectationIsFound` — value mismatch alone does not emit the not-found Warning
- [x] `scripts/check-go-cli.sh` passed (format / vet / lint / test / rebuild)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

