### PR TITLE
fix: suppress the JIT inlining warning in Debug code optimization mode

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -143,8 +143,11 @@ trace` on a line inside the edited method body — it resolves against the patch
 directly (see the pause point interaction below) — drive the game, and check the hit
 count: zero hits means the calling path never reached the method, which no patch (or
 compile) can fix. To chase an early return inside the method, arm a second marker on the
-suspected early-return line. The other known cause is JIT inlining of tiny methods, which
-the response already flags with a single aggregated warning listing the at-risk methods.
+suspected early-return line. The other known cause is JIT inlining, which the response flags
+with a single aggregated warning listing the at-risk methods: `[AggressiveInlining]` methods
+always, tiny bodies only when the Editor's Code Optimization mode is Release (the default
+Debug mode does not inline them). If `uloop hot-reload --status` shows the method's
+`InvocationCount` increasing, the calls you exercised are reaching the patched body.
 
 ## Convergence and lifecycle
 
@@ -198,7 +201,7 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`
-- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough (or marked `[AggressiveInlining]`) to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
+- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods at risk of being already JIT-inlined into existing callers — those marked `[AggressiveInlining]`, plus (only when Code Optimization is Release) those with tiny pre-patch bodies — meaning the change may not show at those call sites, the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `UnchangedTotal` (number): Methods left untouched because their bodies match the source baseline from the last compile; `0` when no baseline was available
 - `ActivePatchTotal` (number): Methods still patched after this run

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -143,8 +143,11 @@ trace` on a line inside the edited method body — it resolves against the patch
 directly (see the pause point interaction below) — drive the game, and check the hit
 count: zero hits means the calling path never reached the method, which no patch (or
 compile) can fix. To chase an early return inside the method, arm a second marker on the
-suspected early-return line. The other known cause is JIT inlining of tiny methods, which
-the response already flags with a single aggregated warning listing the at-risk methods.
+suspected early-return line. The other known cause is JIT inlining, which the response flags
+with a single aggregated warning listing the at-risk methods: `[AggressiveInlining]` methods
+always, tiny bodies only when the Editor's Code Optimization mode is Release (the default
+Debug mode does not inline them). If `uloop hot-reload --status` shows the method's
+`InvocationCount` increasing, the calls you exercised are reaching the patched body.
 
 ## Convergence and lifecycle
 
@@ -198,7 +201,7 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`
-- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough (or marked `[AggressiveInlining]`) to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
+- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods at risk of being already JIT-inlined into existing callers — those marked `[AggressiveInlining]`, plus (only when Code Optimization is Release) those with tiny pre-patch bodies — meaning the change may not show at those call sites, the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `UnchangedTotal` (number): Methods left untouched because their bodies match the source baseline from the last compile; `0` when no baseline was available
 - `ActivePatchTotal` (number): Methods still patched after this run

--- a/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs
@@ -118,6 +118,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return total;
         }
 
+        // Why AggressiveInlining: Debug still treats these as at-risk so orchestrator aggregation
+        // / dedupe E2E can run without requiring Release code optimization.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int InlineRiskAlpha()
+        {
+            return 1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int InlineRiskBeta()
+        {
+            return 2;
+        }
+
         private List<int> BuildCells()
         {
             return new List<int> { 1, 2, 3 };

--- a/Assets/Tests/Editor/HotReload/HotReloadJitInliningInvestigationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadJitInliningInvestigationTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Documents Mono's code-optimization-dependent inlining of tiny getters into warmed callers
+    /// (PR-4 To-Do 12 measurement kept as a lasting regression).
+    /// </summary>
+    public class HotReloadJitInliningInvestigationTests
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadPatcher.RevertAll();
+        }
+
+        /// <summary>
+        /// What: after warming ReadProbe, patching Probe is visible under Debug and invisible
+        /// under Release — matching the measured Mono inlining behavior that drives branch (a).
+        /// </summary>
+        [Test]
+        public async Task SmallGetter_AfterCallerWarmup_PatchVisibilityMatchesCodeOptimizationMode()
+        {
+            CodeOptimization mode = CompilationPipeline.codeOptimization;
+            string fixturePath = ResolveShapeFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string editedSource = onDisk.Replace(
+                "public static int Probe => 1;",
+                "public static int Probe => 2;",
+                StringComparison.Ordinal);
+            Assert.That(editedSource, Is.Not.EqualTo(onDisk), "Precondition: Probe body must differ.");
+
+            int warmSum = 0;
+            for (int index = 0; index < 64; index++)
+            {
+                warmSum += HotReloadJitInliningInvestigationFixture.ReadProbe();
+            }
+
+            Assert.That(warmSum, Is.EqualTo(64), "Precondition: warmed caller must see the compiled Probe.");
+
+            string editedPath = WriteEditedSource("JitInliningInvestigationProbe.cs", editedSource);
+            HotReloadOrchestratorResult patched = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            bool probePatched = false;
+            foreach (HotReloadMethodOutcome outcome in patched.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Patched
+                    && outcome.Method.Contains("get_Probe"))
+                {
+                    probePatched = true;
+                    break;
+                }
+            }
+
+            Assert.That(
+                probePatched,
+                Is.True,
+                "Probe getter must patch.\n" + FormatOutcomes(patched));
+
+            int afterPatch = HotReloadJitInliningInvestigationFixture.ReadProbe();
+            if (mode == CodeOptimization.Release)
+            {
+                Assert.That(
+                    afterPatch,
+                    Is.EqualTo(1),
+                    "Release: Mono inlines the tiny getter into the warmed caller, so the patch is invisible.");
+            }
+            else
+            {
+                Assert.That(
+                    afterPatch,
+                    Is.EqualTo(2),
+                    "Debug: the warmed caller reaches the patched getter body.");
+            }
+        }
+
+        private static string ResolveShapeFixturePath()
+        {
+            return Path.GetFullPath(
+                Path.Combine(
+                    Application.dataPath,
+                    "Tests",
+                    "Editor",
+                    "HotReload",
+                    "HotReloadShapeFixtures.cs"));
+        }
+
+        private static string WriteEditedSource(string fileName, string contents)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string path = Path.Combine(directory, fileName);
+            File.WriteAllText(path, contents);
+            return path;
+        }
+
+        private static string FormatOutcomes(HotReloadOrchestratorResult result)
+        {
+            List<string> lines = new List<string>();
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                lines.Add(outcome.Kind + " " + outcome.Method + " :: " + outcome.Reason);
+            }
+
+            return string.Join("\n", lines);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadJitInliningInvestigationTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadJitInliningInvestigationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30c118f7c96e44e659333985f82f3039
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadJitInliningRiskTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadJitInliningRiskTests.cs
@@ -1,0 +1,93 @@
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Pure-function coverage for the hot-reload JIT-inlining risk heuristic (PR-4 branch a).
+    /// </summary>
+    public class HotReloadJitInliningRiskTests
+    {
+        /// <summary>
+        /// What: [AggressiveInlining] is always treated as at-risk, including Debug mode.
+        /// </summary>
+        [Test]
+        public void Evaluate_AggressiveInlining_IsAtRiskInDebugAndRelease()
+        {
+            Assert.That(
+                HotReloadJitInliningRisk.Evaluate(
+                    hasAggressiveInlining: true,
+                    ilByteLength: HotReloadConstants.SmallMethodInliningRiskThresholdBytes + 100,
+                    codeOptimization: CodeOptimization.Debug),
+                Is.True);
+            Assert.That(
+                HotReloadJitInliningRisk.Evaluate(
+                    hasAggressiveInlining: true,
+                    ilByteLength: HotReloadConstants.SmallMethodInliningRiskThresholdBytes + 100,
+                    codeOptimization: CodeOptimization.Release),
+                Is.True);
+        }
+
+        /// <summary>
+        /// What: the IL-size heuristic fires only under Release code optimization.
+        /// </summary>
+        [Test]
+        public void Evaluate_SmallIlBody_IsAtRiskOnlyInRelease()
+        {
+            Assert.That(
+                HotReloadJitInliningRisk.Evaluate(
+                    hasAggressiveInlining: false,
+                    ilByteLength: HotReloadConstants.SmallMethodInliningRiskThresholdBytes,
+                    codeOptimization: CodeOptimization.Debug),
+                Is.False);
+            Assert.That(
+                HotReloadJitInliningRisk.Evaluate(
+                    hasAggressiveInlining: false,
+                    ilByteLength: HotReloadConstants.SmallMethodInliningRiskThresholdBytes,
+                    codeOptimization: CodeOptimization.Release),
+                Is.True);
+        }
+
+        /// <summary>
+        /// What: bodies larger than the threshold are not flagged by the IL-size heuristic.
+        /// </summary>
+        [Test]
+        public void Evaluate_LargeIlBody_IsNotAtRiskFromSizeAlone()
+        {
+            Assert.That(
+                HotReloadJitInliningRisk.Evaluate(
+                    hasAggressiveInlining: false,
+                    ilByteLength: HotReloadConstants.SmallMethodInliningRiskThresholdBytes + 1,
+                    codeOptimization: CodeOptimization.Release),
+                Is.False);
+            Assert.That(
+                HotReloadJitInliningRisk.Evaluate(
+                    hasAggressiveInlining: false,
+                    ilByteLength: null,
+                    codeOptimization: CodeOptimization.Release),
+                Is.False);
+        }
+
+        /// <summary>
+        /// What: FormatAggregatedWarning ends with the status-based self-check sentence.
+        /// </summary>
+        [Test]
+        public void FormatAggregatedWarning_EndsWithStatusSelfCheckSentence()
+        {
+            string warning = HotReloadJitInliningRisk.FormatAggregatedWarning(
+                atRiskCount: 1,
+                patchedTotal: 3,
+                methodLabels: new[] { "Demo.get_Probe()" });
+
+            Assert.That(warning, Does.Contain("1 of 3 patched methods had pre-patch bodies"));
+            Assert.That(warning, Does.Contain("Demo.get_Probe()"));
+            Assert.That(
+                warning,
+                Does.EndWith(
+                    " If 'uloop hot-reload --status' shows the method's InvocationCount increasing afterwards, its call sites are reaching the patched body and this warning did not apply."));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadJitInliningRiskTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadJitInliningRiskTests.cs
@@ -83,11 +83,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 methodLabels: new[] { "Demo.get_Probe()" });
 
             Assert.That(warning, Does.Contain("1 of 3 patched methods had pre-patch bodies"));
-            Assert.That(warning, Does.Contain("Demo.get_Probe()"));
+            Assert.That(warning, Does.Contain("Demo.get_Probe()."));
             Assert.That(
                 warning,
                 Does.EndWith(
-                    " If 'uloop hot-reload --status' shows the method's InvocationCount increasing afterwards, its call sites are reaching the patched body and this warning did not apply."));
+                    " If 'uloop hot-reload --status' shows the method's InvocationCount increasing afterwards, the calls you exercised are reaching the patched body and this warning did not apply to them."));
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadJitInliningRiskTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadJitInliningRiskTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0a2b11ddd7b8d4c01910481adcf25d69
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -528,6 +528,76 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: [AggressiveInlining] patched methods still emit exactly one aggregated
+        /// inline-risk warning under Debug, listing every at-risk method.
+        /// </summary>
+        [Test]
+        public async Task Run_MultipleAggressiveInliningMethods_AggregatesInlineRiskWarningOnce()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "MultipleAggressiveInliningInlineRisk.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                    inlineRiskAlphaMethod:
+                    "[MethodImpl(MethodImplOptions.AggressiveInlining)]\n"
+                    + "        public int InlineRiskAlpha()\n"
+                    + "        {\n"
+                    + "            return 11;\n"
+                    + "        }",
+                    inlineRiskBetaMethod:
+                    "[MethodImpl(MethodImplOptions.AggressiveInlining)]\n"
+                    + "        public int InlineRiskBeta()\n"
+                    + "        {\n"
+                    + "            return 22;\n"
+                    + "        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.InlineRiskAlpha));
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.InlineRiskBeta));
+
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind != HotReloadMethodOutcomeKind.Patched)
+                {
+                    continue;
+                }
+
+                Assert.That(outcome.Reason, Is.Empty, "Patched Reason must not carry per-method inline-risk text.");
+            }
+
+            int aggregatedInlineRiskCount = 0;
+            foreach (string warning in result.Warnings)
+            {
+                if (warning.Contains("patched methods had pre-patch bodies")
+                    && warning.Contains(nameof(HotReloadE2EFixture.InlineRiskAlpha))
+                    && warning.Contains(nameof(HotReloadE2EFixture.InlineRiskBeta)))
+                {
+                    aggregatedInlineRiskCount++;
+                }
+            }
+
+            Assert.That(
+                aggregatedInlineRiskCount,
+                Is.EqualTo(1),
+                "Expected exactly one aggregated inline-risk warning listing the at-risk methods.");
+
+            int declarationDriftCount = CountWarningsContaining(
+                result.Warnings,
+                "Edits outside method bodies");
+            Assert.That(
+                result.Warnings,
+                Has.Count.EqualTo(1 + declarationDriftCount),
+                "Expected the aggregated inline-risk warning plus any declaration-drift warning(s).");
+        }
+
+        /// <summary>
         /// What: duplicate file inputs re-patch the same small method yet Debug emits no
         /// IL-size inline-risk warning (branch a); declaration-drift warnings still appear twice.
         /// </summary>
@@ -579,6 +649,78 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             int declarationDriftCount = CountWarningsContaining(
                 result.Warnings,
                 "Edits outside method bodies");
+            Assert.That(
+                declarationDriftCount,
+                Is.EqualTo(2),
+                "Duplicate file inputs each emit a declaration-drift warning.");
+        }
+
+        /// <summary>
+        /// What: duplicate file inputs re-patch an [AggressiveInlining] method twice yet the
+        /// aggregated warning lists that method once.
+        /// </summary>
+        [Test]
+        public async Task Run_DuplicateFileInputs_ListsEachAtRiskMethodOnceInAggregatedWarning()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "DuplicateInputAggressiveInliningInlineRisk.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                    inlineRiskAlphaMethod:
+                    "[MethodImpl(MethodImplOptions.AggressiveInlining)]\n"
+                    + "        public int InlineRiskAlpha()\n"
+                    + "        {\n"
+                    + "            return 11;\n"
+                    + "        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath, fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.InlineRiskAlpha));
+
+            // Methods and PatchedTotal keep reflecting raw patch operations on purpose:
+            // the duplicated input re-patches every fixture method once per file entry.
+            int inlineRiskAlphaPatchedOperations = 0;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Patched
+                    && outcome.Method.Contains(nameof(HotReloadE2EFixture.InlineRiskAlpha)))
+                {
+                    inlineRiskAlphaPatchedOperations++;
+                }
+            }
+
+            Assert.That(inlineRiskAlphaPatchedOperations, Is.EqualTo(2));
+
+            int declarationDriftCount = CountWarningsContaining(
+                result.Warnings,
+                "Edits outside method bodies");
+            Assert.That(
+                result.Warnings,
+                Has.Count.EqualTo(1 + declarationDriftCount),
+                "Expected the aggregated inline-risk warning plus one declaration-drift warning per duplicate file input.");
+
+            string aggregatedWarning = null;
+            foreach (string warning in result.Warnings)
+            {
+                if (warning.Contains("patched methods had pre-patch bodies")
+                    && warning.Contains(nameof(HotReloadE2EFixture.InlineRiskAlpha)))
+                {
+                    aggregatedWarning = warning;
+                    break;
+                }
+            }
+
+            Assert.That(aggregatedWarning, Is.Not.Null, "Expected an aggregated inline-risk warning.");
+            Assert.That(
+                CountOccurrences(aggregatedWarning, nameof(HotReloadE2EFixture.InlineRiskAlpha)),
+                Is.EqualTo(1),
+                "The aggregated warning must list a re-patched method once, not once per patch operation.");
             Assert.That(
                 declarationDriftCount,
                 Is.EqualTo(2),
@@ -1677,7 +1819,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string modeEnumDeclaration = null,
             string centerOfCellMethod = null,
             string callsBaseMethod = null,
-            string explicitAccessorsBlock = null)
+            string explicitAccessorsBlock = null,
+            string inlineRiskAlphaMethod = null,
+            string inlineRiskBetaMethod = null)
         {
             string sumGrid = sumGridMethod ??
                 "public int SumGrid(int[,] grid)\n        {\n            return -1;\n        }";
@@ -1739,6 +1883,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + "        public int Counter;\n"
                 + "\n"
                 + "        private int this[int index] => _secret + index;";
+            string inlineRiskAlpha = inlineRiskAlphaMethod ??
+                "[MethodImpl(MethodImplOptions.AggressiveInlining)]\n"
+                + "        public int InlineRiskAlpha()\n"
+                + "        {\n"
+                + "            return 1;\n"
+                + "        }";
+            string inlineRiskBeta = inlineRiskBetaMethod ??
+                "[MethodImpl(MethodImplOptions.AggressiveInlining)]\n"
+                + "        public int InlineRiskBeta()\n"
+                + "        {\n"
+                + "            return 2;\n"
+                + "        }";
 
             return @"using System;
 using System.Collections;
@@ -1811,6 +1967,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         " + sumGrid + @"
 
         " + centerOfCell + @"
+
+        " + inlineRiskAlpha + @"
+
+        " + inlineRiskBeta + @"
 
         public int CountEnumerator(List<int>.Enumerator enumerator)
         {

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 
 using Newtonsoft.Json.Linq;
 
+using UnityEditor.Compilation;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
@@ -474,12 +475,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: patching multiple small methods emits one aggregated inline-risk warning and
-        /// leaves each Patched outcome's Reason empty.
+        /// What: under Debug code optimization, size-only small methods do not emit the
+        /// aggregated inline-risk warning (branch a); Patched Reason stays empty.
         /// </summary>
         [Test]
-        public async Task Run_MultipleSmallPatchedMethods_AggregatesInlineRiskWarningOnce()
+        public async Task Run_MultipleSmallPatchedMethods_OmitsInlineRiskWarningInDebug()
         {
+            Assert.That(
+                CompilationPipeline.codeOptimization,
+                Is.EqualTo(CodeOptimization.Debug),
+                "This regression pins Debug behavior; run under Debug code optimization.");
+
             string fixturePath = ResolveE2EFixturePath();
             string editedPath = WriteEditedSource(
                 "MultipleSmallInlineRisk.cs",
@@ -502,7 +508,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertHasPatched(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
             AssertHasPatched(result, nameof(HotReloadE2EFixture.CenterOfCell));
 
-            int patchedWithEmptyReason = 0;
             foreach (HotReloadMethodOutcome outcome in result.Methods)
             {
                 if (outcome.Kind != HotReloadMethodOutcomeKind.Patched)
@@ -511,42 +516,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 }
 
                 Assert.That(outcome.Reason, Is.Empty, "Patched Reason must not carry per-method inline-risk text.");
-                patchedWithEmptyReason++;
             }
 
-            Assert.That(patchedWithEmptyReason, Is.GreaterThanOrEqualTo(2));
-
-            int aggregatedInlineRiskCount = 0;
             foreach (string warning in result.Warnings)
             {
-                if (warning.Contains("patched methods had pre-patch bodies")
-                    && warning.Contains(nameof(HotReloadE2EFixture.ComputeWithPrivate))
-                    && warning.Contains(nameof(HotReloadE2EFixture.CenterOfCell)))
-                {
-                    aggregatedInlineRiskCount++;
-                }
+                Assert.That(
+                    warning.Contains("patched methods had pre-patch bodies"),
+                    Is.False,
+                    "Debug must not emit IL-size inline-risk warnings: " + warning);
             }
-
-            Assert.That(
-                aggregatedInlineRiskCount,
-                Is.EqualTo(1),
-                "Expected exactly one aggregated inline-risk warning listing the at-risk methods.");
-
-            int declarationDriftCount = CountWarningsContaining(
-                result.Warnings,
-                "Edits outside method bodies");
-            Assert.That(
-                result.Warnings,
-                Has.Count.EqualTo(1 + declarationDriftCount),
-                "Expected the aggregated inline-risk warning plus any declaration-drift warning(s).");
         }
 
         /// <summary>
-        /// Verifies duplicate file inputs re-patch the same method yet the aggregated warning lists it once.
+        /// What: duplicate file inputs re-patch the same small method yet Debug emits no
+        /// IL-size inline-risk warning (branch a); declaration-drift warnings still appear twice.
         /// </summary>
         [Test]
-        public async Task Run_DuplicateFileInputs_ListsEachAtRiskMethodOnceInAggregatedWarning()
+        public async Task Run_DuplicateFileInputs_OmitsInlineRiskWarningInDebug()
         {
+            Assert.That(
+                CompilationPipeline.codeOptimization,
+                Is.EqualTo(CodeOptimization.Debug),
+                "This regression pins Debug behavior; run under Debug code optimization.");
+
             string fixturePath = ResolveE2EFixturePath();
             string editedPath = WriteEditedSource(
                 "DuplicateInputInlineRisk.cs",
@@ -576,30 +568,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(computeWithPrivatePatchedOperations, Is.EqualTo(2));
 
+            foreach (string warning in result.Warnings)
+            {
+                Assert.That(
+                    warning.Contains("patched methods had pre-patch bodies"),
+                    Is.False,
+                    "Debug must not emit IL-size inline-risk warnings: " + warning);
+            }
+
             int declarationDriftCount = CountWarningsContaining(
                 result.Warnings,
                 "Edits outside method bodies");
-            Assert.That(
-                result.Warnings,
-                Has.Count.EqualTo(1 + declarationDriftCount),
-                "Expected the aggregated inline-risk warning plus one declaration-drift warning per duplicate file input.");
-
-            string aggregatedWarning = null;
-            foreach (string warning in result.Warnings)
-            {
-                if (warning.Contains("patched methods had pre-patch bodies")
-                    && warning.Contains(nameof(HotReloadE2EFixture.ComputeWithPrivate)))
-                {
-                    aggregatedWarning = warning;
-                    break;
-                }
-            }
-
-            Assert.That(aggregatedWarning, Is.Not.Null, "Expected an aggregated inline-risk warning.");
-            Assert.That(
-                CountOccurrences(aggregatedWarning, nameof(HotReloadE2EFixture.ComputeWithPrivate)),
-                Is.EqualTo(1),
-                "The aggregated warning must list a re-patched method once, not once per patch operation.");
             Assert.That(
                 declarationDriftCount,
                 Is.EqualTo(2),

--- a/Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
     /// <summary>
@@ -111,6 +113,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             {
                 return _score;
             }
+        }
+    }
+
+    /// <summary>
+    /// Probe pair for JIT-inlining investigation: a tiny getter (eligible for Mono inlining)
+    /// and a NoInlining caller that is warmed before the getter is patched.
+    /// </summary>
+    internal static class HotReloadJitInliningInvestigationFixture
+    {
+        public static int Probe => 1;
+
+        // Why NoInlining on the caller only: keep ReadProbe as a stable call site while leaving
+        // Probe eligible for inlining into that already-JITed body.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static int ReadProbe()
+        {
+            return Probe;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadJitInliningRisk.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadJitInliningRisk.cs
@@ -47,8 +47,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(methodLabels.Count == atRiskCount, "methodLabels count must match atRiskCount.");
 
             string methods = string.Join(", ", methodLabels);
-            return $"{atRiskCount} of {patchedTotal} patched methods had pre-patch bodies small enough (or marked [AggressiveInlining]) that the Mono JIT may already have inlined them into callers compiled before the patch; those call sites keep the old behavior until a real compile: {methods}"
-                + " If 'uloop hot-reload --status' shows the method's InvocationCount increasing afterwards, its call sites are reaching the patched body and this warning did not apply.";
+            return $"{atRiskCount} of {patchedTotal} patched methods had pre-patch bodies small enough (or marked [AggressiveInlining]) that the Mono JIT may already have inlined them into callers compiled before the patch; those call sites keep the old behavior until a real compile: {methods}."
+                + " If 'uloop hot-reload --status' shows the method's InvocationCount increasing afterwards, the calls you exercised are reaching the patched body and this warning did not apply to them.";
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadJitInliningRisk.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadJitInliningRisk.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+
+using UnityEditor.Compilation;
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Pure heuristic for whether a patched method is likely already JIT-inlined into callers.
+    /// Callers inject CompilationPipeline.codeOptimization so EditMode tests can cover both modes.
+    /// </summary>
+    internal static class HotReloadJitInliningRisk
+    {
+        /// <summary>
+        /// Returns true when the method should contribute to the aggregated inline-risk warning.
+        /// [AggressiveInlining] always qualifies; the IL-size heuristic applies only in Release.
+        /// </summary>
+        public static bool Evaluate(
+            bool hasAggressiveInlining,
+            int? ilByteLength,
+            CodeOptimization codeOptimization)
+        {
+            if (hasAggressiveInlining)
+            {
+                return true;
+            }
+
+            if (codeOptimization != CodeOptimization.Release)
+            {
+                return false;
+            }
+
+            return ilByteLength.HasValue
+                && ilByteLength.Value <= HotReloadConstants.SmallMethodInliningRiskThresholdBytes;
+        }
+
+        /// <summary>
+        /// Builds the single aggregated Warning line for methods that Evaluate flagged.
+        /// </summary>
+        public static string FormatAggregatedWarning(
+            int atRiskCount,
+            int patchedTotal,
+            IReadOnlyList<string> methodLabels)
+        {
+            Debug.Assert(atRiskCount > 0, "atRiskCount must be positive.");
+            Debug.Assert(methodLabels != null, "methodLabels must not be null.");
+            Debug.Assert(methodLabels.Count == atRiskCount, "methodLabels count must match atRiskCount.");
+
+            string methods = string.Join(", ", methodLabels);
+            return $"{atRiskCount} of {patchedTotal} patched methods had pre-patch bodies small enough (or marked [AggressiveInlining]) that the Mono JIT may already have inlined them into callers compiled before the patch; those call sites keep the old behavior until a real compile: {methods}"
+                + " If 'uloop hot-reload --status' shows the method's InvocationCount increasing afterwards, its call sites are reaching the patched body and this warning did not apply.";
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadJitInliningRisk.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadJitInliningRisk.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15875b2cd467142e2aed21f479b6d64f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -516,12 +516,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int patchedTotal,
             IReadOnlyList<string> methodLabels)
         {
-            Debug.Assert(atRiskCount > 0, "atRiskCount must be positive.");
-            Debug.Assert(methodLabels != null, "methodLabels must not be null.");
-            Debug.Assert(methodLabels.Count == atRiskCount, "methodLabels count must match atRiskCount.");
-
-            string methods = string.Join(", ", methodLabels);
-            return $"{atRiskCount} of {patchedTotal} patched methods had pre-patch bodies small enough (or marked [AggressiveInlining]) that the Mono JIT may already have inlined them into callers compiled before the patch; those call sites keep the old behavior until a real compile: {methods}";
+            return HotReloadJitInliningRisk.FormatAggregatedWarning(atRiskCount, patchedTotal, methodLabels);
         }
 
         // Duplicate file inputs process the same source twice, producing duplicates across

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -6,6 +6,7 @@ using System.Text;
 
 using HarmonyLib;
 
+using UnityEditor.Compilation;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -714,15 +715,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         // Heuristic only: [AggressiveInlining] is a hint, and IL size cannot predict Mono's real
         // inlining decision. Exists to surface a warning when HitCount-like symptoms appear.
+        // Why inject codeOptimization: Debug mode does not inline tiny getters into warmed callers
+        // (measured PR-4 To-Do 12), so the IL-size heuristic must stay Release-only.
         private static bool IsLikelyJitInlined(MethodBase method)
         {
-            if ((method.GetMethodImplementationFlags() & MethodImplAttributes.AggressiveInlining) != 0)
-            {
-                return true;
-            }
-
+            bool hasAggressiveInlining =
+                (method.GetMethodImplementationFlags() & MethodImplAttributes.AggressiveInlining) != 0;
             byte[] ilBytes = method.GetMethodBody()?.GetILAsByteArray();
-            return ilBytes != null && ilBytes.Length <= HotReloadConstants.SmallMethodInliningRiskThresholdBytes;
+            int? ilByteLength = ilBytes == null ? (int?)null : ilBytes.Length;
+            return HotReloadJitInliningRisk.Evaluate(
+                hasAggressiveInlining,
+                ilByteLength,
+                CompilationPipeline.codeOptimization);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -143,8 +143,11 @@ trace` on a line inside the edited method body — it resolves against the patch
 directly (see the pause point interaction below) — drive the game, and check the hit
 count: zero hits means the calling path never reached the method, which no patch (or
 compile) can fix. To chase an early return inside the method, arm a second marker on the
-suspected early-return line. The other known cause is JIT inlining of tiny methods, which
-the response already flags with a single aggregated warning listing the at-risk methods.
+suspected early-return line. The other known cause is JIT inlining, which the response flags
+with a single aggregated warning listing the at-risk methods: `[AggressiveInlining]` methods
+always, tiny bodies only when the Editor's Code Optimization mode is Release (the default
+Debug mode does not inline them). If `uloop hot-reload --status` shows the method's
+`InvocationCount` increasing, the calls you exercised are reaching the patched body.
 
 ## Convergence and lifecycle
 
@@ -198,7 +201,7 @@ Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, or `Failed` on apply runs, or `Active` on `--status` runs; empty on `--revert-all` runs. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`
-- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods whose pre-patch bodies were small enough (or marked `[AggressiveInlining]`) to have been JIT-inlined into existing callers (the change may not show at those call sites), the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
+- `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods at risk of being already JIT-inlined into existing callers — those marked `[AggressiveInlining]`, plus (only when Code Optimization is Release) those with tiny pre-patch bodies — meaning the change may not show at those call sites, the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `UnchangedTotal` (number): Methods left untouched because their bodies match the source baseline from the last compile; `0` when no baseline was available
 - `ActivePatchTotal` (number): Methods still patched after this run


### PR DESCRIPTION
## Summary
- Suppresses the IL-size JIT inlining warning under Debug code optimization (branch a from measured Mono behavior).
- `[AggressiveInlining]` remains always at-risk; the size heuristic applies only in Release.
- Appends the status-based self-check sentence to the aggregated warning.
- Extracts `HotReloadJitInliningRisk.Evaluate` / `FormatAggregatedWarning` as pure, injectable helpers for TDD.

## User Impact
One-line getters no longer spam a false JIT-inlining warning in the default Debug Editor. The warning still appears for `[AggressiveInlining]` and under Release, and now tells agents how to confirm via `--status` InvocationCount.

## Test plan
- [x] Pure unit tests: AggressiveInlining always / small IL only in Release / large IL not flagged / warning ends with self-check sentence
- [x] E2E: Debug omits size-only inline-risk warning for small patched methods
- [x] Regression: warmed `ReadProbe` sees patched `Probe` under Debug
- [x] Filter suite `HotReload|TransformWorker|PausePoint`: 435 Passed / 0 Failed
- [x] `uloop compile` errors 0


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

