### PR TITLE
fix: pass explicit delegate argument types when binding method accessors

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
@@ -84,6 +84,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return _privateSeed;
         }
 
+        private int PrivateSeedValue
+        {
+            get { return _privateSeed; }
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         public int ReadPrivateSeed()
         {

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1846,6 +1846,82 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a non-void private instance call inside a lambda is accessor-rewritten
+        /// (Func&lt;Host, int&gt; MethodDelegate) so the enclosing method Patches.
+        /// </summary>
+        [Test]
+        public async Task Run_LambdaInstancePrivateCall_AccessorizesAndPatches()
+        {
+            string hostPath = ResolveAddedMemberHostPath();
+            string onDisk = File.ReadAllText(hostPath);
+            string edited = onDisk.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            System.Func<int> read = () => PrivateCall();\n"
+                + "            return read();\n        }",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            string editedPath = WriteEditedSource("LambdaInstancePrivateCall.cs", edited);
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { hostPath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
+                    && outcome.Method.Contains(nameof(HotReloadAddedMemberHost.ExistingCaller)))
+                {
+                    Assert.Fail("ExistingCaller must not Failed: " + outcome.Reason);
+                }
+            }
+
+            HotReloadAddedMemberHost host = new HotReloadAddedMemberHost();
+            Assert.That(host.ExistingCaller(0), Is.EqualTo(7));
+        }
+
+        /// <summary>
+        /// What: a private instance property getter read inside a lambda is accessor-rewritten
+        /// (Func&lt;Host, TProp&gt; MethodDelegate) so the enclosing method Patches.
+        /// </summary>
+        [Test]
+        public async Task Run_LambdaInstancePrivatePropertyGetter_AccessorizesAndPatches()
+        {
+            string hostPath = ResolveAddedMemberHostPath();
+            string onDisk = File.ReadAllText(hostPath);
+            string edited = onDisk.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            System.Func<int> read = () => PrivateSeedValue;\n"
+                + "            return read();\n        }",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            string editedPath = WriteEditedSource("LambdaInstancePrivatePropertyGetter.cs", edited);
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { hostPath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
+                    && outcome.Method.Contains(nameof(HotReloadAddedMemberHost.ExistingCaller)))
+                {
+                    Assert.Fail("ExistingCaller must not Failed: " + outcome.Reason);
+                }
+            }
+
+            HotReloadAddedMemberHost host = new HotReloadAddedMemberHost();
+            Assert.That(host.ExistingCaller(0), Is.EqualTo(7));
+        }
+
+        /// <summary>
         /// What: deleting a compiled method surfaces the aggregated removed-members warning.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -482,6 +482,41 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: other?.Inner!.AddedPing() (postfix ! on the chained member) still skips the
+        /// caller as a conditional-access spine; ! is unwrap-only and does not exit the spine.
+        /// </summary>
+        [Test]
+        public async Task Skip_ConditionalAccessInnerSuppressThenAddedMethod_DoesNotRewriteCaller()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public int AddedPing(int value)\n        {\n            return value;\n        }");
+            edited = edited.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            HotReloadAddedMemberHost other = this;\n"
+                + "            other.Inner = this;\n"
+                + "            return other?.Inner!.AddedPing(value) ?? 0;\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("SkipConditionalAccessInnerSuppress.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "conditional access");
+            Assert.That(FindEntry(result, "AddedPing"), Is.Not.Null);
+            Assert.That(
+                FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller)),
+                Is.Null,
+                "other?.Inner!.AddedPing must skip the caller, not rewrite the ! spine.");
+            Assert.That(
+                result.Output.shimSource,
+                Does.Not.Contain("?global::"),
+                "ExtractReceiver must not splice a shim call after ?.");
+        }
+
+        /// <summary>
         /// What: other?.Get().AddedPing() is a MemberBinding-rooted invocation spine (Get sits
         /// between ? and AddedPing) and skips the caller instead of emitting a parse-invalid shim.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -700,6 +700,33 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: MethodDelegate bind emit for a non-void instance method includes explicit
+        /// delegateArgs (virtualCall false plus a Type[] of the declaring type), not a trailing null.
+        /// </summary>
+        [Test]
+        public async Task Emit_InstanceMethodDelegateBind_IncludesExplicitDelegateArgs()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            System.Func<int> read = () => PrivateCall();\n"
+                + "            return read();\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("EmitInstanceMethodDelegateBind.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.hasAccessorDelegates, Is.True);
+            Assert.That(
+                result.Output.shimSource,
+                Does.Contain(", false, new global::System.Type[]{typeof("),
+                "Instance MethodDelegate bind must pass explicit delegateArgs, not null.\n"
+                + result.Output.shimSource);
+        }
+
+        /// <summary>
         /// What: a private call in a conditional-access argument list inside a lambda is
         /// accessor-rewritten (Delegation), not left verbatim.
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -3506,14 +3506,9 @@ internal sealed class AccessorEntry
     private static string BuildFuncOrActionType(IMethodSymbol methodSymbol)
     {
         List<string> typeArguments = new List<string>();
-        if (!methodSymbol.IsStatic)
+        foreach (ITypeSymbol parameterType in EnumerateDelegateParameterTypes(methodSymbol))
         {
-            typeArguments.Add(TypeDisplay(methodSymbol.ContainingType));
-        }
-
-        foreach (IParameterSymbol parameter in methodSymbol.Parameters)
-        {
-            typeArguments.Add(TypeDisplay(parameter.Type));
+            typeArguments.Add(TypeDisplay(parameterType));
         }
 
         if (methodSymbol.ReturnsVoid)
@@ -3542,7 +3537,12 @@ internal sealed class AccessorEntry
     {
         string declaringType = TypeDisplay(methodSymbol.ContainingType);
         string delegateType = BuildFuncOrActionType(methodSymbol);
-        string typeArray = BuildTypeArrayLiteral(methodSymbol);
+        List<ITypeSymbol> delegateParameterTypes = EnumerateDelegateParameterTypes(methodSymbol);
+        // AccessTools.Method matches metadata parameters only; the instance receiver is not one.
+        IReadOnlyList<ITypeSymbol> methodLookupTypes = methodSymbol.IsStatic
+            ? delegateParameterTypes
+            : delegateParameterTypes.GetRange(1, delegateParameterTypes.Count - 1);
+        string typeArray = BuildTypeArrayLiteral(methodLookupTypes);
         // virtualCall must stay true for virtual/override/abstract instance members so a derived
         // override is dispatched; non-virtual private/internal targets keep false (exact method).
         bool virtualCall = !methodSymbol.IsStatic
@@ -3550,39 +3550,39 @@ internal sealed class AccessorEntry
         string virtualCallLiteral = virtualCall ? "true" : "false";
         // Why not null: Harmony then uses Func<> generic arguments including TResult as
         // DynamicMethod parameters, so Func<Host,T> becomes T(Host,T) and bind fails.
-        string delegateArgs = BuildDelegateArgsLiteral(methodSymbol);
+        string delegateArgs = BuildTypeArrayLiteral(delegateParameterTypes);
         return DelegateFieldName + " = global::HarmonyLib.AccessTools.MethodDelegate<"
             + delegateType + ">(global::HarmonyLib.AccessTools.Method(typeof("
             + declaringType + "), \"" + EscapeStringLiteral(metadataName) + "\", "
             + typeArray + "), null, " + virtualCallLiteral + ", " + delegateArgs + ");";
     }
 
-    // Parameter types of the open delegate Harmony should emit, excluding the Func TResult.
-    private static string BuildDelegateArgsLiteral(IMethodSymbol methodSymbol)
+    // Open-delegate parameter types: declaring type first for instance methods, then each
+    // method parameter. Excludes Func TResult so Harmony arity matches the delegate Invoke.
+    private static List<ITypeSymbol> EnumerateDelegateParameterTypes(IMethodSymbol methodSymbol)
     {
-        List<string> typeofs = new List<string>();
+        List<ITypeSymbol> types = new List<ITypeSymbol>();
         if (!methodSymbol.IsStatic)
         {
-            typeofs.Add("typeof(" + TypeDisplay(methodSymbol.ContainingType) + ")");
+            types.Add(methodSymbol.ContainingType);
         }
 
         foreach (IParameterSymbol parameter in methodSymbol.Parameters)
         {
-            typeofs.Add("typeof(" + TypeDisplay(parameter.Type) + ")");
+            types.Add(parameter.Type);
         }
 
-        return "new global::System.Type[] { " + string.Join(", ", typeofs) + " }";
+        return types;
     }
 
-    private static string BuildTypeArrayLiteral(IMethodSymbol methodSymbol)
+    private static string BuildTypeArrayLiteral(IReadOnlyList<ITypeSymbol> types)
     {
-        if (methodSymbol.Parameters.Length == 0)
+        if (types.Count == 0)
         {
             return "new global::System.Type[] { }";
         }
 
-        IEnumerable<string> typeofs = methodSymbol.Parameters.Select(
-            parameter => "typeof(" + TypeDisplay(parameter.Type) + ")");
+        IEnumerable<string> typeofs = types.Select(type => "typeof(" + TypeDisplay(type) + ")");
         return "new global::System.Type[] { " + string.Join(", ", typeofs) + " }";
     }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -3548,10 +3548,30 @@ internal sealed class AccessorEntry
         bool virtualCall = !methodSymbol.IsStatic
             && (methodSymbol.IsVirtual || methodSymbol.IsOverride || methodSymbol.IsAbstract);
         string virtualCallLiteral = virtualCall ? "true" : "false";
+        // Why not null: Harmony then uses Func<> generic arguments including TResult as
+        // DynamicMethod parameters, so Func<Host,T> becomes T(Host,T) and bind fails.
+        string delegateArgs = BuildDelegateArgsLiteral(methodSymbol);
         return DelegateFieldName + " = global::HarmonyLib.AccessTools.MethodDelegate<"
             + delegateType + ">(global::HarmonyLib.AccessTools.Method(typeof("
             + declaringType + "), \"" + EscapeStringLiteral(metadataName) + "\", "
-            + typeArray + "), null, " + virtualCallLiteral + ", null);";
+            + typeArray + "), null, " + virtualCallLiteral + ", " + delegateArgs + ");";
+    }
+
+    // Parameter types of the open delegate Harmony should emit, excluding the Func TResult.
+    private static string BuildDelegateArgsLiteral(IMethodSymbol methodSymbol)
+    {
+        List<string> typeofs = new List<string>();
+        if (!methodSymbol.IsStatic)
+        {
+            typeofs.Add("typeof(" + TypeDisplay(methodSymbol.ContainingType) + ")");
+        }
+
+        foreach (IParameterSymbol parameter in methodSymbol.Parameters)
+        {
+            typeofs.Add("typeof(" + TypeDisplay(parameter.Type) + ")");
+        }
+
+        return "new global::System.Type[] { " + string.Join(", ", typeofs) + " }";
     }
 
     private static string BuildTypeArrayLiteral(IMethodSymbol methodSymbol)


### PR DESCRIPTION
## Summary
- Hot reload now binds private instance methods and instance property getters instead of failing the whole shim type with "method arguments are incompatible".

## User Impact
- Before: editing code that called a non-void private instance method (or read a private instance property) from a lambda/local function failed accessor bind. One bind failure marked every delegation entry on that shim type as Failed, so the edit did not apply.
- After: those accessors bind and the edited method patches. Void instance methods already worked; this restores the non-void and getter paths.

## Changes
- `BuildMethodDelegateBindStatement` now emits Harmony `delegateArgs` as `new Type[] { typeof(declaring type), typeof(p1), … }` (declaring type only for instance members; parameter types only, never the Func `TResult`).
- `virtualCall` is unchanged.
- `EnumerateDelegateParameterTypes` is the shared instance-plus-parameters list for `Func`/`Action` arity and `delegateArgs`; `AccessTools.Method` lookup types are that list without the instance receiver.
- Restored `Run_LambdaInstancePrivateCall_AccessorizesAndPatches` (Patched + runtime value 7).
- Added instance property getter e2e (`Func<Host, TProp>`), a worker test for `other?.Inner!.AddedPing()` spine skip, and a worker pin of the formatted MethodDelegate bind text.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Success, 0 errors
- `dist/darwin-arm64/uloop run-tests --filter-type assembly --filter-value UnityCLILoop.Tests.Editor.HotReload` → 220/220 Passed
