### PR TITLE
ci: run EditMode tests on a Unity version matrix covering 2022.3 and 6000.x

### DIFF
--- a/.github/workflows/unity-editmode-tests.yml
+++ b/.github/workflows/unity-editmode-tests.yml
@@ -10,16 +10,12 @@ permissions:
   contents: read
 
 jobs:
-  editmode-tests:
-    name: EditMode Tests (Linux)
+  concurrency-unit-tests:
+    name: Concurrency Unit Tests
     runs-on: ubuntu-latest
-    env:
-      HAS_UNITY_LICENSE: ${{ secrets.UNITY_LICENSE != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          lfs: true
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
@@ -32,17 +28,48 @@ jobs:
           dotnet test tests/SharedRoslynCompilerWorker.UnitTests/SharedRoslynCompilerWorker.UnitTests.csproj --configuration Release
           dotnet test tests/OutputFileRetention.UnitTests/OutputFileRetention.UnitTests.csproj --configuration Release
 
+  editmode-tests:
+    name: EditMode Tests (${{ matrix.unity-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The committed project version: full EditMode suite plus the strict
+          # zero-warning compile gate.
+          - unity-version: 2022.3.62f3
+            test-filter: ''
+            strict-compile-check: true
+          # Newer editors open the committed 2022.3 project through an ephemeral
+          # in-place upgrade, so obsolete-API warnings are expected there; skip the
+          # zero-warning gate and run only the hot-reload suite, which is the
+          # cross-version compatibility signal these legs exist for. Compile errors
+          # still fail the leg because the test runner cannot run without compiling.
+          - unity-version: 6000.3.15f1
+            test-filter: io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+            strict-compile-check: false
+          - unity-version: 6000.5.8f1
+            test-filter: io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+            strict-compile-check: false
+    env:
+      HAS_UNITY_LICENSE: ${{ secrets.UNITY_LICENSE != '' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          lfs: true
+
       - name: Cache Library folder
         if: env.HAS_UNITY_LICENSE == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: Library
-          key: Library-2022.3.62f1-${{ hashFiles('Packages/src/**/*.cs', 'Assets/**/*.cs', 'Packages/manifest.json', 'Packages/packages-lock.json') }}
+          key: Library-${{ matrix.unity-version }}-${{ hashFiles('Packages/src/**/*.cs', 'Assets/**/*.cs', 'Packages/manifest.json', 'Packages/packages-lock.json') }}
           restore-keys: |
-            Library-2022.3.62f1-
+            Library-${{ matrix.unity-version }}-
 
       - name: Compile Unity project
-        if: env.HAS_UNITY_LICENSE == 'true'
+        if: env.HAS_UNITY_LICENSE == 'true' && matrix.strict-compile-check == true
         id: compile
         uses: game-ci/unity-builder@1d4ee0697f193f54668e98961d79907911f4b4f2
         timeout-minutes: 30
@@ -51,14 +78,14 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
-          unityVersion: 2022.3.62f1
+          unityVersion: ${{ matrix.unity-version }}
           targetPlatform: StandaloneLinux64
           buildMethod: ''
           allowDirtyBuild: true
         continue-on-error: true
 
       - name: Check for compile errors and warnings
-        if: env.HAS_UNITY_LICENSE == 'true'
+        if: env.HAS_UNITY_LICENSE == 'true' && matrix.strict-compile-check == true
         run: |
           LOG_FILE=$(find . -name "*.log" -path "*/build/*" -o -name "Editor.log" 2>/dev/null | head -1)
 
@@ -112,20 +139,23 @@ jobs:
       - name: Run EditMode tests
         if: env.HAS_UNITY_LICENSE == 'true'
         uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9
-        timeout-minutes: 30
+        # 45 minutes: the 6000.x legs upgrade the project in place on a cold Library
+        # cache, which makes the first import much slower than a plain 2022.3 open.
+        timeout-minutes: 45
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
-          unityVersion: 2022.3.62f1
+          unityVersion: ${{ matrix.unity-version }}
           testMode: EditMode
-          checkName: Unity Test Results
+          customParameters: ${{ matrix.test-filter != '' && format('-testFilter {0}', matrix.test-filter) || '' }}
+          checkName: Unity Test Results (${{ matrix.unity-version }})
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always() && env.HAS_UNITY_LICENSE == 'true'
         with:
-          name: Unity test results
+          name: Unity test results (${{ matrix.unity-version }})
           path: artifacts

--- a/.github/workflows/unity-editmode-tests.yml
+++ b/.github/workflows/unity-editmode-tests.yml
@@ -42,9 +42,13 @@ jobs:
             strict-compile-check: true
           # Newer editors open the committed 2022.3 project through an ephemeral
           # in-place upgrade, so obsolete-API warnings are expected there; skip the
-          # zero-warning gate and run only the hot-reload suite, which is the
+          # zero-warning gate and run only the hot-reload suites, which are the
           # cross-version compatibility signal these legs exist for. Compile errors
           # still fail the leg because the test runner cannot run without compiling.
+          # The filter is an unanchored prefix on purpose: it matches both the
+          # ...Tests.Editor.HotReload namespace and the ...HotReloadSpike namespace,
+          # whose publicizer/worker-bootstrap spikes exercise exactly the machinery
+          # that breaks across editor generations.
           - unity-version: 6000.3.15f1
             test-filter: io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             strict-compile-check: false
@@ -145,6 +149,14 @@ jobs:
           # GameCI container.
           sudo rm -rf "Assets/Editor/Editor"
           sudo rm -f "Assets/Editor/Editor.meta"
+          # Fail loudly if the injection moved somewhere this cleanup does not cover,
+          # so the leg points at the real cause instead of a confusing asmdef audit
+          # failure later in the test step.
+          LEFTOVER=$(find Assets -name 'UnityBuilderAction*' -print -quit)
+          if [ -n "$LEFTOVER" ]; then
+            echo "::error::GameCI build script found outside the expected injection path: $LEFTOVER"
+            exit 1
+          fi
 
       - name: Run EditMode tests
         if: env.HAS_UNITY_LICENSE == 'true'

--- a/.github/workflows/unity-editmode-tests.yml
+++ b/.github/workflows/unity-editmode-tests.yml
@@ -136,6 +136,15 @@ jobs:
             fi
           fi
 
+      - name: Remove GameCI build script injected during compile
+        if: env.HAS_UNITY_LICENSE == 'true' && matrix.strict-compile-check == true
+        run: |
+          # unity-builder copies its default build script (UnityBuilderAction) into the
+          # workspace; left in place, the asmdef audit test sees a foreign auto-referenced
+          # assembly and fails.
+          rm -rf "Assets/Editor/Editor"
+          rm -f "Assets/Editor/Editor.meta"
+
       - name: Run EditMode tests
         if: env.HAS_UNITY_LICENSE == 'true'
         uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9

--- a/.github/workflows/unity-editmode-tests.yml
+++ b/.github/workflows/unity-editmode-tests.yml
@@ -141,9 +141,10 @@ jobs:
         run: |
           # unity-builder copies its default build script (UnityBuilderAction) into the
           # workspace; left in place, the asmdef audit test sees a foreign auto-referenced
-          # assembly and fails.
-          rm -rf "Assets/Editor/Editor"
-          rm -f "Assets/Editor/Editor.meta"
+          # assembly and fails. sudo because the files are created root-owned inside the
+          # GameCI container.
+          sudo rm -rf "Assets/Editor/Editor"
+          sudo rm -f "Assets/Editor/Editor.meta"
 
       - name: Run EditMode tests
         if: env.HAS_UNITY_LICENSE == 'true'

--- a/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointVariableFormatterTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointVariableFormatterTests.cs
@@ -14,6 +14,7 @@ using UnityEngine.TestTools;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
@@ -248,7 +249,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopCapturedVariable variable = variables.Single();
             Assert.That(variable.UnityObjectKind, Is.EqualTo(UloopCapturedVariableUnityObjectKind.SceneObject));
             Assert.That(variable.UnityObjectPath, Does.Contain("PausePointFormatterComponentFixture"));
-            Assert.That(variable.UnityObjectInstanceId, Is.EqualTo(componentValue.GetInstanceID()));
+            // Raw GetInstanceID() is an obsolete-as-error API on Unity 6000.5; the production
+            // wrapper is also what populates UnityObjectInstanceId, so compare through it.
+            Assert.That(variable.UnityObjectInstanceId, Is.EqualTo(UnityObjectIdentifier.GetInstanceId(componentValue)));
         }
 
         [Test]

--- a/Assets/Tests/Editor/WatchExpressionCompilerTests.cs
+++ b/Assets/Tests/Editor/WatchExpressionCompilerTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,7 +18,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     [TestFixture]
     public sealed class WatchExpressionCompilerTests
     {
-        private const int MaxCompilationWaitTicks = 600;
+        // Wall-clock bound, not editor-tick bound: the first compile spawns an external
+        // compiler process whose duration is time-based, and batchmode CI burns hundreds of
+        // editor ticks per second while that cold start is still in flight.
+        private static readonly TimeSpan MaxCompilationWait = TimeSpan.FromSeconds(60);
 
         /// <summary>
         /// Verifies a valid expression reaches the compile-only path and produces an evaluator.
@@ -27,16 +32,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             WatchExpressionCompiler compiler = new(new DynamicCodeCompiler());
             Task<WatchCompilationResult> compilationTask = compiler.CompileAsync("1 + 2", CancellationToken.None);
 
-            int waitTicks = 0;
-            while (!compilationTask.IsCompleted && waitTicks < MaxCompilationWaitTicks)
+            Stopwatch waitStopwatch = Stopwatch.StartNew();
+            while (!compilationTask.IsCompleted && waitStopwatch.Elapsed < MaxCompilationWait)
             {
-                waitTicks++;
                 yield return null;
             }
 
             if (!compilationTask.IsCompleted)
             {
-                Assert.Fail($"Watch expression compilation did not complete within {MaxCompilationWaitTicks} editor ticks.");
+                Assert.Fail($"Watch expression compilation did not complete within {MaxCompilationWait.TotalSeconds:F0} seconds.");
                 yield break;
             }
 

--- a/Packages/src/Editor/ToolContracts/AssemblyInfo.cs
+++ b/Packages/src/Editor/ToolContracts/AssemblyInfo.cs
@@ -5,5 +5,6 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Screenshot.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.PausePoint.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]
+[assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.SourcePausePointCapture")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.PlayMode")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Dev")]


### PR DESCRIPTION
## Why

Hot reload silently broke on Unity 6 (#2165–#2168) because CI only ever exercised Unity 2022.3. A version matrix would have caught the resolver-layout and csc regressions before a user did.

## What

`unity-editmode-tests.yml` (schedule + workflow_dispatch only, unchanged triggers):

- **Matrix legs, `fail-fast: false`:**
  - `2022.3.62f3` — full EditMode suite plus the strict zero-warning compile gate. Also fixes the version drift: the workflow pinned `2022.3.62f1` while the committed `ProjectVersion.txt` says `2022.3.62f3`.
  - `6000.3.15f1` and `6000.5.8f1` — hot-reload suite only (`-testFilter io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload`). These legs open the committed 2022.3 project through an ephemeral in-place upgrade, so obsolete-API warnings are expected and the zero-warning gate is skipped; compile errors still fail the leg because the test runner cannot run without compiling.
- Library cache keys, check names, and artifact names are per-version.
- The .NET concurrency unit tests moved to their own job so they run once instead of per leg.

## Verification

- `unityci/editor` ubuntu base images confirmed to exist for all three versions (`ubuntu-2022.3.62f3-base`, `ubuntu-6000.3.15f1-base`, `ubuntu-6000.5.8f1-base`).
- YAML parse validated locally.
- Real proof is a `workflow_dispatch` run on this branch (will be triggered after this PR opens); the `6000.5.8f1` leg's package resolution is the main unknown.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

