### PR TITLE
fix: parenthesize interpolation holes that gain alias-qualified names

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadCoreFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCoreFixtures.cs
@@ -64,10 +64,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     {
         private static int formatCallTotal;
 
+        private const int PaddingWidth = 6;
+
         public string FormatStaticCount()
         {
             formatCallTotal++;
             return $"total: {formatCallTotal}";
+        }
+
+        public string FormatAlignedStaticCount()
+        {
+            formatCallTotal++;
+            return $"total: {formatCallTotal,PaddingWidth}";
         }
     }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadCoreFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCoreFixtures.cs
@@ -58,6 +58,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     }
 
     /// <summary>
+    /// Fixture for shim compile of static field access inside string interpolation holes.
+    /// </summary>
+    internal class HotReloadInterpolationFixture
+    {
+        private static int formatCallTotal;
+
+        public string FormatStaticCount()
+        {
+            formatCallTotal++;
+            return $"total: {formatCallTotal}";
+        }
+    }
+
+    /// <summary>
     /// Hand-written static shims that mirror the production transplant shape
     /// (instance methods become static with a leading <c>instance</c> argument). Generated
     /// shims mirror user signatures verbatim; repo style rules apply to hand-written code only.

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -277,6 +277,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: editing a method that references a private static field inside a string
+        /// interpolation hole still Patches (alias-qualified names must be parenthesized so csc
+        /// does not treat ':' as a format-clause start).
+        /// </summary>
+        [Test]
+        public async Task Run_EditedInterpolationStaticFieldAccess_Patches()
+        {
+            string fixturePath = ResolveCoreFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string editedSource = onDisk.Replace(
+                "return $\"total: {formatCallTotal}\";",
+                "return $\"total=: {formatCallTotal}\";",
+                StringComparison.Ordinal);
+            Assert.That(
+                editedSource,
+                Is.Not.EqualTo(onDisk),
+                "Precondition: FormatStaticCount body must differ from on-disk.");
+
+            string editedPath = WriteEditedSource("InterpolationStaticField.cs", editedSource);
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                contentPathOverride: editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadInterpolationFixture.FormatStaticCount));
+        }
+
+        /// <summary>
         /// What: running hot reload on the on-disk fixture with no edits yields an empty Methods
         /// list, a positive UnchangedTotal, and the all-unchanged Message wording.
         /// </summary>
@@ -1645,6 +1674,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "HotReload",
                 "HotReloadE2EFixtures.cs");
             Assert.That(File.Exists(path), Is.True, "E2E fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string ResolveCoreFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadCoreFixtures.cs");
+            Assert.That(File.Exists(path), Is.True, "Core fixture source missing: " + path);
             return Path.GetFullPath(path);
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -306,6 +306,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: editing a method that uses a private const as an interpolation alignment width
+        /// still Patches (alias-qualified alignment expressions must be parenthesized so csc
+        /// does not treat ':' as a format-clause start).
+        /// </summary>
+        [Test]
+        public async Task Run_EditedInterpolationAlignmentConstAccess_Patches()
+        {
+            string fixturePath = ResolveCoreFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string editedSource = onDisk.Replace(
+                "return $\"total: {formatCallTotal,PaddingWidth}\";",
+                "return $\"total=: {formatCallTotal,PaddingWidth}\";",
+                StringComparison.Ordinal);
+            Assert.That(
+                editedSource,
+                Is.Not.EqualTo(onDisk),
+                "Precondition: FormatAlignedStaticCount body must differ from on-disk.");
+
+            string editedPath = WriteEditedSource("InterpolationAlignmentConst.cs", editedSource);
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                contentPathOverride: editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadInterpolationFixture.FormatAlignedStaticCount));
+        }
+
+        /// <summary>
         /// What: running hot reload on the on-disk fixture with no edits yields an empty Methods
         /// list, a positive UnchangedTotal, and the all-unchanged Message wording.
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -3403,32 +3403,50 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
     public override SyntaxNode VisitInterpolation(InterpolationSyntax node)
     {
         InterpolationSyntax visited = (InterpolationSyntax)base.VisitInterpolation(node);
-        if (visited.Expression is ParenthesizedExpressionSyntax)
-        {
-            return visited;
-        }
 
         // Why: a top-level ':' in an interpolation hole starts a format clause, so a
         // rewrite that inserts bare `global::` yields CS0103 ('global'). Parenthesizing
         // keeps the alias qualifier out of the format-clause scan and still coexists
         // with alignment/format clauses. Nested positions do not need parentheses, but
         // wrapping whenever an AliasQualifiedNameSyntax is present is always safe.
-        bool hasAliasQualifiedName = false;
-        foreach (SyntaxNode descendant in visited.Expression.DescendantNodesAndSelf())
+        // Alignment widths are integer expressions and hit the same ':' scan, so they
+        // need the same wrapping; format clauses are literal text and need none.
+        ExpressionSyntax parenthesizedExpression = ParenthesizeIfAliasQualified(visited.Expression);
+        if (!ReferenceEquals(parenthesizedExpression, visited.Expression))
         {
-            if (descendant is AliasQualifiedNameSyntax)
+            visited = visited.WithExpression(parenthesizedExpression);
+        }
+
+        InterpolationAlignmentClauseSyntax alignmentClause = visited.AlignmentClause;
+        if (alignmentClause != null)
+        {
+            ExpressionSyntax parenthesizedAlignment = ParenthesizeIfAliasQualified(alignmentClause.Value);
+            if (!ReferenceEquals(parenthesizedAlignment, alignmentClause.Value))
             {
-                hasAliasQualifiedName = true;
-                break;
+                visited = visited.WithAlignmentClause(
+                    alignmentClause.WithValue(parenthesizedAlignment));
             }
         }
 
-        if (!hasAliasQualifiedName)
+        return visited;
+    }
+
+    private static ExpressionSyntax ParenthesizeIfAliasQualified(ExpressionSyntax expression)
+    {
+        if (expression is ParenthesizedExpressionSyntax)
         {
-            return visited;
+            return expression;
         }
 
-        return visited.WithExpression(SyntaxFactory.ParenthesizedExpression(visited.Expression));
+        foreach (SyntaxNode descendant in expression.DescendantNodesAndSelf())
+        {
+            if (descendant is AliasQualifiedNameSyntax)
+            {
+                return SyntaxFactory.ParenthesizedExpression(expression);
+            }
+        }
+
+        return expression;
     }
 
     public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -3400,6 +3400,37 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
         return VisitName(node, node);
     }
 
+    public override SyntaxNode VisitInterpolation(InterpolationSyntax node)
+    {
+        InterpolationSyntax visited = (InterpolationSyntax)base.VisitInterpolation(node);
+        if (visited.Expression is ParenthesizedExpressionSyntax)
+        {
+            return visited;
+        }
+
+        // Why: a top-level ':' in an interpolation hole starts a format clause, so a
+        // rewrite that inserts bare `global::` yields CS0103 ('global'). Parenthesizing
+        // keeps the alias qualifier out of the format-clause scan and still coexists
+        // with alignment/format clauses. Nested positions do not need parentheses, but
+        // wrapping whenever an AliasQualifiedNameSyntax is present is always safe.
+        bool hasAliasQualifiedName = false;
+        foreach (SyntaxNode descendant in visited.Expression.DescendantNodesAndSelf())
+        {
+            if (descendant is AliasQualifiedNameSyntax)
+            {
+                hasAliasQualifiedName = true;
+                break;
+            }
+        }
+
+        if (!hasAliasQualifiedName)
+        {
+            return visited;
+        }
+
+        return visited.WithExpression(SyntaxFactory.ParenthesizedExpression(visited.Expression));
+    }
+
     public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
     {
         if (_accessorPlan == null


### PR DESCRIPTION
## Summary
- Hot reload no longer fails when an edited method body reads a static field inside a `$"..."` interpolation hole.
- Shim compile no longer misreads rewritten `global::` names as format clauses.

## User Impact
- Before: editing methods that used static members inside string interpolations could fail hot reload with a confusing `CS0103: The name 'global' does not exist in the current context` shim compile error.
- After: those edits patch successfully, including the demo click-counter path that logs totals via interpolation.

## Changes
- Transform worker parenthesizes interpolation hole expressions that contain alias-qualified names after rewrite.
- Added an EditMode fixture and orchestrator regression that edits such a method and expects `Patched`.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>` → ErrorCount 0
- Red then Green: `Run_EditedInterpolationStaticFieldAccess_Patches` failed with CS0103/`global` before the worker change; Passed after
- `dist/darwin-arm64/uloop hot-reload --files Assets/Tests/Demo/ClickCounterButton.cs` after a one-character `OnClick` log edit → `Success: true`, `OnClick` `Patched`
- HotReload EditMode suite: `PassedCount: 173` / `FailedCount: 0`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

