### PR TITLE
feat: warn when entering Play Mode will drop hot-reload patches and pause points

### DIFF
--- a/.agents/skills/uloop-control-play-mode/SKILL.md
+++ b/.agents/skills/uloop-control-play-mode/SKILL.md
@@ -31,6 +31,7 @@ Returns JSON with the current play mode state:
 - `WasAlreadyStopped`: Whether `Stop` was requested while Play Mode was already stopped
 - `ResumedFromPause`: Whether `Play` resumed a paused Play Mode session instead of starting a new one
 - `Message`: Description of the action performed
+- `Warning`: Set when the action carries a caveat. A fresh `Play` start always notes that the session started from Edit-time scene state; additionally, when active hot-reload patches or enabled pause points exist and Domain Reload is enabled, it reports how many of them the Play-entry domain reload will discard.
 
 ## Notes
 
@@ -43,3 +44,4 @@ Returns JSON with the current play mode state:
 - Before relying on PlayMode behavior as verification evidence, check `uloop get-logs --log-type Error` for pre-existing errors. An error already present when PlayMode starts can otherwise be mistaken for one caused by the action under test.
 - `Status` reads the current state with no side effects: `Changed` is always `false`, no waiting, no scene saving, and it is never rejected by compile errors. It reports whether compile errors would currently block `Play` (`BlockedByCompileErrors` with the `CompileErrors` list), read from the last compile result without triggering a new compile. It does not predict unsaved-changes blocking: `BlockedByUnsavedChanges` describes a failed save attempt during a `Play` request, and `Status` never attempts one.
 - `Play` fails immediately with a `CONTROL_PLAY_MODE_UNSAVED_CHANGES` error when unsaved changes cannot be saved quietly — most commonly an Untitled scene, which has no path to save to. The error message lists exactly which scenes or prefab stages blocked it; save the Untitled scene to an explicit path (or discard the changes), then retry.
+- `Play` from Edit mode triggers a domain reload (unless Enter Play Mode Options disable it), which discards all active hot-reload patches and enabled pause points. The response `Warning` reports the counts being dropped. Edits that were only hot-reloaded are not part of the compiled assemblies, so the new session runs the last compiled code — run `uloop compile` before `Play` to keep them, or re-apply `uloop hot-reload` after Play Mode starts.

--- a/.claude/skills/uloop-control-play-mode/SKILL.md
+++ b/.claude/skills/uloop-control-play-mode/SKILL.md
@@ -31,6 +31,7 @@ Returns JSON with the current play mode state:
 - `WasAlreadyStopped`: Whether `Stop` was requested while Play Mode was already stopped
 - `ResumedFromPause`: Whether `Play` resumed a paused Play Mode session instead of starting a new one
 - `Message`: Description of the action performed
+- `Warning`: Set when the action carries a caveat. A fresh `Play` start always notes that the session started from Edit-time scene state; additionally, when active hot-reload patches or enabled pause points exist and Domain Reload is enabled, it reports how many of them the Play-entry domain reload will discard.
 
 ## Notes
 
@@ -43,3 +44,4 @@ Returns JSON with the current play mode state:
 - Before relying on PlayMode behavior as verification evidence, check `uloop get-logs --log-type Error` for pre-existing errors. An error already present when PlayMode starts can otherwise be mistaken for one caused by the action under test.
 - `Status` reads the current state with no side effects: `Changed` is always `false`, no waiting, no scene saving, and it is never rejected by compile errors. It reports whether compile errors would currently block `Play` (`BlockedByCompileErrors` with the `CompileErrors` list), read from the last compile result without triggering a new compile. It does not predict unsaved-changes blocking: `BlockedByUnsavedChanges` describes a failed save attempt during a `Play` request, and `Status` never attempts one.
 - `Play` fails immediately with a `CONTROL_PLAY_MODE_UNSAVED_CHANGES` error when unsaved changes cannot be saved quietly — most commonly an Untitled scene, which has no path to save to. The error message lists exactly which scenes or prefab stages blocked it; save the Untitled scene to an explicit path (or discard the changes), then retry.
+- `Play` from Edit mode triggers a domain reload (unless Enter Play Mode Options disable it), which discards all active hot-reload patches and enabled pause points. The response `Warning` reports the counts being dropped. Edits that were only hot-reloaded are not part of the compiled assemblies, so the new session runs the last compiled code — run `uloop compile` before `Play` to keep them, or re-apply `uloop hot-reload` after Play Mode starts.

--- a/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
+++ b/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
@@ -476,7 +476,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
                 new StubCompilationFailureGate(false),
                 quietSaver,
-                editorState);
+                editorState,
+                new StubDomainReloadDropStateProvider());
             ControlPlayModeSchema schema = new ControlPlayModeSchema
             {
                 Action = PlayModeAction.Play,
@@ -505,7 +506,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
                 new StubCompilationFailureGate(false),
                 quietSaver,
-                editorState);
+                editorState,
+                new StubDomainReloadDropStateProvider());
             ControlPlayModeSchema schema = new ControlPlayModeSchema
             {
                 Action = PlayModeAction.Play,
@@ -517,6 +519,95 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.ResumedFromPause, Is.False);
             Assert.That(response.Warning, Is.EqualTo(ControlPlayModeUseCase.FreshPlayStartFromNewSessionWarning));
             Assert.That(editorState.IsPlaying, Is.True);
+        }
+
+        /// <summary>
+        /// Verifies Edit-to-Play with active patches concatenates the fresh-start warning
+        /// and the domain-reload drop warning, separated by a single space.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenPlayStartsWithActivePatches_AppendsDropWarningAfterFreshStart()
+        {
+            FakeControlPlayModeEditorStateService editorState = new(isPlaying: false, isPaused: false);
+            StubEditorUnsavedChangesQuietSaver quietSaver = new(
+                saveFailures: System.Array.Empty<string>(),
+                remainingAfterSave: System.Array.Empty<string>());
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
+                new StubCompilationFailureGate(false),
+                quietSaver,
+                editorState,
+                new StubDomainReloadDropStateProvider(patchCount: 2));
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Play,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            string dropWarning = PlayModeStartDomainReloadDropWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart: false,
+                isDomainReloadDisabledOnEnterPlayMode: false,
+                activeHotReloadPatchCount: 2,
+                activePausePointCount: 0);
+            Assert.That(
+                response.Warning,
+                Is.EqualTo(ControlPlayModeUseCase.FreshPlayStartFromNewSessionWarning + " " + dropWarning));
+        }
+
+        /// <summary>
+        /// Verifies resume from pause does not attach the domain-reload drop warning even when
+        /// patches exist, because that path does not reload the domain.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenPlayResumesWithActivePatches_DoesNotAppendDropWarning()
+        {
+            FakeControlPlayModeEditorStateService editorState = new(isPlaying: true, isPaused: true);
+            StubEditorUnsavedChangesQuietSaver quietSaver = new(
+                saveFailures: System.Array.Empty<string>(),
+                remainingAfterSave: System.Array.Empty<string>());
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
+                new StubCompilationFailureGate(false),
+                quietSaver,
+                editorState,
+                new StubDomainReloadDropStateProvider(patchCount: 2));
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Play,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(response.ResumedFromPause, Is.True);
+            Assert.That(response.Warning, Is.Empty);
+        }
+
+        /// <summary>
+        /// Verifies a fresh Play start with zero patches and pause points keeps only the
+        /// existing fresh-start warning.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenPlayStartsWithZeroDropCounts_KeepsOnlyFreshStartWarning()
+        {
+            FakeControlPlayModeEditorStateService editorState = new(isPlaying: false, isPaused: false);
+            StubEditorUnsavedChangesQuietSaver quietSaver = new(
+                saveFailures: System.Array.Empty<string>(),
+                remainingAfterSave: System.Array.Empty<string>());
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
+                new StubCompilationFailureGate(false),
+                quietSaver,
+                editorState,
+                new StubDomainReloadDropStateProvider());
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Play,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(response.Warning, Is.EqualTo(ControlPlayModeUseCase.FreshPlayStartFromNewSessionWarning));
         }
 
         [Test]
@@ -620,6 +711,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             public void Step()
             {
                 StepCallCount++;
+            }
+        }
+
+        private sealed class StubDomainReloadDropStateProvider : IControlPlayModeDomainReloadDropStateProvider
+        {
+            private readonly int _patchCount;
+            private readonly int _pausePointCount;
+            private readonly bool _isDomainReloadDisabled;
+
+            public StubDomainReloadDropStateProvider(
+                int patchCount = 0,
+                int pausePointCount = 0,
+                bool isDomainReloadDisabled = false)
+            {
+                _patchCount = patchCount;
+                _pausePointCount = pausePointCount;
+                _isDomainReloadDisabled = isDomainReloadDisabled;
+            }
+
+            public int GetActiveHotReloadPatchCount()
+            {
+                return _patchCount;
+            }
+
+            public int GetActivePausePointCount()
+            {
+                return _pausePointCount;
+            }
+
+            public bool IsDomainReloadDisabledOnEnterPlayMode()
+            {
+                return _isDomainReloadDisabled;
             }
         }
 

--- a/Assets/Tests/Editor/PlayModeStartDomainReloadDropWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/PlayModeStartDomainReloadDropWarningBuilderTests.cs
@@ -1,0 +1,113 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies the Play-start domain-reload drop Warning only appears when entering Play from
+    /// Edit with Domain Reload enabled and at least one patch or pause point to discard.
+    /// </summary>
+    [TestFixture]
+    public sealed class PlayModeStartDomainReloadDropWarningBuilderTests
+    {
+        /// <summary>
+        /// Verifies resume (already playing) never warns: that path does not domain-reload.
+        /// </summary>
+        [Test]
+        public void BuildWarning_WhenAlreadyPlaying_ReturnsNull()
+        {
+            string warning = PlayModeStartDomainReloadDropWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart: true,
+                isDomainReloadDisabledOnEnterPlayMode: false,
+                activeHotReloadPatchCount: 2,
+                activePausePointCount: 3);
+
+            Assert.That(warning, Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies no warning when Enter Play Mode Options disable Domain Reload.
+        /// </summary>
+        [Test]
+        public void BuildWarning_WhenDomainReloadDisabled_ReturnsNull()
+        {
+            string warning = PlayModeStartDomainReloadDropWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart: false,
+                isDomainReloadDisabledOnEnterPlayMode: true,
+                activeHotReloadPatchCount: 2,
+                activePausePointCount: 3);
+
+            Assert.That(warning, Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies no warning when there are no patches and no pause points to discard.
+        /// </summary>
+        [Test]
+        public void BuildWarning_WhenBothCountsAreZero_ReturnsNull()
+        {
+            string warning = PlayModeStartDomainReloadDropWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart: false,
+                isDomainReloadDisabledOnEnterPlayMode: false,
+                activeHotReloadPatchCount: 0,
+                activePausePointCount: 0);
+
+            Assert.That(warning, Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies the patch-only warning matches the specified wording and count.
+        /// </summary>
+        [Test]
+        public void BuildWarning_WhenOnlyPatchesExist_ReturnsPatchOnlyWording()
+        {
+            string warning = PlayModeStartDomainReloadDropWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart: false,
+                isDomainReloadDisabledOnEnterPlayMode: false,
+                activeHotReloadPatchCount: 2,
+                activePausePointCount: 0);
+
+            Assert.That(
+                warning,
+                Is.EqualTo(
+                    "Entering Play Mode triggers a domain reload that will discard 2 active hot-reload patch(es). The new session runs the last compiled assemblies, so hot-reloaded edits that were never compiled are not in effect — run `uloop compile` before Play to keep them, or re-apply `uloop hot-reload` after Play Mode starts."));
+        }
+
+        /// <summary>
+        /// Verifies the pause-point-only warning matches the specified wording and count.
+        /// </summary>
+        [Test]
+        public void BuildWarning_WhenOnlyPausePointsExist_ReturnsPausePointOnlyWording()
+        {
+            string warning = PlayModeStartDomainReloadDropWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart: false,
+                isDomainReloadDisabledOnEnterPlayMode: false,
+                activeHotReloadPatchCount: 0,
+                activePausePointCount: 3);
+
+            Assert.That(
+                warning,
+                Is.EqualTo(
+                    "Entering Play Mode triggers a domain reload that will discard 3 enabled pause point(s). Re-enable them after Play Mode starts."));
+        }
+
+        /// <summary>
+        /// Verifies the combined warning matches the specified wording and both counts.
+        /// </summary>
+        [Test]
+        public void BuildWarning_WhenPatchesAndPausePointsExist_ReturnsCombinedWording()
+        {
+            string warning = PlayModeStartDomainReloadDropWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart: false,
+                isDomainReloadDisabledOnEnterPlayMode: false,
+                activeHotReloadPatchCount: 2,
+                activePausePointCount: 3);
+
+            Assert.That(
+                warning,
+                Is.EqualTo(
+                    "Entering Play Mode triggers a domain reload that will discard 2 active hot-reload patch(es) and 3 enabled pause point(s). The new session runs the last compiled assemblies, so hot-reloaded edits that were never compiled are not in effect — run `uloop compile` before Play to keep them, or re-apply `uloop hot-reload` and re-enable pause points after Play Mode starts."));
+        }
+    }
+}

--- a/Assets/Tests/Editor/PlayModeStartDomainReloadDropWarningBuilderTests.cs.meta
+++ b/Assets/Tests/Editor/PlayModeStartDomainReloadDropWarningBuilderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a236192f056f24326b8655771e42c776

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeDomainReloadDropStateService.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeDomainReloadDropStateService.cs
@@ -1,0 +1,50 @@
+using System;
+
+using UnityEditor;
+
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Supplies Play-start domain-reload drop counts and Enter Play Mode Options
+    /// for ControlPlayModeUseCase warning construction.
+    /// </summary>
+    public interface IControlPlayModeDomainReloadDropStateProvider
+    {
+        int GetActiveHotReloadPatchCount();
+        int GetActivePausePointCount();
+        bool IsDomainReloadDisabledOnEnterPlayMode();
+    }
+
+    /// <summary>
+    /// Reads live hot-reload patch count, armed pause-point count, and Enter Play Mode
+    /// Domain Reload options for the Play-start drop warning.
+    /// </summary>
+    internal sealed class ControlPlayModeDomainReloadDropStateService : IControlPlayModeDomainReloadDropStateProvider
+    {
+        public int GetActiveHotReloadPatchCount()
+        {
+            Func<int> getter = HotReloadPausePointCoordination.GetActiveHotReloadPatchCount;
+            return getter?.Invoke() ?? 0;
+        }
+
+        public int GetActivePausePointCount()
+        {
+            return UloopPausePointRegistry.GetActiveCount();
+        }
+
+        public bool IsDomainReloadDisabledOnEnterPlayMode()
+        {
+            // Why duplicate this check: the PausePoint assembly is a sibling asmdef and cannot
+            // be referenced, so ControlPlayMode keeps the same EditorSettings condition here.
+            if (!EditorSettings.enterPlayModeOptionsEnabled)
+            {
+                return false;
+            }
+
+            return (EditorSettings.enterPlayModeOptions & EnterPlayModeOptions.DisableDomainReload) != 0;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeDomainReloadDropStateService.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeDomainReloadDropStateService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c3fc15b6008734865803768f542c8af7

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeServices.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeServices.cs
@@ -8,6 +8,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal ControlPlayModeCompilationFailureService CompilationFailureService { get; } = new();
         internal ControlPlayModeCompilationFailureGate CompilationFailureGate { get; } = new();
         internal ControlPlayModeEditorStateService EditorStateService { get; } = new();
+        internal ControlPlayModeDomainReloadDropStateService DomainReloadDropStateService { get; } = new();
 
         internal CliPlayModeRunInBackgroundService RunInBackgroundService { get; } =
             new CliPlayModeRunInBackgroundService(
@@ -35,6 +36,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal static IControlPlayModeEditorStateService EditorStateService =>
             RegistryValue.EditorStateService;
+
+        internal static IControlPlayModeDomainReloadDropStateProvider DomainReloadDropStateProvider =>
+            RegistryValue.DomainReloadDropStateService;
 
         internal static CliPlayModeRunInBackgroundService RunInBackgroundService =>
             RegistryValue.RunInBackgroundService;

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
@@ -30,12 +30,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly IControlPlayModeCompilationFailureGate _compilationFailureGate;
         private readonly IEditorUnsavedChangesQuietSaver _unsavedChangesQuietSaver;
         private readonly IControlPlayModeEditorStateService _editorStateService;
+        private readonly IControlPlayModeDomainReloadDropStateProvider _domainReloadDropStateProvider;
 
         public ControlPlayModeUseCase(
             IControlPlayModeCompilationFailureProvider compilationFailureProvider = null,
             IControlPlayModeCompilationFailureGate compilationFailureGate = null,
             IEditorUnsavedChangesQuietSaver unsavedChangesQuietSaver = null,
-            IControlPlayModeEditorStateService editorStateService = null)
+            IControlPlayModeEditorStateService editorStateService = null,
+            IControlPlayModeDomainReloadDropStateProvider domainReloadDropStateProvider = null)
         {
             _compilationFailureProvider =
                 compilationFailureProvider ?? ControlPlayModeServices.CompilationFailureProvider;
@@ -45,6 +47,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 unsavedChangesQuietSaver ?? new EditorUnsavedChangesQuietSaver();
             _editorStateService =
                 editorStateService ?? ControlPlayModeServices.EditorStateService;
+            _domainReloadDropStateProvider =
+                domainReloadDropStateProvider ?? ControlPlayModeServices.DomainReloadDropStateProvider;
         }
 
         public Task<ControlPlayModeResponse> ExecuteAsync(ControlPlayModeSchema parameters, CancellationToken ct)
@@ -148,6 +152,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private ControlPlayModeActionResult ExecutePlayModeStart(bool wasPaused, bool wasPlaying)
         {
+            // Captured before this method mutates editor state, so the warning reflects the
+            // request-start snapshot the same way CompileUseCase does.
+            int activeHotReloadPatchCount = _domainReloadDropStateProvider.GetActiveHotReloadPatchCount();
+            int activePausePointCount = _domainReloadDropStateProvider.GetActivePausePointCount();
+            bool isDomainReloadDisabledOnEnterPlayMode =
+                _domainReloadDropStateProvider.IsDomainReloadDisabledOnEnterPlayMode();
+
             if (ShouldBlockPlayForCompileErrors(PlayModeAction.Play, wasPlaying))
             {
                 ControlPlayModeCompileError[] compileErrors =
@@ -182,8 +193,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool changed = wasPaused || !wasPlaying;
             bool resumedFromPause = wasPaused && wasPlaying;
             string message = wasPaused ? "Play mode resumed" : "Play mode started";
-            string warning = wasPlaying ? string.Empty : FreshPlayStartFromNewSessionWarning;
+            string warning = JoinWarnings(
+                wasPlaying ? string.Empty : FreshPlayStartFromNewSessionWarning,
+                PlayModeStartDomainReloadDropWarningBuilder.BuildWarning(
+                    wasPlaying,
+                    isDomainReloadDisabledOnEnterPlayMode,
+                    activeHotReloadPatchCount,
+                    activePausePointCount));
             return ControlPlayModeActionResult.FromState(message, changed, false, resumedFromPause, warning);
+        }
+
+        private static string JoinWarnings(string first, string second)
+        {
+            if (string.IsNullOrEmpty(first))
+            {
+                return string.IsNullOrEmpty(second) ? string.Empty : second;
+            }
+
+            if (string.IsNullOrEmpty(second))
+            {
+                return first;
+            }
+
+            return first + " " + second;
         }
 
         private ControlPlayModeActionResult SaveDirtyEditorChangesBeforePlayStart()

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/PlayModeStartDomainReloadDropWarningBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/PlayModeStartDomainReloadDropWarningBuilder.cs
@@ -1,0 +1,47 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Builds the Play-start Warning for the case where entering Play Mode from Edit mode
+    /// will trigger a domain reload while hot-reload patches or enabled pause points exist:
+    /// the reload silently discards both, and edits that were only hot-reloaded are not in
+    /// the compiled assemblies the new session runs.
+    /// </summary>
+    internal static class PlayModeStartDomainReloadDropWarningBuilder
+    {
+        public static string BuildWarning(
+            bool wasPlayingAtRequestStart,
+            bool isDomainReloadDisabledOnEnterPlayMode,
+            int activeHotReloadPatchCount,
+            int activePausePointCount)
+        {
+            if (wasPlayingAtRequestStart || isDomainReloadDisabledOnEnterPlayMode)
+            {
+                return null;
+            }
+            if (activeHotReloadPatchCount <= 0 && activePausePointCount <= 0)
+            {
+                return null;
+            }
+
+            if (activeHotReloadPatchCount > 0 && activePausePointCount > 0)
+            {
+                return "Entering Play Mode triggers a domain reload that will discard "
+                    + activeHotReloadPatchCount
+                    + " active hot-reload patch(es) and "
+                    + activePausePointCount
+                    + " enabled pause point(s). The new session runs the last compiled assemblies, so hot-reloaded edits that were never compiled are not in effect — run `uloop compile` before Play to keep them, or re-apply `uloop hot-reload` and re-enable pause points after Play Mode starts.";
+            }
+
+            if (activeHotReloadPatchCount > 0)
+            {
+                return "Entering Play Mode triggers a domain reload that will discard "
+                    + activeHotReloadPatchCount
+                    + " active hot-reload patch(es). The new session runs the last compiled assemblies, so hot-reloaded edits that were never compiled are not in effect — run `uloop compile` before Play to keep them, or re-apply `uloop hot-reload` after Play Mode starts.";
+            }
+
+            return "Entering Play Mode triggers a domain reload that will discard "
+                + activePausePointCount
+                + " enabled pause point(s). Re-enable them after Play Mode starts.";
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/PlayModeStartDomainReloadDropWarningBuilder.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/PlayModeStartDomainReloadDropWarningBuilder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a58118277c36a487aa9f5a9d350a599a

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/Skill/SKILL.md
@@ -31,6 +31,7 @@ Returns JSON with the current play mode state:
 - `WasAlreadyStopped`: Whether `Stop` was requested while Play Mode was already stopped
 - `ResumedFromPause`: Whether `Play` resumed a paused Play Mode session instead of starting a new one
 - `Message`: Description of the action performed
+- `Warning`: Set when the action carries a caveat. A fresh `Play` start always notes that the session started from Edit-time scene state; additionally, when active hot-reload patches or enabled pause points exist and Domain Reload is enabled, it reports how many of them the Play-entry domain reload will discard.
 
 ## Notes
 
@@ -43,3 +44,4 @@ Returns JSON with the current play mode state:
 - Before relying on PlayMode behavior as verification evidence, check `uloop get-logs --log-type Error` for pre-existing errors. An error already present when PlayMode starts can otherwise be mistaken for one caused by the action under test.
 - `Status` reads the current state with no side effects: `Changed` is always `false`, no waiting, no scene saving, and it is never rejected by compile errors. It reports whether compile errors would currently block `Play` (`BlockedByCompileErrors` with the `CompileErrors` list), read from the last compile result without triggering a new compile. It does not predict unsaved-changes blocking: `BlockedByUnsavedChanges` describes a failed save attempt during a `Play` request, and `Status` never attempts one.
 - `Play` fails immediately with a `CONTROL_PLAY_MODE_UNSAVED_CHANGES` error when unsaved changes cannot be saved quietly — most commonly an Untitled scene, which has no path to save to. The error message lists exactly which scenes or prefab stages blocked it; save the Untitled scene to an explicit path (or discard the changes), then retry.
+- `Play` from Edit mode triggers a domain reload (unless Enter Play Mode Options disable it), which discards all active hot-reload patches and enabled pause points. The response `Warning` reports the counts being dropped. Edits that were only hot-reloaded are not part of the compiled assemblies, so the new session runs the last compiled code — run `uloop compile` before `Play` to keep them, or re-apply `uloop hot-reload` after Play Mode starts.

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/UnityCLILoop.FirstPartyTools.ControlPlayMode.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/UnityCLILoop.FirstPartyTools.ControlPlayMode.Editor.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "GUID:d427b32aad9cb44fc8e962437c9dbcd8",
         "GUID:fc3fd32eddbee40e39c2d76dc184957b",
-        "GUID:5079a8d3a72924a81aa1cbc25f65ed1b"
+        "GUID:5079a8d3a72924a81aa1cbc25f65ed1b",
+        "GUID:527f26a36b5043c2bd4d4036d04cd76d"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -88,6 +88,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 return null;
             };
+            HotReloadPausePointCoordination.GetActiveHotReloadPatchCount = () => ShimByMethod.Count;
             HotReloadPausePointCoordination.GetTransplantLocals = method =>
                 TransplantLocalsByMethod.TryGetValue(method, out IReadOnlyList<LocalBuilder> locals)
                     ? locals

--- a/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
+++ b/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
@@ -21,6 +21,11 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         // original method, or null when the method is not hot-reload patched.
         public static Func<MethodBase, MethodBase> GetActiveShimForMethod { get; set; }
 
+        // Set by HotReloadPatcher. Returns how many methods are currently hot-reload
+        // patched (0 when none). Null means the hot-reload tool has not initialized in
+        // this domain, which also means no patches exist - callers treat null as 0.
+        public static Func<int> GetActiveHotReloadPatchCount { get; set; }
+
         /// <summary>
         /// Set by HotReloadShimRegistry. Argument is a forward-slash path (absolute or
         /// project-relative); returns null when that file has no active shim generation.

--- a/Packages/src/Runtime/PausePoints/AssemblyInfo.cs
+++ b/Packages/src/Runtime/PausePoints/AssemblyInfo.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.ExecuteDynamicCode.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Common.Preflight.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Compile.Editor")]
+[assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.ControlPlayMode.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Infrastructure")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.PlayMode")]


### PR DESCRIPTION
## Summary
- `uloop control-play-mode --action Play` now warns when entering Play Mode from Edit will domain-reload away active hot-reload patches and enabled pause points.
- The response `Warning` reports the counts being dropped, so a hot-reload-then-Play sequence is no longer silent about lost edits.

## User Impact
- Before: Play from Edit triggered a domain reload that discarded hot-reload patches and pause points with no warning. Callers could keep verifying against last-compiled assemblies while believing the patch was still in effect.
- After: A fresh Play start still notes that the session started from Edit-time scene state. When patches or pause points exist and Domain Reload is enabled, `Warning` also names how many of them the Play-entry reload will discard, and points at `uloop compile` before Play or re-applying `uloop hot-reload` after Play starts.

## Changes
- Capture patch count, pause-point count, and Domain Reload options at Play-start request time (before mutating editor state).
- Attach the drop warning only on a successful Play start; compile-error and unsaved-changes blocks still skip it because no reload happens.
- Resume (already playing) and Enter Play Mode Options with Domain Reload disabled do not warn.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Success, ErrorCount 0
- `uloop run-tests --filter-type regex --filter-value "PlayModeStartDomainReloadDropWarningBuilderTests"` → TestCount 6, PassedCount 6
- `uloop run-tests --filter-type regex --filter-value "ControlPlayModeUseCaseTests"` → TestCount 26, PassedCount 26 (run sequentially, not in parallel)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

