### PR TITLE
fix: strip preprocessor directive trivia from shim method copies

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -537,6 +537,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: editing a method wrapped in #if UNITY_EDITOR still patches and returns the
+        /// edited value. Directive trivia must not be copied onto the shim because the matching
+        /// #endif belongs to the next token.
+        /// </summary>
+        [Test]
+        public async Task Run_EditedIfDefGuardedMethod_PatchesBehavior()
+        {
+            string fixturePath = ResolveShapeFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string editedSource = onDisk.Replace(
+                "return 7; // directive-trivia probe",
+                "return 42; // directive-trivia probe",
+                StringComparison.Ordinal);
+            Assert.That(editedSource, Is.Not.EqualTo(onDisk), "Precondition: guarded method body must differ.");
+
+            string editedPath = WriteEditedSource("EditorGuardedReturn.cs", editedSource);
+
+            HotReloadDirectiveTriviaFixture fixture = new HotReloadDirectiveTriviaFixture();
+            Assert.That(fixture.EditorGuardedReturn(), Is.EqualTo(7));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadDirectiveTriviaFixture.EditorGuardedReturn));
+            Assert.That(fixture.EditorGuardedReturn(), Is.EqualTo(42));
+        }
+
+        /// <summary>
         /// What: under Debug code optimization, size-only small methods do not emit the
         /// aggregated inline-risk warning (branch a); Patched Reason stays empty.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs
@@ -132,4 +132,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return Probe;
         }
     }
+
+    /// <summary>
+    /// Method wrapped in <c>#if UNITY_EDITOR</c> so a shim that copies leading directive trivia
+    /// without the matching <c>#endif</c> (which lives on the next token) fails to compile.
+    /// </summary>
+    internal class HotReloadDirectiveTriviaFixture
+    {
+#if UNITY_EDITOR
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int EditorGuardedReturn()
+        {
+            return 7; // directive-trivia probe
+        }
+#endif
+    }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -3868,12 +3868,30 @@ internal static class ShimMethodFactory
             .WithParameterList(SyntaxFactory.ParameterList(parameters))
             .WithExplicitInterfaceSpecifier(null)
             .WithConstraintClauses(default)
-            .WithTriviaFrom(rewrittenOriginal);
+            .WithLeadingTrivia(StripDirectiveTrivia(rewrittenOriginal.GetLeadingTrivia()))
+            .WithTrailingTrivia(StripDirectiveTrivia(rewrittenOriginal.GetTrailingTrivia()));
 
         // Expression-bodied methods must keep their terminating semicolon; block bodies must not.
         return rewrittenOriginal.ExpressionBody != null
             ? shim.WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
             : shim.WithSemicolonToken(default);
+    }
+
+    // Why strip directives: #if sits on the method's leading trivia while its matching #endif
+    // belongs to the next token, so copied directives are unbalanced in the shim; #line mapping
+    // is injected later from annotations and needs no user directives.
+    private static SyntaxTriviaList StripDirectiveTrivia(SyntaxTriviaList trivia)
+    {
+        List<SyntaxTrivia> kept = new List<SyntaxTrivia>();
+        foreach (SyntaxTrivia item in trivia)
+        {
+            if (!item.IsDirective)
+            {
+                kept.Add(item);
+            }
+        }
+
+        return SyntaxFactory.TriviaList(kept);
     }
 
     private static SeparatedSyntaxList<ParameterSyntax> BuildShimParameters(


### PR DESCRIPTION
## Summary
- Hot reload now applies method-body edits inside `#if` / `#endif` blocks instead of failing the patch.

## User Impact
- Before: editing a method declared under `#if UNITY_EDITOR` (or any other preprocessor block) always failed with `CS1027: #endif directive expected`.
- After: those methods patch like any other method-body edit.

## Changes
- Shim method copies no longer keep preprocessor directive trivia from the original method. Matching `#endif` lives on the next token, so copying `#if` alone made the generated shim unbalanced. `#line` mapping is still injected later from annotations.

## Verification
- Red: `Run_EditedIfDefGuardedMethod_PatchesBehavior` failed with `Failed ... EditorGuardedReturn() :: CS1027: #endif directive expected` (`TestCount: 1`, `FailedCount: 1`).
- Green: the same test passed (`TestCount: 1`, `PassedCount: 1`).
- `uloop compile`: `ErrorCount: 0`.
- `uloop run-tests --filter-type regex --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"`: `TestCount: 176`, `PassedCount: 176`, `FailedCount: 0`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

