### PR TITLE
ci: run the hot-reload suite on the newest 6000.7-series editor

### DIFF
--- a/.github/workflows/unity-editmode-tests.yml
+++ b/.github/workflows/unity-editmode-tests.yml
@@ -231,16 +231,12 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           df -h
 
-      - name: Cache Linux editor tarball
-        if: env.HAS_UNITY_LICENSE == 'true'
-        id: editor-tarball-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
-        with:
-          path: ${{ env.UNITY_TARBALL }}
-          key: unity-linux-editor-${{ env.UNITY_VERSION }}-${{ env.UNITY_CHANGESET }}
-
+      # Why not cache the tarball: a single 6000.7 Linux editor archive is
+      # ~4GB and would exceed the 10GB Actions cache quota, evicting the
+      # existing GameCI Library caches. Re-download is ~2 minutes with curl
+      # retries, which is cheaper than that eviction.
       - name: Download Linux editor
-        if: env.HAS_UNITY_LICENSE == 'true' && steps.editor-tarball-cache.outputs.cache-hit != 'true'
+        if: env.HAS_UNITY_LICENSE == 'true'
         run: |
           set -eu
           mkdir -p .unity-ci
@@ -294,11 +290,16 @@ jobs:
           SERIAL=$(tail -c +5 "$RUNNER_TEMP/developer-data.bin" | tr -d "\r\n")
           test "${#SERIAL}" -eq 27
 
+          # Why RUNNER_TEMP: Unity prints -username unmasked in COMMAND LINE
+          # ARGUMENTS. artifacts/ is uploaded from a public repository.
+          ACTIVATE_LOG="$RUNNER_TEMP/unity-activate.log"
+          ACTIVATE_FALLBACK_LOG="$RUNNER_TEMP/unity-activate-fallback.log"
+
           ACTIVATED=false
           ATTEMPT=1
           while [ "$ATTEMPT" -le 3 ]; do
             if "$UNITY_EDITOR" -batchmode -nographics -quit \
-              -logFile artifacts/unity-activate.log \
+              -logFile "$ACTIVATE_LOG" \
               -serial "$SERIAL" \
               -username "$UNITY_EMAIL" \
               -password "$UNITY_PASSWORD" \
@@ -307,17 +308,22 @@ jobs:
               break
             fi
             echo "Serial activation attempt $ATTEMPT failed"
+            tail -n 80 "$ACTIVATE_LOG" || true
             ATTEMPT=$((ATTEMPT + 1))
             sleep $((ATTEMPT * 5))
           done
 
           if [ "$ACTIVATED" != true ]; then
             echo "Serial activation failed; falling back to email/password"
-            "$UNITY_EDITOR" -batchmode -nographics -quit \
-              -logFile artifacts/unity-activate-fallback.log \
+            if ! "$UNITY_EDITOR" -batchmode -nographics -quit \
+              -logFile "$ACTIVATE_FALLBACK_LOG" \
               -username "$UNITY_EMAIL" \
               -password "$UNITY_PASSWORD" \
-              -projectPath "$RUNNER_TEMP/BlankProject"
+              -projectPath "$RUNNER_TEMP/BlankProject"; then
+              echo "Email/password fallback failed"
+              tail -n 80 "$ACTIVATE_FALLBACK_LOG" || true
+              exit 1
+            fi
           fi
 
           # Why: this job invokes the extracted Editor binary, not GameCI's

--- a/.github/workflows/unity-editmode-tests.yml
+++ b/.github/workflows/unity-editmode-tests.yml
@@ -181,3 +181,156 @@ jobs:
         with:
           name: Unity test results (${{ matrix.unity-version }})
           path: artifacts
+
+  resolve-latest-6000-7:
+    name: Resolve latest 6000.7 editor
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      changeset: ${{ steps.resolve.outputs.changeset }}
+      editorUrl: ${{ steps.resolve.outputs.editorUrl }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: cli/.go-version
+
+      - name: Resolve newest 6000.7-series Linux editor
+        id: resolve
+        working-directory: cli/release-automation
+        run: go run ./cmd/resolve-unity-release --series 6000.7 >> "$GITHUB_OUTPUT"
+
+  editmode-tests-latest-alpha:
+    name: EditMode Tests (latest 6000.7)
+    runs-on: ubuntu-latest
+    needs: resolve-latest-6000-7
+    timeout-minutes: 90
+    env:
+      HAS_UNITY_LICENSE: ${{ secrets.UNITY_LICENSE != '' }}
+      UNITY_VERSION: ${{ needs.resolve-latest-6000-7.outputs.version }}
+      UNITY_CHANGESET: ${{ needs.resolve-latest-6000-7.outputs.changeset }}
+      UNITY_EDITOR_URL: ${{ needs.resolve-latest-6000-7.outputs.editorUrl }}
+      UNITY_TARBALL: ${{ runner.temp }}/unity-linux-editor.tar.xz
+      UNITY_INSTALL_DIR: ${{ runner.temp }}/unity-editor
+      HOT_RELOAD_TEST_FILTER: io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+    steps:
+      - name: Checkout repository
+        if: env.HAS_UNITY_LICENSE == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          lfs: true
+
+      - name: Free disk space
+        if: env.HAS_UNITY_LICENSE == 'true'
+        run: |
+          set -eu
+          df -h
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h
+
+      - name: Cache Linux editor tarball
+        if: env.HAS_UNITY_LICENSE == 'true'
+        id: editor-tarball-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: ${{ env.UNITY_TARBALL }}
+          key: unity-linux-editor-${{ env.UNITY_VERSION }}-${{ env.UNITY_CHANGESET }}
+
+      - name: Download Linux editor
+        if: env.HAS_UNITY_LICENSE == 'true' && steps.editor-tarball-cache.outputs.cache-hit != 'true'
+        run: |
+          set -eu
+          curl --fail --location --retry 3 --retry-delay 5 \
+            --output "$UNITY_TARBALL" \
+            "$UNITY_EDITOR_URL"
+          ls -lh "$UNITY_TARBALL"
+
+      - name: Install Linux editor
+        if: env.HAS_UNITY_LICENSE == 'true'
+        id: install-editor
+        run: |
+          set -eu
+          mkdir -p "$UNITY_INSTALL_DIR"
+          tar -xJf "$UNITY_TARBALL" -C "$UNITY_INSTALL_DIR"
+          UNITY_EDITOR=$(find "$UNITY_INSTALL_DIR" -path '*/Editor/Unity' -type f -print -quit)
+          test -n "$UNITY_EDITOR"
+          test -x "$UNITY_EDITOR"
+          echo "UNITY_EDITOR=$UNITY_EDITOR" >> "$GITHUB_ENV"
+          echo "editor=$UNITY_EDITOR" >> "$GITHUB_OUTPUT"
+          echo "Installed Unity $UNITY_VERSION at $UNITY_EDITOR"
+          df -h
+
+      - name: Cache Library folder
+        if: env.HAS_UNITY_LICENSE == 'true'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: Library
+          key: Library-${{ env.UNITY_VERSION }}-${{ hashFiles('Packages/src/**/*.cs', 'Assets/**/*.cs', 'Packages/manifest.json', 'Packages/packages-lock.json') }}
+          restore-keys: |
+            Library-${{ env.UNITY_VERSION }}-
+
+      - name: Activate Unity license and run EditMode tests
+        if: env.HAS_UNITY_LICENSE == 'true'
+        timeout-minutes: 60
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        run: |
+          set -eu
+          mkdir -p artifacts "$RUNNER_TEMP/BlankProject/Assets"
+          trap '"$UNITY_EDITOR" -batchmode -nographics -quit -returnlicense \
+            -logFile /dev/stdout \
+            -username "$UNITY_EMAIL" -password "$UNITY_PASSWORD" \
+            -projectPath "$RUNNER_TEMP/BlankProject" >/dev/null 2>&1 || true' EXIT
+
+          LICENSE_VALUE=$(printf "%s" "$UNITY_LICENSE" | tr "\n" " " | sed -n 's/.*<DeveloperData Value="\([^"]*\)"\/>.*/\1/p')
+          test -n "$LICENSE_VALUE"
+          printf "%s" "$LICENSE_VALUE" | base64 -d > "$RUNNER_TEMP/developer-data.bin"
+          SERIAL=$(tail -c +5 "$RUNNER_TEMP/developer-data.bin" | tr -d "\r\n")
+          test "${#SERIAL}" -eq 27
+
+          ACTIVATED=false
+          ATTEMPT=1
+          while [ "$ATTEMPT" -le 3 ]; do
+            if "$UNITY_EDITOR" -batchmode -nographics -quit \
+              -logFile artifacts/unity-activate.log \
+              -serial "$SERIAL" \
+              -username "$UNITY_EMAIL" \
+              -password "$UNITY_PASSWORD" \
+              -projectPath "$RUNNER_TEMP/BlankProject"; then
+              ACTIVATED=true
+              break
+            fi
+            echo "Serial activation attempt $ATTEMPT failed"
+            ATTEMPT=$((ATTEMPT + 1))
+            sleep $((ATTEMPT * 5))
+          done
+
+          if [ "$ACTIVATED" != true ]; then
+            echo "Serial activation failed; falling back to email/password"
+            "$UNITY_EDITOR" -batchmode -nographics -quit \
+              -logFile artifacts/unity-activate-fallback.log \
+              -username "$UNITY_EMAIL" \
+              -password "$UNITY_PASSWORD" \
+              -projectPath "$RUNNER_TEMP/BlankProject"
+          fi
+
+          "$UNITY_EDITOR" -batchmode -nographics \
+            -projectPath "$GITHUB_WORKSPACE" \
+            -accept-apiupdate \
+            -runTests \
+            -testPlatform EditMode \
+            -testFilter "$HOT_RELOAD_TEST_FILTER" \
+            -testResults artifacts/editmode-latest-6000-7.xml \
+            -logFile artifacts/unity-editmode-latest-6000-7.log
+
+      - name: Upload latest 6000.7 test results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        if: always() && env.HAS_UNITY_LICENSE == 'true'
+        with:
+          name: Unity test results (latest 6000.7)
+          path: artifacts

--- a/.github/workflows/unity-editmode-tests.yml
+++ b/.github/workflows/unity-editmode-tests.yml
@@ -320,9 +320,11 @@ jobs:
               -projectPath "$RUNNER_TEMP/BlankProject"
           fi
 
-          # Why -debugCodeOptimization: Linux batchmode starts in Release.
-          # Pause-point HotReload tests reject Release, and tiny patched
-          # getters get JIT-inlined so they would not observe the edit.
+          # Why: this job invokes the extracted Editor binary, not GameCI's
+          # unity-test-runner (no 6000.7 Docker image). That runner always
+          # passes -debugCodeOptimization; Linux batchmode otherwise starts
+          # in Release, which rejects pause-point enable and JIT-inlines
+          # tiny patched getters.
           "$UNITY_EDITOR" -batchmode -nographics -debugCodeOptimization \
             -projectPath "$GITHUB_WORKSPACE" \
             -accept-apiupdate \

--- a/.github/workflows/unity-editmode-tests.yml
+++ b/.github/workflows/unity-editmode-tests.yml
@@ -236,7 +236,7 @@ jobs:
         id: editor-tarball-cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
-          path: .unity-ci/unity-linux-editor.tar.xz
+          path: ${{ env.UNITY_TARBALL }}
           key: unity-linux-editor-${{ env.UNITY_VERSION }}-${{ env.UNITY_CHANGESET }}
 
       - name: Download Linux editor
@@ -269,9 +269,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: Library
-          key: Library-${{ env.UNITY_VERSION }}-${{ hashFiles('Packages/src/**/*.cs', 'Assets/**/*.cs', 'Packages/manifest.json', 'Packages/packages-lock.json') }}
+          key: Library-${{ env.UNITY_VERSION }}-debug-${{ hashFiles('Packages/src/**/*.cs', 'Assets/**/*.cs', 'Packages/manifest.json', 'Packages/packages-lock.json') }}
           restore-keys: |
-            Library-${{ env.UNITY_VERSION }}-
+            Library-${{ env.UNITY_VERSION }}-debug-
 
       - name: Activate Unity license and run EditMode tests
         if: env.HAS_UNITY_LICENSE == 'true'
@@ -320,7 +320,10 @@ jobs:
               -projectPath "$RUNNER_TEMP/BlankProject"
           fi
 
-          "$UNITY_EDITOR" -batchmode -nographics \
+          # Why -debugCodeOptimization: Linux batchmode starts in Release.
+          # Pause-point HotReload tests reject Release, and tiny patched
+          # getters get JIT-inlined so they would not observe the edit.
+          "$UNITY_EDITOR" -batchmode -nographics -debugCodeOptimization \
             -projectPath "$GITHUB_WORKSPACE" \
             -accept-apiupdate \
             -runTests \

--- a/.github/workflows/unity-editmode-tests.yml
+++ b/.github/workflows/unity-editmode-tests.yml
@@ -213,8 +213,8 @@ jobs:
       UNITY_VERSION: ${{ needs.resolve-latest-6000-7.outputs.version }}
       UNITY_CHANGESET: ${{ needs.resolve-latest-6000-7.outputs.changeset }}
       UNITY_EDITOR_URL: ${{ needs.resolve-latest-6000-7.outputs.editorUrl }}
-      UNITY_TARBALL: ${{ runner.temp }}/unity-linux-editor.tar.xz
-      UNITY_INSTALL_DIR: ${{ runner.temp }}/unity-editor
+      UNITY_TARBALL: .unity-ci/unity-linux-editor.tar.xz
+      UNITY_INSTALL_DIR: .unity-ci/unity-editor
       HOT_RELOAD_TEST_FILTER: io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     steps:
       - name: Checkout repository
@@ -236,13 +236,14 @@ jobs:
         id: editor-tarball-cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
-          path: ${{ env.UNITY_TARBALL }}
+          path: .unity-ci/unity-linux-editor.tar.xz
           key: unity-linux-editor-${{ env.UNITY_VERSION }}-${{ env.UNITY_CHANGESET }}
 
       - name: Download Linux editor
         if: env.HAS_UNITY_LICENSE == 'true' && steps.editor-tarball-cache.outputs.cache-hit != 'true'
         run: |
           set -eu
+          mkdir -p .unity-ci
           curl --fail --location --retry 3 --retry-delay 5 \
             --output "$UNITY_TARBALL" \
             "$UNITY_EDITOR_URL"


### PR DESCRIPTION
## Summary
- Scheduled EditMode coverage now follows the newest Unity 6000.7-series Linux editor, including alphas that GameCI does not ship.

## User Impact
- Before: the EditMode matrix stopped at 6000.5.8f1, so a 6000.7 compile or hot-reload break was invisible until someone opened the editor locally.
- After: the nightly (and manual) EditMode workflow resolves the newest 6000.7-series editor, installs its Linux tarball, and runs the same hot-reload suite as the other 6000.x legs. A 6000.7 break fails the job; there is no `continue-on-error`.

## Changes
- Added `resolve-latest-6000-7` to run `resolve-unity-release --series 6000.7` and expose `version` / `changeset` / `editorUrl`.
- Added `editmode-tests-latest-alpha`: download the Release API Linux TAR_XZ, extract `Editor/Unity`, activate with existing Unity secrets (serial from the ULF, email/password fallback), then `-runTests -testFilter io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload`.
- The extracted Editor binary gets `-debugCodeOptimization` (GameCI's `unity-test-runner` already injects that on the sibling 6000.x legs). Library cache key uses a `debug` prefix.
- Activate logs stay in `$RUNNER_TEMP` and are tailed to workflow stdout only on failure. They are not uploaded. Unity prints `-username` unmasked in `COMMAND LINE ARGUMENTS`; GitHub masks secrets in stdout.
- The Linux editor tarball is not cached. A ~4GB archive exceeds the 10GB Actions cache quota and would evict existing GameCI Library caches; re-download is ~2 minutes.
- The workflow stays `schedule` + `workflow_dispatch` only.

## Verification
- This PR targets `feature/hot-reload`, so repository `pull_request` CI does not run.
- `go test ./internal/architecture -run 'TestWorkflowActions|TestPullRequestWorkflow' -count=1` in `cli/release-automation` passed.

### Leaked artifacts and tarball cache (deleted)
- Run 31707038777 artifact `Unity test results (latest 6000.7)` id 9184264284: `gh api -X DELETE` HTTP 204. Subsequent list for that name is empty.
- Run 31709176858 artifact id 9184940838: same, HTTP 204, subsequent list empty.
- Cache `unity-linux-editor-6000.7.0a4-7305b6f6fd4f` (3.84GB): `gh api -X DELETE .../actions/caches?key=...` HTTP 200, subsequent `total_count=0`. `Library-6000.7.0a4-debug-*` (491MB) kept.

### workflow_dispatch 31707038777 (before Debug flag) — failure
- https://github.com/hatayama/unity-cli-loop/actions/runs/31707038777
- Resolved `6000.7.0a4` / `7305b6f6fd4f`. Binary `.unity-ci/unity-editor/Editor/Unity`. No extra apt (libxml2.so.16 fell back to .so.2). Disk 88G→105G avail. License: ULF serial, no email/password fallback.
- Tests: 181 run / 158 passed / 23 failed (Linux batchmode started in Release). 6000.5 / 6000.3 / 2022.3 green.

### workflow_dispatch 31709176858 (after `-debugCodeOptimization`) — success
- https://github.com/hatayama/unity-cli-loop/actions/runs/31709176858
- EditMode Tests (latest 6000.7) 13m5s. XML **181 passed / 0 failed**. License: ULF serial. 2022.3 green.

### workflow_dispatch 31711509661 (`dd2d90ead`, activate logs off artifacts, no tarball cache) — 6000.7 green
- https://github.com/hatayama/unity-cli-loop/actions/runs/31711509661
- EditMode Tests (latest 6000.7) success in 17m21s. XML **181 passed / 0 failed**. Downloaded artifact contains only `editmode-latest-6000-7.xml` and `unity-editmode-latest-6000-7.log` (no activate logs, no `-username` in COMMAND LINE ARGUMENTS).
- 2022.3 GameCI compile aborted with exit 134 and no Editor.log. This PR does not change the 2022.3 job; that leg was green on 31707038777 and 31709176858, so the failure is treated as infrastructure flake.

### workflow_dispatch 31713286186 — cancelled
- https://github.com/hatayama/unity-cli-loop/actions/runs/31713286186
- 6000.7 already success. 2022.3 `Run EditMode tests` hung past 26 minutes (prior green runs finished that step in 3m36s / 4m31s). Cancelled rather than wait for the 45-minute timeout. Same infrastructure-flake determination as above.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->