### PR TITLE
fix: pair the DotNetSdk csc with its bundled dotnet host

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExternalCompilerPathResolverTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExternalCompilerPathResolverTests.cs
@@ -220,6 +220,60 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.That(resolvedCompilerDirectoryPath, Is.EqualTo(expectedCompilerDirectoryPath));
         }
 
+        /// <summary>
+        /// What: a 6000.7-shaped layout (csc wants net10, NetCoreRuntime has only 8.x, DotNetSdk
+        /// is a complete host+shared 10.x root) pairs host and shared from DotNetSdk.
+        /// </summary>
+        [Test]
+        public void ResolveRuntimePairing_WhenNetCoreRuntimeMajorIsTooLow_ShouldUseDotNetSdkHostAndShared()
+        {
+            string scriptingRootPath = CreateDirectory("Scripting");
+            CreateFile(Path.Combine("Scripting", "NetCoreRuntime", "dotnet"));
+            CreateDirectory(Path.Combine("Scripting", "NetCoreRuntime", "shared", "Microsoft.NETCore.App", "8.0.21"));
+            string expectedHostPath = CreateFile(Path.Combine("Scripting", "DotNetSdk", "dotnet"));
+            string expectedSharedPath = CreateDirectory(
+                Path.Combine("Scripting", "DotNetSdk", "shared", "Microsoft.NETCore.App", "10.0.9"));
+            string compilerDirectoryPath = CreateDirectory(
+                Path.Combine("Scripting", "DotNetSdk", "sdk", "10.0.301", "Roslyn", "bincore"));
+            CreateFile(Path.Combine("Scripting", "DotNetSdk", "sdk", "10.0.301", "Roslyn", "bincore", "csc.dll"));
+            WriteCscRuntimeConfig(compilerDirectoryPath, "10.0.9");
+
+            ExternalCompilerRuntimePairing pairing = ExternalCompilerPathResolver.ResolveRuntimePairing(
+                scriptingRootPath,
+                compilerDirectoryPath,
+                "dotnet");
+
+            Assert.That(pairing.DotnetHostPath, Is.EqualTo(expectedHostPath));
+            Assert.That(pairing.NetCoreRuntimeSharedDirectoryPath, Is.EqualTo(expectedSharedPath));
+        }
+
+        /// <summary>
+        /// What: a 6000.5-shaped layout (DotNetSdk is a complete root but NetCoreRuntime already
+        /// satisfies csc's 8.x requirement) keeps host and shared on NetCoreRuntime.
+        /// </summary>
+        [Test]
+        public void ResolveRuntimePairing_WhenNetCoreRuntimeSatisfiesRequiredMajor_ShouldKeepNetCoreRuntimePair()
+        {
+            string scriptingRootPath = CreateDirectory("Scripting");
+            string expectedHostPath = CreateFile(Path.Combine("Scripting", "NetCoreRuntime", "dotnet"));
+            string expectedSharedPath = CreateDirectory(
+                Path.Combine("Scripting", "NetCoreRuntime", "shared", "Microsoft.NETCore.App", "8.0.21"));
+            CreateFile(Path.Combine("Scripting", "DotNetSdk", "dotnet"));
+            CreateDirectory(Path.Combine("Scripting", "DotNetSdk", "shared", "Microsoft.NETCore.App", "8.0.21"));
+            string compilerDirectoryPath = CreateDirectory(
+                Path.Combine("Scripting", "DotNetSdk", "sdk", "8.0.318", "Roslyn", "bincore"));
+            CreateFile(Path.Combine("Scripting", "DotNetSdk", "sdk", "8.0.318", "Roslyn", "bincore", "csc.dll"));
+            WriteCscRuntimeConfig(compilerDirectoryPath, "8.0.21");
+
+            ExternalCompilerRuntimePairing pairing = ExternalCompilerPathResolver.ResolveRuntimePairing(
+                scriptingRootPath,
+                compilerDirectoryPath,
+                "dotnet");
+
+            Assert.That(pairing.DotnetHostPath, Is.EqualTo(expectedHostPath));
+            Assert.That(pairing.NetCoreRuntimeSharedDirectoryPath, Is.EqualTo(expectedSharedPath));
+        }
+
         [Test]
         public async Task CompileAsync_WhenSharedWorkerBuildFails_ShouldFallbackToOneShotRoslyn()
         {
@@ -383,6 +437,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Directory.CreateDirectory(Path.GetDirectoryName(filePath));
             File.WriteAllText(filePath, string.Empty);
             return filePath;
+        }
+
+        private static void WriteCscRuntimeConfig(string compilerDirectoryPath, string frameworkVersion)
+        {
+            string runtimeConfigPath = Path.Combine(compilerDirectoryPath, "csc.runtimeconfig.json");
+            string json =
+                "{\n"
+                + "  \"runtimeOptions\": {\n"
+                + "    \"framework\": {\n"
+                + "      \"name\": \"Microsoft.NETCore.App\",\n"
+                + "      \"version\": \"" + frameworkVersion + "\"\n"
+                + "    },\n"
+                + "    \"rollForward\": \"Major\"\n"
+                + "  }\n"
+                + "}\n";
+            File.WriteAllText(runtimeConfigPath, json);
         }
 
         private ExternalCompilerPaths CreateExternalCompilerPaths(ExternalCompilerLayoutKind layoutKind)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/ExternalCompilerPathResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/ExternalCompilerPathResolver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Newtonsoft.Json;
 using UnityEditor;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -24,6 +25,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private const string CodeAnalysisCSharpDllFileName = "Microsoft.CodeAnalysis.CSharp.dll";
         private const string NetCoreRuntimeSharedDirectoryName = "shared";
         private const string NetCoreRuntimeSharedFrameworkName = "Microsoft.NETCore.App";
+        private const string CscRuntimeConfigRuntimeOptionsPropertyName = "runtimeOptions";
+        private const string CscRuntimeConfigFrameworkPropertyName = "framework";
+        private const string CscRuntimeConfigVersionPropertyName = "version";
 
         public static ExternalCompilerPaths Resolve()
         {
@@ -142,25 +146,45 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 layoutKind);
         }
 
-        // compilerDirectoryPath is part of the seam so pairing can later read csc.runtimeconfig.json
-        // beside the compiler without changing Resolve()'s call site.
+        // Why NetCoreRuntime first: 6000.3/6000.5 already satisfy csc's required major from
+        // NetCoreRuntime, so switching on "DotNetSdk is a complete root" would change those
+        // layouts' host/shared bytes. Switch only when that major is unsatisfied.
         internal static ExternalCompilerRuntimePairing ResolveRuntimePairing(
             string effectiveScriptingRootPath,
             string compilerDirectoryPath,
             string dotnetHostFileName)
         {
-            string dotnetHostPath = Path.Combine(
+            string netCoreHostPath = Path.Combine(
                 effectiveScriptingRootPath,
                 NetCoreRuntimeDirectoryName,
                 dotnetHostFileName);
-            string netCoreRuntimeSharedRootPath = Path.Combine(
+            string netCoreSharedRootPath = Path.Combine(
                 effectiveScriptingRootPath,
                 NetCoreRuntimeDirectoryName,
                 NetCoreRuntimeSharedDirectoryName,
                 NetCoreRuntimeSharedFrameworkName);
-            string netCoreRuntimeSharedDirectoryPath =
-                ResolveNetCoreRuntimeSharedDirectoryPath(netCoreRuntimeSharedRootPath);
-            return new ExternalCompilerRuntimePairing(dotnetHostPath, netCoreRuntimeSharedDirectoryPath);
+            string netCoreSharedDirectoryPath =
+                ResolveNetCoreRuntimeSharedDirectoryPath(netCoreSharedRootPath);
+            ExternalCompilerRuntimePairing netCorePairing =
+                new ExternalCompilerRuntimePairing(netCoreHostPath, netCoreSharedDirectoryPath);
+
+            int? requiredMajor = ReadRequiredRuntimeMajor(compilerDirectoryPath);
+            if (requiredMajor == null
+                || SharedRootSatisfiesRequiredMajor(netCoreSharedRootPath, requiredMajor.Value))
+            {
+                return netCorePairing;
+            }
+
+            ExternalCompilerRuntimePairing dotNetSdkPairing = TryResolveDotNetSdkRuntimePairing(
+                compilerDirectoryPath,
+                dotnetHostFileName,
+                requiredMajor.Value);
+            if (dotNetSdkPairing == null)
+            {
+                return netCorePairing;
+            }
+
+            return dotNetSdkPairing;
         }
 
         internal static string ResolveScriptingRootPath(string contentsPath)
@@ -403,6 +427,130 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return string.IsNullOrEmpty(installRootPath)
                 ? null
                 : installRootPath;
+        }
+
+        private static int? ReadRequiredRuntimeMajor(string compilerDirectoryPath)
+        {
+            if (string.IsNullOrEmpty(compilerDirectoryPath))
+            {
+                return null;
+            }
+
+            string runtimeConfigPath = Path.Combine(compilerDirectoryPath, CompilerRuntimeConfigFileName);
+            if (!File.Exists(runtimeConfigPath))
+            {
+                return null;
+            }
+
+            string text = File.ReadAllText(runtimeConfigPath);
+            CscRuntimeConfigDto config = JsonConvert.DeserializeObject<CscRuntimeConfigDto>(text);
+            string versionText = config?.RuntimeOptions?.Framework?.Version;
+            if (string.IsNullOrEmpty(versionText) || !Version.TryParse(versionText, out Version version))
+            {
+                return null;
+            }
+
+            return version.Major;
+        }
+
+        private static bool SharedRootSatisfiesRequiredMajor(string sharedRootPath, int requiredMajor)
+        {
+            if (!Directory.Exists(sharedRootPath))
+            {
+                return false;
+            }
+
+            string[] runtimeDirectories = Directory.GetDirectories(sharedRootPath);
+            foreach (string runtimeDirectoryPath in runtimeDirectories)
+            {
+                string versionText = Path.GetFileName(runtimeDirectoryPath);
+                if (Version.TryParse(versionText, out Version version) && version.Major >= requiredMajor)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static ExternalCompilerRuntimePairing TryResolveDotNetSdkRuntimePairing(
+            string compilerDirectoryPath,
+            string dotnetHostFileName,
+            int requiredMajor)
+        {
+            string dotNetSdkRootPath = FindDirectoryContainingSdk(compilerDirectoryPath);
+            if (string.IsNullOrEmpty(dotNetSdkRootPath))
+            {
+                return null;
+            }
+
+            string hostPath = Path.Combine(dotNetSdkRootPath, dotnetHostFileName);
+            if (!File.Exists(hostPath))
+            {
+                return null;
+            }
+
+            string sharedRootPath = Path.Combine(
+                dotNetSdkRootPath,
+                NetCoreRuntimeSharedDirectoryName,
+                NetCoreRuntimeSharedFrameworkName);
+            if (!SharedRootSatisfiesRequiredMajor(sharedRootPath, requiredMajor))
+            {
+                return null;
+            }
+
+            string sharedDirectoryPath = ResolveNetCoreRuntimeSharedDirectoryPath(sharedRootPath);
+            if (string.IsNullOrEmpty(sharedDirectoryPath))
+            {
+                return null;
+            }
+
+            return new ExternalCompilerRuntimePairing(hostPath, sharedDirectoryPath);
+        }
+
+        private static string FindDirectoryContainingSdk(string startDirectoryPath)
+        {
+            if (string.IsNullOrEmpty(startDirectoryPath))
+            {
+                return null;
+            }
+
+            string currentPath = Path.GetFullPath(startDirectoryPath);
+            while (!string.IsNullOrEmpty(currentPath))
+            {
+                if (Directory.Exists(Path.Combine(currentPath, DotNetSdkSdkDirectoryName)))
+                {
+                    return currentPath;
+                }
+
+                string parentPath = Path.GetDirectoryName(currentPath);
+                if (string.IsNullOrEmpty(parentPath) || parentPath == currentPath)
+                {
+                    return null;
+                }
+
+                currentPath = parentPath;
+            }
+
+            return null;
+        }
+
+        private sealed class CscRuntimeConfigDto
+        {
+            [JsonProperty(CscRuntimeConfigRuntimeOptionsPropertyName)]
+            public CscRuntimeConfigRuntimeOptionsDto RuntimeOptions { get; set; }
+        }
+
+        private sealed class CscRuntimeConfigRuntimeOptionsDto
+        {
+            [JsonProperty(CscRuntimeConfigFrameworkPropertyName)]
+            public CscRuntimeConfigFrameworkDto Framework { get; set; }
+        }
+
+        private sealed class CscRuntimeConfigFrameworkDto
+        {
+            [JsonProperty(CscRuntimeConfigVersionPropertyName)]
+            public string Version { get; set; }
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/ExternalCompilerPathResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/ExternalCompilerPathResolver.cs
@@ -64,14 +64,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 missingComponents.Add(Path.Combine(effectiveScriptingRootPath, DotNetSdkDirectoryName, DotNetSdkSdkDirectoryName, "*", RoslynDirectoryName, CompilerBincoreDirectoryName));
             }
 
-            string dotnetHostPath = Path.Combine(effectiveScriptingRootPath, NetCoreRuntimeDirectoryName, dotnetHostFileName);
             string compilerDllPath = Path.Combine(compilerDirectoryPath, CompilerDllFileName);
             string compilerRuntimeConfigPath = Path.Combine(compilerDirectoryPath, CompilerRuntimeConfigFileName);
             string compilerDepsFilePath = Path.Combine(compilerDirectoryPath, CompilerDepsFileName);
             string codeAnalysisDllPath = Path.Combine(compilerDirectoryPath, CodeAnalysisDllFileName);
             string codeAnalysisCSharpDllPath = Path.Combine(compilerDirectoryPath, CodeAnalysisCSharpDllFileName);
-            string netCoreRuntimeSharedRootPath = Path.Combine(effectiveScriptingRootPath, NetCoreRuntimeDirectoryName, NetCoreRuntimeSharedDirectoryName, NetCoreRuntimeSharedFrameworkName);
-            string netCoreRuntimeSharedDirectoryPath = ResolveNetCoreRuntimeSharedDirectoryPath(netCoreRuntimeSharedRootPath);
+            ExternalCompilerRuntimePairing runtimePairing = ResolveRuntimePairing(
+                effectiveScriptingRootPath,
+                compilerDirectoryPath,
+                dotnetHostFileName);
+            string dotnetHostPath = runtimePairing.DotnetHostPath;
+            string netCoreRuntimeSharedDirectoryPath = runtimePairing.NetCoreRuntimeSharedDirectoryPath;
             ExternalCompilerLayoutKind layoutKind = ResolveCompilerLayoutKind(
                 contentsPath,
                 effectiveScriptingRootPath,
@@ -109,7 +112,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (string.IsNullOrEmpty(netCoreRuntimeSharedDirectoryPath))
             {
-                missingComponents.Add(netCoreRuntimeSharedRootPath);
+                missingComponents.Add(
+                    Path.Combine(
+                        effectiveScriptingRootPath,
+                        NetCoreRuntimeDirectoryName,
+                        NetCoreRuntimeSharedDirectoryName,
+                        NetCoreRuntimeSharedFrameworkName));
             }
 
             if (missingComponents.Count > 0)
@@ -132,6 +140,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 codeAnalysisCSharpDllPath,
                 netCoreRuntimeSharedDirectoryPath,
                 layoutKind);
+        }
+
+        // compilerDirectoryPath is part of the seam so pairing can later read csc.runtimeconfig.json
+        // beside the compiler without changing Resolve()'s call site.
+        internal static ExternalCompilerRuntimePairing ResolveRuntimePairing(
+            string effectiveScriptingRootPath,
+            string compilerDirectoryPath,
+            string dotnetHostFileName)
+        {
+            string dotnetHostPath = Path.Combine(
+                effectiveScriptingRootPath,
+                NetCoreRuntimeDirectoryName,
+                dotnetHostFileName);
+            string netCoreRuntimeSharedRootPath = Path.Combine(
+                effectiveScriptingRootPath,
+                NetCoreRuntimeDirectoryName,
+                NetCoreRuntimeSharedDirectoryName,
+                NetCoreRuntimeSharedFrameworkName);
+            string netCoreRuntimeSharedDirectoryPath =
+                ResolveNetCoreRuntimeSharedDirectoryPath(netCoreRuntimeSharedRootPath);
+            return new ExternalCompilerRuntimePairing(dotnetHostPath, netCoreRuntimeSharedDirectoryPath);
         }
 
         internal static string ResolveScriptingRootPath(string contentsPath)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/ExternalCompilerPaths.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/ExternalCompilerPaths.cs
@@ -62,4 +62,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             LayoutKind = layoutKind;
         }
     }
+
+    /// <summary>
+    /// Host and shared-framework paths chosen together for running Unity's bundled csc.
+    /// </summary>
+    internal sealed class ExternalCompilerRuntimePairing
+    {
+        public string DotnetHostPath { get; }
+
+        public string NetCoreRuntimeSharedDirectoryPath { get; }
+
+        public ExternalCompilerRuntimePairing(
+            string dotnetHostPath,
+            string netCoreRuntimeSharedDirectoryPath)
+        {
+            DotnetHostPath = dotnetHostPath;
+            NetCoreRuntimeSharedDirectoryPath = netCoreRuntimeSharedDirectoryPath;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Unity 6000.7 can compile and run dynamic C# / hot-reload worker processes again: csc is launched with the .NET 10 host that ships next to it, instead of the .NET 8 NetCoreRuntime host.

## User Impact
- Before: on Unity 6000.7, csc failed to start with "You must install or update .NET" (exit 150), so execute-dynamic-code and the hot-reload worker could not compile.
- After: when NetCoreRuntime does not provide a runtime major that csc's runtimeconfig requires, host and shared are taken together from the DotNetSdk root that contains that csc. Unity 6000.3 and 6000.5 keep using NetCoreRuntime.

## Changes
- `Resolve()` delegates host/shared selection to `ResolveRuntimePairing` (path arguments, no EditorApplication).
- Pairing reads `csc.runtimeconfig.json` next to the compiler, and switches to DotNetSdk only when NetCoreRuntime's `Microsoft.NETCore.App` majors cannot satisfy the required major.
- A 6000.5-shaped mock (complete DotNetSdk root, but NetCoreRuntime already satisfies 8.x) stays on NetCoreRuntime so "complete root" is not enough to switch.

## Remaining 6000.7 checks (out of scope for this PR)
- `TransformWorkerBootstrap` injects every DLL from the chosen shared directory (`Directory.GetFiles(shared, "*.dll")`). Whether that dump is safe against a 10.x shared folder is unverified here; it needs a 6000.7.0a4 Editor run after this lands.
- End-to-end compile on 6000.7.0a4 is also out of scope (requires switching the running Editor).

## Verification
- Red: `ResolveRuntimePairing_WhenNetCoreRuntimeMajorIsTooLow_ShouldUseDotNetSdkHostAndShared` expected `.../DotNetSdk/dotnet` but was `.../NetCoreRuntime/dotnet` (`TestCount: 1`, `FailedCount: 1`).
- Green: the same test passed (`TestCount: 1`, `PassedCount: 1`).
- `uloop run-tests --filter-type regex --filter-value "ExternalCompilerPathResolverTests"`: `TestCount: 18`, `PassedCount: 18` (includes the 6000.5 keep-NetCoreRuntime guard).
- `uloop run-tests --filter-type regex --filter-value "DynamicCodeToolTests"`: `TestCount: 256`, `PassedCount: 255`, `FailedCount: 0`, `SkippedCount: 1`. The skip is a pre-existing `Assert.Ignore` when `System.Security.Cryptography.Primitives.dll` is absent from this 6000.3 shared folder.
- `uloop compile`: `ErrorCount: 0`.
- This PR targets `feature/hot-reload`, so repository CI (`pull_request.branches: main, v3-beta`) does not run. Local `uloop` is the verification for this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

