### PR TITLE
fix: report publicize resolution failures as per-file outcomes

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -259,10 +259,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // BuildShimReferencePaths reads Application.dataPath / platform; stay on main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
             bool includeHarmonyReference = HasDelegationEntry(workerOutput.entries);
-            List<string> shimReferences = BuildShimReferencePaths(
+            ShimReferencePathsResult shimReferencePaths = TryBuildShimReferencePaths(
                 compilationAssembly,
                 targetDllPath,
                 includeHarmonyReference);
+            if (shimReferencePaths.ErrorMessage != null)
+            {
+                outcomes.Add(
+                    HotReloadMethodOutcome.Failed(
+                        "(file)",
+                        shimReferencePaths.ErrorMessage,
+                        assemblyResolvePath));
+                return new HotReloadFileProcessResult(
+                    outcomes, warnings, 0, unchangedMethodCount: unchangedMethodCount);
+            }
+
+            List<string> shimReferences = shimReferencePaths.References;
             HotReloadShimCompileResult compileResult = await HotReloadShimCompiler.CompileAndLoadAsync(
                 workerOutput.shimSource,
                 shimReferences,
@@ -849,10 +861,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             await MainThreadSwitcher.SwitchToMainThread(ct);
             bool includeHarmonyReference = HasDelegationEntry(retryOutput.entries);
-            List<string> shimReferences = BuildShimReferencePaths(
+            ShimReferencePathsResult shimReferencePaths = TryBuildShimReferencePaths(
                 compilationAssembly,
                 targetDllPath,
                 includeHarmonyReference);
+            if (shimReferencePaths.ErrorMessage != null)
+            {
+                // First-pass publicize already succeeded, so a miss here is rare; abandon
+                // isolation the same way as a retry compile failure.
+                return null;
+            }
+
+            List<string> shimReferences = shimReferencePaths.References;
             HotReloadShimCompileResult retryCompileResult = await HotReloadShimCompiler.CompileAndLoadAsync(
                 retryOutput.shimSource,
                 shimReferences,
@@ -1010,6 +1030,52 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 FailedMethodOutcomes = failedMethodOutcomes;
                 RetryEntries = retryEntries;
                 RetryCompileResult = retryCompileResult;
+            }
+        }
+
+        /// <summary>
+        /// Result of <see cref="TryBuildShimReferencePaths"/>. Exactly one of
+        /// <see cref="References"/> or <see cref="ErrorMessage"/> is set.
+        /// </summary>
+        private sealed class ShimReferencePathsResult
+        {
+            public List<string> References { get; }
+            public string ErrorMessage { get; }
+
+            public ShimReferencePathsResult(List<string> references, string errorMessage)
+            {
+                References = references;
+                ErrorMessage = errorMessage;
+            }
+        }
+
+        /// <summary>
+        /// Builds shim compile references, converting Cecil assembly-resolution failures into an
+        /// error message instead of letting them escape as UNITY_RPC_ERROR.
+        /// </summary>
+        private static ShimReferencePathsResult TryBuildShimReferencePaths(
+            UnityCompilationAssembly compilationAssembly,
+            string targetDllPath,
+            bool includeHarmonyReference)
+        {
+            // Why catch only AssemblyResolutionException: publicize fails when Cecil cannot
+            // resolve engine/netstandard types during Write; that is a per-file hot-reload
+            // outcome, not an internal tool crash. Other exceptions must still Fail Fast.
+            try
+            {
+                return new ShimReferencePathsResult(
+                    BuildShimReferencePaths(
+                        compilationAssembly,
+                        targetDllPath,
+                        includeHarmonyReference),
+                    null);
+            }
+            catch (AssemblyResolutionException resolutionException)
+            {
+                return new ShimReferencePathsResult(
+                    null,
+                    "Publicizing referenced assemblies failed: " + resolutionException.Message
+                    + " Hot reload could not build shim references for this file.");
             }
         }
 


### PR DESCRIPTION
## Summary
- Hot reload now reports assembly publicize failures as a per-file `Failed` outcome instead of crashing the tool with an opaque internal error.
- Agents and users can see that referenced-assembly publicizing failed (including the unresolved assembly name such as `netstandard`).

## User Impact
- Before: when Cecil could not resolve an assembly while publicizing shim references, the command failed with `UNITY_RPC_ERROR` / `"Internal error"` and no actionable method outcome.
- After: the response stays a normal hot-reload result with `Kind: "Failed"`, `Method: "(file)"`, and a reason that starts with `Publicizing referenced assemblies failed:` plus the unresolved assembly detail.

## Changes
- Wrap shim-reference building in a narrow `AssemblyResolutionException` catch that returns an error result DTO.
- Map that error to the existing per-file Failed outcome path in `ProcessFileAsync`; isolation retries abandon with `null` on the same failure.
- No automated test: reproducing this path needs a project ScriptAssemblies DLL that forces Cecil resolution of external types; covered by Unity 6 live verification instead.

## Verification
- Live (Unity 6000.3.15): temporarily added an optional-parameter method that forces `netstandard` resolution during publicize, edited `OnClick`, ran `uloop hot-reload` → `Failed` / `(file)` / reason contains `Publicizing referenced assemblies failed` and `netstandard` (not `UNITY_RPC_ERROR`). Restored the demo file, recompiled, and removed `Library/UloopHotReload/PublicizedRefs` (0-byte cache pollution while atomic writes are still unfixed).
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload` → all Passed.
- Repository CI does not run for PRs targeting `feature/hot-reload` (`pull_request.branches` is `main` / `v3-beta` only); local verification substitutes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

