### PR TITLE
feat: apply added methods through the shim assembly

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberRegistryTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberRegistryTests.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using System.Reflection;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Pure ledger coverage for added-method registration, overwrite, per-file clear, and revert.
+    /// </summary>
+    public class HotReloadAddedMemberRegistryTests
+    {
+        private const string FileOne = "Assets/Tests/Editor/HotReload/FileOne.cs";
+        private const string FileTwo = "Assets/Tests/Editor/HotReload/FileTwo.cs";
+
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadAddedMemberRegistry.Clear();
+        }
+
+        /// <summary>
+        /// What: Register records the shim and Describe lists it; a second Register of the same
+        /// key overwrites rather than stacking.
+        /// </summary>
+        [Test]
+        public void Register_OverwritesSameKey_AndDescribeListsIt()
+        {
+            MethodInfo firstShim = RequireExistingCaller();
+            MethodInfo secondShim = RequireReadPrivateSeed();
+            HotReloadAddedMemberRegistry.BeginFileGeneration(FileOne);
+            HotReloadAddedMemberRegistry.Register(FileOne, "Host.AddedPing(System.Int32)", firstShim, FileOne);
+            HotReloadAddedMemberRegistry.Register(FileOne, "Host.AddedPing(System.Int32)", secondShim, FileOne);
+
+            Assert.That(HotReloadAddedMemberRegistry.Count, Is.EqualTo(1));
+            IReadOnlyList<HotReloadAddedMemberInfo> listed = HotReloadAddedMemberRegistry.Describe();
+            Assert.That(listed.Count, Is.EqualTo(1));
+            Assert.That(listed[0].MethodKey, Is.EqualTo("Host.AddedPing(System.Int32)"));
+            Assert.That(listed[0].ShimMethod, Is.EqualTo(secondShim));
+            Assert.That(listed[0].FilePath, Is.EqualTo(FileOne));
+        }
+
+        /// <summary>
+        /// What: BeginFileGeneration drops that file's members and leaves another file intact.
+        /// </summary>
+        [Test]
+        public void BeginFileGeneration_ClearsOnlyThatFile()
+        {
+            MethodInfo shim = RequireExistingCaller();
+            HotReloadAddedMemberRegistry.BeginFileGeneration(FileOne);
+            HotReloadAddedMemberRegistry.Register(FileOne, "Host.AddedOne()", shim, FileOne);
+            HotReloadAddedMemberRegistry.BeginFileGeneration(FileTwo);
+            HotReloadAddedMemberRegistry.Register(FileTwo, "Host.AddedTwo()", shim, FileTwo);
+
+            HotReloadAddedMemberRegistry.BeginFileGeneration(FileOne);
+
+            Assert.That(HotReloadAddedMemberRegistry.Count, Is.EqualTo(1));
+            IReadOnlyList<HotReloadAddedMemberInfo> listed = HotReloadAddedMemberRegistry.Describe();
+            Assert.That(listed[0].MethodKey, Is.EqualTo("Host.AddedTwo()"));
+        }
+
+        /// <summary>
+        /// What: Clear removes every file's added members.
+        /// </summary>
+        [Test]
+        public void Clear_RemovesAllFiles()
+        {
+            MethodInfo shim = RequireExistingCaller();
+            HotReloadAddedMemberRegistry.BeginFileGeneration(FileOne);
+            HotReloadAddedMemberRegistry.Register(FileOne, "Host.AddedOne()", shim, FileOne);
+            HotReloadAddedMemberRegistry.BeginFileGeneration(FileTwo);
+            HotReloadAddedMemberRegistry.Register(FileTwo, "Host.AddedTwo()", shim, FileTwo);
+
+            HotReloadAddedMemberRegistry.Clear();
+
+            Assert.That(HotReloadAddedMemberRegistry.Count, Is.EqualTo(0));
+            Assert.That(HotReloadAddedMemberRegistry.Describe(), Is.Empty);
+        }
+
+        private static MethodInfo RequireExistingCaller()
+        {
+            MethodInfo method = typeof(HotReloadAddedMemberHost).GetMethod(
+                nameof(HotReloadAddedMemberHost.ExistingCaller),
+                BindingFlags.Instance | BindingFlags.Public);
+            Assert.That(method, Is.Not.Null);
+            return method;
+        }
+
+        private static MethodInfo RequireReadPrivateSeed()
+        {
+            MethodInfo method = typeof(HotReloadAddedMemberHost).GetMethod(
+                nameof(HotReloadAddedMemberHost.ReadPrivateSeed),
+                BindingFlags.Instance | BindingFlags.Public);
+            Assert.That(method, Is.Not.Null);
+            return method;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberRegistryTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberRegistryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e7ebd588da0840dab4da7de16f6e882
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMethodApplyFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMethodApplyFixture.cs
@@ -1,0 +1,17 @@
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled host for added-method apply E2E. Kept separate from HotReloadE2EFixture so
+    /// twelve-method patch suites cannot interfere with Added registration.
+    /// </summary>
+    public class HotReloadAddedMethodApplyFixture
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int ExistingCaller(int value)
+        {
+            return value;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMethodApplyFixture.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMethodApplyFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c9a38f886177849078c458ffd9ebe902
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -13,6 +13,7 @@ using UnityEditor.Compilation;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
@@ -1742,10 +1743,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertNoFileLevelFailure(result);
             AssertHasPatched(result, nameof(HotReloadAddedMemberHost.ExistingValue));
             AssertHasPatched(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
-            AssertHasSkipped(
-                result,
-                "AddedPing",
-                HotReloadConstants.AddedMethodDeferredSkipReason);
+            AssertHasAdded(result, "AddedPing");
 
             bool failIsolated = false;
             foreach (HotReloadMethodOutcome outcome in result.Methods)
@@ -1769,10 +1767,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: an added method that reads a private field still shim-compiles (Harmony is
-        /// injected from hasAccessorDelegates) and the added method itself is Skipped.
+        /// injected from hasAccessorDelegates) and the added method itself is Added.
         /// </summary>
         [Test]
-        public async Task Run_AddedMethodWithPrivateAccess_ShimCompilesAndSkipsAddedApply()
+        public async Task Run_AddedMethodWithPrivateAccess_ShimCompilesAndAdds()
         {
             string hostPath = ResolveAddedMemberHostPath();
             string onDisk = File.ReadAllText(hostPath);
@@ -1797,13 +1795,164 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             AssertNoFileLevelFailure(result);
             AssertHasPatched(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
-            AssertHasSkipped(
-                result,
-                "AddedReadPrivate",
-                HotReloadConstants.AddedMethodDeferredSkipReason);
+            AssertHasAdded(result, "AddedReadPrivate");
 
             HotReloadAddedMemberHost host = new HotReloadAddedMemberHost();
             Assert.That(host.ExistingCaller(0), Is.EqualTo(7));
+        }
+
+        /// <summary>
+        /// What: adding a method and calling it from the same file applies the added shim
+        /// (Kind Added) and the patched caller returns the new method's result.
+        /// </summary>
+        [Test]
+        public async Task Run_AddedMethod_AppliesThroughShimAndUpdatesRuntime()
+        {
+            string fixturePath = ResolveAddedMethodApplyFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = onDisk.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedPing(value);\n        }\n\n"
+                + "        public int AddedPing(int value)\n        {\n            return value + 1;\n        }",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            string editedPath = WriteEditedSource("AddedMethodApplyE2E.cs", edited);
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadAddedMethodApplyFixture.ExistingCaller));
+            AssertHasAdded(result, "AddedPing");
+            Assert.That(result.ActivePatchTotal, Is.GreaterThanOrEqualTo(2));
+
+            bool foundAddedStatus = false;
+            foreach (HotReloadAddedMemberInfo added in HotReloadAddedMemberRegistry.Describe())
+            {
+                if (added.MethodKey.Contains("AddedPing"))
+                {
+                    foundAddedStatus = true;
+                }
+            }
+
+            Assert.That(foundAddedStatus, Is.True, "AddedPing must appear in the added-member registry.");
+
+            HotReloadAddedMethodApplyFixture host = new HotReloadAddedMethodApplyFixture();
+            Assert.That(host.ExistingCaller(3), Is.EqualTo(4));
+        }
+
+        /// <summary>
+        /// What: re-applying without the added method clears that file's added-member ledger
+        /// so --status cannot keep a method the source no longer declares.
+        /// </summary>
+        [Test]
+        public async Task Run_ReapplyWithoutAddedMethod_ClearsAddedMemberRegistry()
+        {
+            string fixturePath = ResolveAddedMethodApplyFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string withAdded = onDisk.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedPing(value);\n        }\n\n"
+                + "        public int AddedPing(int value)\n        {\n            return value + 1;\n        }",
+                StringComparison.Ordinal);
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("AddedMethodApplyThenRemove1.cs", withAdded),
+                CancellationToken.None);
+            AssertHasAdded(first, "AddedPing");
+
+            string valueOnly = onDisk.Replace(
+                "            return value;\n        }",
+                "            return value + 10;\n        }",
+                StringComparison.Ordinal);
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("AddedMethodApplyThenRemove2.cs", valueOnly),
+                CancellationToken.None);
+            AssertHasPatched(second, nameof(HotReloadAddedMethodApplyFixture.ExistingCaller));
+            foreach (HotReloadMethodOutcome outcome in second.Methods)
+            {
+                Assert.That(
+                    outcome.Kind,
+                    Is.Not.EqualTo(HotReloadMethodOutcomeKind.Added),
+                    "Re-apply without AddedPing must not keep an Added outcome.\n"
+                    + FormatOutcomes(second));
+            }
+
+            foreach (HotReloadAddedMemberInfo added in HotReloadAddedMemberRegistry.Describe())
+            {
+                Assert.That(
+                    added.MethodKey,
+                    Does.Not.Contain("AddedPing"),
+                    "Per-file clear must drop AddedPing on re-apply.");
+            }
+
+            HotReloadAddedMethodApplyFixture host = new HotReloadAddedMethodApplyFixture();
+            Assert.That(host.ExistingCaller(3), Is.EqualTo(13));
+        }
+
+        /// <summary>
+        /// What: an added method is not registered on the pause-point shim ledger, so enabling
+        /// a marker on its source line follows the existing not-found path and does not crash.
+        /// </summary>
+        [Test]
+        public async Task Run_AddedMethod_DoesNotRegisterPausePointShim()
+        {
+            string fixturePath = ResolveAddedMethodApplyFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = onDisk.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedPing(value);\n        }\n\n"
+                + "        public int AddedPing(int value)\n        {\n            return value + 1;\n        }",
+                StringComparison.Ordinal);
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("AddedMethodPausePoint.cs", edited),
+                CancellationToken.None);
+            AssertHasAdded(result, "AddedPing");
+
+            string projectRelativePath =
+                "Assets/Tests/Editor/HotReload/HotReloadAddedMethodApplyFixture.cs";
+            HotReloadShimFileLookup lookup =
+                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(projectRelativePath);
+            if (lookup != null)
+            {
+                foreach (HotReloadShimMethodLookup method in lookup.Methods)
+                {
+                    Assert.That(
+                        method.OriginalMethod.Name,
+                        Is.Not.EqualTo("AddedPing"),
+                        "Added methods must not be registered as pause-point shim originals.");
+                }
+            }
+
+            int addedLine = FindLineNumberContaining(edited, "return value + 1;");
+            Assert.That(addedLine, Is.GreaterThan(0));
+            UloopPausePointRegistry.ConfigureForTests(new OrchestratorPausePointPauseController(), () => DateTime.UtcNow);
+            try
+            {
+                PausePointResponse enable = new PausePointUseCase().Enable(new EnablePausePointSchema
+                {
+                    File = projectRelativePath,
+                    Line = addedLine,
+                    TimeoutSeconds = 30,
+                    Mode = UloopPausePointCaptureMode.Continuous
+                });
+                if (enable.Success)
+                {
+                    Assert.That(
+                        enable.ResolvedMethod,
+                        Does.Not.Contain("AddedPing"),
+                        "Enable must not bind a pause point onto the added-method shim.");
+                }
+            }
+            finally
+            {
+                SourcePausePointPatcher.UnpatchAll();
+                UloopPausePointRegistry.ResetForTests();
+            }
         }
 
         /// <summary>
@@ -2063,6 +2212,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + reasonFragment + "'.\n" + FormatOutcomes(result));
         }
 
+        private static void AssertHasAdded(HotReloadOrchestratorResult result, string methodName)
+        {
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Added
+                    && outcome.Method.Contains(methodName))
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail("Expected Added outcome for " + methodName + ".\n" + FormatOutcomes(result));
+        }
+
         private static void AssertHasPatched(HotReloadOrchestratorResult result, string methodName)
         {
             foreach (HotReloadMethodOutcome outcome in result.Methods)
@@ -2091,6 +2254,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             return string.Join("\n", lines);
+        }
+
+        private static string ResolveAddedMethodApplyFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadAddedMethodApplyFixture.cs");
+            Assert.That(File.Exists(path), Is.True, "Added-method apply fixture source missing: " + path);
+            return Path.GetFullPath(path);
         }
 
         private static string ResolveAddedMemberHostPath()
@@ -2483,6 +2658,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     }
 }
 ";
+        }
+
+        private sealed class OrchestratorPausePointPauseController : IUloopPausePointPauseController
+        {
+            public bool IsPlaying => true;
+
+            public bool IsPaused => false;
+
+            public void Pause()
+            {
+            }
+
+            public void Resume()
+            {
+            }
         }
     }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1826,7 +1826,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertNoFileLevelFailure(result);
             AssertHasPatched(result, nameof(HotReloadAddedMethodApplyFixture.ExistingCaller));
             AssertHasAdded(result, "AddedPing");
-            Assert.That(result.ActivePatchTotal, Is.GreaterThanOrEqualTo(2));
+            Assert.That(result.ActivePatchTotal, Is.EqualTo(2));
 
             bool foundAddedStatus = false;
             foreach (HotReloadAddedMemberInfo added in HotReloadAddedMemberRegistry.Describe())
@@ -1894,6 +1894,49 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: after applying an added method, a later hot-reload against the on-disk baseline
+        /// (all-unchanged) clears that file's added-member ledger so --status and Play warnings
+        /// do not keep counting it.
+        /// </summary>
+        [Test]
+        public async Task Run_ReapplyOnDiskAfterAddedMethod_ClearsAddedMemberRegistry()
+        {
+            string fixturePath = ResolveAddedMethodApplyFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string withAdded = onDisk.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedPing(value);\n        }\n\n"
+                + "        public int AddedPing(int value)\n        {\n            return value + 1;\n        }",
+                StringComparison.Ordinal);
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("AddedMethodApplyThenOnDisk1.cs", withAdded),
+                CancellationToken.None);
+            AssertHasAdded(first, "AddedPing");
+            HotReloadAddedMethodApplyFixture host = new HotReloadAddedMethodApplyFixture();
+            Assert.That(host.ExistingCaller(3), Is.EqualTo(4));
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                contentPathOverride: null,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(second);
+            Assert.That(second.Methods, Is.Empty, FormatOutcomes(second));
+            Assert.That(second.UnchangedTotal, Is.GreaterThan(0));
+            Assert.That(second.ActivePatchTotal, Is.EqualTo(0));
+            foreach (HotReloadAddedMemberInfo added in HotReloadAddedMemberRegistry.Describe())
+            {
+                Assert.That(
+                    added.MethodKey,
+                    Does.Not.Contain("AddedPing"),
+                    "All-unchanged re-apply must drop AddedPing from the added-member ledger.");
+            }
+
+            Assert.That(host.ExistingCaller(3), Is.EqualTo(3));
+        }
+
+        /// <summary>
         /// What: an added method is not registered on the pause-point shim ledger, so enabling
         /// a marker on its source line follows the existing not-found path and does not crash.
         /// </summary>
@@ -1917,15 +1960,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Assets/Tests/Editor/HotReload/HotReloadAddedMethodApplyFixture.cs";
             HotReloadShimFileLookup lookup =
                 HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(projectRelativePath);
-            if (lookup != null)
+            Assert.That(
+                lookup,
+                Is.Not.Null,
+                "ExistingCaller patch must still expose a pause-point shim lookup.");
+            foreach (HotReloadShimMethodLookup method in lookup.Methods)
             {
-                foreach (HotReloadShimMethodLookup method in lookup.Methods)
-                {
-                    Assert.That(
-                        method.OriginalMethod.Name,
-                        Is.Not.EqualTo("AddedPing"),
-                        "Added methods must not be registered as pause-point shim originals.");
-                }
+                Assert.That(
+                    method.OriginalMethod.Name,
+                    Is.Not.EqualTo("AddedPing"),
+                    "Added methods must not be registered as pause-point shim originals.");
             }
 
             int addedLine = FindLineNumberContaining(edited, "return value + 1;");
@@ -1940,13 +1984,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     TimeoutSeconds = 30,
                     Mode = UloopPausePointCaptureMode.Continuous
                 });
-                if (enable.Success)
-                {
-                    Assert.That(
-                        enable.ResolvedMethod,
-                        Does.Not.Contain("AddedPing"),
-                        "Enable must not bind a pause point onto the added-method shim.");
-                }
+                Assert.That(
+                    enable.Success,
+                    Is.False,
+                    "Enable on an added-method line must take the not-found path, not bind a shim.");
+                Assert.That(
+                    enable.ErrorCode,
+                    Is.EqualTo(SourcePausePointConstants.ErrorCodeResolveFailed));
+                Assert.That(
+                    enable.ResolvedMethod,
+                    Does.Not.Contain("AddedPing"));
             }
             finally
             {

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -331,6 +331,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: an Added outcome appends Added: N to the apply message.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_WithAddedOutcome_AppendsAddedCount()
+        {
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>
+                {
+                    HotReloadMethodOutcome.Patched("Type.Caller", "Assets/A.cs"),
+                    HotReloadMethodOutcome.Added("Type.AddedPing", "Assets/A.cs")
+                },
+                new List<string>(),
+                patchedTotal: 1,
+                activePatchTotal: 2);
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+            Assert.That(response.Methods[1].Kind, Is.EqualTo("Added"));
+            Assert.That(
+                response.Message,
+                Is.EqualTo(
+                    "Hot reload applied. PatchedTotal=1, ActivePatchTotal=2. Added: 1."));
+        }
+
+        /// <summary>
         /// What: BuildApplyResponse keeps LifecycleNote on Methods and aggregates a count into
         /// Message instead of concatenating every note (two notes must not paste both paragraphs).
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -259,7 +259,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(response, Is.Not.Null);
             Assert.That(response.Success, Is.True);
             Assert.That(response.ClearedCount, Is.EqualTo(0));
-            Assert.That(response.Message, Is.EqualTo("No active hot-reload patches to revert."));
+            Assert.That(response.Message, Is.EqualTo("No active hot-reload changes to revert."));
         }
 
         /// <summary>
@@ -348,7 +348,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
 
-            Assert.That(response.Methods[1].Kind, Is.EqualTo("Added"));
+            Assert.That(response.Methods[1].Kind, Is.EqualTo(HotReloadConstants.AddedMemberStatusKind));
             Assert.That(
                 response.Message,
                 Is.EqualTo(

--- a/Assets/Tests/Editor/PlayModeStartDomainReloadDropWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/PlayModeStartDomainReloadDropWarningBuilderTests.cs
@@ -71,7 +71,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 warning,
                 Is.EqualTo(
-                    "Entering Play Mode triggers a domain reload that will discard 2 active hot-reload patch(es). The new session runs the last compiled assemblies, so hot-reloaded edits that were never compiled are not in effect — run `uloop compile` before Play to keep them, or re-apply `uloop hot-reload` after Play Mode starts."));
+                    "Entering Play Mode triggers a domain reload that will discard 2 active hot-reload change(s). The new session runs the last compiled assemblies, so hot-reloaded edits that were never compiled are not in effect — run `uloop compile` before Play to keep them, or re-apply `uloop hot-reload` after Play Mode starts."));
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 warning,
                 Is.EqualTo(
-                    "Entering Play Mode triggers a domain reload that will discard 2 active hot-reload patch(es) and 3 enabled pause point(s). The new session runs the last compiled assemblies, so hot-reloaded edits that were never compiled are not in effect — run `uloop compile` before Play to keep them, or re-apply `uloop hot-reload` and re-enable pause points after Play Mode starts."));
+                    "Entering Play Mode triggers a domain reload that will discard 2 active hot-reload change(s) and 3 enabled pause point(s). The new session runs the last compiled assemblies, so hot-reloaded edits that were never compiled are not in effect — run `uloop compile` before Play to keep them, or re-apply `uloop hot-reload` and re-enable pause points after Play Mode starts."));
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/PlayModeStartDomainReloadDropWarningBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/PlayModeStartDomainReloadDropWarningBuilder.cs
@@ -27,7 +27,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 return "Entering Play Mode triggers a domain reload that will discard "
                     + activeHotReloadPatchCount
-                    + " active hot-reload patch(es) and "
+                    + " active hot-reload change(s) and "
                     + activePausePointCount
                     + " enabled pause point(s). The new session runs the last compiled assemblies, so hot-reloaded edits that were never compiled are not in effect — run `uloop compile` before Play to keep them, or re-apply `uloop hot-reload` and re-enable pause points after Play Mode starts.";
             }
@@ -36,7 +36,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 return "Entering Play Mode triggers a domain reload that will discard "
                     + activeHotReloadPatchCount
-                    + " active hot-reload patch(es). The new session runs the last compiled assemblies, so hot-reloaded edits that were never compiled are not in effect — run `uloop compile` before Play to keep them, or re-apply `uloop hot-reload` after Play Mode starts.";
+                    + " active hot-reload change(s). The new session runs the last compiled assemblies, so hot-reloaded edits that were never compiled are not in effect — run `uloop compile` before Play to keep them, or re-apply `uloop hot-reload` after Play Mode starts.";
             }
 
             return "Entering Play Mode triggers a domain reload that will discard "

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAddedMemberRegistry.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAddedMemberRegistry.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Per-file ledger of added-method shims that have no compiled MethodBase to patch.
+    /// Pause-point does not consult this ledger; added methods stay unregistered there.
+    /// </summary>
+    internal static class HotReloadAddedMemberRegistry
+    {
+        private static readonly Dictionary<string, FileGeneration> GenerationsByPath =
+            new Dictionary<string, FileGeneration>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Drops any prior added members for <paramref name="projectRelativePath"/> so a
+        /// re-apply cannot keep methods the edited source no longer declares.
+        /// </summary>
+        public static void BeginFileGeneration(string projectRelativePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+            GenerationsByPath[projectRelativePath] = new FileGeneration();
+        }
+
+        public static void Register(
+            string projectRelativePath,
+            string methodKey,
+            MethodInfo shimMethod,
+            string filePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(methodKey), "methodKey must not be empty.");
+            Debug.Assert(shimMethod != null, "shimMethod must not be null.");
+            Debug.Assert(
+                GenerationsByPath.ContainsKey(projectRelativePath),
+                "BeginFileGeneration must run before Register for this path.");
+
+            GenerationsByPath[projectRelativePath].Members[methodKey] =
+                new AddedMemberEntry(shimMethod, filePath ?? string.Empty);
+        }
+
+        public static void Clear()
+        {
+            GenerationsByPath.Clear();
+        }
+
+        public static int Count
+        {
+            get
+            {
+                int count = 0;
+                foreach (KeyValuePair<string, FileGeneration> pair in GenerationsByPath)
+                {
+                    count += pair.Value.Members.Count;
+                }
+
+                return count;
+            }
+        }
+
+        public static IReadOnlyList<HotReloadAddedMemberInfo> Describe()
+        {
+            List<HotReloadAddedMemberInfo> members = new List<HotReloadAddedMemberInfo>(Count);
+            foreach (KeyValuePair<string, FileGeneration> pair in GenerationsByPath)
+            {
+                foreach (KeyValuePair<string, AddedMemberEntry> member in pair.Value.Members)
+                {
+                    members.Add(
+                        new HotReloadAddedMemberInfo(
+                            member.Key,
+                            member.Value.FilePath,
+                            member.Value.ShimMethod));
+                }
+            }
+
+            members.Sort(
+                (left, right) => string.CompareOrdinal(left.MethodKey, right.MethodKey));
+            return members;
+        }
+
+        private sealed class FileGeneration
+        {
+            public Dictionary<string, AddedMemberEntry> Members { get; } =
+                new Dictionary<string, AddedMemberEntry>(StringComparer.Ordinal);
+        }
+
+        private sealed class AddedMemberEntry
+        {
+            public MethodInfo ShimMethod { get; }
+
+            public string FilePath { get; }
+
+            public AddedMemberEntry(MethodInfo shimMethod, string filePath)
+            {
+                ShimMethod = shimMethod;
+                FilePath = filePath;
+            }
+        }
+    }
+
+    /// <summary>
+    /// One added-method shim recorded for --status Kind "Added".
+    /// </summary>
+    internal sealed class HotReloadAddedMemberInfo
+    {
+        public string MethodKey { get; }
+
+        public string FilePath { get; }
+
+        public MethodInfo ShimMethod { get; }
+
+        public HotReloadAddedMemberInfo(string methodKey, string filePath, MethodInfo shimMethod)
+        {
+            MethodKey = methodKey ?? string.Empty;
+            FilePath = filePath ?? string.Empty;
+            ShimMethod = shimMethod;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAddedMemberRegistry.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAddedMemberRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 55e65d2e959384347a31ba8cb1e277cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -55,6 +55,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // in TransformWorker~/TransformWorker.cs.
         public const string PatchKindAddedMethod = "addedMethod";
 
+        // --status Kind for rows sourced from HotReloadAddedMemberRegistry (no compiled MethodBase).
+        public const string AddedMemberStatusKind = "Added";
+
         // Isolation retry drops callers of a failed added shim so retry does not CS0103; they
         // are not Failed (the compile error was in the added body) and must not stay silent.
         public const string IsolatedAddedMethodCallerSkipReason =

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -44,21 +44,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public const string BurstCompileAttributeFullName = "Unity.Burst.BurstCompileAttribute";
 
-        // Why not "applied": this PR defers added-method ApplyEntry (Skipped). Call sites in
-        // edited bodies already route to the shim; PR-2 replaces the skip with Added.
+        // Why not "applied": this sentence is the cross-file / unsupported-kind hint appended
+        // to NewMember compile failures. Same-file added methods are applied through the shim.
         public const string NewMemberCompileHint =
-            "Same-file added methods are not applied in this pass; call sites in edited bodies already "
-            + "route to the shim. Cross-file references and unsupported member kinds still require a "
-            + "real compile (uloop compile).";
+            "Same-file added methods are applied through the shim assembly. Cross-file references "
+            + "and unsupported member kinds still require a real compile (uloop compile).";
 
         // Wire value for TransformWorkerEntryDto.patchKind when the worker emits a shim for a
         // method that exists only in the edited source. Keep in sync with PatchKinds.AddedMethod
         // in TransformWorker~/TransformWorker.cs.
         public const string PatchKindAddedMethod = "addedMethod";
-
-        // Why Skipped (not Failed): ApplyEntry cannot Resolve an added method until PR-2.
-        public const string AddedMethodDeferredSkipReason =
-            "Added-method application lands in the next change; call sites in edited bodies already route to the shim.";
 
         // Isolation retry drops callers of a failed added shim so retry does not CS0103; they
         // are not Failed (the compile error was in the added body) and must not stay silent.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -88,7 +88,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 outcomes,
                 warnings,
                 patchedTotal,
-                HotReloadPatcher.ActivePatchCount,
+                HotReloadPatcher.ActiveChangeCount,
                 suppressedPausePointIds,
                 unchangedTotal,
                 retargetedPausePointIds);
@@ -355,11 +355,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 compileResult.AssemblyBytes,
                 compileResult.PdbBytes,
                 compileResult.Assembly);
+            HotReloadAddedMemberRegistry.BeginFileGeneration(projectRelativePath);
             Dictionary<string, string> bindFailureReasonByShimTypeName =
                 BindShimAccessors(compileResult.Assembly);
             List<string> inlineRiskMethodLabels = new List<string>();
             int patchedCount = 0;
-            entriesToPatch = TakePatchableEntries(entriesToPatch, outcomes, assemblyResolvePath);
             foreach (TransformWorkerEntryDto entry in entriesToPatch)
             {
                 HotReloadMethodOutcome outcome = ApplyEntry(
@@ -445,6 +445,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameterTypeFullNames,
                 genericArity: 0);
 
+            if (entry.patchKind == HotReloadConstants.PatchKindAddedMethod)
+            {
+                return ApplyAddedMethodEntry(
+                    entry,
+                    methodLabel,
+                    shimAssembly,
+                    bindFailureReasonByShimTypeName,
+                    filePath,
+                    projectRelativePath);
+            }
+
             // Only "delegation" selects the forwarding patch; null/empty/anything else is transplant.
             HotReloadPatchShape patchShape = entry.patchKind == HotReloadConstants.PatchKindDelegation
                 ? HotReloadPatchShape.Delegation
@@ -479,24 +490,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     filePath);
             }
 
-            MethodInfo shimMethod = shimType.GetMethod(
-                entry.shimMethodName,
-                BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+            (MethodInfo shimMethod, string shimLookupError) = FindShimMethod(shimType, entry.shimMethodName);
             if (shimMethod == null)
             {
-                // Fall back to a broader lookup — DeclaredOnly can miss when the compiler emits
-                // unexpected metadata flags, but still prefer public static.
-                shimMethod = shimType.GetMethod(
-                    entry.shimMethodName,
-                    BindingFlags.Public | BindingFlags.Static);
-            }
-
-            if (shimMethod == null)
-            {
-                return HotReloadMethodOutcome.Failed(
-                    methodLabel,
-                    "Shim method not found: " + entry.shimTypeName + "." + entry.shimMethodName,
-                    filePath);
+                return HotReloadMethodOutcome.Failed(methodLabel, shimLookupError, filePath);
             }
 
             // Why before Apply: Apply notifies OnHotReloadPatchStateChanged(true) after the
@@ -533,6 +530,70 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return HotReloadMethodOutcome.Patched(methodLabel, filePath, entry.lifecycleNote);
+        }
+
+        private static HotReloadMethodOutcome ApplyAddedMethodEntry(
+            TransformWorkerEntryDto entry,
+            string methodLabel,
+            Assembly shimAssembly,
+            IReadOnlyDictionary<string, string> bindFailureReasonByShimTypeName,
+            string filePath,
+            string projectRelativePath)
+        {
+            // Added methods with accessors share the shim type's __BindAccessors; a bind
+            // failure leaves those delegates unbound, so the entry must not be registered.
+            if (bindFailureReasonByShimTypeName.TryGetValue(
+                    entry.shimTypeName ?? string.Empty,
+                    out string bindFailureReason))
+            {
+                return HotReloadMethodOutcome.Failed(methodLabel, bindFailureReason, filePath);
+            }
+
+            Type shimType = FindShimType(shimAssembly, entry.shimTypeName);
+            if (shimType == null)
+            {
+                return HotReloadMethodOutcome.Failed(
+                    methodLabel,
+                    "Shim type not found in compiled shim assembly: " + entry.shimTypeName,
+                    filePath);
+            }
+
+            (MethodInfo shimMethod, string shimLookupError) = FindShimMethod(shimType, entry.shimMethodName);
+            if (shimMethod == null)
+            {
+                return HotReloadMethodOutcome.Failed(methodLabel, shimLookupError, filePath);
+            }
+
+            HotReloadAddedMemberRegistry.Register(
+                projectRelativePath,
+                methodLabel,
+                shimMethod,
+                filePath);
+            return HotReloadMethodOutcome.Added(methodLabel, filePath, entry.lifecycleNote);
+        }
+
+        private static (MethodInfo ShimMethod, string ErrorMessage) FindShimMethod(
+            Type shimType,
+            string shimMethodName)
+        {
+            MethodInfo shimMethod = shimType.GetMethod(
+                shimMethodName,
+                BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+            if (shimMethod == null)
+            {
+                // Fall back to a broader lookup — DeclaredOnly can miss when the compiler emits
+                // unexpected metadata flags, but still prefer public static.
+                shimMethod = shimType.GetMethod(
+                    shimMethodName,
+                    BindingFlags.Public | BindingFlags.Static);
+            }
+
+            if (shimMethod == null)
+            {
+                return (null, "Shim method not found: " + shimType.Name + "." + shimMethodName);
+            }
+
+            return (shimMethod, null);
         }
 
         private static string FormatInlineRiskAggregatedWarning(
@@ -607,9 +668,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         /// <summary>
         /// Invokes each shim type's binder (emitted when the type carries at least one accessor
-        /// delegate) once, before any patch is applied, so no delegation shim can run with
-        /// unbound accessor delegates. Returns bind failures keyed by shim type name; every
-        /// delegation entry in a failed type becomes Failed instead of being patched.
+        /// delegate) once, before any patch is applied, so no delegation shim or added-method
+        /// accessor rewrite can run with unbound accessor delegates. Returns bind failures keyed
+        /// by shim type name; every delegation entry and added-method entry in a failed type
+        /// becomes Failed instead of being patched or registered.
         /// Internal so tests can pin the failure contract directly — an end-to-end bind failure
         /// cannot be fabricated once shim compilation has succeeded against the same assembly.
         /// </summary>
@@ -804,43 +866,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return false;
-        }
-
-        // Why not ApplyEntry: added methods are absent from the compiled assembly, so Resolve
-        // always fails. PR-2 replaces this Skipped outcome with Added.
-        private static TransformWorkerEntryDto[] TakePatchableEntries(
-            TransformWorkerEntryDto[] entries,
-            List<HotReloadMethodOutcome> outcomes,
-            string filePath)
-        {
-            if (entries == null || entries.Length == 0)
-            {
-                return Array.Empty<TransformWorkerEntryDto>();
-            }
-
-            List<TransformWorkerEntryDto> patchable = new List<TransformWorkerEntryDto>();
-            foreach (TransformWorkerEntryDto entry in entries)
-            {
-                if (entry.patchKind == HotReloadConstants.PatchKindAddedMethod)
-                {
-                    string[] parameterTypeFullNames = entry.parameterTypeFullNames ?? Array.Empty<string>();
-                    string methodLabel = HotReloadPatcher.FormatMethodKeyParts(
-                        entry.typeMetadataName,
-                        entry.methodName,
-                        parameterTypeFullNames,
-                        genericArity: 0);
-                    outcomes.Add(
-                        HotReloadMethodOutcome.Skipped(
-                            methodLabel,
-                            HotReloadConstants.AddedMethodDeferredSkipReason,
-                            filePath));
-                    continue;
-                }
-
-                patchable.Add(entry);
-            }
-
-            return patchable.ToArray();
         }
 
         private static string FormatRemovedMembersWarning(TransformWorkerRemovedMemberDto[] removedMembers)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -258,6 +258,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 || workerOutput.entries == null
                 || workerOutput.entries.Length == 0)
             {
+                // Why only on this success path: deleting an added method and restoring callers
+                // yields empty entries, so the post-shim-compile BeginFileGeneration never runs.
+                // Worker failure and shim-compile failure return earlier or later without
+                // clearing — same as leaving existing Harmony patches in place when apply does
+                // not succeed.
+                HotReloadAddedMemberRegistry.BeginFileGeneration(projectRelativePath);
                 return new HotReloadFileProcessResult(
                     outcomes, warnings, 0, unchangedMethodCount: unchangedMethodCount);
             }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
@@ -36,7 +36,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     }
 
     /// <summary>
-    /// Per-method outcome: Patched, Skipped, or Failed.
+    /// Per-method outcome: Patched, Skipped, Failed, or Added.
     /// </summary>
     internal sealed class HotReloadMethodOutcome
     {
@@ -92,12 +92,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 filePath,
                 string.Empty);
         }
+
+        public static HotReloadMethodOutcome Added(
+            string method,
+            string filePath,
+            string lifecycleNote = null)
+        {
+            return new HotReloadMethodOutcome(
+                HotReloadMethodOutcomeKind.Added,
+                method,
+                string.Empty,
+                filePath,
+                lifecycleNote);
+        }
     }
 
     internal enum HotReloadMethodOutcomeKind
     {
         Patched = 0,
         Skipped = 1,
-        Failed = 2
+        Failed = 2,
+        Added = 3
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -88,7 +88,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 return null;
             };
-            HotReloadPausePointCoordination.GetActiveHotReloadPatchCount = () => ShimByMethod.Count;
+            HotReloadPausePointCoordination.GetActiveHotReloadPatchCount = () => ActiveChangeCount;
             HotReloadPausePointCoordination.GetTransplantLocals = method =>
                 TransplantLocalsByMethod.TryGetValue(method, out IReadOnlyList<LocalBuilder> locals)
                     ? locals
@@ -238,6 +238,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ShimByMethod.Clear();
             FilePathByMethod.Clear();
             HotReloadShimRegistry.Clear();
+            HotReloadAddedMemberRegistry.Clear();
             TransplantLocalsByMethod.Clear();
             TransplantPreambleLengthByMethod.Clear();
             HotReloadInvocationRegistry.Clear();
@@ -281,6 +282,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// How many methods currently have an active patch recorded in the ledger.
         /// </summary>
         public static int ActivePatchCount => ShimByMethod.Count;
+
+        /// <summary>
+        /// Harmony patches plus added-method shims. Domain reload drops both, so Play-entry
+        /// warnings and ActivePatchTotal count this sum.
+        /// </summary>
+        public static int ActiveChangeCount =>
+            ShimByMethod.Count + HotReloadAddedMemberRegistry.Count;
 
         /// <summary>
         /// Returns a sorted list of active patches (method key + source file path) for status

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -130,8 +130,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ClearedCount = clearedCount,
                 ActivePatchTotal = HotReloadPatcher.ActiveChangeCount,
                 Message = clearedCount == 0
-                    ? "No active hot-reload patches to revert."
-                    : "Reverted all active hot-reload patches."
+                    ? "No active hot-reload changes to revert."
+                    : "Reverted all active hot-reload changes."
             };
         }
 
@@ -160,7 +160,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 methods.Add(
                     new HotReloadMethodResult
                     {
-                        Kind = "Added",
+                        Kind = HotReloadConstants.AddedMemberStatusKind,
                         Method = added.MethodKey,
                         FilePath = added.FilePath
                     });
@@ -172,7 +172,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Success = true,
                 Methods = methods,
                 ActivePatchTotal = count,
-                Message = $"{count} method(s) currently patched."
+                Message = $"{count} change(s) currently active."
             };
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -122,13 +122,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static HotReloadResponse ExecuteRevertAll()
         {
-            int clearedCount = HotReloadPatcher.ActivePatchCount;
+            int clearedCount = HotReloadPatcher.ActiveChangeCount;
             HotReloadPatcher.RevertAll();
             return new HotReloadResponse
             {
                 Success = true,
                 ClearedCount = clearedCount,
-                ActivePatchTotal = HotReloadPatcher.ActivePatchCount,
+                ActivePatchTotal = HotReloadPatcher.ActiveChangeCount,
                 Message = clearedCount == 0
                     ? "No active hot-reload patches to revert."
                     : "Reverted all active hot-reload patches."
@@ -138,7 +138,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static HotReloadResponse ExecuteStatus()
         {
             IReadOnlyList<HotReloadActivePatchInfo> active = HotReloadPatcher.DescribeActivePatches();
-            List<HotReloadMethodResult> methods = new List<HotReloadMethodResult>(active.Count);
+            IReadOnlyList<HotReloadAddedMemberInfo> addedMembers = HotReloadAddedMemberRegistry.Describe();
+            List<HotReloadMethodResult> methods =
+                new List<HotReloadMethodResult>(active.Count + addedMembers.Count);
             for (int index = 0; index < active.Count; index++)
             {
                 HotReloadActivePatchInfo patch = active[index];
@@ -152,7 +154,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     });
             }
 
-            int count = active.Count;
+            for (int index = 0; index < addedMembers.Count; index++)
+            {
+                HotReloadAddedMemberInfo added = addedMembers[index];
+                methods.Add(
+                    new HotReloadMethodResult
+                    {
+                        Kind = "Added",
+                        Method = added.MethodKey,
+                        FilePath = added.FilePath
+                    });
+            }
+
+            int count = methods.Count;
             return new HotReloadResponse
             {
                 Success = true,
@@ -305,6 +319,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             string message;
+            int addedCount = CountAddedOutcomes(result);
             if (hasFailure)
             {
                 message = "Hot reload finished with one or more Failed method outcomes. See Methods.";
@@ -314,7 +329,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 message = "Hot reload found no patchable method bodies in the given files; nothing was changed. "
                     + "Hot reload only replaces existing ordinary method bodies; use uloop compile for other edits.";
             }
-            else if (result.PatchedTotal == 0)
+            else if (result.PatchedTotal == 0 && addedCount == 0)
             {
                 message = "Hot reload finished with no methods patched. See Methods for Skipped reasons.";
             }
@@ -322,6 +337,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 message = "Hot reload applied. PatchedTotal=" + result.PatchedTotal
                     + ", ActivePatchTotal=" + result.ActivePatchTotal + ".";
+                if (addedCount > 0)
+                {
+                    message += " Added: " + addedCount + ".";
+                }
             }
 
             if (result.UnchangedTotal > 0)
@@ -348,6 +367,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return message;
+        }
+
+        private static int CountAddedOutcomes(HotReloadOrchestratorResult result)
+        {
+            int addedCount = 0;
+            for (int index = 0; index < result.Methods.Count; index++)
+            {
+                if (result.Methods[index].Kind == HotReloadMethodOutcomeKind.Added)
+                {
+                    addedCount++;
+                }
+            }
+
+            return addedCount;
         }
 
         private static HotReloadResponse CreateValidationFailure(string message)


### PR DESCRIPTION
## Summary
- Same-file added methods are now applied through the shim assembly (Kind `Added`) instead of being skipped after call sites already rewrite to the shim.
- All-unchanged re-apply (delete the added method and restore callers) now clears that file's added-member ledger, matching Harmony peel on the empty-entries path.

## User Impact
- Before: hot reload could rewrite callers onto an added-method shim, but the added method itself was reported Skipped and did not appear in `--status` or Play-entry warnings. After deleting the added method and restoring callers, `--status` and Play-entry warnings could keep counting it until `--revert-all`.
- After: the added method is registered, callers run it, `--status` lists Kind `Added`, revert-all clears it, Play-entry warnings count it as a hot-reload change, and an all-unchanged re-apply drops it from the ledger.

## Changes
- New `HotReloadAddedMemberRegistry` (per-file clear, overwrite, revert-all).
- `ApplyEntry` registers `patchKind: addedMethod` as `HotReloadMethodOutcomeKind.Added` without Harmony matching; bind failures on that shim type still fail the entry.
- Empty-entries early return (after `RevertUnchangedPatches`) also `BeginFileGeneration` for that file so added members do not survive all-unchanged re-apply. Worker failure and shim-compile failure still do not clear. The post-shim-compile `BeginFileGeneration` is unchanged (double-clear is harmless).
- `--status` emits Kind `Added` rows; apply message includes `Added: N`; `GetActiveHotReloadPatchCount` sums Harmony patches plus added methods.
- `--status` / `--revert-all` messages use `change(s)` so the count still matches when added methods are included.
- Play-entry warning wording is `change(s)` so the count still matches when added methods are included.
- Pause-point does not register added methods on the shim ledger.

## Docs
- SKILL.md update deferred to the docs PR.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Success, 0 errors
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value HotReload` → 228/228 Passed (includes `Run_ReapplyOnDiskAfterAddedMethod_ClearsAddedMemberRegistry`)
- Play-warning wording tests → 8/8 Passed
- CLI E2E (assemblies locked; on-disk fixture edited then restored; `dist/darwin-arm64/uloop hot-reload --files Assets/Tests/Editor/HotReload/HotReloadAddedMethodApplyFixture.cs`):
  - Before: `ExistingCaller(3)` → `3`
  - Apply: Kind `Patched` ExistingCaller + Kind `Added` AddedPing; `PatchedTotal=1`, `ActivePatchTotal=2`, `Added: 1`
  - After: `ExistingCaller(3)` → `4`
  - `--status`: Active + Added; `2 change(s) currently active.`
  - `--revert-all`: `ClearedCount=2`; `Reverted all active hot-reload changes.`
