### PR TITLE
feat: add HotReloadAddedFieldStore for added-field state

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadAddedFieldStoreTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedFieldStoreTests.cs
@@ -101,6 +101,28 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: storing null for Nullable&lt;T&gt; is a real value, not a miss that re-runs
+        /// the initializer (boxed null is a null reference, unlike non-nullable value types).
+        /// </summary>
+        [Test]
+        public void Set_NullNullableInt_GetOrInitDoesNotReinitialize()
+        {
+            StoreHost host = new StoreHost();
+            string key = HotReloadAddedFieldStore.FormatFieldKey(HostTypeName, FieldName);
+            int calls = 0;
+
+            HotReloadAddedFieldStore.Set<int?>(host, key, null);
+            int? value = HotReloadAddedFieldStore.GetOrInit<int?>(host, key, () =>
+            {
+                calls++;
+                return 7;
+            });
+
+            Assert.That(value, Is.Null);
+            Assert.That(calls, Is.EqualTo(0));
+        }
+
+        /// <summary>
         /// What: a stored value whose runtime type is not T is discarded and the initializer
         /// runs again (added-field type change).
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedFieldStoreTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedFieldStoreTests.cs
@@ -1,0 +1,215 @@
+using System;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Pure coverage for the added-field side table: instance CWT storage, static storage,
+    /// type-change reinitialization, and Clear.
+    /// </summary>
+    public class HotReloadAddedFieldStoreTests
+    {
+        private const string HostTypeName = "Host";
+        private const string FieldName = "count";
+
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadAddedFieldStore.Clear();
+        }
+
+        /// <summary>
+        /// What: a missing instance field runs the initializer once and then returns the stored
+        /// value without running it again.
+        /// </summary>
+        [Test]
+        public void GetOrInit_MissingThenPresent_RunsInitializerOnce()
+        {
+            StoreHost host = new StoreHost();
+            string key = HotReloadAddedFieldStore.FormatFieldKey(HostTypeName, FieldName);
+            int calls = 0;
+
+            int first = HotReloadAddedFieldStore.GetOrInit(host, key, () =>
+            {
+                calls++;
+                return 3;
+            });
+            int second = HotReloadAddedFieldStore.GetOrInit(host, key, () =>
+            {
+                calls++;
+                return 99;
+            });
+
+            Assert.That(first, Is.EqualTo(3));
+            Assert.That(second, Is.EqualTo(3));
+            Assert.That(calls, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// What: a null initializer stores default(T) so a field with no initializer reads as
+        /// the type's default until Set.
+        /// </summary>
+        [Test]
+        public void GetOrInit_NullInitializer_StoresDefault()
+        {
+            StoreHost host = new StoreHost();
+            string key = HotReloadAddedFieldStore.FormatFieldKey(HostTypeName, FieldName);
+
+            int value = HotReloadAddedFieldStore.GetOrInit<int>(host, key, null);
+
+            Assert.That(value, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: Set overwrites the stored value so a later GetOrInit returns it.
+        /// </summary>
+        [Test]
+        public void Set_ThenGetOrInit_ReturnsStoredValue()
+        {
+            StoreHost host = new StoreHost();
+            string key = HotReloadAddedFieldStore.FormatFieldKey(HostTypeName, FieldName);
+
+            HotReloadAddedFieldStore.Set(host, key, 8);
+            int value = HotReloadAddedFieldStore.GetOrInit(host, key, () => 1);
+
+            Assert.That(value, Is.EqualTo(8));
+        }
+
+        /// <summary>
+        /// What: storing null for a reference field is a real value, not a miss that re-runs
+        /// the initializer.
+        /// </summary>
+        [Test]
+        public void Set_NullReference_GetOrInitDoesNotReinitialize()
+        {
+            StoreHost host = new StoreHost();
+            string key = HotReloadAddedFieldStore.FormatFieldKey(HostTypeName, "label");
+            int calls = 0;
+
+            HotReloadAddedFieldStore.Set<string>(host, key, null);
+            string value = HotReloadAddedFieldStore.GetOrInit(host, key, () =>
+            {
+                calls++;
+                return "fresh";
+            });
+
+            Assert.That(value, Is.Null);
+            Assert.That(calls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: a stored value whose runtime type is not T is discarded and the initializer
+        /// runs again (added-field type change).
+        /// </summary>
+        [Test]
+        public void GetOrInit_TypeMismatch_DiscardsAndReinitializes()
+        {
+            StoreHost host = new StoreHost();
+            string key = HotReloadAddedFieldStore.FormatFieldKey(HostTypeName, FieldName);
+            int calls = 0;
+
+            HotReloadAddedFieldStore.Set(host, key, "old");
+            int value = HotReloadAddedFieldStore.GetOrInit(host, key, () =>
+            {
+                calls++;
+                return 7;
+            });
+
+            Assert.That(value, Is.EqualTo(7));
+            Assert.That(calls, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// What: two host instances keep independent values for the same field key.
+        /// </summary>
+        [Test]
+        public void GetOrInit_TwoInstances_AreIndependent()
+        {
+            StoreHost left = new StoreHost();
+            StoreHost right = new StoreHost();
+            string key = HotReloadAddedFieldStore.FormatFieldKey(HostTypeName, FieldName);
+
+            HotReloadAddedFieldStore.Set(left, key, 1);
+            HotReloadAddedFieldStore.Set(right, key, 2);
+
+            Assert.That(HotReloadAddedFieldStore.GetOrInit(left, key, () => 0), Is.EqualTo(1));
+            Assert.That(HotReloadAddedFieldStore.GetOrInit(right, key, () => 0), Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// What: static GetOrInit/Set share one table keyed only by fieldKey.
+        /// </summary>
+        [Test]
+        public void GetOrInitStatic_SetStatic_RoundTrip()
+        {
+            string key = HotReloadAddedFieldStore.FormatFieldKey(HostTypeName, "seed");
+            int calls = 0;
+
+            int first = HotReloadAddedFieldStore.GetOrInitStatic(key, () =>
+            {
+                calls++;
+                return 4;
+            });
+            HotReloadAddedFieldStore.SetStatic(key, 11);
+            int second = HotReloadAddedFieldStore.GetOrInitStatic(key, () =>
+            {
+                calls++;
+                return 99;
+            });
+
+            Assert.That(first, Is.EqualTo(4));
+            Assert.That(second, Is.EqualTo(11));
+            Assert.That(calls, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// What: a static type mismatch discards the old value and reinitializes.
+        /// </summary>
+        [Test]
+        public void GetOrInitStatic_TypeMismatch_DiscardsAndReinitializes()
+        {
+            string key = HotReloadAddedFieldStore.FormatFieldKey(HostTypeName, "seed");
+            HotReloadAddedFieldStore.SetStatic(key, "old");
+
+            int value = HotReloadAddedFieldStore.GetOrInitStatic(key, () => 5);
+
+            Assert.That(value, Is.EqualTo(5));
+        }
+
+        /// <summary>
+        /// What: Clear drops both instance and static entries so the next read reinitializes.
+        /// </summary>
+        [Test]
+        public void Clear_DropsInstanceAndStaticValues()
+        {
+            StoreHost host = new StoreHost();
+            string instanceKey = HotReloadAddedFieldStore.FormatFieldKey(HostTypeName, FieldName);
+            string staticKey = HotReloadAddedFieldStore.FormatFieldKey(HostTypeName, "seed");
+            HotReloadAddedFieldStore.Set(host, instanceKey, 1);
+            HotReloadAddedFieldStore.SetStatic(staticKey, 2);
+
+            HotReloadAddedFieldStore.Clear();
+
+            Assert.That(HotReloadAddedFieldStore.GetOrInit(host, instanceKey, () => 10), Is.EqualTo(10));
+            Assert.That(HotReloadAddedFieldStore.GetOrInitStatic(staticKey, () => 20), Is.EqualTo(20));
+        }
+
+        /// <summary>
+        /// What: FormatFieldKey joins type metadata name and field name with the store separator.
+        /// </summary>
+        [Test]
+        public void FormatFieldKey_JoinsTypeAndField()
+        {
+            Assert.That(
+                HotReloadAddedFieldStore.FormatFieldKey("Ns.Host", "count"),
+                Is.EqualTo("Ns.Host" + HotReloadAddedFieldStore.FieldKeySeparator + "count"));
+        }
+
+        private sealed class StoreHost
+        {
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedFieldStoreTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedFieldStoreTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04aa9fdddbb6a4a1c8aa9d10b506642e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -9,6 +9,8 @@ using NUnit.Framework;
 
 using Newtonsoft.Json.Linq;
 
+using HarmonyLib;
+
 using UnityEditor.Compilation;
 using UnityEngine;
 
@@ -28,6 +30,103 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void TearDown()
         {
             HotReloadPatcher.RevertAll();
+        }
+
+        /// <summary>
+        /// What: the added-field store assembly is injected only when the store flag is set,
+        /// matching the Harmony optional-reference pattern.
+        /// </summary>
+        [Test]
+        public void AppendOptionalShimAssemblyReferences_StoreFlag_AddsToolContractsAssembly()
+        {
+            List<string> references = new List<string>();
+            HotReloadOrchestrator.AppendOptionalShimAssemblyReferences(
+                references,
+                includeHarmonyReference: false,
+                includeAddedFieldStoreReference: true);
+
+            Assert.That(references.Count, Is.EqualTo(1));
+            Assert.That(
+                references[0],
+                Is.EqualTo(typeof(HotReloadAddedFieldStore).Assembly.Location));
+        }
+
+        /// <summary>
+        /// What: both optional flags false leave the reference list unchanged.
+        /// </summary>
+        [Test]
+        public void AppendOptionalShimAssemblyReferences_BothFlagsFalse_AddsNothing()
+        {
+            List<string> references = new List<string>();
+            HotReloadOrchestrator.AppendOptionalShimAssemblyReferences(
+                references,
+                includeHarmonyReference: false,
+                includeAddedFieldStoreReference: false);
+
+            Assert.That(references, Is.Empty);
+        }
+
+        /// <summary>
+        /// What: the Harmony flag still injects Harmony without also adding the store assembly.
+        /// </summary>
+        [Test]
+        public void AppendOptionalShimAssemblyReferences_HarmonyFlagOnly_AddsHarmony()
+        {
+            List<string> references = new List<string>();
+            HotReloadOrchestrator.AppendOptionalShimAssemblyReferences(
+                references,
+                includeHarmonyReference: true,
+                includeAddedFieldStoreReference: false);
+
+            Assert.That(references.Count, Is.EqualTo(1));
+            Assert.That(references[0], Is.EqualTo(typeof(Harmony).Assembly.Location));
+        }
+
+        /// <summary>
+        /// What: a publicized ToolContracts path already in the list is not duplicated when
+        /// the store flag would otherwise append the raw Location (CS1703).
+        /// </summary>
+        [Test]
+        public void AppendOptionalShimAssemblyReferences_ExistingPublicizedStore_DoesNotDuplicate()
+        {
+            string fileName = Path.GetFileName(typeof(HotReloadAddedFieldStore).Assembly.Location);
+            string publicizedPath = Path.Combine(
+                HotReloadConstants.PublicizedRefsRelativeDirectory,
+                fileName);
+            List<string> references = new List<string> { publicizedPath };
+
+            HotReloadOrchestrator.AppendOptionalShimAssemblyReferences(
+                references,
+                includeHarmonyReference: false,
+                includeAddedFieldStoreReference: true);
+
+            Assert.That(references.Count, Is.EqualTo(1));
+            Assert.That(references[0], Is.EqualTo(publicizedPath));
+        }
+
+        /// <summary>
+        /// What: a synthetic worker output with hasAddedFieldRewrites true causes the first-pass
+        /// NeedsAddedFieldStoreReference → AppendOptional chain to include the store assembly.
+        /// </summary>
+        [Test]
+        public void NeedsAddedFieldStoreReference_TrueOutput_AppendsStoreAssembly()
+        {
+            TransformWorkerOutputDto output = new TransformWorkerOutputDto
+            {
+                hasAddedFieldRewrites = true
+            };
+            bool includeStore = HotReloadOrchestrator.NeedsAddedFieldStoreReference(output);
+            List<string> references = new List<string>();
+            HotReloadOrchestrator.AppendOptionalShimAssemblyReferences(
+                references,
+                includeHarmonyReference: false,
+                includeAddedFieldStoreReference: includeStore);
+
+            Assert.That(includeStore, Is.True);
+            Assert.That(references.Count, Is.EqualTo(1));
+            Assert.That(
+                references[0],
+                Is.EqualTo(typeof(HotReloadAddedFieldStore).Assembly.Location));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -128,56 +128,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: the added-field store assembly is injected only when the store flag is set,
-        /// matching the Harmony optional-reference pattern.
-        /// </summary>
-        [Test]
-        public void AppendOptionalShimAssemblyReferences_StoreFlag_AddsToolContractsAssembly()
-        {
-            List<string> references = new List<string>();
-            HotReloadOrchestrator.AppendOptionalShimAssemblyReferences(
-                references,
-                includeHarmonyReference: false,
-                includeAddedFieldStoreReference: true);
-
-            Assert.That(references.Count, Is.EqualTo(1));
-            Assert.That(
-                references[0],
-                Is.EqualTo(typeof(HotReloadAddedFieldStore).Assembly.Location));
-        }
-
-        /// <summary>
-        /// What: both optional flags false leave the reference list unchanged.
-        /// </summary>
-        [Test]
-        public void AppendOptionalShimAssemblyReferences_BothFlagsFalse_AddsNothing()
-        {
-            List<string> references = new List<string>();
-            HotReloadOrchestrator.AppendOptionalShimAssemblyReferences(
-                references,
-                includeHarmonyReference: false,
-                includeAddedFieldStoreReference: false);
-
-            Assert.That(references, Is.Empty);
-        }
-
-        /// <summary>
-        /// What: the Harmony flag still injects Harmony without also adding the store assembly.
-        /// </summary>
-        [Test]
-        public void AppendOptionalShimAssemblyReferences_HarmonyFlagOnly_AddsHarmony()
-        {
-            List<string> references = new List<string>();
-            HotReloadOrchestrator.AppendOptionalShimAssemblyReferences(
-                references,
-                includeHarmonyReference: true,
-                includeAddedFieldStoreReference: false);
-
-            Assert.That(references.Count, Is.EqualTo(1));
-            Assert.That(references[0], Is.EqualTo(typeof(Harmony).Assembly.Location));
-        }
-
-        /// <summary>
         /// What: DescribeActivePatches lists the patched fixture method after Apply and is empty
         /// after RevertAll.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -109,6 +109,75 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: RevertAll clears the added-field side table so instance and static values
+        /// reinitialize on the next read.
+        /// </summary>
+        [Test]
+        public void RevertAll_ClearsAddedFieldStore()
+        {
+            object host = new object();
+            string instanceKey = HotReloadAddedFieldStore.FormatFieldKey("Host", "count");
+            string staticKey = HotReloadAddedFieldStore.FormatFieldKey("Host", "seed");
+            HotReloadAddedFieldStore.Set(host, instanceKey, 1);
+            HotReloadAddedFieldStore.SetStatic(staticKey, 2);
+
+            HotReloadPatcher.RevertAll();
+
+            Assert.That(HotReloadAddedFieldStore.GetOrInit(host, instanceKey, () => 10), Is.EqualTo(10));
+            Assert.That(HotReloadAddedFieldStore.GetOrInitStatic(staticKey, () => 20), Is.EqualTo(20));
+        }
+
+        /// <summary>
+        /// What: the added-field store assembly is injected only when the store flag is set,
+        /// matching the Harmony optional-reference pattern.
+        /// </summary>
+        [Test]
+        public void AppendOptionalShimAssemblyReferences_StoreFlag_AddsToolContractsAssembly()
+        {
+            List<string> references = new List<string>();
+            HotReloadOrchestrator.AppendOptionalShimAssemblyReferences(
+                references,
+                includeHarmonyReference: false,
+                includeAddedFieldStoreReference: true);
+
+            Assert.That(references.Count, Is.EqualTo(1));
+            Assert.That(
+                references[0],
+                Is.EqualTo(typeof(HotReloadAddedFieldStore).Assembly.Location));
+        }
+
+        /// <summary>
+        /// What: both optional flags false leave the reference list unchanged.
+        /// </summary>
+        [Test]
+        public void AppendOptionalShimAssemblyReferences_BothFlagsFalse_AddsNothing()
+        {
+            List<string> references = new List<string>();
+            HotReloadOrchestrator.AppendOptionalShimAssemblyReferences(
+                references,
+                includeHarmonyReference: false,
+                includeAddedFieldStoreReference: false);
+
+            Assert.That(references, Is.Empty);
+        }
+
+        /// <summary>
+        /// What: the Harmony flag still injects Harmony without also adding the store assembly.
+        /// </summary>
+        [Test]
+        public void AppendOptionalShimAssemblyReferences_HarmonyFlagOnly_AddsHarmony()
+        {
+            List<string> references = new List<string>();
+            HotReloadOrchestrator.AppendOptionalShimAssemblyReferences(
+                references,
+                includeHarmonyReference: true,
+                includeAddedFieldStoreReference: false);
+
+            Assert.That(references.Count, Is.EqualTo(1));
+            Assert.That(references[0], Is.EqualTo(typeof(Harmony).Assembly.Location));
+        }
+
+        /// <summary>
         /// What: DescribeActivePatches lists the patched fixture method after Apply and is empty
         /// after RevertAll.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -1636,5 +1636,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(nested.removedMembers[0].name, Is.EqualTo("Gone"));
             Assert.That(nested.entries[0].calledAddedMethodKeys, Is.EqualTo(new[] { "T::Added()" }));
         }
+
+        /// <summary>
+        /// What: omitted hasAddedFieldRewrites deserializes as false, and an explicit true
+        /// survives Newtonsoft so isolation retry can inject the store assembly.
+        /// </summary>
+        [Test]
+        public void Deserialize_HasAddedFieldRewrites_OmittedFalseAndTrueRoundTrip()
+        {
+            string omittedJson = "{\"shimSource\":\"\",\"entries\":[],\"skipped\":[],\"parseErrors\":[]}";
+            TransformWorkerOutputDto omitted =
+                JsonConvert.DeserializeObject<TransformWorkerOutputDto>(omittedJson);
+            Assert.That(omitted.hasAddedFieldRewrites, Is.False);
+
+            string trueJson =
+                "{\"shimSource\":\"\",\"entries\":[],\"skipped\":[],\"parseErrors\":[],"
+                + "\"hasAddedFieldRewrites\":true}";
+            TransformWorkerOutputDto enabled =
+                JsonConvert.DeserializeObject<TransformWorkerOutputDto>(trueJson);
+            Assert.That(enabled.hasAddedFieldRewrites, Is.True);
+        }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -271,10 +271,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // BuildShimReferencePaths reads Application.dataPath / platform; stay on main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
             bool includeHarmonyReference = NeedsHarmonyReference(workerOutput);
+            bool includeAddedFieldStoreReference = NeedsAddedFieldStoreReference(workerOutput);
             ShimReferencePathsResult shimReferencePaths = TryBuildShimReferencePaths(
                 compilationAssembly,
                 targetDllPath,
-                includeHarmonyReference);
+                includeHarmonyReference,
+                includeAddedFieldStoreReference);
             if (shimReferencePaths.ErrorMessage != null)
             {
                 outcomes.Add(
@@ -856,6 +858,34 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return HasDelegationEntry(output.entries) || output.hasAccessorDelegates;
         }
 
+        private static bool NeedsAddedFieldStoreReference(TransformWorkerOutputDto output)
+        {
+            Debug.Assert(output != null, "output must not be null.");
+            return output.hasAddedFieldRewrites;
+        }
+
+        /// <summary>
+        /// Appends Harmony and/or the added-field store assembly when the worker output needs them.
+        /// Visible to tests so injection can be asserted without running CompilationPipeline.
+        /// </summary>
+        internal static void AppendOptionalShimAssemblyReferences(
+            List<string> references,
+            bool includeHarmonyReference,
+            bool includeAddedFieldStoreReference)
+        {
+            Debug.Assert(references != null, "references must not be null.");
+
+            if (includeHarmonyReference)
+            {
+                references.Add(typeof(Harmony).Assembly.Location);
+            }
+
+            if (includeAddedFieldStoreReference)
+            {
+                references.Add(typeof(HotReloadAddedFieldStore).Assembly.Location);
+            }
+        }
+
         private static bool HasDelegationEntry(TransformWorkerEntryDto[] entries)
         {
             if (entries == null)
@@ -1001,10 +1031,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             await MainThreadSwitcher.SwitchToMainThread(ct);
             bool includeHarmonyReference = NeedsHarmonyReference(retryOutput);
+            bool includeAddedFieldStoreReference = NeedsAddedFieldStoreReference(retryOutput);
             ShimReferencePathsResult shimReferencePaths = TryBuildShimReferencePaths(
                 compilationAssembly,
                 targetDllPath,
-                includeHarmonyReference);
+                includeHarmonyReference,
+                includeAddedFieldStoreReference);
             if (shimReferencePaths.ErrorMessage != null)
             {
                 // First-pass publicize already succeeded, so a miss here is rare; abandon
@@ -1314,7 +1346,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static ShimReferencePathsResult TryBuildShimReferencePaths(
             UnityCompilationAssembly compilationAssembly,
             string targetDllPath,
-            bool includeHarmonyReference)
+            bool includeHarmonyReference,
+            bool includeAddedFieldStoreReference)
         {
             // Why catch only AssemblyResolutionException: publicize fails when Cecil cannot
             // resolve engine/netstandard types during Write; that is a per-file hot-reload
@@ -1325,7 +1358,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     BuildShimReferencePaths(
                         compilationAssembly,
                         targetDllPath,
-                        includeHarmonyReference),
+                        includeHarmonyReference,
+                        includeAddedFieldStoreReference),
                     null);
             }
             catch (AssemblyResolutionException resolutionException)
@@ -1341,11 +1375,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Publicize ScriptAssemblies references; leave engine/system DLLs untouched. Never include
         /// the original (non-publicized) target assembly. Harmony is added when the worker
         /// emitted a delegation entry or accessor delegates (addedMethod entries can need them).
+        /// The added-field store assembly is added when the worker rewrote added-field accesses.
         /// </summary>
         private static List<string> BuildShimReferencePaths(
             UnityCompilationAssembly compilationAssembly,
             string targetDllPath,
-            bool includeHarmonyReference)
+            bool includeHarmonyReference,
+            bool includeAddedFieldStoreReference)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string scriptAssembliesDirectory = Path.GetFullPath(
@@ -1362,10 +1398,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 resolverSearchDirectories);
             references.Add(publicizedTarget);
 
-            if (includeHarmonyReference)
-            {
-                references.Add(typeof(Harmony).Assembly.Location);
-            }
+            AppendOptionalShimAssemblyReferences(
+                references,
+                includeHarmonyReference,
+                includeAddedFieldStoreReference);
 
             if (compilationAssembly.allReferences == null)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -858,7 +858,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return HasDelegationEntry(output.entries) || output.hasAccessorDelegates;
         }
 
-        private static bool NeedsAddedFieldStoreReference(TransformWorkerOutputDto output)
+        internal static bool NeedsAddedFieldStoreReference(TransformWorkerOutputDto output)
         {
             Debug.Assert(output != null, "output must not be null.");
             return output.hasAddedFieldRewrites;
@@ -877,13 +877,37 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (includeHarmonyReference)
             {
-                references.Add(typeof(Harmony).Assembly.Location);
+                AppendIfMissingByFileName(references, typeof(Harmony).Assembly.Location);
             }
 
             if (includeAddedFieldStoreReference)
             {
-                references.Add(typeof(HotReloadAddedFieldStore).Assembly.Location);
+                AppendIfMissingByFileName(
+                    references,
+                    typeof(HotReloadAddedFieldStore).Assembly.Location);
             }
+        }
+
+        // Why filename (not full path): ToolContracts lives under ScriptAssemblies and is
+        // publicized, so the list may already hold a publicized copy while Location is the raw
+        // DLL. Adding both is CS1703. Harmony is a plugin outside ScriptAssemblies, so this
+        // collision does not arise there, but the same skip is still correct.
+        private static void AppendIfMissingByFileName(List<string> references, string assemblyPath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assemblyPath), "assemblyPath must not be empty.");
+            string fileName = Path.GetFileName(assemblyPath);
+            for (int index = 0; index < references.Count; index++)
+            {
+                if (string.Equals(
+                    Path.GetFileName(references[index]),
+                    fileName,
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+            }
+
+            references.Add(assemblyPath);
         }
 
         private static bool HasDelegationEntry(TransformWorkerEntryDto[] entries)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -239,6 +239,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             FilePathByMethod.Clear();
             HotReloadShimRegistry.Clear();
             HotReloadAddedMemberRegistry.Clear();
+            HotReloadAddedFieldStore.Clear();
             TransplantLocalsByMethod.Clear();
             TransplantPreambleLengthByMethod.Clear();
             HotReloadInvocationRegistry.Clear();

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -63,6 +63,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // True when any emitted shim type contains Harmony accessor delegates. Drives Harmony
         // reference injection; patchKind "addedMethod" entries can also need accessors (B2).
         public bool hasAccessorDelegates;
+
+        // True when any emitted shim body rewrites an added-field access to HotReloadAddedFieldStore.
+        // Drives ToolContracts assembly injection at both the first compile and isolation retry.
+        public bool hasAddedFieldRewrites;
     }
 
     [Serializable]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -447,7 +447,8 @@ public static class TransformWorkerProgram
             UnchangedMethods = unchangedMethods.ToArray(),
             BaselineDisabledByDuplicateKeys = baselineDisabledByDuplicateKeys,
             RemovedMembers = removedMembers.ToArray(),
-            HasAccessorDelegates = hasAccessorDelegates
+            HasAccessorDelegates = hasAccessorDelegates,
+            HasAddedFieldRewrites = false
         };
     }
 
@@ -5599,6 +5600,11 @@ internal sealed class WorkerOutput
     public WorkerRemovedMember[] RemovedMembers { get; set; }
 
     public bool HasAccessorDelegates { get; set; }
+
+    // True when shim bodies rewrite added-field accesses to HotReloadAddedFieldStore.
+    // Keep in sync with TransformWorkerOutputDto.hasAddedFieldRewrites. Always false until
+    // the added-field rewrite PR starts emitting store calls.
+    public bool HasAddedFieldRewrites { get; set; }
 }
 
 internal sealed class WorkerRemovedMember

--- a/Packages/src/Editor/ToolContracts/HotReloadAddedFieldStore.cs
+++ b/Packages/src/Editor/ToolContracts/HotReloadAddedFieldStore.cs
@@ -10,6 +10,8 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
     /// Side table for hot-reload added fields. Compiled types cannot gain real fields, so
     /// shims store values here. Instance entries follow the host object's lifetime via
     /// ConditionalWeakTable; static entries live until Clear or domain reload.
+    /// Editor main thread only. Thread safety is the caller's responsibility (the current
+    /// hot-reload pipeline applies and clears on the main thread).
     /// </summary>
     public static class HotReloadAddedFieldStore
     {
@@ -35,6 +37,8 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         /// <summary>
         /// Returns the stored instance field, running <paramref name="initializer"/> (or
         /// default(T) when it is null) on first access or after a stored type mismatch.
+        /// Reference-type instances only. Struct hosts box on every access and would always
+        /// reinitialize; the worker (PR-4) skips struct hosts.
         /// </summary>
         public static T GetOrInit<T>(object instance, string fieldKey, Func<T> initializer)
         {
@@ -129,9 +133,11 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
                 return (true, typed);
             }
 
-            // Why treat null as a hit for reference T: Set stores null in the dictionary, and
-            // `is T` is false for null. Value types are boxed and never stored as null.
-            if (stored == null && !typeof(T).IsValueType)
+            // Why treat null as a hit for reference T and Nullable<T>: Set stores a null
+            // dictionary value, and `is T` is false for null. Non-nullable value types are
+            // boxed and never stored as null.
+            if (stored == null
+                && (!typeof(T).IsValueType || Nullable.GetUnderlyingType(typeof(T)) != null))
             {
                 return (true, default);
             }

--- a/Packages/src/Editor/ToolContracts/HotReloadAddedFieldStore.cs
+++ b/Packages/src/Editor/ToolContracts/HotReloadAddedFieldStore.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.ToolContracts
+{
+    /// <summary>
+    /// Side table for hot-reload added fields. Compiled types cannot gain real fields, so
+    /// shims store values here. Instance entries follow the host object's lifetime via
+    /// ConditionalWeakTable; static entries live until Clear or domain reload.
+    /// </summary>
+    public static class HotReloadAddedFieldStore
+    {
+        // Keep in sync with the transform worker when it starts emitting field keys (PR-4).
+        public const string FieldKeySeparator = "::";
+
+        private static ConditionalWeakTable<object, Dictionary<string, object>> InstanceTables =
+            new ConditionalWeakTable<object, Dictionary<string, object>>();
+
+        private static readonly Dictionary<string, object> StaticValues =
+            new Dictionary<string, object>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Builds the store key "<TypeMetadataName>::<fieldName>".
+        /// </summary>
+        public static string FormatFieldKey(string typeMetadataName, string fieldName)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(typeMetadataName), "typeMetadataName must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(fieldName), "fieldName must not be empty.");
+            return typeMetadataName + FieldKeySeparator + fieldName;
+        }
+
+        /// <summary>
+        /// Returns the stored instance field, running <paramref name="initializer"/> (or
+        /// default(T) when it is null) on first access or after a stored type mismatch.
+        /// </summary>
+        public static T GetOrInit<T>(object instance, string fieldKey, Func<T> initializer)
+        {
+            Debug.Assert(instance != null, "instance must not be null.");
+            Debug.Assert(!string.IsNullOrEmpty(fieldKey), "fieldKey must not be empty.");
+
+            Dictionary<string, object> fields = GetOrCreateInstanceTable(instance);
+            if (fields.TryGetValue(fieldKey, out object stored))
+            {
+                (bool readable, T existing) = TryReadAs<T>(stored);
+                if (readable)
+                {
+                    return existing;
+                }
+            }
+
+            T created = CreateValue(initializer);
+            fields[fieldKey] = created;
+            return created;
+        }
+
+        public static void Set<T>(object instance, string fieldKey, T value)
+        {
+            Debug.Assert(instance != null, "instance must not be null.");
+            Debug.Assert(!string.IsNullOrEmpty(fieldKey), "fieldKey must not be empty.");
+
+            Dictionary<string, object> fields = GetOrCreateInstanceTable(instance);
+            fields[fieldKey] = value;
+        }
+
+        /// <summary>
+        /// Returns the stored static field, running <paramref name="initializer"/> (or
+        /// default(T) when it is null) on first access or after a stored type mismatch.
+        /// </summary>
+        public static T GetOrInitStatic<T>(string fieldKey, Func<T> initializer)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(fieldKey), "fieldKey must not be empty.");
+
+            if (StaticValues.TryGetValue(fieldKey, out object stored))
+            {
+                (bool readable, T existing) = TryReadAs<T>(stored);
+                if (readable)
+                {
+                    return existing;
+                }
+            }
+
+            T created = CreateValue(initializer);
+            StaticValues[fieldKey] = created;
+            return created;
+        }
+
+        public static void SetStatic<T>(string fieldKey, T value)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(fieldKey), "fieldKey must not be empty.");
+            StaticValues[fieldKey] = value;
+        }
+
+        /// <summary>
+        /// Drops every instance and static entry. Called from RevertAll; domain reload also
+        /// drops the tables because they are static.
+        /// </summary>
+        public static void Clear()
+        {
+            // Why replace rather than ConditionalWeakTable.Clear: replacing drops the old
+            // table for GC even on profiles where Clear is missing, and matches static Clear.
+            InstanceTables = new ConditionalWeakTable<object, Dictionary<string, object>>();
+            StaticValues.Clear();
+        }
+
+        private static Dictionary<string, object> GetOrCreateInstanceTable(object instance)
+        {
+            return InstanceTables.GetValue(
+                instance,
+                _ => new Dictionary<string, object>(StringComparer.Ordinal));
+        }
+
+        private static T CreateValue<T>(Func<T> initializer)
+        {
+            if (initializer == null)
+            {
+                return default;
+            }
+
+            return initializer();
+        }
+
+        private static (bool Readable, T Value) TryReadAs<T>(object stored)
+        {
+            if (stored is T typed)
+            {
+                return (true, typed);
+            }
+
+            // Why treat null as a hit for reference T: Set stores null in the dictionary, and
+            // `is T` is false for null. Value types are boxed and never stored as null.
+            if (stored == null && !typeof(T).IsValueType)
+            {
+                return (true, default);
+            }
+
+            return (false, default);
+        }
+    }
+}

--- a/Packages/src/Editor/ToolContracts/HotReloadAddedFieldStore.cs.meta
+++ b/Packages/src/Editor/ToolContracts/HotReloadAddedFieldStore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7928fcc8831d44ca6a800010aa3bee39
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Added a side table that can hold values for fields that exist only in edited source, so the next hot-reload step can rewrite those accesses without putting Harmony or UnityEditor onto the shim compile.

## User Impact
- This PR does not change `uloop hot-reload` behavior yet. Added fields still fail until the follow-up rewrite PR.
- After that rewrite lands, instance values will follow each object and `--revert-all` (or a domain reload) will drop them.

## Changes
- New `HotReloadAddedFieldStore` in the ToolContracts assembly (`references: []`): `GetOrInit` / `Set` / `GetOrInitStatic` / `SetStatic` / `Clear`, with type-mismatch reinitialization.
- `Set<int?>(..., null)` then `GetOrInit<int?>` keeps the explicit null (does not re-run the initializer).
- `RevertAll` clears the store.
- Worker output flag `hasAddedFieldRewrites` (always false until rewrite) drives optional ToolContracts injection on the first shim compile and isolation retry, same pattern as Harmony. Injection skips when a same-filename assembly (including a publicized copy) is already on the list, so CS1703 cannot arise.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Success, 0 errors
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value HotReload` → 246/246 Passed
