### PR TITLE
fix: offset chain-join pause points by the transplant preamble

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
@@ -120,6 +120,44 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: after a transplant hot-reload, pausing on the return that uses a string assigned
+        /// in the immediately preceding straight-line statement captures that local's real value.
+        /// Why this shape: the transplant preamble is two instructions; an earlier assignment
+        /// (including the loop in Enable_OnHotReloadedTransplantBody_HitsAndCapturesAddedLocal)
+        /// still shows the final value when capture runs two instructions early.
+        /// </summary>
+        [Test]
+        public async Task Enable_OnHotReloadedTransplantBody_CapturesStringAssignedOnPreviousLine()
+        {
+            string editedSource = BuildEditedComputeWithPrecedingStringLocal();
+            int enableLine = FindLineNumber(editedSource, "return tagged.Length;");
+            Assert.That(enableLine, Is.GreaterThan(0));
+
+            await HotReloadFromEditedSourceAsync(editedSource, "ContractTransplantPrecedingString.cs");
+
+            PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureProjectRelativePath,
+                Line = enableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.Continuous
+            });
+            Assert.That(enable.Success, Is.True, enable.Message + " / " + enable.RecommendedNextAction);
+            Assert.That(enable.RetargetedToHotReloadPatch, Is.True);
+            Assert.That(enable.ResolvedLine, Is.GreaterThan(0));
+
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            int result = fixture.ComputeWithPrivate(5);
+            Assert.That(result, Is.EqualTo("patched-tag".Length));
+
+            UloopPausePointSnapshot status = UloopPausePointRegistry.GetStatus(enable.Id);
+            Assert.That(status.IsHit, Is.True);
+            UloopCapturedVariable tagged = status.CapturedVariables.FirstOrDefault(v => v.Name == "tagged");
+            Assert.That(tagged, Is.Not.Null, FormatCaptured(status));
+            Assert.That(tagged.Value, Is.EqualTo("patched-tag"));
+        }
+
+        /// <summary>
         /// What: after a delegation hot-reload, enable on the shim body hits with synthetic
         /// "this" and never exposes __uloopInstance as a captured parameter name.
         /// </summary>
@@ -826,6 +864,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + "            }\n"
                 + "\n"
                 + "            return boosted;\n"
+                + "        }";
+            string edited = onDisk.Replace(original, replacement, StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            return edited;
+        }
+
+        private static string BuildEditedComputeWithPrecedingStringLocal()
+        {
+            string onDisk = File.ReadAllText(ResolveFixtureAbsolutePath());
+            const string original =
+                "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }";
+            // Why no loop: an earlier assignment still has its final value when capture runs two
+            // instructions early (the transplant preamble). The string must be stored on the
+            // statement immediately before return so a preamble-offset bug captures null.
+            const string replacement =
+                "public int ComputeWithPrivate(int delta)\n        {\n"
+                + "            string tagged = \"patched-tag\";\n"
+                + "            return tagged.Length;\n"
                 + "        }";
             string edited = onDisk.Replace(original, replacement, StringComparison.Ordinal);
             Assert.That(edited, Is.Not.EqualTo(onDisk));

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -52,6 +52,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static readonly Dictionary<MethodBase, IReadOnlyList<LocalBuilder>> TransplantLocalsByMethod =
             new Dictionary<MethodBase, IReadOnlyList<LocalBuilder>>();
 
+        // How many instructions PrependInvocationCountIncrement inserted on the latest transplant
+        // (or delegation) rebuild of each original. Pause-point reads this only for chain-join.
+        private static readonly Dictionary<MethodBase, int> TransplantPreambleLengthByMethod =
+            new Dictionary<MethodBase, int>();
+
         // Harmony resolves transpilers as static methods, so the shim cannot be a parameter.
         // Production looks up the target method in the ledger; the apply path also stashes the
         // pending shim here so the first Patch call can read it before the ledger entry
@@ -87,6 +92,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 TransplantLocalsByMethod.TryGetValue(method, out IReadOnlyList<LocalBuilder> locals)
                     ? locals
                     : null;
+            HotReloadPausePointCoordination.GetTransplantPreambleLength = method =>
+                TransplantPreambleLengthByMethod.TryGetValue(method, out int length)
+                    ? length
+                    : 0;
         }
 
         /// <summary>
@@ -132,6 +141,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ShimByMethod.Remove(method);
                 FilePathByMethod.Remove(method);
                 TransplantLocalsByMethod.Remove(method);
+                TransplantPreambleLengthByMethod.Remove(method);
                 HotReloadInvocationRegistry.Remove(FormatMethodKey(method));
                 HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
                 // Mirror the ledger removal: if the re-Patch below fails, its contained Unpatch
@@ -185,6 +195,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // wrapper, restoring the original body (verified by the extern-shim test).
                 HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
                 TransplantLocalsByMethod.Remove(method);
+                TransplantPreambleLengthByMethod.Remove(method);
                 // Why after Unpatch: retarget may have already replaced markers onto the shim;
                 // restore them onto the original body now that GetActiveShim is null.
                 HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
@@ -227,6 +238,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             FilePathByMethod.Clear();
             HotReloadShimRegistry.Clear();
             TransplantLocalsByMethod.Clear();
+            TransplantPreambleLengthByMethod.Clear();
             HotReloadInvocationRegistry.Clear();
             _pendingShimMethod = null;
             _pendingOriginalMethod = null;
@@ -257,6 +269,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             FilePathByMethod.Remove(method);
             HotReloadShimRegistry.RemoveMethod(method);
             TransplantLocalsByMethod.Remove(method);
+            TransplantPreambleLengthByMethod.Remove(method);
             HotReloadInvocationRegistry.Remove(FormatMethodKey(method));
             HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
             HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
@@ -441,8 +454,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 instructions[0].labels.Clear();
             }
 
+            int countBeforeInsert = instructions.Count;
             instructions.Insert(0, increment);
             instructions.Insert(0, loadKey);
+            TransplantPreambleLengthByMethod[original] = instructions.Count - countBeforeInsert;
         }
 
         private static CodeInstruction CreateLoadArgumentInstruction(int slot)

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -519,7 +519,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             SourcePausePointPatchInjection injection = new(
                 id,
-                shim.InstructionIndex,
+                InstructionIndexForInjection(targetKind, method, shim.InstructionIndex),
                 isStatic,
                 isDeclaringTypeValueType,
                 shim.Parameters,
@@ -529,6 +529,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 shim.InstanceFromFirstArgument);
 
             return CommitPatch(id, method, shim.LogicalOwner, injection, normalizedFile, requestedLine);
+        }
+
+        // Why add preamble only for TransplantChainJoin: the recorded index is from the shim's
+        // raw IL. Transplant prepends ldstr+call before that stream; ShimDirect and OriginalBody
+        // have no such prefix.
+        private static int InstructionIndexForInjection(
+            SourcePausePointPatchInjectionTargetKind targetKind,
+            MethodBase method,
+            int instructionIndex)
+        {
+            if (targetKind != SourcePausePointPatchInjectionTargetKind.TransplantChainJoin)
+            {
+                return instructionIndex;
+            }
+
+            Func<MethodBase, int> getPreambleLength =
+                HotReloadPausePointCoordination.GetTransplantPreambleLength;
+            if (getPreambleLength == null)
+            {
+                return instructionIndex;
+            }
+
+            return instructionIndex + getPreambleLength(method);
         }
 
         private static bool TryReuseExistingPatch(

--- a/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
+++ b/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
@@ -40,6 +40,13 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         /// </summary>
         public static Func<MethodBase, IReadOnlyList<LocalBuilder>> GetTransplantLocals { get; set; }
 
+        /// <summary>
+        /// Set by HotReloadPatcher. Returns how many instructions the latest rebuild prepended
+        /// before the patched body (0 when none). Pause-point must add this only to
+        /// TransplantChainJoin indexes; ShimDirect and OriginalBody have no transplant preamble.
+        /// </summary>
+        public static Func<MethodBase, int> GetTransplantPreambleLength { get; set; }
+
         // Set by SourcePausePointPatcher. Returns the marker ids currently injected
         // into the method (empty when none).
         public static Func<MethodBase, IReadOnlyList<string>> GetArmedMarkerIdsOnMethod { get; set; }


### PR DESCRIPTION
## Summary
- Pause points on a hot-reloaded method now capture locals at the requested line instead of two instructions earlier.

## User Impact
- Before: after hot reload, a pause point on a return that used a local assigned on the previous line reported that local as `null` (or `0` for value types), even though the method's return value was already correct.
- After: the captured local matches the value assigned on the previous statement.

## Changes
- The hot-reload transplant records how many instructions it actually prepended (the invocation-count preamble).
- Source pause-point chain-join injections add that length to the shim-raw instruction index. Shim-direct and original-body injections are unchanged.

## Verification
- Red: `Enable_OnHotReloadedTransplantBody_CapturesStringAssignedOnPreviousLine` failed with `Expected: "patched-tag" But was: "null"` (`TestCount: 1`, `FailedCount: 1`).
- Green: the same test passed (`TestCount: 1`, `PassedCount: 1`).
- `uloop run-tests --filter-type regex --filter-value "HotReloadPausePointContractTests"`: `TestCount: 20`, `PassedCount: 20`.
- `uloop run-tests --filter-type regex --filter-value "HotReloadPausePoint"`: `TestCount: 23`, `PassedCount: 23`.
- CLI E2E: temporary edit of `LongSingleReturn` (string local then `return tagged;`) → `uloop hot-reload` Patched → `enable-pause-point --mode trace` with `RetargetedToHotReloadPatch: true` → invoke → `pause-point-status --expect` `AllExpectationsPassed: true` (`tagged` was the real string, not `null`). Then `clear-pause-point --all`, `hot-reload --revert-all`, file restore.
- `uloop compile`: `ErrorCount: 0`.
- This PR targets `feature/hot-reload`, so repository CI (`pull_request.branches: main, v3-beta`) does not run. Local `uloop` is the verification for this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

