### PR TITLE
feat: classify added and removed members in the transform worker

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Runtime.CompilerServices;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled host type for added-member worker tests. Tests copy this source, add members,
+    /// and run the transform worker against the already-compiled assembly as ground truth.
+    /// </summary>
+    public class HotReloadAddedMemberHost
+    {
+        public int PublicSeed = 3;
+
+        private int _privateSeed = 7;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int ExistingValue()
+        {
+            return 1;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int ExistingCaller(int value)
+        {
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int ExistingFail(int value)
+        {
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int ReadPrivateSeed()
+        {
+            return _privateSeed;
+        }
+    }
+
+    /// <summary>
+    /// Compiled MonoBehaviour host so Unity-message added-method warnings can be classified
+    /// against a real compiled type rather than a throwaway uncompiled class.
+    /// </summary>
+    public class HotReloadAddedMemberBehaviour : MonoBehaviour
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void ExistingTick()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Compiled interface used to skip explicit-interface added methods.
+    /// </summary>
+    public interface IHotReloadAddedMemberPing
+    {
+        int Ping(int value);
+    }
+
+    /// <summary>
+    /// Compiled host that already implements the interface so an added explicit implementation
+    /// is a new method on an existing type, not a new type.
+    /// </summary>
+    public class HotReloadAddedMemberInterfaceHost : IHotReloadAddedMemberPing
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Ping(int value)
+        {
+            return value;
+        }
+    }
+
+    /// <summary>
+    /// Compiled virtual host so added override/virtual methods can be skipped against a real type.
+    /// </summary>
+    public class HotReloadAddedMemberVirtualHost
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public virtual int ExistingVirtual(int value)
+        {
+            return value;
+        }
+    }
+
+    /// <summary>
+    /// Compiled derived host so an added override can be classified against a real compiled type.
+    /// </summary>
+    public class HotReloadAddedMemberVirtualChild : HotReloadAddedMemberVirtualHost
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int ChildExisting()
+        {
+            return 1;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
@@ -62,6 +62,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+        private int PrivateCall()
+        {
+            return _privateSeed;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public int ReadPrivateSeed()
         {
             return _privateSeed;

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
@@ -34,6 +34,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+        public int ArrowRead() => 1;
+
+        public int ExistingGetter
+        {
+            get { return 1; }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int ExistingDynamic(object value)
+        {
+            return 0;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public int ReadPrivateSeed()
         {
             return _privateSeed;
@@ -94,6 +108,77 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public int ChildExisting()
         {
             return 1;
+        }
+    }
+
+    /// <summary>
+    /// Compiled lifecycle hosts so worker tests bind against real types rather than throwaways.
+    /// </summary>
+    public class HotReloadLifecycleMonoPrivateStartFixture : MonoBehaviour
+    {
+        private void Start()
+        {
+            int x = 1;
+            x += 1;
+        }
+    }
+
+    /// <summary>
+    /// Compiled POCO Start host for the lifecycle-note gate.
+    /// </summary>
+    public class HotReloadLifecyclePocoStartFixture
+    {
+        private void Start()
+        {
+            int x = 1;
+            x += 1;
+        }
+    }
+
+    /// <summary>
+    /// Compiled public Start host; name-only notes must not flag this.
+    /// </summary>
+    public class HotReloadLifecycleMonoPublicStartFixture : MonoBehaviour
+    {
+        public void Start()
+        {
+            int x = 1;
+            x += 1;
+        }
+    }
+
+    /// <summary>
+    /// Compiled parameterized Start host; Unity will not invoke this as a message.
+    /// </summary>
+    public class HotReloadLifecycleMonoParamStartFixture : MonoBehaviour
+    {
+        private void Start(int delay)
+        {
+            int x = delay;
+            x += 1;
+        }
+    }
+
+    /// <summary>
+    /// Compiled Awake host for the direct one-shot lifecycle note.
+    /// </summary>
+    public class HotReloadLifecycleAwakeFixture : MonoBehaviour
+    {
+        private void Awake()
+        {
+            int x = 1;
+            x += 1;
+        }
+    }
+
+    /// <summary>
+    /// Compiled alias-shadow host so the local-vs-global using-alias test is not a new type.
+    /// </summary>
+    internal class HotReloadAliasShadowFixture
+    {
+        public string Build()
+        {
+            return "ok";
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
@@ -13,6 +13,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     {
         public int PublicSeed = 3;
 
+        public HotReloadAddedMemberHost Inner;
+
         private int _privateSeed = 7;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -43,6 +45,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public int ExistingDynamic(object value)
+        {
+            return 0;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int ExistingDynamicList(System.Collections.Generic.List<object> values)
+        {
+            return 0;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int ExistingDynamicArray(object[] values)
         {
             return 0;
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
@@ -15,6 +15,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         public HotReloadAddedMemberHost Inner;
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public HotReloadAddedMemberHost Get()
+        {
+            return this;
+        }
+
+        public HotReloadAddedMemberHost this[int index]
+        {
+            get { return this; }
+        }
+
         private int _privateSeed = 7;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -62,6 +73,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+        private static int PrivateStaticSeven()
+        {
+            return 7;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private int PrivateCall()
         {
             return _privateSeed;
@@ -92,6 +109,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     public interface IHotReloadAddedMemberPing
     {
         int Ping(int value);
+    }
+
+    /// <summary>
+    /// Compiled interface with a default method so edits to interface members can be skipped
+    /// without becoming Harmony patch candidates.
+    /// </summary>
+    public interface IHotReloadAddedMemberDefault
+    {
+        int ExistingDefault() => 1;
     }
 
     /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f6bd0fad9c7914fbd9b0746c9f167208
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1700,6 +1700,64 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(115));
         }
 
+        /// <summary>
+        /// What: an added method plus its caller plus an unrelated shim-compile failure still
+        /// isolates per-method (the file is not collapsed to a single (shim-compile) Failed).
+        /// </summary>
+        [Test]
+        public async Task Run_AddedMethodCallerAndUnrelatedShimFailure_IsolatesWithoutWipingFile()
+        {
+            string hostPath = ResolveAddedMemberHostPath();
+            string onDisk = File.ReadAllText(hostPath);
+            string edited = onDisk.Replace(
+                "        public int ExistingValue()\n        {\n            return 1;\n        }",
+                "        public int ExistingValue()\n        {\n            return 10;\n        }",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedPing(value);\n        }",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                "        public int ExistingFail(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingFail(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                "        public int ReadPrivateSeed()\n        {\n            return _privateSeed;\n        }\n    }",
+                "        public int ReadPrivateSeed()\n        {\n            return _privateSeed;\n        }\n\n"
+                + "        public int AddedPing(int value)\n        {\n            return value + 1;\n        }\n    }",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            string editedPath = WriteEditedSource("AddedMethodIsolation.cs", edited);
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { hostPath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadAddedMemberHost.ExistingValue));
+            AssertHasPatched(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+
+            bool failIsolated = false;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
+                    && outcome.Method.Contains(nameof(HotReloadAddedMemberHost.ExistingFail)))
+                {
+                    failIsolated = true;
+                }
+            }
+
+            Assert.That(
+                failIsolated,
+                Is.True,
+                "ExistingFail must isolate as a per-method Failed.\n" + FormatOutcomes(result));
+
+            HotReloadAddedMemberHost host = new HotReloadAddedMemberHost();
+            Assert.That(host.ExistingValue(), Is.EqualTo(10));
+            Assert.That(host.ExistingCaller(3), Is.EqualTo(4));
+        }
+
         private static int FindLineNumberContaining(string source, string fragment)
         {
             string[] lines = source.Replace("\r\n", "\n").Split('\n');
@@ -1754,6 +1812,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             return string.Join("\n", lines);
+        }
+
+        private static string ResolveAddedMemberHostPath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadAddedMemberHost.cs");
+            Assert.That(File.Exists(path), Is.True, "Added-member host source missing: " + path);
+            return Path.GetFullPath(path);
         }
 
         private static string ResolveE2EFixturePath()

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -715,10 +715,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             int declarationDriftCount = CountWarningsContaining(
                 result.Warnings,
                 "Edits outside method bodies");
+            int removedMembersCount = CountWarningsContaining(
+                result.Warnings,
+                "Removed members stay present");
             Assert.That(
                 result.Warnings,
-                Has.Count.EqualTo(1 + declarationDriftCount),
-                "Expected the aggregated inline-risk warning plus any declaration-drift warning(s).");
+                Has.Count.EqualTo(1 + declarationDriftCount + removedMembersCount),
+                "Expected the aggregated inline-risk warning plus drift/removed-member warning(s).");
         }
 
         /// <summary>
@@ -824,10 +827,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             int declarationDriftCount = CountWarningsContaining(
                 result.Warnings,
                 "Edits outside method bodies");
+            int removedMembersCount = CountWarningsContaining(
+                result.Warnings,
+                "Removed members stay present");
             Assert.That(
                 result.Warnings,
-                Has.Count.EqualTo(1 + declarationDriftCount),
-                "Expected the aggregated inline-risk warning plus one declaration-drift warning per duplicate file input.");
+                Has.Count.EqualTo(1 + declarationDriftCount + removedMembersCount),
+                "Expected the aggregated inline-risk warning plus drift/removed-member warning(s).");
 
             string aggregatedWarning = null;
             foreach (string warning in result.Warnings)
@@ -1737,6 +1743,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertNoFileLevelFailure(result);
             AssertHasPatched(result, nameof(HotReloadAddedMemberHost.ExistingValue));
             AssertHasPatched(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            AssertHasSkipped(
+                result,
+                "AddedPing",
+                HotReloadConstants.AddedMethodDeferredSkipReason);
 
             bool failIsolated = false;
             foreach (HotReloadMethodOutcome outcome in result.Methods)
@@ -1756,6 +1766,136 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadAddedMemberHost host = new HotReloadAddedMemberHost();
             Assert.That(host.ExistingValue(), Is.EqualTo(10));
             Assert.That(host.ExistingCaller(3), Is.EqualTo(4));
+        }
+
+        /// <summary>
+        /// What: an added method that reads a private field still shim-compiles (Harmony is
+        /// injected from hasAccessorDelegates) and the added method itself is Skipped.
+        /// </summary>
+        [Test]
+        public async Task Run_AddedMethodWithPrivateAccess_ShimCompilesAndSkipsAddedApply()
+        {
+            string hostPath = ResolveAddedMemberHostPath();
+            string onDisk = File.ReadAllText(hostPath);
+            string edited = onDisk.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedReadPrivate();\n        }",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                "        public int ReadPrivateSeed()\n        {\n            return _privateSeed;\n        }",
+                "        public int ReadPrivateSeed()\n        {\n            return _privateSeed;\n        }\n\n"
+                + "        public int AddedReadPrivate()\n        {\n"
+                + "            System.Func<int> read = () => _privateSeed;\n"
+                + "            return read();\n        }",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            string editedPath = WriteEditedSource("AddedMethodHarmony.cs", edited);
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { hostPath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            AssertHasSkipped(
+                result,
+                "AddedReadPrivate",
+                HotReloadConstants.AddedMethodDeferredSkipReason);
+
+            HotReloadAddedMemberHost host = new HotReloadAddedMemberHost();
+            Assert.That(host.ExistingCaller(0), Is.EqualTo(7));
+        }
+
+        /// <summary>
+        /// What: deleting a compiled method surfaces the aggregated removed-members warning.
+        /// </summary>
+        [Test]
+        public async Task Run_RemovedMethod_EmitsAggregatedRemovedMembersWarning()
+        {
+            string hostPath = ResolveAddedMemberHostPath();
+            string onDisk = File.ReadAllText(hostPath);
+            string edited = onDisk.Replace(
+                "        [MethodImpl(MethodImplOptions.NoInlining)]\n"
+                + "        public int ExistingFail(int value)\n        {\n            return value;\n        }\n\n",
+                string.Empty,
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            string editedPath = WriteEditedSource("RemovedMethodWarning.cs", edited);
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { hostPath },
+                editedPath,
+                CancellationToken.None);
+
+            Assert.That(result.Warnings, Is.Not.Null);
+            bool foundWarning = false;
+            foreach (string warning in result.Warnings)
+            {
+                if (warning.Contains(nameof(HotReloadAddedMemberHost.ExistingFail))
+                    && warning.Contains("'uloop compile'"))
+                {
+                    foundWarning = true;
+                }
+            }
+
+            Assert.That(
+                foundWarning,
+                Is.True,
+                "Removed ExistingFail must appear in the aggregated warning.\n"
+                + string.Join("\n", result.Warnings));
+        }
+
+        /// <summary>
+        /// What: a broken added-method body isolates that added method (and its callers) without
+        /// collapsing the file; an unrelated edited method still patches.
+        /// </summary>
+        [Test]
+        public async Task Run_AddedMethodBodyFailure_IsolatesWithoutWipingFile()
+        {
+            string hostPath = ResolveAddedMemberHostPath();
+            string onDisk = File.ReadAllText(hostPath);
+            string edited = onDisk.Replace(
+                "        public int ExistingValue()\n        {\n            return 1;\n        }",
+                "        public int ExistingValue()\n        {\n            return 10;\n        }",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedPing(value);\n        }",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                "        public int ReadPrivateSeed()\n        {\n            return _privateSeed;\n        }",
+                "        public int ReadPrivateSeed()\n        {\n            return _privateSeed;\n        }\n\n"
+                + "        public int AddedPing(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            string editedPath = WriteEditedSource("AddedMethodBodyFailure.cs", edited);
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { hostPath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadAddedMemberHost.ExistingValue));
+
+            bool addedFailed = false;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
+                    && outcome.Method.Contains("AddedPing"))
+                {
+                    addedFailed = true;
+                }
+            }
+
+            Assert.That(
+                addedFailed,
+                Is.True,
+                "AddedPing must isolate as a per-method Failed.\n" + FormatOutcomes(result));
+
+            HotReloadAddedMemberHost host = new HotReloadAddedMemberHost();
+            Assert.That(host.ExistingValue(), Is.EqualTo(10));
         }
 
         private static int FindLineNumberContaining(string source, string fragment)
@@ -1782,6 +1922,27 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     Assert.Fail("Unexpected file-level failure: " + outcome.Reason);
                 }
             }
+        }
+
+        private static void AssertHasSkipped(
+            HotReloadOrchestratorResult result,
+            string methodName,
+            string reasonFragment)
+        {
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Skipped
+                    && outcome.Method.Contains(methodName)
+                    && outcome.Reason != null
+                    && outcome.Reason.Contains(reasonFragment))
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail(
+                "Expected Skipped outcome for " + methodName + " with reason containing '"
+                + reasonFragment + "'.\n" + FormatOutcomes(result));
         }
 
         private static void AssertHasPatched(HotReloadOrchestratorResult result, string methodName)

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1807,11 +1807,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a private call in a conditional-access argument list is accessor-rewritten so
-        /// the enclosing method still Patches (it must not Failed with CS0122).
+        /// What: a private call in a conditional-access argument list inside a lambda is
+        /// accessor-rewritten (Delegation) so the enclosing method Patches (not CS0122 Failed).
         /// </summary>
         [Test]
-        public async Task Run_ConditionalAccessArgumentPrivateCall_AccessorizesAndPatches()
+        public async Task Run_LambdaConditionalAccessArgumentPrivateCall_AccessorizesAndPatches()
         {
             string hostPath = ResolveAddedMemberHostPath();
             string onDisk = File.ReadAllText(hostPath);
@@ -1819,10 +1819,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
                 "        public int ExistingCaller(int value)\n        {\n"
                 + "            HotReloadAddedMemberHost other = this;\n"
-                + "            return other?.ExistingFail(PrivateCall()) ?? 0;\n        }",
+                + "            System.Func<int> read = () => other?.ExistingFail(PrivateStaticSeven()) ?? 0;\n"
+                + "            return read();\n        }",
                 StringComparison.Ordinal);
             Assert.That(edited, Is.Not.EqualTo(onDisk));
-            string editedPath = WriteEditedSource("ConditionalAccessPrivateArg.cs", edited);
+            string editedPath = WriteEditedSource("LambdaConditionalAccessPrivateArg.cs", edited);
 
             HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
                 new[] { hostPath },

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1807,6 +1807,44 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a private call in a conditional-access argument list is accessor-rewritten so
+        /// the enclosing method still Patches (it must not Failed with CS0122).
+        /// </summary>
+        [Test]
+        public async Task Run_ConditionalAccessArgumentPrivateCall_AccessorizesAndPatches()
+        {
+            string hostPath = ResolveAddedMemberHostPath();
+            string onDisk = File.ReadAllText(hostPath);
+            string edited = onDisk.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            HotReloadAddedMemberHost other = this;\n"
+                + "            return other?.ExistingFail(PrivateCall()) ?? 0;\n        }",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            string editedPath = WriteEditedSource("ConditionalAccessPrivateArg.cs", edited);
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { hostPath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
+                    && outcome.Method.Contains(nameof(HotReloadAddedMemberHost.ExistingCaller)))
+                {
+                    Assert.Fail("ExistingCaller must not Failed: " + outcome.Reason);
+                }
+            }
+
+            HotReloadAddedMemberHost host = new HotReloadAddedMemberHost();
+            Assert.That(host.ExistingCaller(0), Is.EqualTo(7));
+        }
+
+        /// <summary>
         /// What: deleting a compiled method surfaces the aggregated removed-members warning.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -711,17 +711,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 aggregatedInlineRiskCount,
                 Is.EqualTo(1),
                 "Expected exactly one aggregated inline-risk warning listing the at-risk methods.");
-
-            int declarationDriftCount = CountWarningsContaining(
-                result.Warnings,
-                "Edits outside method bodies");
-            int removedMembersCount = CountWarningsContaining(
-                result.Warnings,
-                "Removed members stay present");
             Assert.That(
-                result.Warnings,
-                Has.Count.EqualTo(1 + declarationDriftCount + removedMembersCount),
-                "Expected the aggregated inline-risk warning plus drift/removed-member warning(s).");
+                CountWarningsContaining(result.Warnings, "Edits outside method bodies"),
+                Is.EqualTo(1),
+                "Reconstructed fixture source differs outside method bodies once.");
+            Assert.That(
+                CountWarningsContaining(result.Warnings, "Removed members stay present"),
+                Is.EqualTo(1),
+                "Reconstructed fixture source omits compiled members once.");
+            Assert.That(
+                result.Warnings.Count,
+                Is.EqualTo(3),
+                "Exactly one inline-risk, one drift, and one removed-members warning.");
         }
 
         /// <summary>
@@ -824,16 +825,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(inlineRiskAlphaPatchedOperations, Is.EqualTo(2));
 
-            int declarationDriftCount = CountWarningsContaining(
-                result.Warnings,
-                "Edits outside method bodies");
-            int removedMembersCount = CountWarningsContaining(
-                result.Warnings,
-                "Removed members stay present");
             Assert.That(
-                result.Warnings,
-                Has.Count.EqualTo(1 + declarationDriftCount + removedMembersCount),
-                "Expected the aggregated inline-risk warning plus drift/removed-member warning(s).");
+                CountWarningsContaining(result.Warnings, "Edits outside method bodies"),
+                Is.EqualTo(2),
+                "Duplicate file inputs each emit a declaration-drift warning.");
+            Assert.That(
+                CountWarningsContaining(result.Warnings, "Removed members stay present"),
+                Is.EqualTo(2),
+                "Duplicate file inputs each emit a removed-members warning.");
+            Assert.That(
+                result.Warnings.Count,
+                Is.EqualTo(5),
+                "One aggregated inline-risk warning plus two drift and two removed-members warnings.");
 
             string aggregatedWarning = null;
             foreach (string warning in result.Warnings)
@@ -851,10 +854,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CountOccurrences(aggregatedWarning, nameof(HotReloadE2EFixture.InlineRiskAlpha)),
                 Is.EqualTo(1),
                 "The aggregated warning must list a re-patched method once, not once per patch operation.");
-            Assert.That(
-                declarationDriftCount,
-                Is.EqualTo(2),
-                "Duplicate file inputs each emit a declaration-drift warning.");
         }
 
         /// <summary>
@@ -1893,6 +1892,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 addedFailed,
                 Is.True,
                 "AddedPing must isolate as a per-method Failed.\n" + FormatOutcomes(result));
+            AssertHasSkipped(
+                result,
+                nameof(HotReloadAddedMemberHost.ExistingCaller),
+                HotReloadConstants.IsolatedAddedMethodCallerSkipReason);
 
             HotReloadAddedMemberHost host = new HotReloadAddedMemberHost();
             Assert.That(host.ExistingValue(), Is.EqualTo(10));

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1811,7 +1811,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// accessor-rewritten (Delegation) so the enclosing method Patches (not CS0122 Failed).
         /// </summary>
         [Test]
-        public async Task Run_LambdaConditionalAccessArgumentPrivateCall_AccessorizesAndPatches()
+        public async Task Run_LambdaConditionalAccessArgumentPrivateStaticSeven_AccessorizesAndPatches()
         {
             string hostPath = ResolveAddedMemberHostPath();
             string onDisk = File.ReadAllText(hostPath);

--- a/Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs
@@ -114,6 +114,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 return _score;
             }
         }
+
+        private int _value;
+
+        public int Value
+        {
+            get { return _value; }
+            set { _value = value; }
+        }
     }
 
     /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -214,8 +214,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Success, Is.True, result.ErrorMessage);
 
             AssertHasSkip(result, "AddedVirtual", "vtable slot");
-            AssertHasSkip(result, "ExistingVirtual", "vtable slot");
-            AssertHasSkip(result, "AddedGeneric", "Generic");
+            AssertHasSkip(
+                result,
+                "HotReloadAddedMemberVirtualChild.ExistingVirtual",
+                "vtable slot");
+            AssertHasSkip(result, "AddedGeneric", "Added generic");
             AssertHasSkip(result, "CaptureAdded", "method group");
             Assert.That(FindEntry(result, "AddedInstance"), Is.Not.Null, "Added instance method must still emit.");
         }
@@ -351,6 +354,235 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(caller, Is.Not.Null);
             string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
             Assert.That(slice, Does.Contain(added.shimMethodName));
+        }
+
+        /// <summary>
+        /// What: excludedAddedMethodKeys drops the added shim itself so a broken added body can
+        /// be isolated without re-emitting it.
+        /// </summary>
+        [Test]
+        public async Task Isolation_ExcludedAddedMethodKeys_DropsAddedMethodShim()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public int AddedPing(int value)\n        {\n            return value + 1;\n        }");
+            edited = edited.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedPing(value);\n        }",
+                StringComparison.Ordinal);
+            string addedKey = BuildHostMethodKey("AddedPing", "System.Int32");
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("IsolationDropAdded.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk,
+                excludedAddedMethodKeys: new[] { addedKey });
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, "AddedPing"), Is.Null, "Excluded added method must not emit.");
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "cannot emit");
+        }
+
+        /// <summary>
+        /// What: a caller of a skipped added method is skipped with the unavailable-call reason
+        /// instead of leaving a bare CS0103 in the shim; static method-group capture is skipped
+        /// the same way as instance capture.
+        /// </summary>
+        [Test]
+        public async Task Skip_CallersOfSkippedAddedAndStaticMethodGroup_UseDedicatedReasons()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public virtual int AddedVirtual(int value)\n        {\n            return value;\n        }\n\n"
+                + "        public static int AddedStatic(int value)\n        {\n            return value;\n        }");
+            edited = edited.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedVirtual(value);\n        }",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                "        public int ExistingValue()\n        {\n            return 1;\n        }",
+                "        public int ExistingValue()\n        {\n"
+                + "            System.Func<int, int> bound = AddedStatic;\n"
+                + "            return bound(1);\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("SkipUnavailableAndStaticGroup.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, "AddedVirtual", "vtable slot");
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "cannot emit");
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingValue), "method group");
+            Assert.That(FindEntry(result, "AddedStatic"), Is.Not.Null);
+        }
+
+        /// <summary>
+        /// What: an added-method call through conditional access skips the referencing method
+        /// rather than rewriting the receiver to __uloopInstance.
+        /// </summary>
+        [Test]
+        public async Task Skip_ConditionalAccessAddedMethodCall_UsesDedicatedReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public int AddedPing(int value)\n        {\n            return value;\n        }");
+            edited = edited.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            HotReloadAddedMemberHost other = this;\n"
+                + "            return other?.AddedPing(value) ?? 0;\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("SkipConditionalAccess.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "conditional access");
+            Assert.That(FindEntry(result, "AddedPing"), Is.Not.Null);
+            Assert.That(
+                result.Output.shimSource,
+                Does.Not.Contain("?.AddedPing"),
+                "Skipped caller must not emit a broken conditional-access rewrite.");
+        }
+
+        /// <summary>
+        /// What: a type absent from the compiled assembly skips every method with the new-type
+        /// out-of-scope reason instead of emitting MethodNotFound entries.
+        /// </summary>
+        [Test]
+        public async Task Skip_NewTypeAbsentFromCompiledAssembly_UsesOutOfScopeReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "    internal class HotReloadAliasShadowFixture\n",
+                "    public class HotReloadBrandNewType\n    {\n"
+                + "        public int Fresh()\n        {\n            return 1;\n        }\n    }\n\n"
+                + "    internal class HotReloadAliasShadowFixture\n",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("SkipNewType.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, "HotReloadBrandNewType.Fresh", "New types are out of scope");
+            Assert.That(FindEntry(result, "Fresh"), Is.Null);
+        }
+
+        /// <summary>
+        /// What: a compiled method whose source parameter is rewritten as dynamic is still
+        /// classified Existing (dynamic normalizes to System.Object), not Added.
+        /// </summary>
+        [Test]
+        public async Task Classify_DynamicParameter_DoesNotMisclassifyExistingMethodAsAdded()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int ExistingDynamic(object value)\n        {\n            return 0;\n        }",
+                "        public int ExistingDynamic(dynamic value)\n        {\n            return 1;\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("DynamicNotAdded.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            TransformWorkerEntryDto entry = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingDynamic));
+            Assert.That(entry, Is.Not.Null);
+            Assert.That(entry.patchKind, Is.Not.EqualTo(HotReloadConstants.PatchKindAddedMethod));
+            Assert.That(entry.parameterTypeFullNames, Is.EqualTo(new[] { "System.Object" }));
+        }
+
+        /// <summary>
+        /// What: a property getter that calls an added method records calledAddedMethodKeys, and
+        /// a getter that captures an added method group is skipped.
+        /// </summary>
+        [Test]
+        public async Task Getter_AddedMethodCallAndMethodGroup_SetsKeysOrSkips()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public int AddedPing(int value)\n        {\n            return value;\n        }");
+            edited = edited.Replace(
+                "        public int ExistingGetter\n        {\n            get { return 1; }\n        }",
+                "        public int ExistingGetter\n        {\n            get { return AddedPing(1); }\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult callResult = await RunWorkerOnSourceAsync(
+                WriteEdited("GetterCallsAdded.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(callResult.Success, Is.True, callResult.ErrorMessage);
+            TransformWorkerEntryDto getter = FindEntry(callResult, "get_ExistingGetter");
+            Assert.That(getter, Is.Not.Null);
+            Assert.That(
+                getter.calledAddedMethodKeys,
+                Does.Contain(BuildHostMethodKey("AddedPing", "System.Int32")));
+
+            string groupEdited = WithHostMembers(
+                onDisk,
+                "public int AddedPing(int value)\n        {\n            return value;\n        }");
+            groupEdited = groupEdited.Replace(
+                "        public int ExistingGetter\n        {\n            get { return 1; }\n        }",
+                "        public int ExistingGetter\n        {\n"
+                + "            get { System.Func<int, int> bound = AddedPing; return bound(1); }\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult groupResult = await RunWorkerOnSourceAsync(
+                WriteEdited("GetterMethodGroup.cs", groupEdited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(groupResult.Success, Is.True, groupResult.ErrorMessage);
+            AssertHasSkip(groupResult, "get_ExistingGetter", "method group");
+            Assert.That(FindEntry(groupResult, "AddedPing"), Is.Not.Null);
+        }
+
+        /// <summary>
+        /// What: an added explicit interface implementation is skipped so the compiled
+        /// IHotReloadAddedMemberPing / InterfaceHost fixtures are not dead.
+        /// </summary>
+        [Test]
+        public async Task Skip_AddedExplicitInterfaceImplementation_UsesExplicitReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        int Ping(int value);",
+                "        int Ping(int value);\n        int Extra(int value);",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                "        public int Ping(int value)\n        {\n            return value;\n        }",
+                "        public int Ping(int value)\n        {\n            return value;\n        }\n\n"
+                + "        int IHotReloadAddedMemberPing.Extra(int value)\n        {\n            return value;\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("SkipExplicitInterface.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, "IHotReloadAddedMemberPing.Extra", "Explicit interface");
+            Assert.That(FindEntry(result, "Extra"), Is.Null);
+        }
+
+        /// <summary>
+        /// What: a skipped added method declaration is stripped before drift compare so the skip
+        /// reason is the only signal (no fields/initializers warning).
+        /// </summary>
+        [Test]
+        public async Task Drift_SkippedAddedMethod_DoesNotFireOutsideBodyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public virtual int AddedVirtual(int value)\n        {\n            return value;\n        }");
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("DriftSkippedAdded.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, "AddedVirtual", "vtable slot");
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.None.Contain("Edits outside method bodies"),
+                "Skipped added declarations must not fire fields/initializers drift.\n"
+                + string.Join("\n", result.Output.declarationDriftWarnings ?? Array.Empty<string>()));
         }
 
         /// <summary>
@@ -508,7 +740,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string sourcePath,
             string projectRelativePath,
             string snapshotSource = null,
-            string[] excludedMethodKeys = null)
+            string[] excludedMethodKeys = null,
+            string[] excludedAddedMethodKeys = null)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string targetDllPath = Path.Combine(
@@ -544,7 +777,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource = snapshotSource,
                 projectRelativePath = projectRelativePath,
                 assemblySourcePaths = assemblySourcePaths,
-                excludedMethodKeys = excludedMethodKeys ?? Array.Empty<string>()
+                excludedMethodKeys = excludedMethodKeys ?? Array.Empty<string>(),
+                excludedAddedMethodKeys = excludedAddedMethodKeys ?? Array.Empty<string>()
             };
 
             return await TransformWorkerClient.RunAsync(input, CancellationToken.None);

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -1,0 +1,609 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Worker coverage for added/removed method classification, shim emit, call-site rewrite,
+    /// skip reasons, Unity-message warnings, outside-body drift stripping, and isolation G1.
+    /// </summary>
+    public class TransformWorkerAddedMemberTests
+    {
+        private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+        private const string HostProjectRelativePath =
+            "Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs";
+
+        private const string HostCloseMarker =
+            "        public int ReadPrivateSeed()\n        {\n            return _privateSeed;\n        }\n    }";
+
+        /// <summary>
+        /// What: a method present only in the edited source is classified Added, an existing
+        /// edited method stays transplant, and a snapshot-only method is reported removed.
+        /// </summary>
+        [Test]
+        public async Task Classify_AddedExistingAndRemovedMethods_MatchCompiledAssemblyGroundTruth()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public int AddedPing(int value)\n        {\n            return value + 1;\n        }");
+            edited = edited.Replace(
+                "        [MethodImpl(MethodImplOptions.NoInlining)]\n"
+                + "        public int ExistingFail(int value)\n        {\n            return value;\n        }\n\n",
+                string.Empty,
+                StringComparison.Ordinal);
+            string sourcePath = WriteEdited("ClassifyAddedExistingRemoved.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto added = FindEntry(result, "AddedPing");
+            Assert.That(added, Is.Not.Null, "AddedPing must be an entry.");
+            Assert.That(added.patchKind, Is.EqualTo(HotReloadConstants.PatchKindAddedMethod));
+
+            TransformWorkerEntryDto existing = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingValue));
+            Assert.That(existing, Is.Null, "Unedited ExistingValue must not be an entry when snapshot matches.");
+
+            Assert.That(result.Output.removedMembers, Is.Not.Null);
+            bool foundRemoved = false;
+            foreach (TransformWorkerRemovedMemberDto removed in result.Output.removedMembers)
+            {
+                if (removed.kind == HotReloadConstants.RemovedMemberKindMethod
+                    && removed.name == nameof(HotReloadAddedMemberHost.ExistingFail))
+                {
+                    foundRemoved = true;
+                }
+            }
+
+            Assert.That(foundRemoved, Is.True, "ExistingFail must be reported as a removed method.");
+        }
+
+        /// <summary>
+        /// What: an added method entry is emitted as a public static shim method in shimSource.
+        /// </summary>
+        [Test]
+        public async Task Emit_AddedInstanceMethod_ProducesStaticShimMethod()
+        {
+            TransformWorkerClientResult result = await RunHostWithAddedMembersAsync(
+                "public int AddedPing(int value)\n        {\n            return value + 1;\n        }");
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto added = FindEntry(result, "AddedPing");
+            Assert.That(added, Is.Not.Null);
+            Assert.That(added.shimMethodName, Does.Contain("__shim"));
+            Assert.That(result.Output.shimSource, Does.Contain("public static int " + added.shimMethodName));
+            Assert.That(result.Output.shimSource, Does.Contain("__uloopInstance"));
+        }
+
+        /// <summary>
+        /// What: implicit-this, explicit-this, receiver-expression, and static added-method calls
+        /// plus mutual and recursive added-method calls are rewritten to the shim static form.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_AddedMethodCallSites_UseShimStaticInvocations()
+        {
+            string extra =
+                "public int AddedInstance(int value)\n        {\n            return AddedStatic(value);\n        }\n\n"
+                + "        public static int AddedStatic(int value)\n        {\n            return value + 1;\n        }\n\n"
+                + "        public int AddedRecursive(int value)\n        {\n"
+                + "            if (value <= 0) return 0;\n"
+                + "            return AddedRecursive(value - 1);\n        }\n\n"
+                + "        public int AddedMutualA(int value)\n        {\n            return AddedMutualB(value);\n        }\n\n"
+                + "        public int AddedMutualB(int value)\n        {\n            return value;\n        }";
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, extra);
+            edited = edited.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return AddedInstance(value) + this.AddedInstance(value) + AddedStatic(value);\n"
+                + "        }",
+                StringComparison.Ordinal);
+            string sourcePath = WriteEdited("RewriteCallSites.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto addedInstance = FindEntry(result, "AddedInstance");
+            TransformWorkerEntryDto addedStatic = FindEntry(result, "AddedStatic");
+            TransformWorkerEntryDto addedRecursive = FindEntry(result, "AddedRecursive");
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(addedInstance, Is.Not.Null);
+            Assert.That(addedStatic, Is.Not.Null);
+            Assert.That(addedRecursive, Is.Not.Null);
+            Assert.That(caller, Is.Not.Null);
+
+            string callerSlice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(callerSlice, Does.Contain(addedInstance.shimMethodName + "(__uloopInstance, value)"));
+            Assert.That(callerSlice, Does.Contain(addedStatic.shimMethodName + "(value)"));
+
+            string instanceSlice = SliceShimMethod(result.Output.shimSource, addedInstance.shimMethodName);
+            Assert.That(instanceSlice, Does.Contain(addedStatic.shimMethodName + "(value)"));
+
+            string recursiveSlice = SliceShimMethod(result.Output.shimSource, addedRecursive.shimMethodName);
+            Assert.That(recursiveSlice, Does.Contain(addedRecursive.shimMethodName + "(__uloopInstance, value - 1)"));
+
+            TransformWorkerEntryDto mutualA = FindEntry(result, "AddedMutualA");
+            TransformWorkerEntryDto mutualB = FindEntry(result, "AddedMutualB");
+            Assert.That(mutualA, Is.Not.Null);
+            Assert.That(mutualB, Is.Not.Null);
+            string mutualSlice = SliceShimMethod(result.Output.shimSource, mutualA.shimMethodName);
+            Assert.That(mutualSlice, Does.Contain(mutualB.shimMethodName));
+            Assert.That(
+                caller.calledAddedMethodKeys,
+                Does.Contain(BuildHostMethodKey("AddedInstance", "System.Int32")));
+        }
+
+        /// <summary>
+        /// What: nameof(added method) is folded to a string literal so shim compile does not
+        /// need to resolve the added name.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_NameofAddedMethod_FoldsToStringLiteral()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public int AddedPing(int value)\n        {\n            return value;\n        }");
+            edited = edited.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return nameof(AddedPing).Length + value;\n        }",
+                StringComparison.Ordinal);
+            string sourcePath = WriteEdited("NameofAddedMethod.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null);
+            string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(slice, Does.Contain("\"AddedPing\""));
+            Assert.That(slice, Does.Not.Contain("nameof("));
+        }
+
+        /// <summary>
+        /// What: added virtual, override, generic, and method-group-capturing methods are skipped
+        /// with the documented reasons; the captured added instance method itself still emits.
+        /// </summary>
+        [Test]
+        public async Task Skip_UnsupportedAddedMethods_UseDedicatedReasons()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public virtual int ExistingVirtual(int value)\n        {\n            return value;\n        }",
+                "        public virtual int ExistingVirtual(int value)\n        {\n            return value;\n        }\n\n"
+                + "        public virtual int AddedVirtual(int value)\n        {\n            return value;\n        }",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                "        public int ChildExisting()\n        {\n            return 1;\n        }",
+                "        public int ChildExisting()\n        {\n            return 1;\n        }\n\n"
+                + "        public override int ExistingVirtual(int value)\n        {\n            return value + 1;\n        }",
+                StringComparison.Ordinal);
+            edited = WithHostMembers(
+                edited,
+                "public int AddedGeneric<T>(T value)\n        {\n            return 0;\n        }\n\n"
+                + "        public int AddedInstance(int value)\n        {\n            return value;\n        }\n\n"
+                + "        public int CaptureAdded()\n        {\n"
+                + "            System.Func<int, int> bound = AddedInstance;\n"
+                + "            return bound(1);\n        }");
+            string sourcePath = WriteEdited("SkipUnsupportedAdded.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            AssertHasSkip(result, "AddedVirtual", "vtable slot");
+            AssertHasSkip(result, "ExistingVirtual", "vtable slot");
+            AssertHasSkip(result, "AddedGeneric", "Generic");
+            AssertHasSkip(result, "CaptureAdded", "method group");
+            Assert.That(FindEntry(result, "AddedInstance"), Is.Not.Null, "Added instance method must still emit.");
+        }
+
+        /// <summary>
+        /// What: an added method that reads a private field becomes a delegation-style accessor
+        /// rewrite while keeping patchKind addedMethod, and hasAccessorDelegates is true.
+        /// </summary>
+        [Test]
+        public async Task AddedMethod_PrivateFieldAccess_EmitsAccessorsAndAddedMethodKind()
+        {
+            TransformWorkerClientResult result = await RunHostWithAddedMembersAsync(
+                "public int AddedReadPrivate()\n        {\n"
+                + "            System.Func<int> read = () => _privateSeed;\n"
+                + "            return read();\n        }");
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto added = FindEntry(result, "AddedReadPrivate");
+            Assert.That(added, Is.Not.Null);
+            Assert.That(added.patchKind, Is.EqualTo(HotReloadConstants.PatchKindAddedMethod));
+            Assert.That(result.Output.hasAccessorDelegates, Is.True);
+            Assert.That(result.Output.shimSource, Does.Contain("__BindAccessors"));
+        }
+
+        /// <summary>
+        /// What: adding Update on a compiled MonoBehaviour-derived type keeps the entry and emits
+        /// the Unity-message warning.
+        /// </summary>
+        [Test]
+        public async Task Warn_AddedUnityMessageOnMonoBehaviour_KeepsEntryAndEmitsWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public void ExistingTick()\n        {\n        }",
+                "        public void ExistingTick()\n        {\n        }\n\n"
+                + "        public void Update()\n        {\n        }",
+                StringComparison.Ordinal);
+            string sourcePath = WriteEdited("AddedUnityMessage.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto added = FindEntry(result, "Update");
+            Assert.That(added, Is.Not.Null, "Added Update must still be an entry.");
+            Assert.That(added.patchKind, Is.EqualTo(HotReloadConstants.PatchKindAddedMethod));
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.Some.Contain("Update").And.Contain("uloop compile"));
+        }
+
+        /// <summary>
+        /// What: adding or removing a method does not emit the outside-method-body drift warning;
+        /// a field-initializer change still does.
+        /// </summary>
+        [Test]
+        public async Task Drift_HandledAddedAndRemovedMethods_DoNotFireOutsideBodyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string addedOnly = WithHostMembers(
+                onDisk,
+                "public int AddedPing(int value)\n        {\n            return value;\n        }");
+            TransformWorkerClientResult addedResult = await RunWorkerOnSourceAsync(
+                WriteEdited("DriftAddedOnly.cs", addedOnly),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(addedResult.Success, Is.True, addedResult.ErrorMessage);
+            Assert.That(
+                addedResult.Output.declarationDriftWarnings,
+                Has.None.Contain("Edits outside method bodies"),
+                "Handled method addition must not fire outside-body drift.\n"
+                + string.Join("\n", addedResult.Output.declarationDriftWarnings ?? Array.Empty<string>()));
+
+            string removedOnly = onDisk.Replace(
+                "        [MethodImpl(MethodImplOptions.NoInlining)]\n"
+                + "        public int ExistingFail(int value)\n        {\n            return value;\n        }\n\n",
+                string.Empty,
+                StringComparison.Ordinal);
+            TransformWorkerClientResult removedResult = await RunWorkerOnSourceAsync(
+                WriteEdited("DriftRemovedOnly.cs", removedOnly),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(removedResult.Success, Is.True, removedResult.ErrorMessage);
+            Assert.That(
+                removedResult.Output.declarationDriftWarnings,
+                Has.None.Contain("Edits outside method bodies"),
+                "Handled method removal must not fire outside-body drift.\n"
+                + string.Join("\n", removedResult.Output.declarationDriftWarnings ?? Array.Empty<string>()));
+
+            string fieldAndAdded = addedOnly.Replace(
+                "public int PublicSeed = 3;",
+                "public int PublicSeed = 4;",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult fieldResult = await RunWorkerOnSourceAsync(
+                WriteEdited("DriftFieldAndAdded.cs", fieldAndAdded),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(fieldResult.Success, Is.True, fieldResult.ErrorMessage);
+            Assert.That(
+                fieldResult.Output.declarationDriftWarnings,
+                Has.Some.Contain("Edits outside method bodies"),
+                "Field initializer drift must still fire after handled method additions are stripped.");
+        }
+
+        /// <summary>
+        /// What: excluding an added method key still emits that added method so remaining callers
+        /// can compile on isolation retry (G1).
+        /// </summary>
+        [Test]
+        public async Task Isolation_ExcludedAddedMethodKey_StillEmitsAddedMethodShim()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public int AddedPing(int value)\n        {\n            return value + 1;\n        }");
+            edited = edited.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedPing(value);\n        }",
+                StringComparison.Ordinal);
+            string addedKey = BuildHostMethodKey("AddedPing", "System.Int32");
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("IsolationKeepAdded.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk,
+                excludedMethodKeys: new[] { addedKey });
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto added = FindEntry(result, "AddedPing");
+            Assert.That(added, Is.Not.Null, "Added method must not be dropped by excludedMethodKeys.");
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null);
+            string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(slice, Does.Contain(added.shimMethodName));
+        }
+
+        /// <summary>
+        /// What: baseline null does not report removed members even when the edited source drops
+        /// a compiled method.
+        /// </summary>
+        [Test]
+        public async Task Classify_NoBaseline_DoesNotReportRemovedMembers()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        [MethodImpl(MethodImplOptions.NoInlining)]\n"
+                + "        public int ExistingFail(int value)\n        {\n            return value;\n        }\n\n",
+                string.Empty,
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("NoBaselineRemoved.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: null);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.removedMembers, Is.Not.Null);
+            Assert.That(result.Output.removedMembers, Is.Empty);
+        }
+
+        private static async Task<TransformWorkerClientResult> RunHostWithAddedMembersAsync(string extraMembers)
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, extraMembers);
+            return await RunWorkerOnSourceAsync(
+                WriteEdited("HostWithAddedMembers.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+        }
+
+        private static string WithHostMembers(string onDisk, string extraMembers)
+        {
+            Assert.That(onDisk, Does.Contain(HostCloseMarker));
+            return onDisk.Replace(
+                HostCloseMarker,
+                "        public int ReadPrivateSeed()\n        {\n            return _privateSeed;\n        }\n\n        "
+                + extraMembers
+                + "\n    }",
+                StringComparison.Ordinal);
+        }
+
+        private static string BuildHostMethodKey(string methodName, params string[] parameterTypeFullNames)
+        {
+            return typeof(HotReloadAddedMemberHost).FullName
+                + "::" + methodName + "("
+                + string.Join(",", parameterTypeFullNames) + ")";
+        }
+
+        private static TransformWorkerEntryDto FindEntry(TransformWorkerClientResult result, string methodName)
+        {
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                if (entry.methodName == methodName)
+                {
+                    return entry;
+                }
+            }
+
+            return null;
+        }
+
+        private static void AssertHasSkip(
+            TransformWorkerClientResult result,
+            string methodNameFragment,
+            string reasonFragment)
+        {
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                if (skipped.method != null
+                    && skipped.method.Contains(methodNameFragment)
+                    && skipped.reason != null
+                    && skipped.reason.Contains(reasonFragment))
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail(
+                "Expected skip for '" + methodNameFragment + "' with reason containing '"
+                + reasonFragment + "'. Skipped="
+                + FormatSkipped(result.Output.skipped));
+        }
+
+        private static string FormatSkipped(TransformWorkerSkippedDto[] skipped)
+        {
+            if (skipped == null || skipped.Length == 0)
+            {
+                return "(none)";
+            }
+
+            List<string> rows = new List<string>();
+            foreach (TransformWorkerSkippedDto entry in skipped)
+            {
+                rows.Add(entry.method + " :: " + entry.reason);
+            }
+
+            return string.Join("\n", rows);
+        }
+
+        private static string SliceShimMethod(string shimSource, string shimMethodName)
+        {
+            int nameIndex = shimSource.IndexOf(shimMethodName, StringComparison.Ordinal);
+            Assert.That(nameIndex, Is.GreaterThanOrEqualTo(0), "Shim method missing: " + shimMethodName);
+            int declarationStart = shimSource.LastIndexOf("public static", nameIndex, StringComparison.Ordinal);
+            int openBrace = shimSource.IndexOf('{', nameIndex);
+            Assert.That(openBrace, Is.GreaterThan(0));
+            int depth = 0;
+            for (int index = openBrace; index < shimSource.Length; index++)
+            {
+                if (shimSource[index] == '{')
+                {
+                    depth++;
+                }
+                else if (shimSource[index] == '}')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        return shimSource.Substring(declarationStart, index - declarationStart + 1);
+                    }
+                }
+            }
+
+            Assert.Fail("Unbalanced shim method: " + shimMethodName);
+            return string.Empty;
+        }
+
+        private static string WriteEdited(string fileName, string contents)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string path = Path.Combine(directory, fileName);
+            File.WriteAllText(path, contents);
+            return path;
+        }
+
+        private static string ResolveHostPath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadAddedMemberHost.cs");
+            Assert.That(File.Exists(path), Is.True, "Added-member host source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static async Task<TransformWorkerClientResult> RunWorkerOnSourceAsync(
+            string sourcePath,
+            string projectRelativePath,
+            string snapshotSource = null,
+            string[] excludedMethodKeys = null)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string targetDllPath = Path.Combine(
+                projectRoot,
+                "Library",
+                "ScriptAssemblies",
+                TestAssemblyName + ".dll");
+            Assert.That(File.Exists(targetDllPath), Is.True, "Test assembly dll missing: " + targetDllPath);
+
+            UnityEditor.Compilation.Assembly compilationAssembly = null;
+            foreach (UnityEditor.Compilation.Assembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name == TestAssemblyName)
+                {
+                    compilationAssembly = assembly;
+                    break;
+                }
+            }
+
+            Assert.That(compilationAssembly, Is.Not.Null, "CompilationPipeline assembly not found.");
+
+            string[] referencePaths = BuildAbsoluteReferencePaths(
+                compilationAssembly.allReferences,
+                targetDllPath);
+            string[] assemblySourcePaths = BuildAbsoluteAssemblySourcePaths(compilationAssembly.sourceFiles);
+
+            TransformWorkerInputDto input = new TransformWorkerInputDto
+            {
+                sourcePath = sourcePath,
+                defines = compilationAssembly.defines ?? Array.Empty<string>(),
+                referencePaths = referencePaths,
+                targetTypesAssemblyPath = targetDllPath,
+                snapshotSource = snapshotSource,
+                projectRelativePath = projectRelativePath,
+                assemblySourcePaths = assemblySourcePaths,
+                excludedMethodKeys = excludedMethodKeys ?? Array.Empty<string>()
+            };
+
+            return await TransformWorkerClient.RunAsync(input, CancellationToken.None);
+        }
+
+        private static string[] BuildAbsoluteReferencePaths(string[] allReferences, string targetDllPath)
+        {
+            List<string> paths = new List<string>();
+            if (allReferences != null)
+            {
+                foreach (string reference in allReferences)
+                {
+                    if (string.IsNullOrEmpty(reference) || !File.Exists(reference))
+                    {
+                        continue;
+                    }
+
+                    paths.Add(Path.GetFullPath(reference));
+                }
+            }
+
+            string fullTarget = Path.GetFullPath(targetDllPath);
+            bool hasTarget = false;
+            foreach (string path in paths)
+            {
+                if (string.Equals(path, fullTarget, StringComparison.OrdinalIgnoreCase))
+                {
+                    hasTarget = true;
+                    break;
+                }
+            }
+
+            if (!hasTarget)
+            {
+                paths.Add(fullTarget);
+            }
+
+            return paths.ToArray();
+        }
+
+        private static string[] BuildAbsoluteAssemblySourcePaths(string[] sourceFiles)
+        {
+            if (sourceFiles == null || sourceFiles.Length == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string[] paths = new string[sourceFiles.Length];
+            for (int index = 0; index < sourceFiles.Length; index++)
+            {
+                string normalizedRelativePath = sourceFiles[index].Replace('\\', '/');
+                string absoluteSourcePath = Path.Combine(
+                    projectRoot,
+                    normalizedRelativePath.Replace('/', Path.DirectorySeparatorChar));
+                paths[index] = Path.GetFullPath(absoluteSourcePath);
+            }
+
+            return paths;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -619,8 +619,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "((Host)obj).AddedPing must rewrite to the added shim.\n" + callerSlice);
             Assert.That(
                 callerSlice,
-                Does.Contain("obj"),
+                Does.Contain("((HotReloadAddedMemberHost)obj)"),
                 "Cast receiver must be spliced into the shim call, not replaced with __uloopInstance.\n"
+                + callerSlice);
+            Assert.That(
+                callerSlice,
+                Does.Not.Contain(added.shimMethodName + "(__uloopInstance"),
+                "AddedPing rewrite must pass the cast receiver, not the shim instance parameter.\n"
                 + callerSlice);
         }
 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -587,11 +587,84 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a cast receiver ((Host)obj).AddedPing is not a conditional-access spine, so the
+        /// caller is rewritten to the added-method shim instead of skipped.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_CastReceiverAddedMethodCall_RewritesToShim()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public int AddedPing(int value)\n        {\n            return value;\n        }");
+            edited = edited.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            object obj = this;\n"
+                + "            return ((HotReloadAddedMemberHost)obj).AddedPing(value);\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("RewriteCastReceiverAdded.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            TransformWorkerEntryDto added = FindEntry(result, "AddedPing");
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(added, Is.Not.Null, "AddedPing must still emit.");
+            Assert.That(caller, Is.Not.Null, "((Host)obj).AddedPing must not skip as conditional access.");
+            string callerSlice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(
+                callerSlice,
+                Does.Contain(added.shimMethodName),
+                "((Host)obj).AddedPing must rewrite to the added shim.\n" + callerSlice);
+            Assert.That(
+                callerSlice,
+                Does.Contain("obj"),
+                "Cast receiver must be spliced into the shim call, not replaced with __uloopInstance.\n"
+                + callerSlice);
+        }
+
+        /// <summary>
+        /// What: a private instance call through a cast receiver inside a lambda is
+        /// accessor-rewritten (Delegation); the cast is not treated as a ?. spine.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_CastReceiverPrivateCallInLambda_EmitsMethodAccessor()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            object obj = this;\n"
+                + "            System.Func<int> read = () => ((HotReloadAddedMemberHost)obj).PrivateCall();\n"
+                + "            return read();\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("RewriteCastReceiverPrivateCall.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null, "Cast-receiver PrivateCall in a lambda must not skip.");
+            Assert.That(caller.patchKind, Is.EqualTo(HotReloadConstants.PatchKindDelegation));
+            Assert.That(result.Output.hasAccessorDelegates, Is.True);
+            string callerSlice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(
+                callerSlice,
+                Does.Contain("__M_PrivateCall"),
+                "((Host)obj).PrivateCall must be accessor-rewritten.\n" + callerSlice);
+            Assert.That(
+                callerSlice,
+                Does.Not.Contain(".PrivateCall()"),
+                "PrivateCall must not remain a verbatim instance call in the shim.\n" + callerSlice);
+        }
+
+        /// <summary>
         /// What: a private call in a conditional-access argument list inside a lambda is
         /// accessor-rewritten (Delegation), not left verbatim.
         /// </summary>
         [Test]
-        public async Task Rewrite_LambdaConditionalAccessArgumentPrivateCall_EmitsMethodAccessor()
+        public async Task Rewrite_LambdaConditionalAccessArgumentPrivateStaticSeven_EmitsMethodAccessor()
         {
             string onDisk = File.ReadAllText(ResolveHostPath());
             string edited = onDisk.Replace(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -447,6 +447,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a chained conditional-access call (other?.Inner.AddedPing) skips the referencing
+        /// method; MemberAccess-under-WhenNotNull is the same hole as a bare MemberBinding.
+        /// </summary>
+        [Test]
+        public async Task Skip_ChainedConditionalAccessAddedMethodCall_UsesDedicatedReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public int AddedPing(int value)\n        {\n            return value;\n        }");
+            edited = edited.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            HotReloadAddedMemberHost other = this;\n"
+                + "            other.Inner = this;\n"
+                + "            return other?.Inner.AddedPing(value) ?? 0;\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("SkipChainedConditionalAccess.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "conditional access");
+            Assert.That(FindEntry(result, "AddedPing"), Is.Not.Null);
+            Assert.That(
+                result.Output.shimSource,
+                Does.Not.Contain("?.Inner"),
+                "Chained ?. must not emit a parse-invalid rewritten receiver.");
+        }
+
+        /// <summary>
         /// What: a type absent from the compiled assembly skips every method with the new-type
         /// out-of-scope reason instead of emitting MethodNotFound entries.
         /// </summary>
@@ -467,6 +498,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             AssertHasSkip(result, "HotReloadBrandNewType.Fresh", "New types are out of scope");
             Assert.That(FindEntry(result, "Fresh"), Is.Null);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.None.Contain("Edits outside method bodies"),
+                "Skipped new-type declarations must not fire fields/initializers drift.\n"
+                + string.Join("\n", result.Output.declarationDriftWarnings ?? Array.Empty<string>()));
         }
 
         /// <summary>
@@ -490,6 +526,47 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(entry, Is.Not.Null);
             Assert.That(entry.patchKind, Is.Not.EqualTo(HotReloadConstants.PatchKindAddedMethod));
             Assert.That(entry.parameterTypeFullNames, Is.EqualTo(new[] { "System.Object" }));
+        }
+
+        /// <summary>
+        /// What: nested dynamic in List&lt;dynamic&gt; and dynamic[] still matches compiled
+        /// List&lt;object&gt; / object[] so the existing methods are not classified Added.
+        /// </summary>
+        [Test]
+        public async Task Classify_NestedDynamicParameter_DoesNotMisclassifyExistingMethodAsAdded()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int ExistingDynamicList(System.Collections.Generic.List<object> values)\n"
+                + "        {\n            return 0;\n        }",
+                "        public int ExistingDynamicList(System.Collections.Generic.List<dynamic> values)\n"
+                + "        {\n            return 1;\n        }",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                "        public int ExistingDynamicArray(object[] values)\n        {\n            return 0;\n        }",
+                "        public int ExistingDynamicArray(dynamic[] values)\n        {\n            return 1;\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("NestedDynamicNotAdded.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto listEntry = FindEntry(
+                result,
+                nameof(HotReloadAddedMemberHost.ExistingDynamicList));
+            Assert.That(listEntry, Is.Not.Null);
+            Assert.That(listEntry.patchKind, Is.Not.EqualTo(HotReloadConstants.PatchKindAddedMethod));
+            Assert.That(
+                listEntry.parameterTypeFullNames,
+                Is.EqualTo(new[] { "System.Collections.Generic.List`1<System.Object>" }));
+
+            TransformWorkerEntryDto arrayEntry = FindEntry(
+                result,
+                nameof(HotReloadAddedMemberHost.ExistingDynamicArray));
+            Assert.That(arrayEntry, Is.Not.Null);
+            Assert.That(arrayEntry.patchKind, Is.Not.EqualTo(HotReloadConstants.PatchKindAddedMethod));
+            Assert.That(arrayEntry.parameterTypeFullNames, Is.EqualTo(new[] { "System.Object[]" }));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -482,6 +482,78 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: other?.Get().AddedPing() is a MemberBinding-rooted invocation spine (Get sits
+        /// between ? and AddedPing) and skips the caller instead of emitting a parse-invalid shim.
+        /// </summary>
+        [Test]
+        public async Task Skip_ConditionalAccessGetThenAddedMethod_DoesNotRewriteCaller()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public int AddedPing(int value)\n        {\n            return value;\n        }");
+            edited = edited.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            HotReloadAddedMemberHost other = this;\n"
+                + "            return other?.Get().AddedPing(value) ?? 0;\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("SkipConditionalAccessGet.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "conditional access");
+            Assert.That(FindEntry(result, "AddedPing"), Is.Not.Null);
+            Assert.That(
+                FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller)),
+                Is.Null,
+                "other?.Get().AddedPing must skip the caller, not rewrite to Shim(.Get()).");
+            Assert.That(
+                result.Output.shimSource,
+                Does.Not.Contain("?global::"),
+                "ExtractReceiver must not splice a shim call after ?.");
+            Assert.That(
+                result.Output.shimSource,
+                Does.Not.Contain(".Get()"),
+                "MemberBinding-rooted Get() must not be spliced as a shim receiver.");
+        }
+
+        /// <summary>
+        /// What: other?[0].AddedPing() (element binding under WhenNotNull) skips the caller
+        /// instead of rewriting the receiver.
+        /// </summary>
+        [Test]
+        public async Task Skip_ElementBindingConditionalAccessAddedMethod_DoesNotRewriteCaller()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public int AddedPing(int value)\n        {\n            return value;\n        }");
+            edited = edited.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            HotReloadAddedMemberHost other = this;\n"
+                + "            return other?[0].AddedPing(value) ?? 0;\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("SkipConditionalAccessIndexer.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "conditional access");
+            Assert.That(FindEntry(result, "AddedPing"), Is.Not.Null);
+            Assert.That(
+                FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller)),
+                Is.Null,
+                "other?[0].AddedPing must skip the caller, not rewrite the element-binding receiver.");
+            Assert.That(
+                result.Output.shimSource,
+                Does.Not.Contain("?global::"),
+                "ExtractReceiver must not splice a shim call after ?.");
+        }
+
+        /// <summary>
         /// What: an added-method call in a conditional-access argument list is rewritten to the
         /// shim; the caller is not skipped for ConditionalAccess.
         /// </summary>
@@ -512,6 +584,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 callerSlice,
                 Does.Contain(added.shimMethodName + "(__uloopInstance, 1)"),
                 "AddedPing inside the ?. argument list must rewrite to the shim.\n" + callerSlice);
+        }
+
+        /// <summary>
+        /// What: a private call in a conditional-access argument list inside a lambda is
+        /// accessor-rewritten (Delegation), not left verbatim.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_LambdaConditionalAccessArgumentPrivateCall_EmitsMethodAccessor()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            HotReloadAddedMemberHost other = this;\n"
+                + "            System.Func<int> read = () => other?.ExistingFail(PrivateStaticSeven()) ?? 0;\n"
+                + "            return read();\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("LambdaConditionalAccessPrivateArg.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null, "Lambda ?. argument caller must not skip.");
+            Assert.That(caller.patchKind, Is.EqualTo(HotReloadConstants.PatchKindDelegation));
+            Assert.That(result.Output.hasAccessorDelegates, Is.True);
+            string callerSlice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(
+                callerSlice,
+                Does.Contain("__M_PrivateStaticSeven()"),
+                "PrivateStaticSeven inside other?.ExistingFail(...) must be accessor-rewritten.\n"
+                + callerSlice);
+            Assert.That(
+                callerSlice,
+                Does.Not.Contain("ExistingFail(PrivateStaticSeven())"),
+                "PrivateStaticSeven must not remain a verbatim call in the shim.\n" + callerSlice);
         }
 
         /// <summary>
@@ -568,6 +676,55 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 result.Output.declarationDriftWarnings,
                 Has.None.Contain("Edits outside method bodies"),
                 "Skipped new-interface declarations must not fire fields/initializers drift.\n"
+                + string.Join("\n", result.Output.declarationDriftWarnings ?? Array.Empty<string>()));
+        }
+
+        /// <summary>
+        /// What: editing a compiled interface default method is skipped with the interface-member
+        /// reason and does not emit a Transplant entry.
+        /// </summary>
+        [Test]
+        public async Task Skip_CompiledInterfaceDefaultMethodEdit_UsesInterfaceMemberReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        int ExistingDefault() => 1;",
+                "        int ExistingDefault() => 2;",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("SkipCompiledInterfaceDefault.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, "ExistingDefault", "Interface members are not patchable");
+            Assert.That(FindEntry(result, "ExistingDefault"), Is.Null);
+        }
+
+        /// <summary>
+        /// What: adding a member to a compiled interface is reported as Skipped with the
+        /// interface-member reason (not an outside-body drift warning).
+        /// </summary>
+        [Test]
+        public async Task Skip_AddedMemberOnCompiledInterface_UsesInterfaceMemberReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        int Ping(int value);",
+                "        int Ping(int value);\n        int Extra(int value);",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("SkipAddedCompiledInterfaceMember.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, "Extra", "Interface members are not patchable");
+            Assert.That(FindEntry(result, "Extra"), Is.Null);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.None.Contain("Edits outside method bodies"),
+                "Added compiled-interface members must surface as Skipped, not drift.\n"
                 + string.Join("\n", result.Output.declarationDriftWarnings ?? Array.Empty<string>()));
         }
 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -448,10 +448,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: a chained conditional-access call (other?.Inner.AddedPing) skips the referencing
-        /// method; MemberAccess-under-WhenNotNull is the same hole as a bare MemberBinding.
+        /// method with the same ConditionalAccess reason as a simple MemberBinding call.
         /// </summary>
         [Test]
-        public async Task Skip_ChainedConditionalAccessAddedMethodCall_UsesDedicatedReason()
+        public async Task Skip_ChainedConditionalAccessAddedMethodCall_DoesNotRewriteCaller()
         {
             string onDisk = File.ReadAllText(ResolveHostPath());
             string edited = WithHostMembers(
@@ -472,9 +472,46 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "conditional access");
             Assert.That(FindEntry(result, "AddedPing"), Is.Not.Null);
             Assert.That(
+                FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller)),
+                Is.Null,
+                "Chained ?. caller must be skipped, not rewritten into a parse-invalid shim.");
+            Assert.That(
                 result.Output.shimSource,
-                Does.Not.Contain("?.Inner"),
-                "Chained ?. must not emit a parse-invalid rewritten receiver.");
+                Does.Not.Contain("?global::"),
+                "ExtractReceiver must not splice a shim call after ?.");
+        }
+
+        /// <summary>
+        /// What: an added-method call in a conditional-access argument list is rewritten to the
+        /// shim; the caller is not skipped for ConditionalAccess.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_AddedMethodCallInConditionalAccessArgument_DoesNotSkipCaller()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public int AddedPing(int value)\n        {\n            return value;\n        }");
+            edited = edited.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            HotReloadAddedMemberHost other = this;\n"
+                + "            return other?.ExistingFail(AddedPing(1)) ?? 0;\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("RewriteConditionalAccessArgument.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            TransformWorkerEntryDto added = FindEntry(result, "AddedPing");
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(added, Is.Not.Null, "AddedPing must still emit.");
+            Assert.That(caller, Is.Not.Null, "Caller of other?.Existing(AddedPing) must not skip.");
+            string callerSlice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(
+                callerSlice,
+                Does.Contain(added.shimMethodName + "(__uloopInstance, 1)"),
+                "AddedPing inside the ?. argument list must rewrite to the shim.\n" + callerSlice);
         }
 
         /// <summary>
@@ -502,6 +539,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 result.Output.declarationDriftWarnings,
                 Has.None.Contain("Edits outside method bodies"),
                 "Skipped new-type declarations must not fire fields/initializers drift.\n"
+                + string.Join("\n", result.Output.declarationDriftWarnings ?? Array.Empty<string>()));
+        }
+
+        /// <summary>
+        /// What: a type absent as a new interface with a default method is stripped as a whole
+        /// so it does not fire the outside-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Skip_NewInterfaceAbsentFromCompiledAssembly_DoesNotFireOutsideBodyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "    internal class HotReloadAliasShadowFixture\n",
+                "    public interface IHotReloadBrandNewInterface\n    {\n"
+                + "        int Fresh() => 1;\n    }\n\n"
+                + "    internal class HotReloadAliasShadowFixture\n",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("SkipNewInterface.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, "IHotReloadBrandNewInterface.Fresh", "New types are out of scope");
+            Assert.That(FindEntry(result, "Fresh"), Is.Null);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.None.Contain("Edits outside method bodies"),
+                "Skipped new-interface declarations must not fire fields/initializers drift.\n"
                 + string.Join("\n", result.Output.declarationDriftWarnings ?? Array.Empty<string>()));
         }
 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f9cff83567ad04656976a4f92933f01c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -245,12 +245,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: an expression-bodied method maps its #line to the arrow expression's original
-        /// start line (not the declaration keyword line when they differ).
+        /// start line (not the declaration keyword line when they differ). Uses the compiled
+        /// HotReloadAddedMemberHost.ArrowRead so the type is present in the test assembly.
         /// </summary>
         [Test]
         public async Task BootstrapAndRun_ArrowBodyMethod_LineDirectiveUsesArrowExpressionLine()
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string hostPath = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadAddedMemberHost.cs");
+            string onDisk = File.ReadAllText(hostPath);
+            string edited = onDisk.Replace(
+                "        public int ArrowRead() => 1;",
+                "        public int ArrowRead()\n            => 42;",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk), "Precondition: ArrowRead must become multi-line.");
+
             string tempDirectory = Path.Combine(
                 projectRoot,
                 "Library",
@@ -259,36 +273,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "ArrowLineDirective");
             Directory.CreateDirectory(tempDirectory);
             string sourcePath = Path.Combine(tempDirectory, "ArrowBodyFixture.cs");
-            // Line 1 blank intentionally so the arrow expression starts on line 7 while the
-            // method keyword is on line 6 — the #line must report 7.
-            // Why a constant body: private-field access would force Delegation against a type that
-            // is not in the compiled test assembly; a literal return keeps Transplant and still
-            // exercises arrow-expression line mapping.
-            const string sourceText =
-                "\nnamespace ArrowLineDirectiveFixture\n{\n    public class ArrowHost\n    {\n"
-                + "        public int Read()\n"
-                + "            => 42;\n"
-                + "    }\n}\n";
-            File.WriteAllText(sourcePath, sourceText);
+            File.WriteAllText(sourcePath, edited);
 
-            string projectRelativePath = "Library/UloopHotReload/TestSources/ArrowLineDirective/ArrowBodyFixture.cs";
-            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(sourcePath, projectRelativePath);
+            string projectRelativePath = "Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs";
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                projectRelativePath,
+                snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(result.Output.entries, Is.Not.Empty);
 
             TransformWorkerEntryDto arrowEntry = null;
             foreach (TransformWorkerEntryDto entry in result.Output.entries)
             {
-                if (entry.methodName == "Read")
+                if (entry.methodName == nameof(HotReloadAddedMemberHost.ArrowRead))
                 {
                     arrowEntry = entry;
                     break;
                 }
             }
 
-            Assert.That(arrowEntry, Is.Not.Null, "Read entry missing.");
+            Assert.That(arrowEntry, Is.Not.Null, "ArrowRead entry missing.");
+            int expectedLine = FindLineNumberContaining(edited, "=> 42;");
+            Assert.That(expectedLine, Is.GreaterThan(0));
             // Why not SliceShimMethod: expression-bodied shims have no `{` block to bound a slice.
-            string expectedLineDirective = "#line 7 \"" + projectRelativePath + "\"";
+            string expectedLineDirective = "#line " + expectedLine + " \"" + projectRelativePath + "\"";
             Assert.That(
                 result.Output.shimSource,
                 Does.Contain(expectedLineDirective),
@@ -979,6 +988,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             string monoPrivateSource =
                 "using UnityEngine;\n"
+                + "namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload\n{\n"
                 + "public class HotReloadLifecycleMonoPrivateStartFixture : MonoBehaviour\n"
                 + "{\n"
                 + "    private void Start()\n"
@@ -986,18 +996,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + "        int x = 1;\n"
                 + "        x += 1;\n"
                 + "    }\n"
-                + "}\n";
+                + "}\n}\n";
             string pocoSource =
-                "public class HotReloadLifecyclePocoStartFixture\n"
+                "namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload\n{\n"
+                + "public class HotReloadLifecyclePocoStartFixture\n"
                 + "{\n"
                 + "    private void Start()\n"
                 + "    {\n"
                 + "        int x = 1;\n"
                 + "        x += 1;\n"
                 + "    }\n"
-                + "}\n";
+                + "}\n}\n";
             string monoPublicSource =
                 "using UnityEngine;\n"
+                + "namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload\n{\n"
                 + "public class HotReloadLifecycleMonoPublicStartFixture : MonoBehaviour\n"
                 + "{\n"
                 + "    public void Start()\n"
@@ -1005,9 +1017,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + "        int x = 1;\n"
                 + "        x += 1;\n"
                 + "    }\n"
-                + "}\n";
+                + "}\n}\n";
             string monoParameterizedSource =
                 "using UnityEngine;\n"
+                + "namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload\n{\n"
                 + "public class HotReloadLifecycleMonoParamStartFixture : MonoBehaviour\n"
                 + "{\n"
                 + "    private void Start(int delay)\n"
@@ -1015,7 +1028,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + "        int x = delay;\n"
                 + "        x += 1;\n"
                 + "    }\n"
-                + "}\n";
+                + "}\n}\n";
 
             TransformWorkerEntryDto monoPrivateEntry =
                 await RunWorkerAndFindEntryAsync(
@@ -1238,35 +1251,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task Run_WithSnapshotDifferingOnlyInSetter_DoesNotEmitUnchangedGetter()
         {
-            const string source =
-                "namespace GetterBaselineScope\n"
-                + "{\n"
-                + "    public class Host\n"
-                + "    {\n"
-                + "        private int _value;\n"
-                + "        public int Value\n"
-                + "        {\n"
-                + "            get { return _value; }\n"
-                + "            set { _value = value; }\n"
-                + "        }\n"
-                + "    }\n"
-                + "}\n";
-            string snapshotSource = source.Replace(
+            string sourcePath = ResolveShapeFixturePath();
+            string onDisk = File.ReadAllText(sourcePath);
+            string snapshotSource = onDisk.Replace(
                 "set { _value = value; }",
                 "set { _value = value + 1; }",
                 StringComparison.Ordinal);
-
-            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
-            string directory = Path.Combine(
-                projectRoot,
-                HotReloadConstants.TestSourcesRelativeDirectory);
-            Directory.CreateDirectory(directory);
-            string sourcePath = Path.Combine(directory, "SetterOnlyBaseline.cs");
-            File.WriteAllText(sourcePath, source);
+            Assert.That(snapshotSource, Is.Not.EqualTo(onDisk), "Precondition: setter must differ.");
 
             TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
                 sourcePath,
-                "Library/UloopHotReload/TestSources/SetterOnlyBaseline.cs",
+                ResolveShapeFixtureProjectRelativePath(),
                 snapshotSource: snapshotSource);
 
             Assert.That(result.Success, Is.True, result.ErrorMessage);
@@ -1307,6 +1302,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             string source =
                 "using UnityEngine;\n"
+                + "namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload\n{\n"
                 + "public class HotReloadLifecycleAwakeFixture : MonoBehaviour\n"
                 + "{\n"
                 + "    private void Awake()\n"
@@ -1314,7 +1310,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + "        int x = 1;\n"
                 + "        x += 1;\n"
                 + "    }\n"
-                + "}\n";
+                + "}\n}\n";
 
             TransformWorkerEntryDto awakeEntry =
                 await RunWorkerAndFindEntryAsync(source, "LifecycleAwake.cs", "Awake");
@@ -1543,6 +1539,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return "Assets/Tests/Editor/HotReload/HotReloadShapeFixtures.cs";
         }
 
+        private static int FindLineNumberContaining(string source, string fragment)
+        {
+            string[] lines = source.Replace("\r\n", "\n").Split('\n');
+            for (int index = 0; index < lines.Length; index++)
+            {
+                if (lines[index].Contains(fragment))
+                {
+                    return index + 1;
+                }
+            }
+
+            return -1;
+        }
+
         private static string FormatEntryMethodNames(TransformWorkerEntryDto[] entries)
         {
             if (entries == null || entries.Length == 0)
@@ -1593,10 +1603,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.Null,
                 "Omitted calledAddedMethodKeys must deserialize as null.");
 
-            omitted.removedMembers ??= Array.Empty<TransformWorkerRemovedMemberDto>();
-            omitted.entries[0].calledAddedMethodKeys ??= Array.Empty<string>();
+            TransformWorkerClient.CoalesceOutput(omitted);
+            Assert.That(omitted.removedMembers, Is.Not.Null);
             Assert.That(omitted.removedMembers, Is.Empty);
+            Assert.That(omitted.entries[0].calledAddedMethodKeys, Is.Not.Null);
             Assert.That(omitted.entries[0].calledAddedMethodKeys, Is.Empty);
+            Assert.That(omitted.declarationDriftWarnings, Is.Not.Null);
+            Assert.That(omitted.unchangedMethods, Is.Not.Null);
+            Assert.That(omitted.parseErrors, Is.Not.Null);
+            Assert.That(omitted.skipped, Is.Not.Null);
+            Assert.That(omitted.entries[0].parameterTypeFullNames, Is.Not.Null);
+            Assert.That(omitted.shimSource, Is.Not.Null);
 
             string emptyJson =
                 "{\"shimSource\":\"\",\"entries\":[{\"methodName\":\"Caller\",\"calledAddedMethodKeys\":[]}],"

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -294,6 +294,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             Assert.That(arrowEntry, Is.Not.Null, "ArrowRead entry missing.");
+            // Why a separate arrow line: FindLineNumberContaining("=> 42;") must not match the
+            // method-keyword line. Keep ArrowRead as `public int ArrowRead()\n            => 42;`
+            // so the #line target stays the expression start, not the declaration.
             int expectedLine = FindLineNumberContaining(edited, "=> 42;");
             Assert.That(expectedLine, Is.GreaterThan(0));
             // Why not SliceShimMethod: expression-bodied shims have no `{` block to bound a slice.

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Newtonsoft.Json;
+
 using NUnit.Framework;
 
 using UnityEditor.Compilation;
@@ -1571,6 +1573,48 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             return string.Join(", ", names);
+        }
+
+        /// <summary>
+        /// What: worker System.Text.Json may omit null nested arrays while Unity Newtonsoft
+        /// deserializes omitted fields as null; empty arrays round-trip as empty. Client coalesce
+        /// must turn both into non-null empty arrays so later readers never see null.
+        /// </summary>
+        [Test]
+        public void Deserialize_RemovedMembersAndCalledAddedMethodKeys_NullAndEmptyRoundTrip()
+        {
+            string omittedJson =
+                "{\"shimSource\":\"\",\"entries\":[{\"methodName\":\"Caller\"}],\"skipped\":[],\"parseErrors\":[]}";
+            TransformWorkerOutputDto omitted =
+                JsonConvert.DeserializeObject<TransformWorkerOutputDto>(omittedJson);
+            Assert.That(omitted.removedMembers, Is.Null, "Omitted removedMembers must deserialize as null.");
+            Assert.That(
+                omitted.entries[0].calledAddedMethodKeys,
+                Is.Null,
+                "Omitted calledAddedMethodKeys must deserialize as null.");
+
+            omitted.removedMembers ??= Array.Empty<TransformWorkerRemovedMemberDto>();
+            omitted.entries[0].calledAddedMethodKeys ??= Array.Empty<string>();
+            Assert.That(omitted.removedMembers, Is.Empty);
+            Assert.That(omitted.entries[0].calledAddedMethodKeys, Is.Empty);
+
+            string emptyJson =
+                "{\"shimSource\":\"\",\"entries\":[{\"methodName\":\"Caller\",\"calledAddedMethodKeys\":[]}],"
+                + "\"removedMembers\":[]}";
+            TransformWorkerOutputDto empty = JsonConvert.DeserializeObject<TransformWorkerOutputDto>(emptyJson);
+            Assert.That(empty.removedMembers, Is.Not.Null);
+            Assert.That(empty.removedMembers.Length, Is.EqualTo(0));
+            Assert.That(empty.entries[0].calledAddedMethodKeys, Is.Not.Null);
+            Assert.That(empty.entries[0].calledAddedMethodKeys.Length, Is.EqualTo(0));
+
+            string nestedJson =
+                "{\"removedMembers\":[{\"kind\":\"method\",\"name\":\"Gone\"}],"
+                + "\"entries\":[{\"methodName\":\"Caller\",\"calledAddedMethodKeys\":[\"T::Added()\"]}]}";
+            TransformWorkerOutputDto nested = JsonConvert.DeserializeObject<TransformWorkerOutputDto>(nestedJson);
+            Assert.That(nested.removedMembers.Length, Is.EqualTo(1));
+            Assert.That(nested.removedMembers[0].kind, Is.EqualTo("method"));
+            Assert.That(nested.removedMembers[0].name, Is.EqualTo("Gone"));
+            Assert.That(nested.entries[0].calledAddedMethodKeys, Is.EqualTo(new[] { "T::Added()" }));
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -44,18 +44,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public const string BurstCompileAttributeFullName = "Unity.Burst.BurstCompileAttribute";
 
+        // Why not "applied": this PR defers added-method ApplyEntry (Skipped). Call sites in
+        // edited bodies already route to the shim; PR-2 replaces the skip with Added.
         public const string NewMemberCompileHint =
-            "Same-file added methods are applied by hot reload; cross-file references and unsupported "
-            + "member kinds still require a real compile (uloop compile).";
+            "Same-file added methods are not applied in this pass; call sites in edited bodies already "
+            + "route to the shim. Cross-file references and unsupported member kinds still require a "
+            + "real compile (uloop compile).";
 
         // Wire value for TransformWorkerEntryDto.patchKind when the worker emits a shim for a
         // method that exists only in the edited source. Keep in sync with PatchKinds.AddedMethod
         // in TransformWorker~/TransformWorker.cs.
         public const string PatchKindAddedMethod = "addedMethod";
 
-        // Wire values for TransformWorkerRemovedMemberDto.kind.
+        // Why Skipped (not Failed): ApplyEntry cannot Resolve an added method until PR-2.
+        public const string AddedMethodDeferredSkipReason =
+            "Added-method application lands in the next change; call sites in edited bodies already route to the shim.";
+
+        // Wire value for TransformWorkerRemovedMemberDto.kind.
+        // Keep in sync with RemovedMemberKinds.Method in TransformWorker~/TransformWorker.cs.
         public const string RemovedMemberKindMethod = "method";
-        public const string RemovedMemberKindField = "field";
+
+        // Format: comma-separated removed member names.
+        public const string RemovedMembersWarningFormat =
+            "Removed members stay present in the compiled assembly until 'uloop compile'; "
+            + "edited bodies no longer call them: {0}.";
 
         public const string MissingUsingCompileHint =
             "This can mean a missing using or global using (hot reload collects global usings from the edited file's assembly).";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -60,6 +60,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string AddedMethodDeferredSkipReason =
             "Added-method application lands in the next change; call sites in edited bodies already route to the shim.";
 
+        // Isolation retry drops callers of a failed added shim so retry does not CS0103; they
+        // are not Failed (the compile error was in the added body) and must not stay silent.
+        public const string IsolatedAddedMethodCallerSkipReason =
+            "Calls an added method whose shim failed to compile; the caller was left unpatched. "
+            + "Run 'uloop compile'.";
+
         // Wire value for TransformWorkerRemovedMemberDto.kind.
         // Keep in sync with RemovedMemberKinds.Method in TransformWorker~/TransformWorker.cs.
         public const string RemovedMemberKindMethod = "method";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -45,7 +45,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string BurstCompileAttributeFullName = "Unity.Burst.BurstCompileAttribute";
 
         public const string NewMemberCompileHint =
-            "Adding new members requires a real compile (uloop compile); hot reload only replaces existing method bodies.";
+            "Same-file added methods are applied by hot reload; cross-file references and unsupported "
+            + "member kinds still require a real compile (uloop compile).";
+
+        // Wire value for TransformWorkerEntryDto.patchKind when the worker emits a shim for a
+        // method that exists only in the edited source. Keep in sync with PatchKinds.AddedMethod
+        // in TransformWorker~/TransformWorker.cs.
+        public const string PatchKindAddedMethod = "addedMethod";
+
+        // Wire values for TransformWorkerRemovedMemberDto.kind.
+        public const string RemovedMemberKindMethod = "method";
+        public const string RemovedMemberKindField = "field";
 
         public const string MissingUsingCompileHint =
             "This can mean a missing using or global using (hot reload collects global usings from the edited file's assembly).";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -1252,8 +1252,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 TransformWorkerEntryDto[] retryEntries,
                 HotReloadShimCompileResult retryCompileResult)
             {
+                Debug.Assert(skippedCallerOutcomes != null, "skippedCallerOutcomes must not be null.");
                 FailedMethodOutcomes = failedMethodOutcomes;
-                SkippedCallerOutcomes = skippedCallerOutcomes ?? new List<HotReloadMethodOutcome>();
+                SkippedCallerOutcomes = skippedCallerOutcomes;
                 RetryEntries = retryEntries;
                 RetryCompileResult = retryCompileResult;
             }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -833,7 +833,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             List<HotReloadMethodOutcome> failedMethodOutcomes =
                 BuildFailedMethodOutcomes(attribution, assemblyResolvePath);
-            string[] excludedMethodKeys = BuildExcludedMethodKeys(attribution.FailedEntries);
+            string[] excludedMethodKeys = BuildExcludedMethodKeys(
+                attribution.FailedEntries,
+                workerOutput.entries);
 
             return await RunIsolationRetryAsync(
                 workerInput,
@@ -936,15 +938,54 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return failedMethodOutcomes;
         }
 
-        private static string[] BuildExcludedMethodKeys(IReadOnlyList<TransformWorkerEntryDto> failedEntries)
+        private static string[] BuildExcludedMethodKeys(
+            IReadOnlyList<TransformWorkerEntryDto> failedEntries,
+            TransformWorkerEntryDto[] allEntries)
         {
-            string[] excludedMethodKeys = new string[failedEntries.Count];
-            for (int index = 0; index < failedEntries.Count; index++)
+            HashSet<string> excludedKeys = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<string> failedAddedMethodKeys = new HashSet<string>(StringComparer.Ordinal);
+            foreach (TransformWorkerEntryDto failedEntry in failedEntries)
             {
-                excludedMethodKeys[index] = BuildMethodKey(failedEntries[index]);
+                string methodKey = BuildMethodKey(failedEntry);
+                if (failedEntry.patchKind == HotReloadConstants.PatchKindAddedMethod)
+                {
+                    // Why not exclude the added method: dropping its shim leaves remaining
+                    // callers with CS0103 and isolation collapses to a file-level Failed (G1).
+                    failedAddedMethodKeys.Add(methodKey);
+                    continue;
+                }
+
+                excludedKeys.Add(methodKey);
             }
 
-            return excludedMethodKeys;
+            if (failedAddedMethodKeys.Count == 0 || allEntries == null)
+            {
+                string[] keys = new string[excludedKeys.Count];
+                excludedKeys.CopyTo(keys);
+                return keys;
+            }
+
+            foreach (TransformWorkerEntryDto entry in allEntries)
+            {
+                if (entry.patchKind == HotReloadConstants.PatchKindAddedMethod
+                    || entry.calledAddedMethodKeys == null)
+                {
+                    continue;
+                }
+
+                foreach (string calledKey in entry.calledAddedMethodKeys)
+                {
+                    if (failedAddedMethodKeys.Contains(calledKey))
+                    {
+                        excludedKeys.Add(BuildMethodKey(entry));
+                        break;
+                    }
+                }
+            }
+
+            string[] result = new string[excludedKeys.Count];
+            excludedKeys.CopyTo(result);
+            return result;
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -328,6 +328,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 outcomes.AddRange(isolation.FailedMethodOutcomes);
+                outcomes.AddRange(isolation.SkippedCallerOutcomes);
                 if (isolation.RetryEntries.Length == 0)
                 {
                     return new HotReloadFileProcessResult(
@@ -908,11 +909,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             IsolationExclusions exclusions = BuildIsolationExclusions(
                 attribution.FailedEntries,
                 workerOutput.entries);
+            List<HotReloadMethodOutcome> skippedCallerOutcomes = BuildSkippedCallerOutcomes(
+                exclusions.CallerEntries,
+                assemblyResolvePath);
 
             return await RunIsolationRetryAsync(
                 workerInput,
                 exclusions,
                 failedMethodOutcomes,
+                skippedCallerOutcomes,
                 compilationAssembly,
                 targetDllPath,
                 defines,
@@ -923,6 +928,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             TransformWorkerInputDto workerInput,
             IsolationExclusions exclusions,
             List<HotReloadMethodOutcome> failedMethodOutcomes,
+            List<HotReloadMethodOutcome> skippedCallerOutcomes,
             UnityCompilationAssembly compilationAssembly,
             string targetDllPath,
             string[] defines,
@@ -956,7 +962,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (string.IsNullOrEmpty(retryOutput.shimSource) || retryOutput.entries.Length == 0)
             {
                 return new HotReloadShimIsolationResult(
-                    failedMethodOutcomes, Array.Empty<TransformWorkerEntryDto>(), null);
+                    failedMethodOutcomes,
+                    skippedCallerOutcomes,
+                    Array.Empty<TransformWorkerEntryDto>(),
+                    null);
             }
 
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -984,7 +993,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return null;
             }
 
-            return new HotReloadShimIsolationResult(failedMethodOutcomes, retryOutput.entries, retryCompileResult);
+            return new HotReloadShimIsolationResult(
+                failedMethodOutcomes,
+                skippedCallerOutcomes,
+                retryOutput.entries,
+                retryCompileResult);
         }
 
         private static List<HotReloadMethodOutcome> BuildFailedMethodOutcomes(
@@ -1018,6 +1031,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HashSet<string> excludedKeys = new HashSet<string>(StringComparer.Ordinal);
             HashSet<string> excludedAddedMethodKeys = new HashSet<string>(StringComparer.Ordinal);
             HashSet<string> failedAddedMethodKeys = new HashSet<string>(StringComparer.Ordinal);
+            List<TransformWorkerEntryDto> excludedCallerEntries = new List<TransformWorkerEntryDto>();
             foreach (TransformWorkerEntryDto failedEntry in failedEntries)
             {
                 string methodKey = BuildMethodKey(failedEntry);
@@ -1034,23 +1048,50 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 excludedKeys.Add(methodKey);
             }
 
+            HashSet<string> failedEntryKeys = new HashSet<string>(StringComparer.Ordinal);
+            foreach (TransformWorkerEntryDto failedEntry in failedEntries)
+            {
+                failedEntryKeys.Add(BuildMethodKey(failedEntry));
+            }
+
             if (failedAddedMethodKeys.Count > 0 && allEntries != null)
             {
                 foreach (TransformWorkerEntryDto entry in allEntries)
                 {
-                    if (entry.patchKind == HotReloadConstants.PatchKindAddedMethod
-                        || entry.calledAddedMethodKeys == null)
+                    if (entry.calledAddedMethodKeys == null)
                     {
                         continue;
                     }
 
+                    string callerKey = BuildMethodKey(entry);
+                    if (failedEntryKeys.Contains(callerKey))
+                    {
+                        continue;
+                    }
+
+                    bool callsFailedAdded = false;
                     foreach (string calledKey in entry.calledAddedMethodKeys)
                     {
                         if (failedAddedMethodKeys.Contains(calledKey))
                         {
-                            excludedKeys.Add(BuildMethodKey(entry));
+                            callsFailedAdded = true;
                             break;
                         }
+                    }
+
+                    if (!callsFailedAdded)
+                    {
+                        continue;
+                    }
+
+                    excludedCallerEntries.Add(entry);
+                    if (entry.patchKind == HotReloadConstants.PatchKindAddedMethod)
+                    {
+                        excludedAddedMethodKeys.Add(callerKey);
+                    }
+                    else
+                    {
+                        excludedKeys.Add(callerKey);
                     }
                 }
             }
@@ -1059,7 +1100,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             excludedKeys.CopyTo(excludedMethodKeys);
             string[] excludedAddedKeys = new string[excludedAddedMethodKeys.Count];
             excludedAddedMethodKeys.CopyTo(excludedAddedKeys);
-            return new IsolationExclusions(excludedMethodKeys, excludedAddedKeys);
+            return new IsolationExclusions(
+                excludedMethodKeys,
+                excludedAddedKeys,
+                excludedCallerEntries);
+        }
+
+        private static List<HotReloadMethodOutcome> BuildSkippedCallerOutcomes(
+            IReadOnlyList<TransformWorkerEntryDto> callerEntries,
+            string assemblyResolvePath)
+        {
+            List<HotReloadMethodOutcome> skippedCallerOutcomes = new List<HotReloadMethodOutcome>();
+            foreach (TransformWorkerEntryDto caller in callerEntries)
+            {
+                string methodLabel = HotReloadPatcher.FormatMethodKeyParts(
+                    caller.typeMetadataName,
+                    caller.methodName,
+                    caller.parameterTypeFullNames ?? Array.Empty<string>(),
+                    genericArity: 0);
+                skippedCallerOutcomes.Add(
+                    HotReloadMethodOutcome.Skipped(
+                        methodLabel,
+                        HotReloadConstants.IsolatedAddedMethodCallerSkipReason,
+                        assemblyResolvePath));
+            }
+
+            return skippedCallerOutcomes;
         }
 
         /// <summary>
@@ -1155,11 +1221,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             public string[] ExcludedMethodKeys { get; }
             public string[] ExcludedAddedMethodKeys { get; }
+            public IReadOnlyList<TransformWorkerEntryDto> CallerEntries { get; }
 
-            public IsolationExclusions(string[] excludedMethodKeys, string[] excludedAddedMethodKeys)
+            public IsolationExclusions(
+                string[] excludedMethodKeys,
+                string[] excludedAddedMethodKeys,
+                IReadOnlyList<TransformWorkerEntryDto> callerEntries)
             {
                 ExcludedMethodKeys = excludedMethodKeys;
                 ExcludedAddedMethodKeys = excludedAddedMethodKeys;
+                CallerEntries = callerEntries;
             }
         }
 
@@ -1171,15 +1242,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private sealed class HotReloadShimIsolationResult
         {
             public List<HotReloadMethodOutcome> FailedMethodOutcomes { get; }
+            public List<HotReloadMethodOutcome> SkippedCallerOutcomes { get; }
             public TransformWorkerEntryDto[] RetryEntries { get; }
             public HotReloadShimCompileResult RetryCompileResult { get; }
 
             public HotReloadShimIsolationResult(
                 List<HotReloadMethodOutcome> failedMethodOutcomes,
+                List<HotReloadMethodOutcome> skippedCallerOutcomes,
                 TransformWorkerEntryDto[] retryEntries,
                 HotReloadShimCompileResult retryCompileResult)
             {
                 FailedMethodOutcomes = failedMethodOutcomes;
+                SkippedCallerOutcomes = skippedCallerOutcomes ?? new List<HotReloadMethodOutcome>();
                 RetryEntries = retryEntries;
                 RetryCompileResult = retryCompileResult;
             }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -240,6 +240,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
             }
 
+            if (workerOutput.removedMembers != null && workerOutput.removedMembers.Length > 0)
+            {
+                warnings.Add(FormatRemovedMembersWarning(workerOutput.removedMembers));
+            }
+
             TransformWorkerUnchangedMethodDto[] unchangedMethods =
                 workerOutput.unchangedMethods ?? Array.Empty<TransformWorkerUnchangedMethodDto>();
             int unchangedMethodCount = unchangedMethods.Length;
@@ -259,7 +264,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // BuildShimReferencePaths reads Application.dataPath / platform; stay on main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
-            bool includeHarmonyReference = HasDelegationEntry(workerOutput.entries);
+            bool includeHarmonyReference = NeedsHarmonyReference(workerOutput);
             ShimReferencePathsResult shimReferencePaths = TryBuildShimReferencePaths(
                 compilationAssembly,
                 targetDllPath,
@@ -353,6 +358,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 BindShimAccessors(compileResult.Assembly);
             List<string> inlineRiskMethodLabels = new List<string>();
             int patchedCount = 0;
+            entriesToPatch = TakePatchableEntries(entriesToPatch, outcomes, assemblyResolvePath);
             foreach (TransformWorkerEntryDto entry in entriesToPatch)
             {
                 HotReloadMethodOutcome outcome = ApplyEntry(
@@ -776,8 +782,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return paths.ToArray();
         }
 
+        private static bool NeedsHarmonyReference(TransformWorkerOutputDto output)
+        {
+            return HasDelegationEntry(output.entries) || output.hasAccessorDelegates;
+        }
+
         private static bool HasDelegationEntry(TransformWorkerEntryDto[] entries)
         {
+            if (entries == null)
+            {
+                return false;
+            }
+
             foreach (TransformWorkerEntryDto entry in entries)
             {
                 if (entry.patchKind == HotReloadConstants.PatchKindDelegation)
@@ -787,6 +803,62 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return false;
+        }
+
+        // Why not ApplyEntry: added methods are absent from the compiled assembly, so Resolve
+        // always fails. PR-2 replaces this Skipped outcome with Added.
+        private static TransformWorkerEntryDto[] TakePatchableEntries(
+            TransformWorkerEntryDto[] entries,
+            List<HotReloadMethodOutcome> outcomes,
+            string filePath)
+        {
+            if (entries == null || entries.Length == 0)
+            {
+                return Array.Empty<TransformWorkerEntryDto>();
+            }
+
+            List<TransformWorkerEntryDto> patchable = new List<TransformWorkerEntryDto>();
+            foreach (TransformWorkerEntryDto entry in entries)
+            {
+                if (entry.patchKind == HotReloadConstants.PatchKindAddedMethod)
+                {
+                    string[] parameterTypeFullNames = entry.parameterTypeFullNames ?? Array.Empty<string>();
+                    string methodLabel = HotReloadPatcher.FormatMethodKeyParts(
+                        entry.typeMetadataName,
+                        entry.methodName,
+                        parameterTypeFullNames,
+                        genericArity: 0);
+                    outcomes.Add(
+                        HotReloadMethodOutcome.Skipped(
+                            methodLabel,
+                            HotReloadConstants.AddedMethodDeferredSkipReason,
+                            filePath));
+                    continue;
+                }
+
+                patchable.Add(entry);
+            }
+
+            return patchable.ToArray();
+        }
+
+        private static string FormatRemovedMembersWarning(TransformWorkerRemovedMemberDto[] removedMembers)
+        {
+            List<string> names = new List<string>();
+            HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (TransformWorkerRemovedMemberDto removed in removedMembers)
+            {
+                if (removed == null || string.IsNullOrEmpty(removed.name) || !seen.Add(removed.name))
+                {
+                    continue;
+                }
+
+                names.Add(removed.name);
+            }
+
+            return string.Format(
+                HotReloadConstants.RemovedMembersWarningFormat,
+                string.Join(", ", names));
         }
 
         // Keep in sync with TransformWorkerProgram.BuildMethodKey (out-of-process worker side).
@@ -833,13 +905,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             List<HotReloadMethodOutcome> failedMethodOutcomes =
                 BuildFailedMethodOutcomes(attribution, assemblyResolvePath);
-            string[] excludedMethodKeys = BuildExcludedMethodKeys(
+            IsolationExclusions exclusions = BuildIsolationExclusions(
                 attribution.FailedEntries,
                 workerOutput.entries);
 
             return await RunIsolationRetryAsync(
                 workerInput,
-                excludedMethodKeys,
+                exclusions,
                 failedMethodOutcomes,
                 compilationAssembly,
                 targetDllPath,
@@ -849,7 +921,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static async Task<HotReloadShimIsolationResult> RunIsolationRetryAsync(
             TransformWorkerInputDto workerInput,
-            string[] excludedMethodKeys,
+            IsolationExclusions exclusions,
             List<HotReloadMethodOutcome> failedMethodOutcomes,
             UnityCompilationAssembly compilationAssembly,
             string targetDllPath,
@@ -862,7 +934,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 defines = workerInput.defines,
                 referencePaths = workerInput.referencePaths,
                 targetTypesAssemblyPath = workerInput.targetTypesAssemblyPath,
-                excludedMethodKeys = excludedMethodKeys,
+                excludedMethodKeys = exclusions.ExcludedMethodKeys,
+                excludedAddedMethodKeys = exclusions.ExcludedAddedMethodKeys,
                 // Why copy: omitting snapshotSource would make the retry patch unedited methods
                 // again and diverge the retry entries set from the first-pass isolation baseline.
                 snapshotSource = workerInput.snapshotSource,
@@ -887,7 +960,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             await MainThreadSwitcher.SwitchToMainThread(ct);
-            bool includeHarmonyReference = HasDelegationEntry(retryOutput.entries);
+            bool includeHarmonyReference = NeedsHarmonyReference(retryOutput);
             ShimReferencePathsResult shimReferencePaths = TryBuildShimReferencePaths(
                 compilationAssembly,
                 targetDllPath,
@@ -938,54 +1011,55 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return failedMethodOutcomes;
         }
 
-        private static string[] BuildExcludedMethodKeys(
+        private static IsolationExclusions BuildIsolationExclusions(
             IReadOnlyList<TransformWorkerEntryDto> failedEntries,
             TransformWorkerEntryDto[] allEntries)
         {
             HashSet<string> excludedKeys = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<string> excludedAddedMethodKeys = new HashSet<string>(StringComparer.Ordinal);
             HashSet<string> failedAddedMethodKeys = new HashSet<string>(StringComparer.Ordinal);
             foreach (TransformWorkerEntryDto failedEntry in failedEntries)
             {
                 string methodKey = BuildMethodKey(failedEntry);
                 if (failedEntry.patchKind == HotReloadConstants.PatchKindAddedMethod)
                 {
-                    // Why not exclude the added method: dropping its shim leaves remaining
-                    // callers with CS0103 and isolation collapses to a file-level Failed (G1).
+                    // Why a separate set: dropping a healthy added shim via excludedMethodKeys
+                    // leaves remaining callers with CS0103 (G1). A broken added body must still
+                    // be excluded together with its callers so retry does not re-emit it.
                     failedAddedMethodKeys.Add(methodKey);
+                    excludedAddedMethodKeys.Add(methodKey);
                     continue;
                 }
 
                 excludedKeys.Add(methodKey);
             }
 
-            if (failedAddedMethodKeys.Count == 0 || allEntries == null)
+            if (failedAddedMethodKeys.Count > 0 && allEntries != null)
             {
-                string[] keys = new string[excludedKeys.Count];
-                excludedKeys.CopyTo(keys);
-                return keys;
-            }
-
-            foreach (TransformWorkerEntryDto entry in allEntries)
-            {
-                if (entry.patchKind == HotReloadConstants.PatchKindAddedMethod
-                    || entry.calledAddedMethodKeys == null)
+                foreach (TransformWorkerEntryDto entry in allEntries)
                 {
-                    continue;
-                }
-
-                foreach (string calledKey in entry.calledAddedMethodKeys)
-                {
-                    if (failedAddedMethodKeys.Contains(calledKey))
+                    if (entry.patchKind == HotReloadConstants.PatchKindAddedMethod
+                        || entry.calledAddedMethodKeys == null)
                     {
-                        excludedKeys.Add(BuildMethodKey(entry));
-                        break;
+                        continue;
+                    }
+
+                    foreach (string calledKey in entry.calledAddedMethodKeys)
+                    {
+                        if (failedAddedMethodKeys.Contains(calledKey))
+                        {
+                            excludedKeys.Add(BuildMethodKey(entry));
+                            break;
+                        }
                     }
                 }
             }
 
-            string[] result = new string[excludedKeys.Count];
-            excludedKeys.CopyTo(result);
-            return result;
+            string[] excludedMethodKeys = new string[excludedKeys.Count];
+            excludedKeys.CopyTo(excludedMethodKeys);
+            string[] excludedAddedKeys = new string[excludedAddedMethodKeys.Count];
+            excludedAddedMethodKeys.CopyTo(excludedAddedKeys);
+            return new IsolationExclusions(excludedMethodKeys, excludedAddedKeys);
         }
 
         /// <summary>
@@ -1077,6 +1151,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
+        private sealed class IsolationExclusions
+        {
+            public string[] ExcludedMethodKeys { get; }
+            public string[] ExcludedAddedMethodKeys { get; }
+
+            public IsolationExclusions(string[] excludedMethodKeys, string[] excludedAddedMethodKeys)
+            {
+                ExcludedMethodKeys = excludedMethodKeys;
+                ExcludedAddedMethodKeys = excludedAddedMethodKeys;
+            }
+        }
+
         /// <summary>
         /// Outcome of <see cref="TryIsolateShimCompileFailureAsync"/>. <see cref="RetryEntries"/>
         /// empty means the retry worker run produced nothing to patch (still a valid, non-null
@@ -1147,8 +1233,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         /// <summary>
         /// Publicize ScriptAssemblies references; leave engine/system DLLs untouched. Never include
-        /// the original (non-publicized) target assembly. Harmony is added only when the worker
-        /// emitted at least one delegation entry so transplant-only compiles stay byte-identical.
+        /// the original (non-publicized) target assembly. Harmony is added when the worker
+        /// emitted a delegation entry or accessor delegates (addedMethod entries can need them).
         /// </summary>
         private static List<string> BuildShimReferencePaths(
             UnityCompilationAssembly compilationAssembly,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
@@ -88,20 +88,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         "Failed to deserialize transform worker output JSON.");
                 }
 
-                output.entries ??= Array.Empty<TransformWorkerEntryDto>();
-                output.skipped ??= Array.Empty<TransformWorkerSkippedDto>();
-                output.parseErrors ??= Array.Empty<string>();
-                output.declarationDriftWarnings ??= Array.Empty<string>();
-                output.unchangedMethods ??= Array.Empty<TransformWorkerUnchangedMethodDto>();
-                output.removedMembers ??= Array.Empty<TransformWorkerRemovedMemberDto>();
-                output.shimSource ??= string.Empty;
-                foreach (TransformWorkerEntryDto entry in output.entries)
-                {
-                    entry.patchKind ??= string.Empty;
-                    entry.calledAddedMethodKeys ??= Array.Empty<string>();
-                    entry.parameterTypeFullNames ??= Array.Empty<string>();
-                }
-
+                CoalesceOutput(output);
                 return TransformWorkerClientResult.SuccessResult(output);
             }
             finally
@@ -110,6 +97,31 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     Directory.Delete(tempDirectory, recursive: true);
                 }
+            }
+        }
+
+        // Why internal: tests must exercise this path instead of re-implementing ??=.
+        internal static void CoalesceOutput(TransformWorkerOutputDto output)
+        {
+            Debug.Assert(output != null, "output must not be null.");
+
+            output.entries ??= Array.Empty<TransformWorkerEntryDto>();
+            output.skipped ??= Array.Empty<TransformWorkerSkippedDto>();
+            output.parseErrors ??= Array.Empty<string>();
+            output.declarationDriftWarnings ??= Array.Empty<string>();
+            output.unchangedMethods ??= Array.Empty<TransformWorkerUnchangedMethodDto>();
+            output.removedMembers ??= Array.Empty<TransformWorkerRemovedMemberDto>();
+            output.shimSource ??= string.Empty;
+            foreach (TransformWorkerEntryDto entry in output.entries)
+            {
+                if (entry == null)
+                {
+                    continue;
+                }
+
+                entry.patchKind ??= string.Empty;
+                entry.calledAddedMethodKeys ??= Array.Empty<string>();
+                entry.parameterTypeFullNames ??= Array.Empty<string>();
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
@@ -91,10 +91,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 output.entries ??= Array.Empty<TransformWorkerEntryDto>();
                 output.skipped ??= Array.Empty<TransformWorkerSkippedDto>();
                 output.parseErrors ??= Array.Empty<string>();
+                output.declarationDriftWarnings ??= Array.Empty<string>();
+                output.unchangedMethods ??= Array.Empty<TransformWorkerUnchangedMethodDto>();
+                output.removedMembers ??= Array.Empty<TransformWorkerRemovedMemberDto>();
                 output.shimSource ??= string.Empty;
                 foreach (TransformWorkerEntryDto entry in output.entries)
                 {
                     entry.patchKind ??= string.Empty;
+                    entry.calledAddedMethodKeys ??= Array.Empty<string>();
+                    entry.parameterTypeFullNames ??= Array.Empty<string>();
                 }
 
                 return TransformWorkerClientResult.SuccessResult(output);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -17,6 +17,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // first compile round; the retry worker run drops these methods entirely.
         public string[] excludedMethodKeys;
 
+        // Added-method keys whose shim bodies failed the first compile. Distinct from
+        // excludedMethodKeys so a healthy added shim is not dropped when an existing method fails
+        // (G1), while a broken added body can still be excluded together with its callers.
+        public string[] excludedAddedMethodKeys;
+
         // Verified snapshot text for edited-method detection. Null = no baseline, patch all methods.
         // Why pass text (not a path): avoids an IO race between orchestrator verification and worker
         // read that would crash the whole file under the no-try-catch policy.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -50,6 +50,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // True when snapshotSource was provided but a duplicate syntax-method key on either side
         // disabled baseline comparison (silent patch-all fallback). False when snapshotSource is null.
         public bool baselineDisabledByDuplicateKeys;
+
+        // Members present in the snapshot (or compiled assembly for fields in later PRs) but
+        // absent from the edited source. Null/omitted deserializes as empty after client coalesce.
+        public TransformWorkerRemovedMemberDto[] removedMembers;
+
+        // True when any emitted shim type contains Harmony accessor delegates. Drives Harmony
+        // reference injection; patchKind "addedMethod" entries can also need accessors (B2).
+        public bool hasAccessorDelegates;
+    }
+
+    [Serializable]
+    internal sealed class TransformWorkerRemovedMemberDto
+    {
+        // "method" | "field"
+        public string kind;
+        public string name;
     }
 
     [Serializable]
@@ -69,8 +85,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string shimTypeName;
         public string shimMethodName;
 
-        // "transplant" | "delegation". Null/empty is treated as transplant by the orchestrator.
+        // "transplant" | "delegation" | "addedMethod". Null/empty is treated as transplant by the orchestrator.
         public string patchKind;
+
+        // Method keys of added methods this entry's body calls. Null/omitted is empty.
+        // Isolation retry excludes these callers instead of dropping the added-method shim (G1).
+        public string[] calledAddedMethodKeys;
 
         // 1-based, both ends inclusive, within the original edited source file (not shimSource).
         // Used to attribute shim compile errors whose #line-mapped locations fall in this method.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -935,9 +935,13 @@ public static class TransformWorkerProgram
         AddedMethodCatalog addedMethodCatalog)
     {
         StripHandledMethodDeclarationsRewriter stripSnapshot =
-            new StripHandledMethodDeclarationsRewriter(addedMethodCatalog.RemovedSyntaxKeys);
+            new StripHandledMethodDeclarationsRewriter(
+                addedMethodCatalog.RemovedSyntaxKeys,
+                Array.Empty<string>());
         StripHandledMethodDeclarationsRewriter stripCurrent =
-            new StripHandledMethodDeclarationsRewriter(addedMethodCatalog.AddedSyntaxKeys);
+            new StripHandledMethodDeclarationsRewriter(
+                addedMethodCatalog.AddedSyntaxKeys,
+                addedMethodCatalog.AddedTypeSyntaxKeys);
         StripMethodBodiesRewriter bodyStripper = new StripMethodBodiesRewriter();
         SyntaxNode strippedSnapshot = bodyStripper.Visit(stripSnapshot.Visit(snapshotRoot));
         SyntaxNode strippedCurrent = bodyStripper.Visit(stripCurrent.Visit(currentRoot));
@@ -951,10 +955,51 @@ public static class TransformWorkerProgram
     private sealed class StripHandledMethodDeclarationsRewriter : CSharpSyntaxRewriter
     {
         private readonly HashSet<string> _syntaxKeysToStrip;
+        private readonly HashSet<string> _typeSyntaxKeysToStrip;
 
-        public StripHandledMethodDeclarationsRewriter(IReadOnlyCollection<string> syntaxKeysToStrip)
+        public StripHandledMethodDeclarationsRewriter(
+            IReadOnlyCollection<string> syntaxKeysToStrip,
+            IReadOnlyCollection<string> typeSyntaxKeysToStrip)
         {
             _syntaxKeysToStrip = new HashSet<string>(syntaxKeysToStrip, StringComparer.Ordinal);
+            _typeSyntaxKeysToStrip = new HashSet<string>(
+                typeSyntaxKeysToStrip ?? Array.Empty<string>(),
+                StringComparer.Ordinal);
+        }
+
+        public override SyntaxNode VisitClassDeclaration(ClassDeclarationSyntax node)
+        {
+            if (ShouldStripType(node))
+            {
+                return null;
+            }
+
+            return base.VisitClassDeclaration(node);
+        }
+
+        public override SyntaxNode VisitStructDeclaration(StructDeclarationSyntax node)
+        {
+            if (ShouldStripType(node))
+            {
+                return null;
+            }
+
+            return base.VisitStructDeclaration(node);
+        }
+
+        public override SyntaxNode VisitRecordDeclaration(RecordDeclarationSyntax node)
+        {
+            if (ShouldStripType(node))
+            {
+                return null;
+            }
+
+            return base.VisitRecordDeclaration(node);
+        }
+
+        private bool ShouldStripType(TypeDeclarationSyntax node)
+        {
+            return _typeSyntaxKeysToStrip.Contains(BuildTypeMetadataNameFromSyntax(node));
         }
 
         public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
@@ -2074,7 +2119,7 @@ public static class TransformWorkerProgram
         INamedTypeSymbol compiledType = FindCompiledType(typeState.TypeSymbol, targetTypesAssemblySymbol);
         if (compiledType == null)
         {
-            SkipAllMethodsOnUncompiledType(typeState, semanticModel, skipped);
+            SkipAllMethodsOnUncompiledType(typeState, semanticModel, skipped, addedMethodCatalog);
             return (shimTypeCounter, globalShimMethodCounter);
         }
 
@@ -2325,9 +2370,11 @@ public static class TransformWorkerProgram
     private static void SkipAllMethodsOnUncompiledType(
         TypeEmitState typeState,
         SemanticModel semanticModel,
-        List<WorkerSkipped> skipped)
+        List<WorkerSkipped> skipped,
+        AddedMethodCatalog addedMethodCatalog)
     {
         typeState.TypeIsAbsentFromCompiledAssembly = true;
+        addedMethodCatalog.AddAddedTypeSyntaxKey(typeState.TypeMetadataNameFromSyntax);
         foreach (MethodDeclarationSyntax methodDeclaration in typeState.TypeDeclaration.Members
             .OfType<MethodDeclarationSyntax>())
         {
@@ -2337,6 +2384,8 @@ public static class TransformWorkerProgram
                 continue;
             }
 
+            addedMethodCatalog.AddAddedSyntaxKey(
+                BuildSyntaxMethodKey(typeState.TypeMetadataNameFromSyntax, methodDeclaration));
             skipped.Add(new WorkerSkipped
             {
                 Method = FormatMethodLabel(methodSymbol),
@@ -2442,7 +2491,9 @@ public static class TransformWorkerProgram
             }
 
             string calledKey = BuildMethodKeyFromSymbol(methodSymbol);
-            if (invocation.Expression is MemberBindingExpressionSyntax
+            // Why WhenNotNull (not MemberBinding only): other?.Inner.AddedPing(1) has
+            // MemberAccess as the invocation expression; the MemberBinding sits inside it.
+            if (IsInsideConditionalAccessWhenNotNull(invocation)
                 && addedMethodCatalog.IsClassifiedAdded(calledKey))
             {
                 return AddedMethodSkipReasons.ConditionalAccess;
@@ -2523,6 +2574,25 @@ public static class TransformWorkerProgram
             && bindingInvocation.Expression == memberBinding)
         {
             return true;
+        }
+
+        return false;
+    }
+
+    // Why WhenNotNull walk: other?.AddedPing() binds as MemberBinding, but
+    // other?.Inner.AddedPing() is MemberAccess under the same ConditionalAccess.WhenNotNull.
+    internal static bool IsInsideConditionalAccessWhenNotNull(SyntaxNode node)
+    {
+        SyntaxNode current = node;
+        while (current != null)
+        {
+            if (current.Parent is ConditionalAccessExpressionSyntax conditionalAccess
+                && conditionalAccess.WhenNotNull == current)
+            {
+                return true;
+            }
+
+            current = current.Parent;
         }
 
         return false;
@@ -4308,10 +4378,11 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
         }
 
         ISymbol invokedSymbol = _semanticModel.GetSymbolInfo(node).Symbol;
-        if (node.Expression is MemberBindingExpressionSyntax)
+        if (TransformWorkerProgram.IsInsideConditionalAccessWhenNotNull(node))
         {
-            // Why not rewrite: ExtractReceiver does not handle MemberBinding and would invent
-            // __uloopInstance, breaking ?. short-circuit. Callers are skipped instead.
+            // Why not rewrite: ExtractReceiver cannot recover the conditional-access receiver
+            // (simple ?. is MemberBinding; chained ?.Inner.M() is MemberAccess under WhenNotNull)
+            // and would emit a parse-invalid shim. Callers are skipped instead.
             return base.VisitInvocationExpression(node);
         }
 
@@ -5070,12 +5141,7 @@ internal static class CecilTypeNames
     public static string ToParameterTypeFullName(IParameterSymbol parameterSymbol)
     {
         // Roslyn's IParameterSymbol.Type omits the byref wrapper; Cecil FullName uses a trailing '&'.
-        // Why dynamic → System.Object: source `dynamic` is TypeKind.Dynamic ("dynamic") while
-        // compiled metadata is System.Object; leaving them distinct misclassifies existing
-        // methods as Added.
-        string typeName = parameterSymbol.Type != null && parameterSymbol.Type.TypeKind == TypeKind.Dynamic
-            ? "System.Object"
-            : ToCecilFullName(parameterSymbol.Type);
+        string typeName = ToCecilFullName(parameterSymbol.Type);
         if (parameterSymbol.RefKind != RefKind.None)
         {
             return typeName + "&";
@@ -5086,6 +5152,12 @@ internal static class CecilTypeNames
 
     private static string ToCecilFullName(ITypeSymbol typeSymbol)
     {
+        // Why here (not only the parameter top level): source `List<dynamic>` / `dynamic[]`
+        // nest TypeKind.Dynamic while compiled metadata uses System.Object at the same depth.
+        if (typeSymbol != null && typeSymbol.TypeKind == TypeKind.Dynamic)
+        {
+            return "System.Object";
+        }
         if (typeSymbol is IPointerTypeSymbol pointerType)
         {
             return ToCecilFullName(pointerType.PointedAtType) + "*";
@@ -5204,9 +5276,12 @@ internal sealed class AddedMethodCatalog
         new Dictionary<string, AddedMethodBinding>(StringComparer.Ordinal);
     private readonly HashSet<string> _classifiedAddedKeys = new HashSet<string>(StringComparer.Ordinal);
     private readonly HashSet<string> _addedSyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
+    private readonly HashSet<string> _addedTypeSyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
     private readonly HashSet<string> _removedSyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
 
     public IReadOnlyCollection<string> AddedSyntaxKeys => _addedSyntaxKeys;
+
+    public IReadOnlyCollection<string> AddedTypeSyntaxKeys => _addedTypeSyntaxKeys;
 
     public IReadOnlyCollection<string> RemovedSyntaxKeys => _removedSyntaxKeys;
 
@@ -5237,6 +5312,14 @@ internal sealed class AddedMethodCatalog
     public void AddAddedSyntaxKey(string syntaxKey)
     {
         _addedSyntaxKeys.Add(syntaxKey);
+    }
+
+    public void AddAddedTypeSyntaxKey(string typeSyntaxKey)
+    {
+        if (typeSyntaxKey != null)
+        {
+            _addedTypeSyntaxKeys.Add(typeSyntaxKey);
+        }
     }
 
     public void AddRemovedSyntaxKey(string syntaxKey)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -997,6 +997,16 @@ public static class TransformWorkerProgram
             return base.VisitRecordDeclaration(node);
         }
 
+        public override SyntaxNode VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
+        {
+            if (ShouldStripType(node))
+            {
+                return null;
+            }
+
+            return base.VisitInterfaceDeclaration(node);
+        }
+
         private bool ShouldStripType(TypeDeclarationSyntax node)
         {
             return _typeSyntaxKeysToStrip.Contains(BuildTypeMetadataNameFromSyntax(node));
@@ -1616,12 +1626,16 @@ public static class TransformWorkerProgram
 
     private static IEnumerable<TypeDeclarationSyntax> EnumerateTypeDeclarations(CompilationUnitSyntax root)
     {
+        // Why interfaces: a new interface (including default methods) is absent from the compiled
+        // assembly; enumerating it registers the type syntax key so the strip rewriter can drop
+        // it instead of firing a false outside-body drift warning.
         return root.DescendantNodes()
             .OfType<TypeDeclarationSyntax>()
             .Where(static typeDeclaration =>
                 typeDeclaration is ClassDeclarationSyntax
                 || typeDeclaration is StructDeclarationSyntax
-                || typeDeclaration is RecordDeclarationSyntax);
+                || typeDeclaration is RecordDeclarationSyntax
+                || typeDeclaration is InterfaceDeclarationSyntax);
     }
 
     // methodDeclaration may be null for property getters (bodyNode must still be in the bound tree).
@@ -2384,8 +2398,6 @@ public static class TransformWorkerProgram
                 continue;
             }
 
-            addedMethodCatalog.AddAddedSyntaxKey(
-                BuildSyntaxMethodKey(typeState.TypeMetadataNameFromSyntax, methodDeclaration));
             skipped.Add(new WorkerSkipped
             {
                 Method = FormatMethodLabel(methodSymbol),
@@ -2491,9 +2503,10 @@ public static class TransformWorkerProgram
             }
 
             string calledKey = BuildMethodKeyFromSymbol(methodSymbol);
-            // Why WhenNotNull (not MemberBinding only): other?.Inner.AddedPing(1) has
-            // MemberAccess as the invocation expression; the MemberBinding sits inside it.
-            if (IsInsideConditionalAccessWhenNotNull(invocation)
+            // Why the receiver spine (not a WhenNotNull ancestor walk): other?.Inner.AddedPing()
+            // is MemberAccess whose leftmost expression is MemberBinding. An ancestor walk also
+            // matches argument-list / lambda invocations that are ordinary rewrite targets.
+            if (IsConditionalAccessReceiverSpine(invocation)
                 && addedMethodCatalog.IsClassifiedAdded(calledKey))
             {
                 return AddedMethodSkipReasons.ConditionalAccess;
@@ -2579,20 +2592,32 @@ public static class TransformWorkerProgram
         return false;
     }
 
-    // Why WhenNotNull walk: other?.AddedPing() binds as MemberBinding, but
-    // other?.Inner.AddedPing() is MemberAccess under the same ConditionalAccess.WhenNotNull.
-    internal static bool IsInsideConditionalAccessWhenNotNull(SyntaxNode node)
+    // Why the receiver spine: other?.Inner.AddedPing() / other?[0].AddedPing() walk left
+    // through MemberAccess/ElementAccess to a MemberBinding/ElementBinding. Argument-list
+    // and lambda invocations (list?.Add(PrivateCall()), other?.Existing(AddedPing(1))) do not.
+    internal static bool IsConditionalAccessReceiverSpine(InvocationExpressionSyntax invocation)
     {
-        SyntaxNode current = node;
+        ExpressionSyntax current = invocation.Expression;
         while (current != null)
         {
-            if (current.Parent is ConditionalAccessExpressionSyntax conditionalAccess
-                && conditionalAccess.WhenNotNull == current)
+            if (current is MemberBindingExpressionSyntax || current is ElementBindingExpressionSyntax)
             {
                 return true;
             }
 
-            current = current.Parent;
+            if (current is MemberAccessExpressionSyntax memberAccess)
+            {
+                current = memberAccess.Expression;
+                continue;
+            }
+
+            if (current is ElementAccessExpressionSyntax elementAccess)
+            {
+                current = elementAccess.Expression;
+                continue;
+            }
+
+            return false;
         }
 
         return false;
@@ -4378,11 +4403,11 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
         }
 
         ISymbol invokedSymbol = _semanticModel.GetSymbolInfo(node).Symbol;
-        if (TransformWorkerProgram.IsInsideConditionalAccessWhenNotNull(node))
+        if (TransformWorkerProgram.IsConditionalAccessReceiverSpine(node))
         {
-            // Why not rewrite: ExtractReceiver cannot recover the conditional-access receiver
-            // (simple ?. is MemberBinding; chained ?.Inner.M() is MemberAccess under WhenNotNull)
-            // and would emit a parse-invalid shim. Callers are skipped instead.
+            // Why not rewrite the spine invocation: ExtractReceiver cannot recover a
+            // MemberBinding/ElementBinding receiver and would emit a parse-invalid shim.
+            // Arguments and lambdas are not on the spine; base.Visit still rewrites those.
             return base.VisitInvocationExpression(node);
         }
 
@@ -5158,6 +5183,7 @@ internal static class CecilTypeNames
         {
             return "System.Object";
         }
+
         if (typeSymbol is IPointerTypeSymbol pointerType)
         {
             return ToCecilFullName(pointerType.PointedAtType) + "*";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -2177,6 +2177,31 @@ public static class TransformWorkerProgram
             string syntaxMethodKey = BuildSyntaxMethodKey(
                 typeState.TypeMetadataNameFromSyntax,
                 methodDeclaration);
+            if (typeState.TypeSymbol.TypeKind == TypeKind.Interface)
+            {
+                if (!isAddedMethod && hasBaseline
+                    && snapshotMethodMap.TryGetValue(syntaxMethodKey, out MethodDeclarationSyntax snapshotDecl)
+                    && plainCurrentMethodMap.TryGetValue(syntaxMethodKey, out MethodDeclarationSyntax plainDecl)
+                    && SyntaxFactory.AreEquivalent(snapshotDecl, plainDecl, topLevel: false))
+                {
+                    // Why not unchangedMethods: RevertUnchangedPatches Resolve/ReadAssembly is
+                    // wasted for members Harmony will never patch. Stay inert.
+                    continue;
+                }
+
+                skipped.Add(new WorkerSkipped
+                {
+                    Method = FormatMethodLabel(methodSymbol),
+                    Reason = AddedMethodSkipReasons.InterfaceMember
+                });
+                if (isAddedMethod)
+                {
+                    addedMethodCatalog.AddAddedSyntaxKey(syntaxMethodKey);
+                }
+
+                continue;
+            }
+
             if (!isAddedMethod && hasBaseline)
             {
                 // Why plainDecl: compare unannotated nodes; annotated methodDeclaration breaks
@@ -2504,7 +2529,7 @@ public static class TransformWorkerProgram
 
             string calledKey = BuildMethodKeyFromSymbol(methodSymbol);
             // Why the receiver spine (not a WhenNotNull ancestor walk): other?.Inner.AddedPing()
-            // is MemberAccess whose leftmost expression is MemberBinding. An ancestor walk also
+            // and other?.Get().AddedPing() walk left to a MemberBinding. An ancestor walk also
             // matches argument-list / lambda invocations that are ordinary rewrite targets.
             if (IsConditionalAccessReceiverSpine(invocation)
                 && addedMethodCatalog.IsClassifiedAdded(calledKey))
@@ -2592,9 +2617,9 @@ public static class TransformWorkerProgram
         return false;
     }
 
-    // Why the receiver spine: other?.Inner.AddedPing() / other?[0].AddedPing() walk left
-    // through MemberAccess/ElementAccess to a MemberBinding/ElementBinding. Argument-list
-    // and lambda invocations (list?.Add(PrivateCall()), other?.Existing(AddedPing(1))) do not.
+    // Why conservative unknown→true: false means rewrite. ExtractReceiver cannot recover a
+    // MemberBinding-rooted receiver (other?.Get().AddedPing() / other?.Inner!.AddedPing())
+    // and would emit a parse-invalid shim. Over-skip is safe; under-skip is file-level Failed.
     internal static bool IsConditionalAccessReceiverSpine(InvocationExpressionSyntax invocation)
     {
         ExpressionSyntax current = invocation.Expression;
@@ -2605,22 +2630,67 @@ public static class TransformWorkerProgram
                 return true;
             }
 
-            if (current is MemberAccessExpressionSyntax memberAccess)
+            ExpressionSyntax unwrapped = TryUnwrapReceiverSpineExpression(current);
+            if (unwrapped != null)
             {
-                current = memberAccess.Expression;
+                current = unwrapped;
                 continue;
             }
 
-            if (current is ElementAccessExpressionSyntax elementAccess)
+            if (IsNormalReceiverTerminal(current))
             {
-                current = elementAccess.Expression;
-                continue;
+                return false;
             }
 
-            return false;
+            return true;
         }
 
         return false;
+    }
+
+    private static ExpressionSyntax TryUnwrapReceiverSpineExpression(ExpressionSyntax expression)
+    {
+        if (expression is MemberAccessExpressionSyntax memberAccess)
+        {
+            return memberAccess.Expression;
+        }
+
+        if (expression is ElementAccessExpressionSyntax elementAccess)
+        {
+            return elementAccess.Expression;
+        }
+
+        if (expression is InvocationExpressionSyntax innerInvocation)
+        {
+            return innerInvocation.Expression;
+        }
+
+        if (expression is PostfixUnaryExpressionSyntax postfix)
+        {
+            return postfix.Operand;
+        }
+
+        if (expression is ConditionalAccessExpressionSyntax conditionalAccess)
+        {
+            return conditionalAccess.Expression;
+        }
+
+        if (expression is ParenthesizedExpressionSyntax parenthesized)
+        {
+            return parenthesized.Expression;
+        }
+
+        return null;
+    }
+
+    private static bool IsNormalReceiverTerminal(ExpressionSyntax expression)
+    {
+        return expression is SimpleNameSyntax
+            || expression is ThisExpressionSyntax
+            || expression is BaseExpressionSyntax
+            || expression is PredefinedTypeSyntax
+            || expression is AliasQualifiedNameSyntax
+            || expression is QualifiedNameSyntax;
     }
 
     private static string[] CollectCalledAddedMethodKeys(
@@ -5400,6 +5470,9 @@ internal static class AddedMethodSkipReasons
 
     public const string NewTypeOutOfScope =
         "New types are out of scope for hot reload; run 'uloop compile' to add them.";
+
+    public const string InterfaceMember =
+        "Interface members are not patchable";
 }
 
 internal static class UnityMessageNames

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -2617,9 +2617,12 @@ public static class TransformWorkerProgram
         return false;
     }
 
-    // Why conservative unknown→true: false means rewrite. ExtractReceiver cannot recover a
-    // MemberBinding-rooted receiver (other?.Get().AddedPing() / other?.Inner!.AddedPing())
-    // and would emit a parse-invalid shim. Over-skip is safe; under-skip is file-level Failed.
+    // Why unknown→false: MemberBinding/ElementBinding can appear as the leftmost receiver
+    // only along MemberAccess / ElementAccess / Invocation / postfix ! / ConditionalAccess /
+    // Parenthesized. Cast / new / await / ternary / literals are complete expressions;
+    // ExtractReceiver splices them as valid source. Returning true here would skip ordinary
+    // calls with a "conditional access" reason and would suppress accessor rewrite of private
+    // methods on those receivers (fields would still rewrite — VisitMemberAccess has no guard).
     internal static bool IsConditionalAccessReceiverSpine(InvocationExpressionSyntax invocation)
     {
         ExpressionSyntax current = invocation.Expression;
@@ -2637,12 +2640,7 @@ public static class TransformWorkerProgram
                 continue;
             }
 
-            if (IsNormalReceiverTerminal(current))
-            {
-                return false;
-            }
-
-            return true;
+            return false;
         }
 
         return false;
@@ -2665,7 +2663,8 @@ public static class TransformWorkerProgram
             return innerInvocation.Expression;
         }
 
-        if (expression is PostfixUnaryExpressionSyntax postfix)
+        if (expression is PostfixUnaryExpressionSyntax postfix
+            && postfix.IsKind(SyntaxKind.SuppressNullableWarningExpression))
         {
             return postfix.Operand;
         }
@@ -2681,16 +2680,6 @@ public static class TransformWorkerProgram
         }
 
         return null;
-    }
-
-    private static bool IsNormalReceiverTerminal(ExpressionSyntax expression)
-    {
-        return expression is SimpleNameSyntax
-            || expression is ThisExpressionSyntax
-            || expression is BaseExpressionSyntax
-            || expression is PredefinedTypeSyntax
-            || expression is AliasQualifiedNameSyntax
-            || expression is QualifiedNameSyntax;
     }
 
     private static string[] CollectCalledAddedMethodKeys(
@@ -5472,7 +5461,7 @@ internal static class AddedMethodSkipReasons
         "New types are out of scope for hot reload; run 'uloop compile' to add them.";
 
     public const string InterfaceMember =
-        "Interface members are not patchable";
+        "Interface members are not patchable. Run 'uloop compile'.";
 }
 
 internal static class UnityMessageNames

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -258,14 +258,15 @@ public static class TransformWorkerProgram
         Dictionary<string, IndexerDeclarationSyntax> snapshotIndexerMap = null;
         Dictionary<string, PropertyDeclarationSyntax> plainCurrentPropertyMap = null;
         Dictionary<string, IndexerDeclarationSyntax> plainCurrentIndexerMap = null;
+        CompilationUnitSyntax baselineSnapshotRoot = null;
         // Null disables comparison; empty string is a real (empty) baseline text.
         if (input.SnapshotSource != null)
         {
-            CompilationUnitSyntax snapshotRoot = CSharpSyntaxTree.ParseText(
+            baselineSnapshotRoot = CSharpSyntaxTree.ParseText(
                     SourceText.From(input.SnapshotSource, Encoding.UTF8),
                     parseOptions)
                 .GetCompilationUnitRoot();
-            Dictionary<string, MethodDeclarationSyntax> snapMethods = BuildSyntaxMethodMapOrNull(snapshotRoot);
+            Dictionary<string, MethodDeclarationSyntax> snapMethods = BuildSyntaxMethodMapOrNull(baselineSnapshotRoot);
             // Why plainRoot: annotated current nodes break AreEquivalent for some shapes (see plainRoot above).
             Dictionary<string, MethodDeclarationSyntax> currentMethods = BuildSyntaxMethodMapOrNull(plainRoot);
             if (snapMethods != null && currentMethods != null)
@@ -277,17 +278,10 @@ public static class TransformWorkerProgram
                 plainCurrentMethodMap = currentMethods;
                 // Why null is kept as-is: a colliding property/indexer key only disables accessor
                 // gating for this file; method-level baseline matching still applies.
-                snapshotPropertyMap = BuildSyntaxPropertyMapOrNull(snapshotRoot);
-                snapshotIndexerMap = BuildSyntaxIndexerMapOrNull(snapshotRoot);
+                snapshotPropertyMap = BuildSyntaxPropertyMapOrNull(baselineSnapshotRoot);
+                snapshotIndexerMap = BuildSyntaxIndexerMapOrNull(baselineSnapshotRoot);
                 plainCurrentPropertyMap = BuildSyntaxPropertyMapOrNull(plainRoot);
                 plainCurrentIndexerMap = BuildSyntaxIndexerMapOrNull(plainRoot);
-                // Why plainRoot (not annotated root): StripMethodBodiesRewriter only clears method
-                // bodies, so accessor/ctor annotations would otherwise fake outside-body drift.
-                AppendOutsideMethodBodyDriftWarningIfNeeded(
-                    snapshotRoot,
-                    plainRoot,
-                    Path.GetFileName(input.SourcePath),
-                    declarationDriftWarnings);
             }
             else
             {
@@ -299,11 +293,14 @@ public static class TransformWorkerProgram
         List<WorkerEntry> entries = new List<WorkerEntry>();
         List<WorkerSkipped> skipped = new List<WorkerSkipped>();
         List<WorkerUnchangedMethod> unchangedMethods = new List<WorkerUnchangedMethod>();
+        List<WorkerRemovedMember> removedMembers = new List<WorkerRemovedMember>();
         List<ShimTypeBuilder> shimTypes = new List<ShimTypeBuilder>();
         int globalShimMethodCounter = 0;
         int shimTypeCounter = 0;
         List<UsingDirectiveSyntax> assemblyGlobalUsings =
             CollectAssemblyGlobalUsings(input, parseOptions);
+        AddedMethodCatalog addedMethodCatalog = new AddedMethodCatalog();
+        List<TypeEmitState> typeEmitStates = new List<TypeEmitState>();
 
         foreach (TypeDeclarationSyntax typeDeclaration in EnumerateTypeDeclarations(root))
         {
@@ -327,134 +324,77 @@ public static class TransformWorkerProgram
                 hasBaseline ? plainCurrentPropertyMap : null,
                 hasBaseline ? plainCurrentIndexerMap : null);
 
-            List<MethodDeclarationSyntax> methods = typeDeclaration.Members
-                .OfType<MethodDeclarationSyntax>()
-                .ToList();
-
-            ShimTypeBuilder currentShimType = null;
-            foreach (MethodDeclarationSyntax methodDeclaration in methods)
+            TypeEmitState typeState = new TypeEmitState
             {
-                IMethodSymbol methodSymbol = semanticModel.GetDeclaredSymbol(methodDeclaration);
-                if (methodSymbol == null)
-                {
-                    continue;
-                }
+                TypeDeclaration = typeDeclaration,
+                TypeSymbol = typeSymbol,
+                TypeMetadataNameFromSyntax = typeMetadataNameFromSyntax
+            };
+            (int nextShimTypeCounter, int nextGlobalShimMethodCounter) = QueueTypeMethods(
+                typeState,
+                semanticModel,
+                targetTypesAssemblySymbol,
+                input,
+                hasBaseline,
+                snapshotMethodMap,
+                plainCurrentMethodMap,
+                root,
+                assemblyGlobalUsings,
+                shimTypes,
+                addedMethodCatalog,
+                skipped,
+                unchangedMethods,
+                declarationDriftWarnings,
+                shimTypeCounter,
+                globalShimMethodCounter);
+            shimTypeCounter = nextShimTypeCounter;
+            globalShimMethodCounter = nextGlobalShimMethodCounter;
+            typeEmitStates.Add(typeState);
+        }
 
-                string[] parameterTypeFullNames = methodSymbol.Parameters
-                    .Select(CecilTypeNames.ToParameterTypeFullName)
-                    .ToArray();
+        if (hasBaseline)
+        {
+            CollectRemovedMethods(
+                snapshotMethodMap,
+                plainCurrentMethodMap,
+                addedMethodCatalog,
+                removedMembers);
+        }
 
-                // The orchestrator already reported this method as Failed from the first compile
-                // round; re-emitting it would fail the retry compile again.
-                string methodKey = BuildMethodKey(
-                    CecilTypeNames.ToMetadataName(typeSymbol), methodSymbol.Name, parameterTypeFullNames);
-                if (input.ExcludedMethodKeys.Contains(methodKey))
-                {
-                    continue;
-                }
+        SkipMethodsThatCaptureAddedMethodGroups(
+            typeEmitStates,
+            semanticModel,
+            addedMethodCatalog,
+            skipped);
 
-                // Why after ExcludedMethodKeys: exclusion means "already Failed on first round", so
-                // it must win. Unchanged methods add no per-method signal — skipping them cuts
-                // response noise and avoids pause-point collateral on untouched methods. Identities
-                // are returned so the orchestrator can revert a leftover patch when source matches
-                // the baseline again.
-                if (hasBaseline)
-                {
-                    string syntaxMethodKey = BuildSyntaxMethodKey(typeMetadataNameFromSyntax, methodDeclaration);
-                    // Why plainDecl: compare unannotated nodes; annotated methodDeclaration breaks
-                    // AreEquivalent for long-return / unchecked / switch shapes (see plainRoot).
-                    if (snapshotMethodMap.TryGetValue(syntaxMethodKey, out MethodDeclarationSyntax snapshotDecl)
-                        && plainCurrentMethodMap.TryGetValue(syntaxMethodKey, out MethodDeclarationSyntax plainDecl)
-                        && SyntaxFactory.AreEquivalent(snapshotDecl, plainDecl, topLevel: false))
-                    {
-                        unchangedMethods.Add(new WorkerUnchangedMethod
-                        {
-                            TypeMetadataName = CecilTypeNames.ToMetadataName(typeSymbol),
-                            MethodName = methodSymbol.Name,
-                            ParameterTypeFullNames = parameterTypeFullNames
-                        });
-                        continue;
-                    }
-                }
+        if (hasBaseline && baselineSnapshotRoot != null)
+        {
+            // Why after classification: added/removed method declarations must be stripped
+            // before AreEquivalent, or every method addition would fire "not applied".
+            AppendOutsideMethodBodyDriftWarningIfNeeded(
+                baselineSnapshotRoot,
+                plainRoot,
+                Path.GetFileName(input.SourcePath),
+                declarationDriftWarnings,
+                addedMethodCatalog);
+        }
 
-                SyntaxNode methodBodyNode =
-                    (SyntaxNode)methodDeclaration.Body ?? methodDeclaration.ExpressionBody;
-                MethodTransformDecision decision = DecideMethodTransform(
-                    typeDeclaration,
-                    typeSymbol,
-                    methodDeclaration,
-                    methodSymbol,
-                    methodBodyNode,
-                    semanticModel);
-                if (decision.SkipReason != null)
-                {
-                    skipped.Add(new WorkerSkipped
-                    {
-                        Method = FormatMethodLabel(methodSymbol),
-                        Reason = decision.SkipReason
-                    });
-                    continue;
-                }
-
-                if (currentShimType == null)
-                {
-                    string shimTypeName = typeSymbol.Name + "_UloopHotReloadShims_" + shimTypeCounter;
-                    shimTypeCounter++;
-                    string namespaceName = typeSymbol.ContainingNamespace == null
-                        || typeSymbol.ContainingNamespace.IsGlobalNamespace
-                        ? string.Empty
-                        : typeSymbol.ContainingNamespace.ToDisplayString();
-                    currentShimType = new ShimTypeBuilder(
-                        shimTypeName,
-                        namespaceName,
-                        CollectUsingsForType(root, typeDeclaration, assemblyGlobalUsings));
-                    shimTypes.Add(currentShimType);
-                }
-
-                string shimMethodName = methodSymbol.Name + "__shim" + globalShimMethodCounter;
-                globalShimMethodCounter++;
-
-                FileLinePositionSpan originalSpan = methodDeclaration.GetLocation().GetLineSpan();
-                int sourceStartLine = originalSpan.StartLinePosition.Line + 1;
-                int sourceEndLine = originalSpan.EndLinePosition.Line + 1;
-
-                // Eligibility uses a disposable plan; the rewriter lazily GetOrAdd-s into the
-                // shim-type-level plan so AllocateName stays unique across methods in the type.
-                // methodDeclaration already carries uloop-line annotations from the parse-time pass.
-                AccessorPlan rewritePlan = decision.UsesDelegation
-                    ? currentShimType.AccessorPlan
-                    : null;
-                MethodDeclarationSyntax rewrittenMethod = RewriteMethodBody(
-                    methodDeclaration,
-                    methodSymbol,
-                    typeSymbol,
-                    semanticModel,
-                    rewritePlan);
-                currentShimType.AddMethod(rewrittenMethod, shimMethodName);
-
-                entries.Add(new WorkerEntry
-                {
-                    TypeMetadataName = CecilTypeNames.ToMetadataName(typeSymbol),
-                    MethodName = methodSymbol.Name,
-                    ParameterTypeFullNames = parameterTypeFullNames,
-                    ShimTypeName = currentShimType.ShimTypeName,
-                    ShimMethodName = shimMethodName,
-                    PatchKind = decision.PatchKind,
-                    SourceStartLine = sourceStartLine,
-                    SourceEndLine = sourceEndLine,
-                    LifecycleNote = ComputeLifecycleNote(methodDeclaration, methodSymbol, typeSymbol)
-                });
-            }
-
-            foreach (PropertyDeclarationSyntax propertyDeclaration in typeDeclaration.Members
+        foreach (TypeEmitState typeState in typeEmitStates)
+        {
+            EmitQueuedMethods(
+                typeState,
+                semanticModel,
+                addedMethodCatalog,
+                entries);
+            foreach (PropertyDeclarationSyntax propertyDeclaration in typeState.TypeDeclaration.Members
                 .OfType<PropertyDeclarationSyntax>())
             {
                 (ShimTypeBuilder nextShimType, int nextShimTypeCounter, int nextGlobalShimMethodCounter) =
                     AppendPropertyGetterEntry(
                         propertyDeclaration,
-                        typeDeclaration,
-                        typeSymbol,
-                        typeMetadataNameFromSyntax,
+                        typeState.TypeDeclaration,
+                        typeState.TypeSymbol,
+                        typeState.TypeMetadataNameFromSyntax,
                         semanticModel,
                         root,
                         input,
@@ -467,11 +407,22 @@ public static class TransformWorkerProgram
                         shimTypes,
                         shimTypeCounter,
                         globalShimMethodCounter,
-                        currentShimType,
-                        assemblyGlobalUsings);
-                currentShimType = nextShimType;
+                        typeState.CurrentShimType,
+                        assemblyGlobalUsings,
+                        addedMethodCatalog);
+                typeState.CurrentShimType = nextShimType;
                 shimTypeCounter = nextShimTypeCounter;
                 globalShimMethodCounter = nextGlobalShimMethodCounter;
+            }
+        }
+
+        bool hasAccessorDelegates = false;
+        foreach (ShimTypeBuilder shimType in shimTypes)
+        {
+            if (shimType.AccessorPlan.Entries.Count > 0)
+            {
+                hasAccessorDelegates = true;
+                break;
             }
         }
 
@@ -484,7 +435,9 @@ public static class TransformWorkerProgram
             DeclarationDriftWarnings = declarationDriftWarnings.ToArray(),
             ParseErrors = parseErrors.ToArray(),
             UnchangedMethods = unchangedMethods.ToArray(),
-            BaselineDisabledByDuplicateKeys = baselineDisabledByDuplicateKeys
+            BaselineDisabledByDuplicateKeys = baselineDisabledByDuplicateKeys,
+            RemovedMembers = removedMembers.ToArray(),
+            HasAccessorDelegates = hasAccessorDelegates
         };
     }
 
@@ -754,7 +707,7 @@ public static class TransformWorkerProgram
         + "run 'uloop compile' to apply accessor edits.";
 
     private const string OutsideMethodBodyDriftWarningFormat =
-        "Edits outside method bodies in {0} (fields, initializers, attributes, or added/removed members) are not applied by hot reload; run uloop compile to pick them up.";
+        "Edits outside method bodies in {0} (fields, initializers, or attributes) are not applied by hot reload; run uloop compile to pick them up.";
 
     // Syntax-based method key for same-file snapshot vs current comparison. Do not mix with
     // BuildMethodKey (Cecil/metadata names used by the orchestrator exclusion path).
@@ -968,15 +921,49 @@ public static class TransformWorkerProgram
         CompilationUnitSyntax snapshotRoot,
         CompilationUnitSyntax currentRoot,
         string fileName,
-        List<string> declarationDriftWarnings)
+        List<string> declarationDriftWarnings,
+        AddedMethodCatalog addedMethodCatalog)
     {
-        StripMethodBodiesRewriter rewriter = new StripMethodBodiesRewriter();
-        SyntaxNode strippedSnapshot = rewriter.Visit(snapshotRoot);
-        SyntaxNode strippedCurrent = rewriter.Visit(currentRoot);
+        StripHandledMethodDeclarationsRewriter stripSnapshot =
+            new StripHandledMethodDeclarationsRewriter(addedMethodCatalog.RemovedSyntaxKeys);
+        StripHandledMethodDeclarationsRewriter stripCurrent =
+            new StripHandledMethodDeclarationsRewriter(addedMethodCatalog.AddedSyntaxKeys);
+        StripMethodBodiesRewriter bodyStripper = new StripMethodBodiesRewriter();
+        SyntaxNode strippedSnapshot = bodyStripper.Visit(stripSnapshot.Visit(snapshotRoot));
+        SyntaxNode strippedCurrent = bodyStripper.Visit(stripCurrent.Visit(currentRoot));
         if (!SyntaxFactory.AreEquivalent(strippedSnapshot, strippedCurrent, topLevel: false))
         {
             declarationDriftWarnings.Add(
                 string.Format(CultureInfo.InvariantCulture, OutsideMethodBodyDriftWarningFormat, fileName));
+        }
+    }
+
+    private sealed class StripHandledMethodDeclarationsRewriter : CSharpSyntaxRewriter
+    {
+        private readonly HashSet<string> _syntaxKeysToStrip;
+
+        public StripHandledMethodDeclarationsRewriter(IReadOnlyCollection<string> syntaxKeysToStrip)
+        {
+            _syntaxKeysToStrip = new HashSet<string>(syntaxKeysToStrip, StringComparer.Ordinal);
+        }
+
+        public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            TypeDeclarationSyntax typeDeclaration = node.Parent as TypeDeclarationSyntax;
+            if (typeDeclaration == null)
+            {
+                return base.VisitMethodDeclaration(node);
+            }
+
+            string syntaxKey = BuildSyntaxMethodKey(
+                BuildTypeMetadataNameFromSyntax(typeDeclaration),
+                node);
+            if (_syntaxKeysToStrip.Contains(syntaxKey))
+            {
+                return null;
+            }
+
+            return base.VisitMethodDeclaration(node);
         }
     }
 
@@ -1282,7 +1269,8 @@ public static class TransformWorkerProgram
             int shimTypeCounter,
             int globalShimMethodCounter,
             ShimTypeBuilder currentShimType,
-            List<UsingDirectiveSyntax> assemblyGlobalUsings)
+            List<UsingDirectiveSyntax> assemblyGlobalUsings,
+            AddedMethodCatalog addedMethodCatalog)
     {
         IPropertySymbol propertySymbol = semanticModel.GetDeclaredSymbol(propertyDeclaration);
         if (propertySymbol == null || propertySymbol.GetMethod == null)
@@ -1391,7 +1379,8 @@ public static class TransformWorkerProgram
             getterSymbol,
             typeSymbol,
             semanticModel,
-            rewritePlan);
+            rewritePlan,
+            addedMethodCatalog);
         currentShimType.AddMethod(rewrittenMethod, shimMethodName);
 
         entries.Add(new WorkerEntry
@@ -1486,9 +1475,14 @@ public static class TransformWorkerProgram
         IMethodSymbol getterSymbol,
         INamedTypeSymbol targetType,
         SemanticModel semanticModel,
-        AccessorPlan accessorPlan)
+        AccessorPlan accessorPlan,
+        AddedMethodCatalog addedMethodCatalog)
     {
-        ShimBodyRewriter rewriter = new ShimBodyRewriter(semanticModel, targetType, accessorPlan);
+        ShimBodyRewriter rewriter = new ShimBodyRewriter(
+            semanticModel,
+            targetType,
+            accessorPlan,
+            addedMethodCatalog);
         SyntaxNode rewrittenBody = rewriter.Visit(getterBodyNode);
         // Why transfer: Visit may rebuild ArrowExpressionClause nodes and drop #line annotations.
         rewrittenBody = TransferUloopLineAnnotations(getterBodyNode, rewrittenBody);
@@ -2030,16 +2024,507 @@ public static class TransformWorkerProgram
         }
     }
 
+    private static (int ShimTypeCounter, int GlobalShimMethodCounter) QueueTypeMethods(
+        TypeEmitState typeState,
+        SemanticModel semanticModel,
+        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerInput input,
+        bool hasBaseline,
+        Dictionary<string, MethodDeclarationSyntax> snapshotMethodMap,
+        Dictionary<string, MethodDeclarationSyntax> plainCurrentMethodMap,
+        CompilationUnitSyntax root,
+        List<UsingDirectiveSyntax> assemblyGlobalUsings,
+        List<ShimTypeBuilder> shimTypes,
+        AddedMethodCatalog addedMethodCatalog,
+        List<WorkerSkipped> skipped,
+        List<WorkerUnchangedMethod> unchangedMethods,
+        List<string> declarationDriftWarnings,
+        int shimTypeCounter,
+        int globalShimMethodCounter)
+    {
+        INamedTypeSymbol compiledType = FindCompiledType(typeState.TypeSymbol, targetTypesAssemblySymbol);
+        foreach (MethodDeclarationSyntax methodDeclaration in typeState.TypeDeclaration.Members
+            .OfType<MethodDeclarationSyntax>())
+        {
+            IMethodSymbol methodSymbol = semanticModel.GetDeclaredSymbol(methodDeclaration);
+            if (methodSymbol == null)
+            {
+                continue;
+            }
+
+            string[] parameterTypeFullNames = methodSymbol.Parameters
+                .Select(CecilTypeNames.ToParameterTypeFullName)
+                .ToArray();
+            string methodKey = BuildMethodKey(
+                CecilTypeNames.ToMetadataName(typeState.TypeSymbol),
+                methodSymbol.Name,
+                parameterTypeFullNames);
+            // Why skip explicit-interface methods: compiled GetMembers(simpleName) does not
+            // see them (metadata name is Interface.Method), so they would be misclassified as
+            // Added and skip the unchanged/baseline path.
+            bool isAddedMethod = compiledType != null
+                && methodDeclaration.ExplicitInterfaceSpecifier == null
+                && !CompiledTypeHasOrdinaryMethod(compiledType, methodSymbol);
+
+            // Why added methods ignore ExcludedMethodKeys: dropping their shim leaves callers
+            // with CS0103 on retry and collapses isolation to a file-level Failed (G1).
+            if (!isAddedMethod && input.ExcludedMethodKeys.Contains(methodKey))
+            {
+                continue;
+            }
+
+            string syntaxMethodKey = BuildSyntaxMethodKey(
+                typeState.TypeMetadataNameFromSyntax,
+                methodDeclaration);
+            if (!isAddedMethod && hasBaseline)
+            {
+                // Why plainDecl: compare unannotated nodes; annotated methodDeclaration breaks
+                // AreEquivalent for long-return / unchecked / switch shapes (see plainRoot).
+                if (snapshotMethodMap.TryGetValue(syntaxMethodKey, out MethodDeclarationSyntax snapshotDecl)
+                    && plainCurrentMethodMap.TryGetValue(syntaxMethodKey, out MethodDeclarationSyntax plainDecl)
+                    && SyntaxFactory.AreEquivalent(snapshotDecl, plainDecl, topLevel: false))
+                {
+                    unchangedMethods.Add(new WorkerUnchangedMethod
+                    {
+                        TypeMetadataName = CecilTypeNames.ToMetadataName(typeState.TypeSymbol),
+                        MethodName = methodSymbol.Name,
+                        ParameterTypeFullNames = parameterTypeFullNames
+                    });
+                    continue;
+                }
+            }
+
+            SyntaxNode methodBodyNode =
+                (SyntaxNode)methodDeclaration.Body ?? methodDeclaration.ExpressionBody;
+            MethodTransformDecision decision = DecideMethodTransform(
+                typeState.TypeDeclaration,
+                typeState.TypeSymbol,
+                methodDeclaration,
+                methodSymbol,
+                methodBodyNode,
+                semanticModel);
+            if (isAddedMethod && decision.SkipReason == null)
+            {
+                string addedSkip = EvaluateAddedMethodSkipReason(methodSymbol);
+                if (addedSkip != null)
+                {
+                    decision = MethodTransformDecision.Skip(addedSkip);
+                }
+                else
+                {
+                    decision = MethodTransformDecision.AddedMethod(decision.UsesDelegation);
+                }
+            }
+
+            if (decision.SkipReason != null)
+            {
+                skipped.Add(new WorkerSkipped
+                {
+                    Method = FormatMethodLabel(methodSymbol),
+                    Reason = decision.SkipReason
+                });
+                continue;
+            }
+
+            ShimTypeBuilder shimType;
+            (shimType, shimTypeCounter) = EnsureShimType(
+                typeState,
+                root,
+                assemblyGlobalUsings,
+                shimTypes,
+                shimTypeCounter);
+            string shimMethodName = methodSymbol.Name + "__shim" + globalShimMethodCounter;
+            globalShimMethodCounter++;
+
+            FileLinePositionSpan originalSpan = methodDeclaration.GetLocation().GetLineSpan();
+            QueuedShimMethod queued = new QueuedShimMethod
+            {
+                MethodDeclaration = methodDeclaration,
+                MethodSymbol = methodSymbol,
+                Decision = decision,
+                ShimMethodName = shimMethodName,
+                ShimType = shimType,
+                SourceStartLine = originalSpan.StartLinePosition.Line + 1,
+                SourceEndLine = originalSpan.EndLinePosition.Line + 1,
+                ParameterTypeFullNames = parameterTypeFullNames,
+                MethodKey = methodKey,
+                IsAddedMethod = isAddedMethod
+            };
+            typeState.QueuedMethods.Add(queued);
+
+            if (isAddedMethod)
+            {
+                addedMethodCatalog.Register(
+                    new AddedMethodBinding
+                    {
+                        MethodKey = methodKey,
+                        ShimTypeName = shimType.ShimTypeName,
+                        ShimMethodName = shimMethodName,
+                        NamespaceName = shimType.NamespaceName,
+                        IsStatic = methodSymbol.IsStatic
+                    });
+                addedMethodCatalog.AddAddedSyntaxKey(syntaxMethodKey);
+                AppendUnityMessageWarningIfNeeded(
+                    typeState.TypeSymbol,
+                    methodSymbol,
+                    declarationDriftWarnings);
+            }
+        }
+
+        return (shimTypeCounter, globalShimMethodCounter);
+    }
+
+    private static (ShimTypeBuilder ShimType, int ShimTypeCounter) EnsureShimType(
+        TypeEmitState typeState,
+        CompilationUnitSyntax root,
+        List<UsingDirectiveSyntax> assemblyGlobalUsings,
+        List<ShimTypeBuilder> shimTypes,
+        int shimTypeCounter)
+    {
+        if (typeState.CurrentShimType != null)
+        {
+            return (typeState.CurrentShimType, shimTypeCounter);
+        }
+
+        string shimTypeName = typeState.TypeSymbol.Name + "_UloopHotReloadShims_" + shimTypeCounter;
+        shimTypeCounter++;
+        string namespaceName = typeState.TypeSymbol.ContainingNamespace == null
+            || typeState.TypeSymbol.ContainingNamespace.IsGlobalNamespace
+            ? string.Empty
+            : typeState.TypeSymbol.ContainingNamespace.ToDisplayString();
+        typeState.CurrentShimType = new ShimTypeBuilder(
+            shimTypeName,
+            namespaceName,
+            CollectUsingsForType(root, typeState.TypeDeclaration, assemblyGlobalUsings));
+        shimTypes.Add(typeState.CurrentShimType);
+        return (typeState.CurrentShimType, shimTypeCounter);
+    }
+
+    private static void EmitQueuedMethods(
+        TypeEmitState typeState,
+        SemanticModel semanticModel,
+        AddedMethodCatalog addedMethodCatalog,
+        List<WorkerEntry> entries)
+    {
+        foreach (QueuedShimMethod queued in typeState.QueuedMethods)
+        {
+            AccessorPlan rewritePlan = queued.Decision.UsesDelegation
+                ? queued.ShimType.AccessorPlan
+                : null;
+            MethodDeclarationSyntax rewrittenMethod = RewriteMethodBody(
+                queued.MethodDeclaration,
+                queued.MethodSymbol,
+                typeState.TypeSymbol,
+                semanticModel,
+                rewritePlan,
+                addedMethodCatalog);
+            queued.ShimType.AddMethod(rewrittenMethod, queued.ShimMethodName);
+
+            SyntaxNode bodyNode =
+                (SyntaxNode)queued.MethodDeclaration.Body ?? queued.MethodDeclaration.ExpressionBody;
+            string[] calledAddedMethodKeys = CollectCalledAddedMethodKeys(
+                bodyNode,
+                semanticModel,
+                addedMethodCatalog,
+                queued.MethodKey);
+
+            entries.Add(new WorkerEntry
+            {
+                TypeMetadataName = CecilTypeNames.ToMetadataName(typeState.TypeSymbol),
+                MethodName = queued.MethodSymbol.Name,
+                ParameterTypeFullNames = queued.ParameterTypeFullNames,
+                ShimTypeName = queued.ShimType.ShimTypeName,
+                ShimMethodName = queued.ShimMethodName,
+                PatchKind = queued.Decision.PatchKind,
+                CalledAddedMethodKeys = calledAddedMethodKeys,
+                SourceStartLine = queued.SourceStartLine,
+                SourceEndLine = queued.SourceEndLine,
+                LifecycleNote = ComputeLifecycleNote(
+                    queued.MethodDeclaration,
+                    queued.MethodSymbol,
+                    typeState.TypeSymbol)
+            });
+        }
+    }
+
+    private static void CollectRemovedMethods(
+        Dictionary<string, MethodDeclarationSyntax> snapshotMethodMap,
+        Dictionary<string, MethodDeclarationSyntax> plainCurrentMethodMap,
+        AddedMethodCatalog addedMethodCatalog,
+        List<WorkerRemovedMember> removedMembers)
+    {
+        HashSet<string> seenNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (KeyValuePair<string, MethodDeclarationSyntax> pair in snapshotMethodMap)
+        {
+            if (plainCurrentMethodMap.ContainsKey(pair.Key))
+            {
+                continue;
+            }
+
+            addedMethodCatalog.AddRemovedSyntaxKey(pair.Key);
+            string name = pair.Value.Identifier.Text;
+            if (!seenNames.Add(name))
+            {
+                continue;
+            }
+
+            removedMembers.Add(new WorkerRemovedMember
+            {
+                Kind = RemovedMemberKinds.Method,
+                Name = name
+            });
+        }
+    }
+
+    private static void SkipMethodsThatCaptureAddedMethodGroups(
+        List<TypeEmitState> typeEmitStates,
+        SemanticModel semanticModel,
+        AddedMethodCatalog addedMethodCatalog,
+        List<WorkerSkipped> skipped)
+    {
+        foreach (TypeEmitState typeState in typeEmitStates)
+        {
+            List<QueuedShimMethod> remaining = new List<QueuedShimMethod>();
+            foreach (QueuedShimMethod queued in typeState.QueuedMethods)
+            {
+                SyntaxNode bodyNode =
+                    (SyntaxNode)queued.MethodDeclaration.Body ?? queued.MethodDeclaration.ExpressionBody;
+                if (bodyNode != null
+                    && BodyReferencesAddedInstanceMethodGroup(bodyNode, semanticModel, addedMethodCatalog))
+                {
+                    skipped.Add(new WorkerSkipped
+                    {
+                        Method = FormatMethodLabel(queued.MethodSymbol),
+                        Reason = AddedMethodSkipReasons.MethodGroupReference
+                    });
+                    if (queued.IsAddedMethod)
+                    {
+                        addedMethodCatalog.Unregister(queued.MethodKey);
+                    }
+
+                    continue;
+                }
+
+                remaining.Add(queued);
+            }
+
+            typeState.QueuedMethods.Clear();
+            typeState.QueuedMethods.AddRange(remaining);
+        }
+    }
+
+    private static bool BodyReferencesAddedInstanceMethodGroup(
+        SyntaxNode bodyNode,
+        SemanticModel semanticModel,
+        AddedMethodCatalog addedMethodCatalog)
+    {
+        foreach (IdentifierNameSyntax name in bodyNode.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
+        {
+            if (IsInvocationCalleeName(name) || NameofRules.IsInsideNameofArgument(name))
+            {
+                continue;
+            }
+
+            ISymbol symbol = semanticModel.GetSymbolInfo(name).Symbol;
+            if (symbol is IMethodSymbol methodSymbol
+                && !methodSymbol.IsStatic
+                && addedMethodCatalog.Contains(BuildMethodKeyFromSymbol(methodSymbol)))
+            {
+                return true;
+            }
+        }
+
+        foreach (MemberAccessExpressionSyntax access in bodyNode.DescendantNodesAndSelf()
+            .OfType<MemberAccessExpressionSyntax>())
+        {
+            if ((access.Parent is InvocationExpressionSyntax invocation && invocation.Expression == access)
+                || NameofRules.IsInsideNameofArgument(access))
+            {
+                continue;
+            }
+
+            ISymbol symbol = semanticModel.GetSymbolInfo(access).Symbol;
+            if (symbol is IMethodSymbol methodSymbol
+                && !methodSymbol.IsStatic
+                && addedMethodCatalog.Contains(BuildMethodKeyFromSymbol(methodSymbol)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsInvocationCalleeName(IdentifierNameSyntax name)
+    {
+        if (name.Parent is InvocationExpressionSyntax invocation && invocation.Expression == name)
+        {
+            return true;
+        }
+
+        if (name.Parent is MemberAccessExpressionSyntax memberAccess
+            && memberAccess.Name == name
+            && memberAccess.Parent is InvocationExpressionSyntax memberInvocation
+            && memberInvocation.Expression == memberAccess)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string[] CollectCalledAddedMethodKeys(
+        SyntaxNode bodyNode,
+        SemanticModel semanticModel,
+        AddedMethodCatalog addedMethodCatalog,
+        string selfMethodKey)
+    {
+        if (bodyNode == null)
+        {
+            return Array.Empty<string>();
+        }
+
+        HashSet<string> keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (InvocationExpressionSyntax invocation in bodyNode.DescendantNodesAndSelf()
+            .OfType<InvocationExpressionSyntax>())
+        {
+            if (NameofRules.IsNameofInvocation(invocation))
+            {
+                continue;
+            }
+
+            ISymbol symbol = semanticModel.GetSymbolInfo(invocation).Symbol;
+            if (symbol is not IMethodSymbol methodSymbol)
+            {
+                continue;
+            }
+
+            string calledKey = BuildMethodKeyFromSymbol(methodSymbol);
+            if (calledKey == selfMethodKey)
+            {
+                continue;
+            }
+
+            if (addedMethodCatalog.Contains(calledKey))
+            {
+                keys.Add(calledKey);
+            }
+        }
+
+        if (keys.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        string[] result = new string[keys.Count];
+        keys.CopyTo(result);
+        return result;
+    }
+
+    private static INamedTypeSymbol FindCompiledType(
+        INamedTypeSymbol sourceType,
+        IAssemblySymbol targetTypesAssemblySymbol)
+    {
+        if (sourceType == null || targetTypesAssemblySymbol == null)
+        {
+            return null;
+        }
+
+        return targetTypesAssemblySymbol.GetTypeByMetadataName(ToReflectionMetadataName(sourceType));
+    }
+
+    private static bool CompiledTypeHasOrdinaryMethod(
+        INamedTypeSymbol compiledType,
+        IMethodSymbol sourceMethod)
+    {
+        string[] sourceParameterTypeFullNames = sourceMethod.Parameters
+            .Select(CecilTypeNames.ToParameterTypeFullName)
+            .ToArray();
+        foreach (ISymbol member in compiledType.GetMembers(sourceMethod.Name))
+        {
+            if (member is not IMethodSymbol compiledMethod
+                || compiledMethod.MethodKind != MethodKind.Ordinary
+                || compiledMethod.IsStatic != sourceMethod.IsStatic
+                || compiledMethod.Parameters.Length != sourceParameterTypeFullNames.Length)
+            {
+                continue;
+            }
+
+            bool parametersMatch = true;
+            for (int index = 0; index < sourceParameterTypeFullNames.Length; index++)
+            {
+                if (CecilTypeNames.ToParameterTypeFullName(compiledMethod.Parameters[index])
+                    != sourceParameterTypeFullNames[index])
+                {
+                    parametersMatch = false;
+                    break;
+                }
+            }
+
+            if (parametersMatch)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string EvaluateAddedMethodSkipReason(IMethodSymbol methodSymbol)
+    {
+        if (methodSymbol.IsAbstract || methodSymbol.IsVirtual || methodSymbol.IsOverride)
+        {
+            return AddedMethodSkipReasons.VirtualOrAbstract;
+        }
+
+        return null;
+    }
+
+    private static void AppendUnityMessageWarningIfNeeded(
+        INamedTypeSymbol typeSymbol,
+        IMethodSymbol methodSymbol,
+        List<string> declarationDriftWarnings)
+    {
+        if (!IsUnityEngineMonoBehaviourDerived(typeSymbol)
+            || !UnityMessageNames.Contains(methodSymbol.Name))
+        {
+            return;
+        }
+
+        declarationDriftWarnings.Add(
+            string.Format(
+                CultureInfo.InvariantCulture,
+                UnityMessageNames.AddedMessageWarningFormat,
+                methodSymbol.Name,
+                typeSymbol.ToDisplayString()));
+    }
+
+    private static string BuildMethodKeyFromSymbol(IMethodSymbol methodSymbol)
+    {
+        string[] parameterTypeFullNames = methodSymbol.Parameters
+            .Select(CecilTypeNames.ToParameterTypeFullName)
+            .ToArray();
+        return BuildMethodKey(
+            CecilTypeNames.ToMetadataName(methodSymbol.ContainingType),
+            methodSymbol.Name,
+            parameterTypeFullNames);
+    }
+
     private static MethodDeclarationSyntax RewriteMethodBody(
         MethodDeclarationSyntax methodDeclaration,
         IMethodSymbol methodSymbol,
         INamedTypeSymbol targetType,
         SemanticModel semanticModel,
-        AccessorPlan accessorPlan)
+        AccessorPlan accessorPlan,
+        AddedMethodCatalog addedMethodCatalog)
     {
         // Why a single rewriter: rewriting the tree invalidates SemanticModel for new nodes.
         // Qualify + accessor rewrite both classify symbols on the original tree in one Visit pass.
-        ShimBodyRewriter rewriter = new ShimBodyRewriter(semanticModel, targetType, accessorPlan);
+        ShimBodyRewriter rewriter = new ShimBodyRewriter(
+            semanticModel,
+            targetType,
+            accessorPlan,
+            addedMethodCatalog);
         MethodDeclarationSyntax rewritten = (MethodDeclarationSyntax)rewriter.Visit(methodDeclaration);
         return ShimMethodFactory.ToShimMethod(rewritten, methodSymbol);
     }
@@ -3559,15 +4044,18 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
     private readonly SemanticModel _semanticModel;
     private readonly INamedTypeSymbol _targetType;
     private readonly AccessorPlan _accessorPlan;
+    private readonly AddedMethodCatalog _addedMethodCatalog;
 
     public ShimBodyRewriter(
         SemanticModel semanticModel,
         INamedTypeSymbol targetType,
-        AccessorPlan accessorPlan)
+        AccessorPlan accessorPlan,
+        AddedMethodCatalog addedMethodCatalog)
     {
         _semanticModel = semanticModel;
         _targetType = targetType;
         _accessorPlan = accessorPlan;
+        _addedMethodCatalog = addedMethodCatalog ?? new AddedMethodCatalog();
     }
 
     public override SyntaxNode VisitThisExpression(ThisExpressionSyntax node)
@@ -3637,14 +4125,39 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
 
     public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
     {
-        if (_accessorPlan == null
-            || TransformWorkerProgram.NameofRules.IsNameofInvocation(node)
-            || TransformWorkerProgram.NameofRules.IsInsideNameofArgument(node))
+        // Why first: added-member rewrite must not depend on _accessorPlan. Transplant bodies
+        // have a null plan and would skip rewrite; delegation bodies would otherwise bind
+        // Harmony accessors onto members that do not exist on the compiled type (B1).
+        if (TransformWorkerProgram.NameofRules.IsNameofInvocation(node))
+        {
+            ExpressionSyntax folded = TryFoldNameofAddedMember(node);
+            if (folded != null)
+            {
+                return folded;
+            }
+
+            return base.VisitInvocationExpression(node);
+        }
+
+        if (TransformWorkerProgram.NameofRules.IsInsideNameofArgument(node))
         {
             return base.VisitInvocationExpression(node);
         }
 
-        ISymbol symbol = _semanticModel.GetSymbolInfo(node).Symbol;
+        ISymbol invokedSymbol = _semanticModel.GetSymbolInfo(node).Symbol;
+        if (invokedSymbol is IMethodSymbol addedMethod
+            && addedMethod.MethodKind == MethodKind.Ordinary
+            && _addedMethodCatalog.TryGet(BuildAddedMethodKey(addedMethod), out AddedMethodBinding binding))
+        {
+            return RewriteAddedMethodInvocation(node, addedMethod, binding);
+        }
+
+        if (_accessorPlan == null)
+        {
+            return base.VisitInvocationExpression(node);
+        }
+
+        ISymbol symbol = invokedSymbol;
         if (symbol is not IMethodSymbol methodSymbol
             || methodSymbol.MethodKind != MethodKind.Ordinary
             || !AccessibilityRules.IsInaccessibleFromExternalAssembly(methodSymbol)
@@ -3670,6 +4183,89 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
                 SyntaxFactory.IdentifierName(entry.DelegateFieldName),
                 SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments)))
             .WithTriviaFrom(node);
+    }
+
+    private ExpressionSyntax TryFoldNameofAddedMember(InvocationExpressionSyntax nameofInvocation)
+    {
+        if (nameofInvocation.ArgumentList.Arguments.Count != 1)
+        {
+            return null;
+        }
+
+        ExpressionSyntax argument = nameofInvocation.ArgumentList.Arguments[0].Expression;
+        ISymbol symbol = ResolveNameofArgumentSymbol(argument);
+        if (symbol is not IMethodSymbol methodSymbol
+            || !_addedMethodCatalog.Contains(BuildAddedMethodKey(methodSymbol)))
+        {
+            return null;
+        }
+
+        return SyntaxFactory.LiteralExpression(
+                SyntaxKind.StringLiteralExpression,
+                SyntaxFactory.Literal(methodSymbol.Name))
+            .WithTriviaFrom(nameofInvocation);
+    }
+
+    private ISymbol ResolveNameofArgumentSymbol(ExpressionSyntax argument)
+    {
+        // Why CandidateSymbols: nameof(method) is a method group, so Symbol is often null
+        // and the unique candidate is the added method we need to fold.
+        SymbolInfo symbolInfo = _semanticModel.GetSymbolInfo(argument);
+        if (symbolInfo.Symbol != null)
+        {
+            return symbolInfo.Symbol;
+        }
+
+        if (symbolInfo.CandidateSymbols.Length == 1)
+        {
+            return symbolInfo.CandidateSymbols[0];
+        }
+
+        return null;
+    }
+
+    private SyntaxNode RewriteAddedMethodInvocation(
+        InvocationExpressionSyntax node,
+        IMethodSymbol addedMethod,
+        AddedMethodBinding binding)
+    {
+        string qualifiedShimType = string.IsNullOrEmpty(binding.NamespaceName)
+            ? "global::" + binding.ShimTypeName
+            : "global::" + binding.NamespaceName + "." + binding.ShimTypeName;
+        ExpressionSyntax shimTypeExpression = SyntaxFactory.ParseTypeName(qualifiedShimType);
+        ExpressionSyntax shimAccess = SyntaxFactory.MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            shimTypeExpression,
+            SyntaxFactory.IdentifierName(binding.ShimMethodName));
+
+        List<ArgumentSyntax> arguments = new List<ArgumentSyntax>();
+        if (!addedMethod.IsStatic)
+        {
+            ExpressionSyntax receiver = ExtractReceiver(node.Expression);
+            arguments.Add(SyntaxFactory.Argument(VisitReceiver(receiver)));
+        }
+
+        foreach (ArgumentSyntax argument in node.ArgumentList.Arguments)
+        {
+            arguments.Add((ArgumentSyntax)Visit(argument));
+        }
+
+        return SyntaxFactory.InvocationExpression(
+                shimAccess,
+                SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments)))
+            .WithTriviaFrom(node);
+    }
+
+    private static string BuildAddedMethodKey(IMethodSymbol methodSymbol)
+    {
+        string[] parameterTypeFullNames = methodSymbol.Parameters
+            .Select(CecilTypeNames.ToParameterTypeFullName)
+            .ToArray();
+        return methodSymbol.ContainingType == null
+            ? methodSymbol.Name
+            : CecilTypeNames.ToMetadataName(methodSymbol.ContainingType)
+                + "::" + methodSymbol.Name + "("
+                + string.Join(",", parameterTypeFullNames) + ")";
     }
 
     public override SyntaxNode VisitAssignmentExpression(AssignmentExpressionSyntax node)
@@ -4373,6 +4969,174 @@ internal static class CecilTypeNames
     }
 }
 
+internal sealed class TypeEmitState
+{
+    public TypeDeclarationSyntax TypeDeclaration { get; set; }
+
+    public INamedTypeSymbol TypeSymbol { get; set; }
+
+    public string TypeMetadataNameFromSyntax { get; set; }
+
+    public ShimTypeBuilder CurrentShimType { get; set; }
+
+    public List<QueuedShimMethod> QueuedMethods { get; } = new List<QueuedShimMethod>();
+}
+
+internal sealed class QueuedShimMethod
+{
+    public MethodDeclarationSyntax MethodDeclaration { get; set; }
+
+    public IMethodSymbol MethodSymbol { get; set; }
+
+    public MethodTransformDecision Decision { get; set; }
+
+    public string ShimMethodName { get; set; }
+
+    public ShimTypeBuilder ShimType { get; set; }
+
+    public int SourceStartLine { get; set; }
+
+    public int SourceEndLine { get; set; }
+
+    public string[] ParameterTypeFullNames { get; set; }
+
+    public string MethodKey { get; set; }
+
+    public bool IsAddedMethod { get; set; }
+}
+
+internal sealed class AddedMethodBinding
+{
+    public string MethodKey { get; set; }
+
+    public string ShimTypeName { get; set; }
+
+    public string ShimMethodName { get; set; }
+
+    public string NamespaceName { get; set; }
+
+    public bool IsStatic { get; set; }
+}
+
+internal sealed class AddedMethodCatalog
+{
+    private readonly Dictionary<string, AddedMethodBinding> _byKey =
+        new Dictionary<string, AddedMethodBinding>(StringComparer.Ordinal);
+    private readonly HashSet<string> _addedSyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
+    private readonly HashSet<string> _removedSyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
+
+    public IReadOnlyCollection<string> AddedSyntaxKeys => _addedSyntaxKeys;
+
+    public IReadOnlyCollection<string> RemovedSyntaxKeys => _removedSyntaxKeys;
+
+    public void Register(AddedMethodBinding binding)
+    {
+        _byKey[binding.MethodKey] = binding;
+    }
+
+    public void AddAddedSyntaxKey(string syntaxKey)
+    {
+        _addedSyntaxKeys.Add(syntaxKey);
+    }
+
+    public void AddRemovedSyntaxKey(string syntaxKey)
+    {
+        _removedSyntaxKeys.Add(syntaxKey);
+    }
+
+    public bool Contains(string methodKey)
+    {
+        return methodKey != null && _byKey.ContainsKey(methodKey);
+    }
+
+    public bool TryGet(string methodKey, out AddedMethodBinding binding)
+    {
+        return _byKey.TryGetValue(methodKey, out binding);
+    }
+
+    public void Unregister(string methodKey)
+    {
+        if (methodKey != null)
+        {
+            _byKey.Remove(methodKey);
+        }
+    }
+}
+
+internal static class AddedMethodSkipReasons
+{
+    public const string VirtualOrAbstract =
+        "Added virtual, override, or abstract methods are skipped; the compiled type has no vtable slot. "
+        + "Run 'uloop compile' to add them.";
+
+    public const string MethodGroupReference =
+        "Methods that capture an added instance method as a method group or delegate are skipped; "
+        + "the shim signature does not match. Run 'uloop compile'.";
+}
+
+internal static class UnityMessageNames
+{
+    // Keep in sync with the Unity-message set documented in the hot-reload skill.
+    public const string AddedMessageWarningFormat =
+        "Added Unity message '{0}' on {1} will not be invoked by the engine until 'uloop compile'; "
+        + "Unity discovers messages by reflection on the compiled type.";
+
+    private static readonly HashSet<string> Names = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "Awake",
+        "Start",
+        "OnEnable",
+        "OnDisable",
+        "OnDestroy",
+        "Update",
+        "LateUpdate",
+        "FixedUpdate",
+        "OnGUI",
+        "Reset",
+        "OnValidate",
+        "OnCollisionEnter",
+        "OnCollisionExit",
+        "OnCollisionStay",
+        "OnTriggerEnter",
+        "OnTriggerExit",
+        "OnTriggerStay",
+        "OnCollisionEnter2D",
+        "OnCollisionExit2D",
+        "OnCollisionStay2D",
+        "OnTriggerEnter2D",
+        "OnTriggerExit2D",
+        "OnTriggerStay2D",
+        "OnMouseDown",
+        "OnMouseUp",
+        "OnMouseEnter",
+        "OnMouseExit",
+        "OnMouseOver",
+        "OnMouseDrag",
+        "OnBecameVisible",
+        "OnBecameInvisible",
+        "OnApplicationQuit",
+        "OnApplicationPause",
+        "OnApplicationFocus",
+        "OnTransformChildrenChanged",
+        "OnTransformParentChanged",
+        "OnRectTransformDimensionsChange",
+        "OnParticleCollision",
+        "OnParticleTrigger",
+        "OnControllerColliderHit",
+        "OnJointBreak",
+        "OnJointBreak2D",
+        "OnAnimatorMove",
+        "OnAnimatorIK",
+        "OnDrawGizmos",
+        "OnDrawGizmosSelected"
+    };
+
+    public static bool Contains(string methodName)
+    {
+        return methodName != null && Names.Contains(methodName);
+    }
+}
+
 internal sealed class WorkerInput
 {
     public string SourcePath { get; set; }
@@ -4416,6 +5180,17 @@ internal sealed class WorkerOutput
     public WorkerUnchangedMethod[] UnchangedMethods { get; set; }
 
     public bool BaselineDisabledByDuplicateKeys { get; set; }
+
+    public WorkerRemovedMember[] RemovedMembers { get; set; }
+
+    public bool HasAccessorDelegates { get; set; }
+}
+
+internal sealed class WorkerRemovedMember
+{
+    public string Kind { get; set; }
+
+    public string Name { get; set; }
 }
 
 internal sealed class WorkerUnchangedMethod
@@ -4439,8 +5214,11 @@ internal sealed class WorkerEntry
 
     public string ShimMethodName { get; set; }
 
-    // "transplant" | "delegation" — see PatchKinds.
+    // "transplant" | "delegation" | "addedMethod" — see PatchKinds.
     public string PatchKind { get; set; }
+
+    // Method keys of added methods this entry's body invokes. Empty when none.
+    public string[] CalledAddedMethodKeys { get; set; }
 
     // 1-based, both ends inclusive, within the original edited source file.
     public int SourceStartLine { get; set; }
@@ -4471,6 +5249,15 @@ internal static class PatchKinds
 {
     public const string Transplant = "transplant";
     public const string Delegation = "delegation";
+
+    // Keep in sync with HotReloadConstants.PatchKindAddedMethod.
+    public const string AddedMethod = "addedMethod";
+}
+
+internal static class RemovedMemberKinds
+{
+    public const string Method = "method";
+    public const string Field = "field";
 }
 
 internal sealed class MethodTransformDecision
@@ -4479,7 +5266,7 @@ internal sealed class MethodTransformDecision
 
     public string PatchKind { get; private set; }
 
-    public bool UsesDelegation => PatchKind == PatchKinds.Delegation;
+    public bool UsesDelegation { get; private set; }
 
     public static MethodTransformDecision Skip(string reason)
     {
@@ -4493,7 +5280,20 @@ internal sealed class MethodTransformDecision
 
     public static MethodTransformDecision Delegation()
     {
-        return new MethodTransformDecision { PatchKind = PatchKinds.Delegation };
+        return new MethodTransformDecision
+        {
+            PatchKind = PatchKinds.Delegation,
+            UsesDelegation = true
+        };
+    }
+
+    public static MethodTransformDecision AddedMethod(bool usesDelegation)
+    {
+        return new MethodTransformDecision
+        {
+            PatchKind = PatchKinds.AddedMethod,
+            UsesDelegation = usesDelegation
+        };
     }
 }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -104,6 +104,7 @@ public static class TransformWorkerProgram
         input.Defines ??= Array.Empty<string>();
         input.ReferencePaths ??= Array.Empty<string>();
         input.ExcludedMethodKeys ??= Array.Empty<string>();
+        input.ExcludedAddedMethodKeys ??= Array.Empty<string>();
         input.AssemblySourcePaths ??= Array.Empty<string>();
         return input;
     }
@@ -361,7 +362,7 @@ public static class TransformWorkerProgram
                 removedMembers);
         }
 
-        SkipMethodsThatCaptureAddedMethodGroups(
+        SkipBodiesThatCannotUseAddedMethods(
             typeEmitStates,
             semanticModel,
             addedMethodCatalog,
@@ -389,6 +390,15 @@ public static class TransformWorkerProgram
             foreach (PropertyDeclarationSyntax propertyDeclaration in typeState.TypeDeclaration.Members
                 .OfType<PropertyDeclarationSyntax>())
             {
+                if (typeState.TypeIsAbsentFromCompiledAssembly)
+                {
+                    SkipPropertyGetterOnUncompiledType(
+                        propertyDeclaration,
+                        semanticModel,
+                        skipped);
+                    continue;
+                }
+
                 (ShimTypeBuilder nextShimType, int nextShimTypeCounter, int nextGlobalShimMethodCounter) =
                     AppendPropertyGetterEntry(
                         propertyDeclaration,
@@ -1348,6 +1358,20 @@ public static class TransformWorkerProgram
             return (currentShimType, shimTypeCounter, globalShimMethodCounter);
         }
 
+        string addedCallSiteSkip = EvaluateAddedCallSiteSkipReason(
+            getterBodyNode,
+            semanticModel,
+            addedMethodCatalog);
+        if (addedCallSiteSkip != null)
+        {
+            skipped.Add(new WorkerSkipped
+            {
+                Method = FormatMethodLabel(getterSymbol),
+                Reason = addedCallSiteSkip
+            });
+            return (currentShimType, shimTypeCounter, globalShimMethodCounter);
+        }
+
         if (currentShimType == null)
         {
             string shimTypeName = typeSymbol.Name + "_UloopHotReloadShims_" + shimTypeCounter;
@@ -1391,6 +1415,11 @@ public static class TransformWorkerProgram
             ShimTypeName = currentShimType.ShimTypeName,
             ShimMethodName = shimMethodName,
             PatchKind = decision.PatchKind,
+            CalledAddedMethodKeys = CollectCalledAddedMethodKeys(
+                getterBodyNode,
+                semanticModel,
+                addedMethodCatalog,
+                methodKey),
             SourceStartLine = sourceStartLine,
             SourceEndLine = sourceEndLine,
             LifecycleNote = null
@@ -2043,6 +2072,12 @@ public static class TransformWorkerProgram
         int globalShimMethodCounter)
     {
         INamedTypeSymbol compiledType = FindCompiledType(typeState.TypeSymbol, targetTypesAssemblySymbol);
+        if (compiledType == null)
+        {
+            SkipAllMethodsOnUncompiledType(typeState, semanticModel, skipped);
+            return (shimTypeCounter, globalShimMethodCounter);
+        }
+
         foreach (MethodDeclarationSyntax methodDeclaration in typeState.TypeDeclaration.Members
             .OfType<MethodDeclarationSyntax>())
         {
@@ -2062,13 +2097,20 @@ public static class TransformWorkerProgram
             // Why skip explicit-interface methods: compiled GetMembers(simpleName) does not
             // see them (metadata name is Interface.Method), so they would be misclassified as
             // Added and skip the unchanged/baseline path.
-            bool isAddedMethod = compiledType != null
-                && methodDeclaration.ExplicitInterfaceSpecifier == null
+            bool isAddedMethod = methodDeclaration.ExplicitInterfaceSpecifier == null
                 && !CompiledTypeHasOrdinaryMethod(compiledType, methodSymbol);
 
-            // Why added methods ignore ExcludedMethodKeys: dropping their shim leaves callers
-            // with CS0103 on retry and collapses isolation to a file-level Failed (G1).
-            if (!isAddedMethod && input.ExcludedMethodKeys.Contains(methodKey))
+            if (isAddedMethod)
+            {
+                addedMethodCatalog.MarkClassifiedAdded(methodKey);
+                if (input.ExcludedAddedMethodKeys.Contains(methodKey))
+                {
+                    addedMethodCatalog.AddAddedSyntaxKey(
+                        BuildSyntaxMethodKey(typeState.TypeMetadataNameFromSyntax, methodDeclaration));
+                    continue;
+                }
+            }
+            else if (input.ExcludedMethodKeys.Contains(methodKey))
             {
                 continue;
             }
@@ -2096,24 +2138,21 @@ public static class TransformWorkerProgram
 
             SyntaxNode methodBodyNode =
                 (SyntaxNode)methodDeclaration.Body ?? methodDeclaration.ExpressionBody;
-            MethodTransformDecision decision = DecideMethodTransform(
-                typeState.TypeDeclaration,
-                typeState.TypeSymbol,
-                methodDeclaration,
-                methodSymbol,
-                methodBodyNode,
-                semanticModel);
+            string addedSkip = isAddedMethod
+                ? EvaluateAddedMethodSkipReason(methodSymbol, methodDeclaration)
+                : null;
+            MethodTransformDecision decision = addedSkip != null
+                ? MethodTransformDecision.Skip(addedSkip)
+                : DecideMethodTransform(
+                    typeState.TypeDeclaration,
+                    typeState.TypeSymbol,
+                    methodDeclaration,
+                    methodSymbol,
+                    methodBodyNode,
+                    semanticModel);
             if (isAddedMethod && decision.SkipReason == null)
             {
-                string addedSkip = EvaluateAddedMethodSkipReason(methodSymbol);
-                if (addedSkip != null)
-                {
-                    decision = MethodTransformDecision.Skip(addedSkip);
-                }
-                else
-                {
-                    decision = MethodTransformDecision.AddedMethod(decision.UsesDelegation);
-                }
+                decision = MethodTransformDecision.AddedMethod(decision.UsesDelegation);
             }
 
             if (decision.SkipReason != null)
@@ -2123,6 +2162,13 @@ public static class TransformWorkerProgram
                     Method = FormatMethodLabel(methodSymbol),
                     Reason = decision.SkipReason
                 });
+                if (isAddedMethod)
+                {
+                    // Why strip skipped added declarations: otherwise drift warns about
+                    // fields/initializers for a method the skip reason already explained.
+                    addedMethodCatalog.AddAddedSyntaxKey(syntaxMethodKey);
+                }
+
                 continue;
             }
 
@@ -2276,44 +2322,147 @@ public static class TransformWorkerProgram
         }
     }
 
-    private static void SkipMethodsThatCaptureAddedMethodGroups(
+    private static void SkipAllMethodsOnUncompiledType(
+        TypeEmitState typeState,
+        SemanticModel semanticModel,
+        List<WorkerSkipped> skipped)
+    {
+        typeState.TypeIsAbsentFromCompiledAssembly = true;
+        foreach (MethodDeclarationSyntax methodDeclaration in typeState.TypeDeclaration.Members
+            .OfType<MethodDeclarationSyntax>())
+        {
+            IMethodSymbol methodSymbol = semanticModel.GetDeclaredSymbol(methodDeclaration);
+            if (methodSymbol == null)
+            {
+                continue;
+            }
+
+            skipped.Add(new WorkerSkipped
+            {
+                Method = FormatMethodLabel(methodSymbol),
+                Reason = AddedMethodSkipReasons.NewTypeOutOfScope
+            });
+        }
+    }
+
+    private static void SkipPropertyGetterOnUncompiledType(
+        PropertyDeclarationSyntax propertyDeclaration,
+        SemanticModel semanticModel,
+        List<WorkerSkipped> skipped)
+    {
+        IPropertySymbol propertySymbol = semanticModel.GetDeclaredSymbol(propertyDeclaration);
+        if (propertySymbol == null || propertySymbol.GetMethod == null)
+        {
+            return;
+        }
+
+        (bool hasGetterBody, AccessorDeclarationSyntax _) =
+            TryGetPropertyGetterBody(propertyDeclaration);
+        if (!hasGetterBody)
+        {
+            return;
+        }
+
+        skipped.Add(new WorkerSkipped
+        {
+            Method = FormatMethodLabel(propertySymbol.GetMethod),
+            Reason = AddedMethodSkipReasons.NewTypeOutOfScope
+        });
+    }
+
+    private static void SkipBodiesThatCannotUseAddedMethods(
         List<TypeEmitState> typeEmitStates,
         SemanticModel semanticModel,
         AddedMethodCatalog addedMethodCatalog,
         List<WorkerSkipped> skipped)
     {
-        foreach (TypeEmitState typeState in typeEmitStates)
+        bool progressed;
+        do
         {
-            List<QueuedShimMethod> remaining = new List<QueuedShimMethod>();
-            foreach (QueuedShimMethod queued in typeState.QueuedMethods)
+            progressed = false;
+            foreach (TypeEmitState typeState in typeEmitStates)
             {
-                SyntaxNode bodyNode =
-                    (SyntaxNode)queued.MethodDeclaration.Body ?? queued.MethodDeclaration.ExpressionBody;
-                if (bodyNode != null
-                    && BodyReferencesAddedInstanceMethodGroup(bodyNode, semanticModel, addedMethodCatalog))
+                List<QueuedShimMethod> remaining = new List<QueuedShimMethod>();
+                foreach (QueuedShimMethod queued in typeState.QueuedMethods)
                 {
-                    skipped.Add(new WorkerSkipped
+                    SyntaxNode bodyNode =
+                        (SyntaxNode)queued.MethodDeclaration.Body ?? queued.MethodDeclaration.ExpressionBody;
+                    string skipReason = EvaluateAddedCallSiteSkipReason(
+                        bodyNode,
+                        semanticModel,
+                        addedMethodCatalog);
+                    if (skipReason != null)
                     {
-                        Method = FormatMethodLabel(queued.MethodSymbol),
-                        Reason = AddedMethodSkipReasons.MethodGroupReference
-                    });
-                    if (queued.IsAddedMethod)
-                    {
-                        addedMethodCatalog.Unregister(queued.MethodKey);
+                        skipped.Add(new WorkerSkipped
+                        {
+                            Method = FormatMethodLabel(queued.MethodSymbol),
+                            Reason = skipReason
+                        });
+                        if (queued.IsAddedMethod)
+                        {
+                            addedMethodCatalog.Unregister(queued.MethodKey);
+                        }
+
+                        progressed = true;
+                        continue;
                     }
 
-                    continue;
+                    remaining.Add(queued);
                 }
 
-                remaining.Add(queued);
+                typeState.QueuedMethods.Clear();
+                typeState.QueuedMethods.AddRange(remaining);
             }
-
-            typeState.QueuedMethods.Clear();
-            typeState.QueuedMethods.AddRange(remaining);
         }
+        while (progressed);
     }
 
-    private static bool BodyReferencesAddedInstanceMethodGroup(
+    private static string EvaluateAddedCallSiteSkipReason(
+        SyntaxNode bodyNode,
+        SemanticModel semanticModel,
+        AddedMethodCatalog addedMethodCatalog)
+    {
+        if (bodyNode == null)
+        {
+            return null;
+        }
+
+        foreach (InvocationExpressionSyntax invocation in bodyNode.DescendantNodesAndSelf()
+            .OfType<InvocationExpressionSyntax>())
+        {
+            if (NameofRules.IsNameofInvocation(invocation))
+            {
+                continue;
+            }
+
+            ISymbol symbol = semanticModel.GetSymbolInfo(invocation).Symbol;
+            if (symbol is not IMethodSymbol methodSymbol)
+            {
+                continue;
+            }
+
+            string calledKey = BuildMethodKeyFromSymbol(methodSymbol);
+            if (invocation.Expression is MemberBindingExpressionSyntax
+                && addedMethodCatalog.IsClassifiedAdded(calledKey))
+            {
+                return AddedMethodSkipReasons.ConditionalAccess;
+            }
+
+            if (addedMethodCatalog.IsUnavailableAdded(calledKey))
+            {
+                return AddedMethodSkipReasons.UnavailableAddedCall;
+            }
+        }
+
+        if (BodyReferencesAddedMethodGroup(bodyNode, semanticModel, addedMethodCatalog))
+        {
+            return AddedMethodSkipReasons.MethodGroupReference;
+        }
+
+        return null;
+    }
+
+    private static bool BodyReferencesAddedMethodGroup(
         SyntaxNode bodyNode,
         SemanticModel semanticModel,
         AddedMethodCatalog addedMethodCatalog)
@@ -2327,8 +2476,7 @@ public static class TransformWorkerProgram
 
             ISymbol symbol = semanticModel.GetSymbolInfo(name).Symbol;
             if (symbol is IMethodSymbol methodSymbol
-                && !methodSymbol.IsStatic
-                && addedMethodCatalog.Contains(BuildMethodKeyFromSymbol(methodSymbol)))
+                && addedMethodCatalog.IsClassifiedAdded(BuildMethodKeyFromSymbol(methodSymbol)))
             {
                 return true;
             }
@@ -2345,8 +2493,7 @@ public static class TransformWorkerProgram
 
             ISymbol symbol = semanticModel.GetSymbolInfo(access).Symbol;
             if (symbol is IMethodSymbol methodSymbol
-                && !methodSymbol.IsStatic
-                && addedMethodCatalog.Contains(BuildMethodKeyFromSymbol(methodSymbol)))
+                && addedMethodCatalog.IsClassifiedAdded(BuildMethodKeyFromSymbol(methodSymbol)))
             {
                 return true;
             }
@@ -2366,6 +2513,14 @@ public static class TransformWorkerProgram
             && memberAccess.Name == name
             && memberAccess.Parent is InvocationExpressionSyntax memberInvocation
             && memberInvocation.Expression == memberAccess)
+        {
+            return true;
+        }
+
+        if (name.Parent is MemberBindingExpressionSyntax memberBinding
+            && memberBinding.Name == name
+            && memberBinding.Parent is InvocationExpressionSyntax bindingInvocation
+            && bindingInvocation.Expression == memberBinding)
         {
             return true;
         }
@@ -2470,11 +2625,19 @@ public static class TransformWorkerProgram
         return false;
     }
 
-    private static string EvaluateAddedMethodSkipReason(IMethodSymbol methodSymbol)
+    private static string EvaluateAddedMethodSkipReason(
+        IMethodSymbol methodSymbol,
+        MethodDeclarationSyntax methodDeclaration)
     {
         if (methodSymbol.IsAbstract || methodSymbol.IsVirtual || methodSymbol.IsOverride)
         {
             return AddedMethodSkipReasons.VirtualOrAbstract;
+        }
+
+        bool hasTypeParameters = methodDeclaration != null && methodDeclaration.TypeParameterList != null;
+        if (methodSymbol.IsGenericMethod || hasTypeParameters)
+        {
+            return AddedMethodSkipReasons.Generic;
         }
 
         return null;
@@ -4145,11 +4308,21 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
         }
 
         ISymbol invokedSymbol = _semanticModel.GetSymbolInfo(node).Symbol;
-        if (invokedSymbol is IMethodSymbol addedMethod
-            && addedMethod.MethodKind == MethodKind.Ordinary
-            && _addedMethodCatalog.TryGet(BuildAddedMethodKey(addedMethod), out AddedMethodBinding binding))
+        if (node.Expression is MemberBindingExpressionSyntax)
         {
-            return RewriteAddedMethodInvocation(node, addedMethod, binding);
+            // Why not rewrite: ExtractReceiver does not handle MemberBinding and would invent
+            // __uloopInstance, breaking ?. short-circuit. Callers are skipped instead.
+            return base.VisitInvocationExpression(node);
+        }
+
+        if (invokedSymbol is IMethodSymbol addedMethod
+            && addedMethod.MethodKind == MethodKind.Ordinary)
+        {
+            AddedMethodBinding binding = _addedMethodCatalog.FindOrNull(BuildAddedMethodKey(addedMethod));
+            if (binding != null)
+            {
+                return RewriteAddedMethodInvocation(node, addedMethod, binding);
+            }
         }
 
         if (_accessorPlan == null)
@@ -4897,7 +5070,12 @@ internal static class CecilTypeNames
     public static string ToParameterTypeFullName(IParameterSymbol parameterSymbol)
     {
         // Roslyn's IParameterSymbol.Type omits the byref wrapper; Cecil FullName uses a trailing '&'.
-        string typeName = ToCecilFullName(parameterSymbol.Type);
+        // Why dynamic → System.Object: source `dynamic` is TypeKind.Dynamic ("dynamic") while
+        // compiled metadata is System.Object; leaving them distinct misclassifies existing
+        // methods as Added.
+        string typeName = parameterSymbol.Type != null && parameterSymbol.Type.TypeKind == TypeKind.Dynamic
+            ? "System.Object"
+            : ToCecilFullName(parameterSymbol.Type);
         if (parameterSymbol.RefKind != RefKind.None)
         {
             return typeName + "&";
@@ -4980,6 +5158,8 @@ internal sealed class TypeEmitState
     public ShimTypeBuilder CurrentShimType { get; set; }
 
     public List<QueuedShimMethod> QueuedMethods { get; } = new List<QueuedShimMethod>();
+
+    public bool TypeIsAbsentFromCompiledAssembly { get; set; }
 }
 
 internal sealed class QueuedShimMethod
@@ -5022,6 +5202,7 @@ internal sealed class AddedMethodCatalog
 {
     private readonly Dictionary<string, AddedMethodBinding> _byKey =
         new Dictionary<string, AddedMethodBinding>(StringComparer.Ordinal);
+    private readonly HashSet<string> _classifiedAddedKeys = new HashSet<string>(StringComparer.Ordinal);
     private readonly HashSet<string> _addedSyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
     private readonly HashSet<string> _removedSyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
 
@@ -5032,6 +5213,25 @@ internal sealed class AddedMethodCatalog
     public void Register(AddedMethodBinding binding)
     {
         _byKey[binding.MethodKey] = binding;
+        MarkClassifiedAdded(binding.MethodKey);
+    }
+
+    public void MarkClassifiedAdded(string methodKey)
+    {
+        if (methodKey != null)
+        {
+            _classifiedAddedKeys.Add(methodKey);
+        }
+    }
+
+    public bool IsClassifiedAdded(string methodKey)
+    {
+        return methodKey != null && _classifiedAddedKeys.Contains(methodKey);
+    }
+
+    public bool IsUnavailableAdded(string methodKey)
+    {
+        return IsClassifiedAdded(methodKey) && !Contains(methodKey);
     }
 
     public void AddAddedSyntaxKey(string syntaxKey)
@@ -5049,9 +5249,14 @@ internal sealed class AddedMethodCatalog
         return methodKey != null && _byKey.ContainsKey(methodKey);
     }
 
-    public bool TryGet(string methodKey, out AddedMethodBinding binding)
+    public AddedMethodBinding FindOrNull(string methodKey)
     {
-        return _byKey.TryGetValue(methodKey, out binding);
+        if (methodKey == null)
+        {
+            return null;
+        }
+
+        return _byKey.TryGetValue(methodKey, out AddedMethodBinding binding) ? binding : null;
     }
 
     public void Unregister(string methodKey)
@@ -5069,14 +5274,29 @@ internal static class AddedMethodSkipReasons
         "Added virtual, override, or abstract methods are skipped; the compiled type has no vtable slot. "
         + "Run 'uloop compile' to add them.";
 
+    public const string Generic =
+        "Added generic methods are skipped; hot reload cannot emit a typed shim for them. "
+        + "Run 'uloop compile'.";
+
     public const string MethodGroupReference =
-        "Methods that capture an added instance method as a method group or delegate are skipped; "
+        "Methods that capture an added method as a method group or delegate are skipped; "
         + "the shim signature does not match. Run 'uloop compile'.";
+
+    public const string ConditionalAccess =
+        "Added-method calls through conditional access are skipped; there is no rewrite shape. "
+        + "Run 'uloop compile'.";
+
+    public const string UnavailableAddedCall =
+        "Calls an added method that hot reload cannot emit. Run 'uloop compile'.";
+
+    public const string NewTypeOutOfScope =
+        "New types are out of scope for hot reload; run 'uloop compile' to add them.";
 }
 
 internal static class UnityMessageNames
 {
-    // Keep in sync with the Unity-message set documented in the hot-reload skill.
+    // Keep in sync with the Unity-message set that PR-5 will document in
+    // Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md.
     public const string AddedMessageWarningFormat =
         "Added Unity message '{0}' on {1} will not be invoked by the engine until 'uloop compile'; "
         + "Unity discovers messages by reflection on the compiled type.";
@@ -5151,6 +5371,10 @@ internal sealed class WorkerInput
     // reported Failed from a first compile round; the retry excludes them so it does not fail
     // on the same error again.
     public string[] ExcludedMethodKeys { get; set; }
+
+    // Added-method keys whose shim bodies failed the first compile. Distinct from
+    // ExcludedMethodKeys so a healthy added shim is not dropped when an existing method fails.
+    public string[] ExcludedAddedMethodKeys { get; set; }
 
     // Verified snapshot text for edited-method detection. Null = no baseline, patch all methods.
     // Why pass text (not a path): avoids an IO race between orchestrator verification and worker
@@ -5256,8 +5480,9 @@ internal static class PatchKinds
 
 internal static class RemovedMemberKinds
 {
+    // Keep in sync with HotReloadConstants.RemovedMemberKindMethod.
+    // Method is the only kind in this PR; field classification lands in later PRs.
     public const string Method = "method";
-    public const string Field = "field";
 }
 
 internal sealed class MethodTransformDecision


### PR DESCRIPTION
## Summary
- Same-file method additions are now classified and emitted as shims instead of failing as unknown members.
- Method removals are reported as warnings, and isolation retry no longer drops added-method shims (which previously collapsed the whole file to one compile failure).

## User Impact
- Before: adding a method in an edited file made hot-reload fail at resolve or shim compile, and a single unrelated compile error could wipe the rest of the file when an added method was excluded on retry.
- After: same-file added methods get static shims and call sites in edited bodies are rewritten to those shims. Removed methods are listed. Isolation retry keeps added-method shims so remaining methods can still patch.

## Changes
- Transform worker classifies members against the compiled assembly (Existing / Added / Removed).
- Added methods emit `patchKind: "addedMethod"` shims; call sites, `nameof`, Unity-message warnings, and skip reasons (virtual/override/generic/method-group) are handled in the worker.
- Isolation retry never excludes added-method entries; callers of a failed added method are excluded instead.
- Outside-body drift comparison strips handled add/remove declarations so method additions no longer fire a false "not applied" warning.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Success, 0 errors
- `dist/darwin-arm64/uloop run-tests --filter-type assembly --filter-value UnityCLILoop.Tests.Editor.HotReload` → Passed, 193/193


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

