### PR TITLE
fix: reference consolidated System.Security.Cryptography in the worker build

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
@@ -86,6 +86,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
+        /// What: the worker reference set includes the consolidated System.Security.Cryptography assembly when that file exists.
+        /// </summary>
+        [Test]
+        public void BuildWorkerReferenceSet_WhenConsolidatedCryptographyAssemblyExists_ShouldIncludeConsolidatedReference()
+        {
+            ExternalCompilerPaths externalCompilerPaths = ExternalCompilerPathResolver.Resolve();
+            Assert.That(externalCompilerPaths, Is.Not.Null, "Unity external compiler layout should be available.");
+
+            string consolidatedAssemblyPath = Path.Combine(
+                externalCompilerPaths.NetCoreRuntimeSharedDirectoryPath,
+                "System.Security.Cryptography.dll");
+            if (!File.Exists(consolidatedAssemblyPath))
+            {
+                Assert.Ignore(
+                    "System.Security.Cryptography.dll is not present in this Unity NetCoreRuntime shared directory.");
+            }
+
+            List<string> references =
+                SharedRoslynCompilerWorkerAssemblyBuilder.BuildWorkerReferenceSet(externalCompilerPaths);
+
+            Assert.That(references, Does.Contain(consolidatedAssemblyPath));
+        }
+
+        /// <summary>
         /// Verifies shutdown remains an idempotent no-op before a worker process or directory exists.
         /// </summary>
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerAssemblyBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerAssemblyBuilder.cs
@@ -203,10 +203,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             AddIfExists(references, Path.Combine(sharedRuntimeDirectoryPath, "System.Memory.dll"));
             AddIfExists(references, Path.Combine(sharedRuntimeDirectoryPath, "System.Buffers.dll"));
             AddIfExists(references, Path.Combine(sharedRuntimeDirectoryPath, "System.Threading.Tasks.Extensions.dll"));
-            // Why: the CodeAnalysis Emit API surface references HashAlgorithmName from
-            // System.Security.Cryptography.Primitives; without this reference the worker build itself
-            // fails with CS0012 whenever the worker assembly has to be rebuilt.
+            // Why both cryptography assemblies: older Unity runtimes ship only the Primitives
+            // facade, while Unity 6000.5's .NET 8 runtime defines HashAlgorithmName in the
+            // consolidated System.Security.Cryptography assembly. Both are added conditionally so
+            // whichever layout is present satisfies the CodeAnalysis Emit surface.
             AddIfExists(references, Path.Combine(sharedRuntimeDirectoryPath, "System.Security.Cryptography.Primitives.dll"));
+            AddIfExists(references, Path.Combine(sharedRuntimeDirectoryPath, "System.Security.Cryptography.dll"));
 
             return references;
         }


### PR DESCRIPTION
## Summary
- The shared Roslyn worker now builds on Unity 6000.5, where `HashAlgorithmName` lives on the consolidated `System.Security.Cryptography` assembly.
- Older Unity runtimes that still ship only the Primitives facade keep working because that reference is unchanged.

## User Impact
- Before: on Unity 6000.5 the worker build failed with CS0012 (`HashAlgorithmName` is defined in an assembly that is not referenced: `System.Security.Cryptography, Version=8.0.0.0`). Every dynamic compile and hot-reload shim fell back to one-shot csc.
- After: the worker reference set includes the consolidated cryptography assembly when it exists, so the shared worker starts and serves compiles again.

## Changes
- Add `System.Security.Cryptography.dll` to the worker reference set next to the existing Primitives facade, both via `AddIfExists`.
- Cover the consolidated assembly with a host test that asserts when the file is present (Ignore on older layouts).

## Verification
Local Unity 6000.5.8f1 (repository CI does not run on PRs targeting `feature/hot-reload`; `pull_request.branches` is `main` / `v3-beta` only).

- Red: vibe log `dynamic_code_shared_worker_failure` entries with `first_error` CS0012 `HashAlgorithmName` / `System.Security.Cryptography, Version=8.0.0.0`.
- `uloop compile`: Errors 0.
- `uloop run-tests --filter-type regex --filter-value "SharedRoslynCompilerWorkerHostTests"`: 34/34 passed, 0 skipped (the new consolidated-assembly test asserted on this runtime, it was not ignored).
- After the change, `uloop execute-dynamic-code` with `return 1 + 1;` returned `"Result": "2"`. Incremental vibe log lines were only `execute_dynamic_code_start` and `execute_dynamic_code_complete` — no `dynamic_code_shared_worker_failure` or `dynamic_code_shared_worker_fallback`. The worker assembly was rebuilt as `RoslynCompilerWorker.dll` under the pid-scoped RoslynWorker directory.
- `uloop run-tests --filter-type regex --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"`: 175/175 passed.
- `uloop run-tests --filter-type regex --filter-value "DynamicCodeToolTests|WatchExpressionCompilerTests|SourcePausePoint"`: 391/391 passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

