### PR TITLE
feat: rewrite added-field accesses to the side table in the worker

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadAddedFieldApplyFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedFieldApplyFixture.cs
@@ -1,0 +1,28 @@
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled host for added-field apply E2E. Kept separate from HotReloadE2EFixture and
+    /// the added-method fixture so twelve-method patch suites cannot interfere with store state.
+    /// Static retainers keep instance identity across CLI execute-dynamic-code snippets so
+    /// re-apply can prove stored values survive.
+    /// </summary>
+    public class HotReloadAddedFieldApplyFixture
+    {
+        public static HotReloadAddedFieldApplyFixture RetainedA;
+
+        public static HotReloadAddedFieldApplyFixture RetainedB;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int ReadAdded()
+        {
+            return 0;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void WriteAdded(int value)
+        {
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedFieldApplyFixture.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedFieldApplyFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6aad17451ab1d4cd785acc9afd8cf243
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
@@ -112,6 +112,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     }
 
     /// <summary>
+    /// Compiled op_Increment struct so added-field ++ skip can target a real non-numeric type.
+    /// </summary>
+    public struct HotReloadAddedFieldCounter
+    {
+        public int Value;
+
+        public static HotReloadAddedFieldCounter operator ++(HotReloadAddedFieldCounter counter)
+        {
+            counter.Value += 1;
+            return counter;
+        }
+    }
+
+    /// <summary>
     /// Compiled MonoBehaviour host so Unity-message added-method warnings can be classified
     /// against a real compiled type rather than a throwaway uncompiled class.
     /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
@@ -97,6 +97,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     }
 
     /// <summary>
+    /// Compiled struct host so added-field tests can skip struct types against a real type.
+    /// GetOrInit boxes struct receivers and would reinitialize on every access.
+    /// </summary>
+    public struct HotReloadAddedFieldStructHost
+    {
+        public int Existing;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int ReadExisting()
+        {
+            return Existing;
+        }
+    }
+
+    /// <summary>
     /// Compiled MonoBehaviour host so Unity-message added-method warnings can be classified
     /// against a real compiled type rather than a throwaway uncompiled class.
     /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1943,6 +1943,43 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: adding a field and reading/writing it from edited bodies stores values per
+        /// instance, and a second apply keeps the stored values.
+        /// </summary>
+        [Test]
+        public async Task Run_AddedField_AppliesThroughStoreAndKeepsValuesOnReapply()
+        {
+            string fixturePath = ResolveAddedFieldApplyFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = WithAddedFieldAccesses(onDisk);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("AddedFieldApplyE2E.cs", edited),
+                CancellationToken.None);
+            AssertNoFileLevelFailure(first);
+            AssertHasPatched(first, nameof(HotReloadAddedFieldApplyFixture.ReadAdded));
+            AssertHasPatched(first, nameof(HotReloadAddedFieldApplyFixture.WriteAdded));
+
+            HotReloadAddedFieldApplyFixture firstHost = new HotReloadAddedFieldApplyFixture();
+            HotReloadAddedFieldApplyFixture secondHost = new HotReloadAddedFieldApplyFixture();
+            firstHost.WriteAdded(10);
+            secondHost.WriteAdded(20);
+            Assert.That(firstHost.ReadAdded(), Is.EqualTo(10));
+            Assert.That(secondHost.ReadAdded(), Is.EqualTo(20));
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("AddedFieldApplyE2EReapply.cs", edited),
+                CancellationToken.None);
+            AssertNoFileLevelFailure(second);
+            AssertHasPatched(second, nameof(HotReloadAddedFieldApplyFixture.ReadAdded));
+            Assert.That(firstHost.ReadAdded(), Is.EqualTo(10));
+            Assert.That(secondHost.ReadAdded(), Is.EqualTo(20));
+        }
+
+        /// <summary>
         /// What: re-applying without the added method clears that file's added-member ledger
         /// so --status cannot keep a method the source no longer declares.
         /// </summary>
@@ -2412,6 +2449,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "HotReloadAddedMethodApplyFixture.cs");
             Assert.That(File.Exists(path), Is.True, "Added-method apply fixture source missing: " + path);
             return Path.GetFullPath(path);
+        }
+
+        private static string ResolveAddedFieldApplyFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadAddedFieldApplyFixture.cs");
+            Assert.That(File.Exists(path), Is.True, "Added-field apply fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string WithAddedFieldAccesses(string onDisk)
+        {
+            return onDisk.Replace(
+                "        public int ReadAdded()\n        {\n            return 0;\n        }\n\n"
+                + "        [MethodImpl(MethodImplOptions.NoInlining)]\n"
+                + "        public void WriteAdded(int value)\n        {\n        }",
+                "        public int AddedCount;\n\n"
+                + "        [MethodImpl(MethodImplOptions.NoInlining)]\n"
+                + "        public int ReadAdded()\n        {\n            return AddedCount;\n        }\n\n"
+                + "        [MethodImpl(MethodImplOptions.NoInlining)]\n"
+                + "        public void WriteAdded(int value)\n        {\n            AddedCount = value;\n        }",
+                StringComparison.Ordinal);
         }
 
         private static string ResolveAddedMemberHostPath()

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -252,11 +252,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: an added field initializer that touches a private member skips referencing
-        /// methods so the initializer lambda cannot throw FieldAccessException at runtime.
+        /// What: an added field initializer that touches a host instance member skips, including
+        /// private fields, because the static shim lambda cannot bind those names.
         /// </summary>
         [Test]
-        public async Task Skip_PrivateInitializer_UsesInaccessibleReason()
+        public async Task Skip_PrivateInitializer_UsesLiteralOrExternalStaticReason()
         {
             string onDisk = File.ReadAllText(ResolveHostPath());
             string edited = WithHostMembers(onDisk, "public int AddedFromPrivate = _privateSeed;");
@@ -271,8 +271,62 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HostProjectRelativePath,
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "inaccessible");
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "literal or externally visible static");
             Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
+        }
+
+        /// <summary>
+        /// What: an added field initializer that reads a public instance field of the host is
+        /// skipped; the shim is a different static class so the name would be CS0103.
+        /// </summary>
+        [Test]
+        public async Task Skip_PublicInstanceInitializer_UsesLiteralOrExternalStaticReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public int AddedFromPublic = PublicSeed + 1;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return AddedFromPublic + value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldPublicInit.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "literal or externally visible static");
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
+        }
+
+        /// <summary>
+        /// What: an initializer that only uses a literal and an externally visible static API
+        /// still rewrites to GetOrInit with a static lambda.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_ExternalStaticInitializer_EmitsStaticLambda()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public int AddedFromStatic = Math.Abs(-4);");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return AddedFromStatic + value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldStaticInit.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null);
+            string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(slice, Does.Contain("GetOrInit<"));
+            Assert.That(slice, Does.Contain("static () =>"));
+            Assert.That(slice, Does.Contain("Abs"));
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
         }
 
         /// <summary>
@@ -320,11 +374,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: assigning through a receiver that may have side effects skips so Get and Set
-        /// do not evaluate it twice.
+        /// What: compound assignment through a receiver that may have side effects skips so
+        /// Get and Set do not evaluate it twice.
         /// </summary>
         [Test]
         public async Task Skip_DoubleEvalReceiver_UsesDedicatedReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public int AddedCount;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            Get().AddedCount += value;\n            return value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldDoubleEval.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "side effects");
+        }
+
+        /// <summary>
+        /// What: a simple assignment through a side-effect receiver still rewrites because Set
+        /// evaluates the receiver once.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_SimpleAssignmentSideEffectReceiver_DoesNotSkip()
         {
             string onDisk = File.ReadAllText(ResolveHostPath());
             string edited = WithHostMembers(onDisk, "public int AddedCount;");
@@ -335,11 +412,46 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 StringComparison.Ordinal);
 
             TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
-                WriteEdited("AddedFieldDoubleEval.cs", edited),
+                WriteEdited("AddedFieldSimpleAssignReceiver.cs", edited),
                 HostProjectRelativePath,
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "side effects");
+
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null);
+            string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(slice, Does.Contain("Set<"));
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
+        }
+
+        /// <summary>
+        /// What: byte += and ++ emit a cast back to byte so the Set call matches compound
+        /// conversion and does not pass an int argument.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_ByteCompoundAndIncrement_CastsToByte()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public byte AddedByte;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            AddedByte += 1;\n            AddedByte++;\n            return AddedByte;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldByteCompound.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null);
+            string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(slice, Does.Contain("Set<"));
+            Assert.That(slice, Does.Contain("GetOrInit<"));
+            Assert.That(slice, Does.Contain("(byte)("));
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
         }
 
         /// <summary>
@@ -391,6 +503,177 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "struct");
             Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
+        }
+
+        /// <summary>
+        /// What: an added const on a struct host still folds to a literal because const folding
+        /// does not use the instance store.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_AddedConstOnStructHost_FoldsToLiteral()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int Existing;\n",
+                "        public int Existing;\n\n        public const int AddedConst = 4;\n",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return HotReloadAddedFieldStructHost.AddedConst + value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedConstOnStruct.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null);
+            string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(slice, Does.Contain("4"));
+            Assert.That(slice, Does.Not.Contain("HotReloadAddedFieldStore"));
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
+        }
+
+        /// <summary>
+        /// What: ++ on an added field whose type has op_Increment but is not a numeric primitive
+        /// or enum skips so the rewrite does not emit a broken + 1.
+        /// </summary>
+        [Test]
+        public async Task Skip_NonNumericIncrement_UsesDedicatedReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public HotReloadAddedFieldCounter AddedCounter;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            AddedCounter++;\n            return value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldNonNumericIncrement.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "numeric");
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
+        }
+
+        /// <summary>
+        /// What: an added field whose type is a private nested type skips because GetOrInit&lt;T&gt;
+        /// would be CS0122 in the shim.
+        /// </summary>
+        [Test]
+        public async Task Skip_PrivateFieldType_UsesDedicatedReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "private class HiddenBox { }\n        public HiddenBox AddedHidden;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return AddedHidden == null ? value : value + 1;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldPrivateType.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "not visible");
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
+        }
+
+        /// <summary>
+        /// What: a non-finite added const cannot be emitted as a C# literal, so referencing
+        /// methods skip.
+        /// </summary>
+        [Test]
+        public async Task Skip_NonFiniteAddedConst_UsesUnavailableReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public const double AddedNaN = double.NaN;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return double.IsNaN(AddedNaN) ? value : 0;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedConstNaN.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "cannot emit");
+        }
+
+        /// <summary>
+        /// What: editing an existing field initializer still fires outside-body drift even when
+        /// an added field in the same file is stripped from the comparison.
+        /// </summary>
+        [Test]
+        public async Task Drift_ExistingInitializerEditWithAddedField_StillWarns()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public int AddedCount;");
+            edited = edited.Replace(
+                "        public int PublicSeed = 3;",
+                "        public int PublicSeed = 99;",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return AddedCount + value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldWithInitializerDrift.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            bool foundDrift = false;
+            foreach (string warning in result.Output.declarationDriftWarnings)
+            {
+                if (warning != null && warning.Contains("Edits outside method bodies"))
+                {
+                    foundDrift = true;
+                }
+            }
+
+            Assert.That(foundDrift, Is.True, "Existing field initializer edits must still warn.");
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
+        }
+
+        /// <summary>
+        /// What: a readonly added field can still be read through GetOrInit.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_ReadonlyAddedField_ReadsThroughStore()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public readonly int AddedReadOnly = 5;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return AddedReadOnly + value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldReadonly.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null);
+            string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(slice, Does.Contain("GetOrInit<"));
+            Assert.That(slice, Does.Contain("static () =>"));
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -1,0 +1,648 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Worker coverage for added/removed field classification, store rewrite, const folding,
+    /// initializer visibility skip, and added-field skip/warning reasons.
+    /// </summary>
+    public class TransformWorkerAddedFieldTests
+    {
+        private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+        private const string HostProjectRelativePath =
+            "Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs";
+
+        private const string HostCloseMarker =
+            "        public int ReadPrivateSeed()\n        {\n            return _privateSeed;\n        }\n    }";
+
+        private const string ExistingCallerOriginal =
+            "        public int ExistingCaller(int value)\n        {\n            return value;\n        }";
+
+        /// <summary>
+        /// What: a field present only in the edited source is rewritten to the store, an existing
+        /// field stays a real field access, and a snapshot-only field is reported removed.
+        /// </summary>
+        [Test]
+        public async Task Classify_AddedExistingAndRemovedFields_MatchCompiledAssemblyGroundTruth()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public int AddedCount;");
+            edited = edited.Replace(
+                "        public HotReloadAddedMemberHost Inner;\n\n",
+                string.Empty,
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return PublicSeed + AddedCount + value;\n        }",
+                StringComparison.Ordinal);
+            string sourcePath = WriteEdited("ClassifyAddedExistingRemovedFields.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null);
+            string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(slice, Does.Contain("HotReloadAddedFieldStore"));
+            Assert.That(slice, Does.Contain("::AddedCount"));
+            Assert.That(slice, Does.Contain("PublicSeed"));
+            Assert.That(slice, Does.Not.Contain("::PublicSeed"));
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
+
+            bool foundRemoved = false;
+            foreach (TransformWorkerRemovedMemberDto removed in result.Output.removedMembers)
+            {
+                if (removed.kind == HotReloadConstants.RemovedMemberKindField
+                    && removed.name == nameof(HotReloadAddedMemberHost.Inner))
+                {
+                    foundRemoved = true;
+                }
+            }
+
+            Assert.That(foundRemoved, Is.True, "Inner must be reported as a removed field.");
+        }
+
+        /// <summary>
+        /// What: uses of an added const fold to a value literal so the shim does not need the
+        /// missing const member, and the store flag stays false.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_AddedConst_FoldsToLiteralWithoutStoreFlag()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public const int AddedConst = 4;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return AddedConst + value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedConstFold.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null);
+            string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(slice, Does.Contain("4"));
+            Assert.That(slice, Does.Not.Contain("HotReloadAddedFieldStore"));
+            Assert.That(slice, Does.Not.Contain("AddedConst"));
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
+        }
+
+        /// <summary>
+        /// What: nameof(added field) folds to the field name string, including added consts.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_NameofAddedField_FoldsToStringLiteral()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public int AddedCount;\n        public const int AddedConst = 4;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return nameof(AddedCount).Length + nameof(AddedConst).Length + value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("NameofAddedField.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null);
+            string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(slice, Does.Contain("\"AddedCount\""));
+            Assert.That(slice, Does.Contain("\"AddedConst\""));
+            Assert.That(slice, Does.Not.Contain("nameof("));
+        }
+
+        /// <summary>
+        /// What: added-field reads and writes emit GetOrInit/Set, and an initializer becomes a
+        /// static lambda on the GetOrInit call.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_AddedFieldReadWriteAndInitializer_UsesStoreAndStaticLambda()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public int AddedCount = 5;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            AddedCount = value;\n            return AddedCount;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldReadWrite.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null);
+            string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(slice, Does.Contain("GetOrInit<"));
+            Assert.That(slice, Does.Contain("Set<"));
+            Assert.That(slice, Does.Contain("static () =>"));
+            Assert.That(slice, Does.Contain("5"));
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
+        }
+
+        /// <summary>
+        /// What: static added fields use GetOrInitStatic/SetStatic instead of the instance store.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_AddedStaticField_UsesStaticStore()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public static int AddedStatic;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            AddedStatic = value;\n            return AddedStatic;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedStaticField.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null);
+            string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(slice, Does.Contain("GetOrInitStatic<"));
+            Assert.That(slice, Does.Contain("SetStatic<"));
+            Assert.That(slice, Does.Not.Contain("GetOrInit<"));
+        }
+
+        /// <summary>
+        /// What: compound assignment and increment on an added field expand to Get then Set.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_CompoundAndIncrement_ExpandToGetThenSet()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public int AddedCount;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            AddedCount += value;\n            AddedCount++;\n            ++AddedCount;\n"
+                + "            return AddedCount;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldCompound.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null);
+            string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(slice, Does.Contain("GetOrInit<"));
+            Assert.That(slice, Does.Contain("Set<"));
+            Assert.That(slice, Does.Contain("+ value"));
+            Assert.That(slice, Does.Contain("+ 1"));
+        }
+
+        /// <summary>
+        /// What: adding a field without other outside-body edits does not fire the drift warning
+        /// because handled added field declarations are stripped before comparison.
+        /// </summary>
+        [Test]
+        public async Task Drift_AddedFieldOnly_DoesNotFireOutsideBodyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public int AddedCount;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return AddedCount + value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldNoDrift.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.declarationDriftWarnings, Is.Empty);
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
+        }
+
+        /// <summary>
+        /// What: an added field initializer that touches a private member skips referencing
+        /// methods so the initializer lambda cannot throw FieldAccessException at runtime.
+        /// </summary>
+        [Test]
+        public async Task Skip_PrivateInitializer_UsesInaccessibleReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public int AddedFromPrivate = _privateSeed;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return AddedFromPrivate + value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldPrivateInit.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "inaccessible");
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
+        }
+
+        /// <summary>
+        /// What: passing an added field by ref, out, or in skips the referencing method.
+        /// </summary>
+        [Test]
+        public async Task Skip_RefOutInAddedField_UsesDedicatedReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public int AddedCount;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            int.TryParse(\"1\", out AddedCount);\n            return AddedCount + value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldRef.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "ref, out, or in");
+        }
+
+        /// <summary>
+        /// What: a compound assignment whose value is consumed skips, because Set returns void.
+        /// </summary>
+        [Test]
+        public async Task Skip_ConsumedCompoundAssignment_UsesDedicatedReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public int AddedCount;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            int consumed = AddedCount += value;\n            return consumed;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldConsumed.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "consumed");
+        }
+
+        /// <summary>
+        /// What: assigning through a receiver that may have side effects skips so Get and Set
+        /// do not evaluate it twice.
+        /// </summary>
+        [Test]
+        public async Task Skip_DoubleEvalReceiver_UsesDedicatedReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public int AddedCount;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            Get().AddedCount = value;\n            return value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldDoubleEval.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "side effects");
+        }
+
+        /// <summary>
+        /// What: writing a member of an added value-type field skips because GetOrInit returns
+        /// a copy, so the write would not persist.
+        /// </summary>
+        [Test]
+        public async Task Skip_ValueTypeAddedFieldMemberWrite_UsesDedicatedReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public HotReloadAddedFieldStructHost AddedValue;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            AddedValue.Existing = value;\n            return AddedValue.Existing;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldN2.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "value-type");
+        }
+
+        /// <summary>
+        /// What: added fields on a compiled struct type skip referencing methods because the
+        /// store cannot keep identity without boxing.
+        /// </summary>
+        [Test]
+        public async Task Skip_StructHostAddedField_UsesDedicatedReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int Existing;\n",
+                "        public int Existing;\n\n        public int Added;\n",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            HotReloadAddedFieldStructHost local = default;\n"
+                + "            return local.Added + value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldStructHost.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "struct");
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
+        }
+
+        /// <summary>
+        /// What: a [SerializeField] added field still rewrites to the store and emits an
+        /// Inspector/serialization warning.
+        /// </summary>
+        [Test]
+        public async Task Warning_SerializeField_StillRewrites()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "[SerializeField] public int AddedSerialized;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            AddedSerialized = value;\n            return AddedSerialized;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldSerialize.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null);
+            string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(slice, Does.Contain("HotReloadAddedFieldStore"));
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
+
+            bool foundWarning = false;
+            foreach (string warning in result.Output.declarationDriftWarnings)
+            {
+                if (warning != null
+                    && warning.Contains("AddedSerialized")
+                    && warning.Contains("Inspector"))
+                {
+                    foundWarning = true;
+                }
+            }
+
+            Assert.That(foundWarning, Is.True, "SerializeField added fields must warn about Inspector visibility.");
+        }
+
+        private static async Task<TransformWorkerClientResult> RunWorkerOnSourceAsync(
+            string sourcePath,
+            string projectRelativePath,
+            string snapshotSource = null)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string targetDllPath = Path.Combine(
+                projectRoot,
+                "Library",
+                "ScriptAssemblies",
+                TestAssemblyName + ".dll");
+            Assert.That(File.Exists(targetDllPath), Is.True, "Test assembly dll missing: " + targetDllPath);
+
+            UnityEditor.Compilation.Assembly compilationAssembly = null;
+            foreach (UnityEditor.Compilation.Assembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name == TestAssemblyName)
+                {
+                    compilationAssembly = assembly;
+                    break;
+                }
+            }
+
+            Assert.That(compilationAssembly, Is.Not.Null, "CompilationPipeline assembly not found.");
+
+            TransformWorkerInputDto input = new TransformWorkerInputDto
+            {
+                sourcePath = sourcePath,
+                defines = compilationAssembly.defines ?? Array.Empty<string>(),
+                referencePaths = BuildAbsoluteReferencePaths(
+                    compilationAssembly.allReferences,
+                    targetDllPath),
+                targetTypesAssemblyPath = targetDllPath,
+                snapshotSource = snapshotSource,
+                projectRelativePath = projectRelativePath,
+                assemblySourcePaths = BuildAbsoluteAssemblySourcePaths(compilationAssembly.sourceFiles),
+                excludedMethodKeys = Array.Empty<string>(),
+                excludedAddedMethodKeys = Array.Empty<string>()
+            };
+
+            return await TransformWorkerClient.RunAsync(input, CancellationToken.None);
+        }
+
+        private static string[] BuildAbsoluteReferencePaths(string[] allReferences, string targetDllPath)
+        {
+            List<string> paths = new List<string>();
+            if (allReferences != null)
+            {
+                foreach (string reference in allReferences)
+                {
+                    if (string.IsNullOrEmpty(reference) || !File.Exists(reference))
+                    {
+                        continue;
+                    }
+
+                    paths.Add(Path.GetFullPath(reference));
+                }
+            }
+
+            string fullTarget = Path.GetFullPath(targetDllPath);
+            bool hasTarget = false;
+            foreach (string path in paths)
+            {
+                if (string.Equals(path, fullTarget, StringComparison.OrdinalIgnoreCase))
+                {
+                    hasTarget = true;
+                    break;
+                }
+            }
+
+            if (!hasTarget)
+            {
+                paths.Add(fullTarget);
+            }
+
+            return paths.ToArray();
+        }
+
+        private static string[] BuildAbsoluteAssemblySourcePaths(string[] sourceFiles)
+        {
+            if (sourceFiles == null || sourceFiles.Length == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string[] paths = new string[sourceFiles.Length];
+            for (int index = 0; index < sourceFiles.Length; index++)
+            {
+                string normalizedRelativePath = sourceFiles[index].Replace('\\', '/');
+                string absoluteSourcePath = Path.Combine(
+                    projectRoot,
+                    normalizedRelativePath.Replace('/', Path.DirectorySeparatorChar));
+                paths[index] = Path.GetFullPath(absoluteSourcePath);
+            }
+
+            return paths;
+        }
+
+        private static string WithHostMembers(string onDisk, string extraMembers)
+        {
+            Assert.That(onDisk, Does.Contain(HostCloseMarker));
+            return onDisk.Replace(
+                HostCloseMarker,
+                "        public int ReadPrivateSeed()\n        {\n            return _privateSeed;\n        }\n\n        "
+                + extraMembers
+                + "\n    }",
+                StringComparison.Ordinal);
+        }
+
+        private static TransformWorkerEntryDto FindEntry(TransformWorkerClientResult result, string methodName)
+        {
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                if (entry.methodName == methodName)
+                {
+                    return entry;
+                }
+            }
+
+            return null;
+        }
+
+        private static void AssertHasSkip(
+            TransformWorkerClientResult result,
+            string methodNameFragment,
+            string reasonFragment)
+        {
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                if (skipped.method != null
+                    && skipped.method.Contains(methodNameFragment)
+                    && skipped.reason != null
+                    && skipped.reason.Contains(reasonFragment))
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail(
+                "Expected skip for '" + methodNameFragment + "' with reason containing '"
+                + reasonFragment + "'. Skipped="
+                + FormatSkipped(result.Output.skipped));
+        }
+
+        private static string FormatSkipped(TransformWorkerSkippedDto[] skipped)
+        {
+            if (skipped == null || skipped.Length == 0)
+            {
+                return "(none)";
+            }
+
+            List<string> rows = new List<string>();
+            foreach (TransformWorkerSkippedDto entry in skipped)
+            {
+                rows.Add(entry.method + " :: " + entry.reason);
+            }
+
+            return string.Join("\n", rows);
+        }
+
+        private static string SliceShimMethod(string shimSource, string shimMethodName)
+        {
+            int nameIndex = shimSource.IndexOf(shimMethodName, StringComparison.Ordinal);
+            Assert.That(nameIndex, Is.GreaterThanOrEqualTo(0), "Shim method missing: " + shimMethodName);
+            int declarationStart = shimSource.LastIndexOf("public static", nameIndex, StringComparison.Ordinal);
+            int openBrace = shimSource.IndexOf('{', nameIndex);
+            Assert.That(openBrace, Is.GreaterThan(0));
+            int depth = 0;
+            for (int index = openBrace; index < shimSource.Length; index++)
+            {
+                if (shimSource[index] == '{')
+                {
+                    depth++;
+                }
+                else if (shimSource[index] == '}')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        return shimSource.Substring(declarationStart, index - declarationStart + 1);
+                    }
+                }
+            }
+
+            Assert.Fail("Unbalanced shim method: " + shimMethodName);
+            return string.Empty;
+        }
+
+        private static string WriteEdited(string fileName, string contents)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string path = Path.Combine(directory, fileName);
+            File.WriteAllText(path, contents);
+            return path;
+        }
+
+        private static string ResolveHostPath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadAddedMemberHost.cs");
+            Assert.That(File.Exists(path), Is.True, "Added-member host source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f79c111cb2e244e888a1f06a6d75c5b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -65,8 +65,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             + "Run 'uloop compile'.";
 
         // Wire value for TransformWorkerRemovedMemberDto.kind.
-        // Keep in sync with RemovedMemberKinds.Method in TransformWorker~/TransformWorker.cs.
+        // Keep in sync with RemovedMemberKinds in TransformWorker~/TransformWorker.cs.
         public const string RemovedMemberKindMethod = "method";
+
+        public const string RemovedMemberKindField = "field";
 
         // Format: comma-separated removed member names.
         public const string RemovedMembersWarningFormat =

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -301,6 +301,7 @@ public static class TransformWorkerProgram
         List<UsingDirectiveSyntax> assemblyGlobalUsings =
             CollectAssemblyGlobalUsings(input, parseOptions);
         AddedMethodCatalog addedMethodCatalog = new AddedMethodCatalog();
+        AddedFieldCatalog addedFieldCatalog = new AddedFieldCatalog();
         List<TypeEmitState> typeEmitStates = new List<TypeEmitState>();
 
         foreach (TypeDeclarationSyntax typeDeclaration in EnumerateTypeDeclarations(root))
@@ -343,6 +344,7 @@ public static class TransformWorkerProgram
                 assemblyGlobalUsings,
                 shimTypes,
                 addedMethodCatalog,
+                addedFieldCatalog,
                 skipped,
                 unchangedMethods,
                 declarationDriftWarnings,
@@ -360,24 +362,38 @@ public static class TransformWorkerProgram
                 plainCurrentMethodMap,
                 addedMethodCatalog,
                 removedMembers);
+            Dictionary<string, VariableDeclaratorSyntax> snapshotFieldMap =
+                BuildSyntaxFieldMapOrNull(baselineSnapshotRoot);
+            Dictionary<string, VariableDeclaratorSyntax> currentFieldMap =
+                BuildSyntaxFieldMapOrNull(plainRoot);
+            if (snapshotFieldMap != null && currentFieldMap != null)
+            {
+                CollectRemovedFields(
+                    snapshotFieldMap,
+                    currentFieldMap,
+                    addedFieldCatalog,
+                    removedMembers);
+            }
         }
 
         SkipBodiesThatCannotUseAddedMethods(
             typeEmitStates,
             semanticModel,
             addedMethodCatalog,
+            addedFieldCatalog,
             skipped);
 
         if (hasBaseline && baselineSnapshotRoot != null)
         {
-            // Why after classification: added/removed method declarations must be stripped
-            // before AreEquivalent, or every method addition would fire "not applied".
+            // Why after classification: added/removed method and field declarations must be
+            // stripped before AreEquivalent, or every addition would fire "not applied".
             AppendOutsideMethodBodyDriftWarningIfNeeded(
                 baselineSnapshotRoot,
                 plainRoot,
                 Path.GetFileName(input.SourcePath),
                 declarationDriftWarnings,
-                addedMethodCatalog);
+                addedMethodCatalog,
+                addedFieldCatalog);
         }
 
         foreach (TypeEmitState typeState in typeEmitStates)
@@ -386,6 +402,7 @@ public static class TransformWorkerProgram
                 typeState,
                 semanticModel,
                 addedMethodCatalog,
+                addedFieldCatalog,
                 entries);
             foreach (PropertyDeclarationSyntax propertyDeclaration in typeState.TypeDeclaration.Members
                 .OfType<PropertyDeclarationSyntax>())
@@ -419,7 +436,8 @@ public static class TransformWorkerProgram
                         globalShimMethodCounter,
                         typeState.CurrentShimType,
                         assemblyGlobalUsings,
-                        addedMethodCatalog);
+                        addedMethodCatalog,
+                        addedFieldCatalog);
                 typeState.CurrentShimType = nextShimType;
                 shimTypeCounter = nextShimTypeCounter;
                 globalShimMethodCounter = nextGlobalShimMethodCounter;
@@ -448,7 +466,7 @@ public static class TransformWorkerProgram
             BaselineDisabledByDuplicateKeys = baselineDisabledByDuplicateKeys,
             RemovedMembers = removedMembers.ToArray(),
             HasAccessorDelegates = hasAccessorDelegates,
-            HasAddedFieldRewrites = false
+            HasAddedFieldRewrites = addedFieldCatalog.HasStoreRewrites
         };
     }
 
@@ -756,6 +774,12 @@ public static class TransformWorkerProgram
             + string.Join(",", parameterKeys) + ")";
     }
 
+    // Keep in sync with HotReloadAddedFieldStore.FormatFieldKey / FieldKeySeparator.
+    private static string BuildSyntaxFieldKey(string typeMetadataName, string fieldName)
+    {
+        return typeMetadataName + TransformWorkerProgramMarker.AddedFieldKeySeparator + fieldName;
+    }
+
     private static string BuildSyntaxParameterTypeKey(ParameterSyntax parameter)
     {
         // Why NormalizeWhitespace: trivia / spacing differences must not invent distinct keys.
@@ -884,6 +908,33 @@ public static class TransformWorkerProgram
         return map;
     }
 
+    private static Dictionary<string, VariableDeclaratorSyntax> BuildSyntaxFieldMapOrNull(
+        CompilationUnitSyntax root)
+    {
+        Dictionary<string, VariableDeclaratorSyntax> map =
+            new Dictionary<string, VariableDeclaratorSyntax>(StringComparer.Ordinal);
+        foreach (TypeDeclarationSyntax typeDeclaration in EnumerateTypeDeclarations(root))
+        {
+            string typeMetadataName = BuildTypeMetadataNameFromSyntax(typeDeclaration);
+            foreach (FieldDeclarationSyntax fieldDeclaration in typeDeclaration.Members
+                .OfType<FieldDeclarationSyntax>())
+            {
+                foreach (VariableDeclaratorSyntax variable in fieldDeclaration.Declaration.Variables)
+                {
+                    string key = BuildSyntaxFieldKey(typeMetadataName, variable.Identifier.Text);
+                    if (map.ContainsKey(key))
+                    {
+                        return null;
+                    }
+
+                    map[key] = variable;
+                }
+            }
+        }
+
+        return map;
+    }
+
     private static Dictionary<string, PropertyDeclarationSyntax> BuildSyntaxPropertyMapOrNull(
         CompilationUnitSyntax root)
     {
@@ -933,15 +984,32 @@ public static class TransformWorkerProgram
         CompilationUnitSyntax currentRoot,
         string fileName,
         List<string> declarationDriftWarnings,
-        AddedMethodCatalog addedMethodCatalog)
+        AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog)
     {
-        StripHandledMethodDeclarationsRewriter stripSnapshot =
-            new StripHandledMethodDeclarationsRewriter(
-                addedMethodCatalog.RemovedSyntaxKeys,
+        HashSet<string> snapshotKeys = new HashSet<string>(
+            addedMethodCatalog.RemovedSyntaxKeys,
+            StringComparer.Ordinal);
+        foreach (string key in addedFieldCatalog.RemovedSyntaxKeys)
+        {
+            snapshotKeys.Add(key);
+        }
+
+        HashSet<string> currentKeys = new HashSet<string>(
+            addedMethodCatalog.AddedSyntaxKeys,
+            StringComparer.Ordinal);
+        foreach (string key in addedFieldCatalog.AddedSyntaxKeys)
+        {
+            currentKeys.Add(key);
+        }
+
+        StripHandledMemberDeclarationsRewriter stripSnapshot =
+            new StripHandledMemberDeclarationsRewriter(
+                snapshotKeys,
                 Array.Empty<string>());
-        StripHandledMethodDeclarationsRewriter stripCurrent =
-            new StripHandledMethodDeclarationsRewriter(
-                addedMethodCatalog.AddedSyntaxKeys,
+        StripHandledMemberDeclarationsRewriter stripCurrent =
+            new StripHandledMemberDeclarationsRewriter(
+                currentKeys,
                 addedMethodCatalog.AddedTypeSyntaxKeys);
         StripMethodBodiesRewriter bodyStripper = new StripMethodBodiesRewriter();
         SyntaxNode strippedSnapshot = bodyStripper.Visit(stripSnapshot.Visit(snapshotRoot));
@@ -953,12 +1021,12 @@ public static class TransformWorkerProgram
         }
     }
 
-    private sealed class StripHandledMethodDeclarationsRewriter : CSharpSyntaxRewriter
+    private sealed class StripHandledMemberDeclarationsRewriter : CSharpSyntaxRewriter
     {
         private readonly HashSet<string> _syntaxKeysToStrip;
         private readonly HashSet<string> _typeSyntaxKeysToStrip;
 
-        public StripHandledMethodDeclarationsRewriter(
+        public StripHandledMemberDeclarationsRewriter(
             IReadOnlyCollection<string> syntaxKeysToStrip,
             IReadOnlyCollection<string> typeSyntaxKeysToStrip)
         {
@@ -1030,6 +1098,39 @@ public static class TransformWorkerProgram
             }
 
             return base.VisitMethodDeclaration(node);
+        }
+
+        public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)
+        {
+            TypeDeclarationSyntax typeDeclaration = node.Parent as TypeDeclarationSyntax;
+            if (typeDeclaration == null)
+            {
+                return base.VisitFieldDeclaration(node);
+            }
+
+            string typeMetadataName = BuildTypeMetadataNameFromSyntax(typeDeclaration);
+            List<VariableDeclaratorSyntax> remaining = new List<VariableDeclaratorSyntax>();
+            foreach (VariableDeclaratorSyntax variable in node.Declaration.Variables)
+            {
+                string syntaxKey = BuildSyntaxFieldKey(typeMetadataName, variable.Identifier.Text);
+                if (!_syntaxKeysToStrip.Contains(syntaxKey))
+                {
+                    remaining.Add(variable);
+                }
+            }
+
+            if (remaining.Count == 0)
+            {
+                return null;
+            }
+
+            if (remaining.Count == node.Declaration.Variables.Count)
+            {
+                return base.VisitFieldDeclaration(node);
+            }
+
+            return node.WithDeclaration(
+                node.Declaration.WithVariables(SyntaxFactory.SeparatedList(remaining)));
         }
     }
 
@@ -1336,7 +1437,8 @@ public static class TransformWorkerProgram
             int globalShimMethodCounter,
             ShimTypeBuilder currentShimType,
             List<UsingDirectiveSyntax> assemblyGlobalUsings,
-            AddedMethodCatalog addedMethodCatalog)
+            AddedMethodCatalog addedMethodCatalog,
+            AddedFieldCatalog addedFieldCatalog)
     {
         IPropertySymbol propertySymbol = semanticModel.GetDeclaredSymbol(propertyDeclaration);
         if (propertySymbol == null || propertySymbol.GetMethod == null)
@@ -1417,7 +1519,8 @@ public static class TransformWorkerProgram
         string addedCallSiteSkip = EvaluateAddedCallSiteSkipReason(
             getterBodyNode,
             semanticModel,
-            addedMethodCatalog);
+            addedMethodCatalog,
+            addedFieldCatalog);
         if (addedCallSiteSkip != null)
         {
             skipped.Add(new WorkerSkipped
@@ -1460,7 +1563,8 @@ public static class TransformWorkerProgram
             typeSymbol,
             semanticModel,
             rewritePlan,
-            addedMethodCatalog);
+            addedMethodCatalog,
+            addedFieldCatalog);
         currentShimType.AddMethod(rewrittenMethod, shimMethodName);
 
         entries.Add(new WorkerEntry
@@ -1561,13 +1665,15 @@ public static class TransformWorkerProgram
         INamedTypeSymbol targetType,
         SemanticModel semanticModel,
         AccessorPlan accessorPlan,
-        AddedMethodCatalog addedMethodCatalog)
+        AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog)
     {
         ShimBodyRewriter rewriter = new ShimBodyRewriter(
             semanticModel,
             targetType,
             accessorPlan,
-            addedMethodCatalog);
+            addedMethodCatalog,
+            addedFieldCatalog);
         SyntaxNode rewrittenBody = rewriter.Visit(getterBodyNode);
         // Why transfer: Visit may rebuild ArrowExpressionClause nodes and drop #line annotations.
         rewrittenBody = TransferUloopLineAnnotations(getterBodyNode, rewrittenBody);
@@ -2125,6 +2231,7 @@ public static class TransformWorkerProgram
         List<UsingDirectiveSyntax> assemblyGlobalUsings,
         List<ShimTypeBuilder> shimTypes,
         AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog,
         List<WorkerSkipped> skipped,
         List<WorkerUnchangedMethod> unchangedMethods,
         List<string> declarationDriftWarnings,
@@ -2137,6 +2244,13 @@ public static class TransformWorkerProgram
             SkipAllMethodsOnUncompiledType(typeState, semanticModel, skipped, addedMethodCatalog);
             return (shimTypeCounter, globalShimMethodCounter);
         }
+
+        ClassifyAddedFields(
+            typeState,
+            semanticModel,
+            compiledType,
+            addedFieldCatalog,
+            declarationDriftWarnings);
 
         foreach (MethodDeclarationSyntax methodDeclaration in typeState.TypeDeclaration.Members
             .OfType<MethodDeclarationSyntax>())
@@ -2335,6 +2449,7 @@ public static class TransformWorkerProgram
         TypeEmitState typeState,
         SemanticModel semanticModel,
         AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog,
         List<WorkerEntry> entries)
     {
         foreach (QueuedShimMethod queued in typeState.QueuedMethods)
@@ -2348,7 +2463,8 @@ public static class TransformWorkerProgram
                 typeState.TypeSymbol,
                 semanticModel,
                 rewritePlan,
-                addedMethodCatalog);
+                addedMethodCatalog,
+                addedFieldCatalog);
             queued.ShimType.AddMethod(rewrittenMethod, queued.ShimMethodName);
 
             SyntaxNode bodyNode =
@@ -2392,7 +2508,7 @@ public static class TransformWorkerProgram
                 continue;
             }
 
-            addedMethodCatalog.AddRemovedSyntaxKey(pair.Key);
+                addedMethodCatalog.AddRemovedSyntaxKey(pair.Key);
             string name = pair.Value.Identifier.Text;
             if (!seenNames.Add(name))
             {
@@ -2402,6 +2518,35 @@ public static class TransformWorkerProgram
             removedMembers.Add(new WorkerRemovedMember
             {
                 Kind = RemovedMemberKinds.Method,
+                Name = name
+            });
+        }
+    }
+
+    private static void CollectRemovedFields(
+        Dictionary<string, VariableDeclaratorSyntax> snapshotFieldMap,
+        Dictionary<string, VariableDeclaratorSyntax> plainCurrentFieldMap,
+        AddedFieldCatalog addedFieldCatalog,
+        List<WorkerRemovedMember> removedMembers)
+    {
+        HashSet<string> seenNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (KeyValuePair<string, VariableDeclaratorSyntax> pair in snapshotFieldMap)
+        {
+            if (plainCurrentFieldMap.ContainsKey(pair.Key))
+            {
+                continue;
+            }
+
+            addedFieldCatalog.AddRemovedSyntaxKey(pair.Key);
+            string name = pair.Value.Identifier.Text;
+            if (!seenNames.Add(name))
+            {
+                continue;
+            }
+
+            removedMembers.Add(new WorkerRemovedMember
+            {
+                Kind = RemovedMemberKinds.Field,
                 Name = name
             });
         }
@@ -2461,6 +2606,7 @@ public static class TransformWorkerProgram
         List<TypeEmitState> typeEmitStates,
         SemanticModel semanticModel,
         AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog,
         List<WorkerSkipped> skipped)
     {
         bool progressed;
@@ -2477,7 +2623,8 @@ public static class TransformWorkerProgram
                     string skipReason = EvaluateAddedCallSiteSkipReason(
                         bodyNode,
                         semanticModel,
-                        addedMethodCatalog);
+                        addedMethodCatalog,
+                        addedFieldCatalog);
                     if (skipReason != null)
                     {
                         skipped.Add(new WorkerSkipped
@@ -2507,7 +2654,8 @@ public static class TransformWorkerProgram
     private static string EvaluateAddedCallSiteSkipReason(
         SyntaxNode bodyNode,
         SemanticModel semanticModel,
-        AddedMethodCatalog addedMethodCatalog)
+        AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog)
     {
         if (bodyNode == null)
         {
@@ -2549,7 +2697,7 @@ public static class TransformWorkerProgram
             return AddedMethodSkipReasons.MethodGroupReference;
         }
 
-        return null;
+        return EvaluateAddedFieldSkipReason(bodyNode, semanticModel, addedFieldCatalog);
     }
 
     private static bool BodyReferencesAddedMethodGroup(
@@ -2780,6 +2928,619 @@ public static class TransformWorkerProgram
         return false;
     }
 
+    private static bool CompiledTypeHasField(INamedTypeSymbol compiledType, IFieldSymbol sourceField)
+    {
+        foreach (ISymbol member in compiledType.GetMembers(sourceField.Name))
+        {
+            if (member is IFieldSymbol compiledField
+                && compiledField.IsStatic == sourceField.IsStatic
+                && compiledField.IsConst == sourceField.IsConst)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// What: classifies source fields missing from the compiled type as added, and records
+    /// store/const/unavailable bindings used by skip evaluation and body rewrite.
+    /// </summary>
+    private static void ClassifyAddedFields(
+        TypeEmitState typeState,
+        SemanticModel semanticModel,
+        INamedTypeSymbol compiledType,
+        AddedFieldCatalog addedFieldCatalog,
+        List<string> declarationDriftWarnings)
+    {
+        foreach (FieldDeclarationSyntax fieldDeclaration in typeState.TypeDeclaration.Members
+            .OfType<FieldDeclarationSyntax>())
+        {
+            foreach (VariableDeclaratorSyntax variable in fieldDeclaration.Declaration.Variables)
+            {
+                IFieldSymbol fieldSymbol = semanticModel.GetDeclaredSymbol(variable) as IFieldSymbol;
+                if (fieldSymbol == null || CompiledTypeHasField(compiledType, fieldSymbol))
+                {
+                    continue;
+                }
+
+                ClassifyOneAddedField(
+                    typeState,
+                    semanticModel,
+                    fieldDeclaration,
+                    variable,
+                    fieldSymbol,
+                    addedFieldCatalog,
+                    declarationDriftWarnings);
+            }
+        }
+    }
+
+    private static void ClassifyOneAddedField(
+        TypeEmitState typeState,
+        SemanticModel semanticModel,
+        FieldDeclarationSyntax fieldDeclaration,
+        VariableDeclaratorSyntax variable,
+        IFieldSymbol fieldSymbol,
+        AddedFieldCatalog addedFieldCatalog,
+        List<string> declarationDriftWarnings)
+    {
+        string syntaxKey = BuildSyntaxFieldKey(typeState.TypeMetadataNameFromSyntax, fieldSymbol.Name);
+        string fieldKey = FormatAddedFieldStoreKey(
+            CecilTypeNames.ToMetadataName(typeState.TypeSymbol),
+            fieldSymbol.Name);
+        addedFieldCatalog.MarkClassifiedAdded(fieldKey);
+        addedFieldCatalog.AddAddedSyntaxKey(syntaxKey);
+
+        if (FieldHasSerializationAttribute(fieldDeclaration))
+        {
+            declarationDriftWarnings.Add(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    AddedFieldSkipReasons.SerializeWarningFormat,
+                    fieldSymbol.Name));
+        }
+
+        AddedFieldBinding binding = new AddedFieldBinding
+        {
+            FieldKey = fieldKey,
+            SyntaxKey = syntaxKey,
+            FieldName = fieldSymbol.Name,
+            FieldType = fieldSymbol.Type,
+            IsStatic = fieldSymbol.IsStatic,
+            IsConst = fieldSymbol.IsConst,
+            ConstantValue = fieldSymbol.HasConstantValue ? fieldSymbol.ConstantValue : null,
+            Initializer = variable.Initializer != null ? variable.Initializer.Value : null
+        };
+
+        // Why skip struct hosts: GetOrInit boxes the receiver, so every access looks like a
+        // new instance and re-runs the initializer instead of remembering the value.
+        if (typeState.TypeSymbol.TypeKind == TypeKind.Struct)
+        {
+            binding.UnavailableReason = AddedFieldSkipReasons.StructHost;
+            addedFieldCatalog.RegisterUnavailable(binding);
+            return;
+        }
+
+        if (fieldSymbol.IsConst)
+        {
+            if (TryCreateConstantLiteral(binding.ConstantValue, fieldSymbol.Type) == null)
+            {
+                binding.UnavailableReason = AddedFieldSkipReasons.UnavailableAddedField;
+                addedFieldCatalog.RegisterUnavailable(binding);
+                return;
+            }
+
+            addedFieldCatalog.RegisterConst(binding);
+            return;
+        }
+
+        // Why skip private/internal initializer access: the injected static lambda is a normal
+        // method in the shim assembly and does not get Harmony skip-visibility.
+        if (binding.Initializer != null
+            && SubtreeHasInaccessibleMemberAccess(semanticModel, new[] { binding.Initializer }))
+        {
+            binding.UnavailableReason = AddedFieldSkipReasons.InaccessibleInitializer;
+            addedFieldCatalog.RegisterUnavailable(binding);
+            return;
+        }
+
+        addedFieldCatalog.RegisterStore(binding);
+    }
+
+    private static bool FieldHasSerializationAttribute(FieldDeclarationSyntax fieldDeclaration)
+    {
+        foreach (AttributeListSyntax attributeList in fieldDeclaration.AttributeLists)
+        {
+            foreach (AttributeSyntax attribute in attributeList.Attributes)
+            {
+                string name = attribute.Name.ToString();
+                int lastDot = name.LastIndexOf('.');
+                string simpleName = lastDot >= 0 ? name.Substring(lastDot + 1) : name;
+                if (simpleName == "SerializeField"
+                    || simpleName == "SerializeReference"
+                    || simpleName == "FormerlySerializedAs")
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static string FormatAddedFieldStoreKey(string typeMetadataName, string fieldName)
+    {
+        return typeMetadataName + TransformWorkerProgramMarker.AddedFieldKeySeparator + fieldName;
+    }
+
+    private static string EvaluateAddedFieldSkipReason(
+        SyntaxNode bodyNode,
+        SemanticModel semanticModel,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        if (bodyNode == null || addedFieldCatalog == null || !addedFieldCatalog.HasClassifiedAdded)
+        {
+            return null;
+        }
+
+        string unavailable = BodyReferencesUnavailableAddedField(bodyNode, semanticModel, addedFieldCatalog);
+        if (unavailable != null)
+        {
+            return unavailable;
+        }
+
+        if (BodyPassesAddedFieldByRef(bodyNode, semanticModel, addedFieldCatalog))
+        {
+            return AddedFieldSkipReasons.RefOutIn;
+        }
+
+        if (BodyHasUnsupportedAddedFieldCompound(bodyNode, semanticModel, addedFieldCatalog))
+        {
+            return AddedFieldSkipReasons.UnavailableAddedField;
+        }
+
+        if (BodyHasConsumedAddedFieldWrite(bodyNode, semanticModel, addedFieldCatalog))
+        {
+            return AddedFieldSkipReasons.ConsumedWrite;
+        }
+
+        if (BodyHasDoubleEvalAddedFieldReceiver(bodyNode, semanticModel, addedFieldCatalog))
+        {
+            return AddedFieldSkipReasons.DoubleEvalReceiver;
+        }
+
+        if (BodyHasValueTypeAddedFieldMemberWrite(bodyNode, semanticModel, addedFieldCatalog))
+        {
+            return AddedFieldSkipReasons.ValueTypeMemberWrite;
+        }
+
+        return null;
+    }
+
+    private static string BodyReferencesUnavailableAddedField(
+        SyntaxNode bodyNode,
+        SemanticModel semanticModel,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        foreach (SyntaxNode node in bodyNode.DescendantNodesAndSelf())
+        {
+            if (NameofRules.IsInsideNameofArgument(node))
+            {
+                continue;
+            }
+
+            IFieldSymbol field = TryGetFieldSymbol(semanticModel, node);
+            if (field == null)
+            {
+                continue;
+            }
+
+            AddedFieldBinding binding = addedFieldCatalog.FindOrNull(FormatAddedFieldKeyFromSymbol(field));
+            if (binding != null && binding.UnavailableReason != null)
+            {
+                return binding.UnavailableReason;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool BodyPassesAddedFieldByRef(
+        SyntaxNode bodyNode,
+        SemanticModel semanticModel,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        foreach (ArgumentSyntax argument in bodyNode.DescendantNodesAndSelf().OfType<ArgumentSyntax>())
+        {
+            if (argument.RefKindKeyword.Kind() != SyntaxKind.RefKeyword
+                && argument.RefKindKeyword.Kind() != SyntaxKind.OutKeyword
+                && argument.RefKindKeyword.Kind() != SyntaxKind.InKeyword)
+            {
+                continue;
+            }
+
+            if (IsStoreAddedField(semanticModel, argument.Expression, addedFieldCatalog))
+            {
+                return true;
+            }
+        }
+
+        foreach (RefExpressionSyntax refExpression in bodyNode.DescendantNodesAndSelf()
+            .OfType<RefExpressionSyntax>())
+        {
+            if (IsStoreAddedField(semanticModel, refExpression.Expression, addedFieldCatalog))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool BodyHasUnsupportedAddedFieldCompound(
+        SyntaxNode bodyNode,
+        SemanticModel semanticModel,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        foreach (AssignmentExpressionSyntax assignment in bodyNode.DescendantNodesAndSelf()
+            .OfType<AssignmentExpressionSyntax>())
+        {
+            if (assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                || AccessorEligibility.IsSupportedCompoundAssignmentKind(assignment.Kind()))
+            {
+                continue;
+            }
+
+            if (IsStoreAddedField(semanticModel, assignment.Left, addedFieldCatalog))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool BodyHasConsumedAddedFieldWrite(
+        SyntaxNode bodyNode,
+        SemanticModel semanticModel,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        foreach (AssignmentExpressionSyntax assignment in bodyNode.DescendantNodesAndSelf()
+            .OfType<AssignmentExpressionSyntax>())
+        {
+            if (assignment.Parent is ExpressionStatementSyntax)
+            {
+                continue;
+            }
+
+            if (IsStoreAddedField(semanticModel, assignment.Left, addedFieldCatalog))
+            {
+                return true;
+            }
+        }
+
+        foreach (PrefixUnaryExpressionSyntax prefix in bodyNode.DescendantNodesAndSelf()
+            .OfType<PrefixUnaryExpressionSyntax>())
+        {
+            if (!IsIncrementOrDecrement(prefix.Kind()) || prefix.Parent is ExpressionStatementSyntax)
+            {
+                continue;
+            }
+
+            if (IsStoreAddedField(semanticModel, prefix.Operand, addedFieldCatalog))
+            {
+                return true;
+            }
+        }
+
+        foreach (PostfixUnaryExpressionSyntax postfix in bodyNode.DescendantNodesAndSelf()
+            .OfType<PostfixUnaryExpressionSyntax>())
+        {
+            if (!IsIncrementOrDecrement(postfix.Kind()) || postfix.Parent is ExpressionStatementSyntax)
+            {
+                continue;
+            }
+
+            if (IsStoreAddedField(semanticModel, postfix.Operand, addedFieldCatalog))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool BodyHasDoubleEvalAddedFieldReceiver(
+        SyntaxNode bodyNode,
+        SemanticModel semanticModel,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        foreach (AssignmentExpressionSyntax assignment in bodyNode.DescendantNodesAndSelf()
+            .OfType<AssignmentExpressionSyntax>())
+        {
+            if (!IsStoreAddedInstanceField(semanticModel, assignment.Left, addedFieldCatalog))
+            {
+                continue;
+            }
+
+            if (!AccessorEligibility.IsSideEffectFreeAssignmentReceiver(semanticModel, assignment.Left))
+            {
+                return true;
+            }
+        }
+
+        foreach (PrefixUnaryExpressionSyntax prefix in bodyNode.DescendantNodesAndSelf()
+            .OfType<PrefixUnaryExpressionSyntax>())
+        {
+            if (!IsIncrementOrDecrement(prefix.Kind())
+                || !IsStoreAddedInstanceField(semanticModel, prefix.Operand, addedFieldCatalog))
+            {
+                continue;
+            }
+
+            if (!AccessorEligibility.IsSideEffectFreeAssignmentReceiver(semanticModel, prefix.Operand))
+            {
+                return true;
+            }
+        }
+
+        foreach (PostfixUnaryExpressionSyntax postfix in bodyNode.DescendantNodesAndSelf()
+            .OfType<PostfixUnaryExpressionSyntax>())
+        {
+            if (!IsIncrementOrDecrement(postfix.Kind())
+                || !IsStoreAddedInstanceField(semanticModel, postfix.Operand, addedFieldCatalog))
+            {
+                continue;
+            }
+
+            if (!AccessorEligibility.IsSideEffectFreeAssignmentReceiver(semanticModel, postfix.Operand))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool BodyHasValueTypeAddedFieldMemberWrite(
+        SyntaxNode bodyNode,
+        SemanticModel semanticModel,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        foreach (AssignmentExpressionSyntax assignment in bodyNode.DescendantNodesAndSelf()
+            .OfType<AssignmentExpressionSyntax>())
+        {
+            if (assignment.Left is MemberAccessExpressionSyntax memberAccess
+                && IsStoreAddedValueTypeField(semanticModel, memberAccess.Expression, addedFieldCatalog))
+            {
+                return true;
+            }
+        }
+
+        foreach (InvocationExpressionSyntax invocation in bodyNode.DescendantNodesAndSelf()
+            .OfType<InvocationExpressionSyntax>())
+        {
+            if (NameofRules.IsNameofInvocation(invocation)
+                || invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            {
+                continue;
+            }
+
+            ISymbol invoked = semanticModel.GetSymbolInfo(invocation).Symbol;
+            if (invoked is IMethodSymbol methodSymbol
+                && !methodSymbol.IsStatic
+                && IsStoreAddedValueTypeField(semanticModel, memberAccess.Expression, addedFieldCatalog))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    internal static bool IsIncrementOrDecrement(SyntaxKind kind)
+    {
+        return kind == SyntaxKind.PreIncrementExpression
+            || kind == SyntaxKind.PreDecrementExpression
+            || kind == SyntaxKind.PostIncrementExpression
+            || kind == SyntaxKind.PostDecrementExpression;
+    }
+
+    private static bool IsStoreAddedField(
+        SemanticModel semanticModel,
+        ExpressionSyntax expression,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        IFieldSymbol field = TryGetFieldSymbol(semanticModel, expression);
+        if (field == null)
+        {
+            return false;
+        }
+
+        AddedFieldBinding binding = addedFieldCatalog.FindOrNull(FormatAddedFieldKeyFromSymbol(field));
+        return binding != null && binding.IsStoreRewriteable;
+    }
+
+    private static bool IsStoreAddedInstanceField(
+        SemanticModel semanticModel,
+        ExpressionSyntax expression,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        IFieldSymbol field = TryGetFieldSymbol(semanticModel, expression);
+        if (field == null || field.IsStatic)
+        {
+            return false;
+        }
+
+        AddedFieldBinding binding = addedFieldCatalog.FindOrNull(FormatAddedFieldKeyFromSymbol(field));
+        return binding != null && binding.IsStoreRewriteable;
+    }
+
+    private static bool IsStoreAddedValueTypeField(
+        SemanticModel semanticModel,
+        ExpressionSyntax expression,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        IFieldSymbol field = TryGetFieldSymbol(semanticModel, expression);
+        if (field == null || !field.Type.IsValueType)
+        {
+            return false;
+        }
+
+        AddedFieldBinding binding = addedFieldCatalog.FindOrNull(FormatAddedFieldKeyFromSymbol(field));
+        return binding != null && binding.IsStoreRewriteable;
+    }
+
+    private static IFieldSymbol TryGetFieldSymbol(SemanticModel semanticModel, SyntaxNode node)
+    {
+        if (node == null)
+        {
+            return null;
+        }
+
+        ISymbol symbol = semanticModel.GetSymbolInfo(node).Symbol;
+        return symbol as IFieldSymbol;
+    }
+
+    internal static string FormatAddedFieldKeyFromSymbol(IFieldSymbol fieldSymbol)
+    {
+        if (fieldSymbol.ContainingType == null)
+        {
+            return fieldSymbol.Name;
+        }
+
+        return FormatAddedFieldStoreKey(
+            CecilTypeNames.ToMetadataName(fieldSymbol.ContainingType),
+            fieldSymbol.Name);
+    }
+
+    internal static ExpressionSyntax TryCreateConstantLiteral(object value, ITypeSymbol type)
+    {
+        if (value == null)
+        {
+            return SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
+        }
+
+        if (type != null && type.TypeKind == TypeKind.Enum)
+        {
+            ExpressionSyntax underlyingLiteral = TryCreateNumericOrBoolLiteral(value);
+            if (underlyingLiteral == null)
+            {
+                return null;
+            }
+
+            return SyntaxFactory.CastExpression(
+                SyntaxFactory.ParseTypeName(type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)),
+                underlyingLiteral);
+        }
+
+        if (value is string text)
+        {
+            return SyntaxFactory.LiteralExpression(
+                SyntaxKind.StringLiteralExpression,
+                SyntaxFactory.Literal(text));
+        }
+
+        if (value is char character)
+        {
+            return SyntaxFactory.LiteralExpression(
+                SyntaxKind.CharacterLiteralExpression,
+                SyntaxFactory.Literal(character));
+        }
+
+        return TryCreateNumericOrBoolLiteral(value);
+    }
+
+    private static ExpressionSyntax TryCreateNumericOrBoolLiteral(object value)
+    {
+        if (value is bool flag)
+        {
+            return SyntaxFactory.LiteralExpression(
+                flag ? SyntaxKind.TrueLiteralExpression : SyntaxKind.FalseLiteralExpression);
+        }
+
+        if (value is int intValue)
+        {
+            return SyntaxFactory.LiteralExpression(
+                SyntaxKind.NumericLiteralExpression,
+                SyntaxFactory.Literal(intValue));
+        }
+
+        if (value is uint uintValue)
+        {
+            return SyntaxFactory.LiteralExpression(
+                SyntaxKind.NumericLiteralExpression,
+                SyntaxFactory.Literal(uintValue));
+        }
+
+        if (value is long longValue)
+        {
+            return SyntaxFactory.LiteralExpression(
+                SyntaxKind.NumericLiteralExpression,
+                SyntaxFactory.Literal(longValue));
+        }
+
+        if (value is ulong ulongValue)
+        {
+            return SyntaxFactory.LiteralExpression(
+                SyntaxKind.NumericLiteralExpression,
+                SyntaxFactory.Literal(ulongValue));
+        }
+
+        if (value is float floatValue)
+        {
+            return SyntaxFactory.LiteralExpression(
+                SyntaxKind.NumericLiteralExpression,
+                SyntaxFactory.Literal(floatValue));
+        }
+
+        if (value is double doubleValue)
+        {
+            return SyntaxFactory.LiteralExpression(
+                SyntaxKind.NumericLiteralExpression,
+                SyntaxFactory.Literal(doubleValue));
+        }
+
+        if (value is decimal decimalValue)
+        {
+            return SyntaxFactory.LiteralExpression(
+                SyntaxKind.NumericLiteralExpression,
+                SyntaxFactory.Literal(decimalValue));
+        }
+
+        if (value is byte byteValue)
+        {
+            return SyntaxFactory.LiteralExpression(
+                SyntaxKind.NumericLiteralExpression,
+                SyntaxFactory.Literal(byteValue));
+        }
+
+        if (value is sbyte sbyteValue)
+        {
+            return SyntaxFactory.LiteralExpression(
+                SyntaxKind.NumericLiteralExpression,
+                SyntaxFactory.Literal(sbyteValue));
+        }
+
+        if (value is short shortValue)
+        {
+            return SyntaxFactory.LiteralExpression(
+                SyntaxKind.NumericLiteralExpression,
+                SyntaxFactory.Literal(shortValue));
+        }
+
+        if (value is ushort ushortValue)
+        {
+            return SyntaxFactory.LiteralExpression(
+                SyntaxKind.NumericLiteralExpression,
+                SyntaxFactory.Literal(ushortValue));
+        }
+
+        return null;
+    }
+
     private static string EvaluateAddedMethodSkipReason(
         IMethodSymbol methodSymbol,
         MethodDeclarationSyntax methodDeclaration)
@@ -2834,7 +3595,8 @@ public static class TransformWorkerProgram
         INamedTypeSymbol targetType,
         SemanticModel semanticModel,
         AccessorPlan accessorPlan,
-        AddedMethodCatalog addedMethodCatalog)
+        AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog)
     {
         // Why a single rewriter: rewriting the tree invalidates SemanticModel for new nodes.
         // Qualify + accessor rewrite both classify symbols on the original tree in one Visit pass.
@@ -2842,7 +3604,8 @@ public static class TransformWorkerProgram
             semanticModel,
             targetType,
             accessorPlan,
-            addedMethodCatalog);
+            addedMethodCatalog,
+            addedFieldCatalog);
         MethodDeclarationSyntax rewritten = (MethodDeclarationSyntax)rewriter.Visit(methodDeclaration);
         return ShimMethodFactory.ToShimMethod(rewritten, methodSymbol);
     }
@@ -4278,7 +5041,7 @@ internal static class AccessorEligibility
         return true;
     }
 
-    private static bool IsSupportedCompoundAssignmentKind(SyntaxKind kind)
+    internal static bool IsSupportedCompoundAssignmentKind(SyntaxKind kind)
     {
         return kind == SyntaxKind.AddAssignmentExpression
             || kind == SyntaxKind.SubtractAssignmentExpression
@@ -4298,7 +5061,7 @@ internal static class AccessorEligibility
     /// (properties/methods). Only this/locals/parameters/fields (and type/namespace qualifiers)
     /// are allowed — FieldRef re-reads the same storage, so field links are idempotent.
     /// </summary>
-    private static bool IsSideEffectFreeAssignmentReceiver(
+    internal static bool IsSideEffectFreeAssignmentReceiver(
         SemanticModel semanticModel,
         ExpressionSyntax left)
     {
@@ -4383,17 +5146,20 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
     private readonly INamedTypeSymbol _targetType;
     private readonly AccessorPlan _accessorPlan;
     private readonly AddedMethodCatalog _addedMethodCatalog;
+    private readonly AddedFieldCatalog _addedFieldCatalog;
 
     public ShimBodyRewriter(
         SemanticModel semanticModel,
         INamedTypeSymbol targetType,
         AccessorPlan accessorPlan,
-        AddedMethodCatalog addedMethodCatalog)
+        AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog)
     {
         _semanticModel = semanticModel;
         _targetType = targetType;
         _accessorPlan = accessorPlan;
         _addedMethodCatalog = addedMethodCatalog ?? new AddedMethodCatalog();
+        _addedFieldCatalog = addedFieldCatalog ?? new AddedFieldCatalog();
     }
 
     public override SyntaxNode VisitThisExpression(ThisExpressionSyntax node)
@@ -4543,16 +5309,26 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
 
         ExpressionSyntax argument = nameofInvocation.ArgumentList.Arguments[0].Expression;
         ISymbol symbol = ResolveNameofArgumentSymbol(argument);
-        if (symbol is not IMethodSymbol methodSymbol
-            || !_addedMethodCatalog.Contains(BuildAddedMethodKey(methodSymbol)))
+        if (symbol is IMethodSymbol methodSymbol
+            && _addedMethodCatalog.Contains(BuildAddedMethodKey(methodSymbol)))
         {
-            return null;
+            return SyntaxFactory.LiteralExpression(
+                    SyntaxKind.StringLiteralExpression,
+                    SyntaxFactory.Literal(methodSymbol.Name))
+                .WithTriviaFrom(nameofInvocation);
         }
 
-        return SyntaxFactory.LiteralExpression(
-                SyntaxKind.StringLiteralExpression,
-                SyntaxFactory.Literal(methodSymbol.Name))
-            .WithTriviaFrom(nameofInvocation);
+        if (symbol is IFieldSymbol fieldSymbol
+            && _addedFieldCatalog.FindOrNull(
+                TransformWorkerProgram.FormatAddedFieldKeyFromSymbol(fieldSymbol)) != null)
+        {
+            return SyntaxFactory.LiteralExpression(
+                    SyntaxKind.StringLiteralExpression,
+                    SyntaxFactory.Literal(fieldSymbol.Name))
+                .WithTriviaFrom(nameofInvocation);
+        }
+
+        return null;
     }
 
     private ISymbol ResolveNameofArgumentSymbol(ExpressionSyntax argument)
@@ -4625,7 +5401,18 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
             return base.VisitAssignmentExpression(node);
         }
 
-        if (_accessorPlan == null || TransformWorkerProgram.NameofRules.IsInsideNameofArgument(node))
+        if (TransformWorkerProgram.NameofRules.IsInsideNameofArgument(node))
+        {
+            return base.VisitAssignmentExpression(node);
+        }
+
+        AddedFieldBinding assignedField = FindStoreBinding(_semanticModel.GetSymbolInfo(node.Left).Symbol);
+        if (assignedField != null)
+        {
+            return RewriteAddedFieldAssignment(node, assignedField);
+        }
+
+        if (_accessorPlan == null)
         {
             return base.VisitAssignmentExpression(node);
         }
@@ -4657,15 +5444,284 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
         return base.VisitAssignmentExpression(node);
     }
 
+    public override SyntaxNode VisitPrefixUnaryExpression(PrefixUnaryExpressionSyntax node)
+    {
+        if (TransformWorkerProgram.IsIncrementOrDecrement(node.Kind()))
+        {
+            AddedFieldBinding binding = FindStoreBinding(_semanticModel.GetSymbolInfo(node.Operand).Symbol);
+            if (binding != null)
+            {
+                return RewriteAddedFieldIncrement(node.Operand, binding, node);
+            }
+        }
+
+        return base.VisitPrefixUnaryExpression(node);
+    }
+
+    public override SyntaxNode VisitPostfixUnaryExpression(PostfixUnaryExpressionSyntax node)
+    {
+        if (TransformWorkerProgram.IsIncrementOrDecrement(node.Kind()))
+        {
+            AddedFieldBinding binding = FindStoreBinding(_semanticModel.GetSymbolInfo(node.Operand).Symbol);
+            if (binding != null)
+            {
+                return RewriteAddedFieldIncrement(node.Operand, binding, node);
+            }
+        }
+
+        return base.VisitPostfixUnaryExpression(node);
+    }
+
+    private AddedFieldBinding FindStoreBinding(ISymbol symbol)
+    {
+        if (symbol is not IFieldSymbol fieldSymbol)
+        {
+            return null;
+        }
+
+        AddedFieldBinding binding = _addedFieldCatalog.FindOrNull(
+            TransformWorkerProgram.FormatAddedFieldKeyFromSymbol(fieldSymbol));
+        if (binding == null || !binding.IsStoreRewriteable)
+        {
+            return null;
+        }
+
+        return binding;
+    }
+
+    private AddedFieldBinding FindAnyAddedBinding(ISymbol symbol)
+    {
+        if (symbol is not IFieldSymbol fieldSymbol)
+        {
+            return null;
+        }
+
+        return _addedFieldCatalog.FindOrNull(
+            TransformWorkerProgram.FormatAddedFieldKeyFromSymbol(fieldSymbol));
+    }
+
+    private SyntaxNode TryRewriteAddedFieldRead(
+        ISymbol symbol,
+        ExpressionSyntax receiverSyntax,
+        SyntaxNode triviaSource)
+    {
+        AddedFieldBinding binding = FindAnyAddedBinding(symbol);
+        if (binding == null || binding.UnavailableReason != null)
+        {
+            return null;
+        }
+
+        if (binding.IsConst)
+        {
+            ExpressionSyntax literal = TransformWorkerProgram.TryCreateConstantLiteral(
+                binding.ConstantValue,
+                binding.FieldType);
+            if (literal == null)
+            {
+                return null;
+            }
+
+            return literal.WithTriviaFrom(triviaSource);
+        }
+
+        if (!binding.IsStoreRewriteable)
+        {
+            return null;
+        }
+
+        return CreateAddedFieldGetOrInit(binding, receiverSyntax).WithTriviaFrom(triviaSource);
+    }
+
+    private SyntaxNode RewriteAddedFieldAssignment(
+        AssignmentExpressionSyntax node,
+        AddedFieldBinding binding)
+    {
+        ExpressionSyntax receiver = ExtractAddedFieldReceiver(node.Left, binding.IsStatic);
+        ExpressionSyntax visitedRight = (ExpressionSyntax)Visit(node.Right);
+        if (node.IsKind(SyntaxKind.SimpleAssignmentExpression))
+        {
+            return CreateAddedFieldSet(binding, receiver, visitedRight).WithTriviaFrom(node);
+        }
+
+        SyntaxKind binaryKind = GetCompoundAssignmentBinaryKind(node.Kind());
+        ExpressionSyntax getCall = CreateAddedFieldGetOrInit(binding, receiver);
+        ExpressionSyntax combined = SyntaxFactory.BinaryExpression(binaryKind, getCall, visitedRight);
+        return CreateAddedFieldSet(binding, receiver, combined).WithTriviaFrom(node);
+    }
+
+    private SyntaxNode RewriteAddedFieldIncrement(
+        ExpressionSyntax operand,
+        AddedFieldBinding binding,
+        SyntaxNode triviaSource)
+    {
+        ExpressionSyntax receiver = ExtractAddedFieldReceiver(operand, binding.IsStatic);
+        ExpressionSyntax getCall = CreateAddedFieldGetOrInit(binding, receiver);
+        ExpressionSyntax combined = SyntaxFactory.BinaryExpression(
+            SyntaxKind.AddExpression,
+            getCall,
+            SyntaxFactory.LiteralExpression(
+                SyntaxKind.NumericLiteralExpression,
+                SyntaxFactory.Literal(1)));
+        if (triviaSource is PrefixUnaryExpressionSyntax prefix
+            && prefix.IsKind(SyntaxKind.PreDecrementExpression))
+        {
+            combined = SyntaxFactory.BinaryExpression(
+                SyntaxKind.SubtractExpression,
+                getCall,
+                SyntaxFactory.LiteralExpression(
+                    SyntaxKind.NumericLiteralExpression,
+                    SyntaxFactory.Literal(1)));
+        }
+        else if (triviaSource is PostfixUnaryExpressionSyntax postfix
+            && postfix.IsKind(SyntaxKind.PostDecrementExpression))
+        {
+            combined = SyntaxFactory.BinaryExpression(
+                SyntaxKind.SubtractExpression,
+                getCall,
+                SyntaxFactory.LiteralExpression(
+                    SyntaxKind.NumericLiteralExpression,
+                    SyntaxFactory.Literal(1)));
+        }
+
+        return CreateAddedFieldSet(binding, receiver, combined).WithTriviaFrom(triviaSource);
+    }
+
+    private ExpressionSyntax ExtractAddedFieldReceiver(ExpressionSyntax expression, bool isStatic)
+    {
+        if (isStatic)
+        {
+            return null;
+        }
+
+        ExpressionSyntax receiver = ExtractReceiver(expression);
+        if (receiver is ThisExpressionSyntax || receiver is BaseExpressionSyntax)
+        {
+            return SyntaxFactory.IdentifierName(TransformWorkerProgramMarker.InstanceParameterName);
+        }
+
+        return VisitReceiver(receiver);
+    }
+
+    private InvocationExpressionSyntax CreateAddedFieldGetOrInit(
+        AddedFieldBinding binding,
+        ExpressionSyntax receiver)
+    {
+        _addedFieldCatalog.MarkStoreRewrite();
+        string methodName = binding.IsStatic
+            ? TransformWorkerProgramMarker.AddedFieldGetOrInitStaticMethodName
+            : TransformWorkerProgramMarker.AddedFieldGetOrInitMethodName;
+        List<ArgumentSyntax> arguments = new List<ArgumentSyntax>();
+        if (!binding.IsStatic)
+        {
+            arguments.Add(SyntaxFactory.Argument(receiver));
+        }
+
+        arguments.Add(
+            SyntaxFactory.Argument(
+                SyntaxFactory.LiteralExpression(
+                    SyntaxKind.StringLiteralExpression,
+                    SyntaxFactory.Literal(binding.FieldKey))));
+        arguments.Add(SyntaxFactory.Argument(CreateAddedFieldInitializer(binding)));
+        return CreateAddedFieldStoreInvocation(methodName, binding.FieldType, arguments);
+    }
+
+    private InvocationExpressionSyntax CreateAddedFieldSet(
+        AddedFieldBinding binding,
+        ExpressionSyntax receiver,
+        ExpressionSyntax value)
+    {
+        _addedFieldCatalog.MarkStoreRewrite();
+        string methodName = binding.IsStatic
+            ? TransformWorkerProgramMarker.AddedFieldSetStaticMethodName
+            : TransformWorkerProgramMarker.AddedFieldSetMethodName;
+        List<ArgumentSyntax> arguments = new List<ArgumentSyntax>();
+        if (!binding.IsStatic)
+        {
+            arguments.Add(SyntaxFactory.Argument(receiver));
+        }
+
+        arguments.Add(
+            SyntaxFactory.Argument(
+                SyntaxFactory.LiteralExpression(
+                    SyntaxKind.StringLiteralExpression,
+                    SyntaxFactory.Literal(binding.FieldKey))));
+        arguments.Add(SyntaxFactory.Argument(value));
+        return CreateAddedFieldStoreInvocation(methodName, binding.FieldType, arguments);
+    }
+
+    private static ExpressionSyntax CreateAddedFieldInitializer(AddedFieldBinding binding)
+    {
+        if (binding.Initializer == null)
+        {
+            return SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
+        }
+
+        ExpressionSyntax cloned = SyntaxFactory.ParseExpression(binding.Initializer.ToString());
+        return SyntaxFactory.ParenthesizedLambdaExpression(
+                SyntaxFactory.ParameterList(),
+                cloned)
+            .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.StaticKeyword)));
+    }
+
+    private static InvocationExpressionSyntax CreateAddedFieldStoreInvocation(
+        string methodName,
+        ITypeSymbol fieldType,
+        List<ArgumentSyntax> arguments)
+    {
+        TypeSyntax storeType = SyntaxFactory.ParseTypeName(
+            TransformWorkerProgramMarker.AddedFieldStoreTypeName);
+        TypeSyntax typeArgument = SyntaxFactory.ParseTypeName(
+            fieldType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+        GenericNameSyntax genericName = SyntaxFactory.GenericName(SyntaxFactory.Identifier(methodName))
+            .WithTypeArgumentList(
+                SyntaxFactory.TypeArgumentList(SyntaxFactory.SingletonSeparatedList(typeArgument)));
+        return SyntaxFactory.InvocationExpression(
+            SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                storeType,
+                genericName),
+            SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments)));
+    }
+
+    private static bool IsAssignmentLeft(SyntaxNode node)
+    {
+        return node.Parent is AssignmentExpressionSyntax assignment && assignment.Left == node;
+    }
+
+    private static bool IsIncrementOperand(SyntaxNode node)
+    {
+        if (node.Parent is PrefixUnaryExpressionSyntax prefix
+            && TransformWorkerProgram.IsIncrementOrDecrement(prefix.Kind()))
+        {
+            return true;
+        }
+
+        return node.Parent is PostfixUnaryExpressionSyntax postfix
+            && TransformWorkerProgram.IsIncrementOrDecrement(postfix.Kind());
+    }
+
     public override SyntaxNode VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
     {
-        if (_accessorPlan == null || TransformWorkerProgram.NameofRules.IsInsideNameofArgument(node))
+        if (TransformWorkerProgram.NameofRules.IsInsideNameofArgument(node))
         {
             return base.VisitMemberAccessExpression(node);
         }
 
         ISymbol symbol = _semanticModel.GetSymbolInfo(node).Symbol
             ?? _semanticModel.GetSymbolInfo(node.Name).Symbol;
+        if (!IsAssignmentLeft(node) && !IsIncrementOperand(node))
+        {
+            SyntaxNode addedFieldRead = TryRewriteAddedFieldRead(symbol, node.Expression, node);
+            if (addedFieldRead != null)
+            {
+                return addedFieldRead;
+            }
+        }
+
+        if (_accessorPlan == null)
+        {
+            return base.VisitMemberAccessExpression(node);
+        }
 
         // Method-group invocation targets stay with VisitInvocationExpression; field/property
         // delegate invokes (`this._cb()`) must rewrite here so the call becomes `__F__(recv)()`.
@@ -4704,6 +5760,20 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
         if (symbol == null)
         {
             return original;
+        }
+
+        if (!IsAssignmentLeft(node)
+            && !IsIncrementOperand(node)
+            && !TransformWorkerProgram.NameofRules.IsInsideNameofArgument(node))
+        {
+            SyntaxNode addedFieldRead = TryRewriteAddedFieldRead(
+                symbol,
+                SyntaxFactory.IdentifierName(TransformWorkerProgramMarker.InstanceParameterName),
+                node);
+            if (addedFieldRead != null)
+            {
+                return addedFieldRead;
+            }
         }
 
         // Local/anonymous functions are emitted into the shim assembly — keep bare calls.
@@ -4971,6 +6041,21 @@ internal static class TransformWorkerProgramMarker
     // user parameter or local of that name. The uloop-prefixed name makes collisions
     // practically impossible.
     public const string InstanceParameterName = "__uloopInstance";
+
+    // Keep in sync with HotReloadAddedFieldStore in ToolContracts.
+    public const string AddedFieldStoreTypeName =
+        "global::io.github.hatayama.UnityCliLoop.ToolContracts.HotReloadAddedFieldStore";
+
+    public const string AddedFieldGetOrInitMethodName = "GetOrInit";
+
+    public const string AddedFieldSetMethodName = "Set";
+
+    public const string AddedFieldGetOrInitStaticMethodName = "GetOrInitStatic";
+
+    public const string AddedFieldSetStaticMethodName = "SetStatic";
+
+    // Keep in sync with HotReloadAddedFieldStore.FieldKeySeparator.
+    public const string AddedFieldKeySeparator = "::";
 }
 
 internal static class ShimMethodFactory
@@ -5457,6 +6542,129 @@ internal sealed class AddedMethodCatalog
     }
 }
 
+internal sealed class AddedFieldBinding
+{
+    public string FieldKey { get; set; }
+
+    public string SyntaxKey { get; set; }
+
+    public string FieldName { get; set; }
+
+    public ITypeSymbol FieldType { get; set; }
+
+    public bool IsStatic { get; set; }
+
+    public bool IsConst { get; set; }
+
+    public object ConstantValue { get; set; }
+
+    public ExpressionSyntax Initializer { get; set; }
+
+    public string UnavailableReason { get; set; }
+
+    public bool IsStoreRewriteable => UnavailableReason == null && !IsConst;
+}
+
+internal sealed class AddedFieldCatalog
+{
+    private readonly Dictionary<string, AddedFieldBinding> _byKey =
+        new Dictionary<string, AddedFieldBinding>(StringComparer.Ordinal);
+    private readonly HashSet<string> _classifiedAddedKeys = new HashSet<string>(StringComparer.Ordinal);
+    private readonly HashSet<string> _addedSyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
+    private readonly HashSet<string> _removedSyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
+
+    public IReadOnlyCollection<string> AddedSyntaxKeys => _addedSyntaxKeys;
+
+    public IReadOnlyCollection<string> RemovedSyntaxKeys => _removedSyntaxKeys;
+
+    public bool HasClassifiedAdded => _classifiedAddedKeys.Count > 0;
+
+    public bool HasStoreRewrites { get; private set; }
+
+    public void MarkClassifiedAdded(string fieldKey)
+    {
+        if (fieldKey != null)
+        {
+            _classifiedAddedKeys.Add(fieldKey);
+        }
+    }
+
+    public void AddAddedSyntaxKey(string syntaxKey)
+    {
+        _addedSyntaxKeys.Add(syntaxKey);
+    }
+
+    public void AddRemovedSyntaxKey(string syntaxKey)
+    {
+        _removedSyntaxKeys.Add(syntaxKey);
+    }
+
+    public void RegisterStore(AddedFieldBinding binding)
+    {
+        _byKey[binding.FieldKey] = binding;
+        MarkClassifiedAdded(binding.FieldKey);
+    }
+
+    public void RegisterConst(AddedFieldBinding binding)
+    {
+        _byKey[binding.FieldKey] = binding;
+        MarkClassifiedAdded(binding.FieldKey);
+    }
+
+    public void RegisterUnavailable(AddedFieldBinding binding)
+    {
+        _byKey[binding.FieldKey] = binding;
+        MarkClassifiedAdded(binding.FieldKey);
+    }
+
+    public AddedFieldBinding FindOrNull(string fieldKey)
+    {
+        if (fieldKey == null)
+        {
+            return null;
+        }
+
+        return _byKey.TryGetValue(fieldKey, out AddedFieldBinding binding) ? binding : null;
+    }
+
+    public void MarkStoreRewrite()
+    {
+        HasStoreRewrites = true;
+    }
+}
+
+internal static class AddedFieldSkipReasons
+{
+    public const string StructHost =
+        "Added fields on struct types are skipped; the store requires a reference-type instance. "
+        + "Run 'uloop compile' to add them.";
+
+    public const string InaccessibleInitializer =
+        "Added field initializer accesses inaccessible members; the initializer lambda cannot skip visibility. "
+        + "Run 'uloop compile'.";
+
+    public const string RefOutIn =
+        "Added fields cannot be passed by ref, out, or in. Run 'uloop compile'.";
+
+    public const string ConsumedWrite =
+        "The value of an assignment to an added field is consumed; the store write returns void. "
+        + "Run 'uloop compile'.";
+
+    public const string DoubleEvalReceiver =
+        "Assignment to an added field would evaluate a receiver with possible side effects twice. "
+        + "Run 'uloop compile'.";
+
+    public const string ValueTypeMemberWrite =
+        "Writes to members of an added value-type field cannot be rewritten. Run 'uloop compile'.";
+
+    public const string UnavailableAddedField =
+        "Uses an added field that hot reload cannot emit. Run 'uloop compile'.";
+
+    public const string SerializeWarningFormat =
+        "Added field '{0}' has a serialization attribute, so it will not appear in the Inspector "
+        + "or serialize until 'uloop compile'.";
+}
+
 internal static class AddedMethodSkipReasons
 {
     public const string VirtualOrAbstract =
@@ -5602,8 +6810,7 @@ internal sealed class WorkerOutput
     public bool HasAccessorDelegates { get; set; }
 
     // True when shim bodies rewrite added-field accesses to HotReloadAddedFieldStore.
-    // Keep in sync with TransformWorkerOutputDto.hasAddedFieldRewrites. Always false until
-    // the added-field rewrite PR starts emitting store calls.
+    // Keep in sync with TransformWorkerOutputDto.hasAddedFieldRewrites.
     public bool HasAddedFieldRewrites { get; set; }
 }
 
@@ -5677,9 +6884,10 @@ internal static class PatchKinds
 
 internal static class RemovedMemberKinds
 {
-    // Keep in sync with HotReloadConstants.RemovedMemberKindMethod.
-    // Method is the only kind in this PR; field classification lands in later PRs.
+    // Keep in sync with HotReloadConstants.RemovedMemberKindMethod / RemovedMemberKindField.
     public const string Method = "method";
+
+    public const string Field = "field";
 }
 
 internal sealed class MethodTransformDecision

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -2249,6 +2249,7 @@ public static class TransformWorkerProgram
             typeState,
             semanticModel,
             compiledType,
+            targetTypesAssemblySymbol,
             addedFieldCatalog,
             declarationDriftWarnings);
 
@@ -2508,7 +2509,7 @@ public static class TransformWorkerProgram
                 continue;
             }
 
-                addedMethodCatalog.AddRemovedSyntaxKey(pair.Key);
+            addedMethodCatalog.AddRemovedSyntaxKey(pair.Key);
             string name = pair.Value.Identifier.Text;
             if (!seenNames.Add(name))
             {
@@ -2951,6 +2952,7 @@ public static class TransformWorkerProgram
         TypeEmitState typeState,
         SemanticModel semanticModel,
         INamedTypeSymbol compiledType,
+        IAssemblySymbol targetTypesAssemblySymbol,
         AddedFieldCatalog addedFieldCatalog,
         List<string> declarationDriftWarnings)
     {
@@ -2968,6 +2970,7 @@ public static class TransformWorkerProgram
                 ClassifyOneAddedField(
                     typeState,
                     semanticModel,
+                    targetTypesAssemblySymbol,
                     fieldDeclaration,
                     variable,
                     fieldSymbol,
@@ -2980,6 +2983,7 @@ public static class TransformWorkerProgram
     private static void ClassifyOneAddedField(
         TypeEmitState typeState,
         SemanticModel semanticModel,
+        IAssemblySymbol targetTypesAssemblySymbol,
         FieldDeclarationSyntax fieldDeclaration,
         VariableDeclaratorSyntax variable,
         IFieldSymbol fieldSymbol,
@@ -3014,39 +3018,196 @@ public static class TransformWorkerProgram
             Initializer = variable.Initializer != null ? variable.Initializer.Value : null
         };
 
-        // Why skip struct hosts: GetOrInit boxes the receiver, so every access looks like a
-        // new instance and re-runs the initializer instead of remembering the value.
-        if (typeState.TypeSymbol.TypeKind == TypeKind.Struct)
+        binding.UnavailableReason = EvaluateAddedFieldAvailability(
+            typeState.TypeSymbol,
+            semanticModel,
+            targetTypesAssemblySymbol,
+            fieldSymbol,
+            binding);
+
+        if (binding.UnavailableReason != null)
         {
-            binding.UnavailableReason = AddedFieldSkipReasons.StructHost;
             addedFieldCatalog.RegisterUnavailable(binding);
             return;
         }
 
         if (fieldSymbol.IsConst)
         {
-            if (TryCreateConstantLiteral(binding.ConstantValue, fieldSymbol.Type) == null)
-            {
-                binding.UnavailableReason = AddedFieldSkipReasons.UnavailableAddedField;
-                addedFieldCatalog.RegisterUnavailable(binding);
-                return;
-            }
-
             addedFieldCatalog.RegisterConst(binding);
             return;
         }
 
-        // Why skip private/internal initializer access: the injected static lambda is a normal
-        // method in the shim assembly and does not get Harmony skip-visibility.
-        if (binding.Initializer != null
-            && SubtreeHasInaccessibleMemberAccess(semanticModel, new[] { binding.Initializer }))
+        addedFieldCatalog.RegisterStore(binding);
+    }
+
+    private static string EvaluateAddedFieldAvailability(
+        INamedTypeSymbol hostType,
+        SemanticModel semanticModel,
+        IAssemblySymbol targetTypesAssemblySymbol,
+        IFieldSymbol fieldSymbol,
+        AddedFieldBinding binding)
+    {
+        if (fieldSymbol.IsConst)
         {
-            binding.UnavailableReason = AddedFieldSkipReasons.InaccessibleInitializer;
-            addedFieldCatalog.RegisterUnavailable(binding);
-            return;
+            if (TryCreateConstantLiteral(binding.ConstantValue, fieldSymbol.Type) == null)
+            {
+                return AddedFieldSkipReasons.UnavailableAddedField;
+            }
+
+            return null;
         }
 
-        addedFieldCatalog.RegisterStore(binding);
+        // Why after const: added consts on struct hosts still fold to literals; the store
+        // identity problem only applies to instance/static storage.
+        if (hostType.TypeKind == TypeKind.Struct)
+        {
+            return AddedFieldSkipReasons.StructHost;
+        }
+
+        if (!AccessibilityRules.IsExternallyVisibleType(fieldSymbol.Type))
+        {
+            return AddedFieldSkipReasons.FieldTypeNotExternallyVisible;
+        }
+
+        if (binding.Initializer != null
+            && InitializerCannotEmitInShimLambda(
+                binding.Initializer,
+                semanticModel,
+                hostType,
+                targetTypesAssemblySymbol))
+        {
+            return AddedFieldSkipReasons.InitializerNotLiteralOrExternalStatic;
+        }
+
+        return null;
+    }
+
+    // Why this gate (not inaccessible-only): the initializer is spliced into a static lambda on
+    // a shim type, so even public instance members of the host are CS0103 / CS0026, and
+    // same-file added members do not exist on the compiled type the shim references.
+    private static bool InitializerCannotEmitInShimLambda(
+        ExpressionSyntax initializer,
+        SemanticModel semanticModel,
+        INamedTypeSymbol hostType,
+        IAssemblySymbol targetTypesAssemblySymbol)
+    {
+        foreach (SyntaxNode node in initializer.DescendantNodesAndSelf())
+        {
+            if (NameofRules.IsInsideNameofArgument(node))
+            {
+                continue;
+            }
+
+            if (node is ThisExpressionSyntax || node is BaseExpressionSyntax)
+            {
+                return true;
+            }
+
+            if (HasDisallowedInitializerSymbol(
+                semanticModel.GetSymbolInfo(node).Symbol,
+                hostType,
+                targetTypesAssemblySymbol,
+                initializer.SyntaxTree))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasDisallowedInitializerSymbol(
+        ISymbol symbol,
+        INamedTypeSymbol hostType,
+        IAssemblySymbol targetTypesAssemblySymbol,
+        SyntaxTree currentTree)
+    {
+        if (symbol == null
+            || symbol is INamespaceSymbol
+            || symbol is ITypeSymbol
+            || symbol is ILabelSymbol
+            || symbol is IRangeVariableSymbol)
+        {
+            return false;
+        }
+
+        if (symbol is not IFieldSymbol
+            && symbol is not IPropertySymbol
+            && symbol is not IMethodSymbol
+            && symbol is not IEventSymbol)
+        {
+            return false;
+        }
+
+        if (!symbol.IsStatic)
+        {
+            return true;
+        }
+
+        if (hostType != null
+            && SymbolEqualityComparer.Default.Equals(symbol.ContainingType, hostType))
+        {
+            return true;
+        }
+
+        if (IsSameFileAddedMember(symbol, targetTypesAssemblySymbol, currentTree))
+        {
+            return true;
+        }
+
+        return AccessibilityRules.IsInaccessibleFromExternalAssembly(symbol);
+    }
+
+    private static bool IsSameFileAddedMember(
+        ISymbol symbol,
+        IAssemblySymbol targetTypesAssemblySymbol,
+        SyntaxTree currentTree)
+    {
+        if (symbol.ContainingType == null || currentTree == null)
+        {
+            return false;
+        }
+
+        bool declaredInCurrentTree = false;
+        foreach (SyntaxReference reference in symbol.DeclaringSyntaxReferences)
+        {
+            if (reference.SyntaxTree == currentTree)
+            {
+                declaredInCurrentTree = true;
+                break;
+            }
+        }
+
+        if (!declaredInCurrentTree)
+        {
+            return false;
+        }
+
+        INamedTypeSymbol compiledType = FindCompiledType(symbol.ContainingType, targetTypesAssemblySymbol);
+        if (compiledType == null)
+        {
+            return true;
+        }
+
+        if (symbol is IFieldSymbol fieldSymbol)
+        {
+            return !CompiledTypeHasField(compiledType, fieldSymbol);
+        }
+
+        if (symbol is IMethodSymbol methodSymbol && methodSymbol.MethodKind == MethodKind.Ordinary)
+        {
+            return !CompiledTypeHasOrdinaryMethod(compiledType, methodSymbol);
+        }
+
+        foreach (ISymbol member in compiledType.GetMembers(symbol.Name))
+        {
+            if (member.Kind == symbol.Kind)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static bool FieldHasSerializationAttribute(FieldDeclarationSyntax fieldDeclaration)
@@ -3099,6 +3260,11 @@ public static class TransformWorkerProgram
         if (BodyHasUnsupportedAddedFieldCompound(bodyNode, semanticModel, addedFieldCatalog))
         {
             return AddedFieldSkipReasons.UnavailableAddedField;
+        }
+
+        if (BodyHasNonNumericAddedFieldIncrement(bodyNode, semanticModel, addedFieldCatalog))
+        {
+            return AddedFieldSkipReasons.IncrementNotNumeric;
         }
 
         if (BodyHasConsumedAddedFieldWrite(bodyNode, semanticModel, addedFieldCatalog))
@@ -3260,7 +3426,8 @@ public static class TransformWorkerProgram
         foreach (AssignmentExpressionSyntax assignment in bodyNode.DescendantNodesAndSelf()
             .OfType<AssignmentExpressionSyntax>())
         {
-            if (!IsStoreAddedInstanceField(semanticModel, assignment.Left, addedFieldCatalog))
+            if (assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                || !IsStoreAddedInstanceField(semanticModel, assignment.Left, addedFieldCatalog))
             {
                 continue;
             }
@@ -3302,6 +3469,79 @@ public static class TransformWorkerProgram
         }
 
         return false;
+    }
+
+    private static bool BodyHasNonNumericAddedFieldIncrement(
+        SyntaxNode bodyNode,
+        SemanticModel semanticModel,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        foreach (PrefixUnaryExpressionSyntax prefix in bodyNode.DescendantNodesAndSelf()
+            .OfType<PrefixUnaryExpressionSyntax>())
+        {
+            if (IsNonNumericAddedFieldIncrement(semanticModel, prefix.Kind(), prefix.Operand, addedFieldCatalog))
+            {
+                return true;
+            }
+        }
+
+        foreach (PostfixUnaryExpressionSyntax postfix in bodyNode.DescendantNodesAndSelf()
+            .OfType<PostfixUnaryExpressionSyntax>())
+        {
+            if (IsNonNumericAddedFieldIncrement(semanticModel, postfix.Kind(), postfix.Operand, addedFieldCatalog))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsNonNumericAddedFieldIncrement(
+        SemanticModel semanticModel,
+        SyntaxKind kind,
+        ExpressionSyntax operand,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        if (!IsIncrementOrDecrement(kind) || !IsStoreAddedField(semanticModel, operand, addedFieldCatalog))
+        {
+            return false;
+        }
+
+        IFieldSymbol field = TryGetFieldSymbol(semanticModel, operand);
+        return field != null && !IsIncrementablePrimitiveOrEnum(field.Type);
+    }
+
+    private static bool IsIncrementablePrimitiveOrEnum(ITypeSymbol typeSymbol)
+    {
+        if (typeSymbol == null)
+        {
+            return false;
+        }
+
+        if (typeSymbol.TypeKind == TypeKind.Enum)
+        {
+            return true;
+        }
+
+        switch (typeSymbol.SpecialType)
+        {
+            case SpecialType.System_SByte:
+            case SpecialType.System_Byte:
+            case SpecialType.System_Int16:
+            case SpecialType.System_UInt16:
+            case SpecialType.System_Int32:
+            case SpecialType.System_UInt32:
+            case SpecialType.System_Int64:
+            case SpecialType.System_UInt64:
+            case SpecialType.System_Char:
+            case SpecialType.System_Single:
+            case SpecialType.System_Double:
+            case SpecialType.System_Decimal:
+                return true;
+            default:
+                return false;
+        }
     }
 
     private static bool BodyHasValueTypeAddedFieldMemberWrite(
@@ -3491,6 +3731,11 @@ public static class TransformWorkerProgram
 
         if (value is float floatValue)
         {
+            if (float.IsNaN(floatValue) || float.IsInfinity(floatValue))
+            {
+                return null;
+            }
+
             return SyntaxFactory.LiteralExpression(
                 SyntaxKind.NumericLiteralExpression,
                 SyntaxFactory.Literal(floatValue));
@@ -3498,6 +3743,11 @@ public static class TransformWorkerProgram
 
         if (value is double doubleValue)
         {
+            if (double.IsNaN(doubleValue) || double.IsInfinity(doubleValue))
+            {
+                return null;
+            }
+
             return SyntaxFactory.LiteralExpression(
                 SyntaxKind.NumericLiteralExpression,
                 SyntaxFactory.Literal(doubleValue));
@@ -5546,7 +5796,11 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
         SyntaxKind binaryKind = GetCompoundAssignmentBinaryKind(node.Kind());
         ExpressionSyntax getCall = CreateAddedFieldGetOrInit(binding, receiver);
         ExpressionSyntax combined = SyntaxFactory.BinaryExpression(binaryKind, getCall, visitedRight);
-        return CreateAddedFieldSet(binding, receiver, combined).WithTriviaFrom(node);
+        return CreateAddedFieldSet(
+                binding,
+                receiver,
+                CastToAddedFieldType(combined, binding.FieldType))
+            .WithTriviaFrom(node);
     }
 
     private SyntaxNode RewriteAddedFieldIncrement(
@@ -5556,34 +5810,42 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
     {
         ExpressionSyntax receiver = ExtractAddedFieldReceiver(operand, binding.IsStatic);
         ExpressionSyntax getCall = CreateAddedFieldGetOrInit(binding, receiver);
+        SyntaxKind binaryKind = IsDecrementNode(triviaSource)
+            ? SyntaxKind.SubtractExpression
+            : SyntaxKind.AddExpression;
         ExpressionSyntax combined = SyntaxFactory.BinaryExpression(
-            SyntaxKind.AddExpression,
+            binaryKind,
             getCall,
             SyntaxFactory.LiteralExpression(
                 SyntaxKind.NumericLiteralExpression,
                 SyntaxFactory.Literal(1)));
-        if (triviaSource is PrefixUnaryExpressionSyntax prefix
-            && prefix.IsKind(SyntaxKind.PreDecrementExpression))
+        return CreateAddedFieldSet(
+                binding,
+                receiver,
+                CastToAddedFieldType(combined, binding.FieldType))
+            .WithTriviaFrom(triviaSource);
+    }
+
+    private static bool IsDecrementNode(SyntaxNode node)
+    {
+        if (node is PrefixUnaryExpressionSyntax prefix)
         {
-            combined = SyntaxFactory.BinaryExpression(
-                SyntaxKind.SubtractExpression,
-                getCall,
-                SyntaxFactory.LiteralExpression(
-                    SyntaxKind.NumericLiteralExpression,
-                    SyntaxFactory.Literal(1)));
-        }
-        else if (triviaSource is PostfixUnaryExpressionSyntax postfix
-            && postfix.IsKind(SyntaxKind.PostDecrementExpression))
-        {
-            combined = SyntaxFactory.BinaryExpression(
-                SyntaxKind.SubtractExpression,
-                getCall,
-                SyntaxFactory.LiteralExpression(
-                    SyntaxKind.NumericLiteralExpression,
-                    SyntaxFactory.Literal(1)));
+            return prefix.IsKind(SyntaxKind.PreDecrementExpression);
         }
 
-        return CreateAddedFieldSet(binding, receiver, combined).WithTriviaFrom(triviaSource);
+        return node is PostfixUnaryExpressionSyntax postfix
+            && postfix.IsKind(SyntaxKind.PostDecrementExpression);
+    }
+
+    // Why cast: C# compound assignment and ++/-- apply a conversion back to the field type
+    // (byte += 1 is (byte)(byte + 1)). Emitting the binary without that conversion is CS1503.
+    private static ExpressionSyntax CastToAddedFieldType(ExpressionSyntax expression, ITypeSymbol fieldType)
+    {
+        TypeSyntax typeSyntax = SyntaxFactory.ParseTypeName(
+            fieldType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+        return SyntaxFactory.CastExpression(
+            typeSyntax,
+            SyntaxFactory.ParenthesizedExpression(expression));
     }
 
     private ExpressionSyntax ExtractAddedFieldReceiver(ExpressionSyntax expression, bool isStatic)
@@ -6542,6 +6804,9 @@ internal sealed class AddedMethodCatalog
     }
 }
 
+/// <summary>
+/// What: one added field's store/const/unavailable binding used by skip evaluation and rewrite.
+/// </summary>
 internal sealed class AddedFieldBinding
 {
     public string FieldKey { get; set; }
@@ -6565,6 +6830,10 @@ internal sealed class AddedFieldBinding
     public bool IsStoreRewriteable => UnavailableReason == null && !IsConst;
 }
 
+/// <summary>
+/// What: file-wide catalog of added fields, syntax keys for drift strip, and whether any
+/// shim body actually emitted a HotReloadAddedFieldStore call.
+/// </summary>
 internal sealed class AddedFieldCatalog
 {
     private readonly Dictionary<string, AddedFieldBinding> _byKey =
@@ -6633,15 +6902,27 @@ internal sealed class AddedFieldCatalog
     }
 }
 
+/// <summary>
+/// What: skip and warning strings for added-field classification. Keep in the existing
+/// "reason + run uloop compile" style; the worker cannot reference HotReloadConstants.
+/// </summary>
 internal static class AddedFieldSkipReasons
 {
     public const string StructHost =
         "Added fields on struct types are skipped; the store requires a reference-type instance. "
         + "Run 'uloop compile' to add them.";
 
-    public const string InaccessibleInitializer =
-        "Added field initializer accesses inaccessible members; the initializer lambda cannot skip visibility. "
+    public const string InitializerNotLiteralOrExternalStatic =
+        "Added field initializer is not a literal or externally visible static member; "
+        + "the shim lambda cannot use instance, host-type, or same-file added members. "
         + "Run 'uloop compile'.";
+
+    public const string FieldTypeNotExternallyVisible =
+        "Added field type is not visible to the shim assembly. Run 'uloop compile'.";
+
+    public const string IncrementNotNumeric =
+        "Increment or decrement of an added field is skipped unless the type is a numeric "
+        + "primitive or enum. Run 'uloop compile'.";
 
     public const string RefOutIn =
         "Added fields cannot be passed by ref, out, or in. Run 'uloop compile'.";
@@ -6655,7 +6936,8 @@ internal static class AddedFieldSkipReasons
         + "Run 'uloop compile'.";
 
     public const string ValueTypeMemberWrite =
-        "Writes to members of an added value-type field cannot be rewritten. Run 'uloop compile'.";
+        "Writes to members of an added value-type field, and instance method calls on that field, "
+        + "cannot be rewritten. Run 'uloop compile'.";
 
     public const string UnavailableAddedField =
         "Uses an added field that hot reload cannot emit. Run 'uloop compile'.";

--- a/Packages/src/Editor/ToolContracts/HotReloadAddedFieldStore.cs
+++ b/Packages/src/Editor/ToolContracts/HotReloadAddedFieldStore.cs
@@ -15,7 +15,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
     /// </summary>
     public static class HotReloadAddedFieldStore
     {
-        // Keep in sync with the transform worker when it starts emitting field keys (PR-4).
+        // Keep in sync with TransformWorkerProgramMarker.AddedFieldKeySeparator.
         public const string FieldKeySeparator = "::";
 
         private static ConditionalWeakTable<object, Dictionary<string, object>> InstanceTables =


### PR DESCRIPTION
## Summary
- Hot reload can now keep values of fields added in an edited C# file, without `uloop compile`, by rewriting those accesses onto the existing side table.
- Reads, writes, compound assignments, and increments are applied; unsupported shapes skip with a compile hint instead of compiling a broken shim.

## User Impact
- Before this change, adding a field in an edited file was outside-body drift: the new storage did not exist at runtime.
- After this change, same-file added fields are stored per instance (and per static field) and survive a second hot-reload apply. Inspector-visible serialization still requires `uloop compile`.

## Changes
- Classify added vs compiled fields with the same assembly ground truth as added methods. Added consts fold to literals; `nameof` added fields fold to the name string.
- Rewrite store reads/writes through `HotReloadAddedFieldStore` (`GetOrInit`/`Set` and the static pair), with initializers as `static () => ...` lambdas.
- Skip referencing methods for: struct hosts, inaccessible initializers, `ref`/`out`/`in`, consumed assignment values, double-eval receivers, and member writes on added value-type fields. `[SerializeField]` and similar attributes warn but still rewrite.
- Strip handled added/removed field declarations before outside-body drift comparison. Set `hasAddedFieldRewrites` only when a shim actually emitted a store call.

## Verification
- `dist/darwin-arm64/uloop compile` — Success, 0 errors
- `dist/darwin-arm64/uloop run-tests --filter-type assembly --filter-value UnityCLILoop.Tests.Editor.HotReload` — 261/261
- CLI E2E with assemblies locked: added field + patched `ReadAdded`/`WriteAdded`; instances isolated (`10,20`); re-apply kept `10,20`. Evidence: `/tmp/uloop-pr4-e2e/`
- SKILL.md / catalog wording is deferred to the docs PR, as planned

## Test plan
- [ ] Worker tests cover classification, const fold, store rewrite shapes, B3/N2/ref/consumed/double-eval/struct-host skips, serialize warning, and drift strip
- [ ] Orchestrator E2E on `HotReloadAddedFieldApplyFixture` keeps per-instance values across re-apply
- [ ] CLI evidence above still matches reviewer replay if needed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

