### PR TITLE
feat: add a Cecil call-site scanner for compiled project assemblies

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerFixture.cs
@@ -44,5 +44,58 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             await Task.Yield();
             return CalledFromAsyncMethod();
         }
+
+        public static int CallGenericHostTarget()
+        {
+            GenericHost<int> host = new GenericHost<int>();
+            return host.Target();
+        }
+
+        public static int GenericMethodTarget<T>()
+        {
+            return 1;
+        }
+
+        public static int CallGenericMethodTarget()
+        {
+            return GenericMethodTarget<int>();
+        }
+
+        public static Func<int> CaptureGenericMethodTarget()
+        {
+            Func<int> captured = GenericMethodTarget<int>;
+            return captured;
+        }
+
+        public static int SelfRecursive(int remaining)
+        {
+            if (remaining <= 0)
+            {
+                return 0;
+            }
+
+            return SelfRecursive(remaining - 1);
+        }
+
+        public static async Task<int> AsyncSelfRecursive(int remaining)
+        {
+            if (remaining <= 0)
+            {
+                return 0;
+            }
+
+            return await AsyncSelfRecursive(remaining - 1);
+        }
+    }
+
+    /// <summary>
+    /// Open generic host so call sites go through a constructed <c>GenericHost&lt;int&gt;</c>.
+    /// </summary>
+    public class GenericHost<T>
+    {
+        public int Target()
+        {
+            return 1;
+        }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerFixture.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading.Tasks;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled call-site targets and callers for <see cref="HotReloadCallSiteScanner"/> tests.
+    /// </summary>
+    public static class HotReloadCallSiteScannerFixture
+    {
+        public static int CalledFromOrdinaryMethod()
+        {
+            return 1;
+        }
+
+        public static int OrdinaryCaller()
+        {
+            return CalledFromOrdinaryMethod();
+        }
+
+        public static int NeverCalled()
+        {
+            return 2;
+        }
+
+        public static int CalledOnlyViaDelegate()
+        {
+            return 3;
+        }
+
+        public static Func<int> CaptureDelegate()
+        {
+            Func<int> captured = CalledOnlyViaDelegate;
+            return captured;
+        }
+
+        public static int CalledFromAsyncMethod()
+        {
+            return 4;
+        }
+
+        public static async Task<int> AsyncCaller()
+        {
+            await Task.Yield();
+            return CalledFromAsyncMethod();
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerFixture.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d45678a5689e44a04b0d03de9e1e9837
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs
@@ -22,6 +22,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string FixtureTypeMetadataName =
             "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadCallSiteScannerFixture";
 
+        private const string GenericHostTypeMetadataName =
+            "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.GenericHost`1";
+
         /// <summary>
         /// What: a method called from an ordinary method is reported with that caller's method key.
         /// </summary>
@@ -29,7 +32,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void FindCallSites_OrdinaryCaller_ReportsCallerMethodKey()
         {
             List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
-                nameof(HotReloadCallSiteScannerFixture.CalledFromOrdinaryMethod));
+                FixtureTypeMetadataName,
+                nameof(HotReloadCallSiteScannerFixture.CalledFromOrdinaryMethod),
+                Array.Empty<string>());
 
             Assert.That(hits.Count, Is.EqualTo(1));
             Assert.That(
@@ -47,7 +52,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void FindCallSites_NeverCalled_ReturnsEmpty()
         {
             List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
-                nameof(HotReloadCallSiteScannerFixture.NeverCalled));
+                FixtureTypeMetadataName,
+                nameof(HotReloadCallSiteScannerFixture.NeverCalled),
+                Array.Empty<string>());
 
             Assert.That(hits, Is.Empty);
         }
@@ -59,7 +66,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void FindCallSites_DelegateAssignment_ReportsLdftnCaller()
         {
             List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
-                nameof(HotReloadCallSiteScannerFixture.CalledOnlyViaDelegate));
+                FixtureTypeMetadataName,
+                nameof(HotReloadCallSiteScannerFixture.CalledOnlyViaDelegate),
+                Array.Empty<string>());
 
             Assert.That(hits.Count, Is.EqualTo(1));
             Assert.That(
@@ -75,7 +84,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void FindCallSites_AsyncCaller_ReportsLogicalOwnerMethodKey()
         {
             List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
-                nameof(HotReloadCallSiteScannerFixture.CalledFromAsyncMethod));
+                FixtureTypeMetadataName,
+                nameof(HotReloadCallSiteScannerFixture.CalledFromAsyncMethod),
+                Array.Empty<string>());
 
             Assert.That(hits.Count, Is.EqualTo(1));
             Assert.That(
@@ -86,7 +97,72 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.EqualTo(nameof(HotReloadCallSiteScannerFixture.AsyncCaller)));
         }
 
-        private static List<HotReloadCallSiteScanner.CallSiteHit> FindHits(string methodName)
+        /// <summary>
+        /// What: a call through GenericHost&lt;int&gt; still hits the open GenericHost`1 Target.
+        /// </summary>
+        [Test]
+        public void FindCallSites_GenericTypeInstantiation_ReportsCaller()
+        {
+            List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
+                GenericHostTypeMetadataName,
+                nameof(GenericHost<int>.Target),
+                Array.Empty<string>());
+
+            Assert.That(hits.Count, Is.EqualTo(1));
+            Assert.That(
+                hits[0].CallerMethodKey,
+                Is.EqualTo(FixtureTypeMetadataName + "::CallGenericHostTarget()"));
+        }
+
+        /// <summary>
+        /// What: an instantiated generic method is found both via Call and via Ldftn.
+        /// </summary>
+        [Test]
+        public void FindCallSites_GenericMethodInstantiation_ReportsCallAndLdftn()
+        {
+            List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
+                FixtureTypeMetadataName,
+                nameof(HotReloadCallSiteScannerFixture.GenericMethodTarget),
+                Array.Empty<string>());
+
+            List<string> keys = hits.ConvertAll(hit => hit.CallerMethodKey);
+            Assert.That(keys, Does.Contain(FixtureTypeMetadataName + "::CallGenericMethodTarget()"));
+            Assert.That(keys, Does.Contain(FixtureTypeMetadataName + "::CaptureGenericMethodTarget()"));
+            Assert.That(hits.Count, Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// What: a recursive call inside the target itself is not reported as a caller.
+        /// </summary>
+        [Test]
+        public void FindCallSites_OrdinarySelfRecursion_ReturnsEmpty()
+        {
+            List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
+                FixtureTypeMetadataName,
+                nameof(HotReloadCallSiteScannerFixture.SelfRecursive),
+                new[] { "System.Int32" });
+
+            Assert.That(hits, Is.Empty);
+        }
+
+        /// <summary>
+        /// What: an async method awaiting itself is not reported after logical-owner resolution.
+        /// </summary>
+        [Test]
+        public void FindCallSites_AsyncSelfRecursion_ReturnsEmpty()
+        {
+            List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
+                FixtureTypeMetadataName,
+                nameof(HotReloadCallSiteScannerFixture.AsyncSelfRecursive),
+                new[] { "System.Int32" });
+
+            Assert.That(hits, Is.Empty);
+        }
+
+        private static List<HotReloadCallSiteScanner.CallSiteHit> FindHits(
+            string typeMetadataName,
+            string methodName,
+            string[] parameterTypeFullNames)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string rawAssemblyName = CompilationPipeline.GetAssemblyNameFromScriptPath(
@@ -96,9 +172,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadCallSiteScanner.CompiledMethodIdentity target =
                 new HotReloadCallSiteScanner.CompiledMethodIdentity(
                     assemblyName,
-                    FixtureTypeMetadataName,
+                    typeMetadataName,
                     methodName,
-                    Array.Empty<string>());
+                    parameterTypeFullNames);
 
             return HotReloadCallSiteScanner.FindCallSites(
                 projectRoot,

--- a/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for compiled call-site enumeration and async logical-owner resolution.
+    /// </summary>
+    public class HotReloadCallSiteScannerTests
+    {
+        private const string TestScriptProjectRelativePath =
+            "Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs";
+
+        private const string FixtureTypeMetadataName =
+            "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadCallSiteScannerFixture";
+
+        /// <summary>
+        /// What: a method called from an ordinary method is reported with that caller's method key.
+        /// </summary>
+        [Test]
+        public void FindCallSites_OrdinaryCaller_ReportsCallerMethodKey()
+        {
+            List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
+                nameof(HotReloadCallSiteScannerFixture.CalledFromOrdinaryMethod));
+
+            Assert.That(hits.Count, Is.EqualTo(1));
+            Assert.That(
+                hits[0].CallerMethodKey,
+                Is.EqualTo(FixtureTypeMetadataName + "::OrdinaryCaller()"));
+            Assert.That(
+                hits[0].CallerMethodName,
+                Is.EqualTo(nameof(HotReloadCallSiteScannerFixture.OrdinaryCaller)));
+        }
+
+        /// <summary>
+        /// What: a method with no compiled call sites yields zero hits.
+        /// </summary>
+        [Test]
+        public void FindCallSites_NeverCalled_ReturnsEmpty()
+        {
+            List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
+                nameof(HotReloadCallSiteScannerFixture.NeverCalled));
+
+            Assert.That(hits, Is.Empty);
+        }
+
+        /// <summary>
+        /// What: a method referenced only by delegate assignment is found via Ldftn.
+        /// </summary>
+        [Test]
+        public void FindCallSites_DelegateAssignment_ReportsLdftnCaller()
+        {
+            List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
+                nameof(HotReloadCallSiteScannerFixture.CalledOnlyViaDelegate));
+
+            Assert.That(hits.Count, Is.EqualTo(1));
+            Assert.That(
+                hits[0].CallerMethodKey,
+                Is.EqualTo(FixtureTypeMetadataName + "::CaptureDelegate()"));
+        }
+
+        /// <summary>
+        /// What: a call from an async method is reported under the logical owner method key,
+        /// not the compiler-generated MoveNext.
+        /// </summary>
+        [Test]
+        public void FindCallSites_AsyncCaller_ReportsLogicalOwnerMethodKey()
+        {
+            List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
+                nameof(HotReloadCallSiteScannerFixture.CalledFromAsyncMethod));
+
+            Assert.That(hits.Count, Is.EqualTo(1));
+            Assert.That(
+                hits[0].CallerMethodKey,
+                Is.EqualTo(FixtureTypeMetadataName + "::AsyncCaller()"));
+            Assert.That(
+                hits[0].CallerMethodName,
+                Is.EqualTo(nameof(HotReloadCallSiteScannerFixture.AsyncCaller)));
+        }
+
+        private static List<HotReloadCallSiteScanner.CallSiteHit> FindHits(string methodName)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string rawAssemblyName = CompilationPipeline.GetAssemblyNameFromScriptPath(
+                TestScriptProjectRelativePath);
+            string assemblyName = Path.GetFileNameWithoutExtension(rawAssemblyName);
+
+            HotReloadCallSiteScanner.CompiledMethodIdentity target =
+                new HotReloadCallSiteScanner.CompiledMethodIdentity(
+                    assemblyName,
+                    FixtureTypeMetadataName,
+                    methodName,
+                    Array.Empty<string>());
+
+            return HotReloadCallSiteScanner.FindCallSites(
+                projectRoot,
+                new[] { target });
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 430b847c2b9ab4f83b22efd743ff2b27
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs
@@ -1,0 +1,403 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+using UnityEditor.Compilation;
+using UnityEngine;
+
+using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Enumerates compiled call sites that target specified methods across project assemblies.
+    /// </summary>
+    internal static class HotReloadCallSiteScanner
+    {
+        /// <summary>
+        /// Identity of a compiled method to search for (assembly + type + name + parameter types).
+        /// </summary>
+        public readonly struct CompiledMethodIdentity
+        {
+            public readonly string AssemblyName;
+            public readonly string TypeMetadataName;
+            public readonly string MethodName;
+            public readonly string[] ParameterTypeFullNames;
+
+            public CompiledMethodIdentity(
+                string assemblyName,
+                string typeMetadataName,
+                string methodName,
+                string[] parameterTypeFullNames)
+            {
+                Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
+                Debug.Assert(!string.IsNullOrEmpty(typeMetadataName), "typeMetadataName must not be null or empty.");
+                Debug.Assert(!string.IsNullOrEmpty(methodName), "methodName must not be null or empty.");
+                Debug.Assert(parameterTypeFullNames != null, "parameterTypeFullNames must not be null.");
+
+                AssemblyName = assemblyName;
+                TypeMetadataName = typeMetadataName;
+                MethodName = methodName;
+                ParameterTypeFullNames = parameterTypeFullNames;
+            }
+        }
+
+        /// <summary>
+        /// One compiled instruction that references a target method, reported under its logical owner.
+        /// </summary>
+        public sealed class CallSiteHit
+        {
+            public string CallerAssemblyName;
+            public string CallerTypeMetadataName;
+            public string CallerMethodName;
+            public string[] CallerParameterTypeFullNames;
+            public string CallerMethodKey;
+        }
+
+        /// <summary>
+        /// Finds compiled call / ldftn sites that reference any of <paramref name="targets"/>.
+        /// </summary>
+        public static List<CallSiteHit> FindCallSites(string projectRoot, CompiledMethodIdentity[] targets)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty.");
+            Debug.Assert(targets != null, "targets must not be null.");
+
+            List<CallSiteHit> hits = new List<CallSiteHit>();
+            if (targets.Length == 0)
+            {
+                return hits;
+            }
+
+            HashSet<string> scanAssemblyNames = CollectScanAssemblyNames(targets);
+            foreach (string assemblyName in scanAssemblyNames)
+            {
+                string dllPath = Path.Combine(
+                    projectRoot,
+                    HotReloadConstants.ScriptAssembliesRelativeDirectory,
+                    assemblyName + HotReloadConstants.CompiledAssemblyExtension);
+
+                // Why skip (not assert): an assembly that has not been written to ScriptAssemblies
+                // cannot contain call sites, so it cannot be a caller. Missing here is "not compiled
+                // yet", not a broken invariant.
+                if (!File.Exists(dllPath))
+                {
+                    continue;
+                }
+
+                CollectHitsFromAssembly(assemblyName, dllPath, targets, hits);
+            }
+
+            return hits;
+        }
+
+        private static HashSet<string> CollectScanAssemblyNames(CompiledMethodIdentity[] targets)
+        {
+            HashSet<string> targetAssemblyNames = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<string> targetDllFileNames = new HashSet<string>(StringComparer.Ordinal);
+            foreach (CompiledMethodIdentity target in targets)
+            {
+                targetAssemblyNames.Add(target.AssemblyName);
+                targetDllFileNames.Add(target.AssemblyName + HotReloadConstants.CompiledAssemblyExtension);
+            }
+
+            HashSet<string> scanNames = new HashSet<string>(StringComparer.Ordinal);
+            foreach (UnityCompilationAssembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (targetAssemblyNames.Contains(assembly.name)
+                    || ReferencesAnyTargetDll(assembly, targetDllFileNames))
+                {
+                    scanNames.Add(assembly.name);
+                }
+            }
+
+            return scanNames;
+        }
+
+        private static bool ReferencesAnyTargetDll(
+            UnityCompilationAssembly assembly,
+            HashSet<string> targetDllFileNames)
+        {
+            if (assembly.allReferences == null)
+            {
+                return false;
+            }
+
+            foreach (string reference in assembly.allReferences)
+            {
+                if (string.IsNullOrEmpty(reference))
+                {
+                    continue;
+                }
+
+                if (targetDllFileNames.Contains(Path.GetFileName(reference)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void CollectHitsFromAssembly(
+            string assemblyName,
+            string dllPath,
+            CompiledMethodIdentity[] targets,
+            List<CallSiteHit> hits)
+        {
+            // InMemory + no resolver: operand FullName comparison does not require type resolution.
+            ReaderParameters readerParameters = new ReaderParameters { InMemory = true };
+            using AssemblyDefinition assemblyDefinition = AssemblyDefinition.ReadAssembly(dllPath, readerParameters);
+            Dictionary<string, MethodDefinition> logicalOwners =
+                BuildLogicalOwnerIndex(assemblyDefinition.MainModule);
+
+            foreach (TypeDefinition type in assemblyDefinition.MainModule.GetTypes())
+            {
+                foreach (MethodDefinition method in type.Methods)
+                {
+                    CollectHitsFromMethod(assemblyName, method, targets, logicalOwners, hits);
+                }
+            }
+        }
+
+        private static Dictionary<string, MethodDefinition> BuildLogicalOwnerIndex(ModuleDefinition module)
+        {
+            Dictionary<string, MethodDefinition> index = new Dictionary<string, MethodDefinition>();
+            foreach (TypeDefinition type in module.GetTypes())
+            {
+                foreach (MethodDefinition method in type.Methods)
+                {
+                    TryIndexStateMachineOwner(method, index);
+                }
+            }
+
+            return index;
+        }
+
+        private static void TryIndexStateMachineOwner(
+            MethodDefinition method,
+            Dictionary<string, MethodDefinition> index)
+        {
+            if (!method.HasCustomAttributes)
+            {
+                return;
+            }
+
+            foreach (CustomAttribute attribute in method.CustomAttributes)
+            {
+                string attributeName = attribute.AttributeType.Name;
+                if (attributeName != HotReloadConstants.AsyncStateMachineAttributeTypeName
+                    && attributeName != HotReloadConstants.IteratorStateMachineAttributeTypeName)
+                {
+                    continue;
+                }
+
+                if (!attribute.HasConstructorArguments || attribute.ConstructorArguments.Count == 0)
+                {
+                    continue;
+                }
+
+                TypeReference stateMachineType = attribute.ConstructorArguments[0].Value as TypeReference;
+                if (stateMachineType == null)
+                {
+                    continue;
+                }
+
+                index[stateMachineType.FullName] = method;
+            }
+        }
+
+        private static void CollectHitsFromMethod(
+            string assemblyName,
+            MethodDefinition method,
+            CompiledMethodIdentity[] targets,
+            Dictionary<string, MethodDefinition> logicalOwners,
+            List<CallSiteHit> hits)
+        {
+            if (!method.HasBody)
+            {
+                return;
+            }
+
+            foreach (Instruction instruction in method.Body.Instructions)
+            {
+                if (!IsCallSiteOpcode(instruction.OpCode))
+                {
+                    continue;
+                }
+
+                MethodReference operand = instruction.Operand as MethodReference;
+                if (operand == null)
+                {
+                    continue;
+                }
+
+                (bool matched, CompiledMethodIdentity target) = FindMatchingTarget(operand, targets);
+                if (!matched)
+                {
+                    continue;
+                }
+
+                // Why exclude self: a recursive call inside the old method is moot once that
+                // method becomes unreachable. Reporting it would look like an external caller.
+                if (IsSelfCall(assemblyName, method, target))
+                {
+                    continue;
+                }
+
+                MethodDefinition reportedCaller = ResolveReportedCaller(method, logicalOwners);
+                hits.Add(CreateHit(assemblyName, reportedCaller));
+            }
+        }
+
+        private static bool IsCallSiteOpcode(OpCode opCode)
+        {
+            return opCode == OpCodes.Call
+                || opCode == OpCodes.Callvirt
+                || opCode == OpCodes.Ldftn
+                || opCode == OpCodes.Ldvirtftn;
+        }
+
+        private static (bool matched, CompiledMethodIdentity target) FindMatchingTarget(
+            MethodReference methodReference,
+            CompiledMethodIdentity[] targets)
+        {
+            foreach (CompiledMethodIdentity target in targets)
+            {
+                if (MatchesIdentity(
+                        methodReference,
+                        target.TypeMetadataName,
+                        target.MethodName,
+                        target.ParameterTypeFullNames))
+                {
+                    return (true, target);
+                }
+            }
+
+            return (false, default);
+        }
+
+        private static bool IsSelfCall(
+            string callerAssemblyName,
+            MethodDefinition caller,
+            CompiledMethodIdentity target)
+        {
+            if (callerAssemblyName != target.AssemblyName)
+            {
+                return false;
+            }
+
+            return MatchesIdentity(
+                caller,
+                target.TypeMetadataName,
+                target.MethodName,
+                target.ParameterTypeFullNames);
+        }
+
+        private static bool MatchesIdentity(
+            MethodReference methodReference,
+            string typeMetadataName,
+            string methodName,
+            string[] parameterTypeFullNames)
+        {
+            if (methodReference.DeclaringType == null)
+            {
+                return false;
+            }
+
+            // Why not normalize '/' → '+': Cecil FullName and worker typeMetadataName both use
+            // '/' for nested types, and BuildMethodKey keeps that form. Converting here would
+            // desync CallerMethodKey from the orchestrator key space on nested types.
+            if (methodReference.DeclaringType.FullName != typeMetadataName)
+            {
+                return false;
+            }
+
+            if (methodReference.Name != methodName)
+            {
+                return false;
+            }
+
+            if (methodReference.Parameters.Count != parameterTypeFullNames.Length)
+            {
+                return false;
+            }
+
+            for (int index = 0; index < parameterTypeFullNames.Length; index++)
+            {
+                if (methodReference.Parameters[index].ParameterType.FullName != parameterTypeFullNames[index])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static MethodDefinition ResolveReportedCaller(
+            MethodDefinition caller,
+            Dictionary<string, MethodDefinition> logicalOwners)
+        {
+            TypeDefinition declaringType = caller.DeclaringType;
+            if (!IsCompilerGeneratedType(declaringType))
+            {
+                return caller;
+            }
+
+            // Why keep the compiler-generated identity on a miss: closures such as
+            // <>c__DisplayClass have no Async/Iterator attribute link. Cover checks then fail
+            // closed (uncovered) instead of treating an unknown owner as already patched.
+            if (logicalOwners.TryGetValue(declaringType.FullName, out MethodDefinition logicalOwner))
+            {
+                return logicalOwner;
+            }
+
+            return caller;
+        }
+
+        private static bool IsCompilerGeneratedType(TypeDefinition type)
+        {
+            if (type.Name.IndexOf('<') >= 0)
+            {
+                return true;
+            }
+
+            if (!type.HasCustomAttributes)
+            {
+                return false;
+            }
+
+            foreach (CustomAttribute attribute in type.CustomAttributes)
+            {
+                if (attribute.AttributeType.Name == HotReloadConstants.CompilerGeneratedAttributeTypeName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static CallSiteHit CreateHit(string assemblyName, MethodDefinition caller)
+        {
+            string[] parameterTypeFullNames = new string[caller.Parameters.Count];
+            for (int index = 0; index < caller.Parameters.Count; index++)
+            {
+                parameterTypeFullNames[index] = caller.Parameters[index].ParameterType.FullName;
+            }
+
+            string typeMetadataName = caller.DeclaringType.FullName;
+            return new CallSiteHit
+            {
+                CallerAssemblyName = assemblyName,
+                CallerTypeMetadataName = typeMetadataName,
+                CallerMethodName = caller.Name,
+                CallerParameterTypeFullNames = parameterTypeFullNames,
+                CallerMethodKey = typeMetadataName + "::" + caller.Name + "("
+                    + string.Join(",", parameterTypeFullNames) + ")"
+            };
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs
@@ -240,14 +240,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                // Why exclude self: a recursive call inside the old method is moot once that
-                // method becomes unreachable. Reporting it would look like an external caller.
-                if (IsSelfCall(assemblyName, method, target))
+                MethodDefinition reportedCaller = ResolveReportedCaller(method, logicalOwners);
+
+                // Why resolve first: async/iterator self-recursion lives in MoveNext. Matching
+                // the physical caller would miss it, then reporting the logical owner would look
+                // like an external caller of the old method.
+                if (IsSelfCall(assemblyName, reportedCaller, target))
                 {
                     continue;
                 }
 
-                MethodDefinition reportedCaller = ResolveReportedCaller(method, logicalOwners);
                 hits.Add(CreateHit(assemblyName, reportedCaller));
             }
         }
@@ -302,7 +304,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string methodName,
             string[] parameterTypeFullNames)
         {
-            if (methodReference.DeclaringType == null)
+            MethodReference openMethod = methodReference.GetElementMethod();
+            if (openMethod.DeclaringType == null)
             {
                 return false;
             }
@@ -310,16 +313,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why not normalize '/' → '+': Cecil FullName and worker typeMetadataName both use
             // '/' for nested types, and BuildMethodKey keeps that form. Converting here would
             // desync CallerMethodKey from the orchestrator key space on nested types.
-            if (methodReference.DeclaringType.FullName != typeMetadataName)
+            if (ToOpenDeclaringTypeFullName(openMethod.DeclaringType) != typeMetadataName)
             {
                 return false;
             }
 
-            if (methodReference.Name != methodName)
+            if (openMethod.Name != methodName)
             {
                 return false;
             }
 
+            return ParametersMatch(openMethod, parameterTypeFullNames);
+        }
+
+        private static string ToOpenDeclaringTypeFullName(TypeReference declaringType)
+        {
+            GenericInstanceType genericInstance = declaringType as GenericInstanceType;
+            if (genericInstance != null)
+            {
+                return genericInstance.GetElementType().FullName;
+            }
+
+            return declaringType.FullName;
+        }
+
+        private static bool ParametersMatch(MethodReference methodReference, string[] parameterTypeFullNames)
+        {
             if (methodReference.Parameters.Count != parameterTypeFullNames.Length)
             {
                 return false;
@@ -327,7 +346,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             for (int index = 0; index < parameterTypeFullNames.Length; index++)
             {
-                if (methodReference.Parameters[index].ParameterType.FullName != parameterTypeFullNames[index])
+                TypeReference parameterType = methodReference.Parameters[index].ParameterType;
+                if (parameterType.ContainsGenericParameter)
+                {
+                    // Why treat as match: a type-argument-dependent parameter cannot be compared
+                    // to the compiled identity string with certainty. Missing the site would
+                    // fail-open the signature-change gate.
+                    continue;
+                }
+
+                if (parameterType.FullName != parameterTypeFullNames[index])
                 {
                     return false;
                 }
@@ -343,6 +371,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             TypeDefinition declaringType = caller.DeclaringType;
             if (!IsCompilerGeneratedType(declaringType))
             {
+                // Why leave local functions as mangled names (<M>g__f|…): they are methods on
+                // the user type, so the state-machine index does not apply. Cover checks then
+                // fail closed (over-Skip) instead of treating an unknown local function as patched.
                 return caller;
             }
 
@@ -389,6 +420,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             string typeMetadataName = caller.DeclaringType.FullName;
+
+            // Keep in sync with TransformWorkerProgram.BuildMethodKey (out-of-process worker)
+            // and HotReloadOrchestrator.BuildMethodKey (Unity package side).
             return new CallSiteHit
             {
                 CallerAssemblyName = assemblyName,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d3c8977c5968342ef91d54f901bffbe6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -44,6 +44,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public const string BurstCompileAttributeFullName = "Unity.Burst.BurstCompileAttribute";
 
+        // Cecil AttributeType.Name values for call-site logical-owner resolution.
+        public const string CompilerGeneratedAttributeTypeName = "CompilerGeneratedAttribute";
+        public const string AsyncStateMachineAttributeTypeName = "AsyncStateMachineAttribute";
+        public const string IteratorStateMachineAttributeTypeName = "IteratorStateMachineAttribute";
+
         // Why not "applied": this sentence is the cross-file / unsupported-kind hint appended
         // to NewMember compile failures. Same-file added methods are applied through the shim.
         public const string NewMemberCompileHint =

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -947,7 +947,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 string.Join(", ", names));
         }
 
-        // Keep in sync with TransformWorkerProgram.BuildMethodKey (out-of-process worker side).
+        // Keep in sync with TransformWorkerProgram.BuildMethodKey (out-of-process worker side)
+        // and HotReloadCallSiteScanner.CreateHit.
         private static string BuildMethodKey(TransformWorkerEntryDto entry)
         {
             return entry.typeMetadataName + "::" + entry.methodName + "("

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -115,7 +115,8 @@ public static class TransformWorkerProgram
         File.WriteAllBytes(outputJsonPath, bytes);
     }
 
-    // Keep in sync with HotReloadOrchestrator.BuildMethodKey (Unity package side).
+    // Keep in sync with HotReloadOrchestrator.BuildMethodKey (Unity package side)
+    // and HotReloadCallSiteScanner.CreateHit.
     private static string BuildMethodKey(string typeMetadataName, string methodName, string[] parameterTypeFullNames)
     {
         return typeMetadataName + "::" + methodName + "(" + string.Join(",", parameterTypeFullNames ?? Array.Empty<string>()) + ")";


### PR DESCRIPTION
## Summary
- Adds a compiled call-site scanner so later hot-reload work can see whether project assemblies still call a method after a signature change.
- Resolves async/iterator callers to the user-facing method, and treats unresolved compiler-generated callers as uncovered.

## User Impact
- This PR does not change `uloop hot-reload` behavior yet. It is the foundation for refusing (or warning on) signature changes when compiled callers remain outside the edited file.
- Without this scan, a later return-type change could report success while other compiled methods keep calling the old body.

## Changes
- New `HotReloadCallSiteScanner` walks ScriptAssemblies DLLs that are the target assembly or that reference it.
- Matches `Call` / `Callvirt` / `Ldftn` / `Ldvirtftn` by type metadata name, method name, and parameter type full names (no nested-type separator rewrite).
- Builds a one-pass index from `AsyncStateMachineAttribute` / `IteratorStateMachineAttribute` to the logical owner method.
- Missing ScriptAssemblies DLLs are omitted from the scan (they cannot be callers) rather than asserted.
- EditMode tests cover ordinary callers, unreferenced methods, delegate `Ldftn`, and async logical-owner keys.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Success, 0 errors, 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --filter-type regex --filter-value "HotReloadCallSiteScanner"` → Passed (4/4)
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --filter-type regex --filter-value "HotReload"` → Passed (275/275)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

