### PR TITLE
fix: drop the toonshader dependency and guard Cinemachine 2.x demo scripts

### DIFF
--- a/Assets/Tests/Demo/DemoMouseLook.cs
+++ b/Assets/Tests/Demo/DemoMouseLook.cs
@@ -1,4 +1,4 @@
-#if ULOOP_HAS_INPUT_SYSTEM
+#if ULOOP_HAS_INPUT_SYSTEM && !CINEMACHINE_3_OR_NEWER
 #nullable enable
 using UnityEngine;
 using UnityEngine.InputSystem;

--- a/Assets/Tests/Demo/Editor/DemoMouseSceneBuilder.cs
+++ b/Assets/Tests/Demo/Editor/DemoMouseSceneBuilder.cs
@@ -1,4 +1,4 @@
-#if ULOOP_HAS_INPUT_SYSTEM
+#if ULOOP_HAS_INPUT_SYSTEM && !CINEMACHINE_3_OR_NEWER
 #nullable enable
 using Cinemachine;
 using UnityEditor;

--- a/Assets/Tests/Demo/Editor/UnityCLILoop.Tests.Demo.Editor.asmdef
+++ b/Assets/Tests/Demo/Editor/UnityCLILoop.Tests.Demo.Editor.asmdef
@@ -34,6 +34,11 @@
             "name": "com.unity.inputsystem",
             "expression": "",
             "define": "ULOOP_HAS_INPUT_SYSTEM"
+        },
+        {
+            "name": "com.unity.cinemachine",
+            "expression": "3.0.0",
+            "define": "CINEMACHINE_3_OR_NEWER"
         }
     ],
     "noEngineReferences": false

--- a/Assets/Tests/Demo/UnityCLILoop.Tests.Demo.asmdef
+++ b/Assets/Tests/Demo/UnityCLILoop.Tests.Demo.asmdef
@@ -20,6 +20,11 @@
             "name": "com.unity.inputsystem",
             "expression": "",
             "define": "ULOOP_HAS_INPUT_SYSTEM"
+        },
+        {
+            "name": "com.unity.cinemachine",
+            "expression": "3.0.0",
+            "define": "CINEMACHINE_3_OR_NEWER"
         }
     ],
     "noEngineReferences": false

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -12,7 +12,6 @@
     "com.unity.render-pipelines.universal": "14.0.12",
     "com.unity.terrain-tools": "5.0.6",
     "com.unity.test-framework": "1.3.9",
-    "com.unity.toonshader": "0.12.0-preview",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.imageconversion": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -195,18 +195,6 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.timeline": {
-      "version": "1.7.7",
-      "depth": 2,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.modules.audio": "1.0.0",
-        "com.unity.modules.director": "1.0.0",
-        "com.unity.modules.animation": "1.0.0",
-        "com.unity.modules.particlesystem": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.ugui": {
       "version": "1.0.0",
       "depth": 0,
@@ -232,21 +220,6 @@
       "source": "builtin",
       "dependencies": {}
     },
-    "com.unity.modules.audio": {
-      "version": "1.0.0",
-      "depth": 3,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.modules.director": {
-      "version": "1.0.0",
-      "depth": 3,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.audio": "1.0.0",
-        "com.unity.modules.animation": "1.0.0"
-      }
-    },
     "com.unity.modules.imageconversion": {
       "version": "1.0.0",
       "depth": 0,
@@ -262,12 +235,6 @@
     "com.unity.modules.jsonserialize": {
       "version": "1.0.0",
       "depth": 1,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.modules.particlesystem": {
-      "version": "1.0.0",
-      "depth": 3,
       "source": "builtin",
       "dependencies": {}
     },

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -59,16 +59,6 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
-    "com.unity.film-internal-utilities": {
-      "version": "0.19.2-preview",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.timeline": "1.2.18",
-        "com.unity.modules.uielements": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.ide.rider": {
       "version": "3.0.36",
       "depth": 0,
@@ -214,16 +204,6 @@
         "com.unity.modules.director": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.toonshader": {
-      "version": "0.12.0-preview",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.render-pipelines.core": "10.0.0",
-        "com.unity.film-internal-utilities": "0.19.2-preview"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
## Summary
- Unity 6000.7 can compile this development project again: the unused Toon Shader package is gone, and the Cinemachine 2.x mouse-look demo scripts stay out of the 6000.7 build.

## User Impact
- Before: opening the project in Unity 6000.7 failed compile with CS0246 on the Cinemachine 2.x demo scripts and CS0308 from `com.unity.toonshader` 0.12.0-preview.
- After: those errors are gone on 6000.7. The mouse-input demo scene builder menu item is unavailable wherever Cinemachine is 3.0.0 or newer; that demo is validated on the 6000.3 development line instead.

## Changes
- Removed `com.unity.toonshader` (and its lock-only parent `com.unity.film-internal-utilities`) from the committed package manifest.
- Also removed the orphan lock subtree that parent left behind: `com.unity.timeline`, `com.unity.modules.director`, `com.unity.modules.particlesystem`, and `com.unity.modules.audio`. Those entries were not direct manifest dependencies.
- Demo asmdefs define `CINEMACHINE_3_OR_NEWER` from `com.unity.cinemachine` version `3.0.0`. The two demo scripts compile only under `ULOOP_HAS_INPUT_SYSTEM && !CINEMACHINE_3_OR_NEWER`.

## Verification
- Local Editor: Unity 6000.7.0a4. This PR targets `feature/hot-reload`, so repository `pull_request` CI does not run; the checks below are local.
- `dist/darwin-arm64/uloop compile`: `ErrorCount: 0`. `DemoMouseLook.cs` / `DemoMouseSceneBuilder.cs` produced no warnings.
- Remaining `WarningCount: 10` are existing 6000.7 obsolete/UAL diagnostics on other Demo files, out of this PR's scope (same policy as the 6000.x EditMode job, which does not gate on zero warnings after an in-place upgrade):
  - `Assets/Tests/Demo/UiReplayVerificationController.cs:31` CS0618 `FindObjectsSortMode` / `FindObjectsByType` (2)
  - `Assets/Tests/Demo/Minecraft/Scripts/Player/AutoPlayer.cs:38-39` CS0618 `FindFirstObjectByType` (4, duplicated across two compile passes)
  - `Assets/Tests/Demo/ClickCounterButton.cs:10,21` UAL0010 / UAL0013 (4, duplicated across two compile passes)
- `uloop execute-dynamic-code` type scan: `GetType DemoMouseLook=null; GetType DemoMouseSceneBuilder=null; sawDemoAssembly=True; sawDemoEditorAssembly=True; lookHits=0; builderHits=0`
- `uloop run-tests --filter-type regex --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"`: `TestCount: 181`, `PassedCount: 181`, `FailedCount: 0` (regression only; this suite does not compile the Demo assembly)
- Committed lock after the orphan cleanup: `json.load` succeeds (36 remaining dependency keys); entries with `depth>0`, no remaining parent, and not listed in the manifest: 0; remaining entries depending on the four deleted packages: 0. The staged lock diff was deletions only (`33-`).
- Committed `Packages/manifest.json` / `packages-lock.json` still cannot be exercised by the local 6000.7 Editor (it reads the worktree). The next scheduled 2022.3 EditMode run is the first real check of the committed manifest/lock.
