### PR TITLE
ci: add a resolver for the newest 6000.7-series editor release

### DIFF
--- a/cli/release-automation/cmd/resolve-unity-release/main.go
+++ b/cli/release-automation/cmd/resolve-unity-release/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/hatayama/unity-cli-loop/tools/release-automation/internal/automation"
+)
+
+func main() {
+	os.Exit(automation.RunResolveUnityRelease(os.Stdout, os.Stderr, os.Args[1:]))
+}

--- a/cli/release-automation/internal/automation/testdata/unity-release-empty.json
+++ b/cli/release-automation/internal/automation/testdata/unity-release-empty.json
@@ -1,0 +1,6 @@
+{
+  "offset": 0,
+  "limit": 1,
+  "total": 0,
+  "results": []
+}

--- a/cli/release-automation/internal/automation/testdata/unity-release-latest-first.json
+++ b/cli/release-automation/internal/automation/testdata/unity-release-latest-first.json
@@ -1,0 +1,37 @@
+{
+  "offset": 0,
+  "limit": 25,
+  "total": 2,
+  "results": [
+    {
+      "version": "6000.7.0a5",
+      "shortRevision": "bbbbbbbbbbbb",
+      "downloads": [
+        {
+          "platform": "WINDOWS",
+          "architecture": "X86_64",
+          "type": "EXE",
+          "url": "https://example.invalid/UnitySetup64-6000.7.0a5.exe"
+        },
+        {
+          "platform": "LINUX",
+          "architecture": "X86_64",
+          "type": "TAR_XZ",
+          "url": "https://example.invalid/Unity-6000.7.0a5.tar.xz"
+        }
+      ]
+    },
+    {
+      "version": "6000.7.0a4",
+      "shortRevision": "7305b6f6fd4f",
+      "downloads": [
+        {
+          "platform": "LINUX",
+          "architecture": "X86_64",
+          "type": "TAR_XZ",
+          "url": "https://example.invalid/Unity-6000.7.0a4.tar.xz"
+        }
+      ]
+    }
+  ]
+}

--- a/cli/release-automation/internal/automation/testdata/unity-release-missing-linux.json
+++ b/cli/release-automation/internal/automation/testdata/unity-release-missing-linux.json
@@ -1,0 +1,19 @@
+{
+  "offset": 0,
+  "limit": 1,
+  "total": 1,
+  "results": [
+    {
+      "version": "6000.7.0a4",
+      "shortRevision": "7305b6f6fd4f",
+      "downloads": [
+        {
+          "platform": "MAC_OS",
+          "architecture": "ARM64",
+          "type": "PKG",
+          "url": "https://example.invalid/Unity-6000.7.0a4.pkg"
+        }
+      ]
+    }
+  ]
+}

--- a/cli/release-automation/internal/automation/unity_release_resolver.go
+++ b/cli/release-automation/internal/automation/unity_release_resolver.go
@@ -1,0 +1,205 @@
+package automation
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	defaultUnityReleaseAPIBaseURL    = "https://services.api.unity.com"
+	unityEditorReleasesPath          = "/unity/editor/release/v1/releases"
+	unityReleaseQueryVersion         = "version"
+	unityReleaseQueryOrder           = "order"
+	unityReleaseQueryLimit           = "limit"
+	unityReleaseOrderReleaseDateDesc = "RELEASE_DATE_DESC"
+	unityReleaseLimitLatest          = "1"
+	downloadPlatformLinux            = "LINUX"
+	downloadArchitectureX86_64       = "X86_64"
+	downloadTypeTarXz                = "TAR_XZ"
+	githubOutputVersion              = "version"
+	githubOutputChangeset            = "changeset"
+	githubOutputEditorURL            = "editorUrl"
+)
+
+// UnityRelease is the newest editor in a version series plus its Linux download URL.
+type UnityRelease struct {
+	Version   string
+	Changeset string
+	EditorURL string
+}
+
+// ResolveUnityReleaseRequest is the caller-supplied series and optional HTTP seam for tests.
+type ResolveUnityReleaseRequest struct {
+	Series     string
+	APIBaseURL string
+	HTTPClient *http.Client
+}
+
+type unityReleaseList struct {
+	Results []unityReleaseResult `json:"results"`
+}
+
+type unityReleaseResult struct {
+	Version       string                 `json:"version"`
+	ShortRevision string                 `json:"shortRevision"`
+	Downloads     []unityReleaseDownload `json:"downloads"`
+}
+
+type unityReleaseDownload struct {
+	Platform     string `json:"platform"`
+	Architecture string `json:"architecture"`
+	Type         string `json:"type"`
+	URL          string `json:"url"`
+}
+
+// ResolveUnityRelease fetches the newest editor release for series in one query.
+func ResolveUnityRelease(ctx context.Context, request ResolveUnityReleaseRequest) (UnityRelease, error) {
+	if request.Series == "" {
+		return UnityRelease{}, fmt.Errorf("--series is required")
+	}
+
+	client := request.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	apiBaseURL := request.APIBaseURL
+	if apiBaseURL == "" {
+		apiBaseURL = defaultUnityReleaseAPIBaseURL
+	}
+
+	requestURL, err := unityReleasesRequestURL(apiBaseURL, request.Series)
+	if err != nil {
+		return UnityRelease{}, err
+	}
+
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return UnityRelease{}, fmt.Errorf("build unity release request: %w", err)
+	}
+
+	response, err := client.Do(httpRequest)
+	if err != nil {
+		return UnityRelease{}, fmt.Errorf("unity release API request failed: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusOK {
+		return UnityRelease{}, fmt.Errorf("unity release API returned HTTP %d", response.StatusCode)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return UnityRelease{}, fmt.Errorf("read unity release API response: %w", err)
+	}
+
+	return selectUnityRelease(body)
+}
+
+// WriteGitHubOutput writes version, changeset, and editorUrl as GITHUB_OUTPUT assignments.
+func WriteGitHubOutput(writer io.Writer, release UnityRelease) error {
+	_, err := fmt.Fprintf(
+		writer,
+		"%s=%s\n%s=%s\n%s=%s\n",
+		githubOutputVersion,
+		release.Version,
+		githubOutputChangeset,
+		release.Changeset,
+		githubOutputEditorURL,
+		release.EditorURL,
+	)
+	return err
+}
+
+// RunResolveUnityRelease parses CLI args, resolves the series, and prints GITHUB_OUTPUT lines.
+func RunResolveUnityRelease(stdout io.Writer, stderr io.Writer, args []string) int {
+	flags := flag.NewFlagSet("resolve-unity-release", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	series := flags.String("series", "", "Unity editor version series to resolve, for example 6000.7")
+	parseErr := flags.Parse(args)
+	if parseErr != nil {
+		return 1
+	}
+	if *series == "" {
+		_, _ = fmt.Fprintln(stderr, "resolve-unity-release: --series is required")
+		return 1
+	}
+
+	release, err := ResolveUnityRelease(context.Background(), ResolveUnityReleaseRequest{Series: *series})
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "resolve-unity-release:", err)
+		return 1
+	}
+
+	writeErr := WriteGitHubOutput(stdout, release)
+	if writeErr != nil {
+		_, _ = fmt.Fprintln(stderr, "resolve-unity-release:", writeErr)
+		return 1
+	}
+	return 0
+}
+
+func selectUnityRelease(body []byte) (UnityRelease, error) {
+	var payload unityReleaseList
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return UnityRelease{}, fmt.Errorf("parse unity release response: %w", err)
+	}
+	if len(payload.Results) == 0 {
+		return UnityRelease{}, fmt.Errorf("no unity editor releases matched the requested series")
+	}
+	return releaseFromAPIResult(payload.Results[0])
+}
+
+func releaseFromAPIResult(result unityReleaseResult) (UnityRelease, error) {
+	if result.Version == "" || result.ShortRevision == "" {
+		return UnityRelease{}, fmt.Errorf("unity release is missing version or shortRevision")
+	}
+	editorURL, err := linuxEditorDownloadURL(result.Downloads)
+	if err != nil {
+		return UnityRelease{}, err
+	}
+	return UnityRelease{
+		Version:   result.Version,
+		Changeset: result.ShortRevision,
+		EditorURL: editorURL,
+	}, nil
+}
+
+func linuxEditorDownloadURL(downloads []unityReleaseDownload) (string, error) {
+	for _, download := range downloads {
+		if !isLinuxEditorArchive(download) {
+			continue
+		}
+		if download.URL == "" {
+			return "", fmt.Errorf("unity release LINUX X86_64 TAR_XZ download is missing url")
+		}
+		return download.URL, nil
+	}
+	return "", fmt.Errorf("unity release has no LINUX X86_64 TAR_XZ editor download")
+}
+
+func isLinuxEditorArchive(download unityReleaseDownload) bool {
+	return download.Platform == downloadPlatformLinux &&
+		download.Architecture == downloadArchitectureX86_64 &&
+		download.Type == downloadTypeTarXz
+}
+
+func unityReleasesRequestURL(apiBaseURL string, series string) (string, error) {
+	parsed, err := url.Parse(apiBaseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse unity release API base URL: %w", err)
+	}
+	parsed = parsed.JoinPath(strings.TrimPrefix(unityEditorReleasesPath, "/"))
+	query := parsed.Query()
+	query.Set(unityReleaseQueryVersion, series)
+	query.Set(unityReleaseQueryOrder, unityReleaseOrderReleaseDateDesc)
+	query.Set(unityReleaseQueryLimit, unityReleaseLimitLatest)
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
+}

--- a/cli/release-automation/internal/automation/unity_release_resolver.go
+++ b/cli/release-automation/internal/automation/unity_release_resolver.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 const (
@@ -25,6 +26,7 @@ const (
 	githubOutputVersion              = "version"
 	githubOutputChangeset            = "changeset"
 	githubOutputEditorURL            = "editorUrl"
+	unityReleaseAPITimeout           = 2 * time.Minute
 )
 
 // UnityRelease is the newest editor in a version series plus its Linux download URL.
@@ -131,7 +133,9 @@ func RunResolveUnityRelease(stdout io.Writer, stderr io.Writer, args []string) i
 		return 1
 	}
 
-	release, err := ResolveUnityRelease(context.Background(), ResolveUnityReleaseRequest{Series: *series})
+	ctx, cancel := context.WithTimeout(context.Background(), unityReleaseAPITimeout)
+	defer cancel()
+	release, err := ResolveUnityRelease(ctx, ResolveUnityReleaseRequest{Series: *series})
 	if err != nil {
 		_, _ = fmt.Fprintln(stderr, "resolve-unity-release:", err)
 		return 1

--- a/cli/release-automation/internal/automation/unity_release_resolver_test.go
+++ b/cli/release-automation/internal/automation/unity_release_resolver_test.go
@@ -1,0 +1,146 @@
+package automation
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSelectUnityReleasePicksFirstResultAsLatest(t *testing.T) {
+	// What: a multi-result fixture ordered newest-first selects results[0] and its Linux TAR_XZ URL.
+	body := readUnityReleaseFixture(t, "unity-release-latest-first.json")
+
+	release, err := selectUnityRelease(body)
+	if err != nil {
+		t.Fatalf("expected fixture to parse: %v", err)
+	}
+	if release.Version != "6000.7.0a5" {
+		t.Fatalf("expected first (newest) version, got %q", release.Version)
+	}
+	if release.Changeset != "bbbbbbbbbbbb" {
+		t.Fatalf("expected first shortRevision, got %q", release.Changeset)
+	}
+	if release.EditorURL != "https://example.invalid/Unity-6000.7.0a5.tar.xz" {
+		t.Fatalf("expected first Linux editor URL, got %q", release.EditorURL)
+	}
+}
+
+func TestSelectUnityReleaseRejectsEmptyResults(t *testing.T) {
+	// What: an empty results list is a resolver failure, not a blank GitHub output.
+	body := readUnityReleaseFixture(t, "unity-release-empty.json")
+
+	_, err := selectUnityRelease(body)
+	if err == nil {
+		t.Fatal("expected empty results to fail")
+	}
+	if !strings.Contains(err.Error(), "no unity editor releases") {
+		t.Fatalf("expected empty-results message, got %v", err)
+	}
+}
+
+func TestSelectUnityReleaseRejectsMissingLinuxEditorDownload(t *testing.T) {
+	// What: a release without LINUX/X86_64/TAR_XZ is a resolver failure instead of a hand-built URL.
+	body := readUnityReleaseFixture(t, "unity-release-missing-linux.json")
+
+	_, err := selectUnityRelease(body)
+	if err == nil {
+		t.Fatal("expected missing Linux editor download to fail")
+	}
+	if !strings.Contains(err.Error(), "LINUX") {
+		t.Fatalf("expected missing-download message, got %v", err)
+	}
+}
+
+func TestResolveUnityReleaseFiltersBySeriesQuery(t *testing.T) {
+	// What: the resolver sends one query whose version= parameter is the caller-supplied series, not a hardcoded 6000.7.
+	var captured url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		captured = request.URL.Query()
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write(readUnityReleaseFixture(t, "unity-release-latest-first.json"))
+	}))
+	t.Cleanup(server.Close)
+
+	release, err := ResolveUnityRelease(context.Background(), ResolveUnityReleaseRequest{
+		Series:     "6000.5",
+		APIBaseURL: server.URL,
+		HTTPClient: server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("expected series query to succeed: %v", err)
+	}
+	if captured.Get(unityReleaseQueryVersion) != "6000.5" {
+		t.Fatalf("expected version query %q, got %q", "6000.5", captured.Get(unityReleaseQueryVersion))
+	}
+	if captured.Get(unityReleaseQueryOrder) != unityReleaseOrderReleaseDateDesc {
+		t.Fatalf("expected order %q, got %q", unityReleaseOrderReleaseDateDesc, captured.Get(unityReleaseQueryOrder))
+	}
+	if captured.Get(unityReleaseQueryLimit) != unityReleaseLimitLatest {
+		t.Fatalf("expected limit %q, got %q", unityReleaseLimitLatest, captured.Get(unityReleaseQueryLimit))
+	}
+	if release.Version != "6000.7.0a5" {
+		t.Fatalf("expected parsed version from fixture, got %q", release.Version)
+	}
+}
+
+func TestResolveUnityReleaseRejectsHTTPError(t *testing.T) {
+	// What: a non-200 Unity Release API response fails the resolver with the status code.
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusBadGateway)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := ResolveUnityRelease(context.Background(), ResolveUnityReleaseRequest{
+		Series:     "6000.7",
+		APIBaseURL: server.URL,
+		HTTPClient: server.Client(),
+	})
+	if err == nil {
+		t.Fatal("expected HTTP error to fail")
+	}
+	if !strings.Contains(err.Error(), "502") {
+		t.Fatalf("expected HTTP 502 in error, got %v", err)
+	}
+}
+
+func TestWriteGitHubOutputWritesVersionChangesetAndEditorURL(t *testing.T) {
+	// What: resolver stdout is GITHUB_OUTPUT assignments for version, changeset, and editorUrl.
+	builder := &strings.Builder{}
+	err := WriteGitHubOutput(builder, UnityRelease{
+		Version:   "6000.7.0a4",
+		Changeset: "7305b6f6fd4f",
+		EditorURL: "https://example.invalid/Unity-6000.7.0a4.tar.xz",
+	})
+	if err != nil {
+		t.Fatalf("expected GitHub output write to succeed: %v", err)
+	}
+
+	got := builder.String()
+	want := "version=6000.7.0a4\nchangeset=7305b6f6fd4f\neditorUrl=https://example.invalid/Unity-6000.7.0a4.tar.xz\n"
+	if got != want {
+		t.Fatalf("GitHub output mismatch\nwant %q\ngot  %q", want, got)
+	}
+}
+
+func TestRunResolveUnityReleaseRequiresSeries(t *testing.T) {
+	// What: the CLI rejects a missing --series instead of defaulting to a hardcoded Unity series.
+	exitCode := RunResolveUnityRelease(io.Discard, io.Discard, []string{})
+	if exitCode == 0 {
+		t.Fatal("expected missing --series to exit non-zero")
+	}
+}
+
+func readUnityReleaseFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return body
+}

--- a/cli/release-automation/internal/automation/unity_release_resolver_test.go
+++ b/cli/release-automation/internal/automation/unity_release_resolver_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSelectUnityReleasePicksFirstResultAsLatest(t *testing.T) {
@@ -106,6 +107,25 @@ func TestResolveUnityReleaseRejectsHTTPError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "502") {
 		t.Fatalf("expected HTTP 502 in error, got %v", err)
+	}
+}
+
+func TestResolveUnityReleaseHonorsContextDeadline(t *testing.T) {
+	// What: a stalled Unity Release API fails when the caller context deadline expires.
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		<-request.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := ResolveUnityRelease(ctx, ResolveUnityReleaseRequest{
+		Series:     "6000.7",
+		APIBaseURL: server.URL,
+		HTTPClient: server.Client(),
+	})
+	if err == nil {
+		t.Fatal("expected a deadline to fail a stalled request")
 	}
 }
 


### PR DESCRIPTION
## Summary
- CI can resolve the newest Unity editor in a version series (for example 6000.7) and print the official Linux editor download URL as GitHub Actions output.

## User Impact
- Before: scheduled EditMode jobs could only target GameCI image tags, so 6000.7 alpha/beta editors were unreachable.
- After: a resolver command looks up the newest release in a caller-supplied series and emits `version`, `changeset`, and `editorUrl` for a follow-up install job.

## Changes
- Added `cmd/resolve-unity-release` with required `--series`.
- One Unity Release API query: `version=<series>&order=RELEASE_DATE_DESC&limit=1`. The Linux `X86_64` `TAR_XZ` URL comes from `downloads[]`; it is never hand-built.
- Empty results, HTTP failures, and a missing Linux archive exit non-zero.

## Verification
- This PR targets `feature/hot-reload`, so repository `pull_request` CI does not run.
- Local `scripts/check-go-cli.sh` passed (format, vet, lint, module tests, dist rebuild).
- Resolver tests: series is sent as `version=` (not hardcoded), first fixture result is selected, empty results fail, missing LINUX/X86_64/TAR_XZ fails, HTTP 502 fails, GITHUB_OUTPUT keys are `version` / `changeset` / `editorUrl`, missing `--series` exits non-zero.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

