### PR TITLE
fix: resolve global usings in hot-reload shim compiles

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadGlobalUsings.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGlobalUsings.cs
@@ -1,0 +1,4 @@
+// Why a dedicated alias: a test-assembly global using applies to every file in this
+// assembly, so the name must not collide with existing test identifiers.
+// Why sibling csc.rsp -langversion:10: the project default is C# 9, which cannot parse global using.
+global using HotReloadGlobalAlias = System.Text.StringBuilder;

--- a/Assets/Tests/Editor/HotReload/HotReloadGlobalUsings.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadGlobalUsings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6136a27d788f5492d8b9b90408c0be9e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -568,6 +568,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: editing a method that uses a sibling-file global using alias still patches and
+        /// returns the edited value. The worker must collect assembly global usings; otherwise
+        /// shim compile fails with CS0246.
+        /// </summary>
+        [Test]
+        public async Task Run_EditedMethodUsingSiblingGlobalUsing_PatchesBehavior()
+        {
+            string fixturePath = ResolveShapeFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string editedSource = onDisk.Replace(
+                "builder.Append(\"base\");",
+                "builder.Append(\"patched\");",
+                StringComparison.Ordinal);
+            Assert.That(editedSource, Is.Not.EqualTo(onDisk), "Precondition: global-alias body must differ.");
+
+            string editedPath = WriteEditedSource("BuildWithGlobalAlias.cs", editedSource);
+
+            HotReloadGlobalUsingFixture fixture = new HotReloadGlobalUsingFixture();
+            Assert.That(fixture.BuildWithGlobalAlias(), Is.EqualTo("base"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadGlobalUsingFixture.BuildWithGlobalAlias));
+            Assert.That(fixture.BuildWithGlobalAlias(), Is.EqualTo("patched"));
+        }
+
+        /// <summary>
         /// What: under Debug code optimization, size-only small methods do not emit the
         /// aggregated inline-risk warning (branch a); Patched Reason stays empty.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs
@@ -147,4 +147,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 #endif
     }
+
+    /// <summary>
+    /// Method body that resolves <c>HotReloadGlobalAlias</c> only through a sibling-file
+    /// <c>global using</c>. Shim compile fails with CS0246 unless the worker collects that alias.
+    /// </summary>
+    internal class HotReloadGlobalUsingFixture
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public string BuildWithGlobalAlias()
+        {
+            HotReloadGlobalAlias builder = new HotReloadGlobalAlias();
+            builder.Append("base");
+            return builder.ToString();
+        }
+    }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadShimCompilerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShimCompilerTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
@@ -67,6 +69,50 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(message, Does.Contain(error));
             Assert.That(message, Does.Not.Contain(HotReloadConstants.NewMemberCompileHint));
+        }
+
+        /// <summary>
+        /// What: CS0246 leads with the missing using / global using hint, then the new-member hint.
+        /// </summary>
+        [Test]
+        public void ComposeShimCompileFailureMessage_TypeNotFound_LeadsWithMissingUsingHint()
+        {
+            string message = HotReloadShimCompiler.ComposeShimCompileFailureMessage(
+                new[]
+                {
+                    "CS0246: The type or namespace name 'HotReloadGlobalAlias' could not be found"
+                });
+
+            int usingHintIndex = message.IndexOf(
+                HotReloadConstants.MissingUsingCompileHint,
+                StringComparison.Ordinal);
+            int newMemberHintIndex = message.IndexOf(
+                HotReloadConstants.NewMemberCompileHint,
+                StringComparison.Ordinal);
+            Assert.That(usingHintIndex, Is.GreaterThanOrEqualTo(0));
+            Assert.That(newMemberHintIndex, Is.GreaterThan(usingHintIndex));
+        }
+
+        /// <summary>
+        /// What: CS1061 also leads with the missing using / global using hint.
+        /// </summary>
+        [Test]
+        public void ComposeShimCompileFailureMessage_MissingExtension_LeadsWithMissingUsingHint()
+        {
+            string message = HotReloadShimCompiler.ComposeShimCompileFailureMessage(
+                new[]
+                {
+                    "CS1061: 'int' does not contain a definition for 'Forget'"
+                });
+
+            int usingHintIndex = message.IndexOf(
+                HotReloadConstants.MissingUsingCompileHint,
+                StringComparison.Ordinal);
+            int newMemberHintIndex = message.IndexOf(
+                HotReloadConstants.NewMemberCompileHint,
+                StringComparison.Ordinal);
+            Assert.That(usingHintIndex, Is.GreaterThanOrEqualTo(0));
+            Assert.That(newMemberHintIndex, Is.GreaterThan(usingHintIndex));
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -1440,7 +1440,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return sourceText.IndexOf(" class ", StringComparison.Ordinal) >= 0
                 || sourceText.IndexOf(" struct ", StringComparison.Ordinal) >= 0
                 || sourceText.IndexOf(" interface ", StringComparison.Ordinal) >= 0
-                || sourceText.IndexOf(" enum ", StringComparison.Ordinal) >= 0;
+                || sourceText.IndexOf(" enum ", StringComparison.Ordinal) >= 0
+                || sourceText.IndexOf(" record ", StringComparison.Ordinal) >= 0;
         }
 
         private static string ResolveE2EFixturePath()

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -496,6 +496,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 string projectRelativePath =
                     "Assets/Tests/Editor/HotReload/" + Path.GetFileName(fullPath);
                 string onDisk = File.ReadAllText(fullPath);
+                // Why skip: a global-using-only file has no methods to mark unchanged; the worker
+                // correctly emits empty entries/skipped/unchanged for it.
+                if (!ContainsTypeDeclaration(onDisk))
+                {
+                    continue;
+                }
+
                 TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
                     fullPath,
                     projectRelativePath,
@@ -1362,7 +1369,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 referencePaths = referencePaths,
                 targetTypesAssemblyPath = targetDllPath,
                 snapshotSource = snapshotSource,
-                projectRelativePath = projectRelativePath
+                projectRelativePath = projectRelativePath,
+                assemblySourcePaths = BuildAbsoluteAssemblySourcePaths(
+                    compilationAssembly.sourceFiles)
             };
 
             return await TransformWorkerClient.RunAsync(input, CancellationToken.None);
@@ -1403,6 +1412,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             return paths.ToArray();
+        }
+
+        private static string[] BuildAbsoluteAssemblySourcePaths(string[] sourceFiles)
+        {
+            if (sourceFiles == null || sourceFiles.Length == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string[] paths = new string[sourceFiles.Length];
+            for (int index = 0; index < sourceFiles.Length; index++)
+            {
+                string normalizedRelativePath = sourceFiles[index].Replace('\\', '/');
+                string absoluteSourcePath = Path.Combine(
+                    projectRoot,
+                    normalizedRelativePath.Replace('/', Path.DirectorySeparatorChar));
+                paths[index] = Path.GetFullPath(absoluteSourcePath);
+            }
+
+            return paths;
+        }
+
+        private static bool ContainsTypeDeclaration(string sourceText)
+        {
+            return sourceText.IndexOf(" class ", StringComparison.Ordinal) >= 0
+                || sourceText.IndexOf(" struct ", StringComparison.Ordinal) >= 0
+                || sourceText.IndexOf(" interface ", StringComparison.Ordinal) >= 0
+                || sourceText.IndexOf(" enum ", StringComparison.Ordinal) >= 0;
         }
 
         private static string ResolveE2EFixturePath()

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -1180,6 +1180,56 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a namespace-scoped using alias of the same name as a sibling global using alias
+        /// keeps only the local alias in the shim. Flattening both into one namespace is CS1537,
+        /// even though C# lets the inner alias shadow the global one.
+        /// </summary>
+        [Test]
+        public async Task Run_WithLocalAliasShadowingGlobalAlias_KeepsLocalAliasOnly()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+
+            string editedSource =
+                "namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload\n"
+                + "{\n"
+                + "    using AliasProbe = System.Text.StringBuilder;\n"
+                + "\n"
+                + "    internal class HotReloadAliasShadowFixture\n"
+                + "    {\n"
+                + "        public string Build()\n"
+                + "        {\n"
+                + "            AliasProbe builder = new AliasProbe();\n"
+                + "            builder.Append(\"ok\");\n"
+                + "            return builder.ToString();\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+            string globalSource = "global using AliasProbe = System.Collections.Generic.List<int>;\n";
+            string sourcePath = Path.Combine(directory, "AliasShadowEdited.cs");
+            string globalPath = Path.Combine(directory, "AliasShadowGlobal.cs");
+            File.WriteAllText(sourcePath, editedSource);
+            File.WriteAllText(globalPath, globalSource);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                "Library/UloopHotReload/TestSources/AliasShadowEdited.cs",
+                snapshotSource: null,
+                additionalAssemblySourcePaths: new[] { globalPath });
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.parseErrors, Is.Empty);
+            Assert.That(
+                result.Output.shimSource,
+                Does.Contain("using AliasProbe = System.Text.StringBuilder"));
+            Assert.That(
+                result.Output.shimSource,
+                Does.Not.Contain("using AliasProbe = System.Collections.Generic.List<int>"),
+                "Local AliasProbe must shadow the sibling global alias; both in one namespace is CS1537.");
+        }
+
+        /// <summary>
         /// What: when only a property setter body differs from the snapshot, the unchanged getter
         /// stays out of entries (baseline compare is getter-scoped, not whole-property).
         /// </summary>
@@ -1333,7 +1383,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private static async Task<TransformWorkerClientResult> RunWorkerOnSourceAsync(
             string sourcePath,
             string projectRelativePath,
-            string snapshotSource = null)
+            string snapshotSource = null,
+            string[] additionalAssemblySourcePaths = null)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string targetDllPath = Path.Combine(
@@ -1362,6 +1413,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 compilationAssembly.allReferences,
                 targetDllPath);
 
+            string[] assemblySourcePaths = BuildAbsoluteAssemblySourcePaths(
+                compilationAssembly.sourceFiles);
+            if (additionalAssemblySourcePaths != null && additionalAssemblySourcePaths.Length > 0)
+            {
+                List<string> merged = new List<string>(assemblySourcePaths);
+                foreach (string additionalPath in additionalAssemblySourcePaths)
+                {
+                    merged.Add(Path.GetFullPath(additionalPath));
+                }
+
+                assemblySourcePaths = merged.ToArray();
+            }
+
             TransformWorkerInputDto input = new TransformWorkerInputDto
             {
                 sourcePath = sourcePath,
@@ -1370,8 +1434,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 targetTypesAssemblyPath = targetDllPath,
                 snapshotSource = snapshotSource,
                 projectRelativePath = projectRelativePath,
-                assemblySourcePaths = BuildAbsoluteAssemblySourcePaths(
-                    compilationAssembly.sourceFiles)
+                assemblySourcePaths = assemblySourcePaths
             };
 
             return await TransformWorkerClient.RunAsync(input, CancellationToken.None);

--- a/Assets/Tests/Editor/HotReload/csc.rsp
+++ b/Assets/Tests/Editor/HotReload/csc.rsp
@@ -1,0 +1,1 @@
+-langversion:10

--- a/Assets/Tests/Editor/HotReload/csc.rsp.meta
+++ b/Assets/Tests/Editor/HotReload/csc.rsp.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e4efc55b828df466c81405654f83e718
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -47,6 +47,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string NewMemberCompileHint =
             "Adding new members requires a real compile (uloop compile); hot reload only replaces existing method bodies.";
 
+        public const string MissingUsingCompileHint =
+            "This can mean a missing using or global using (hot reload collects global usings from the edited file's assembly).";
+
         // Wire value for TransformWorkerEntryDto.patchKind when the worker rewrote inaccessible
         // accesses into accessor delegates.
         public const string PatchKindDelegation = "delegation";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -174,7 +174,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 referencePaths = referencePaths,
                 targetTypesAssemblyPath = Path.GetFullPath(targetDllPath),
                 snapshotSource = snapshotSource,
-                projectRelativePath = projectRelativePath
+                projectRelativePath = projectRelativePath,
+                assemblySourcePaths = BuildAssemblySourcePaths(projectRoot, compilationAssembly.sourceFiles)
             };
 
             TransformWorkerClientResult workerResult =
@@ -683,6 +684,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return null;
         }
 
+        // Why Path.Combine then GetFullPath: Unity Assembly.sourceFiles are project-relative
+        // (slash-separated). The worker cwd is Library/UloopHotReload/Worker/<hash>/, so it
+        // can only open absolute paths. Normalization matches HotReloadSourceSnapshotter.
+        private static string[] BuildAssemblySourcePaths(string projectRoot, string[] sourceFiles)
+        {
+            if (sourceFiles == null || sourceFiles.Length == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            string[] paths = new string[sourceFiles.Length];
+            for (int index = 0; index < sourceFiles.Length; index++)
+            {
+                string normalizedRelativePath = sourceFiles[index].Replace('\\', '/');
+                string absoluteSourcePath = Path.Combine(
+                    projectRoot,
+                    normalizedRelativePath.Replace('/', Path.DirectorySeparatorChar));
+                paths[index] = Path.GetFullPath(absoluteSourcePath);
+            }
+
+            return paths;
+        }
+
         private static string CheckMvidGuard(string assemblyName, string targetDllPath)
         {
             ReaderParameters readerParameters = new ReaderParameters { InMemory = true };
@@ -840,7 +864,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Why copy: omitting snapshotSource would make the retry patch unedited methods
                 // again and diverge the retry entries set from the first-pass isolation baseline.
                 snapshotSource = workerInput.snapshotSource,
-                projectRelativePath = workerInput.projectRelativePath
+                projectRelativePath = workerInput.projectRelativePath,
+                assemblySourcePaths = workerInput.assemblySourcePaths
             };
 
             TransformWorkerClientResult retryWorkerResult =

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
@@ -160,21 +160,54 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(errors.Count > 0, "errors must not be empty.");
 
             string message = string.Join("\n", errors);
+            bool hasMissingUsingDiagnostic = false;
+            bool hasMissingMemberDiagnostic = false;
             for (int index = 0; index < errors.Count; index++)
             {
                 string error = errors[index];
-                for (int codeIndex = 0; codeIndex < MissingMemberDiagnosticCodes.Length; codeIndex++)
+                if (ErrorStartsWithDiagnosticCode(error, "CS0246")
+                    || ErrorStartsWithDiagnosticCode(error, "CS1061"))
                 {
-                    // Match the diagnostic-code prefix ("CS0103: …"), not a bare Contains —
-                    // otherwise a message that merely mentions the code text could append the hint.
-                    if (error.StartsWith(MissingMemberDiagnosticCodes[codeIndex] + ":", StringComparison.Ordinal))
-                    {
-                        return message + "\n" + HotReloadConstants.NewMemberCompileHint;
-                    }
+                    hasMissingUsingDiagnostic = true;
+                }
+
+                if (ErrorStartsWithAnyDiagnosticCode(error, MissingMemberDiagnosticCodes))
+                {
+                    hasMissingMemberDiagnostic = true;
                 }
             }
 
+            if (hasMissingUsingDiagnostic)
+            {
+                message += "\n" + HotReloadConstants.MissingUsingCompileHint;
+            }
+
+            if (hasMissingMemberDiagnostic)
+            {
+                message += "\n" + HotReloadConstants.NewMemberCompileHint;
+            }
+
             return message;
+        }
+
+        private static bool ErrorStartsWithAnyDiagnosticCode(string error, string[] diagnosticCodes)
+        {
+            for (int codeIndex = 0; codeIndex < diagnosticCodes.Length; codeIndex++)
+            {
+                if (ErrorStartsWithDiagnosticCode(error, diagnosticCodes[codeIndex]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool ErrorStartsWithDiagnosticCode(string error, string diagnosticCode)
+        {
+            // Match the diagnostic-code prefix ("CS0103: …"), not a bare Contains —
+            // otherwise a message that merely mentions the code text could append the hint.
+            return error.StartsWith(diagnosticCode + ":", StringComparison.Ordinal);
         }
 
         private static List<HotReloadShimCompileError> CollectErrors(CompilerMessage[] compilerMessages)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
@@ -136,6 +136,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             "CS7036"
         };
 
+        private static readonly string[] MissingUsingDiagnosticCodes =
+        {
+            "CS0246",
+            "CS1061"
+        };
+
         /// <summary>
         /// Appends " (line N)" only when the diagnostic's #line-mapped file refers to the user's
         /// project-relative path. Scaffold-path errors keep the bare message.
@@ -165,8 +171,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             for (int index = 0; index < errors.Count; index++)
             {
                 string error = errors[index];
-                if (ErrorStartsWithDiagnosticCode(error, "CS0246")
-                    || ErrorStartsWithDiagnosticCode(error, "CS1061"))
+                if (ErrorStartsWithAnyDiagnosticCode(error, MissingUsingDiagnosticCodes))
                 {
                     hasMissingUsingDiagnostic = true;
                 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -25,6 +25,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Project-relative forward-slash path baked into #line document names so shim compile
         // diagnostics map back to the user's file (not the temp HotReloadShim.cs path).
         public string projectRelativePath;
+
+        // Absolute paths of every source file in the edited file's compilation assembly.
+        // The worker scans these for global using directives. Null/omitted is treated as empty.
+        public string[] assemblySourcePaths;
     }
 
     /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -2146,13 +2146,33 @@ public static class TransformWorkerProgram
         string line;
         while ((line = reader.ReadLine()) != null)
         {
-            if (line.TrimStart().StartsWith("global using", StringComparison.Ordinal))
+            if (LineStartsWithGlobalUsing(line))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    // Why same-line tokens (not ParseText): the prefilter must stay cheaper than parsing every
+    // assembly file. Extra whitespace between global and using is allowed; a comment or line
+    // break between those tokens is out of scope for this filter.
+    private static bool LineStartsWithGlobalUsing(string line)
+    {
+        string trimmed = line.TrimStart();
+        if (!trimmed.StartsWith("global", StringComparison.Ordinal) || trimmed.Length <= 6)
+        {
+            return false;
+        }
+
+        char afterGlobal = trimmed[6];
+        if (afterGlobal != ' ' && afterGlobal != '\t')
+        {
+            return false;
+        }
+
+        return trimmed.Substring(6).TrimStart().StartsWith("using", StringComparison.Ordinal);
     }
 
     private static bool PathsReferToSameSourceFile(string left, string right)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -104,6 +104,7 @@ public static class TransformWorkerProgram
         input.Defines ??= Array.Empty<string>();
         input.ReferencePaths ??= Array.Empty<string>();
         input.ExcludedMethodKeys ??= Array.Empty<string>();
+        input.AssemblySourcePaths ??= Array.Empty<string>();
         return input;
     }
 
@@ -301,6 +302,8 @@ public static class TransformWorkerProgram
         List<ShimTypeBuilder> shimTypes = new List<ShimTypeBuilder>();
         int globalShimMethodCounter = 0;
         int shimTypeCounter = 0;
+        List<UsingDirectiveSyntax> assemblyGlobalUsings =
+            CollectAssemblyGlobalUsings(input, parseOptions);
 
         foreach (TypeDeclarationSyntax typeDeclaration in EnumerateTypeDeclarations(root))
         {
@@ -404,7 +407,7 @@ public static class TransformWorkerProgram
                     currentShimType = new ShimTypeBuilder(
                         shimTypeName,
                         namespaceName,
-                        CollectUsingsForType(root, typeDeclaration));
+                        CollectUsingsForType(root, typeDeclaration, assemblyGlobalUsings));
                     shimTypes.Add(currentShimType);
                 }
 
@@ -464,7 +467,8 @@ public static class TransformWorkerProgram
                         shimTypes,
                         shimTypeCounter,
                         globalShimMethodCounter,
-                        currentShimType);
+                        currentShimType,
+                        assemblyGlobalUsings);
                 currentShimType = nextShimType;
                 shimTypeCounter = nextShimTypeCounter;
                 globalShimMethodCounter = nextGlobalShimMethodCounter;
@@ -1277,7 +1281,8 @@ public static class TransformWorkerProgram
             List<ShimTypeBuilder> shimTypes,
             int shimTypeCounter,
             int globalShimMethodCounter,
-            ShimTypeBuilder currentShimType)
+            ShimTypeBuilder currentShimType,
+            List<UsingDirectiveSyntax> assemblyGlobalUsings)
     {
         IPropertySymbol propertySymbol = semanticModel.GetDeclaredSymbol(propertyDeclaration);
         if (propertySymbol == null || propertySymbol.GetMethod == null)
@@ -1366,7 +1371,7 @@ public static class TransformWorkerProgram
             currentShimType = new ShimTypeBuilder(
                 shimTypeName,
                 namespaceName,
-                CollectUsingsForType(root, typeDeclaration));
+                CollectUsingsForType(root, typeDeclaration, assemblyGlobalUsings));
             shimTypes.Add(currentShimType);
         }
 
@@ -2046,7 +2051,8 @@ public static class TransformWorkerProgram
 
     private static List<UsingDirectiveSyntax> CollectUsingsForType(
         CompilationUnitSyntax root,
-        TypeDeclarationSyntax typeDeclaration)
+        TypeDeclarationSyntax typeDeclaration,
+        List<UsingDirectiveSyntax> assemblyGlobalUsings)
     {
         List<UsingDirectiveSyntax> usings = new List<UsingDirectiveSyntax>();
         foreach (UsingDirectiveSyntax usingDirective in root.Usings)
@@ -2065,7 +2071,139 @@ public static class TransformWorkerProgram
             }
         }
 
+        foreach (UsingDirectiveSyntax assemblyUsing in assemblyGlobalUsings)
+        {
+            if (!ContainsEquivalentUsing(usings, assemblyUsing))
+            {
+                usings.Add(assemblyUsing);
+            }
+        }
+
         return usings;
+    }
+
+    // Why skip SourcePath: the edited file's usings already come from the in-memory tree.
+    // Reading the on-disk copy would pick up the pre-edit source.
+    private static List<UsingDirectiveSyntax> CollectAssemblyGlobalUsings(
+        WorkerInput input,
+        CSharpParseOptions parseOptions)
+    {
+        List<UsingDirectiveSyntax> collected = new List<UsingDirectiveSyntax>();
+        foreach (string assemblySourcePath in input.AssemblySourcePaths)
+        {
+            if (string.IsNullOrEmpty(assemblySourcePath)
+                || PathsReferToSameSourceFile(assemblySourcePath, input.SourcePath)
+                || !File.Exists(assemblySourcePath))
+            {
+                continue;
+            }
+
+            string text = File.ReadAllText(
+                assemblySourcePath,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            if (!FileContainsGlobalUsingLine(text))
+            {
+                continue;
+            }
+
+            AppendGlobalUsingsFromParsedText(collected, text, parseOptions, assemblySourcePath);
+        }
+
+        return collected;
+    }
+
+    private static void AppendGlobalUsingsFromParsedText(
+        List<UsingDirectiveSyntax> collected,
+        string text,
+        CSharpParseOptions parseOptions,
+        string assemblySourcePath)
+    {
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            SourceText.From(text, Encoding.UTF8),
+            parseOptions,
+            path: assemblySourcePath);
+        CompilationUnitSyntax unit = tree.GetCompilationUnitRoot();
+        foreach (UsingDirectiveSyntax usingDirective in unit.Usings)
+        {
+            if (!usingDirective.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword))
+            {
+                continue;
+            }
+
+            UsingDirectiveSyntax asOrdinary = usingDirective
+                .WithGlobalKeyword(default)
+                .WithoutTrivia();
+            if (!ContainsEquivalentUsing(collected, asOrdinary))
+            {
+                collected.Add(asOrdinary);
+            }
+        }
+    }
+
+    private static bool FileContainsGlobalUsingLine(string text)
+    {
+        using StringReader reader = new StringReader(text);
+        string line;
+        while ((line = reader.ReadLine()) != null)
+        {
+            if (line.TrimStart().StartsWith("global using", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool PathsReferToSameSourceFile(string left, string right)
+    {
+        if (string.IsNullOrEmpty(left) || string.IsNullOrEmpty(right))
+        {
+            return false;
+        }
+
+        string normalizedLeft = Path.GetFullPath(left);
+        string normalizedRight = Path.GetFullPath(right);
+        StringComparison comparison = Path.DirectorySeparatorChar == '\\'
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return string.Equals(normalizedLeft, normalizedRight, comparison);
+    }
+
+    private static bool ContainsEquivalentUsing(
+        List<UsingDirectiveSyntax> usings,
+        UsingDirectiveSyntax candidate)
+    {
+        foreach (UsingDirectiveSyntax existing in usings)
+        {
+            if (UsingDirectivesMatch(existing, candidate))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool UsingDirectivesMatch(UsingDirectiveSyntax left, UsingDirectiveSyntax right)
+    {
+        bool leftStatic = left.StaticKeyword.IsKind(SyntaxKind.StaticKeyword);
+        bool rightStatic = right.StaticKeyword.IsKind(SyntaxKind.StaticKeyword);
+        if (leftStatic != rightStatic)
+        {
+            return false;
+        }
+
+        string leftAlias = left.Alias == null ? string.Empty : left.Alias.Name.ToString();
+        string rightAlias = right.Alias == null ? string.Empty : right.Alias.Name.ToString();
+        if (leftAlias != rightAlias)
+        {
+            return false;
+        }
+
+        string leftName = left.Name == null ? string.Empty : left.Name.ToString();
+        string rightName = right.Name == null ? string.Empty : right.Name.ToString();
+        return leftName == rightName;
     }
 }
 
@@ -4209,6 +4347,10 @@ internal sealed class WorkerInput
 
     // Project-relative forward-slash path embedded in #line document names.
     public string ProjectRelativePath { get; set; }
+
+    // Absolute paths of every source file in the edited file's compilation assembly.
+    // Null/omitted is treated as empty (no sibling global usings collected).
+    public string[] AssemblySourcePaths { get; set; }
 }
 
 internal sealed class WorkerOutput

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -2073,13 +2073,41 @@ public static class TransformWorkerProgram
 
         foreach (UsingDirectiveSyntax assemblyUsing in assemblyGlobalUsings)
         {
-            if (!ContainsEquivalentUsing(usings, assemblyUsing))
+            if (!ShouldSkipAssemblyUsing(usings, assemblyUsing))
             {
                 usings.Add(assemblyUsing);
             }
         }
 
         return usings;
+    }
+
+    // Why skip same alias name regardless of target: C# lets a namespace-scoped alias shadow a
+    // global one. Flattening both into the shim's single namespace is CS1537.
+    private static bool ShouldSkipAssemblyUsing(
+        List<UsingDirectiveSyntax> existingUsings,
+        UsingDirectiveSyntax assemblyUsing)
+    {
+        if (ContainsEquivalentUsing(existingUsings, assemblyUsing))
+        {
+            return true;
+        }
+
+        if (assemblyUsing.Alias == null)
+        {
+            return false;
+        }
+
+        string aliasName = assemblyUsing.Alias.Name.ToString();
+        foreach (UsingDirectiveSyntax existing in existingUsings)
+        {
+            if (existing.Alias != null && existing.Alias.Name.ToString() == aliasName)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // Why skip SourcePath: the edited file's usings already come from the in-memory tree.


### PR DESCRIPTION
## Summary
- Hot reload now compiles shim methods that depend on `global using` directives declared in other files of the same assembly.
- A namespace-scoped using alias of the same name as a sibling `global using` alias keeps the local alias (C# shadowing). Flattening both into the shim namespace is CS1537.

## User Impact
- Before: editing a method that used a type or extension brought in only by a sibling `global using` failed shim compile with CS0246/CS1061, and the failure text pointed at "adding new members". Legal C# that shadowed a global alias with a local alias of the same name also failed shim compile with CS1537.
- After: those methods patch, CS0246/CS1061 failures lead with a missing using / global using hint, and same-name alias shadowing compiles the way C# does.

## Changes
- `TransformWorkerInputDto` gained `assemblySourcePaths` (absolute paths of the compilation assembly's sources).
- Both construction sites set the field: the first worker run in `HotReloadOrchestrator` and the hand-copied retry input. Omitting the retry copy would make isolation retry drop sibling global usings.
- The worker prefilters those files for `global using` lines, parses with the same defines, and merges `GlobalKeyword` usings as ordinary usings (deduped). It skips `input.SourcePath` so the on-disk pre-edit copy cannot replace the in-memory tree.
- When merging assembly global usings, an alias whose name already exists in the edited file's usings is skipped (target ignored). Non-alias usings keep exact-match dedup.
- CS0246/CS1061 shim-compile messages now lead with the missing using hint, then the existing new-member hint.

## Verification
- Red (global using): `Run_EditedMethodUsingSiblingGlobalUsing_PatchesBehavior` failed with `CS0246: The type or namespace name 'HotReloadGlobalAlias' could not be found` (`TestCount: 1`, `FailedCount: 1`).
- Green (global using): the same test passed (`TestCount: 1`, `PassedCount: 1`). Hint unit tests `ComposeShimCompileFailureMessage_TypeNotFound_LeadsWithMissingUsingHint` and `ComposeShimCompileFailureMessage_MissingExtension_LeadsWithMissingUsingHint` passed.
- Red (alias shadow): `Run_WithLocalAliasShadowingGlobalAlias_KeepsLocalAliasOnly` failed because the shim contained both `using AliasProbe = System.Text.StringBuilder` and `using AliasProbe = System.Collections.Generic.List<int>` (`TestCount: 1`, `FailedCount: 1`).
- Green (alias shadow): the same test passed; shim keeps the local alias only (`TestCount: 1`, `PassedCount: 1`).
- `uloop compile`: `ErrorCount: 0`.
- `uloop run-tests --filter-type regex --filter-value "HotReload|TransformWorker"`: `TestCount: 180`, `PassedCount: 180`, `FailedCount: 0`.
- This PR targets `feature/hot-reload`, so repository CI (`pull_request.branches: main, v3-beta`) does not run. Local `uloop` is the verification for this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
