### PR TITLE
feat: gate signature changes on compiled call sites outside the edited file

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs
@@ -146,6 +146,61 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: one scan with two targets attributes each hit to the matching TargetMethodKey.
+        /// </summary>
+        [Test]
+        public void FindCallSites_TwoTargets_AttributesEachHitToMatchingTargetKey()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string rawAssemblyName = CompilationPipeline.GetAssemblyNameFromScriptPath(
+                TestScriptProjectRelativePath);
+            string assemblyName = Path.GetFileNameWithoutExtension(rawAssemblyName);
+            string ordinaryTargetKey = FixtureTypeMetadataName + "::CalledFromOrdinaryMethod()";
+            string delegateTargetKey = FixtureTypeMetadataName + "::CalledOnlyViaDelegate()";
+
+            List<HotReloadCallSiteScanner.CallSiteHit> hits = HotReloadCallSiteScanner.FindCallSites(
+                projectRoot,
+                new[]
+                {
+                    new HotReloadCallSiteScanner.CompiledMethodIdentity(
+                        assemblyName,
+                        FixtureTypeMetadataName,
+                        nameof(HotReloadCallSiteScannerFixture.CalledFromOrdinaryMethod),
+                        Array.Empty<string>()),
+                    new HotReloadCallSiteScanner.CompiledMethodIdentity(
+                        assemblyName,
+                        FixtureTypeMetadataName,
+                        nameof(HotReloadCallSiteScannerFixture.CalledOnlyViaDelegate),
+                        Array.Empty<string>())
+                });
+
+            Assert.That(hits.Count, Is.EqualTo(2));
+            HotReloadCallSiteScanner.CallSiteHit ordinaryHit = null;
+            HotReloadCallSiteScanner.CallSiteHit delegateHit = null;
+            foreach (HotReloadCallSiteScanner.CallSiteHit hit in hits)
+            {
+                if (hit.TargetMethodKey == ordinaryTargetKey)
+                {
+                    ordinaryHit = hit;
+                }
+
+                if (hit.TargetMethodKey == delegateTargetKey)
+                {
+                    delegateHit = hit;
+                }
+            }
+
+            Assert.That(ordinaryHit, Is.Not.Null, "Ordinary target must own its hit.");
+            Assert.That(
+                ordinaryHit.CallerMethodKey,
+                Is.EqualTo(FixtureTypeMetadataName + "::OrdinaryCaller()"));
+            Assert.That(delegateHit, Is.Not.Null, "Delegate target must own its hit.");
+            Assert.That(
+                delegateHit.CallerMethodKey,
+                Is.EqualTo(FixtureTypeMetadataName + "::CaptureDelegate()"));
+        }
+
+        /// <summary>
         /// What: an async method awaiting itself is not reported after logical-owner resolution.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -821,7 +821,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Reconstructed fixture source omits compiled members once.");
             int staleSignatureCount = CountWarningsContaining(
                 result.Warnings,
-                "Compiled code outside this file still calls the removed signature");
+                "Compiled code outside this hot reload still calls the removed signature");
             Assert.That(
                 result.Warnings.Count,
                 Is.EqualTo(3 + staleSignatureCount),
@@ -938,7 +938,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Duplicate file inputs each emit a removed-members warning.");
             int staleSignatureCount = CountWarningsContaining(
                 result.Warnings,
-                "Compiled code outside this file still calls the removed signature");
+                "Compiled code outside this hot reload still calls the removed signature");
             Assert.That(
                 result.Warnings.Count,
                 Is.EqualTo(5 + staleSignatureCount),
@@ -2182,6 +2182,173 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: the coverage recheck reports no loss when the covering caller stays in the
+        /// final apply set with the replacement.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_CoveredCallerRemains_ReturnsEmpty()
+        {
+            TransformWorkerEntryDto replacement = CreateReplacementEntry("Host", "Target");
+            TransformWorkerEntryDto caller = CreateOrdinaryEntry("Host", "Caller");
+            List<HotReloadCallSiteScanner.CallSiteHit> hits = new List<HotReloadCallSiteScanner.CallSiteHit>
+            {
+                CreateCallSiteHit("Host::Caller(System.Int32)", "Host::Target(System.Int32)")
+            };
+
+            List<string> lost = HotReloadOrchestrator.FindSignatureChangeCoverageLosses(
+                new[] { replacement, caller },
+                hits,
+                new[] { "Host::Target(System.Int32)" });
+
+            Assert.That(lost, Is.Empty);
+        }
+
+        /// <summary>
+        /// What: the coverage recheck reports the replacement when its covering caller key
+        /// dropped out of the final apply set.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_CallerKeyDropped_ReturnsReplacementKey()
+        {
+            TransformWorkerEntryDto replacement = CreateReplacementEntry("Host", "Target");
+            List<HotReloadCallSiteScanner.CallSiteHit> hits = new List<HotReloadCallSiteScanner.CallSiteHit>
+            {
+                CreateCallSiteHit("Host::Caller(System.Int32)", "Host::Target(System.Int32)")
+            };
+
+            List<string> lost = HotReloadOrchestrator.FindSignatureChangeCoverageLosses(
+                new[] { replacement },
+                hits,
+                new[] { "Host::Target(System.Int32)" });
+
+            Assert.That(lost, Is.EqualTo(new[] { "Host::Target(System.Int32)" }));
+        }
+
+        /// <summary>
+        /// What: an unchanged same-file caller that only needs an implicit int-to-long conversion
+        /// is not an apply entry, so the return-type change is skipped with the hot-reload wording.
+        /// </summary>
+        [Test]
+        public async Task Run_ReturnTypeChange_UnchangedSameFileCaller_SkipsReplacement()
+        {
+            string fixturePath = ResolveSignatureChangeUnchangedCallerFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = onDisk.Replace(
+                "        public int Target(int value)\n        {\n            return value;\n        }",
+                "        public long Target(int value)\n        {\n            return value + 1L;\n        }",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeUnchangedCaller.cs", edited),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            string expectedLabel =
+                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                + ".HotReloadSignatureChangeUnchangedCallerFixture.Target(System.Int32)";
+            AssertHasSkipped(
+                result,
+                nameof(HotReloadSignatureChangeUnchangedCallerFixture.Target),
+                string.Format(
+                    HotReloadConstants.SignatureChangedGateSkipReasonFormat,
+                    expectedLabel));
+        }
+
+        /// <summary>
+        /// What: deleting a same-file helper that called Target does not gate Target's return-type
+        /// change when no other compiled caller remains.
+        /// </summary>
+        [Test]
+        public async Task Run_ReturnTypeChange_DeletedHelperCaller_AppliesReplacement()
+        {
+            string fixturePath = ResolveSignatureChangeHelperDeleteFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = onDisk
+                .Replace(
+                    "        public int Target(int value)\n        {\n            return value;\n        }",
+                    "        public long Target(int value)\n        {\n            return value + 1L;\n        }",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "\n\n        [MethodImpl(MethodImplOptions.NoInlining)]\n"
+                    + "        public int Helper(int value)\n        {\n            return Target(value);\n        }",
+                    string.Empty,
+                    StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            Assert.That(edited, Does.Not.Contain("public int Helper"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeHelperDelete.cs", edited),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasAdded(result, nameof(HotReloadSignatureChangeHelperDeleteFixture.Target));
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                Assert.That(
+                    outcome.Kind,
+                    Is.Not.EqualTo(HotReloadMethodOutcomeKind.Skipped),
+                    "Helper deletion must not gate Target.\n" + FormatOutcomes(result));
+            }
+        }
+
+        /// <summary>
+        /// What: after the gate passes because the same-file caller is an entry, a shim compile
+        /// failure on only that caller drops it from the retry set and the coverage recheck
+        /// fails the file instead of applying the replacement.
+        /// </summary>
+        [Test]
+        public async Task Run_ReturnTypeChange_CallerShimCompileFailure_FailsCoverageRecheck()
+        {
+            string fixturePath = ResolveSignatureChangeSameFileFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = onDisk
+                .Replace(
+                    "        public int Target(int value)\n        {\n            return value;\n        }",
+                    "        public long Target(int value)\n        {\n            return value + 1L;\n        }",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "            return Target(value);\n        }",
+                    "            return (int)Target(value) + MissingHelperAddedByEdit(value);\n        }",
+                    StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeCallerCompileFailure.cs", edited),
+                CancellationToken.None);
+
+            string expectedReplacementKey =
+                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                + ".HotReloadSignatureChangeSameFileFixture::Target(System.Int32)";
+            string expectedReason = string.Format(
+                HotReloadConstants.SignatureChangeCoverageLostFailureFormat,
+                expectedReplacementKey);
+            bool foundGateFailure = false;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
+                    && outcome.Method == "(signature-change-gate)"
+                    && outcome.Reason == expectedReason)
+                {
+                    foundGateFailure = true;
+                }
+
+                Assert.That(
+                    outcome.Kind,
+                    Is.Not.EqualTo(HotReloadMethodOutcomeKind.Added),
+                    "Coverage loss must not apply the replacement.\n" + FormatOutcomes(result));
+            }
+
+            Assert.That(
+                foundGateFailure,
+                Is.True,
+                "Expected file Failed (signature-change-gate).\n" + FormatOutcomes(result));
+        }
+
+        /// <summary>
         /// What: after applying an added method, a later hot-reload against the on-disk baseline
         /// (all-unchanged) clears that file's added-member ledger so --status and Play warnings
         /// do not keep counting it.
@@ -2631,6 +2798,70 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.True,
                 "Signature-change external host source missing: " + path);
             return Path.GetFullPath(path);
+        }
+
+        private static string ResolveSignatureChangeUnchangedCallerFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadSignatureChangeUnchangedCallerFixture.cs");
+            Assert.That(
+                File.Exists(path),
+                Is.True,
+                "Signature-change unchanged-caller fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string ResolveSignatureChangeHelperDeleteFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadSignatureChangeHelperDeleteFixture.cs");
+            Assert.That(
+                File.Exists(path),
+                Is.True,
+                "Signature-change helper-delete fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static TransformWorkerEntryDto CreateReplacementEntry(string typeName, string methodName)
+        {
+            return new TransformWorkerEntryDto
+            {
+                typeMetadataName = typeName,
+                methodName = methodName,
+                parameterTypeFullNames = new[] { "System.Int32" },
+                replacesCompiledMethod = true,
+                patchKind = HotReloadConstants.PatchKindAddedMethod
+            };
+        }
+
+        private static TransformWorkerEntryDto CreateOrdinaryEntry(string typeName, string methodName)
+        {
+            return new TransformWorkerEntryDto
+            {
+                typeMetadataName = typeName,
+                methodName = methodName,
+                parameterTypeFullNames = new[] { "System.Int32" },
+                replacesCompiledMethod = false
+            };
+        }
+
+        private static HotReloadCallSiteScanner.CallSiteHit CreateCallSiteHit(
+            string callerMethodKey,
+            string targetMethodKey)
+        {
+            return new HotReloadCallSiteScanner.CallSiteHit
+            {
+                CallerMethodKey = callerMethodKey,
+                TargetMethodKey = targetMethodKey
+            };
         }
 
         private static string WithSameFileReturnTypeChange(string onDisk)

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -819,10 +819,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CountWarningsContaining(result.Warnings, "Removed members stay present"),
                 Is.EqualTo(1),
                 "Reconstructed fixture source omits compiled members once.");
+            int staleSignatureCount = CountWarningsContaining(
+                result.Warnings,
+                "Compiled code outside this file still calls the removed signature");
             Assert.That(
                 result.Warnings.Count,
-                Is.EqualTo(3),
-                "Exactly one inline-risk, one drift, and one removed-members warning.");
+                Is.EqualTo(3 + staleSignatureCount),
+                "Exactly one inline-risk, one drift, one removed-members warning, plus stale-signature rows.");
         }
 
         /// <summary>
@@ -933,10 +936,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CountWarningsContaining(result.Warnings, "Removed members stay present"),
                 Is.EqualTo(2),
                 "Duplicate file inputs each emit a removed-members warning.");
+            int staleSignatureCount = CountWarningsContaining(
+                result.Warnings,
+                "Compiled code outside this file still calls the removed signature");
             Assert.That(
                 result.Warnings.Count,
-                Is.EqualTo(5),
-                "One aggregated inline-risk warning plus two drift and two removed-members warnings.");
+                Is.EqualTo(5 + staleSignatureCount),
+                "One aggregated inline-risk warning plus two drift, two removed-members, and stale-signature rows.");
 
             string aggregatedWarning = null;
             foreach (string warning in result.Warnings)
@@ -2030,6 +2036,152 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a return-type change whose compiled callers all live in the edited file applies
+        /// as Added plus a Patched caller, and the caller returns the new method's value.
+        /// </summary>
+        [Test]
+        public async Task Run_ReturnTypeChange_SameFileCallers_AppliesAddedAndPatchesCaller()
+        {
+            string fixturePath = ResolveSignatureChangeSameFileFixturePath();
+            string edited = WithSameFileReturnTypeChange(File.ReadAllText(fixturePath));
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeSameFile.cs", edited),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasAdded(result, nameof(HotReloadSignatureChangeSameFileFixture.Target));
+            AssertHasPatched(result, nameof(HotReloadSignatureChangeSameFileFixture.ExistingCaller));
+            Assert.That(result.ActivePatchTotal, Is.EqualTo(2));
+
+            HotReloadSignatureChangeSameFileFixture host = new HotReloadSignatureChangeSameFileFixture();
+            Assert.That(host.ExistingCaller(3), Is.EqualTo(4));
+        }
+
+        /// <summary>
+        /// What: a return-type change with a compiled caller in another class is skipped together
+        /// with the same-file caller, while an unrelated body edit in the same file still patches.
+        /// </summary>
+        [Test]
+        public async Task Run_ReturnTypeChange_ExternalCaller_SkipsReplacementAndSameFileCaller()
+        {
+            string fixturePath = ResolveSignatureChangeExternalHostPath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = onDisk
+                .Replace(
+                    "        public int Target(int value)\n        {\n            return value;\n        }",
+                    "        public long Target(int value)\n        {\n            return value + 1L;\n        }",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "            return Target(value);\n        }",
+                    "            return (int)Target(value);\n        }",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "        public int Unrelated(int value)\n        {\n            return value;\n        }",
+                    "        public int Unrelated(int value)\n        {\n            return value + 1;\n        }",
+                    StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeExternal.cs", edited),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasSkipped(
+                result,
+                nameof(HotReloadSignatureChangeExternalHost.Target),
+                "The return type of");
+            AssertHasSkipped(
+                result,
+                nameof(HotReloadSignatureChangeExternalHost.SameFileCaller),
+                HotReloadConstants.SignatureChangedGatedCallerSkipReason);
+            AssertHasPatched(result, nameof(HotReloadSignatureChangeExternalHost.Unrelated));
+
+            HotReloadSignatureChangeExternalHost host = new HotReloadSignatureChangeExternalHost();
+            Assert.That(host.Unrelated(3), Is.EqualTo(4));
+            Assert.That(host.Target(3), Is.EqualTo(3));
+            Assert.That(host.SameFileCaller(3), Is.EqualTo(3));
+        }
+
+        /// <summary>
+        /// What: deleting a method that still has a compiled caller outside the file applies other
+        /// edits and names that caller in a stale-signature warning.
+        /// </summary>
+        [Test]
+        public async Task Run_DeletedMethod_ExternalCaller_WarnsStaleSignature()
+        {
+            string fixturePath = ResolveSignatureChangeExternalHostPath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = onDisk.Replace(
+                "        public int Unrelated(int value)\n        {\n            return value;\n        }\n\n"
+                + "        [MethodImpl(MethodImplOptions.NoInlining)]\n"
+                + "        public int ToDelete(int value)\n        {\n            return value;\n        }",
+                "        public int Unrelated(int value)\n        {\n            return value + 1;\n        }",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            Assert.That(edited, Does.Not.Contain("ToDelete"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeDeleted.cs", edited),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadSignatureChangeExternalHost.Unrelated));
+            string expectedCallerKey =
+                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                + ".HotReloadSignatureChangeExternalCaller::CallDeleted(System.Int32)";
+            string expectedSignatureKey =
+                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                + ".HotReloadSignatureChangeExternalHost::ToDelete(System.Int32)";
+            string expectedWarning = string.Format(
+                HotReloadConstants.StaleSignatureCallersWarningFormat,
+                expectedSignatureKey,
+                expectedCallerKey);
+            Assert.That(result.Warnings, Does.Contain(expectedWarning), FormatOutcomes(result));
+
+            HotReloadSignatureChangeExternalHost host = new HotReloadSignatureChangeExternalHost();
+            Assert.That(host.Unrelated(3), Is.EqualTo(4));
+        }
+
+        /// <summary>
+        /// What: re-applying the same same-file return-type change does not double the added-member
+        /// registry or ActivePatchTotal.
+        /// </summary>
+        [Test]
+        public async Task Run_ReturnTypeChange_Reapply_DoesNotDoubleRegistry()
+        {
+            string fixturePath = ResolveSignatureChangeSameFileFixturePath();
+            string edited = WithSameFileReturnTypeChange(File.ReadAllText(fixturePath));
+
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeReapply1.cs", edited),
+                CancellationToken.None);
+            AssertNoFileLevelFailure(first);
+            AssertHasAdded(first, nameof(HotReloadSignatureChangeSameFileFixture.Target));
+            int firstRegistryCount = CountAddedMembersContaining(
+                nameof(HotReloadSignatureChangeSameFileFixture.Target));
+            Assert.That(first.ActivePatchTotal, Is.EqualTo(2));
+            Assert.That(firstRegistryCount, Is.EqualTo(1));
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeReapply2.cs", edited),
+                CancellationToken.None);
+            AssertNoFileLevelFailure(second);
+            AssertHasAdded(second, nameof(HotReloadSignatureChangeSameFileFixture.Target));
+            Assert.That(second.ActivePatchTotal, Is.EqualTo(2));
+            Assert.That(
+                CountAddedMembersContaining(nameof(HotReloadSignatureChangeSameFileFixture.Target)),
+                Is.EqualTo(1));
+
+            HotReloadSignatureChangeSameFileFixture host = new HotReloadSignatureChangeSameFileFixture();
+            Assert.That(host.ExistingCaller(3), Is.EqualTo(4));
+        }
+
+        /// <summary>
         /// What: after applying an added method, a later hot-reload against the on-disk baseline
         /// (all-unchanged) clears that file's added-member ledger so --status and Play warnings
         /// do not keep counting it.
@@ -2449,6 +2601,65 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "HotReloadAddedMethodApplyFixture.cs");
             Assert.That(File.Exists(path), Is.True, "Added-method apply fixture source missing: " + path);
             return Path.GetFullPath(path);
+        }
+
+        private static string ResolveSignatureChangeSameFileFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadSignatureChangeSameFileFixture.cs");
+            Assert.That(
+                File.Exists(path),
+                Is.True,
+                "Signature-change same-file fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string ResolveSignatureChangeExternalHostPath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadSignatureChangeExternalHost.cs");
+            Assert.That(
+                File.Exists(path),
+                Is.True,
+                "Signature-change external host source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string WithSameFileReturnTypeChange(string onDisk)
+        {
+            string edited = onDisk
+                .Replace(
+                    "        public int Target(int value)\n        {\n            return value;\n        }",
+                    "        public long Target(int value)\n        {\n            return value + 1L;\n        }",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "            return Target(value);\n        }",
+                    "            return (int)Target(value);\n        }",
+                    StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            return edited;
+        }
+
+        private static int CountAddedMembersContaining(string methodName)
+        {
+            int count = 0;
+            foreach (HotReloadAddedMemberInfo added in HotReloadAddedMemberRegistry.Describe())
+            {
+                if (added.MethodKey.Contains(methodName))
+                {
+                    count++;
+                }
+            }
+
+            return count;
         }
 
         private static string ResolveAddedFieldApplyFixturePath()

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeExternalCaller.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeExternalCaller.cs
@@ -1,0 +1,23 @@
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled callers outside the edited host file so the signature-change gate sees
+    /// uncovered call sites.
+    /// </summary>
+    public class HotReloadSignatureChangeExternalCaller
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int CallTarget(int value)
+        {
+            return new HotReloadSignatureChangeExternalHost().Target(value);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int CallDeleted(int value)
+        {
+            return new HotReloadSignatureChangeExternalHost().ToDelete(value);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeExternalCaller.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeExternalCaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a284af2e43ec7413d8e278991f23146e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeExternalHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeExternalHost.cs
@@ -1,0 +1,35 @@
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled host with a return-type-change target, a same-file caller, an unrelated
+    /// method, and a deletable method. External callers live in another file.
+    /// </summary>
+    public class HotReloadSignatureChangeExternalHost
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Target(int value)
+        {
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int SameFileCaller(int value)
+        {
+            return Target(value);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Unrelated(int value)
+        {
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int ToDelete(int value)
+        {
+            return value;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeExternalHost.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeExternalHost.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: baf09bbda7ecc4544a5da4ea953d1355
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeHelperDeleteFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeHelperDeleteFixture.cs
@@ -1,0 +1,23 @@
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled host used to pin that deleting a helper which called Target does not gate a
+    /// same-file return-type change of Target.
+    /// </summary>
+    public class HotReloadSignatureChangeHelperDeleteFixture
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Target(int value)
+        {
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Helper(int value)
+        {
+            return Target(value);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeHelperDeleteFixture.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeHelperDeleteFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b65f96c8b27ec483795871b9c110500e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeSameFileFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeSameFileFixture.cs
@@ -1,0 +1,22 @@
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled host whose return-type-change target is only called from this file.
+    /// </summary>
+    public class HotReloadSignatureChangeSameFileFixture
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Target(int value)
+        {
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int ExistingCaller(int value)
+        {
+            return Target(value);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeSameFileFixture.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeSameFileFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 71bea1d3510104dbf81cd9b8bf1677aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeUnchangedCallerFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeUnchangedCallerFixture.cs
@@ -1,0 +1,23 @@
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled host whose same-file caller stays unchanged after an int-to-long return-type
+    /// change because of an implicit widening conversion.
+    /// </summary>
+    public class HotReloadSignatureChangeUnchangedCallerFixture
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Target(int value)
+        {
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public long StoreTarget(int value)
+        {
+            return Target(value);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeUnchangedCallerFixture.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeUnchangedCallerFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa20614418c1e427aa41036110b25888
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs
@@ -55,6 +55,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public string CallerMethodName;
             public string[] CallerParameterTypeFullNames;
             public string CallerMethodKey;
+            public string TargetMethodKey;
         }
 
         /// <summary>
@@ -250,7 +251,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                hits.Add(CreateHit(assemblyName, reportedCaller));
+                hits.Add(CreateHit(assemblyName, reportedCaller, target));
             }
         }
 
@@ -411,7 +412,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return false;
         }
 
-        private static CallSiteHit CreateHit(string assemblyName, MethodDefinition caller)
+        private static CallSiteHit CreateHit(
+            string assemblyName,
+            MethodDefinition caller,
+            CompiledMethodIdentity target)
         {
             string[] parameterTypeFullNames = new string[caller.Parameters.Count];
             for (int index = 0; index < caller.Parameters.Count; index++)
@@ -430,7 +434,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 CallerMethodName = caller.Name,
                 CallerParameterTypeFullNames = parameterTypeFullNames,
                 CallerMethodKey = typeMetadataName + "::" + caller.Name + "("
-                    + string.Join(",", parameterTypeFullNames) + ")"
+                    + string.Join(",", parameterTypeFullNames) + ")",
+                TargetMethodKey = target.TypeMetadataName + "::" + target.MethodName + "("
+                    + string.Join(",", target.ParameterTypeFullNames) + ")"
             };
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -70,13 +70,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             + "Run 'uloop compile'.";
 
         public const string SignatureChangedGateSkipReasonFormat =
-            "The return type of '{0}' changed, but compiled code outside this file still calls the old method. Applying it would leave those callers on the old version. Run 'uloop compile'.";
+            "The return type of '{0}' changed, but compiled code outside this hot reload still calls the old method. Applying it would leave those callers on the old version. Run 'uloop compile'.";
 
         public const string SignatureChangedGatedCallerSkipReason =
-            "Calls a method whose signature change was not applied because compiled callers exist outside this file; this caller was left unpatched. Run 'uloop compile'.";
+            "Calls a method whose signature change was not applied because compiled callers exist outside this hot reload; this caller was left unpatched. Run 'uloop compile'.";
 
         public const string StaleSignatureCallersWarningFormat =
-            "Compiled code outside this file still calls the removed signature '{0}': {1}. Those call sites keep the previous behavior until 'uloop compile'.";
+            "Compiled code outside this hot reload still calls the removed signature '{0}': {1}. Those call sites keep the previous behavior until 'uloop compile'.";
+
+        public const string SignatureChangeCoverageLostFailureFormat =
+            "Isolation excluded compiled callers of '{0}'; applying the rest would leave those callers on the old version. Run 'uloop compile'.";
 
         // Wire value for TransformWorkerRemovedMemberDto.kind.
         // Keep in sync with RemovedMemberKinds in TransformWorker~/TransformWorker.cs.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -69,6 +69,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             "Calls an added method whose shim failed to compile; the caller was left unpatched. "
             + "Run 'uloop compile'.";
 
+        public const string SignatureChangedGateSkipReasonFormat =
+            "The return type of '{0}' changed, but compiled code outside this file still calls the old method. Applying it would leave those callers on the old version. Run 'uloop compile'.";
+
+        public const string SignatureChangedGatedCallerSkipReason =
+            "Calls a method whose signature change was not applied because compiled callers exist outside this file; this caller was left unpatched. Run 'uloop compile'.";
+
+        public const string StaleSignatureCallersWarningFormat =
+            "Compiled code outside this file still calls the removed signature '{0}': {1}. Those call sites keep the previous behavior until 'uloop compile'.";
+
         // Wire value for TransformWorkerRemovedMemberDto.kind.
         // Keep in sync with RemovedMemberKinds in TransformWorker~/TransformWorker.cs.
         public const string RemovedMemberKindMethod = "method";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -346,6 +346,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 compileResult = firstCompile.CompileResult;
             }
 
+            if (gateResult.DidScan)
+            {
+                // Why after entriesToPatch is final and before Harmony: isolation or a gate
+                // retry can drop a covering caller without dropping the replacement. A third
+                // worker run is not allowed (max two); fail the file instead of applying.
+                List<string> lostReplacementKeys = FindSignatureChangeCoverageLosses(
+                    entriesToPatch,
+                    gateResult.Hits,
+                    gateResult.ScanTargetKeys);
+                if (lostReplacementKeys.Count > 0)
+                {
+                    outcomes.Add(
+                        HotReloadMethodOutcome.Failed(
+                            "(signature-change-gate)",
+                            string.Format(
+                                HotReloadConstants.SignatureChangeCoverageLostFailureFormat,
+                                string.Join(", ", lostReplacementKeys)),
+                            assemblyResolvePath));
+                    return new HotReloadFileProcessResult(
+                        outcomes, warnings, 0, unchangedMethodCount: unchangedMethodCount);
+                }
+            }
+
             // Harmony Patch/Unpatch and method resolution against loaded modules require main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
             // Why before ApplyEntry: OnHotReloadPatchStateChanged(true) runs inside Apply and
@@ -1389,7 +1412,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 uncoveredCallersByTarget);
             if (gatedReplacements.Count == 0)
             {
-                return SignatureChangeGateResult.WarningsOnly(staleWarnings);
+                return SignatureChangeGateResult.WarningsOnly(
+                    staleWarnings,
+                    hits,
+                    CollectScanTargetKeys(targets));
             }
 
             IsolationExclusions exclusions = BuildIsolationExclusions(gatedReplacements, entries);
@@ -1413,10 +1439,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ct).ConfigureAwait(false);
             if (retry.Isolation == null)
             {
-                return SignatureChangeGateResult.Failed(retry.FailureMessage, staleWarnings);
+                return SignatureChangeGateResult.Failed(retry.FailureMessage);
             }
 
-            return SignatureChangeGateResult.Retried(retry.Isolation, skippedOutcomes, staleWarnings);
+            return SignatureChangeGateResult.Retried(
+                retry.Isolation,
+                skippedOutcomes,
+                staleWarnings,
+                hits,
+                CollectScanTargetKeys(targets));
         }
 
         private static List<TransformWorkerEntryDto> CollectReplacementEntries(
@@ -1501,6 +1532,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             foreach (HotReloadCallSiteScanner.CompiledMethodIdentity target in targets)
             {
+                // Why include removed-signature targets: a deleted helper that called the
+                // replaced method is already stale (removed-members warning). Treating that
+                // corpse as uncovered would gate a same-file helper-delete + return-type
+                // change, which is still a consistent old world. Fail-closed only for live
+                // compiled callers that will keep invoking the old method.
                 coveredKeys.Add(
                     BuildMethodKeyParts(
                         target.TypeMetadataName,
@@ -1564,6 +1600,67 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return warnings;
+        }
+
+        /// <summary>
+        /// Rechecks scan hits against the final apply set. Returns replacement keys that would
+        /// still have uncovered compiled callers after isolation or a gate retry shrank entries.
+        /// </summary>
+        internal static List<string> FindSignatureChangeCoverageLosses(
+            TransformWorkerEntryDto[] entriesToPatch,
+            IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits,
+            IReadOnlyList<string> scanTargetKeys)
+        {
+            Debug.Assert(entriesToPatch != null, "entriesToPatch must not be null.");
+            Debug.Assert(hits != null, "hits must not be null.");
+            Debug.Assert(scanTargetKeys != null, "scanTargetKeys must not be null.");
+
+            HashSet<string> coveredKeys = new HashSet<string>(StringComparer.Ordinal);
+            foreach (TransformWorkerEntryDto entry in entriesToPatch)
+            {
+                coveredKeys.Add(BuildMethodKey(entry));
+            }
+
+            foreach (string targetKey in scanTargetKeys)
+            {
+                coveredKeys.Add(targetKey);
+            }
+
+            Dictionary<string, List<string>> uncoveredCallersByTarget =
+                CollectUncoveredCallersByTarget(hits, coveredKeys);
+            List<string> lostReplacementKeys = new List<string>();
+            foreach (TransformWorkerEntryDto entry in entriesToPatch)
+            {
+                if (!entry.replacesCompiledMethod)
+                {
+                    continue;
+                }
+
+                string methodKey = BuildMethodKey(entry);
+                if (uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> callers)
+                    && callers.Count > 0)
+                {
+                    lostReplacementKeys.Add(methodKey);
+                }
+            }
+
+            return lostReplacementKeys;
+        }
+
+        private static List<string> CollectScanTargetKeys(
+            HotReloadCallSiteScanner.CompiledMethodIdentity[] targets)
+        {
+            List<string> keys = new List<string>(targets.Length);
+            foreach (HotReloadCallSiteScanner.CompiledMethodIdentity target in targets)
+            {
+                keys.Add(
+                    BuildMethodKeyParts(
+                        target.TypeMetadataName,
+                        target.MethodName,
+                        target.ParameterTypeFullNames));
+            }
+
+            return keys;
         }
 
         private static List<TransformWorkerEntryDto> CollectGatedReplacementEntries(
@@ -1741,53 +1838,73 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public bool FileFailed { get; }
             public string FailureMessage { get; }
             public bool UsedWorkerRetry { get; }
+            public bool DidScan { get; }
             public HotReloadShimIsolationResult Isolation { get; }
             public List<HotReloadMethodOutcome> SkippedOutcomes { get; }
             public List<string> Warnings { get; }
+            public List<HotReloadCallSiteScanner.CallSiteHit> Hits { get; }
+            public List<string> ScanTargetKeys { get; }
 
             private SignatureChangeGateResult(
                 bool fileFailed,
                 string failureMessage,
                 bool usedWorkerRetry,
+                bool didScan,
                 HotReloadShimIsolationResult isolation,
                 List<HotReloadMethodOutcome> skippedOutcomes,
-                List<string> warnings)
+                List<string> warnings,
+                List<HotReloadCallSiteScanner.CallSiteHit> hits,
+                List<string> scanTargetKeys)
             {
                 FileFailed = fileFailed;
                 FailureMessage = failureMessage;
                 UsedWorkerRetry = usedWorkerRetry;
+                DidScan = didScan;
                 Isolation = isolation;
                 SkippedOutcomes = skippedOutcomes ?? new List<HotReloadMethodOutcome>();
                 Warnings = warnings ?? new List<string>();
+                Hits = hits ?? new List<HotReloadCallSiteScanner.CallSiteHit>();
+                ScanTargetKeys = scanTargetKeys ?? new List<string>();
             }
 
             public static SignatureChangeGateResult NoWork()
             {
-                return new SignatureChangeGateResult(false, null, false, null, null, null);
+                return new SignatureChangeGateResult(
+                    false, null, false, false, null, null, null, null, null);
             }
 
-            public static SignatureChangeGateResult WarningsOnly(List<string> warnings)
+            public static SignatureChangeGateResult WarningsOnly(
+                List<string> warnings,
+                List<HotReloadCallSiteScanner.CallSiteHit> hits,
+                List<string> scanTargetKeys)
             {
-                return new SignatureChangeGateResult(false, null, false, null, null, warnings);
+                return new SignatureChangeGateResult(
+                    false, null, false, true, null, null, warnings, hits, scanTargetKeys);
             }
 
-            public static SignatureChangeGateResult Failed(string failureMessage, List<string> warnings)
+            public static SignatureChangeGateResult Failed(string failureMessage)
             {
-                return new SignatureChangeGateResult(true, failureMessage, false, null, null, warnings);
+                return new SignatureChangeGateResult(
+                    true, failureMessage, false, false, null, null, null, null, null);
             }
 
             public static SignatureChangeGateResult Retried(
                 HotReloadShimIsolationResult isolation,
                 List<HotReloadMethodOutcome> skippedOutcomes,
-                List<string> warnings)
+                List<string> warnings,
+                List<HotReloadCallSiteScanner.CallSiteHit> hits,
+                List<string> scanTargetKeys)
             {
                 return new SignatureChangeGateResult(
                     false,
                     null,
                     true,
+                    true,
                     isolation,
                     skippedOutcomes,
-                    warnings);
+                    warnings,
+                    hits,
+                    scanTargetKeys);
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -254,7 +254,52 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             await MainThreadSwitcher.SwitchToMainThread(ct);
             RevertUnchangedPatches(assemblyName, unchangedMethods);
 
-            if (string.IsNullOrEmpty(workerOutput.shimSource)
+            SignatureChangeGateResult gateResult = await TryApplySignatureChangeGateAsync(
+                projectRoot,
+                assemblyName,
+                workerInput,
+                workerOutput,
+                compilationAssembly,
+                targetDllPath,
+                defines,
+                assemblyResolvePath,
+                ct).ConfigureAwait(false);
+            if (gateResult.FileFailed)
+            {
+                // Why not apply first-pass entries: a gate retry null means the replacement was
+                // not isolated. Falling through would apply the unguarded return-type change.
+                outcomes.Add(
+                    HotReloadMethodOutcome.Failed(
+                        "(signature-change-gate)",
+                        gateResult.FailureMessage,
+                        assemblyResolvePath));
+                return new HotReloadFileProcessResult(
+                    outcomes, warnings, 0, unchangedMethodCount: unchangedMethodCount);
+            }
+
+            outcomes.AddRange(gateResult.SkippedOutcomes);
+            warnings.AddRange(gateResult.Warnings);
+
+            TransformWorkerEntryDto[] entriesToPatch;
+            HotReloadShimCompileResult compileResult;
+            if (gateResult.UsedWorkerRetry)
+            {
+                if (gateResult.Isolation.RetryEntries.Length == 0)
+                {
+                    return new HotReloadFileProcessResult(
+                        outcomes,
+                        warnings,
+                        0,
+                        suppressedPausePointIds,
+                        new List<string>(),
+                        unchangedMethodCount,
+                        retargetedPausePointIds);
+                }
+
+                entriesToPatch = gateResult.Isolation.RetryEntries;
+                compileResult = gateResult.Isolation.RetryCompileResult;
+            }
+            else if (string.IsNullOrEmpty(workerOutput.shimSource)
                 || workerOutput.entries == null
                 || workerOutput.entries.Length == 0)
             {
@@ -267,77 +312,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return new HotReloadFileProcessResult(
                     outcomes, warnings, 0, unchangedMethodCount: unchangedMethodCount);
             }
-
-            // BuildShimReferencePaths reads Application.dataPath / platform; stay on main thread.
-            await MainThreadSwitcher.SwitchToMainThread(ct);
-            bool includeHarmonyReference = NeedsHarmonyReference(workerOutput);
-            bool includeAddedFieldStoreReference = NeedsAddedFieldStoreReference(workerOutput);
-            ShimReferencePathsResult shimReferencePaths = TryBuildShimReferencePaths(
-                compilationAssembly,
-                targetDllPath,
-                includeHarmonyReference,
-                includeAddedFieldStoreReference);
-            if (shimReferencePaths.ErrorMessage != null)
+            else
             {
-                outcomes.Add(
-                    HotReloadMethodOutcome.Failed(
-                        "(file)",
-                        shimReferencePaths.ErrorMessage,
-                        assemblyResolvePath));
-                return new HotReloadFileProcessResult(
-                    outcomes, warnings, 0, unchangedMethodCount: unchangedMethodCount);
-            }
-
-            List<string> shimReferences = shimReferencePaths.References;
-            HotReloadShimCompileResult compileResult = await HotReloadShimCompiler.CompileAndLoadAsync(
-                workerOutput.shimSource,
-                shimReferences,
-                defines,
-                projectRelativePath,
-                ct).ConfigureAwait(false);
-
-            TransformWorkerEntryDto[] entriesToPatch = workerOutput.entries;
-            if (!compileResult.Success)
-            {
-                HotReloadShimIsolationResult isolation = await TryIsolateShimCompileFailureAsync(
+                ShimFirstCompileResult firstCompile = await CompileShimFirstPassAsync(
                     workerInput,
                     workerOutput,
-                    compileResult,
                     compilationAssembly,
                     targetDllPath,
                     defines,
                     assemblyResolvePath,
                     ct).ConfigureAwait(false);
-                if (isolation == null)
+                if (firstCompile.FileFailed)
                 {
-                    // Why: CompileAndLoadAsync appends "(line N)" only for diagnostics whose
-                    // #line-mapped file matches projectRelativePath — scaffold-only errors stay
-                    // bare. Single-entry failures skip isolation and always take this path.
-                    // Why attribute single-entry failures: "(shim-compile)" hides which method
-                    // body failed when the agent edited only one method.
-                    string failureMethodLabel = "(shim-compile)";
-                    if (entriesToPatch.Length == 1)
-                    {
-                        TransformWorkerEntryDto soleEntry = entriesToPatch[0];
-                        failureMethodLabel = HotReloadPatcher.FormatMethodKeyParts(
-                            soleEntry.typeMetadataName,
-                            soleEntry.methodName,
-                            soleEntry.parameterTypeFullNames ?? Array.Empty<string>(),
-                            genericArity: 0);
-                    }
-
-                    outcomes.Add(
-                        HotReloadMethodOutcome.Failed(
-                            failureMethodLabel,
-                            compileResult.ErrorMessage,
-                            assemblyResolvePath));
+                    outcomes.AddRange(firstCompile.Outcomes);
                     return new HotReloadFileProcessResult(
                         outcomes, warnings, 0, unchangedMethodCount: unchangedMethodCount);
                 }
 
-                outcomes.AddRange(isolation.FailedMethodOutcomes);
-                outcomes.AddRange(isolation.SkippedCallerOutcomes);
-                if (isolation.RetryEntries.Length == 0)
+                outcomes.AddRange(firstCompile.Outcomes);
+                if (firstCompile.EntriesToPatch.Length == 0)
                 {
                     return new HotReloadFileProcessResult(
                         outcomes,
@@ -349,8 +342,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         retargetedPausePointIds);
                 }
 
-                entriesToPatch = isolation.RetryEntries;
-                compileResult = isolation.RetryCompileResult;
+                entriesToPatch = firstCompile.EntriesToPatch;
+                compileResult = firstCompile.CompileResult;
             }
 
             // Harmony Patch/Unpatch and method resolution against loaded modules require main thread.
@@ -951,8 +944,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // and HotReloadCallSiteScanner.CreateHit.
         private static string BuildMethodKey(TransformWorkerEntryDto entry)
         {
-            return entry.typeMetadataName + "::" + entry.methodName + "("
-                + string.Join(",", entry.parameterTypeFullNames ?? Array.Empty<string>()) + ")";
+            return BuildMethodKeyParts(
+                entry.typeMetadataName,
+                entry.methodName,
+                entry.parameterTypeFullNames);
+        }
+
+        private static string BuildMethodKeyParts(
+            string typeMetadataName,
+            string methodName,
+            string[] parameterTypeFullNames)
+        {
+            return typeMetadataName + "::" + methodName + "("
+                + string.Join(",", parameterTypeFullNames ?? Array.Empty<string>()) + ")";
         }
 
         /// <summary>
@@ -997,9 +1001,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 workerOutput.entries);
             List<HotReloadMethodOutcome> skippedCallerOutcomes = BuildSkippedCallerOutcomes(
                 exclusions.CallerEntries,
-                assemblyResolvePath);
+                assemblyResolvePath,
+                HotReloadConstants.IsolatedAddedMethodCallerSkipReason);
 
-            return await RunIsolationRetryAsync(
+            IsolationRetryRunResult retry = await RunIsolationRetryAsync(
                 workerInput,
                 exclusions,
                 failedMethodOutcomes,
@@ -1008,9 +1013,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 targetDllPath,
                 defines,
                 ct).ConfigureAwait(false);
+            return retry.Isolation;
         }
 
-        private static async Task<HotReloadShimIsolationResult> RunIsolationRetryAsync(
+        private static async Task<IsolationRetryRunResult> RunIsolationRetryAsync(
             TransformWorkerInputDto workerInput,
             IsolationExclusions exclusions,
             List<HotReloadMethodOutcome> failedMethodOutcomes,
@@ -1039,7 +1045,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 await TransformWorkerClient.RunAsync(retryInput, ct).ConfigureAwait(false);
             if (!retryWorkerResult.Success)
             {
-                return null;
+                return IsolationRetryRunResult.Failed(
+                    "Retry worker failed: " + retryWorkerResult.ErrorMessage);
             }
 
             // The first run already surfaced parseErrors / skipped / drift warnings; consuming
@@ -1047,11 +1054,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             TransformWorkerOutputDto retryOutput = retryWorkerResult.Output;
             if (string.IsNullOrEmpty(retryOutput.shimSource) || retryOutput.entries.Length == 0)
             {
-                return new HotReloadShimIsolationResult(
-                    failedMethodOutcomes,
-                    skippedCallerOutcomes,
-                    Array.Empty<TransformWorkerEntryDto>(),
-                    null);
+                return IsolationRetryRunResult.Succeeded(
+                    new HotReloadShimIsolationResult(
+                        failedMethodOutcomes,
+                        skippedCallerOutcomes,
+                        Array.Empty<TransformWorkerEntryDto>(),
+                        null));
             }
 
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -1066,7 +1074,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 // First-pass publicize already succeeded, so a miss here is rare; abandon
                 // isolation the same way as a retry compile failure.
-                return null;
+                return IsolationRetryRunResult.Failed(
+                    "Retry could not build shim references: " + shimReferencePaths.ErrorMessage);
             }
 
             List<string> shimReferences = shimReferencePaths.References;
@@ -1078,14 +1087,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ct).ConfigureAwait(false);
             if (!retryCompileResult.Success)
             {
-                return null;
+                return IsolationRetryRunResult.Failed(
+                    "Retry shim compile failed: " + retryCompileResult.ErrorMessage);
             }
 
-            return new HotReloadShimIsolationResult(
-                failedMethodOutcomes,
-                skippedCallerOutcomes,
-                retryOutput.entries,
-                retryCompileResult);
+            return IsolationRetryRunResult.Succeeded(
+                new HotReloadShimIsolationResult(
+                    failedMethodOutcomes,
+                    skippedCallerOutcomes,
+                    retryOutput.entries,
+                    retryCompileResult));
         }
 
         private static List<HotReloadMethodOutcome> BuildFailedMethodOutcomes(
@@ -1142,45 +1153,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 failedEntryKeys.Add(BuildMethodKey(failedEntry));
             }
 
-            if (failedAddedMethodKeys.Count > 0 && allEntries != null)
+            List<TransformWorkerEntryDto> callers = CollectCallerEntriesOfAddedMethods(
+                failedAddedMethodKeys,
+                failedEntryKeys,
+                allEntries);
+            foreach (TransformWorkerEntryDto entry in callers)
             {
-                foreach (TransformWorkerEntryDto entry in allEntries)
+                excludedCallerEntries.Add(entry);
+                string callerKey = BuildMethodKey(entry);
+                if (entry.patchKind == HotReloadConstants.PatchKindAddedMethod)
                 {
-                    if (entry.calledAddedMethodKeys == null)
-                    {
-                        continue;
-                    }
-
-                    string callerKey = BuildMethodKey(entry);
-                    if (failedEntryKeys.Contains(callerKey))
-                    {
-                        continue;
-                    }
-
-                    bool callsFailedAdded = false;
-                    foreach (string calledKey in entry.calledAddedMethodKeys)
-                    {
-                        if (failedAddedMethodKeys.Contains(calledKey))
-                        {
-                            callsFailedAdded = true;
-                            break;
-                        }
-                    }
-
-                    if (!callsFailedAdded)
-                    {
-                        continue;
-                    }
-
-                    excludedCallerEntries.Add(entry);
-                    if (entry.patchKind == HotReloadConstants.PatchKindAddedMethod)
-                    {
-                        excludedAddedMethodKeys.Add(callerKey);
-                    }
-                    else
-                    {
-                        excludedKeys.Add(callerKey);
-                    }
+                    excludedAddedMethodKeys.Add(callerKey);
+                }
+                else
+                {
+                    excludedKeys.Add(callerKey);
                 }
             }
 
@@ -1194,9 +1181,55 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 excludedCallerEntries);
         }
 
+        private static List<TransformWorkerEntryDto> CollectCallerEntriesOfAddedMethods(
+            HashSet<string> addedMethodKeys,
+            HashSet<string> alreadyExcludedEntryKeys,
+            TransformWorkerEntryDto[] allEntries)
+        {
+            List<TransformWorkerEntryDto> callerEntries = new List<TransformWorkerEntryDto>();
+            if (addedMethodKeys.Count == 0 || allEntries == null)
+            {
+                return callerEntries;
+            }
+
+            foreach (TransformWorkerEntryDto entry in allEntries)
+            {
+                if (entry.calledAddedMethodKeys == null)
+                {
+                    continue;
+                }
+
+                string callerKey = BuildMethodKey(entry);
+                if (alreadyExcludedEntryKeys.Contains(callerKey))
+                {
+                    continue;
+                }
+
+                bool callsAdded = false;
+                foreach (string calledKey in entry.calledAddedMethodKeys)
+                {
+                    if (addedMethodKeys.Contains(calledKey))
+                    {
+                        callsAdded = true;
+                        break;
+                    }
+                }
+
+                if (!callsAdded)
+                {
+                    continue;
+                }
+
+                callerEntries.Add(entry);
+            }
+
+            return callerEntries;
+        }
+
         private static List<HotReloadMethodOutcome> BuildSkippedCallerOutcomes(
             IReadOnlyList<TransformWorkerEntryDto> callerEntries,
-            string assemblyResolvePath)
+            string assemblyResolvePath,
+            string skipReason)
         {
             List<HotReloadMethodOutcome> skippedCallerOutcomes = new List<HotReloadMethodOutcome>();
             foreach (TransformWorkerEntryDto caller in callerEntries)
@@ -1209,11 +1242,370 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 skippedCallerOutcomes.Add(
                     HotReloadMethodOutcome.Skipped(
                         methodLabel,
-                        HotReloadConstants.IsolatedAddedMethodCallerSkipReason,
+                        skipReason,
                         assemblyResolvePath));
             }
 
             return skippedCallerOutcomes;
+        }
+
+        /// <summary>
+        /// First shim compile plus optional compile-failure isolation. Signature-change gate
+        /// retries never call this — they already consumed the one worker retry.
+        /// </summary>
+        private static async Task<ShimFirstCompileResult> CompileShimFirstPassAsync(
+            TransformWorkerInputDto workerInput,
+            TransformWorkerOutputDto workerOutput,
+            UnityCompilationAssembly compilationAssembly,
+            string targetDllPath,
+            string[] defines,
+            string assemblyResolvePath,
+            CancellationToken ct)
+        {
+            // BuildShimReferencePaths reads Application.dataPath / platform; stay on main thread.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+            bool includeHarmonyReference = NeedsHarmonyReference(workerOutput);
+            bool includeAddedFieldStoreReference = NeedsAddedFieldStoreReference(workerOutput);
+            ShimReferencePathsResult shimReferencePaths = TryBuildShimReferencePaths(
+                compilationAssembly,
+                targetDllPath,
+                includeHarmonyReference,
+                includeAddedFieldStoreReference);
+            if (shimReferencePaths.ErrorMessage != null)
+            {
+                return ShimFirstCompileResult.Failed(
+                    HotReloadMethodOutcome.Failed(
+                        "(file)",
+                        shimReferencePaths.ErrorMessage,
+                        assemblyResolvePath));
+            }
+
+            List<string> shimReferences = shimReferencePaths.References;
+            HotReloadShimCompileResult compileResult = await HotReloadShimCompiler.CompileAndLoadAsync(
+                workerOutput.shimSource,
+                shimReferences,
+                defines,
+                workerInput.projectRelativePath,
+                ct).ConfigureAwait(false);
+
+            TransformWorkerEntryDto[] entriesToPatch = workerOutput.entries;
+            if (compileResult.Success)
+            {
+                return ShimFirstCompileResult.Succeeded(entriesToPatch, compileResult);
+            }
+
+            // Why isolate only here: a signature-change gate retry already used
+            // RunIsolationRetryAsync (worker run #2). Calling isolation after that would be a
+            // third worker run. Gate retry compile failures return Failed from the gate and
+            // never reach this first-compile path.
+            HotReloadShimIsolationResult isolation = await TryIsolateShimCompileFailureAsync(
+                workerInput,
+                workerOutput,
+                compileResult,
+                compilationAssembly,
+                targetDllPath,
+                defines,
+                assemblyResolvePath,
+                ct).ConfigureAwait(false);
+            if (isolation == null)
+            {
+                // Why: CompileAndLoadAsync appends "(line N)" only for diagnostics whose
+                // #line-mapped file matches projectRelativePath — scaffold-only errors stay
+                // bare. Single-entry failures skip isolation and always take this path.
+                // Why attribute single-entry failures: "(shim-compile)" hides which method
+                // body failed when the agent edited only one method.
+                string failureMethodLabel = "(shim-compile)";
+                if (entriesToPatch.Length == 1)
+                {
+                    TransformWorkerEntryDto soleEntry = entriesToPatch[0];
+                    failureMethodLabel = HotReloadPatcher.FormatMethodKeyParts(
+                        soleEntry.typeMetadataName,
+                        soleEntry.methodName,
+                        soleEntry.parameterTypeFullNames ?? Array.Empty<string>(),
+                        genericArity: 0);
+                }
+
+                return ShimFirstCompileResult.Failed(
+                    HotReloadMethodOutcome.Failed(
+                        failureMethodLabel,
+                        compileResult.ErrorMessage,
+                        assemblyResolvePath));
+            }
+
+            List<HotReloadMethodOutcome> isolationOutcomes = new List<HotReloadMethodOutcome>();
+            isolationOutcomes.AddRange(isolation.FailedMethodOutcomes);
+            isolationOutcomes.AddRange(isolation.SkippedCallerOutcomes);
+            if (isolation.RetryEntries.Length == 0)
+            {
+                return ShimFirstCompileResult.SucceededEmpty(isolationOutcomes);
+            }
+
+            return ShimFirstCompileResult.Succeeded(
+                isolation.RetryEntries,
+                isolation.RetryCompileResult,
+                isolationOutcomes);
+        }
+
+        /// <summary>
+        /// Scans compiled call sites after worker #1 and before the first shim compile. No
+        /// trigger means the scanner is not called.
+        /// </summary>
+        private static async Task<SignatureChangeGateResult> TryApplySignatureChangeGateAsync(
+            string projectRoot,
+            string assemblyName,
+            TransformWorkerInputDto workerInput,
+            TransformWorkerOutputDto workerOutput,
+            UnityCompilationAssembly compilationAssembly,
+            string targetDllPath,
+            string[] defines,
+            string assemblyResolvePath,
+            CancellationToken ct)
+        {
+            TransformWorkerEntryDto[] entries = workerOutput.entries ?? Array.Empty<TransformWorkerEntryDto>();
+            TransformWorkerRemovedMethodSignatureDto[] removedSignatures =
+                workerOutput.removedMethodSignatures
+                ?? Array.Empty<TransformWorkerRemovedMethodSignatureDto>();
+            List<TransformWorkerEntryDto> replacementEntries = CollectReplacementEntries(entries);
+            if (replacementEntries.Count == 0 && removedSignatures.Length == 0)
+            {
+                return SignatureChangeGateResult.NoWork();
+            }
+
+            HotReloadCallSiteScanner.CompiledMethodIdentity[] targets = CollectScanTargets(
+                assemblyName,
+                replacementEntries,
+                removedSignatures);
+            List<HotReloadCallSiteScanner.CallSiteHit> hits =
+                HotReloadCallSiteScanner.FindCallSites(projectRoot, targets);
+            HashSet<string> coveredKeys = CollectCoveredMethodKeys(entries, targets);
+            Dictionary<string, List<string>> uncoveredCallersByTarget =
+                CollectUncoveredCallersByTarget(hits, coveredKeys);
+
+            List<string> staleWarnings = CollectStaleSignatureWarnings(
+                removedSignatures,
+                uncoveredCallersByTarget);
+            List<TransformWorkerEntryDto> gatedReplacements = CollectGatedReplacementEntries(
+                replacementEntries,
+                uncoveredCallersByTarget);
+            if (gatedReplacements.Count == 0)
+            {
+                return SignatureChangeGateResult.WarningsOnly(staleWarnings);
+            }
+
+            IsolationExclusions exclusions = BuildIsolationExclusions(gatedReplacements, entries);
+            List<HotReloadMethodOutcome> skippedOutcomes = BuildGatedReplacementSkipOutcomes(
+                gatedReplacements,
+                assemblyResolvePath);
+            skippedOutcomes.AddRange(
+                BuildSkippedCallerOutcomes(
+                    exclusions.CallerEntries,
+                    assemblyResolvePath,
+                    HotReloadConstants.SignatureChangedGatedCallerSkipReason));
+
+            IsolationRetryRunResult retry = await RunIsolationRetryAsync(
+                workerInput,
+                exclusions,
+                new List<HotReloadMethodOutcome>(),
+                new List<HotReloadMethodOutcome>(),
+                compilationAssembly,
+                targetDllPath,
+                defines,
+                ct).ConfigureAwait(false);
+            if (retry.Isolation == null)
+            {
+                return SignatureChangeGateResult.Failed(retry.FailureMessage, staleWarnings);
+            }
+
+            return SignatureChangeGateResult.Retried(retry.Isolation, skippedOutcomes, staleWarnings);
+        }
+
+        private static List<TransformWorkerEntryDto> CollectReplacementEntries(
+            TransformWorkerEntryDto[] entries)
+        {
+            List<TransformWorkerEntryDto> replacements = new List<TransformWorkerEntryDto>();
+            foreach (TransformWorkerEntryDto entry in entries)
+            {
+                if (entry.replacesCompiledMethod)
+                {
+                    replacements.Add(entry);
+                }
+            }
+
+            return replacements;
+        }
+
+        private static HotReloadCallSiteScanner.CompiledMethodIdentity[] CollectScanTargets(
+            string assemblyName,
+            IReadOnlyList<TransformWorkerEntryDto> replacementEntries,
+            TransformWorkerRemovedMethodSignatureDto[] removedSignatures)
+        {
+            List<HotReloadCallSiteScanner.CompiledMethodIdentity> targets =
+                new List<HotReloadCallSiteScanner.CompiledMethodIdentity>();
+            HashSet<string> seenKeys = new HashSet<string>(StringComparer.Ordinal);
+            foreach (TransformWorkerEntryDto entry in replacementEntries)
+            {
+                TryAddScanTarget(
+                    targets,
+                    seenKeys,
+                    assemblyName,
+                    entry.typeMetadataName,
+                    entry.methodName,
+                    entry.parameterTypeFullNames);
+            }
+
+            foreach (TransformWorkerRemovedMethodSignatureDto signature in removedSignatures)
+            {
+                TryAddScanTarget(
+                    targets,
+                    seenKeys,
+                    assemblyName,
+                    signature.typeMetadataName,
+                    signature.methodName,
+                    signature.parameterTypeFullNames);
+            }
+
+            return targets.ToArray();
+        }
+
+        private static void TryAddScanTarget(
+            List<HotReloadCallSiteScanner.CompiledMethodIdentity> targets,
+            HashSet<string> seenKeys,
+            string assemblyName,
+            string typeMetadataName,
+            string methodName,
+            string[] parameterTypeFullNames)
+        {
+            string methodKey = BuildMethodKeyParts(typeMetadataName, methodName, parameterTypeFullNames);
+            if (!seenKeys.Add(methodKey))
+            {
+                return;
+            }
+
+            targets.Add(
+                new HotReloadCallSiteScanner.CompiledMethodIdentity(
+                    assemblyName,
+                    typeMetadataName,
+                    methodName,
+                    parameterTypeFullNames ?? Array.Empty<string>()));
+        }
+
+        private static HashSet<string> CollectCoveredMethodKeys(
+            TransformWorkerEntryDto[] entries,
+            HotReloadCallSiteScanner.CompiledMethodIdentity[] targets)
+        {
+            HashSet<string> coveredKeys = new HashSet<string>(StringComparer.Ordinal);
+            foreach (TransformWorkerEntryDto entry in entries)
+            {
+                coveredKeys.Add(BuildMethodKey(entry));
+            }
+
+            foreach (HotReloadCallSiteScanner.CompiledMethodIdentity target in targets)
+            {
+                coveredKeys.Add(
+                    BuildMethodKeyParts(
+                        target.TypeMetadataName,
+                        target.MethodName,
+                        target.ParameterTypeFullNames));
+            }
+
+            return coveredKeys;
+        }
+
+        private static Dictionary<string, List<string>> CollectUncoveredCallersByTarget(
+            IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits,
+            HashSet<string> coveredKeys)
+        {
+            Dictionary<string, List<string>> uncoveredCallersByTarget =
+                new Dictionary<string, List<string>>(StringComparer.Ordinal);
+            foreach (HotReloadCallSiteScanner.CallSiteHit hit in hits)
+            {
+                if (coveredKeys.Contains(hit.CallerMethodKey))
+                {
+                    continue;
+                }
+
+                if (!uncoveredCallersByTarget.TryGetValue(hit.TargetMethodKey, out List<string> callers))
+                {
+                    callers = new List<string>();
+                    uncoveredCallersByTarget.Add(hit.TargetMethodKey, callers);
+                }
+
+                if (!callers.Contains(hit.CallerMethodKey))
+                {
+                    callers.Add(hit.CallerMethodKey);
+                }
+            }
+
+            return uncoveredCallersByTarget;
+        }
+
+        private static List<string> CollectStaleSignatureWarnings(
+            TransformWorkerRemovedMethodSignatureDto[] removedSignatures,
+            Dictionary<string, List<string>> uncoveredCallersByTarget)
+        {
+            List<string> warnings = new List<string>();
+            foreach (TransformWorkerRemovedMethodSignatureDto signature in removedSignatures)
+            {
+                string methodKey = BuildMethodKeyParts(
+                    signature.typeMetadataName,
+                    signature.methodName,
+                    signature.parameterTypeFullNames);
+                if (!uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> callers)
+                    || callers.Count == 0)
+                {
+                    continue;
+                }
+
+                warnings.Add(
+                    string.Format(
+                        HotReloadConstants.StaleSignatureCallersWarningFormat,
+                        methodKey,
+                        string.Join(", ", callers)));
+            }
+
+            return warnings;
+        }
+
+        private static List<TransformWorkerEntryDto> CollectGatedReplacementEntries(
+            IReadOnlyList<TransformWorkerEntryDto> replacementEntries,
+            Dictionary<string, List<string>> uncoveredCallersByTarget)
+        {
+            List<TransformWorkerEntryDto> gated = new List<TransformWorkerEntryDto>();
+            foreach (TransformWorkerEntryDto entry in replacementEntries)
+            {
+                string methodKey = BuildMethodKey(entry);
+                if (uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> callers)
+                    && callers.Count > 0)
+                {
+                    gated.Add(entry);
+                }
+            }
+
+            return gated;
+        }
+
+        private static List<HotReloadMethodOutcome> BuildGatedReplacementSkipOutcomes(
+            IReadOnlyList<TransformWorkerEntryDto> gatedReplacements,
+            string assemblyResolvePath)
+        {
+            List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
+            foreach (TransformWorkerEntryDto entry in gatedReplacements)
+            {
+                string methodLabel = HotReloadPatcher.FormatMethodKeyParts(
+                    entry.typeMetadataName,
+                    entry.methodName,
+                    entry.parameterTypeFullNames ?? Array.Empty<string>(),
+                    genericArity: 0);
+                outcomes.Add(
+                    HotReloadMethodOutcome.Skipped(
+                        methodLabel,
+                        string.Format(
+                            HotReloadConstants.SignatureChangedGateSkipReasonFormat,
+                            methodLabel),
+                        assemblyResolvePath));
+            }
+
+            return outcomes;
         }
 
         /// <summary>
@@ -1319,6 +1711,129 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ExcludedMethodKeys = excludedMethodKeys;
                 ExcludedAddedMethodKeys = excludedAddedMethodKeys;
                 CallerEntries = callerEntries;
+            }
+        }
+
+        private sealed class IsolationRetryRunResult
+        {
+            public HotReloadShimIsolationResult Isolation { get; }
+            public string FailureMessage { get; }
+
+            private IsolationRetryRunResult(HotReloadShimIsolationResult isolation, string failureMessage)
+            {
+                Isolation = isolation;
+                FailureMessage = failureMessage;
+            }
+
+            public static IsolationRetryRunResult Succeeded(HotReloadShimIsolationResult isolation)
+            {
+                return new IsolationRetryRunResult(isolation, null);
+            }
+
+            public static IsolationRetryRunResult Failed(string failureMessage)
+            {
+                return new IsolationRetryRunResult(null, failureMessage);
+            }
+        }
+
+        private sealed class SignatureChangeGateResult
+        {
+            public bool FileFailed { get; }
+            public string FailureMessage { get; }
+            public bool UsedWorkerRetry { get; }
+            public HotReloadShimIsolationResult Isolation { get; }
+            public List<HotReloadMethodOutcome> SkippedOutcomes { get; }
+            public List<string> Warnings { get; }
+
+            private SignatureChangeGateResult(
+                bool fileFailed,
+                string failureMessage,
+                bool usedWorkerRetry,
+                HotReloadShimIsolationResult isolation,
+                List<HotReloadMethodOutcome> skippedOutcomes,
+                List<string> warnings)
+            {
+                FileFailed = fileFailed;
+                FailureMessage = failureMessage;
+                UsedWorkerRetry = usedWorkerRetry;
+                Isolation = isolation;
+                SkippedOutcomes = skippedOutcomes ?? new List<HotReloadMethodOutcome>();
+                Warnings = warnings ?? new List<string>();
+            }
+
+            public static SignatureChangeGateResult NoWork()
+            {
+                return new SignatureChangeGateResult(false, null, false, null, null, null);
+            }
+
+            public static SignatureChangeGateResult WarningsOnly(List<string> warnings)
+            {
+                return new SignatureChangeGateResult(false, null, false, null, null, warnings);
+            }
+
+            public static SignatureChangeGateResult Failed(string failureMessage, List<string> warnings)
+            {
+                return new SignatureChangeGateResult(true, failureMessage, false, null, null, warnings);
+            }
+
+            public static SignatureChangeGateResult Retried(
+                HotReloadShimIsolationResult isolation,
+                List<HotReloadMethodOutcome> skippedOutcomes,
+                List<string> warnings)
+            {
+                return new SignatureChangeGateResult(
+                    false,
+                    null,
+                    true,
+                    isolation,
+                    skippedOutcomes,
+                    warnings);
+            }
+        }
+
+        private sealed class ShimFirstCompileResult
+        {
+            public bool FileFailed { get; }
+            public List<HotReloadMethodOutcome> Outcomes { get; }
+            public TransformWorkerEntryDto[] EntriesToPatch { get; }
+            public HotReloadShimCompileResult CompileResult { get; }
+
+            private ShimFirstCompileResult(
+                bool fileFailed,
+                List<HotReloadMethodOutcome> outcomes,
+                TransformWorkerEntryDto[] entriesToPatch,
+                HotReloadShimCompileResult compileResult)
+            {
+                FileFailed = fileFailed;
+                Outcomes = outcomes ?? new List<HotReloadMethodOutcome>();
+                EntriesToPatch = entriesToPatch ?? Array.Empty<TransformWorkerEntryDto>();
+                CompileResult = compileResult;
+            }
+
+            public static ShimFirstCompileResult Failed(HotReloadMethodOutcome outcome)
+            {
+                return new ShimFirstCompileResult(
+                    true,
+                    new List<HotReloadMethodOutcome> { outcome },
+                    Array.Empty<TransformWorkerEntryDto>(),
+                    null);
+            }
+
+            public static ShimFirstCompileResult SucceededEmpty(List<HotReloadMethodOutcome> outcomes)
+            {
+                return new ShimFirstCompileResult(
+                    false,
+                    outcomes,
+                    Array.Empty<TransformWorkerEntryDto>(),
+                    null);
+            }
+
+            public static ShimFirstCompileResult Succeeded(
+                TransformWorkerEntryDto[] entriesToPatch,
+                HotReloadShimCompileResult compileResult,
+                List<HotReloadMethodOutcome> outcomes = null)
+            {
+                return new ShimFirstCompileResult(false, outcomes, entriesToPatch, compileResult);
             }
         }
 


### PR DESCRIPTION
## Summary
- Hot reload now refuses a return-type change when compiled code outside the edited file still calls the old method, and tells you to run `uloop compile`.
- Deleting or renaming a method still applies, but the warning now names the leftover compiled callers instead of only listing the removed name.

## User Impact
- Before: changing a method's return type could report success while other compiled callers kept running the old body.
- After: that replacement is skipped (together with same-file callers of it) when outside callers exist. Same-file-only changes still apply. Removed signatures keep applying, with a caller-named warning.

## Changes
- After the first worker run and before the first shim compile, scan compiled call sites when a replacement or removed signature is present.
- Uncovered return-type replacements reuse the existing isolation retry (max two worker runs). A failed gate retry fails the file as `(signature-change-gate)` and does not apply the first-pass entries.
- Call-site hits now carry the target method key so one scan can attribute callers per identity.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Success
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --filter-type regex --filter-value "HotReload"` → 289/289
- CLI E2E (assemblies locked): same-file return-type change apply → `--status` → revert-all. Raw JSON in `/tmp/uloop-sigchange-e2e/`
  - call-before `ExistingCaller(3)` = 3
  - apply: Added `Target` + Patched `ExistingCaller`, ActivePatchTotal=2
  - call-after = 4
  - status: 2 active
  - revert-all-final: ClearedCount=2
- Repository CI does not run on PRs targeting `feature/hot-reload` (`pull_request.branches` is `main` / `v3-beta` only). Local compile + HotReload suite is the gate.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

