### PR TITLE
fix: dedupe const-only drift warnings and add file paths to status rows

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -458,6 +458,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 {
                     foundActiveGetter = true;
                     Assert.That(method.InvocationCount, Is.GreaterThanOrEqualTo(1L));
+                    Assert.That(
+                        method.FilePath,
+                        Is.EqualTo("Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs"),
+                        "Status Active rows must carry the project-relative source path from apply.");
                 }
             }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -41,7 +41,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(-5), "Precondition: original sentinel body.");
 
             HotReloadPatchResult result = HotReloadPatcher.Apply(
-                original, shim, HotReloadPatchShape.Transplant);
+                original, shim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs");
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(47));
         }
@@ -59,7 +59,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(HotReloadCoreFixture.StaticPing(), Is.EqualTo("original"));
             HotReloadPatchResult result = HotReloadPatcher.Apply(
-                original, shim, HotReloadPatchShape.Transplant);
+                original, shim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs");
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(HotReloadCoreFixture.StaticPing(), Is.EqualTo("patched"));
         }
@@ -80,7 +80,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(fixture.VoidHits, Is.EqualTo(-1), "Precondition: original void body.");
 
             HotReloadPatchResult result = HotReloadPatcher.Apply(
-                original, shim, HotReloadPatchShape.Transplant);
+                original, shim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs");
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             fixture.VoidBump();
             Assert.That(fixture.VoidHits, Is.EqualTo(7));
@@ -99,7 +99,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             HotReloadCoreFixture fixture = new HotReloadCoreFixture();
             Assert.That(
-                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
+                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
                 Is.True);
             Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(47));
 
@@ -121,17 +121,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 typeof(HotReloadHandwrittenShims), nameof(HotReloadHandwrittenShims.ReplaceableCompute__shim0));
 
             Assert.That(
-                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
+                HotReloadPatcher.Apply(
+                    original, shim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
                 Is.True);
 
-            IReadOnlyList<string> afterApply = HotReloadPatcher.DescribeActivePatches();
+            IReadOnlyList<HotReloadActivePatchInfo> afterApply = HotReloadPatcher.DescribeActivePatches();
             Assert.That(afterApply.Count, Is.EqualTo(1));
             Assert.That(
-                afterApply[0],
+                afterApply[0].MethodKey,
                 Does.Contain(nameof(HotReloadCoreFixture)).And.Contain(nameof(HotReloadCoreFixture.ReplaceableCompute)));
+            Assert.That(afterApply[0].FilePath, Is.EqualTo("Assets/Tests/Fixture.cs"));
 
             HotReloadPatcher.RevertAll();
-            IReadOnlyList<string> afterRevert = HotReloadPatcher.DescribeActivePatches();
+            IReadOnlyList<HotReloadActivePatchInfo> afterRevert = HotReloadPatcher.DescribeActivePatches();
             Assert.That(afterRevert, Is.Empty);
         }
 
@@ -150,12 +152,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             HotReloadCoreFixture fixture = new HotReloadCoreFixture();
             Assert.That(
-                HotReloadPatcher.Apply(original, shim0, HotReloadPatchShape.Transplant).Success,
+                HotReloadPatcher.Apply(original, shim0, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
                 Is.True);
             Assert.That(fixture.ReplaceableCompute(1), Is.EqualTo(43));
 
             Assert.That(
-                HotReloadPatcher.Apply(original, shim1, HotReloadPatchShape.Transplant).Success,
+                HotReloadPatcher.Apply(original, shim1, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
                 Is.True);
             Assert.That(fixture.ReplaceableCompute(1), Is.EqualTo(100));
 
@@ -179,7 +181,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 typeof(HotReloadHandwrittenShims), nameof(HotReloadHandwrittenShims.ReplaceableCompute__shim0));
 
             HotReloadPatchResult result = HotReloadPatcher.Apply(
-                original, shim, HotReloadPatchShape.Transplant);
+                original, shim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs");
             Assert.That(result.Success, Is.False);
             Assert.That(result.FailureReason, Is.EqualTo(HotReloadPatchFailureReason.UnpatchableValueType));
         }
@@ -204,7 +206,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Precondition: original async sentinel body.");
 
             HotReloadPatchResult result = HotReloadPatcher.Apply(
-                original, shim, HotReloadPatchShape.Delegation);
+                original, shim, HotReloadPatchShape.Delegation, "Assets/Tests/Fixture.cs");
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(await fixture.ReplaceableComputeAsync(5), Is.EqualTo(10 + 5 + 1));
 
@@ -230,7 +232,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 typeof(HotReloadPatcherTests), nameof(ExternShimStub));
 
             HotReloadPatchResult result = HotReloadPatcher.Apply(
-                original, shim, HotReloadPatchShape.Transplant);
+                original, shim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs");
 
             Assert.That(result.Success, Is.False);
             Assert.That(result.FailureReason, Is.EqualTo(HotReloadPatchFailureReason.ApplyFailed));
@@ -256,7 +258,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(0L));
             Assert.That(
-                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
+                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
                 Is.True);
             Assert.That(
                 HotReloadInvocationRegistry.GetCount(methodKey),
@@ -301,14 +303,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             HotReloadCoreFixture fixture = new HotReloadCoreFixture();
             Assert.That(
-                HotReloadPatcher.Apply(original, shim0, HotReloadPatchShape.Transplant).Success,
+                HotReloadPatcher.Apply(original, shim0, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
                 Is.True);
             Assert.That(fixture.ReplaceableCompute(1), Is.EqualTo(43));
             Assert.That(fixture.ReplaceableCompute(1), Is.EqualTo(43));
             Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(2L));
 
             Assert.That(
-                HotReloadPatcher.Apply(original, shim1, HotReloadPatchShape.Transplant).Success,
+                HotReloadPatcher.Apply(original, shim1, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
                 Is.True);
             Assert.That(
                 HotReloadInvocationRegistry.GetCount(methodKey),
@@ -412,7 +414,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             HotReloadCoreFixture fixture = new HotReloadCoreFixture();
             Assert.That(
-                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
+                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
                 Is.True);
             Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(47));
             Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(1L));

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
@@ -597,7 +597,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 nameof(HotReloadPausePointContractShims.ReplaceableCompute__shim0));
 
             Assert.That(
-                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
+                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
                 Is.True);
 
             const int requestedLine = 42;
@@ -663,7 +663,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 nameof(HotReloadPausePointContractShims.ReplaceableCompute__shim0));
 
             Assert.That(
-                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant).Success,
+                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
                 Is.True);
             HotReloadPatcher.RevertAll();
 
@@ -696,7 +696,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.True);
 
             HotReloadPatchResult applyResult = HotReloadPatcher.Apply(
-                original, shim, HotReloadPatchShape.Delegation);
+                original, shim, HotReloadPatchShape.Delegation, "Assets/Tests/Fixture.cs");
             Assert.That(applyResult.Success, Is.True, applyResult.ErrorMessage);
             Assert.That(UloopPausePointRegistry.GetStatus(id).SuppressedByHotReload, Is.True);
             Assert.That(

--- a/Assets/Tests/Editor/HotReload/HotReloadTransplantControlFlowTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadTransplantControlFlowTests.cs
@@ -137,7 +137,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 typeof(HotReloadTransplantControlFlowTests), shimName);
 
             HotReloadPatchResult result = HotReloadPatcher.Apply(
-                original, shim, HotReloadPatchShape.Transplant);
+                original, shim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs");
             Assert.That(result.Success, Is.True, result.ErrorMessage);
 
             return OriginalToCenter(new Vector3Int(1, 2, 3));
@@ -219,7 +219,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 typeof(HotReloadTransplantControlFlowTests), nameof(ShimToCenterThrowInTry));
 
             HotReloadPatchResult result = HotReloadPatcher.Apply(
-                original, shim, HotReloadPatchShape.Transplant);
+                original, shim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs");
             Assert.That(result.Success, Is.True, result.ErrorMessage);
 
             Assert.Throws<InvalidOperationException>(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -751,6 +751,44 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: editing only an enum member value emits the dedicated const-drift warning and
+        /// does not also emit the generic outside-method-body warning.
+        /// </summary>
+        [Test]
+        public async Task Run_WithEnumMemberValueOnlyEdit_EmitsConstDriftWithoutOutsideBodyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveE2EFixturePath());
+            string editedSource = onDisk.Replace(
+                "Active = 1",
+                "Active = 2",
+                StringComparison.Ordinal);
+            Assert.That(editedSource, Is.Not.EqualTo(onDisk), "Precondition: enum member value must differ.");
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string sourcePath = Path.Combine(directory, "EnumMemberOnlyDriftWarning.cs");
+            File.WriteAllText(sourcePath, editedSource);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                ResolveE2EFixtureProjectRelativePath(),
+                snapshotSource: onDisk);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.declarationDriftWarnings, Is.Not.Null);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.Some.Contain("HotReloadE2EMode.Active").And.Contain("is 2 in the edited source but 1"),
+                "Enum-member-only edits must keep the dedicated const-drift warning.\n"
+                + string.Join("\n", result.Output.declarationDriftWarnings));
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.None.Contain("Edits outside method bodies"),
+                "Enum-member-only edits must not also emit the generic outside-body warning.");
+        }
+
+        /// <summary>
         /// What: a non-const field initializer change still emits the generic outside-method-body
         /// warning (const stripping must not hide ordinary field initializer drift).
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -713,6 +713,77 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: editing only a const value emits the dedicated const-drift warning and does not
+        /// also emit the generic outside-method-body warning.
+        /// </summary>
+        [Test]
+        public async Task Run_WithConstValueOnlyEdit_EmitsConstDriftWithoutOutsideBodyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveE2EFixturePath());
+            string editedSource = onDisk.Replace(
+                "private const int TuningConst = 3;",
+                "private const int TuningConst = 4;",
+                StringComparison.Ordinal);
+            Assert.That(editedSource, Is.Not.EqualTo(onDisk), "Precondition: const value must differ.");
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string sourcePath = Path.Combine(directory, "ConstOnlyDriftWarning.cs");
+            File.WriteAllText(sourcePath, editedSource);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                ResolveE2EFixtureProjectRelativePath(),
+                snapshotSource: onDisk);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.declarationDriftWarnings, Is.Not.Null);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.Some.Contain("TuningConst").And.Contain("is 4 in the edited source but 3"),
+                "Const-only edits must keep the dedicated const-drift warning.\n"
+                + string.Join("\n", result.Output.declarationDriftWarnings));
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.None.Contain("Edits outside method bodies"),
+                "Const-only edits must not also emit the generic outside-body warning.");
+        }
+
+        /// <summary>
+        /// What: a non-const field initializer change still emits the generic outside-method-body
+        /// warning (const stripping must not hide ordinary field initializer drift).
+        /// </summary>
+        [Test]
+        public async Task Run_WithNonConstFieldInitializerEdit_StillEmitsOutsideBodyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveE2EFixturePath());
+            string editedSource = onDisk.Replace(
+                "private int _secret = 10;",
+                "private int _secret = 12;",
+                StringComparison.Ordinal);
+            Assert.That(editedSource, Is.Not.EqualTo(onDisk), "Precondition: field initializer must differ.");
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string sourcePath = Path.Combine(directory, "NonConstFieldInitializerDrift.cs");
+            File.WriteAllText(sourcePath, editedSource);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                ResolveE2EFixtureProjectRelativePath(),
+                snapshotSource: onDisk);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.declarationDriftWarnings, Is.Not.Null);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.Some.Contain("Edits outside method bodies"),
+                "Non-const field initializer edits must still emit the outside-body warning.");
+        }
+
+        /// <summary>
         /// What: a snapshot that duplicates a method key falls back to no-baseline behavior
         /// (same entries as a null snapshot, empty unchangedMethods) and sets
         /// baselineDisabledByDuplicateKeys so the orchestrator can warn.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadActivePatchInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadActivePatchInfo.cs
@@ -1,0 +1,18 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// One active hot-reload patch for --status: method key plus the source file path
+    /// that was applied (project-relative when applied through the orchestrator).
+    /// </summary>
+    internal sealed class HotReloadActivePatchInfo
+    {
+        public string MethodKey { get; }
+        public string FilePath { get; }
+
+        public HotReloadActivePatchInfo(string methodKey, string filePath)
+        {
+            MethodKey = methodKey ?? string.Empty;
+            FilePath = filePath ?? string.Empty;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadActivePatchInfo.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadActivePatchInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a84997ecd432447e39c0500c681cbea5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -489,7 +489,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     patchShape == HotReloadPatchShape.Delegation,
                     entry.sourceStartLine,
                     entry.sourceEndLine));
-            HotReloadPatchResult patchResult = HotReloadPatcher.Apply(matchResult.Method, shimMethod, patchShape);
+            HotReloadPatchResult patchResult = HotReloadPatcher.Apply(
+                matchResult.Method,
+                shimMethod,
+                patchShape,
+                projectRelativePath);
             if (!patchResult.Success)
             {
                 HotReloadShimRegistry.RemoveMethod(matchResult.Method);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -44,6 +44,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static readonly Dictionary<MethodBase, MethodInfo> ShimByMethod =
             new Dictionary<MethodBase, MethodInfo>();
 
+        // Parallel to ShimByMethod: project-relative (or test) path of the source that was applied.
+        private static readonly Dictionary<MethodBase, string> FilePathByMethod =
+            new Dictionary<MethodBase, string>();
+
         // Transplant LocalBuilders (shim slot order) from the latest rebuild of each original.
         private static readonly Dictionary<MethodBase, IReadOnlyList<LocalBuilder>> TransplantLocalsByMethod =
             new Dictionary<MethodBase, IReadOnlyList<LocalBuilder>>();
@@ -95,7 +99,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public static HotReloadPatchResult Apply(
             MethodBase method,
             MethodInfo shimMethodInfo,
-            HotReloadPatchShape patchShape)
+            HotReloadPatchShape patchShape,
+            string filePath)
         {
             if (method == null)
             {
@@ -125,6 +130,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Do not RemoveMethod from the shim registry here: ApplyEntry already registered
                 // this method into the new generation before calling Apply.
                 ShimByMethod.Remove(method);
+                FilePathByMethod.Remove(method);
                 TransplantLocalsByMethod.Remove(method);
                 HotReloadInvocationRegistry.Remove(FormatMethodKey(method));
                 HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
@@ -154,6 +160,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         priority = Priority.First
                     });
                 ShimByMethod[method] = shimMethodInfo;
+                FilePathByMethod[method] = filePath ?? string.Empty;
                 HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, true);
             }
             catch (Exception exception)
@@ -167,6 +174,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Why Remove before Unpatch: Invoke(true) may have written ShimByMethod before
                 // a later failure; rebuild must not see an active shim (same as re-apply path).
                 ShimByMethod.Remove(method);
+                FilePathByMethod.Remove(method);
                 HotReloadInvocationRegistry.Remove(FormatMethodKey(method));
                 // User-approved exception to the no-try-catch policy: Harmony emit/JIT
                 // failures cannot be pre-validated (the IL shape is only known inside
@@ -216,6 +224,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // so GetActiveShimForMethod / GetShimLookupForFile agree during rebuild.
             List<MethodBase> revertedMethods = new List<MethodBase>(ShimByMethod.Keys);
             ShimByMethod.Clear();
+            FilePathByMethod.Clear();
             HotReloadShimRegistry.Clear();
             TransplantLocalsByMethod.Clear();
             HotReloadInvocationRegistry.Clear();
@@ -245,6 +254,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // pause-point guard sees GetActiveShimForMethod == null so surviving markers are
             // re-instrumented into the restored original IL. Registry removal stays in the same
             // pre-Unpatch window so lookup and ledger never disagree mid-rebuild.
+            FilePathByMethod.Remove(method);
             HotReloadShimRegistry.RemoveMethod(method);
             TransplantLocalsByMethod.Remove(method);
             HotReloadInvocationRegistry.Remove(FormatMethodKey(method));
@@ -259,19 +269,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public static int ActivePatchCount => ShimByMethod.Count;
 
         /// <summary>
-        /// Returns a sorted list of labels for every method currently recorded in the
-        /// patch ledger, for status reporting without applying or reverting patches.
+        /// Returns a sorted list of active patches (method key + source file path) for status
+        /// reporting without applying or reverting patches.
         /// </summary>
-        public static IReadOnlyList<string> DescribeActivePatches()
+        public static IReadOnlyList<HotReloadActivePatchInfo> DescribeActivePatches()
         {
-            List<string> labels = new List<string>(ShimByMethod.Count);
-            foreach (MethodBase method in ShimByMethod.Keys)
+            List<HotReloadActivePatchInfo> patches =
+                new List<HotReloadActivePatchInfo>(ShimByMethod.Count);
+            foreach (KeyValuePair<MethodBase, MethodInfo> pair in ShimByMethod)
             {
-                labels.Add(FormatMethodKey(method));
+                string methodKey = FormatMethodKey(pair.Key);
+                string filePath = string.Empty;
+                if (FilePathByMethod.TryGetValue(pair.Key, out string recordedPath))
+                {
+                    filePath = recordedPath;
+                }
+
+                patches.Add(new HotReloadActivePatchInfo(methodKey, filePath));
             }
 
-            labels.Sort(StringComparer.Ordinal);
-            return labels;
+            patches.Sort(
+                (left, right) => string.CompareOrdinal(left.MethodKey, right.MethodKey));
+            return patches;
         }
 
         // What: status / counter key from a resolved MethodBase (apply outcomes use the same

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -137,17 +137,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static HotReloadResponse ExecuteStatus()
         {
-            IReadOnlyList<string> active = HotReloadPatcher.DescribeActivePatches();
+            IReadOnlyList<HotReloadActivePatchInfo> active = HotReloadPatcher.DescribeActivePatches();
             List<HotReloadMethodResult> methods = new List<HotReloadMethodResult>(active.Count);
             for (int index = 0; index < active.Count; index++)
             {
-                string methodKey = active[index];
+                HotReloadActivePatchInfo patch = active[index];
                 methods.Add(
                     new HotReloadMethodResult
                     {
                         Kind = "Active",
-                        Method = methodKey,
-                        InvocationCount = HotReloadInvocationRegistry.GetCount(methodKey)
+                        Method = patch.MethodKey,
+                        FilePath = patch.FilePath,
+                        InvocationCount = HotReloadInvocationRegistry.GetCount(patch.MethodKey)
                     });
             }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -1035,6 +1035,49 @@ public static class TransformWorkerProgram
             return visited.WithAccessorList(
                 SyntaxFactory.AccessorList(SyntaxFactory.List(accessors)));
         }
+
+        // Why strip const initializers: const drift has its own warning with both values;
+        // leaving EqualsValueClause here would also trip the generic outside-body warning.
+        public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)
+        {
+            FieldDeclarationSyntax visited = (FieldDeclarationSyntax)base.VisitFieldDeclaration(node);
+            bool isConst = false;
+            foreach (SyntaxToken modifier in visited.Modifiers)
+            {
+                if (modifier.IsKind(SyntaxKind.ConstKeyword))
+                {
+                    isConst = true;
+                    break;
+                }
+            }
+
+            if (!isConst)
+            {
+                return visited;
+            }
+
+            List<VariableDeclaratorSyntax> declarators = new List<VariableDeclaratorSyntax>();
+            foreach (VariableDeclaratorSyntax declarator in visited.Declaration.Variables)
+            {
+                declarators.Add(declarator.WithInitializer(null));
+            }
+
+            return visited.WithDeclaration(
+                visited.Declaration.WithVariables(SyntaxFactory.SeparatedList(declarators)));
+        }
+
+        // Why strip enum member values: enum constants use the same dedicated const-drift path.
+        public override SyntaxNode VisitEnumMemberDeclaration(EnumMemberDeclarationSyntax node)
+        {
+            EnumMemberDeclarationSyntax visited =
+                (EnumMemberDeclarationSyntax)base.VisitEnumMemberDeclaration(node);
+            if (visited.EqualsValue == null)
+            {
+                return visited;
+            }
+
+            return visited.WithEqualsValue(null);
+        }
     }
 
     // What: reports each property/indexer accessor that has an explicit body as Skipped.


### PR DESCRIPTION
## Summary
- Editing only a `const` (or enum member) value no longer also emits the generic “Edits outside method bodies” warning; the dedicated const-drift warning with both values remains.
- `uloop hot-reload --status` Active rows now include `FilePath`, matching the project-relative path from apply.

## User Impact
Const-only edits stop looking like two different kinds of drift, so agents spend less time chasing a duplicate outside-body warning. Status output can point back to the edited source file the same way apply outcomes already do.

## Test plan
- [x] `Run_WithConstValueOnlyEdit_EmitsConstDriftWithoutOutsideBodyWarning` — const drift present, no outside-body line
- [x] `Run_WithNonConstFieldInitializerEdit_StillEmitsOutsideBodyWarning` — non-const initializer still warns
- [x] `DescribeActivePatches_AfterApply_ListsFixture_AndClearsAfterRevertAll` — DTO carries file path
- [x] `Run_EditedPropertyGetter_ApplyStatusRevert_UpdatesRuntimeValue` — status `FilePath` equals shape fixture project-relative path
- [x] Filter suite `HotReload|TransformWorker|PausePoint` → 439 Passed
- [x] `uloop compile` → ErrorCount 0

Note: PRs into `feature/hot-reload` typically do not run repository CI; local `uloop` verification above is the check for this PR.
