### PR TITLE
feat: classify return-type changes as added-method replacements in the worker

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
@@ -261,4 +261,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return "ok";
         }
     }
+
+    /// <summary>
+    /// Partial host so worker tests can prove deleted-method signatures are omitted on partials.
+    /// </summary>
+    public partial class HotReloadAddedMemberPartialHost
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int PartialKept()
+        {
+            return 1;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int PartialRemoved()
+        {
+            return 2;
+        }
+    }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberPartialHost.Other.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberPartialHost.Other.cs
@@ -1,0 +1,17 @@
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Other file of <see cref="HotReloadAddedMemberPartialHost"/> so the compiled type
+    /// has members this file does not declare.
+    /// </summary>
+    public partial class HotReloadAddedMemberPartialHost
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int PartialOtherFile()
+        {
+            return 3;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberPartialHost.Other.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberPartialHost.Other.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 989e557a7fa3548b5a1fae2c6307642b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -1047,6 +1047,142 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Output.removedMembers, Is.Empty);
         }
 
+        /// <summary>
+        /// What: a return-type-only change is classified as an addedMethod replacement with
+        /// replacesCompiledMethod, the old name in removedMembers, and the old identity in
+        /// removedMethodSignatures.
+        /// </summary>
+        [Test]
+        public async Task Classify_ReturnTypeChange_IsAddedReplacementWithRemovedSignature()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int ExistingValue()\n        {\n            return 1;\n        }",
+                "        public long ExistingValue()\n        {\n            return 1L;\n        }",
+                StringComparison.Ordinal);
+            string sourcePath = WriteEdited("ReturnTypeChange.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto entry = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingValue));
+            Assert.That(entry, Is.Not.Null);
+            Assert.That(entry.patchKind, Is.EqualTo(HotReloadConstants.PatchKindAddedMethod));
+            Assert.That(entry.replacesCompiledMethod, Is.True);
+            AssertHasRemovedMemberName(result, nameof(HotReloadAddedMemberHost.ExistingValue));
+            Assert.That(
+                HasRemovedSignature(
+                    result.Output,
+                    typeof(HotReloadAddedMemberHost).FullName,
+                    nameof(HotReloadAddedMemberHost.ExistingValue)),
+                Is.True);
+        }
+
+        /// <summary>
+        /// What: a return-type change that is also virtual is skipped with the existing
+        /// added-method vtable reason.
+        /// </summary>
+        [Test]
+        public async Task Classify_ReturnTypeChangeOnVirtual_IsSkippedWithVtableReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int ExistingValue()\n        {\n            return 1;\n        }",
+                "        public virtual long ExistingValue()\n        {\n            return 1L;\n        }",
+                StringComparison.Ordinal);
+            string sourcePath = WriteEdited("ReturnTypeChangeVirtual.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingValue), "vtable slot");
+            Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingValue)), Is.Null);
+        }
+
+        /// <summary>
+        /// What: a parameter-type change reports the old compiled identity in
+        /// removedMethodSignatures in addition to the name-only removed warning.
+        /// </summary>
+        [Test]
+        public async Task Classify_ParameterTypeChange_ReportsOldSignature()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(string value)\n        {\n            return value.Length;\n        }",
+                StringComparison.Ordinal);
+            string sourcePath = WriteEdited("ParameterTypeChange.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasRemovedMemberName(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(
+                HasRemovedSignature(
+                    result.Output,
+                    typeof(HotReloadAddedMemberHost).FullName,
+                    nameof(HotReloadAddedMemberHost.ExistingCaller),
+                    "System.Int32"),
+                Is.True);
+        }
+
+        /// <summary>
+        /// What: deleting a method on a partial type keeps the name warning and leaves
+        /// removedMethodSignatures empty so other-file declarations are not treated as deleted.
+        /// </summary>
+        [Test]
+        public async Task Classify_PartialTypeMethodDeletion_OmitsRemovedSignatures()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int PartialRemoved()\n        {\n            return 2;\n        }\n",
+                string.Empty,
+                StringComparison.Ordinal);
+            string sourcePath = WriteEdited("PartialMethodDeletion.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasRemovedMemberName(result, nameof(HotReloadAddedMemberPartialHost.PartialRemoved));
+            Assert.That(result.Output.removedMethodSignatures, Is.Not.Null);
+            Assert.That(result.Output.removedMethodSignatures, Is.Empty);
+        }
+
+        /// <summary>
+        /// What: an existing method whose return type is unchanged stays a normal edit
+        /// (not an addedMethod replacement).
+        /// </summary>
+        [Test]
+        public async Task Classify_UnchangedReturnType_IsNotReplacement()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int ExistingValue()\n        {\n            return 1;\n        }",
+                "        public int ExistingValue()\n        {\n            return 99;\n        }",
+                StringComparison.Ordinal);
+            string sourcePath = WriteEdited("UnchangedReturnType.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto entry = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingValue));
+            Assert.That(entry, Is.Not.Null);
+            Assert.That(entry.patchKind, Is.Not.EqualTo(HotReloadConstants.PatchKindAddedMethod));
+            Assert.That(entry.replacesCompiledMethod, Is.False);
+        }
+
         private static async Task<TransformWorkerClientResult> RunHostWithAddedMembersAsync(string extraMembers)
         {
             string onDisk = File.ReadAllText(ResolveHostPath());
@@ -1086,6 +1222,63 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             return null;
+        }
+
+        private static void AssertHasRemovedMemberName(TransformWorkerClientResult result, string name)
+        {
+            Assert.That(result.Output.removedMembers, Is.Not.Null);
+            foreach (TransformWorkerRemovedMemberDto removed in result.Output.removedMembers)
+            {
+                if (removed.kind == HotReloadConstants.RemovedMemberKindMethod && removed.name == name)
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail("Expected removed member name '" + name + "'.");
+        }
+
+        private static bool HasRemovedSignature(
+            TransformWorkerOutputDto output,
+            string typeMetadataName,
+            string methodName,
+            params string[] parameterTypeFullNames)
+        {
+            if (output.removedMethodSignatures == null)
+            {
+                return false;
+            }
+
+            foreach (TransformWorkerRemovedMethodSignatureDto signature in output.removedMethodSignatures)
+            {
+                if (signature.typeMetadataName != typeMetadataName || signature.methodName != methodName)
+                {
+                    continue;
+                }
+
+                if (signature.parameterTypeFullNames == null
+                    || signature.parameterTypeFullNames.Length != parameterTypeFullNames.Length)
+                {
+                    continue;
+                }
+
+                bool match = true;
+                for (int index = 0; index < parameterTypeFullNames.Length; index++)
+                {
+                    if (signature.parameterTypeFullNames[index] != parameterTypeFullNames[index])
+                    {
+                        match = false;
+                        break;
+                    }
+                }
+
+                if (match)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static void AssertHasSkip(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -1102,6 +1102,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingValue), "vtable slot");
             Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingValue)), Is.Null);
+            Assert.That(result.Output.removedMembers, Is.Empty);
+            Assert.That(result.Output.removedMethodSignatures, Is.Empty);
+        }
+
+        /// <summary>
+        /// What: changing a value return to a ref return is ReturnTypeChanged, not Matched,
+        /// because ToCecilFullName alone cannot see byref.
+        /// </summary>
+        [Test]
+        public async Task Classify_RefReturnTypeChange_IsAddedReplacement()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int ExistingValue()\n        {\n            return 1;\n        }",
+                "        public ref int ExistingValue()\n        {\n            return ref PublicSeed;\n        }",
+                StringComparison.Ordinal);
+            string sourcePath = WriteEdited("RefReturnTypeChange.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto entry = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingValue));
+            Assert.That(entry, Is.Not.Null);
+            Assert.That(entry.patchKind, Is.EqualTo(HotReloadConstants.PatchKindAddedMethod));
+            Assert.That(entry.replacesCompiledMethod, Is.True);
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -1609,6 +1609,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             TransformWorkerClient.CoalesceOutput(omitted);
             Assert.That(omitted.removedMembers, Is.Not.Null);
             Assert.That(omitted.removedMembers, Is.Empty);
+            Assert.That(omitted.removedMethodSignatures, Is.Not.Null);
+            Assert.That(omitted.removedMethodSignatures, Is.Empty);
             Assert.That(omitted.entries[0].calledAddedMethodKeys, Is.Not.Null);
             Assert.That(omitted.entries[0].calledAddedMethodKeys, Is.Empty);
             Assert.That(omitted.declarationDriftWarnings, Is.Not.Null);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
@@ -111,6 +111,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             output.declarationDriftWarnings ??= Array.Empty<string>();
             output.unchangedMethods ??= Array.Empty<TransformWorkerUnchangedMethodDto>();
             output.removedMembers ??= Array.Empty<TransformWorkerRemovedMemberDto>();
+            output.removedMethodSignatures ??= Array.Empty<TransformWorkerRemovedMethodSignatureDto>();
             output.shimSource ??= string.Empty;
             foreach (TransformWorkerEntryDto entry in output.entries)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -67,6 +67,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // True when any emitted shim body rewrites an added-field access to HotReloadAddedFieldStore.
         // Drives ToolContracts assembly injection at both the first compile and isolation retry.
         public bool hasAddedFieldRewrites;
+
+        // Compiled identities of methods that left the edited file (or whose return type changed).
+        // Null/omitted deserializes as empty after client coalesce.
+        public TransformWorkerRemovedMethodSignatureDto[] removedMethodSignatures;
+    }
+
+    [Serializable]
+    internal sealed class TransformWorkerRemovedMethodSignatureDto
+    {
+        public string typeMetadataName;
+        public string methodName;
+        public string[] parameterTypeFullNames;
     }
 
     [Serializable]
@@ -109,6 +121,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Null/empty when the method is not a one-shot lifecycle method and is not only called
         // from them inside this file.
         public string lifecycleNote;
+
+        // True when this addedMethod entry replaces a compiled method whose return type changed.
+        public bool replacesCompiledMethod;
     }
 
     [Serializable]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -2285,19 +2285,13 @@ public static class TransformWorkerProgram
             // Why skip explicit-interface methods: compiled GetMembers(simpleName) does not
             // see them (metadata name is Interface.Method), so they would be misclassified as
             // Added and skip the unchanged/baseline path.
-            (CompiledMethodMatch compiledMatch, string _) =
-                MatchCompiledOrdinaryMethod(compiledType, methodSymbol);
-            bool isAddedMethod = methodDeclaration.ExplicitInterfaceSpecifier == null
-                && compiledMatch != CompiledMethodMatch.Matched;
-            bool replacesCompiledMethod = compiledMatch == CompiledMethodMatch.ReturnTypeChanged;
-            if (replacesCompiledMethod)
+            bool isAddedMethod = false;
+            bool replacesCompiledMethod = false;
+            if (methodDeclaration.ExplicitInterfaceSpecifier == null)
             {
-                AddRemovedMethodName(removedMembers, methodSymbol.Name);
-                AddRemovedMethodSignature(
-                    removedMethodSignatures,
-                    typeState.TypeSymbol,
-                    methodSymbol.Name,
-                    parameterTypeFullNames);
+                CompiledMethodMatch compiledMatch = MatchCompiledOrdinaryMethod(compiledType, methodSymbol);
+                isAddedMethod = compiledMatch != CompiledMethodMatch.Matched;
+                replacesCompiledMethod = compiledMatch == CompiledMethodMatch.ReturnTypeChanged;
             }
 
             if (isAddedMethod)
@@ -2423,6 +2417,16 @@ public static class TransformWorkerProgram
                 ReplacesCompiledMethod = replacesCompiledMethod
             };
             typeState.QueuedMethods.Add(queued);
+
+            if (replacesCompiledMethod)
+            {
+                AddRemovedMethodName(removedMembers, methodSymbol.Name);
+                AddRemovedMethodSignature(
+                    removedMethodSignatures,
+                    typeState.TypeSymbol,
+                    methodSymbol.Name,
+                    parameterTypeFullNames);
+            }
 
             if (isAddedMethod)
             {
@@ -3090,7 +3094,7 @@ public static class TransformWorkerProgram
         return targetTypesAssemblySymbol.GetTypeByMetadataName(ToReflectionMetadataName(sourceType));
     }
 
-    private static (CompiledMethodMatch Match, string CompiledReturnTypeFullName) MatchCompiledOrdinaryMethod(
+    private static CompiledMethodMatch MatchCompiledOrdinaryMethod(
         INamedTypeSymbol compiledType,
         IMethodSymbol sourceMethod)
     {
@@ -3123,17 +3127,30 @@ public static class TransformWorkerProgram
                 continue;
             }
 
-            string compiledReturnTypeFullName = CecilTypeNames.ToCecilFullName(compiledMethod.ReturnType);
-            string sourceReturnTypeFullName = CecilTypeNames.ToCecilFullName(sourceMethod.ReturnType);
-            if (compiledReturnTypeFullName == sourceReturnTypeFullName)
+            if (ReturnTypesMatch(compiledMethod, sourceMethod))
             {
-                return (CompiledMethodMatch.Matched, compiledReturnTypeFullName);
+                return CompiledMethodMatch.Matched;
             }
 
-            return (CompiledMethodMatch.ReturnTypeChanged, compiledReturnTypeFullName);
+            return CompiledMethodMatch.ReturnTypeChanged;
         }
 
-        return (CompiledMethodMatch.NotFound, null);
+        return CompiledMethodMatch.NotFound;
+    }
+
+    private static bool ReturnTypesMatch(IMethodSymbol compiledMethod, IMethodSymbol sourceMethod)
+    {
+        if (CecilTypeNames.ToCecilFullName(compiledMethod.ReturnType)
+            != CecilTypeNames.ToCecilFullName(sourceMethod.ReturnType))
+        {
+            return false;
+        }
+
+        // Why compare byref flags separately: ToCecilFullName sees only ITypeSymbol, so
+        // int F() and ref int F() both become System.Int32. Missing this would transplant
+        // the new body onto the old non-byref signature.
+        return compiledMethod.ReturnsByRef == sourceMethod.ReturnsByRef
+            && compiledMethod.ReturnsByRefReadonly == sourceMethod.ReturnsByRefReadonly;
     }
 
     private static bool CompiledTypeHasField(INamedTypeSymbol compiledType, IFieldSymbol sourceField)
@@ -3403,7 +3420,7 @@ public static class TransformWorkerProgram
 
         if (symbol is IMethodSymbol methodSymbol && methodSymbol.MethodKind == MethodKind.Ordinary)
         {
-            (CompiledMethodMatch match, string _) = MatchCompiledOrdinaryMethod(compiledType, methodSymbol);
+            CompiledMethodMatch match = MatchCompiledOrdinaryMethod(compiledType, methodSymbol);
             // Why map ReturnTypeChanged to added: the compiled method still has the old
             // signature, so treating it as a direct shim reference would bind the old body.
             return match != CompiledMethodMatch.Matched;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -296,6 +296,7 @@ public static class TransformWorkerProgram
         List<WorkerSkipped> skipped = new List<WorkerSkipped>();
         List<WorkerUnchangedMethod> unchangedMethods = new List<WorkerUnchangedMethod>();
         List<WorkerRemovedMember> removedMembers = new List<WorkerRemovedMember>();
+        List<WorkerRemovedMethodSignature> removedMethodSignatures = new List<WorkerRemovedMethodSignature>();
         List<ShimTypeBuilder> shimTypes = new List<ShimTypeBuilder>();
         int globalShimMethodCounter = 0;
         int shimTypeCounter = 0;
@@ -349,6 +350,8 @@ public static class TransformWorkerProgram
                 skipped,
                 unchangedMethods,
                 declarationDriftWarnings,
+                removedMembers,
+                removedMethodSignatures,
                 shimTypeCounter,
                 globalShimMethodCounter);
             shimTypeCounter = nextShimTypeCounter;
@@ -363,6 +366,12 @@ public static class TransformWorkerProgram
                 plainCurrentMethodMap,
                 addedMethodCatalog,
                 removedMembers);
+            CollectRemovedMethodSignaturesForDeletedNames(
+                typeEmitStates,
+                semanticModel,
+                targetTypesAssemblySymbol,
+                removedMembers,
+                removedMethodSignatures);
             Dictionary<string, VariableDeclaratorSyntax> snapshotFieldMap =
                 BuildSyntaxFieldMapOrNull(baselineSnapshotRoot);
             Dictionary<string, VariableDeclaratorSyntax> currentFieldMap =
@@ -466,6 +475,7 @@ public static class TransformWorkerProgram
             UnchangedMethods = unchangedMethods.ToArray(),
             BaselineDisabledByDuplicateKeys = baselineDisabledByDuplicateKeys,
             RemovedMembers = removedMembers.ToArray(),
+            RemovedMethodSignatures = removedMethodSignatures.ToArray(),
             HasAccessorDelegates = hasAccessorDelegates,
             HasAddedFieldRewrites = addedFieldCatalog.HasStoreRewrites
         };
@@ -2236,6 +2246,8 @@ public static class TransformWorkerProgram
         List<WorkerSkipped> skipped,
         List<WorkerUnchangedMethod> unchangedMethods,
         List<string> declarationDriftWarnings,
+        List<WorkerRemovedMember> removedMembers,
+        List<WorkerRemovedMethodSignature> removedMethodSignatures,
         int shimTypeCounter,
         int globalShimMethodCounter)
     {
@@ -2273,8 +2285,20 @@ public static class TransformWorkerProgram
             // Why skip explicit-interface methods: compiled GetMembers(simpleName) does not
             // see them (metadata name is Interface.Method), so they would be misclassified as
             // Added and skip the unchanged/baseline path.
+            (CompiledMethodMatch compiledMatch, string _) =
+                MatchCompiledOrdinaryMethod(compiledType, methodSymbol);
             bool isAddedMethod = methodDeclaration.ExplicitInterfaceSpecifier == null
-                && !CompiledTypeHasOrdinaryMethod(compiledType, methodSymbol);
+                && compiledMatch != CompiledMethodMatch.Matched;
+            bool replacesCompiledMethod = compiledMatch == CompiledMethodMatch.ReturnTypeChanged;
+            if (replacesCompiledMethod)
+            {
+                AddRemovedMethodName(removedMembers, methodSymbol.Name);
+                AddRemovedMethodSignature(
+                    removedMethodSignatures,
+                    typeState.TypeSymbol,
+                    methodSymbol.Name,
+                    parameterTypeFullNames);
+            }
 
             if (isAddedMethod)
             {
@@ -2395,7 +2419,8 @@ public static class TransformWorkerProgram
                 SourceEndLine = originalSpan.EndLinePosition.Line + 1,
                 ParameterTypeFullNames = parameterTypeFullNames,
                 MethodKey = methodKey,
-                IsAddedMethod = isAddedMethod
+                IsAddedMethod = isAddedMethod,
+                ReplacesCompiledMethod = replacesCompiledMethod
             };
             typeState.QueuedMethods.Add(queued);
 
@@ -2491,7 +2516,8 @@ public static class TransformWorkerProgram
                 LifecycleNote = ComputeLifecycleNote(
                     queued.MethodDeclaration,
                     queued.MethodSymbol,
-                    typeState.TypeSymbol)
+                    typeState.TypeSymbol),
+                ReplacesCompiledMethod = queued.ReplacesCompiledMethod
             });
         }
     }
@@ -2503,6 +2529,14 @@ public static class TransformWorkerProgram
         List<WorkerRemovedMember> removedMembers)
     {
         HashSet<string> seenNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (WorkerRemovedMember existing in removedMembers)
+        {
+            if (existing.Kind == RemovedMemberKinds.Method)
+            {
+                seenNames.Add(existing.Name);
+            }
+        }
+
         foreach (KeyValuePair<string, MethodDeclarationSyntax> pair in snapshotMethodMap)
         {
             if (plainCurrentMethodMap.ContainsKey(pair.Key))
@@ -2523,6 +2557,169 @@ public static class TransformWorkerProgram
                 Name = name
             });
         }
+    }
+
+    private static void CollectRemovedMethodSignaturesForDeletedNames(
+        List<TypeEmitState> typeEmitStates,
+        SemanticModel semanticModel,
+        IAssemblySymbol targetTypesAssemblySymbol,
+        List<WorkerRemovedMember> removedMembers,
+        List<WorkerRemovedMethodSignature> removedMethodSignatures)
+    {
+        HashSet<string> removedMethodNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (WorkerRemovedMember removed in removedMembers)
+        {
+            if (removed.Kind == RemovedMemberKinds.Method)
+            {
+                removedMethodNames.Add(removed.Name);
+            }
+        }
+
+        if (removedMethodNames.Count == 0)
+        {
+            return;
+        }
+
+        foreach (TypeEmitState typeState in typeEmitStates)
+        {
+            if (typeState.TypeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword))
+            {
+                // Why skip: a compiled type includes methods declared in other files of a
+                // partial. A name missing from this file is not proof the method was deleted.
+                continue;
+            }
+
+            INamedTypeSymbol compiledType = FindCompiledType(typeState.TypeSymbol, targetTypesAssemblySymbol);
+            if (compiledType == null)
+            {
+                continue;
+            }
+
+            foreach (ISymbol member in compiledType.GetMembers())
+            {
+                if (member is not IMethodSymbol compiledMethod
+                    || compiledMethod.MethodKind != MethodKind.Ordinary
+                    || !removedMethodNames.Contains(compiledMethod.Name))
+                {
+                    continue;
+                }
+
+                if (SourceDeclarationCoversCompiledMethod(typeState, semanticModel, compiledMethod))
+                {
+                    continue;
+                }
+
+                string[] parameterTypeFullNames = compiledMethod.Parameters
+                    .Select(CecilTypeNames.ToParameterTypeFullName)
+                    .ToArray();
+                AddRemovedMethodSignature(
+                    removedMethodSignatures,
+                    typeState.TypeSymbol,
+                    compiledMethod.Name,
+                    parameterTypeFullNames);
+            }
+        }
+    }
+
+    private static bool SourceDeclarationCoversCompiledMethod(
+        TypeEmitState typeState,
+        SemanticModel semanticModel,
+        IMethodSymbol compiledMethod)
+    {
+        string[] compiledParameterTypeFullNames = compiledMethod.Parameters
+            .Select(CecilTypeNames.ToParameterTypeFullName)
+            .ToArray();
+        foreach (MethodDeclarationSyntax methodDeclaration in typeState.TypeDeclaration.Members
+            .OfType<MethodDeclarationSyntax>())
+        {
+            IMethodSymbol sourceMethod = semanticModel.GetDeclaredSymbol(methodDeclaration);
+            if (sourceMethod == null
+                || sourceMethod.MethodKind != MethodKind.Ordinary
+                || sourceMethod.Name != compiledMethod.Name
+                || sourceMethod.IsStatic != compiledMethod.IsStatic
+                || sourceMethod.Parameters.Length != compiledParameterTypeFullNames.Length)
+            {
+                continue;
+            }
+
+            bool parametersMatch = true;
+            for (int index = 0; index < compiledParameterTypeFullNames.Length; index++)
+            {
+                if (CecilTypeNames.ToParameterTypeFullName(sourceMethod.Parameters[index])
+                    != compiledParameterTypeFullNames[index])
+                {
+                    parametersMatch = false;
+                    break;
+                }
+            }
+
+            if (parametersMatch)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void AddRemovedMethodName(List<WorkerRemovedMember> removedMembers, string name)
+    {
+        foreach (WorkerRemovedMember existing in removedMembers)
+        {
+            if (existing.Kind == RemovedMemberKinds.Method && existing.Name == name)
+            {
+                return;
+            }
+        }
+
+        removedMembers.Add(new WorkerRemovedMember
+        {
+            Kind = RemovedMemberKinds.Method,
+            Name = name
+        });
+    }
+
+    private static void AddRemovedMethodSignature(
+        List<WorkerRemovedMethodSignature> removedMethodSignatures,
+        INamedTypeSymbol sourceType,
+        string methodName,
+        string[] parameterTypeFullNames)
+    {
+        string typeMetadataName = CecilTypeNames.ToMetadataName(sourceType);
+        foreach (WorkerRemovedMethodSignature existing in removedMethodSignatures)
+        {
+            if (existing.TypeMetadataName == typeMetadataName
+                && existing.MethodName == methodName
+                && ParameterTypeFullNamesEqual(existing.ParameterTypeFullNames, parameterTypeFullNames))
+            {
+                return;
+            }
+        }
+
+        removedMethodSignatures.Add(new WorkerRemovedMethodSignature
+        {
+            TypeMetadataName = typeMetadataName,
+            MethodName = methodName,
+            ParameterTypeFullNames = parameterTypeFullNames
+        });
+    }
+
+    private static bool ParameterTypeFullNamesEqual(string[] left, string[] right)
+    {
+        if (left == null || right == null || left.Length != right.Length)
+        {
+            return false;
+        }
+
+        for (int index = 0; index < left.Length; index++)
+        {
+            if (left[index] != right[index])
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static void CollectRemovedFields(
@@ -2893,7 +3090,7 @@ public static class TransformWorkerProgram
         return targetTypesAssemblySymbol.GetTypeByMetadataName(ToReflectionMetadataName(sourceType));
     }
 
-    private static bool CompiledTypeHasOrdinaryMethod(
+    private static (CompiledMethodMatch Match, string CompiledReturnTypeFullName) MatchCompiledOrdinaryMethod(
         INamedTypeSymbol compiledType,
         IMethodSymbol sourceMethod)
     {
@@ -2921,13 +3118,22 @@ public static class TransformWorkerProgram
                 }
             }
 
-            if (parametersMatch)
+            if (!parametersMatch)
             {
-                return true;
+                continue;
             }
+
+            string compiledReturnTypeFullName = CecilTypeNames.ToCecilFullName(compiledMethod.ReturnType);
+            string sourceReturnTypeFullName = CecilTypeNames.ToCecilFullName(sourceMethod.ReturnType);
+            if (compiledReturnTypeFullName == sourceReturnTypeFullName)
+            {
+                return (CompiledMethodMatch.Matched, compiledReturnTypeFullName);
+            }
+
+            return (CompiledMethodMatch.ReturnTypeChanged, compiledReturnTypeFullName);
         }
 
-        return false;
+        return (CompiledMethodMatch.NotFound, null);
     }
 
     private static bool CompiledTypeHasField(INamedTypeSymbol compiledType, IFieldSymbol sourceField)
@@ -3197,7 +3403,10 @@ public static class TransformWorkerProgram
 
         if (symbol is IMethodSymbol methodSymbol && methodSymbol.MethodKind == MethodKind.Ordinary)
         {
-            return !CompiledTypeHasOrdinaryMethod(compiledType, methodSymbol);
+            (CompiledMethodMatch match, string _) = MatchCompiledOrdinaryMethod(compiledType, methodSymbol);
+            // Why map ReturnTypeChanged to added: the compiled method still has the old
+            // signature, so treating it as a direct shim reference would bind the old body.
+            return match != CompiledMethodMatch.Matched;
         }
 
         foreach (ISymbol member in compiledType.GetMembers(symbol.Name))
@@ -6603,7 +6812,7 @@ internal static class CecilTypeNames
         return typeName;
     }
 
-    private static string ToCecilFullName(ITypeSymbol typeSymbol)
+    public static string ToCecilFullName(ITypeSymbol typeSymbol)
     {
         // Why here (not only the parameter top level): source `List<dynamic>` / `dynamic[]`
         // nest TypeKind.Dynamic while compiled metadata uses System.Object at the same depth.
@@ -6709,6 +6918,8 @@ internal sealed class QueuedShimMethod
     public string MethodKey { get; set; }
 
     public bool IsAddedMethod { get; set; }
+
+    public bool ReplacesCompiledMethod { get; set; }
 }
 
 internal sealed class AddedMethodBinding
@@ -7090,6 +7301,8 @@ internal sealed class WorkerOutput
 
     public WorkerRemovedMember[] RemovedMembers { get; set; }
 
+    public WorkerRemovedMethodSignature[] RemovedMethodSignatures { get; set; }
+
     public bool HasAccessorDelegates { get; set; }
 
     // True when shim bodies rewrite added-field accesses to HotReloadAddedFieldStore.
@@ -7102,6 +7315,22 @@ internal sealed class WorkerRemovedMember
     public string Kind { get; set; }
 
     public string Name { get; set; }
+}
+
+internal sealed class WorkerRemovedMethodSignature
+{
+    public string TypeMetadataName { get; set; }
+
+    public string MethodName { get; set; }
+
+    public string[] ParameterTypeFullNames { get; set; }
+}
+
+internal enum CompiledMethodMatch
+{
+    NotFound,
+    Matched,
+    ReturnTypeChanged
 }
 
 internal sealed class WorkerUnchangedMethod
@@ -7138,6 +7367,8 @@ internal sealed class WorkerEntry
 
     // Null when the method is not a one-shot lifecycle method and is not only called from them.
     public string LifecycleNote { get; set; }
+
+    public bool ReplacesCompiledMethod { get; set; }
 }
 
 internal static class LifecycleNotes


### PR DESCRIPTION
## Summary
- Return-type-only edits are now classified as added-method replacements instead of body patches on the old compiled method.
- The worker also emits the old compiled method identity so later work can warn or skip when leftover callers remain.

## User Impact
- Before: changing a method's return type could be reported as a successful edit of the old method, then fail at call time or apply the new body to the old signature.
- After: that edit is treated as "old method removed + new method added". Unsupported cases (virtual/generic) still skip with the existing added-method reasons.

## Changes
- `MatchCompiledOrdinaryMethod` replaces the boolean compiled-method check with NotFound / Matched / ReturnTypeChanged.
- ReturnTypeChanged entries set `replacesCompiledMethod` and record the old name plus the old compiled identity.
- Deleted methods (non-partial types) also emit `removedMethodSignatures`. Partial types keep the name-only warning.
- Same-file added-member lookup treats ReturnTypeChanged as "not a compiled method" so shims do not bind the old signature.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Success, 0 errors, 0 warnings
- New tests: return-type change replacement, virtual skip, parameter-type old signature, partial deletion omits signatures, unchanged return type is not a replacement
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --filter-type regex --filter-value "HotReload"` → Passed (284/284)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

