### PR TITLE
fix: write publicized copies atomically and reject empty cached DLLs

### DIFF
--- a/Assets/Tests/Editor/HotReload/ReferencePublicizerTests.cs
+++ b/Assets/Tests/Editor/HotReload/ReferencePublicizerTests.cs
@@ -80,6 +80,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a 0-byte file at the publicized cache path is rejected and regenerated instead
+        /// of being treated as a valid hit (recovers from failed Write pollution).
+        /// </summary>
+        [Test]
+        public void GetOrCreatePublicizedCopy_RegeneratesWhenCachedDllIsEmpty()
+        {
+            string sourceDllPath = ResolveTestAssemblyDllPath();
+            IReadOnlyCollection<string> searchDirectories = PublicizerTestSearchDirectories.ForHotReloadTestAssembly();
+            string outputPath = ReferencePublicizer.GetOrCreatePublicizedCopy(sourceDllPath, searchDirectories);
+            Assert.That(new FileInfo(outputPath).Length, Is.GreaterThan(0), "Precondition: first publicize must write bytes.");
+
+            File.Delete(outputPath);
+            File.WriteAllBytes(outputPath, Array.Empty<byte>());
+            Assert.That(new FileInfo(outputPath).Length, Is.EqualTo(0), "Precondition: planted cache must be empty.");
+
+            string regeneratedPath = ReferencePublicizer.GetOrCreatePublicizedCopy(sourceDllPath, searchDirectories);
+            Assert.That(regeneratedPath, Is.EqualTo(outputPath), "Regeneration must target the same Mvid cache path.");
+            Assert.That(
+                new FileInfo(regeneratedPath).Length,
+                Is.GreaterThan(0),
+                "Empty cached DLL must be replaced with a non-empty publicized copy.");
+        }
+
+        /// <summary>
         /// What: pruning stale publicized copies does not delete hyphenated sibling assembly
         /// caches that share a prefix (e.g. Assembly-CSharp vs Assembly-CSharp-Editor).
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/ReferencePublicizer.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/ReferencePublicizer.cs
@@ -89,9 +89,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string outputDllPath = Path.Combine(
                 outputDirectory,
                 assemblyName + "-" + mvid + HotReloadConstants.CompiledAssemblyExtension);
-            if (File.Exists(outputDllPath))
+            if (File.Exists(outputDllPath) && new FileInfo(outputDllPath).Length > 0)
             {
                 return outputDllPath;
+            }
+
+            // Why: older versions wrote the publicized DLL in place; a failed Write could leave
+            // a 0-byte file that File.Exists alone treated as a valid cache hit. Delete it so
+            // this call regenerates instead of poisoning later shim compiles.
+            if (File.Exists(outputDllPath))
+            {
+                File.Delete(outputDllPath);
             }
 
             // An Mvid change means the assembly already reloaded; no in-flight compile can still
@@ -112,7 +120,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
             }
 
-            assemblyDefinition.Write(outputDllPath);
+            // Write to a temp path then Move so a thrown Write cannot leave a 0-byte final cache.
+            string tempDllPath = outputDllPath + ".tmp-" + Guid.NewGuid().ToString("N");
+            try
+            {
+                assemblyDefinition.Write(tempDllPath);
+                File.Move(tempDllPath, outputDllPath);
+            }
+            finally
+            {
+                if (File.Exists(tempDllPath))
+                {
+                    File.Delete(tempDllPath);
+                }
+            }
+
             return outputDllPath;
         }
 


### PR DESCRIPTION
## Summary
- Publicized assembly caches are written atomically and empty cache files are no longer treated as hits.
- A previous failed publicize can no longer poison later hot-reload runs with a 0-byte DLL at the final cache path.

## User Impact
- Before: when publicize failed mid-Write, a 0-byte file could remain under `Library/UloopHotReload/PublicizedRefs/`. Later runs reused that path via `File.Exists` and then failed with unrelated shim-compile errors.
- After: empty cached DLLs are deleted and regenerated, and successful writes land via temp file + move so a failed Write cannot leave a 0-byte final path.

## Changes
- Cache hit requires `File.Exists` and `Length > 0`; empty files are deleted before regenerate.
- `AssemblyDefinition.Write` targets `<output>.tmp-<guid>` then `File.Move`s into place; `try/finally` deletes any leftover temp (no catch — exceptions still propagate to the per-file Failed path).
- EditMode regression: plant a 0-byte cache and assert the next call regenerates a non-empty DLL.

## Verification
- Red: `GetOrCreatePublicizedCopy_RegeneratesWhenCachedDllIsEmpty` failed with expected length `0`.
- Green: that test and `GetOrCreatePublicizedCopy_RewritesPrivateMembersAndCachesByMvid` both Passed.
- Full HotReload EditMode suite Passed locally.
- Repository CI does not run for PRs targeting `feature/hot-reload`; local verification substitutes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

