### PR TITLE
fix: derive publicizer resolver search directories from compilation references

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadSpikeS1PublicizedAccessTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSpikeS1PublicizedAccessTests.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 using UnityEditor.Compilation;
 using UnityEngine;
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload;
 using Assembly = System.Reflection.Assembly;
 using CecilFieldAttributes = Mono.Cecil.FieldAttributes;
 using CecilMethodAttributes = Mono.Cecil.MethodAttributes;
@@ -570,9 +571,30 @@ namespace System.Runtime.CompilerServices
         private static void WritePublicizedCopy(string sourceDllPath, string outputDllPath)
         {
             // InMemory read: the source dll is the currently loaded script assembly, so the copy
-            // must not keep a file handle on it.
-            ReaderParameters readerParameters = new() { InMemory = true };
-            using AssemblyDefinition assemblyDefinition = AssemblyDefinition.ReadAssembly(sourceDllPath, readerParameters);
+            // must not keep a file handle on it. Resolver search dirs match production publicize
+            // so optional-parameter default enums (netstandard) resolve during Write.
+            IReadOnlyCollection<string> searchDirectories =
+                PublicizerTestSearchDirectories.ForHotReloadTestAssembly();
+            using DefaultAssemblyResolver assemblyResolver = new DefaultAssemblyResolver();
+            assemblyResolver.AddSearchDirectory(Path.GetDirectoryName(sourceDllPath));
+            foreach (string searchDirectory in searchDirectories)
+            {
+                if (string.IsNullOrEmpty(searchDirectory) || !Directory.Exists(searchDirectory))
+                {
+                    continue;
+                }
+
+                assemblyResolver.AddSearchDirectory(searchDirectory);
+            }
+
+            ReaderParameters readerParameters = new ReaderParameters
+            {
+                InMemory = true,
+                AssemblyResolver = assemblyResolver
+            };
+            using AssemblyDefinition assemblyDefinition = AssemblyDefinition.ReadAssembly(
+                sourceDllPath,
+                readerParameters);
             foreach (ModuleDefinition module in assemblyDefinition.Modules)
             {
                 foreach (TypeDefinition type in module.GetTypes())

--- a/Assets/Tests/Editor/HotReload/PublicizerTestSearchDirectories.cs
+++ b/Assets/Tests/Editor/HotReload/PublicizerTestSearchDirectories.cs
@@ -1,18 +1,18 @@
-using System;
 using System.Collections.Generic;
-using System.IO;
 
 using NUnit.Framework;
 
 using UnityEditor.Compilation;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 
 using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
     /// <summary>
-    /// Builds the same Cecil resolver search-directory set production uses for this test
-    /// assembly: directories of existing <see cref="UnityCompilationAssembly.allReferences"/>.
+    /// Resolves Cecil resolver search directories for this test assembly via the production
+    /// <see cref="ReferencePublicizer.CollectResolverSearchDirectories"/> helper.
     /// </summary>
     internal static class PublicizerTestSearchDirectories
     {
@@ -26,27 +26,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.Not.Null,
                 "CompilationPipeline assembly not found: " + HotReloadTestAssemblyName);
 
-            HashSet<string> directories = new HashSet<string>(StringComparer.Ordinal);
-            if (compilationAssembly.allReferences == null)
-            {
-                return directories;
-            }
-
-            foreach (string reference in compilationAssembly.allReferences)
-            {
-                if (string.IsNullOrEmpty(reference) || !File.Exists(reference))
-                {
-                    continue;
-                }
-
-                string directory = Path.GetDirectoryName(Path.GetFullPath(reference));
-                if (!string.IsNullOrEmpty(directory))
-                {
-                    directories.Add(directory);
-                }
-            }
-
-            return directories;
+            return ReferencePublicizer.CollectResolverSearchDirectories(compilationAssembly.allReferences);
         }
 
         private static UnityCompilationAssembly FindHotReloadTestAssembly()

--- a/Assets/Tests/Editor/HotReload/PublicizerTestSearchDirectories.cs
+++ b/Assets/Tests/Editor/HotReload/PublicizerTestSearchDirectories.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+
+using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Builds the same Cecil resolver search-directory set production uses for this test
+    /// assembly: directories of existing <see cref="UnityCompilationAssembly.allReferences"/>.
+    /// </summary>
+    internal static class PublicizerTestSearchDirectories
+    {
+        private const string HotReloadTestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+
+        public static IReadOnlyCollection<string> ForHotReloadTestAssembly()
+        {
+            UnityCompilationAssembly compilationAssembly = FindHotReloadTestAssembly();
+            Assert.That(
+                compilationAssembly,
+                Is.Not.Null,
+                "CompilationPipeline assembly not found: " + HotReloadTestAssemblyName);
+
+            HashSet<string> directories = new HashSet<string>(StringComparer.Ordinal);
+            if (compilationAssembly.allReferences == null)
+            {
+                return directories;
+            }
+
+            foreach (string reference in compilationAssembly.allReferences)
+            {
+                if (string.IsNullOrEmpty(reference) || !File.Exists(reference))
+                {
+                    continue;
+                }
+
+                string directory = Path.GetDirectoryName(Path.GetFullPath(reference));
+                if (!string.IsNullOrEmpty(directory))
+                {
+                    directories.Add(directory);
+                }
+            }
+
+            return directories;
+        }
+
+        private static UnityCompilationAssembly FindHotReloadTestAssembly()
+        {
+            UnityCompilationAssembly[] assemblies = CompilationPipeline.GetAssemblies(AssembliesType.Editor);
+            foreach (UnityCompilationAssembly assembly in assemblies)
+            {
+                if (assembly.name == HotReloadTestAssemblyName)
+                {
+                    return assembly;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/PublicizerTestSearchDirectories.cs.meta
+++ b/Assets/Tests/Editor/HotReload/PublicizerTestSearchDirectories.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8fd745ff1a126407bbb939b686472dc3

--- a/Assets/Tests/Editor/HotReload/ReferencePublicizerTests.cs
+++ b/Assets/Tests/Editor/HotReload/ReferencePublicizerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -30,7 +31,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void GetOrCreatePublicizedCopy_RewritesPrivateMembersAndCachesByMvid()
         {
             string sourceDllPath = ResolveTestAssemblyDllPath();
-            string firstPath = ReferencePublicizer.GetOrCreatePublicizedCopy(sourceDllPath);
+            IReadOnlyCollection<string> searchDirectories = PublicizerTestSearchDirectories.ForHotReloadTestAssembly();
+            string firstPath = ReferencePublicizer.GetOrCreatePublicizedCopy(sourceDllPath, searchDirectories);
 
             // Plant a distinctive mtime: a cache hit must leave it alone, while a regenerate
             // would rewrite the file and replace this marker with "now". Avoids Thread.Sleep
@@ -38,7 +40,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             DateTime markerWriteTimeUtc = new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc);
             File.SetLastWriteTimeUtc(firstPath, markerWriteTimeUtc);
 
-            string secondPath = ReferencePublicizer.GetOrCreatePublicizedCopy(sourceDllPath);
+            string secondPath = ReferencePublicizer.GetOrCreatePublicizedCopy(sourceDllPath, searchDirectories);
 
             Assert.That(firstPath, Is.EqualTo(secondPath), "Second call must reuse the cached publicized copy.");
             Assert.That(
@@ -101,7 +103,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 TestAssemblyName + "-" + Guid.NewGuid().ToString("N") + ".dll");
             File.WriteAllBytes(staleSameAssemblyPath, new byte[] { 0x4D, 0x5A });
 
-            string publicizedPath = ReferencePublicizer.GetOrCreatePublicizedCopy(ResolveTestAssemblyDllPath());
+            string publicizedPath = ReferencePublicizer.GetOrCreatePublicizedCopy(
+                ResolveTestAssemblyDllPath(),
+                PublicizerTestSearchDirectories.ForHotReloadTestAssembly());
 
             Assert.That(File.Exists(publicizedPath), Is.True, "Current-mvid publicized copy must be written.");
             Assert.That(
@@ -187,7 +191,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public void GetOrCreatePublicizedCopy_KeepsEventBackingFieldNonPublic()
         {
-            string publicizedPath = ReferencePublicizer.GetOrCreatePublicizedCopy(ResolveTestAssemblyDllPath());
+            string publicizedPath = ReferencePublicizer.GetOrCreatePublicizedCopy(
+                ResolveTestAssemblyDllPath(),
+                PublicizerTestSearchDirectories.ForHotReloadTestAssembly());
             using AssemblyDefinition publicizedAssembly = AssemblyDefinition.ReadAssembly(publicizedPath);
 
             const string eventFixtureTypeFullName =

--- a/Assets/Tests/Editor/HotReload/SpikeAccessFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/SpikeAccessFixtures.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
@@ -16,6 +17,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReloadSpike
         private void BumpByOne()
         {
             _counter++;
+        }
+
+        // Optional enum default forces Cecil to resolve netstandard while writing a publicized
+        // copy; without a working resolver Unity 6 fails publicize with AssemblyResolutionException.
+        public static bool ContainsWithComparison(
+            string source,
+            string value,
+            StringComparison comparisonType = StringComparison.OrdinalIgnoreCase)
+        {
+            return source.IndexOf(value, comparisonType) >= 0;
         }
 
         // Why NoInlining on both patch targets below: these tests verify detour mechanics,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -1095,23 +1095,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // Derive Cecil search dirs from Unity's actual compile references so publicize
             // resolves netstandard/engine modules without hardcoding Editor Contents layouts.
-            HashSet<string> resolverSearchDirectories = new HashSet<string>(StringComparer.Ordinal);
-            if (compilationAssembly.allReferences != null)
-            {
-                foreach (string reference in compilationAssembly.allReferences)
-                {
-                    if (string.IsNullOrEmpty(reference) || !File.Exists(reference))
-                    {
-                        continue;
-                    }
-
-                    string directory = Path.GetDirectoryName(Path.GetFullPath(reference));
-                    if (!string.IsNullOrEmpty(directory))
-                    {
-                        resolverSearchDirectories.Add(directory);
-                    }
-                }
-            }
+            IReadOnlyCollection<string> resolverSearchDirectories =
+                ReferencePublicizer.CollectResolverSearchDirectories(compilationAssembly.allReferences);
 
             List<string> references = new List<string>();
             string publicizedTarget = ReferencePublicizer.GetOrCreatePublicizedCopy(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -1093,8 +1093,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string scriptAssembliesDirectory = Path.GetFullPath(
                 Path.Combine(projectRoot, HotReloadConstants.ScriptAssembliesRelativeDirectory));
 
+            // Derive Cecil search dirs from Unity's actual compile references so publicize
+            // resolves netstandard/engine modules without hardcoding Editor Contents layouts.
+            HashSet<string> resolverSearchDirectories = new HashSet<string>(StringComparer.Ordinal);
+            if (compilationAssembly.allReferences != null)
+            {
+                foreach (string reference in compilationAssembly.allReferences)
+                {
+                    if (string.IsNullOrEmpty(reference) || !File.Exists(reference))
+                    {
+                        continue;
+                    }
+
+                    string directory = Path.GetDirectoryName(Path.GetFullPath(reference));
+                    if (!string.IsNullOrEmpty(directory))
+                    {
+                        resolverSearchDirectories.Add(directory);
+                    }
+                }
+            }
+
             List<string> references = new List<string>();
-            string publicizedTarget = ReferencePublicizer.GetOrCreatePublicizedCopy(targetDllPath);
+            string publicizedTarget = ReferencePublicizer.GetOrCreatePublicizedCopy(
+                targetDllPath,
+                resolverSearchDirectories);
             references.Add(publicizedTarget);
 
             if (includeHarmonyReference)
@@ -1126,7 +1148,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (IsUnderDirectory(fullReference, scriptAssembliesDirectory)
                     && HotReloadConstants.IsPublicizableProjectAssemblyFileName(referenceFileName))
                 {
-                    references.Add(ReferencePublicizer.GetOrCreatePublicizedCopy(fullReference));
+                    references.Add(
+                        ReferencePublicizer.GetOrCreatePublicizedCopy(
+                            fullReference,
+                            resolverSearchDirectories));
                 }
                 else
                 {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/ReferencePublicizer.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/ReferencePublicizer.cs
@@ -1,9 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 using Mono.Cecil;
-
-using UnityEditor;
 
 using UnityEngine;
 
@@ -24,10 +23,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Returns the path of a cached publicized copy for <paramref name="sourceDllPath"/>,
         /// writing it on first use. Only <c>Library/ScriptAssemblies/</c> DLLs are accepted —
         /// engine and system assemblies must not be rewritten.
+        /// <paramref name="resolverSearchDirectories"/> are extra Cecil search dirs derived by
+        /// the caller from compilation references (Unity Editor layout must not be hardcoded).
         /// </summary>
-        public static string GetOrCreatePublicizedCopy(string sourceDllPath)
+        public static string GetOrCreatePublicizedCopy(
+            string sourceDllPath,
+            IReadOnlyCollection<string> resolverSearchDirectories)
         {
             Debug.Assert(!string.IsNullOrEmpty(sourceDllPath), "sourceDllPath must not be null or empty.");
+            Debug.Assert(resolverSearchDirectories != null, "resolverSearchDirectories must not be null.");
 
             string fullSourceDllPath = Path.GetFullPath(sourceDllPath);
             Debug.Assert(File.Exists(fullSourceDllPath), "sourceDllPath must point to an existing DLL.");
@@ -36,7 +40,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // InMemory: the source DLL is the currently loaded script assembly; keep no file handle.
             // A search-path resolver is required so Cecil can satisfy assembly refs while rewriting
             // (missing mscorlib/netstandard otherwise throws AssemblyResolutionException on Write).
-            using DefaultAssemblyResolver assemblyResolver = CreateAssemblyResolver(fullSourceDllPath);
+            using DefaultAssemblyResolver assemblyResolver = CreateAssemblyResolver(
+                fullSourceDllPath,
+                resolverSearchDirectories);
             ReaderParameters readerParameters = new ReaderParameters
             {
                 InMemory = true,
@@ -141,8 +147,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return Path.Combine(projectRoot, HotReloadConstants.PublicizedRefsRelativeDirectory);
         }
 
-        private static DefaultAssemblyResolver CreateAssemblyResolver(string sourceDllPath)
+        private static DefaultAssemblyResolver CreateAssemblyResolver(
+            string sourceDllPath,
+            IReadOnlyCollection<string> resolverSearchDirectories)
         {
+            Debug.Assert(resolverSearchDirectories != null, "resolverSearchDirectories must not be null.");
+
             DefaultAssemblyResolver resolver = new DefaultAssemblyResolver();
             resolver.AddSearchDirectory(Path.GetDirectoryName(sourceDllPath));
 
@@ -150,18 +160,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             resolver.AddSearchDirectory(
                 Path.Combine(projectRoot, HotReloadConstants.ScriptAssembliesRelativeDirectory));
 
-            string contentsPath = EditorApplication.applicationContentsPath;
-            if (!string.IsNullOrEmpty(contentsPath))
+            foreach (string searchDirectory in resolverSearchDirectories)
             {
-                resolver.AddSearchDirectory(Path.Combine(contentsPath, "Managed"));
-                resolver.AddSearchDirectory(Path.Combine(contentsPath, "Managed", "UnityEngine"));
-                resolver.AddSearchDirectory(Path.Combine(contentsPath, "UnityReferenceAssemblies", "unity-4.8-api"));
+                if (string.IsNullOrEmpty(searchDirectory) || !Directory.Exists(searchDirectory))
+                {
+                    continue;
+                }
+
+                resolver.AddSearchDirectory(searchDirectory);
             }
 
             // Why not: walk AppDomain assemblies for extra search dirs — Assembly.Load(byte[])
             // shims throw NotSupportedException on .Location, and hot reload loads those shims into
-            // the same domain. ScriptAssemblies + Editor Managed cover the project/engine refs
-            // publicize needs for Write.
+            // the same domain. Search directories come from the caller's compilation references
+            // instead; hardcoding Editor Contents Managed paths fails on Unity 6 layouts.
 
             return resolver;
         }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/ReferencePublicizer.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/ReferencePublicizer.cs
@@ -20,6 +20,37 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal static class ReferencePublicizer
     {
         /// <summary>
+        /// Collects distinct directory paths of existing DLL references for Cecil
+        /// <see cref="DefaultAssemblyResolver"/> search. Null <paramref name="referencePaths"/>
+        /// yields an empty set so callers need not special-case Unity's null allReferences.
+        /// </summary>
+        internal static IReadOnlyCollection<string> CollectResolverSearchDirectories(
+            IReadOnlyCollection<string> referencePaths)
+        {
+            HashSet<string> directories = new HashSet<string>(StringComparer.Ordinal);
+            if (referencePaths == null)
+            {
+                return directories;
+            }
+
+            foreach (string reference in referencePaths)
+            {
+                if (string.IsNullOrEmpty(reference) || !File.Exists(reference))
+                {
+                    continue;
+                }
+
+                string directory = Path.GetDirectoryName(Path.GetFullPath(reference));
+                if (!string.IsNullOrEmpty(directory))
+                {
+                    directories.Add(directory);
+                }
+            }
+
+            return directories;
+        }
+
+        /// <summary>
         /// Returns the path of a cached publicized copy for <paramref name="sourceDllPath"/>,
         /// writing it on first use. Only <c>Library/ScriptAssemblies/</c> DLLs are accepted —
         /// engine and system assemblies must not be rewritten.


### PR DESCRIPTION
## Summary
- Hot reload publicize now resolves engine and netstandard assemblies on Unity 6 by deriving Cecil search directories from Unity's compilation references.
- Publicize no longer depends on Unity 2019-era Editor Contents directory layouts that do not exist on Unity 6.

## User Impact
- Before: publicizing a project assembly that required external type resolution during Write could fail with `AssemblyResolutionException` (for example `netstandard` / `mscorlib`) on Unity 6.
- After: the same publicize path finds those assemblies through the directories Unity already used to compile the target assembly.

## Changes
- `ReferencePublicizer.GetOrCreatePublicizedCopy` takes an explicit search-directory collection; hardcoded `EditorApplication.applicationContentsPath` Managed paths are removed.
- `HotReloadOrchestrator.BuildShimReferencePaths` builds that collection once from `compilationAssembly.allReferences`.
- Test helper `PublicizerTestSearchDirectories` mirrors the production derivation for EditMode tests.
- S1 spike `WritePublicizedCopy` also configures a Cecil resolver from the same helper (second publicize path in the test assembly).
- Fixture adds an optional-parameter method so Write-time resolution is exercised.

## Verification
- Red: after adding the optional-parameter fixture, `ReferencePublicizerTests` and `HotReloadSpikeS1PublicizedAccessTests` failed with `AssemblyResolutionException` (13 failures).
- Green: same filters Passed (`TestCount: 13`).
- Full HotReload EditMode suite Passed locally.
- Repository CI does not run for PRs targeting `feature/hot-reload`; local verification substitutes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

