### PR TITLE
fix: Unity no longer installs a duplicate CLI over a Homebrew-managed uloop

### DIFF
--- a/Assets/Tests/Editor/CliPathSetupFlowTests.cs
+++ b/Assets/Tests/Editor/CliPathSetupFlowTests.cs
@@ -174,6 +174,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 return true;
             }
 
+            public bool IsHomebrewManagedInstallPath(string cliExecutablePath)
+            {
+                return false;
+            }
+
             public bool HasPackageOwnedCurrentUserInstall(RuntimePlatform platform)
             {
                 return true;

--- a/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
+++ b/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
@@ -163,6 +163,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 return false;
             }
 
+            public bool IsHomebrewManagedInstallPath(string cliExecutablePath)
+            {
+                return false;
+            }
+
             public bool HasPackageOwnedCurrentUserInstall(RuntimePlatform platform)
             {
                 return false;

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -15,18 +15,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     /// </summary>
     public class CliSetupSectionTests
     {
-        [TestCase(false, false, false, false, false, false, null, "3.0.0", "Install CLI")]
-        [TestCase(false, false, false, false, false, true, null, "3.0.0", "Fix PATH")]
-        [TestCase(true, false, false, false, true, false, "3.0.0", "3.0.0", "Uninstall CLI")]
-        [TestCase(true, false, false, false, false, false, "3.0.0", "3.0.0", "Install CLI")]
-        [TestCase(true, false, false, false, true, true, "3.0.0", "3.0.0", "Fix PATH")]
-        [TestCase(true, false, false, true, true, false, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
-        [TestCase(true, false, false, true, true, true, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
-        [TestCase(true, false, false, true, true, false, "3.0.0", "3.0.0", "Update CLI (v3.0.0 required)")]
-        [TestCase(true, true, false, false, true, false, "3.0.0", "3.0.0", "Uninstalling...")]
-        [TestCase(true, true, false, false, true, true, "3.0.0", "3.0.0", "Fixing PATH...")]
-        [TestCase(false, true, false, false, false, false, null, "3.0.0", "Installing...")]
-        [TestCase(false, false, true, false, false, false, null, "3.0.0", "Checking...")]
+        [TestCase(false, false, false, false, false, false, false, null, "3.0.0", "Install CLI")]
+        [TestCase(false, false, false, false, false, true, false, null, "3.0.0", "Fix PATH")]
+        [TestCase(true, false, false, false, true, false, false, "3.0.0", "3.0.0", "Uninstall CLI")]
+        [TestCase(true, false, false, false, false, false, false, "3.0.0", "3.0.0", "Install CLI")]
+        [TestCase(true, false, false, false, true, true, false, "3.0.0", "3.0.0", "Fix PATH")]
+        [TestCase(true, false, false, true, true, false, false, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
+        [TestCase(true, false, false, true, true, true, false, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
+        [TestCase(true, false, false, true, true, false, false, "3.0.0", "3.0.0", "Update CLI (v3.0.0 required)")]
+        [TestCase(true, true, false, false, true, false, false, "3.0.0", "3.0.0", "Uninstalling...")]
+        [TestCase(true, true, false, false, true, true, false, "3.0.0", "3.0.0", "Fixing PATH...")]
+        [TestCase(false, true, false, false, false, false, false, null, "3.0.0", "Installing...")]
+        [TestCase(false, false, true, false, false, false, false, null, "3.0.0", "Checking...")]
+        [TestCase(true, false, false, false, false, false, true, "3.0.0", "3.0.0", "Managed by Homebrew")]
+        [TestCase(true, false, false, true, false, false, true, "2.9.0", "3.0.0", "Managed by Homebrew")]
+        [TestCase(true, false, true, false, false, false, true, "3.0.0", "3.0.0", "Checking...")]
         public void GetInstallCliButtonText_ReturnsExpectedText(
             bool isCliInstalled,
             bool isInstallingCli,
@@ -34,6 +37,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool needsUpdate,
             bool canUninstallCli,
             bool needsCliPathSetup,
+            bool isHomebrewManagedCli,
             string cliVersion,
             string requiredCliVersion,
             string expectedText)
@@ -45,25 +49,81 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 needsUpdate,
                 canUninstallCli,
                 needsCliPathSetup,
+                isHomebrewManagedCli,
                 cliVersion,
                 requiredCliVersion);
 
             Assert.That(text, Is.EqualTo(expectedText));
         }
 
-        [TestCase(false, false, true)]
-        [TestCase(true, false, false)]
-        [TestCase(false, true, false)]
+        [TestCase(false, false, false, true)]
+        [TestCase(true, false, false, false)]
+        [TestCase(false, true, false, false)]
+        [TestCase(false, false, true, false)]
         public void IsInstallCliButtonEnabled_ReturnsExpectedValue(
             bool isInstallingCli,
             bool isChecking,
+            bool isHomebrewManagedCli,
             bool expectedEnabled)
         {
             bool enabled = CliSetupSection.IsInstallCliButtonEnabled(
                 isInstallingCli,
-                isChecking);
+                isChecking,
+                isHomebrewManagedCli);
 
             Assert.That(enabled, Is.EqualTo(expectedEnabled));
+        }
+
+        [TestCase(true, false, false, false, null, "3.0.0", "CLI: Checking...")]
+        [TestCase(false, false, false, false, null, "3.0.0", "CLI: Not installed")]
+        [TestCase(false, true, false, false, "3.0.0", "3.0.0", "CLI: v3.0.0")]
+        [TestCase(false, true, true, false, "3.0.0", "3.0.0", "CLI: v3.0.0")]
+        [TestCase(
+            false,
+            true,
+            true,
+            true,
+            "2.9.0",
+            "3.0.0",
+            "CLI: v2.9.0 (requires v3.0.0; run: brew upgrade uloop)")]
+        public void GetCliStatusText_ReturnsExpectedText(
+            bool isChecking,
+            bool isCliInstalled,
+            bool isHomebrewManagedCli,
+            bool needsUpdate,
+            string cliVersion,
+            string requiredCliVersion,
+            string expectedText)
+        {
+            // Verifies that a Homebrew-managed CLI below the pin minimum shows the brew upgrade command.
+            string text = CliSetupSection.GetCliStatusText(
+                isChecking,
+                isCliInstalled,
+                isHomebrewManagedCli,
+                needsUpdate,
+                cliVersion,
+                requiredCliVersion);
+
+            Assert.That(text, Is.EqualTo(expectedText));
+        }
+
+        [Test]
+        public void Update_WhenCliIsHomebrewManaged_DisablesPrimaryButton()
+        {
+            // Verifies the Settings primary button cannot trigger an install for a Homebrew-managed CLI.
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            CliSetupData data = CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Installed,
+                isHomebrewManagedCli: true);
+
+            section.Update(data);
+
+            Button installCliButton = root.Q<Button>("install-cli-button");
+            Assert.That(installCliButton.text, Is.EqualTo("Managed by Homebrew"));
+            Assert.That(installCliButton.enabledSelf, Is.False);
         }
 
         [TestCase(true, false, true, true)]
@@ -372,7 +432,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool isChecking,
             SkillInstallState selectedTargetInstallState,
             IReadOnlyList<SkillSetupTargetInfo> installableSkillTargets = null,
-            bool? isSkillStateChecking = null)
+            bool? isSkillStateChecking = null,
+            bool isHomebrewManagedCli = false)
         {
             return new CliSetupData(
                 isCliInstalled,
@@ -381,6 +442,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 needsUpdate: false,
                 canUninstallCli: true,
                 needsCliPathSetup: false,
+                isHomebrewManagedCli,
                 isInstallingCli: false,
                 isChecking,
                 isSkillStateChecking: isSkillStateChecking ?? isChecking,

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -57,24 +57,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(text, Is.EqualTo(expectedText));
         }
 
-        [TestCase(false, false, false, true, true)]
-        [TestCase(true, false, false, true, false)]
-        [TestCase(false, true, false, true, false)]
-        [TestCase(false, false, true, true, false)]
-        [TestCase(false, false, true, false, true)]
+        [TestCase(false, false, false, "3.0.0", true)]
+        [TestCase(true, false, false, "3.0.0", false)]
+        [TestCase(false, true, false, "3.0.0", false)]
+        [TestCase(false, false, true, "3.0.0", false)]
+        [TestCase(false, false, true, null, true)]
+        [TestCase(false, false, true, "", true)]
         public void IsInstallCliButtonEnabled_ReturnsExpectedValue(
             bool isInstallingCli,
             bool isChecking,
             bool isHomebrewManagedCli,
-            bool isCliInstalled,
+            string cliVersion,
             bool expectedEnabled)
         {
-            // Verifies a Homebrew path with no usable CLI keeps the install action reachable.
+            // Verifies a Homebrew path whose binary reports no version keeps the install action reachable.
             bool enabled = CliSetupSection.IsInstallCliButtonEnabled(
                 isInstallingCli,
                 isChecking,
                 isHomebrewManagedCli,
-                isCliInstalled);
+                cliVersion);
 
             Assert.That(enabled, Is.EqualTo(expectedEnabled));
         }
@@ -114,6 +115,27 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Button installCliButton = root.Q<Button>("install-cli-button");
             Assert.That(installCliButton.text, Is.EqualTo("Managed by Homebrew"));
             Assert.That(installCliButton.enabledSelf, Is.False);
+        }
+
+        [Test]
+        public void Update_WhenHomebrewPathReportsNoVersion_KeepsPathRepairReachable()
+        {
+            // Verifies a Homebrew path whose binary answers no version probe still offers PATH repair.
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            CliSetupData data = CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Installed,
+                isHomebrewManagedCli: true,
+                cliVersion: null,
+                needsCliPathSetup: true);
+
+            section.Update(data);
+
+            Button installCliButton = root.Q<Button>("install-cli-button");
+            Assert.That(installCliButton.text, Is.EqualTo("Fix PATH"));
+            Assert.That(installCliButton.enabledSelf, Is.True);
         }
 
         [Test]
@@ -490,7 +512,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool? isSkillStateChecking = null,
             bool isHomebrewManagedCli = false,
             bool needsUpdate = false,
-            string cliVersion = "3.0.0")
+            string cliVersion = "3.0.0",
+            bool needsCliPathSetup = false)
         {
             return new CliSetupData(
                 isCliInstalled,
@@ -498,7 +521,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 requiredCliVersion: "3.0.0",
                 needsUpdate,
                 canUninstallCli: true,
-                needsCliPathSetup: false,
+                needsCliPathSetup,
                 isHomebrewManagedCli,
                 isInstallingCli: false,
                 isChecking,

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -30,6 +30,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(true, false, false, false, false, false, true, "3.0.0", "3.0.0", "Managed by Homebrew")]
         [TestCase(true, false, false, true, false, false, true, "2.9.0", "3.0.0", "Managed by Homebrew")]
         [TestCase(true, false, true, false, false, false, true, "3.0.0", "3.0.0", "Checking...")]
+        [TestCase(false, false, false, false, false, false, true, null, "3.0.0", "Install CLI")]
         public void GetInstallCliButtonText_ReturnsExpectedText(
             bool isCliInstalled,
             bool isInstallingCli,
@@ -56,20 +57,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(text, Is.EqualTo(expectedText));
         }
 
-        [TestCase(false, false, false, true)]
-        [TestCase(true, false, false, false)]
-        [TestCase(false, true, false, false)]
-        [TestCase(false, false, true, false)]
+        [TestCase(false, false, false, true, true)]
+        [TestCase(true, false, false, true, false)]
+        [TestCase(false, true, false, true, false)]
+        [TestCase(false, false, true, true, false)]
+        [TestCase(false, false, true, false, true)]
         public void IsInstallCliButtonEnabled_ReturnsExpectedValue(
             bool isInstallingCli,
             bool isChecking,
             bool isHomebrewManagedCli,
+            bool isCliInstalled,
             bool expectedEnabled)
         {
+            // Verifies a Homebrew path with no usable CLI keeps the install action reachable.
             bool enabled = CliSetupSection.IsInstallCliButtonEnabled(
                 isInstallingCli,
                 isChecking,
-                isHomebrewManagedCli);
+                isHomebrewManagedCli,
+                isCliInstalled);
 
             Assert.That(enabled, Is.EqualTo(expectedEnabled));
         }
@@ -132,7 +137,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(statusLabel.text, Is.EqualTo("CLI: v2.9.0"));
             Assert.That(
                 warningLabel.text,
-                Is.EqualTo("Homebrew-managed CLI v2.9.0 is older than the required v3.0.0.\n"
+                Is.EqualTo("Homebrew-managed CLI v2.9.0 does not meet the required v3.0.0.\n"
                     + "Run this command in your terminal:\nbrew upgrade uloop"));
             Assert.That(warningLabel.ClassListContains("unity-cli-loop-warning-message--visible"), Is.True);
         }

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -193,6 +193,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void Update_WhenHomebrewCliMeetsVersionButNeedsUpdate_ShowsReinstallGuidance()
+        {
+            // Verifies a Homebrew binary that is current but does not answer as the dispatcher
+            // is not told to upgrade, because brew would report nothing to do.
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            CliSetupData data = CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Installed,
+                isHomebrewManagedCli: true,
+                needsUpdate: true,
+                cliVersion: "3.0.0");
+
+            section.Update(data);
+
+            Label warningLabel = root.Q<Label>("cli-homebrew-upgrade-message");
+            Assert.That(
+                warningLabel.text,
+                Is.EqualTo("Homebrew-managed CLI v3.0.0 did not answer as the required uloop CLI.\n"
+                    + "Run this command in your terminal:\nbrew reinstall uloop"));
+            Assert.That(warningLabel.ClassListContains("unity-cli-loop-warning-message--visible"), Is.True);
+        }
+
+        [Test]
         public void Update_WhenHomebrewManagedCliIsUpToDate_HidesUpgradeWarning()
         {
             // Verifies the upgrade warning stays hidden while the Homebrew CLI satisfies the required version.

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -132,7 +132,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(statusLabel.text, Is.EqualTo("CLI: v2.9.0"));
             Assert.That(
                 warningLabel.text,
-                Is.EqualTo("Homebrew-managed CLI v2.9.0 is older than the required v3.0.0.\nbrew upgrade uloop"));
+                Is.EqualTo("Homebrew-managed CLI v2.9.0 is older than the required v3.0.0.\n"
+                    + "Run this command in your terminal:\nbrew upgrade uloop"));
             Assert.That(warningLabel.ClassListContains("unity-cli-loop-warning-message--visible"), Is.True);
         }
 

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -30,7 +30,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(true, false, false, false, false, false, true, "3.0.0", "3.0.0", "Managed by Homebrew")]
         [TestCase(true, false, false, true, false, false, true, "2.9.0", "3.0.0", "Managed by Homebrew")]
         [TestCase(true, false, true, false, false, false, true, "3.0.0", "3.0.0", "Checking...")]
-        [TestCase(false, false, false, false, false, false, true, null, "3.0.0", "Install CLI")]
+        [TestCase(false, false, false, false, false, false, true, null, "3.0.0", "Managed by Homebrew")]
+        [TestCase(true, false, false, false, false, true, true, "3.0.0", "3.0.0", "Fix PATH")]
+        [TestCase(true, true, false, false, false, true, true, "3.0.0", "3.0.0", "Fixing PATH...")]
         public void GetInstallCliButtonText_ReturnsExpectedText(
             bool isCliInstalled,
             bool isInstallingCli,
@@ -57,25 +59,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(text, Is.EqualTo(expectedText));
         }
 
-        [TestCase(false, false, false, "3.0.0", true)]
-        [TestCase(true, false, false, "3.0.0", false)]
-        [TestCase(false, true, false, "3.0.0", false)]
-        [TestCase(false, false, true, "3.0.0", false)]
-        [TestCase(false, false, true, null, true)]
-        [TestCase(false, false, true, "", true)]
+        [TestCase(false, false, false, false, true)]
+        [TestCase(true, false, false, false, false)]
+        [TestCase(false, true, false, false, false)]
+        [TestCase(false, false, true, false, false)]
+        [TestCase(false, false, true, true, true)]
+        [TestCase(true, false, true, true, false)]
         public void IsInstallCliButtonEnabled_ReturnsExpectedValue(
             bool isInstallingCli,
             bool isChecking,
             bool isHomebrewManagedCli,
-            string cliVersion,
+            bool needsCliPathSetup,
             bool expectedEnabled)
         {
-            // Verifies a Homebrew path whose binary reports no version keeps the install action reachable.
+            // Verifies a Homebrew-managed CLI leaves only PATH repair, which writes no binary, enabled.
             bool enabled = CliSetupSection.IsInstallCliButtonEnabled(
                 isInstallingCli,
                 isChecking,
                 isHomebrewManagedCli,
-                cliVersion);
+                needsCliPathSetup);
 
             Assert.That(enabled, Is.EqualTo(expectedEnabled));
         }
@@ -136,6 +138,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Button installCliButton = root.Q<Button>("install-cli-button");
             Assert.That(installCliButton.text, Is.EqualTo("Fix PATH"));
             Assert.That(installCliButton.enabledSelf, Is.True);
+        }
+
+        [Test]
+        public void Update_WhenHomebrewPathReportsNoVersion_ShowsReinstallGuidance()
+        {
+            // Verifies a broken Homebrew binary is explained instead of offering a duplicate install.
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            CliSetupData data = CreateData(
+                isCliInstalled: false,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Installed,
+                isHomebrewManagedCli: true,
+                cliVersion: null);
+
+            section.Update(data);
+
+            Button installCliButton = root.Q<Button>("install-cli-button");
+            Label warningLabel = root.Q<Label>("cli-homebrew-upgrade-message");
+            Assert.That(installCliButton.text, Is.EqualTo("Managed by Homebrew"));
+            Assert.That(installCliButton.enabledSelf, Is.False);
+            Assert.That(
+                warningLabel.text,
+                Is.EqualTo("Homebrew-managed CLI did not report a version.\n"
+                    + "Run this command in your terminal:\nbrew reinstall uloop"));
+            Assert.That(warningLabel.ClassListContains("unity-cli-loop-warning-message--visible"), Is.True);
         }
 
         [Test]

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -74,35 +74,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(enabled, Is.EqualTo(expectedEnabled));
         }
 
-        [TestCase(true, false, false, false, null, "3.0.0", "CLI: Checking...")]
-        [TestCase(false, false, false, false, null, "3.0.0", "CLI: Not installed")]
-        [TestCase(false, true, false, false, "3.0.0", "3.0.0", "CLI: v3.0.0")]
-        [TestCase(false, true, true, false, "3.0.0", "3.0.0", "CLI: v3.0.0")]
-        [TestCase(
-            false,
-            true,
-            true,
-            true,
-            "2.9.0",
-            "3.0.0",
-            "CLI: v2.9.0 (requires v3.0.0; run: brew upgrade uloop)")]
+        [TestCase(true, false, null, "CLI: Checking...")]
+        [TestCase(false, false, null, "CLI: Not installed")]
+        [TestCase(false, true, "3.0.0", "CLI: v3.0.0")]
         public void GetCliStatusText_ReturnsExpectedText(
             bool isChecking,
             bool isCliInstalled,
-            bool isHomebrewManagedCli,
-            bool needsUpdate,
             string cliVersion,
-            string requiredCliVersion,
             string expectedText)
         {
-            // Verifies that a Homebrew-managed CLI below the pin minimum shows the brew upgrade command.
+            // Verifies the status line stays a short single-line summary of the detected CLI.
             string text = CliSetupSection.GetCliStatusText(
                 isChecking,
                 isCliInstalled,
-                isHomebrewManagedCli,
-                needsUpdate,
-                cliVersion,
-                requiredCliVersion);
+                cliVersion);
 
             Assert.That(text, Is.EqualTo(expectedText));
         }
@@ -124,6 +109,69 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Button installCliButton = root.Q<Button>("install-cli-button");
             Assert.That(installCliButton.text, Is.EqualTo("Managed by Homebrew"));
             Assert.That(installCliButton.enabledSelf, Is.False);
+        }
+
+        [Test]
+        public void Update_WhenHomebrewManagedCliNeedsUpdate_ShowsUpgradeWarning()
+        {
+            // Verifies the brew upgrade command is shown in a dedicated warning block, not in the status line.
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            CliSetupData data = CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Installed,
+                isHomebrewManagedCli: true,
+                needsUpdate: true,
+                cliVersion: "2.9.0");
+
+            section.Update(data);
+
+            Label statusLabel = root.Q<Label>("cli-status-label");
+            Label warningLabel = root.Q<Label>("cli-homebrew-upgrade-message");
+            Assert.That(statusLabel.text, Is.EqualTo("CLI: v2.9.0"));
+            Assert.That(
+                warningLabel.text,
+                Is.EqualTo("Homebrew-managed CLI v2.9.0 is older than the required v3.0.0.\nbrew upgrade uloop"));
+            Assert.That(warningLabel.ClassListContains("unity-cli-loop-warning-message--visible"), Is.True);
+        }
+
+        [Test]
+        public void Update_WhenHomebrewManagedCliIsUpToDate_HidesUpgradeWarning()
+        {
+            // Verifies the upgrade warning stays hidden while the Homebrew CLI satisfies the required version.
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            CliSetupData data = CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Installed,
+                isHomebrewManagedCli: true);
+
+            section.Update(data);
+
+            Label warningLabel = root.Q<Label>("cli-homebrew-upgrade-message");
+            Assert.That(warningLabel.text, Is.Empty);
+            Assert.That(warningLabel.ClassListContains("unity-cli-loop-warning-message--visible"), Is.False);
+        }
+
+        [Test]
+        public void Update_WhenCliIsNotHomebrewManaged_HidesUpgradeWarning()
+        {
+            // Verifies a package-installed CLI that needs an update keeps using the primary button, not the warning.
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            CliSetupData data = CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Installed,
+                needsUpdate: true,
+                cliVersion: "2.9.0");
+
+            section.Update(data);
+
+            Label warningLabel = root.Q<Label>("cli-homebrew-upgrade-message");
+            Assert.That(warningLabel.ClassListContains("unity-cli-loop-warning-message--visible"), Is.False);
         }
 
         [TestCase(true, false, true, true)]
@@ -399,6 +447,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             root.Add(new VisualElement { name = "cli-status-icon" });
             root.Add(new Label { name = "cli-status-label" });
             root.Add(new Button { name = "refresh-cli-version-button" });
+            root.Add(new Label { name = "cli-homebrew-upgrade-message" });
             root.Add(new Button { name = "install-cli-button" });
             VisualElement installProgress = new() { name = "cli-install-progress" };
             installProgress.Add(new Label { name = "cli-install-progress-label" });
@@ -433,13 +482,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             SkillInstallState selectedTargetInstallState,
             IReadOnlyList<SkillSetupTargetInfo> installableSkillTargets = null,
             bool? isSkillStateChecking = null,
-            bool isHomebrewManagedCli = false)
+            bool isHomebrewManagedCli = false,
+            bool needsUpdate = false,
+            string cliVersion = "3.0.0")
         {
             return new CliSetupData(
                 isCliInstalled,
-                cliVersion: "3.0.0",
+                cliVersion,
                 requiredCliVersion: "3.0.0",
-                needsUpdate: false,
+                needsUpdate,
                 canUninstallCli: true,
                 needsCliPathSetup: false,
                 isHomebrewManagedCli,

--- a/Assets/Tests/Editor/HomebrewManagedCliPolicyTests.cs
+++ b/Assets/Tests/Editor/HomebrewManagedCliPolicyTests.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies Homebrew-managed CLI path classification.
+    /// </summary>
+    public class HomebrewManagedCliPolicyTests
+    {
+        /// <summary>
+        /// Verifies that a Cellar path is classified as Homebrew-managed for every Homebrew prefix.
+        /// </summary>
+        [TestCase("/opt/homebrew/Cellar/uloop/3.0.0/bin/uloop")]
+        [TestCase("/usr/local/Cellar/uloop/3.0.0/bin/uloop")]
+        [TestCase("/home/linuxbrew/.linuxbrew/Cellar/uloop/3.0.0/bin/uloop")]
+        public void IsHomebrewManagedPath_WithCellarSegment_ReturnsTrue(string executablePath)
+        {
+            bool result = HomebrewManagedCliPolicy.IsHomebrewManagedPath(
+                executablePath,
+                directoryPath => false);
+
+            Assert.That(result, Is.True);
+        }
+
+        /// <summary>
+        /// Verifies that a linked prefix/bin path is Homebrew-managed when its sibling Cellar formula directory exists.
+        /// </summary>
+        [Test]
+        public void IsHomebrewManagedPath_WithLinkedBinPathAndCellarFormulaDirectory_ReturnsTrue()
+        {
+            List<string> probedDirectories = new();
+
+            bool result = HomebrewManagedCliPolicy.IsHomebrewManagedPath(
+                "/opt/homebrew/bin/uloop",
+                directoryPath =>
+                {
+                    probedDirectories.Add(directoryPath);
+                    return true;
+                });
+
+            Assert.That(result, Is.True);
+            Assert.That(probedDirectories, Is.EqualTo(new[] { "/opt/homebrew/Cellar/uloop" }));
+        }
+
+        /// <summary>
+        /// Verifies that a linked prefix/bin path without a Cellar formula directory is not Homebrew-managed.
+        /// </summary>
+        [TestCase("/usr/local/bin/uloop")]
+        [TestCase("/Users/dev/.local/bin/uloop")]
+        public void IsHomebrewManagedPath_WithoutCellarFormulaDirectory_ReturnsFalse(string executablePath)
+        {
+            bool result = HomebrewManagedCliPolicy.IsHomebrewManagedPath(
+                executablePath,
+                directoryPath => false);
+
+            Assert.That(result, Is.False);
+        }
+
+        /// <summary>
+        /// Verifies that a Windows backslash path is normalized instead of being read as a single segment.
+        /// </summary>
+        [Test]
+        public void IsHomebrewManagedPath_WithWindowsBackslashPath_ProbesNormalizedCellarDirectory()
+        {
+            List<string> probedDirectories = new();
+
+            bool result = HomebrewManagedCliPolicy.IsHomebrewManagedPath(
+                "C:\\Users\\dev\\AppData\\Local\\Programs\\uloop\\bin\\uloop.exe",
+                directoryPath =>
+                {
+                    probedDirectories.Add(directoryPath);
+                    return false;
+                });
+
+            Assert.That(result, Is.False);
+            Assert.That(
+                probedDirectories,
+                Is.EqualTo(new[] { "C:/Users/dev/AppData/Local/Programs/uloop/Cellar/uloop.exe" }));
+        }
+
+        /// <summary>
+        /// Verifies that a directory name merely containing "Cellar" is not treated as a Cellar segment.
+        /// </summary>
+        [Test]
+        public void IsHomebrewManagedPath_WithPartialCellarSegment_ReturnsFalse()
+        {
+            bool result = HomebrewManagedCliPolicy.IsHomebrewManagedPath(
+                "/Users/dev/CellarTools/uloop",
+                directoryPath => false);
+
+            Assert.That(result, Is.False);
+        }
+
+        /// <summary>
+        /// Verifies that an unknown executable path is never classified as Homebrew-managed.
+        /// </summary>
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("uloop")]
+        public void IsHomebrewManagedPath_WithoutUsablePath_ReturnsFalse(string executablePath)
+        {
+            bool result = HomebrewManagedCliPolicy.IsHomebrewManagedPath(
+                executablePath,
+                directoryPath => true);
+
+            Assert.That(result, Is.False);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HomebrewManagedCliPolicyTests.cs
+++ b/Assets/Tests/Editor/HomebrewManagedCliPolicyTests.cs
@@ -109,5 +109,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(result, Is.False);
         }
+
+        /// <summary>
+        /// Verifies the package stands down only when a usable CLI was detected at a Homebrew path.
+        /// </summary>
+        [TestCase(true, true, true)]
+        [TestCase(true, false, false)]
+        [TestCase(false, true, false)]
+        [TestCase(false, false, false)]
+        public void ShouldDeferToHomebrew_ReturnsExpectedValue(
+            bool isHomebrewManagedPath,
+            bool isCliDetected,
+            bool expected)
+        {
+            bool result = HomebrewManagedCliPolicy.ShouldDeferToHomebrew(isHomebrewManagedPath, isCliDetected);
+
+            Assert.That(result, Is.EqualTo(expected));
+        }
     }
 }

--- a/Assets/Tests/Editor/HomebrewManagedCliPolicyTests.cs
+++ b/Assets/Tests/Editor/HomebrewManagedCliPolicyTests.cs
@@ -131,18 +131,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
-        /// Verifies the package stands down only when a usable CLI was detected at a Homebrew path.
+        /// Verifies brew guidance is shown for every Homebrew path that does not yield a usable CLI.
         /// </summary>
-        [TestCase(true, true, true)]
-        [TestCase(true, false, false)]
-        [TestCase(false, true, false)]
+        [TestCase(true, false, true)]
+        [TestCase(true, true, false)]
         [TestCase(false, false, false)]
-        public void ShouldDeferToHomebrew_ReturnsExpectedValue(
+        [TestCase(false, true, false)]
+        public void ShouldShowUpgradeGuidance_ReturnsExpectedValue(
             bool isHomebrewManagedPath,
-            bool isCliDetected,
+            bool isCliUsable,
             bool expected)
         {
-            bool result = HomebrewManagedCliPolicy.ShouldDeferToHomebrew(isHomebrewManagedPath, isCliDetected);
+            bool result = HomebrewManagedCliPolicy.ShouldShowUpgradeGuidance(isHomebrewManagedPath, isCliUsable);
 
             Assert.That(result, Is.EqualTo(expected));
         }

--- a/Assets/Tests/Editor/HomebrewManagedCliPolicyTests.cs
+++ b/Assets/Tests/Editor/HomebrewManagedCliPolicyTests.cs
@@ -61,6 +61,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// Verifies that an executable outside a prefix/bin directory is never probed as a Homebrew link.
+        /// </summary>
+        [Test]
+        public void IsHomebrewManagedPath_WithNonBinParentDirectory_DoesNotProbeCellar()
+        {
+            List<string> probedDirectories = new();
+
+            bool result = HomebrewManagedCliPolicy.IsHomebrewManagedPath(
+                "/opt/homebrew/sbin/uloop",
+                directoryPath =>
+                {
+                    probedDirectories.Add(directoryPath);
+                    return true;
+                });
+
+            Assert.That(result, Is.False);
+            Assert.That(probedDirectories, Is.Empty);
+        }
+
+        /// <summary>
         /// Verifies that a Windows backslash path is normalized instead of being read as a single segment.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HomebrewManagedCliPolicyTests.cs.meta
+++ b/Assets/Tests/Editor/HomebrewManagedCliPolicyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47fef160d1c11406cb324a25b71e00d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -473,6 +473,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(false, false, true, false, false, false, null, "3.0.0", "Checking...")]
         [TestCase(true, false, false, false, false, true, "3.0.0", "3.0.0", "Managed by Homebrew")]
         [TestCase(true, false, false, true, false, true, "2.9.0", "3.0.0", "Managed by Homebrew")]
+        [TestCase(false, false, false, false, false, true, null, "3.0.0", "Install CLI")]
         public void GetCliButtonTextForSetupWizard_ReturnsExpectedLabel(
             bool cliInstalled,
             bool isInstallingCli,
@@ -522,7 +523,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             true,
             "2.9.0",
             true,
-            "Homebrew-managed CLI v2.9.0 is older than the required v3.0.0.\n"
+            "Homebrew-managed CLI v2.9.0 does not meet the required v3.0.0.\n"
             + "Run this command in your terminal:\nbrew upgrade uloop")]
         [TestCase(true, "3.0.0", false, "")]
         [TestCase(false, "2.9.0", false, "")]
@@ -566,7 +567,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(false, false, false, true, false, false, false)]
         [TestCase(false, false, false, false, true, false, false)]
         [TestCase(true, false, false, false, false, true, false)]
-        [TestCase(false, false, false, false, false, true, false)]
+        [TestCase(false, false, false, false, false, true, true)]
         public void IsCliButtonEnabledForSetupWizard_ReturnsExpectedValue(
             bool cliInstalled,
             bool cliVersionMatched,
@@ -576,6 +577,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool isHomebrewManagedCli,
             bool expectedEnabled)
         {
+            // Verifies a Homebrew path with no usable CLI keeps the install action reachable.
             bool enabled = SetupWizardCliStepPresenter.IsCliButtonEnabledForSetupWizard(
                 cliInstalled,
                 cliVersionMatched,

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -473,7 +473,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(false, false, true, false, false, false, null, "3.0.0", "Checking...")]
         [TestCase(true, false, false, false, false, true, "3.0.0", "3.0.0", "Managed by Homebrew")]
         [TestCase(true, false, false, true, false, true, "2.9.0", "3.0.0", "Managed by Homebrew")]
-        [TestCase(false, false, false, false, false, true, null, "3.0.0", "Install CLI")]
+        [TestCase(false, false, false, false, false, true, null, "3.0.0", "Managed by Homebrew")]
+        [TestCase(true, false, false, false, true, true, "3.0.0", "3.0.0", "Fix PATH")]
+        [TestCase(true, true, false, false, true, true, "3.0.0", "3.0.0", "Fixing PATH...")]
         public void GetCliButtonTextForSetupWizard_ReturnsExpectedLabel(
             bool cliInstalled,
             bool isInstallingCli,
@@ -525,15 +527,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             true,
             "Homebrew-managed CLI v2.9.0 does not meet the required v3.0.0.\n"
             + "Run this command in your terminal:\nbrew upgrade uloop")]
+        [TestCase(
+            true,
+            null,
+            true,
+            "Homebrew-managed CLI did not report a version.\n"
+            + "Run this command in your terminal:\nbrew reinstall uloop")]
         [TestCase(true, "3.0.0", false, "")]
         [TestCase(false, "2.9.0", false, "")]
+        [TestCase(false, null, false, "")]
         public void Update_TogglesHomebrewUpgradeWarning(
             bool isHomebrewManagedCli,
             string cliVersion,
             bool expectedVisible,
             string expectedText)
         {
-            // Verifies the wizard shows the brew upgrade command as a warning block only for an outdated Homebrew CLI.
+            // Verifies the wizard explains every unusable Homebrew CLI, and stays silent otherwise.
             VisualElement statusIcon = new();
             Label statusLabel = new();
             Label homebrewUpgradeMessage = new() { name = "cli-homebrew-upgrade-message" };
@@ -546,7 +555,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 () => { });
 
             presenter.Update(
-                cliInstalled: true,
+                cliInstalled: !string.IsNullOrEmpty(cliVersion),
                 cliVersion,
                 cliIsDispatcher: true,
                 requiredCliVersion: "3.0.0",
@@ -567,7 +576,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(false, false, false, true, false, false, false)]
         [TestCase(false, false, false, false, true, false, false)]
         [TestCase(true, false, false, false, false, true, false)]
-        [TestCase(false, false, false, false, false, true, true)]
+        [TestCase(false, false, false, false, false, true, false)]
+        [TestCase(true, false, true, false, false, true, true)]
         public void IsCliButtonEnabledForSetupWizard_ReturnsExpectedValue(
             bool cliInstalled,
             bool cliVersionMatched,
@@ -577,7 +587,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool isHomebrewManagedCli,
             bool expectedEnabled)
         {
-            // Verifies a Homebrew path with no usable CLI keeps the install action reachable.
+            // Verifies a Homebrew-managed CLI leaves only PATH repair, which writes no binary, enabled.
             bool enabled = SetupWizardCliStepPresenter.IsCliButtonEnabledForSetupWizard(
                 cliInstalled,
                 cliVersionMatched,

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -461,22 +461,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(canManageSkills, Is.True);
         }
 
-        [TestCase(false, false, false, false, false, null, "3.0.0", "Install CLI")]
-        [TestCase(false, false, false, false, true, null, "3.0.0", "Fix PATH")]
-        [TestCase(true, false, false, false, false, "3.0.0", "3.0.0", "Installed")]
-        [TestCase(true, false, false, false, true, "3.0.0", "3.0.0", "Fix PATH")]
-        [TestCase(true, false, false, true, false, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
-        [TestCase(true, false, false, true, true, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
-        [TestCase(true, false, false, true, false, "3.0.0", "3.0.0", "Update CLI (v3.0.0 required)")]
-        [TestCase(true, true, false, false, false, "3.0.0", "3.0.0", "Installing...")]
-        [TestCase(true, true, false, false, true, "3.0.0", "3.0.0", "Fixing PATH...")]
-        [TestCase(false, false, true, false, false, null, "3.0.0", "Checking...")]
+        [TestCase(false, false, false, false, false, false, null, "3.0.0", "Install CLI")]
+        [TestCase(false, false, false, false, true, false, null, "3.0.0", "Fix PATH")]
+        [TestCase(true, false, false, false, false, false, "3.0.0", "3.0.0", "Installed")]
+        [TestCase(true, false, false, false, true, false, "3.0.0", "3.0.0", "Fix PATH")]
+        [TestCase(true, false, false, true, false, false, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
+        [TestCase(true, false, false, true, true, false, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
+        [TestCase(true, false, false, true, false, false, "3.0.0", "3.0.0", "Update CLI (v3.0.0 required)")]
+        [TestCase(true, true, false, false, false, false, "3.0.0", "3.0.0", "Installing...")]
+        [TestCase(true, true, false, false, true, false, "3.0.0", "3.0.0", "Fixing PATH...")]
+        [TestCase(false, false, true, false, false, false, null, "3.0.0", "Checking...")]
+        [TestCase(true, false, false, false, false, true, "3.0.0", "3.0.0", "Managed by Homebrew")]
+        [TestCase(true, false, false, true, false, true, "2.9.0", "3.0.0", "Managed by Homebrew")]
         public void GetCliButtonTextForSetupWizard_ReturnsExpectedLabel(
             bool cliInstalled,
             bool isInstallingCli,
             bool isChecking,
             bool needsUpdate,
             bool needsCliPathSetup,
+            bool isHomebrewManagedCli,
             string cliVersion,
             string requiredCliVersion,
             string expectedLabel)
@@ -487,45 +490,54 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 isChecking,
                 needsUpdate,
                 needsCliPathSetup,
+                isHomebrewManagedCli,
                 cliVersion,
                 requiredCliVersion);
 
             Assert.That(label, Is.EqualTo(expectedLabel));
         }
 
-        [TestCase(false, false, null, "3.0.0", "Not installed")]
-        [TestCase(true, true, "3.0.0", "3.0.0", "v3.0.0")]
-        [TestCase(true, false, "2.9.0", "3.0.0", "v2.9.0 (requires v3.0.0)")]
-        [TestCase(true, false, "3.0.0", "3.0.0", "v3.0.0 (update required)")]
+        [TestCase(false, false, false, null, "3.0.0", "Not installed")]
+        [TestCase(true, true, false, "3.0.0", "3.0.0", "v3.0.0")]
+        [TestCase(true, false, false, "2.9.0", "3.0.0", "v2.9.0 (requires v3.0.0)")]
+        [TestCase(true, false, false, "3.0.0", "3.0.0", "v3.0.0 (update required)")]
+        [TestCase(true, true, true, "3.0.0", "3.0.0", "v3.0.0")]
+        [TestCase(true, false, true, "2.9.0", "3.0.0", "v2.9.0 (requires v3.0.0; run: brew upgrade uloop)")]
         public void GetCliStatusTextForSetupWizard_ReturnsExpectedLabel(
             bool cliInstalled,
             bool cliCompatible,
+            bool isHomebrewManagedCli,
             string cliVersion,
             string requiredCliVersion,
             string expectedLabel)
         {
-            // Verifies that same-version replacement prompts do not expose dispatcher internals.
+            // Verifies that same-version replacement prompts do not expose dispatcher internals,
+            // and that a Homebrew-managed CLI below the pin minimum shows the brew upgrade command.
             string label = SetupWizardCliStepPresenter.GetCliStatusTextForSetupWizard(
                 cliInstalled,
                 cliCompatible,
+                isHomebrewManagedCli,
                 cliVersion,
                 requiredCliVersion);
 
             Assert.That(label, Is.EqualTo(expectedLabel));
         }
 
-        [TestCase(false, false, false, false, false, true)]
-        [TestCase(true, false, true, false, false, true)]
-        [TestCase(true, false, false, false, false, true)]
-        [TestCase(true, true, false, false, false, false)]
-        [TestCase(false, false, false, true, false, false)]
-        [TestCase(false, false, false, false, true, false)]
+        [TestCase(false, false, false, false, false, false, true)]
+        [TestCase(true, false, true, false, false, false, true)]
+        [TestCase(true, false, false, false, false, false, true)]
+        [TestCase(true, true, false, false, false, false, false)]
+        [TestCase(false, false, false, true, false, false, false)]
+        [TestCase(false, false, false, false, true, false, false)]
+        [TestCase(true, false, false, false, false, true, false)]
+        [TestCase(false, false, false, false, false, true, false)]
         public void IsCliButtonEnabledForSetupWizard_ReturnsExpectedValue(
             bool cliInstalled,
             bool cliVersionMatched,
             bool needsCliPathSetup,
             bool isInstallingCli,
             bool isChecking,
+            bool isHomebrewManagedCli,
             bool expectedEnabled)
         {
             bool enabled = SetupWizardCliStepPresenter.IsCliButtonEnabledForSetupWizard(
@@ -533,7 +545,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 cliVersionMatched,
                 needsCliPathSetup,
                 isInstallingCli,
-                isChecking);
+                isChecking,
+                isHomebrewManagedCli);
 
             Assert.That(enabled, Is.EqualTo(expectedEnabled));
         }

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -525,20 +525,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             true,
             "2.9.0",
             true,
+            true,
             "Homebrew-managed CLI v2.9.0 does not meet the required v3.0.0.\n"
             + "Run this command in your terminal:\nbrew upgrade uloop")]
         [TestCase(
             true,
             null,
             true,
+            true,
             "Homebrew-managed CLI did not report a version.\n"
             + "Run this command in your terminal:\nbrew reinstall uloop")]
-        [TestCase(true, "3.0.0", false, "")]
-        [TestCase(false, "2.9.0", false, "")]
-        [TestCase(false, null, false, "")]
+        [TestCase(
+            true,
+            "3.0.0",
+            false,
+            true,
+            "Homebrew-managed CLI v3.0.0 did not answer as the required uloop CLI.\n"
+            + "Run this command in your terminal:\nbrew reinstall uloop")]
+        [TestCase(true, "3.0.0", true, false, "")]
+        [TestCase(false, "2.9.0", true, false, "")]
+        [TestCase(false, null, true, false, "")]
         public void Update_TogglesHomebrewUpgradeWarning(
             bool isHomebrewManagedCli,
             string cliVersion,
+            bool cliIsDispatcher,
             bool expectedVisible,
             string expectedText)
         {
@@ -557,7 +567,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             presenter.Update(
                 cliInstalled: !string.IsNullOrEmpty(cliVersion),
                 cliVersion,
-                cliIsDispatcher: true,
+                cliIsDispatcher,
                 requiredCliVersion: "3.0.0",
                 isInstallingCli: false,
                 needsCliPathSetup: false,

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -518,7 +518,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(label, Is.EqualTo(expectedLabel));
         }
 
-        [TestCase(true, "2.9.0", true, "Homebrew-managed CLI v2.9.0 is older than the required v3.0.0.\nbrew upgrade uloop")]
+        [TestCase(
+            true,
+            "2.9.0",
+            true,
+            "Homebrew-managed CLI v2.9.0 is older than the required v3.0.0.\n"
+            + "Run this command in your terminal:\nbrew upgrade uloop")]
         [TestCase(true, "3.0.0", false, "")]
         [TestCase(false, "2.9.0", false, "")]
         public void Update_TogglesHomebrewUpgradeWarning(

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -497,30 +497,61 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(label, Is.EqualTo(expectedLabel));
         }
 
-        [TestCase(false, false, false, null, "3.0.0", "Not installed")]
-        [TestCase(true, true, false, "3.0.0", "3.0.0", "v3.0.0")]
-        [TestCase(true, false, false, "2.9.0", "3.0.0", "v2.9.0 (requires v3.0.0)")]
-        [TestCase(true, false, false, "3.0.0", "3.0.0", "v3.0.0 (update required)")]
-        [TestCase(true, true, true, "3.0.0", "3.0.0", "v3.0.0")]
-        [TestCase(true, false, true, "2.9.0", "3.0.0", "v2.9.0 (requires v3.0.0; run: brew upgrade uloop)")]
+        [TestCase(false, false, null, "3.0.0", "Not installed")]
+        [TestCase(true, true, "3.0.0", "3.0.0", "v3.0.0")]
+        [TestCase(true, false, "2.9.0", "3.0.0", "v2.9.0 (requires v3.0.0)")]
+        [TestCase(true, false, "3.0.0", "3.0.0", "v3.0.0 (update required)")]
         public void GetCliStatusTextForSetupWizard_ReturnsExpectedLabel(
             bool cliInstalled,
             bool cliCompatible,
-            bool isHomebrewManagedCli,
             string cliVersion,
             string requiredCliVersion,
             string expectedLabel)
         {
-            // Verifies that same-version replacement prompts do not expose dispatcher internals,
-            // and that a Homebrew-managed CLI below the pin minimum shows the brew upgrade command.
+            // Verifies that same-version replacement prompts do not expose dispatcher internals.
             string label = SetupWizardCliStepPresenter.GetCliStatusTextForSetupWizard(
                 cliInstalled,
                 cliCompatible,
-                isHomebrewManagedCli,
                 cliVersion,
                 requiredCliVersion);
 
             Assert.That(label, Is.EqualTo(expectedLabel));
+        }
+
+        [TestCase(true, "2.9.0", true, "Homebrew-managed CLI v2.9.0 is older than the required v3.0.0.\nbrew upgrade uloop")]
+        [TestCase(true, "3.0.0", false, "")]
+        [TestCase(false, "2.9.0", false, "")]
+        public void Update_TogglesHomebrewUpgradeWarning(
+            bool isHomebrewManagedCli,
+            string cliVersion,
+            bool expectedVisible,
+            string expectedText)
+        {
+            // Verifies the wizard shows the brew upgrade command as a warning block only for an outdated Homebrew CLI.
+            VisualElement statusIcon = new();
+            Label statusLabel = new();
+            Label homebrewUpgradeMessage = new() { name = "cli-homebrew-upgrade-message" };
+            Button installButton = new();
+            SetupWizardCliStepPresenter presenter = new(
+                statusIcon,
+                statusLabel,
+                homebrewUpgradeMessage,
+                installButton,
+                () => { });
+
+            presenter.Update(
+                cliInstalled: true,
+                cliVersion,
+                cliIsDispatcher: true,
+                requiredCliVersion: "3.0.0",
+                isInstallingCli: false,
+                needsCliPathSetup: false,
+                isHomebrewManagedCli);
+
+            Assert.That(
+                homebrewUpgradeMessage.ClassListContains("setup-warning-message--visible"),
+                Is.EqualTo(expectedVisible));
+            Assert.That(homebrewUpgradeMessage.text, Is.EqualTo(expectedText));
         }
 
         [TestCase(false, false, false, false, false, false, true)]

--- a/Assets/Tests/Editor/SkillsTargetSelectionResolverTests.cs
+++ b/Assets/Tests/Editor/SkillsTargetSelectionResolverTests.cs
@@ -61,6 +61,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 needsUpdate: false,
                 canUninstallCli: true,
                 needsCliPathSetup: false,
+                isHomebrewManagedCli: false,
                 isInstallingCli: false,
                 isChecking: false,
                 isSkillStateChecking: false,

--- a/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
@@ -65,8 +65,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(false, "", false, true, false, "InstallOrUpdate")]
         [TestCase(false, "3.0.0", true, false, true, "None")]
         [TestCase(false, "2.9.0", true, false, true, "None")]
-        [TestCase(true, "3.0.0", true, false, true, "None")]
-        [TestCase(false, null, false, false, true, "InstallOrUpdate")]
+        [TestCase(false, null, false, false, true, "None")]
+        [TestCase(true, "3.0.0", true, false, true, "RepairPath")]
+        [TestCase(true, "2.9.0", true, false, true, "RepairPath")]
         public void ResolveCliPrimaryButtonAction_ReturnsClickedPrimaryAction(
             bool needsCliPathSetup,
             string cliVersion,
@@ -76,7 +77,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string expected)
         {
             // Verifies that the Settings window chooses repair only when dispatcher replacement is unnecessary,
-            // and that a detected Homebrew install leaves no executable action at all.
+            // and that a Homebrew-managed path leaves PATH repair as its only executable action.
             CliSetupPrimaryAction result =
                 UnityCliLoopSettingsCliSetupPresenter.ResolveCliPrimaryButtonAction(
                     needsCliPathSetup,

--- a/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
@@ -53,30 +53,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result, Is.EqualTo(expected));
         }
 
-        [TestCase(true, "3.0.0", true, true, "RepairPath")]
-        [TestCase(true, "3.0.1", true, true, "RepairPath")]
-        [TestCase(true, "3.0.0", false, true, "InstallOrUpdate")]
-        [TestCase(true, "2.9.0", true, true, "InstallOrUpdate")]
-        [TestCase(false, "3.0.0", true, true, "Uninstall")]
-        [TestCase(false, "3.0.1", true, true, "Uninstall")]
-        [TestCase(false, "3.0.0", false, true, "InstallOrUpdate")]
-        [TestCase(false, "3.0.0", true, false, "InstallOrUpdate")]
-        [TestCase(false, null, false, true, "InstallOrUpdate")]
-        [TestCase(false, "", false, true, "InstallOrUpdate")]
+        [TestCase(true, "3.0.0", true, true, false, "RepairPath")]
+        [TestCase(true, "3.0.1", true, true, false, "RepairPath")]
+        [TestCase(true, "3.0.0", false, true, false, "InstallOrUpdate")]
+        [TestCase(true, "2.9.0", true, true, false, "InstallOrUpdate")]
+        [TestCase(false, "3.0.0", true, true, false, "Uninstall")]
+        [TestCase(false, "3.0.1", true, true, false, "Uninstall")]
+        [TestCase(false, "3.0.0", false, true, false, "InstallOrUpdate")]
+        [TestCase(false, "3.0.0", true, false, false, "InstallOrUpdate")]
+        [TestCase(false, null, false, true, false, "InstallOrUpdate")]
+        [TestCase(false, "", false, true, false, "InstallOrUpdate")]
+        [TestCase(false, "3.0.0", true, false, true, "None")]
+        [TestCase(false, "2.9.0", true, false, true, "None")]
+        [TestCase(true, "3.0.0", true, false, true, "None")]
+        [TestCase(false, null, false, false, true, "InstallOrUpdate")]
         public void ResolveCliPrimaryButtonAction_ReturnsClickedPrimaryAction(
             bool needsCliPathSetup,
             string cliVersion,
             bool cliIsDispatcher,
             bool canUninstallCli,
+            bool isHomebrewManagedCli,
             string expected)
         {
-            // Verifies that the Settings window chooses repair only when dispatcher replacement is unnecessary.
+            // Verifies that the Settings window chooses repair only when dispatcher replacement is unnecessary,
+            // and that a detected Homebrew install leaves no executable action at all.
             CliSetupPrimaryAction result =
                 UnityCliLoopSettingsCliSetupPresenter.ResolveCliPrimaryButtonAction(
                     needsCliPathSetup,
                     cliVersion,
                     cliIsDispatcher,
                     canUninstallCli,
+                    isHomebrewManagedCli,
                     TestMinimumDispatcherVersion);
 
             Assert.That(result.ToString(), Is.EqualTo(expected));

--- a/Packages/src/Editor/Application/CliSetupApplicationService.cs
+++ b/Packages/src/Editor/Application/CliSetupApplicationService.cs
@@ -75,6 +75,7 @@ namespace io.github.hatayama.UnityCliLoop.Application
     public interface INativeCliInstaller
     {
         bool IsPackageOwnedCurrentUserInstallPath(string cliExecutablePath, RuntimePlatform platform);
+        bool IsHomebrewManagedInstallPath(string cliExecutablePath);
         bool HasPackageOwnedCurrentUserInstall(RuntimePlatform platform);
         Task<CliInstallResult> InstallGlobalCliAsync(
             RuntimePlatform platform,
@@ -167,6 +168,11 @@ namespace io.github.hatayama.UnityCliLoop.Application
             RuntimePlatform platform)
         {
             return _nativeCliInstaller.IsPackageOwnedCurrentUserInstallPath(cliExecutablePath, platform);
+        }
+
+        public bool IsHomebrewManagedInstallPath(string cliExecutablePath)
+        {
+            return _nativeCliInstaller.IsHomebrewManagedInstallPath(cliExecutablePath);
         }
 
         public bool HasPackageOwnedCurrentUserInstall(RuntimePlatform platform)

--- a/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
+++ b/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
@@ -12,7 +12,7 @@ namespace io.github.hatayama.UnityCliLoop.Application
         public const string HOMEBREW_MANAGED_BUTTON_TEXT = "Managed by Homebrew";
 
         /// <summary>
-        /// Formats the warning text that tells a Homebrew user how to reach the required CLI version.
+        /// Formats the warning text that tells a Homebrew user which brew command makes the CLI usable.
         /// </summary>
         /// <remarks>
         /// Why the line breaks: the command is not run by Unity, so the text has to say where it belongs,
@@ -23,6 +23,15 @@ namespace io.github.hatayama.UnityCliLoop.Application
         /// </remarks>
         public static string GetHomebrewUpgradeGuidanceText(string cliVersion, string requiredCliVersion)
         {
+            if (string.IsNullOrEmpty(cliVersion))
+            {
+                // Why reinstall: a binary that answers no version probe is broken rather than outdated,
+                // and upgrading an already current formula would report nothing to do.
+                return "Homebrew-managed CLI did not report a version.\n"
+                    + "Run this command in your terminal:\n"
+                    + $"{CliConstants.HOMEBREW_REINSTALL_COMMAND}";
+            }
+
             return $"Homebrew-managed CLI v{cliVersion} does not meet the required v{requiredCliVersion}.\n"
                 + "Run this command in your terminal:\n"
                 + $"{CliConstants.HOMEBREW_UPGRADE_COMMAND}";

--- a/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
+++ b/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
@@ -12,11 +12,16 @@ namespace io.github.hatayama.UnityCliLoop.Application
         public const string HOMEBREW_MANAGED_BUTTON_TEXT = "Managed by Homebrew";
 
         /// <summary>
-        /// Formats the status text that tells a Homebrew user how to reach the required CLI version.
+        /// Formats the warning text that tells a Homebrew user how to reach the required CLI version.
         /// </summary>
-        public static string GetHomebrewUpgradeStatusText(string cliVersion, string requiredCliVersion)
+        /// <remarks>
+        /// Why the line break: the command must stay on its own line so it can be selected and copied
+        /// without picking up the surrounding sentence.
+        /// </remarks>
+        public static string GetHomebrewUpgradeGuidanceText(string cliVersion, string requiredCliVersion)
         {
-            return $"v{cliVersion} (requires v{requiredCliVersion}; run: {CliConstants.HOMEBREW_UPGRADE_COMMAND})";
+            return $"Homebrew-managed CLI v{cliVersion} is older than the required v{requiredCliVersion}.\n"
+                + $"{CliConstants.HOMEBREW_UPGRADE_COMMAND}";
         }
 
         public static string GetCliReplacementButtonText(string action, string cliVersion, string requiredCliVersion)

--- a/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
+++ b/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
@@ -18,16 +18,23 @@ namespace io.github.hatayama.UnityCliLoop.Application
         /// Why the line breaks: the command is not run by Unity, so the text has to say where it belongs,
         /// and the command must stay on its own line so it can be selected and copied without picking up
         /// the surrounding sentence.
-        /// Why not "older than": an update is also required when the detected binary is not the dispatcher
-        /// or reports a version that cannot be compared, and neither case means the version is lower.
+        /// Why the version is compared here: an update is also required when the detected binary does not
+        /// answer as the dispatcher, which happens at versions that already satisfy the requirement. Telling
+        /// such a user to upgrade names a command that reports nothing to do, so those cases point at a
+        /// reinstall instead and the text never claims a comparison that is not true.
         /// </remarks>
         public static string GetHomebrewUpgradeGuidanceText(string cliVersion, string requiredCliVersion)
         {
             if (string.IsNullOrEmpty(cliVersion))
             {
-                // Why reinstall: a binary that answers no version probe is broken rather than outdated,
-                // and upgrading an already current formula would report nothing to do.
                 return "Homebrew-managed CLI did not report a version.\n"
+                    + "Run this command in your terminal:\n"
+                    + $"{CliConstants.HOMEBREW_REINSTALL_COMMAND}";
+            }
+
+            if (CliVersionComparer.IsVersionGreaterThanOrEqual(cliVersion, requiredCliVersion))
+            {
+                return $"Homebrew-managed CLI v{cliVersion} did not answer as the required uloop CLI.\n"
                     + "Run this command in your terminal:\n"
                     + $"{CliConstants.HOMEBREW_REINSTALL_COMMAND}";
             }

--- a/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
+++ b/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
@@ -7,6 +7,18 @@ namespace io.github.hatayama.UnityCliLoop.Application
     /// </summary>
     public static class CliSetupLabelFormatter
     {
+        // Why: uloop installed by Homebrew must be updated and removed through brew itself,
+        // so the package offers no primary action for it.
+        public const string HOMEBREW_MANAGED_BUTTON_TEXT = "Managed by Homebrew";
+
+        /// <summary>
+        /// Formats the status text that tells a Homebrew user how to reach the required CLI version.
+        /// </summary>
+        public static string GetHomebrewUpgradeStatusText(string cliVersion, string requiredCliVersion)
+        {
+            return $"v{cliVersion} (requires v{requiredCliVersion}; run: {CliConstants.HOMEBREW_UPGRADE_COMMAND})";
+        }
+
         public static string GetCliReplacementButtonText(string action, string cliVersion, string requiredCliVersion)
         {
             if (ShouldShowRequiredVersionText(cliVersion, requiredCliVersion))

--- a/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
+++ b/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
@@ -15,12 +15,14 @@ namespace io.github.hatayama.UnityCliLoop.Application
         /// Formats the warning text that tells a Homebrew user how to reach the required CLI version.
         /// </summary>
         /// <remarks>
-        /// Why the line break: the command must stay on its own line so it can be selected and copied
-        /// without picking up the surrounding sentence.
+        /// Why the line breaks: the command is not run by Unity, so the text has to say where it belongs,
+        /// and the command must stay on its own line so it can be selected and copied without picking up
+        /// the surrounding sentence.
         /// </remarks>
         public static string GetHomebrewUpgradeGuidanceText(string cliVersion, string requiredCliVersion)
         {
             return $"Homebrew-managed CLI v{cliVersion} is older than the required v{requiredCliVersion}.\n"
+                + "Run this command in your terminal:\n"
                 + $"{CliConstants.HOMEBREW_UPGRADE_COMMAND}";
         }
 

--- a/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
+++ b/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
@@ -18,10 +18,12 @@ namespace io.github.hatayama.UnityCliLoop.Application
         /// Why the line breaks: the command is not run by Unity, so the text has to say where it belongs,
         /// and the command must stay on its own line so it can be selected and copied without picking up
         /// the surrounding sentence.
+        /// Why not "older than": an update is also required when the detected binary is not the dispatcher
+        /// or reports a version that cannot be compared, and neither case means the version is lower.
         /// </remarks>
         public static string GetHomebrewUpgradeGuidanceText(string cliVersion, string requiredCliVersion)
         {
-            return $"Homebrew-managed CLI v{cliVersion} is older than the required v{requiredCliVersion}.\n"
+            return $"Homebrew-managed CLI v{cliVersion} does not meet the required v{requiredCliVersion}.\n"
                 + "Run this command in your terminal:\n"
                 + $"{CliConstants.HOMEBREW_UPGRADE_COMMAND}";
         }

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -39,6 +39,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public const string PACKAGE_SOURCE_DIR_NAME = "src";
         public const string HOMEBREW_CELLAR_DIR_NAME = "Cellar";
         public const string HOMEBREW_UPGRADE_COMMAND = "brew upgrade " + EXECUTABLE_NAME;
+        public const string HOMEBREW_REINSTALL_COMMAND = "brew reinstall " + EXECUTABLE_NAME;
         public const string GLOBAL_UNIX_COMMAND_NAME = EXECUTABLE_NAME;
         public const string GLOBAL_WINDOWS_COMMAND_NAME = EXECUTABLE_NAME + ".exe";
     }

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -37,6 +37,8 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public const string V3_CLI_INVOCATION_MIGRATION_SKILL_NAME = "v3-cli-invocation-migration";
         public const string UNITY_PACKAGES_DIR_NAME = "Packages";
         public const string PACKAGE_SOURCE_DIR_NAME = "src";
+        public const string HOMEBREW_CELLAR_DIR_NAME = "Cellar";
+        public const string HOMEBREW_UPGRADE_COMMAND = "brew upgrade " + EXECUTABLE_NAME;
         public const string GLOBAL_UNIX_COMMAND_NAME = EXECUTABLE_NAME;
         public const string GLOBAL_WINDOWS_COMMAND_NAME = EXECUTABLE_NAME + ".exe";
     }

--- a/Packages/src/Editor/Domain/CliSetupPrimaryActionPolicy.cs
+++ b/Packages/src/Editor/Domain/CliSetupPrimaryActionPolicy.cs
@@ -33,17 +33,19 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         /// Why the Homebrew branch lives here and not only in the button state: the primary action is
         /// resolved again after a forced refresh, so a Homebrew install that appears between click and
         /// action would otherwise still run an install and leave a second binary beside brew's own.
+        /// Why PATH repair survives it: repair neither writes nor removes a binary, it only makes an
+        /// already installed package-owned CLI reachable, so it is the one action that stays safe.
         /// </remarks>
         public static CliSetupPrimaryAction ResolveSettingsPrimaryAction(
             bool needsCliPathSetup,
             bool needsUpdate,
             bool isCliInstalled,
             bool canUninstallCli,
-            bool shouldDeferToHomebrew)
+            bool isHomebrewManagedCli)
         {
-            if (shouldDeferToHomebrew)
+            if (isHomebrewManagedCli)
             {
-                return CliSetupPrimaryAction.None;
+                return needsCliPathSetup ? CliSetupPrimaryAction.RepairPath : CliSetupPrimaryAction.None;
             }
 
             if (ShouldRepairCliPath(needsCliPathSetup, needsUpdate))

--- a/Packages/src/Editor/Domain/CliSetupPrimaryActionPolicy.cs
+++ b/Packages/src/Editor/Domain/CliSetupPrimaryActionPolicy.cs
@@ -29,12 +29,23 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             return canUninstallCli && isCliInstalled && !needsUpdate;
         }
 
+        /// <remarks>
+        /// Why the Homebrew branch lives here and not only in the button state: the primary action is
+        /// resolved again after a forced refresh, so a Homebrew install that appears between click and
+        /// action would otherwise still run an install and leave a second binary beside brew's own.
+        /// </remarks>
         public static CliSetupPrimaryAction ResolveSettingsPrimaryAction(
             bool needsCliPathSetup,
             bool needsUpdate,
             bool isCliInstalled,
-            bool canUninstallCli)
+            bool canUninstallCli,
+            bool shouldDeferToHomebrew)
         {
+            if (shouldDeferToHomebrew)
+            {
+                return CliSetupPrimaryAction.None;
+            }
+
             if (ShouldRepairCliPath(needsCliPathSetup, needsUpdate))
             {
                 return CliSetupPrimaryAction.RepairPath;

--- a/Packages/src/Editor/Domain/HomebrewManagedCliPolicy.cs
+++ b/Packages/src/Editor/Domain/HomebrewManagedCliPolicy.cs
@@ -45,16 +45,16 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         }
 
         /// <summary>
-        /// Reports whether the package must stand down and leave CLI installs and updates to Homebrew.
+        /// Reports whether the guidance that points at a brew command must be shown.
         /// </summary>
         /// <remarks>
-        /// Why isCliDetected: shell detection reports a path even when the binary answers no version
-        /// probe, and a Homebrew path alone would then disable every primary action while the status
-        /// line still reads "not installed", leaving no way forward.
+        /// Why not gate the stand-down on this too: a Homebrew path whose binary answers no version
+        /// probe is still owned by brew, so installing over it would split ownership. Such a path
+        /// stands down like any other and is explained by this guidance instead.
         /// </remarks>
-        public static bool ShouldDeferToHomebrew(bool isHomebrewManagedPath, bool isCliDetected)
+        public static bool ShouldShowUpgradeGuidance(bool isHomebrewManagedPath, bool isCliUsable)
         {
-            return isHomebrewManagedPath && isCliDetected;
+            return isHomebrewManagedPath && !isCliUsable;
         }
 
         /// <summary>

--- a/Packages/src/Editor/Domain/HomebrewManagedCliPolicy.cs
+++ b/Packages/src/Editor/Domain/HomebrewManagedCliPolicy.cs
@@ -10,6 +10,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
     {
         private const char PATH_SEPARATOR = '/';
         private const char WINDOWS_PATH_SEPARATOR = '\\';
+        private const string HOMEBREW_LINK_DIR_NAME = "bin";
 
         /// <summary>
         /// Reports whether the executable at the given path is installed and owned by Homebrew.
@@ -59,9 +60,18 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         /// <summary>
         /// Builds the Cellar formula directory that a prefix/bin executable would be linked from.
         /// </summary>
+        /// <remarks>
+        /// Why the bin check: brew links formulae only into prefix/bin, so any other parent directory
+        /// cannot be a Homebrew link and must not be classified by the sibling-Cellar probe.
+        /// </remarks>
         private static string BuildCellarFormulaDirectory(string[] segments)
         {
-            if (segments.Length < 2)
+            if (segments.Length < 3)
+            {
+                return null;
+            }
+
+            if (!string.Equals(segments[segments.Length - 2], HOMEBREW_LINK_DIR_NAME, StringComparison.Ordinal))
             {
                 return null;
             }

--- a/Packages/src/Editor/Domain/HomebrewManagedCliPolicy.cs
+++ b/Packages/src/Editor/Domain/HomebrewManagedCliPolicy.cs
@@ -44,6 +44,19 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         }
 
         /// <summary>
+        /// Reports whether the package must stand down and leave CLI installs and updates to Homebrew.
+        /// </summary>
+        /// <remarks>
+        /// Why isCliDetected: shell detection reports a path even when the binary answers no version
+        /// probe, and a Homebrew path alone would then disable every primary action while the status
+        /// line still reads "not installed", leaving no way forward.
+        /// </remarks>
+        public static bool ShouldDeferToHomebrew(bool isHomebrewManagedPath, bool isCliDetected)
+        {
+            return isHomebrewManagedPath && isCliDetected;
+        }
+
+        /// <summary>
         /// Builds the Cellar formula directory that a prefix/bin executable would be linked from.
         /// </summary>
         private static string BuildCellarFormulaDirectory(string[] segments)

--- a/Packages/src/Editor/Domain/HomebrewManagedCliPolicy.cs
+++ b/Packages/src/Editor/Domain/HomebrewManagedCliPolicy.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Classifies whether a detected uloop executable is owned by Homebrew.
+    /// </summary>
+    public static class HomebrewManagedCliPolicy
+    {
+        private const char PATH_SEPARATOR = '/';
+        private const char WINDOWS_PATH_SEPARATOR = '\\';
+
+        /// <summary>
+        /// Reports whether the executable at the given path is installed and owned by Homebrew.
+        /// </summary>
+        /// <remarks>
+        /// Why two shapes: brew expands every formula under a Cellar segment and symlinks it from
+        /// prefix/bin, and shell detection reports the unresolved prefix/bin path returned by
+        /// "command -v". Unity's .NET profile cannot resolve symlinks, so a linked path is
+        /// recognized by probing the sibling Cellar formula directory instead.
+        /// </remarks>
+        public static bool IsHomebrewManagedPath(string executablePath, Func<string, bool> directoryExists)
+        {
+            Debug.Assert(directoryExists != null, "directoryExists must not be null");
+
+            if (string.IsNullOrWhiteSpace(executablePath))
+            {
+                return false;
+            }
+
+            string normalizedPath = executablePath.Replace(WINDOWS_PATH_SEPARATOR, PATH_SEPARATOR);
+            string[] segments = normalizedPath.Split(PATH_SEPARATOR);
+            foreach (string segment in segments)
+            {
+                if (string.Equals(segment, CliConstants.HOMEBREW_CELLAR_DIR_NAME, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            string cellarFormulaDirectory = BuildCellarFormulaDirectory(segments);
+            return cellarFormulaDirectory != null && directoryExists(cellarFormulaDirectory);
+        }
+
+        /// <summary>
+        /// Builds the Cellar formula directory that a prefix/bin executable would be linked from.
+        /// </summary>
+        private static string BuildCellarFormulaDirectory(string[] segments)
+        {
+            if (segments.Length < 2)
+            {
+                return null;
+            }
+
+            string formulaName = segments[segments.Length - 1];
+            string prefix = string.Join(
+                PATH_SEPARATOR.ToString(),
+                segments,
+                0,
+                segments.Length - 2);
+            return prefix + PATH_SEPARATOR + CliConstants.HOMEBREW_CELLAR_DIR_NAME + PATH_SEPARATOR + formulaName;
+        }
+    }
+}

--- a/Packages/src/Editor/Domain/HomebrewManagedCliPolicy.cs.meta
+++ b/Packages/src/Editor/Domain/HomebrewManagedCliPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41885ec57c20948df8a843918075538b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliInstallPathResolver.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliInstallPathResolver.cs
@@ -155,6 +155,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return IsPackageOwnedInstallPath(executablePath, installDirectory, platform);
         }
 
+        /// <summary>
+        /// Reports whether the detected CLI executable is owned by Homebrew.
+        /// </summary>
+        internal static bool IsHomebrewManagedInstallPath(string executablePath)
+        {
+            return HomebrewManagedCliPolicy.IsHomebrewManagedPath(executablePath, Directory.Exists);
+        }
+
         internal static bool IsPackageOwnedInstallPath(
             string executablePath,
             string installDirectory,

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs
@@ -181,6 +181,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return NativeCliInstallPathResolver.IsPackageOwnedCurrentUserInstallPath(cliExecutablePath, platform);
         }
 
+        public bool IsHomebrewManagedInstallPath(string cliExecutablePath)
+        {
+            return NativeCliInstallPathResolver.IsHomebrewManagedInstallPath(cliExecutablePath);
+        }
+
         public bool HasPackageOwnedCurrentUserInstall(RuntimePlatform platform)
         {
             return NativeCliInstallPathResolver.HasPackageOwnedCurrentUserInstall(platform);

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs
@@ -96,7 +96,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 cliVersion,
                 requiredCliVersion);
             UpdateHomebrewUpgradeMessage(
-                isHomebrewManagedCli && cliInstalled && !cliCompatible,
+                HomebrewManagedCliPolicy.ShouldDeferToHomebrew(isHomebrewManagedCli, cliInstalled) && !cliCompatible,
                 cliVersion,
                 requiredCliVersion);
             ViewDataBinder.ToggleClass(_statusIcon, "setup-status-icon--success", cliCompatible);
@@ -152,7 +152,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return "Checking...";
             }
 
-            if (isHomebrewManagedCli)
+            if (HomebrewManagedCliPolicy.ShouldDeferToHomebrew(isHomebrewManagedCli, cliInstalled))
             {
                 return CliSetupLabelFormatter.HOMEBREW_MANAGED_BUTTON_TEXT;
             }
@@ -193,7 +193,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool isChecking,
             bool isHomebrewManagedCli)
         {
-            if (isHomebrewManagedCli)
+            if (HomebrewManagedCliPolicy.ShouldDeferToHomebrew(isHomebrewManagedCli, cliInstalled))
             {
                 return false;
             }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs
@@ -96,7 +96,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 cliVersion,
                 requiredCliVersion);
             UpdateHomebrewUpgradeMessage(
-                HomebrewManagedCliPolicy.ShouldDeferToHomebrew(isHomebrewManagedCli, cliInstalled) && !cliCompatible,
+                HomebrewManagedCliPolicy.ShouldShowUpgradeGuidance(isHomebrewManagedCli, cliCompatible),
                 cliVersion,
                 requiredCliVersion);
             ViewDataBinder.ToggleClass(_statusIcon, "setup-status-icon--success", cliCompatible);
@@ -152,9 +152,16 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return "Checking...";
             }
 
-            if (HomebrewManagedCliPolicy.ShouldDeferToHomebrew(isHomebrewManagedCli, cliInstalled))
+            if (isHomebrewManagedCli)
             {
-                return CliSetupLabelFormatter.HOMEBREW_MANAGED_BUTTON_TEXT;
+                if (isInstallingCli)
+                {
+                    return "Fixing PATH...";
+                }
+
+                return needsCliPathSetup
+                    ? "Fix PATH"
+                    : CliSetupLabelFormatter.HOMEBREW_MANAGED_BUTTON_TEXT;
             }
 
             if (isInstallingCli)
@@ -193,12 +200,17 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool isChecking,
             bool isHomebrewManagedCli)
         {
-            if (HomebrewManagedCliPolicy.ShouldDeferToHomebrew(isHomebrewManagedCli, cliInstalled))
+            if (isInstallingCli || isChecking)
             {
                 return false;
             }
 
-            return !isInstallingCli && !isChecking && (!cliInstalled || !cliVersionMatched || needsCliPathSetup);
+            if (isHomebrewManagedCli)
+            {
+                return needsCliPathSetup;
+            }
+
+            return !cliInstalled || !cliVersionMatched || needsCliPathSetup;
         }
     }
 }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs
@@ -54,7 +54,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool cliIsDispatcher,
             string requiredCliVersion,
             bool isInstallingCli,
-            bool needsCliPathSetup)
+            bool needsCliPathSetup,
+            bool isHomebrewManagedCli)
         {
             CliSetupCompatibilityState state = CliSetupCompatibility.Evaluate(
                 cliVersion,
@@ -66,6 +67,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 false,
                 state.NeedsUpdate,
                 needsCliPathSetup,
+                isHomebrewManagedCli,
                 cliVersion,
                 requiredCliVersion);
             bool cliVersionMatched = state.IsCompatible && cliInstalled;
@@ -74,12 +76,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 cliVersionMatched,
                 needsCliPathSetup,
                 isInstallingCli,
-                isChecking: false);
+                isChecking: false,
+                isHomebrewManagedCli);
 
             bool cliCompatible = cliInstalled && cliVersionMatched;
             _statusLabel.text = GetCliStatusTextForSetupWizard(
                 cliInstalled,
                 cliCompatible,
+                isHomebrewManagedCli,
                 cliVersion,
                 requiredCliVersion);
             ViewDataBinder.ToggleClass(_statusIcon, "setup-status-icon--success", cliCompatible);
@@ -91,6 +95,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal static string GetCliStatusTextForSetupWizard(
             bool cliInstalled,
             bool cliCompatible,
+            bool isHomebrewManagedCli,
             string cliVersion,
             string requiredCliVersion)
         {
@@ -102,6 +107,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             if (cliCompatible)
             {
                 return $"v{cliVersion}";
+            }
+
+            if (isHomebrewManagedCli)
+            {
+                return CliSetupLabelFormatter.GetHomebrewUpgradeStatusText(cliVersion, requiredCliVersion);
             }
 
             if (CliSetupLabelFormatter.ShouldShowRequiredVersionText(cliVersion, requiredCliVersion))
@@ -118,12 +128,18 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool isChecking,
             bool needsUpdate,
             bool needsCliPathSetup,
+            bool isHomebrewManagedCli,
             string cliVersion,
             string requiredCliVersion)
         {
             if (isChecking)
             {
                 return "Checking...";
+            }
+
+            if (isHomebrewManagedCli)
+            {
+                return CliSetupLabelFormatter.HOMEBREW_MANAGED_BUTTON_TEXT;
             }
 
             if (isInstallingCli)
@@ -159,8 +175,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool cliVersionMatched,
             bool needsCliPathSetup,
             bool isInstallingCli,
-            bool isChecking)
+            bool isChecking,
+            bool isHomebrewManagedCli)
         {
+            if (isHomebrewManagedCli)
+            {
+                return false;
+            }
+
             return !isInstallingCli && !isChecking && (!cliInstalled || !cliVersionMatched || needsCliPathSetup);
         }
     }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs
@@ -13,21 +13,30 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     {
         private readonly VisualElement _statusIcon;
         private readonly Label _statusLabel;
+        private readonly Label _homebrewUpgradeMessage;
         private readonly Button _installButton;
 
         internal SetupWizardCliStepPresenter(
             VisualElement statusIcon,
             Label statusLabel,
+            Label homebrewUpgradeMessage,
             Button installButton,
             System.Action onInstallClicked)
         {
             Debug.Assert(statusIcon != null, "statusIcon must not be null");
             Debug.Assert(statusLabel != null, "statusLabel must not be null");
+            Debug.Assert(homebrewUpgradeMessage != null, "homebrewUpgradeMessage must not be null");
             Debug.Assert(installButton != null, "installButton must not be null");
             Debug.Assert(onInstallClicked != null, "onInstallClicked must not be null");
 
             _statusIcon = statusIcon ?? throw new System.ArgumentNullException(nameof(statusIcon));
             _statusLabel = statusLabel ?? throw new System.ArgumentNullException(nameof(statusLabel));
+            _homebrewUpgradeMessage = homebrewUpgradeMessage
+                ?? throw new System.ArgumentNullException(nameof(homebrewUpgradeMessage));
+            // Why: the warning carries a command to run, so it must be copyable.
+            // UI Toolkit only starts a selection on a focusable text element.
+            _homebrewUpgradeMessage.focusable = true;
+            _homebrewUpgradeMessage.selection.isSelectable = true;
             _installButton = installButton ?? throw new System.ArgumentNullException(nameof(installButton));
             _installButton.clicked += onInstallClicked
                 ?? throw new System.ArgumentNullException(nameof(onInstallClicked));
@@ -38,6 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             ViewDataBinder.ToggleClass(_statusIcon, "setup-status-icon--success", false);
             ViewDataBinder.ToggleClass(_statusIcon, "setup-status-icon--pending", true);
             _statusLabel.text = "Checking...";
+            UpdateHomebrewUpgradeMessage(isVisible: false, cliVersion: null, requiredCliVersion: null);
             _installButton.SetEnabled(false);
             _installButton.text = "Checking...";
         }
@@ -83,7 +93,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _statusLabel.text = GetCliStatusTextForSetupWizard(
                 cliInstalled,
                 cliCompatible,
-                isHomebrewManagedCli,
+                cliVersion,
+                requiredCliVersion);
+            UpdateHomebrewUpgradeMessage(
+                isHomebrewManagedCli && cliInstalled && !cliCompatible,
                 cliVersion,
                 requiredCliVersion);
             ViewDataBinder.ToggleClass(_statusIcon, "setup-status-icon--success", cliCompatible);
@@ -92,10 +105,17 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _installButton.text = buttonText;
         }
 
+        private void UpdateHomebrewUpgradeMessage(bool isVisible, string cliVersion, string requiredCliVersion)
+        {
+            _homebrewUpgradeMessage.text = isVisible
+                ? CliSetupLabelFormatter.GetHomebrewUpgradeGuidanceText(cliVersion, requiredCliVersion)
+                : string.Empty;
+            ViewDataBinder.ToggleClass(_homebrewUpgradeMessage, "setup-warning-message--visible", isVisible);
+        }
+
         internal static string GetCliStatusTextForSetupWizard(
             bool cliInstalled,
             bool cliCompatible,
-            bool isHomebrewManagedCli,
             string cliVersion,
             string requiredCliVersion)
         {
@@ -107,11 +127,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             if (cliCompatible)
             {
                 return $"v{cliVersion}";
-            }
-
-            if (isHomebrewManagedCli)
-            {
-                return CliSetupLabelFormatter.GetHomebrewUpgradeStatusText(cliVersion, requiredCliVersion);
             }
 
             if (CliSetupLabelFormatter.ShouldShowRequiredVersionText(cliVersion, requiredCliVersion))

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs
@@ -108,8 +108,15 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
             // Why here: the refresh above can reveal a Homebrew install that appeared after the click,
             // and installing over it would leave a second binary beside the one brew owns.
-            if (HomebrewManagedCliPolicy.ShouldDeferToHomebrew(IsHomebrewManagedCli(), IsCliInstalled(cliVersion)))
+            // PATH repair stays allowed because it writes no binary.
+            if (IsHomebrewManagedCli())
             {
+                if (_needsCliPathSetup)
+                {
+                    await HandleRepairCliPathSetup(ct);
+                    return;
+                }
+
                 _refreshUi(true);
                 return;
             }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs
@@ -106,6 +106,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             string cliVersion = _cliSetupApplicationService.GetCachedCliVersion();
             bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
+            // Why here: the refresh above can reveal a Homebrew install that appeared after the click,
+            // and installing over it would leave a second binary beside the one brew owns.
+            if (HomebrewManagedCliPolicy.ShouldDeferToHomebrew(IsHomebrewManagedCli(), IsCliInstalled(cliVersion)))
+            {
+                _refreshUi(true);
+                return;
+            }
+
             CliSetupCompatibilityState state = EvaluateCliSetupCompatibilityForSetupWizard(
                 cliVersion,
                 cliIsDispatcher,

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs
@@ -83,7 +83,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 cliIsDispatcher,
                 requiredCliVersion,
                 _isInstallingCli,
-                _needsCliPathSetup);
+                _needsCliPathSetup,
+                IsHomebrewManagedCli());
+        }
+
+        private bool IsHomebrewManagedCli()
+        {
+            return _cliSetupApplicationService.IsHomebrewManagedInstallPath(
+                _cliSetupApplicationService.GetCachedCliExecutablePath());
         }
 
         private void HandleInstallCli()
@@ -116,7 +123,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 cliIsDispatcher: false,
                 requiredCliVersion: GetMinimumRequiredCliVersion(),
                 isInstallingCli: _isInstallingCli,
-                needsCliPathSetup: _needsCliPathSetup);
+                needsCliPathSetup: _needsCliPathSetup,
+                isHomebrewManagedCli: IsHomebrewManagedCli());
             _installProgressView.Show();
             Progress<string> installProgress = new(_installProgressView.SetDetailLine);
 
@@ -187,7 +195,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 cliIsDispatcher: _cliSetupApplicationService.GetCachedCliIsDispatcher(),
                 requiredCliVersion: GetMinimumRequiredCliVersion(),
                 isInstallingCli: _isInstallingCli,
-                needsCliPathSetup: _needsCliPathSetup);
+                needsCliPathSetup: _needsCliPathSetup,
+                isHomebrewManagedCli: IsHomebrewManagedCli());
 
             try
             {

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs
@@ -28,6 +28,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal SetupWizardCliWorkflowController(
             VisualElement cliStatusIcon,
             Label cliStatusLabel,
+            Label cliHomebrewUpgradeMessage,
             Button installCliButton,
             VisualElement installProgressContainer,
             Label installProgressLabel,
@@ -49,6 +50,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _cliStepPresenter = new SetupWizardCliStepPresenter(
                 cliStatusIcon,
                 cliStatusLabel,
+                cliHomebrewUpgradeMessage,
                 installCliButton,
                 HandleInstallCli);
         }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -297,6 +297,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             VisualElement cliStatusIcon = rootVisualElement.Q<VisualElement>("cli-status-icon");
             Label cliStatusLabel = rootVisualElement.Q<Label>("cli-status-label");
+            Label cliHomebrewUpgradeMessage = rootVisualElement.Q<Label>("cli-homebrew-upgrade-message");
             Button installCliButton = rootVisualElement.Q<Button>("install-cli-button");
             VisualElement installProgressContainer = rootVisualElement.Q<VisualElement>("cli-install-progress");
             Label installProgressLabel = rootVisualElement.Q<Label>("cli-install-progress-label");
@@ -323,6 +324,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 nodejsOk,
                 cliStatusIcon,
                 cliStatusLabel,
+                cliHomebrewUpgradeMessage,
                 installCliButton,
                 installProgressContainer,
                 installProgressLabel,

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
@@ -148,6 +148,8 @@
     margin-bottom: 10px;
 }
 
+/* Why the explicit side margins: the warning must line up with the button below it,
+   so both declare the same horizontal margin instead of inheriting the Button default. */
 .setup-warning-message {
     display: none;
     background-color: #5c4a00;
@@ -156,8 +158,16 @@
     border-width: 1px;
     border-radius: 3px;
     padding: 8px;
-    margin-bottom: 4px;
+    margin-top: 6px;
+    margin-bottom: 8px;
+    margin-left: 3px;
+    margin-right: 3px;
     white-space: normal;
+}
+
+#install-cli-button {
+    margin-left: 3px;
+    margin-right: 3px;
 }
 
 .setup-warning-message--visible {

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
@@ -148,6 +148,22 @@
     margin-bottom: 10px;
 }
 
+.setup-warning-message {
+    display: none;
+    background-color: #5c4a00;
+    border-color: #7a6400;
+    color: var(--setup-color-warning);
+    border-width: 1px;
+    border-radius: 3px;
+    padding: 8px;
+    margin-bottom: 4px;
+    white-space: normal;
+}
+
+.setup-warning-message--visible {
+    display: flex;
+}
+
 .setup-progress-bar {
     height: 14px;
     margin-top: 6px;

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uxml
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uxml
@@ -19,6 +19,7 @@
                     <ui:VisualElement name="cli-status-icon" class="setup-status-icon" />
                     <ui:Label name="cli-status-label" text="Checking..." class="setup-step__status-label" />
                 </ui:VisualElement>
+                <ui:Label name="cli-homebrew-upgrade-message" text="" class="setup-warning-message" />
                 <ui:Button name="install-cli-button" text="Install CLI" class="setup-button" />
                 <ui:VisualElement name="cli-install-progress" class="setup-install-progress" style="display: none;">
                     <ui:Label name="cli-install-progress-label" text="" class="setup-install-progress__detail" />

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWorkflowController.cs
@@ -33,6 +33,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             VisualElement nodejsOk,
             VisualElement cliStatusIcon,
             Label cliStatusLabel,
+            Label cliHomebrewUpgradeMessage,
             Button installCliButton,
             VisualElement installProgressContainer,
             Label installProgressLabel,
@@ -65,6 +66,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _cliWorkflow = new SetupWizardCliWorkflowController(
                 cliStatusIcon,
                 cliStatusLabel,
+                cliHomebrewUpgradeMessage,
                 installCliButton,
                 installProgressContainer,
                 installProgressLabel,

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -114,7 +114,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void UpdateHomebrewUpgradeMessage(CliSetupData data)
         {
-            bool isVisible = !data.IsChecking && data.IsHomebrewManagedCli && data.NeedsUpdate;
+            bool isVisible = !data.IsChecking
+                && HomebrewManagedCliPolicy.ShouldDeferToHomebrew(data.IsHomebrewManagedCli, data.IsCliInstalled)
+                && data.NeedsUpdate;
             _cliHomebrewUpgradeMessage.text = isVisible
                 ? CliSetupLabelFormatter.GetHomebrewUpgradeGuidanceText(data.CliVersion, data.RequiredCliVersion)
                 : string.Empty;
@@ -144,7 +146,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool enabled = IsInstallCliButtonEnabled(
                 data.IsInstallingCli,
                 data.IsChecking,
-                data.IsHomebrewManagedCli);
+                data.IsHomebrewManagedCli,
+                data.IsCliInstalled);
             bool isUninstallStyle = !data.NeedsCliPathSetup && IsUninstallCliAction(
                 data.IsCliInstalled,
                 data.NeedsUpdate,
@@ -208,7 +211,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return "Checking...";
             }
 
-            if (isHomebrewManagedCli)
+            if (HomebrewManagedCliPolicy.ShouldDeferToHomebrew(isHomebrewManagedCli, isCliInstalled))
             {
                 return CliSetupLabelFormatter.HOMEBREW_MANAGED_BUTTON_TEXT;
             }
@@ -245,9 +248,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal static bool IsInstallCliButtonEnabled(
             bool isInstallingCli,
             bool isChecking,
-            bool isHomebrewManagedCli)
+            bool isHomebrewManagedCli,
+            bool isCliInstalled)
         {
-            return !isInstallingCli && !isChecking && !isHomebrewManagedCli;
+            return !isInstallingCli
+                && !isChecking
+                && !HomebrewManagedCliPolicy.ShouldDeferToHomebrew(isHomebrewManagedCli, isCliInstalled);
         }
 
         internal static string GetCliStatusText(

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -16,6 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     {
         private readonly VisualElement _cliStatusIcon;
         private readonly Label _cliStatusLabel;
+        private readonly Label _cliHomebrewUpgradeMessage;
         private readonly Button _refreshCliVersionButton;
         private readonly Button _installCliButton;
         private readonly CliInstallProgressView _installProgressView;
@@ -36,6 +37,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             _cliStatusIcon = root.Q<VisualElement>("cli-status-icon");
             _cliStatusLabel = root.Q<Label>("cli-status-label");
+            _cliHomebrewUpgradeMessage = root.Q<Label>("cli-homebrew-upgrade-message");
+            // Why: the warning carries a command to run, so it must be copyable.
+            // UI Toolkit only starts a selection on a focusable text element.
+            _cliHomebrewUpgradeMessage.focusable = true;
+            _cliHomebrewUpgradeMessage.selection.isSelectable = true;
             _refreshCliVersionButton = root.Q<Button>("refresh-cli-version-button");
             _installCliButton = root.Q<Button>("install-cli-button");
             _installProgressView = new CliInstallProgressView(
@@ -102,10 +108,20 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _cliStatusLabel.text = GetCliStatusText(
                 data.IsChecking,
                 data.IsCliInstalled,
-                data.IsHomebrewManagedCli,
-                data.NeedsUpdate,
-                data.CliVersion,
-                data.RequiredCliVersion);
+                data.CliVersion);
+            UpdateHomebrewUpgradeMessage(data);
+        }
+
+        private void UpdateHomebrewUpgradeMessage(CliSetupData data)
+        {
+            bool isVisible = !data.IsChecking && data.IsHomebrewManagedCli && data.NeedsUpdate;
+            _cliHomebrewUpgradeMessage.text = isVisible
+                ? CliSetupLabelFormatter.GetHomebrewUpgradeGuidanceText(data.CliVersion, data.RequiredCliVersion)
+                : string.Empty;
+            ViewDataBinder.ToggleClass(
+                _cliHomebrewUpgradeMessage,
+                "unity-cli-loop-warning-message--visible",
+                isVisible);
         }
 
         private void UpdateRefreshButton(CliSetupData data)
@@ -237,10 +253,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal static string GetCliStatusText(
             bool isChecking,
             bool isCliInstalled,
-            bool isHomebrewManagedCli,
-            bool needsUpdate,
-            string cliVersion,
-            string requiredCliVersion)
+            string cliVersion)
         {
             if (isChecking)
             {
@@ -250,11 +263,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             if (!isCliInstalled || cliVersion == null)
             {
                 return "CLI: Not installed";
-            }
-
-            if (isHomebrewManagedCli && needsUpdate)
-            {
-                return "CLI: " + CliSetupLabelFormatter.GetHomebrewUpgradeStatusText(cliVersion, requiredCliVersion);
             }
 
             return $"CLI: v{cliVersion}";

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -88,24 +88,24 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void UpdateCliStatus(CliSetupData data)
         {
-            if (data.IsChecking)
-            {
-                ViewDataBinder.ToggleClass(_cliStatusIcon, "unity-cli-loop-cli-status-icon--installed", false);
-                ViewDataBinder.ToggleClass(_cliStatusIcon, "unity-cli-loop-cli-status-icon--not-installed", false);
-                _cliStatusLabel.text = "CLI: Checking...";
-                return;
-            }
+            bool isInstalledIconVisible = !data.IsChecking && data.IsCliInstalled;
+            bool isNotInstalledIconVisible = !data.IsChecking && !data.IsCliInstalled;
+            ViewDataBinder.ToggleClass(
+                _cliStatusIcon,
+                "unity-cli-loop-cli-status-icon--installed",
+                isInstalledIconVisible);
+            ViewDataBinder.ToggleClass(
+                _cliStatusIcon,
+                "unity-cli-loop-cli-status-icon--not-installed",
+                isNotInstalledIconVisible);
 
-            ViewDataBinder.ToggleClass(_cliStatusIcon, "unity-cli-loop-cli-status-icon--installed", data.IsCliInstalled);
-            ViewDataBinder.ToggleClass(_cliStatusIcon, "unity-cli-loop-cli-status-icon--not-installed", !data.IsCliInstalled);
-
-            if (data.IsCliInstalled && data.CliVersion != null)
-            {
-                _cliStatusLabel.text = $"CLI: v{data.CliVersion}";
-                return;
-            }
-
-            _cliStatusLabel.text = "CLI: Not installed";
+            _cliStatusLabel.text = GetCliStatusText(
+                data.IsChecking,
+                data.IsCliInstalled,
+                data.IsHomebrewManagedCli,
+                data.NeedsUpdate,
+                data.CliVersion,
+                data.RequiredCliVersion);
         }
 
         private void UpdateRefreshButton(CliSetupData data)
@@ -122,11 +122,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 data.NeedsUpdate,
                 data.CanUninstallCli,
                 data.NeedsCliPathSetup,
+                data.IsHomebrewManagedCli,
                 data.CliVersion,
                 data.RequiredCliVersion);
             bool enabled = IsInstallCliButtonEnabled(
                 data.IsInstallingCli,
-                data.IsChecking);
+                data.IsChecking,
+                data.IsHomebrewManagedCli);
             bool isUninstallStyle = !data.NeedsCliPathSetup && IsUninstallCliAction(
                 data.IsCliInstalled,
                 data.NeedsUpdate,
@@ -181,12 +183,18 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool needsUpdate,
             bool canUninstallCli,
             bool needsCliPathSetup,
+            bool isHomebrewManagedCli,
             string cliVersion,
             string requiredCliVersion)
         {
             if (isChecking)
             {
                 return "Checking...";
+            }
+
+            if (isHomebrewManagedCli)
+            {
+                return CliSetupLabelFormatter.HOMEBREW_MANAGED_BUTTON_TEXT;
             }
 
             bool isUninstallAction = IsUninstallCliAction(isCliInstalled, needsUpdate, canUninstallCli);
@@ -220,9 +228,36 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         internal static bool IsInstallCliButtonEnabled(
             bool isInstallingCli,
-            bool isChecking)
+            bool isChecking,
+            bool isHomebrewManagedCli)
         {
-            return !isInstallingCli && !isChecking;
+            return !isInstallingCli && !isChecking && !isHomebrewManagedCli;
+        }
+
+        internal static string GetCliStatusText(
+            bool isChecking,
+            bool isCliInstalled,
+            bool isHomebrewManagedCli,
+            bool needsUpdate,
+            string cliVersion,
+            string requiredCliVersion)
+        {
+            if (isChecking)
+            {
+                return "CLI: Checking...";
+            }
+
+            if (!isCliInstalled || cliVersion == null)
+            {
+                return "CLI: Not installed";
+            }
+
+            if (isHomebrewManagedCli && needsUpdate)
+            {
+                return "CLI: " + CliSetupLabelFormatter.GetHomebrewUpgradeStatusText(cliVersion, requiredCliVersion);
+            }
+
+            return $"CLI: v{cliVersion}";
         }
 
         internal static bool IsUninstallCliAction(

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -115,7 +115,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private void UpdateHomebrewUpgradeMessage(CliSetupData data)
         {
             bool isVisible = !data.IsChecking
-                && HomebrewManagedCliPolicy.ShouldDeferToHomebrew(data.IsHomebrewManagedCli, data.IsCliInstalled)
+                && HomebrewManagedCliPolicy.ShouldDeferToHomebrew(
+                    data.IsHomebrewManagedCli,
+                    !string.IsNullOrEmpty(data.CliVersion))
                 && data.NeedsUpdate;
             _cliHomebrewUpgradeMessage.text = isVisible
                 ? CliSetupLabelFormatter.GetHomebrewUpgradeGuidanceText(data.CliVersion, data.RequiredCliVersion)
@@ -147,7 +149,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 data.IsInstallingCli,
                 data.IsChecking,
                 data.IsHomebrewManagedCli,
-                data.IsCliInstalled);
+                data.CliVersion);
             bool isUninstallStyle = !data.NeedsCliPathSetup && IsUninstallCliAction(
                 data.IsCliInstalled,
                 data.NeedsUpdate,
@@ -211,7 +213,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return "Checking...";
             }
 
-            if (HomebrewManagedCliPolicy.ShouldDeferToHomebrew(isHomebrewManagedCli, isCliInstalled))
+            if (HomebrewManagedCliPolicy.ShouldDeferToHomebrew(
+                    isHomebrewManagedCli,
+                    !string.IsNullOrEmpty(cliVersion)))
             {
                 return CliSetupLabelFormatter.HOMEBREW_MANAGED_BUTTON_TEXT;
             }
@@ -249,11 +253,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool isInstallingCli,
             bool isChecking,
             bool isHomebrewManagedCli,
-            bool isCliInstalled)
+            string cliVersion)
         {
             return !isInstallingCli
                 && !isChecking
-                && !HomebrewManagedCliPolicy.ShouldDeferToHomebrew(isHomebrewManagedCli, isCliInstalled);
+                && !HomebrewManagedCliPolicy.ShouldDeferToHomebrew(
+                    isHomebrewManagedCli,
+                    !string.IsNullOrEmpty(cliVersion));
         }
 
         internal static string GetCliStatusText(

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -114,11 +114,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void UpdateHomebrewUpgradeMessage(CliSetupData data)
         {
+            bool isCliUsable = !string.IsNullOrEmpty(data.CliVersion) && !data.NeedsUpdate;
             bool isVisible = !data.IsChecking
-                && HomebrewManagedCliPolicy.ShouldDeferToHomebrew(
-                    data.IsHomebrewManagedCli,
-                    !string.IsNullOrEmpty(data.CliVersion))
-                && data.NeedsUpdate;
+                && HomebrewManagedCliPolicy.ShouldShowUpgradeGuidance(data.IsHomebrewManagedCli, isCliUsable);
             _cliHomebrewUpgradeMessage.text = isVisible
                 ? CliSetupLabelFormatter.GetHomebrewUpgradeGuidanceText(data.CliVersion, data.RequiredCliVersion)
                 : string.Empty;
@@ -149,7 +147,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 data.IsInstallingCli,
                 data.IsChecking,
                 data.IsHomebrewManagedCli,
-                data.CliVersion);
+                data.NeedsCliPathSetup);
             bool isUninstallStyle = !data.NeedsCliPathSetup && IsUninstallCliAction(
                 data.IsCliInstalled,
                 data.NeedsUpdate,
@@ -213,11 +211,16 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return "Checking...";
             }
 
-            if (HomebrewManagedCliPolicy.ShouldDeferToHomebrew(
-                    isHomebrewManagedCli,
-                    !string.IsNullOrEmpty(cliVersion)))
+            if (isHomebrewManagedCli)
             {
-                return CliSetupLabelFormatter.HOMEBREW_MANAGED_BUTTON_TEXT;
+                if (isInstallingCli)
+                {
+                    return "Fixing PATH...";
+                }
+
+                return needsCliPathSetup
+                    ? "Fix PATH"
+                    : CliSetupLabelFormatter.HOMEBREW_MANAGED_BUTTON_TEXT;
             }
 
             bool isUninstallAction = IsUninstallCliAction(isCliInstalled, needsUpdate, canUninstallCli);
@@ -253,13 +256,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool isInstallingCli,
             bool isChecking,
             bool isHomebrewManagedCli,
-            string cliVersion)
+            bool needsCliPathSetup)
         {
-            return !isInstallingCli
-                && !isChecking
-                && !HomebrewManagedCliPolicy.ShouldDeferToHomebrew(
-                    isHomebrewManagedCli,
-                    !string.IsNullOrEmpty(cliVersion));
+            if (isInstallingCli || isChecking)
+            {
+                return false;
+            }
+
+            return !isHomebrewManagedCli || needsCliPathSetup;
         }
 
         internal static string GetCliStatusText(

--- a/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindow.uss
+++ b/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindow.uss
@@ -179,8 +179,19 @@
     margin-top: 8px;
 }
 
+/* Why the explicit side margins: the warning above must line up with the button edges,
+   so both declare the same horizontal margin instead of inheriting the Button default. */
 #install-cli-button {
     margin-top: 2px;
+    margin-left: 3px;
+    margin-right: 3px;
+}
+
+#cli-homebrew-upgrade-message {
+    margin-top: 6px;
+    margin-bottom: 8px;
+    margin-left: 3px;
+    margin-right: 3px;
 }
 
 .unity-cli-loop-install-progress {

--- a/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindow.uxml
+++ b/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindow.uxml
@@ -11,6 +11,7 @@
                             <ui:Label name="cli-status-label" text="CLI: Checking..." />
                             <ui:Button name="refresh-cli-version-button" text="↻" class="unity-cli-loop-button--refresh" />
                         </ui:VisualElement>
+                        <ui:Label name="cli-homebrew-upgrade-message" text="" class="unity-cli-loop-warning-message" />
                         <ui:Button name="install-cli-button" text="Install CLI" class="unity-cli-loop-button unity-cli-loop-button--configure" />
                         <ui:VisualElement name="cli-install-progress" class="unity-cli-loop-install-progress" style="display: none;">
                             <ui:Label name="cli-install-progress-label" text="" class="unity-cli-loop-install-progress__detail" />

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
@@ -442,6 +442,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool canUninstallCli = _cliSetupApplicationService.IsPackageOwnedCurrentUserInstallPath(
                 cliExecutablePath,
                 UnityEngine.Application.platform);
+            bool isHomebrewManagedCli = _cliSetupApplicationService.IsHomebrewManagedInstallPath(cliExecutablePath);
             bool isChecking = !_cliSetupApplicationService.IsCliCheckCompleted()
                 || isRefreshingVersion
                 || isRefreshingCliPathSetup;
@@ -465,6 +466,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 state.NeedsUpdate,
                 canUninstallCli,
                 needsCliPathSetup,
+                isHomebrewManagedCli,
                 isInstallingCli,
                 isChecking,
                 isSkillStateChecking,

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
@@ -156,7 +156,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 needsUpdate,
                 isCliInstalled,
                 canUninstallCli,
-                HomebrewManagedCliPolicy.ShouldDeferToHomebrew(isHomebrewManagedCli, isCliInstalled));
+                isHomebrewManagedCli);
         }
 
         internal static CliSetupPrimaryAction ResolveExecutableCliPrimaryButtonAction(

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
@@ -116,12 +116,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool canUninstallCli = _cliSetupApplicationService.IsPackageOwnedCurrentUserInstallPath(
                 cliExecutablePath,
                 UnityEngine.Application.platform);
+            bool isHomebrewManagedCli = _cliSetupApplicationService.IsHomebrewManagedInstallPath(cliExecutablePath);
             string requiredCliVersion = _cliSetupApplicationService.GetMinimumRequiredCliVersion();
             return ResolveCliPrimaryButtonAction(
                 needsCliPathSetup,
                 cliVersion,
                 cliIsDispatcher,
                 canUninstallCli,
+                isHomebrewManagedCli,
                 requiredCliVersion);
         }
 
@@ -144,6 +146,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string cliVersion,
             bool cliIsDispatcher,
             bool canUninstallCli,
+            bool isHomebrewManagedCli,
             string requiredCliVersion)
         {
             bool needsUpdate = IsCliUpdateNeeded(cliVersion, cliIsDispatcher, requiredCliVersion);
@@ -152,7 +155,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 needsCliPathSetup,
                 needsUpdate,
                 isCliInstalled,
-                canUninstallCli);
+                canUninstallCli,
+                HomebrewManagedCliPolicy.ShouldDeferToHomebrew(isHomebrewManagedCli, isCliInstalled));
         }
 
         internal static CliSetupPrimaryAction ResolveExecutableCliPrimaryButtonAction(

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowViewData.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowViewData.cs
@@ -86,6 +86,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         public readonly bool NeedsUpdate;
         public readonly bool CanUninstallCli;
         public readonly bool NeedsCliPathSetup;
+        public readonly bool IsHomebrewManagedCli;
         public readonly bool IsInstallingCli;
         public readonly bool IsChecking;
         public readonly bool IsSkillStateChecking;
@@ -106,6 +107,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool needsUpdate,
             bool canUninstallCli,
             bool needsCliPathSetup,
+            bool isHomebrewManagedCli,
             bool isInstallingCli,
             bool isChecking,
             bool isSkillStateChecking,
@@ -125,6 +127,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             NeedsUpdate = needsUpdate;
             CanUninstallCli = canUninstallCli;
             NeedsCliPathSetup = needsCliPathSetup;
+            IsHomebrewManagedCli = isHomebrewManagedCli;
             IsInstallingCli = isInstallingCli;
             IsChecking = isChecking;
             IsSkillStateChecking = isSkillStateChecking;

--- a/docs/package-manager-distribution.md
+++ b/docs/package-manager-distribution.md
@@ -29,8 +29,10 @@ including beta tags. There is no separate stable-only formula yet.
   binary in `~/.local/bin` while brew keeps its own on PATH. When such an install is
   below the pin minimum, a warning block above the button names the required version
   and the selectable `brew upgrade uloop` command so the disabled button is not a
-  dead end; a Homebrew binary that answers no version probe points at
-  `brew reinstall uloop` instead. PATH repair is the one action that survives the
+  dead end. A Homebrew binary that answers no version probe, or that reports a
+  version at or above the minimum yet does not answer as the dispatcher, points at
+  `brew reinstall uloop` instead — upgrading it would report nothing to do. PATH
+  repair is the one action that survives the
   stand-down, because it writes no binary and only makes an already installed
   package-owned CLI reachable.
 

--- a/docs/package-manager-distribution.md
+++ b/docs/package-manager-distribution.md
@@ -29,7 +29,10 @@ including beta tags. There is no separate stable-only formula yet.
   binary in `~/.local/bin` while brew keeps its own on PATH. When such an install is
   below the pin minimum, a warning block above the button names the required version
   and the selectable `brew upgrade uloop` command so the disabled button is not a
-  dead end.
+  dead end; a Homebrew binary that answers no version probe points at
+  `brew reinstall uloop` instead. PATH repair is the one action that survives the
+  stand-down, because it writes no binary and only makes an already installed
+  package-owned CLI reachable.
 
 ## Known follow-ups
 

--- a/docs/package-manager-distribution.md
+++ b/docs/package-manager-distribution.md
@@ -27,8 +27,9 @@ including beta tags. There is no separate stable-only formula yet.
   Homebrew-managed install: the primary button is disabled and reads
   `Managed by Homebrew`. Installing from Unity would place a second, package-owned
   binary in `~/.local/bin` while brew keeps its own on PATH. When such an install is
-  below the pin minimum, the status line names the required version and
-  `brew upgrade uloop` so the disabled button is not a dead end.
+  below the pin minimum, a warning block above the button names the required version
+  and the selectable `brew upgrade uloop` command so the disabled button is not a
+  dead end.
 
 ## Known follow-ups
 

--- a/docs/package-manager-distribution.md
+++ b/docs/package-manager-distribution.md
@@ -23,6 +23,12 @@ including beta tags. There is no separate stable-only formula yet.
 - `uloop update` refuses Homebrew-managed installs and directs users to
   `brew upgrade uloop`. The dispatcher freshness path does the same for required
   updates and skips optional auto-updates.
+- The Unity Settings window and the Setup Wizard offer no CLI action for a
+  Homebrew-managed install: the primary button is disabled and reads
+  `Managed by Homebrew`. Installing from Unity would place a second, package-owned
+  binary in `~/.local/bin` while brew keeps its own on PATH. When such an install is
+  below the pin minimum, the status line names the required version and
+  `brew upgrade uloop` so the disabled button is not a dead end.
 
 ## Known follow-ups
 


### PR DESCRIPTION
## Summary
- Unity no longer offers a CLI install that would place a second `uloop` next to a Homebrew-managed one.
- For a Homebrew install, both the Settings window and the Setup Wizard show a disabled `Managed by Homebrew` button with a warning block above it naming the brew command that fixes the situation.

## User Impact

Before: `uloop` installed with `brew install hatayama/tap/uloop` is found by shell detection, so Unity reported it as installed — but only the package-owned path was recognized as "ours". The primary button therefore read `Install CLI` (or `Update CLI` when the pin required a newer version), and pressing it wrote a second binary into `~/.local/bin` while Homebrew kept its own on PATH. The two installs then drifted apart, which is the split the CLI-side update guard was added to prevent. The Setup Wizard had the same path, and it can open by itself when the required CLI version changes.

After: a Homebrew install gets no install, update, or uninstall action from Unity at all — the button is disabled and reads `Managed by Homebrew`, matching how `uloop update` already refuses these installs. When the Homebrew CLI cannot be used as-is, a warning block above the button says what to do and puts the command on its own selectable line:

- below the required version → `brew upgrade uloop`
- answers no version probe at all (broken or partially upgraded formula) → `brew reinstall uloop`
- reports a version at or above the required one yet does not answer as the dispatcher → `brew reinstall uloop`, because upgrading a current formula would report nothing to do

PATH repair is the one action that survives the stand-down: it writes no binary and only makes an already installed package-owned CLI reachable, so a user whose Homebrew binary shadows a working package-owned one still gets an enabled `Fix PATH`. Package-owned and PATH-only installs behave exactly as before.

## Changes
- Classify the detected executable as Homebrew-managed and thread the result into the Settings section and the Setup Wizard CLI step (button label, enabled state, warning block).
- Resolve the stand-down in the primary-action policy, not only in the button state, so a Homebrew install that appears between the click and the forced refresh cannot still run an install.
- Detection mirrors the dispatcher rule (an exact `Cellar` path segment) and additionally recognizes the linked `<prefix>/bin` form: shell detection reports what `command -v` prints, which is the symlink, and Unity's .NET profile cannot resolve symlinks — so the sibling `<prefix>/Cellar/<formula>` directory is probed, and only for an executable that sits directly in a `bin` directory. Backslash paths are normalized first, so a Windows path is never misread.
- Document the Unity-side behavior in `docs/package-manager-distribution.md`.

## Verification
- `uloop compile` — 0 errors, 0 warnings.
- `uloop run-tests` over the affected fixtures (CLI setup section, Setup Wizard, Homebrew policy, Settings CLI actions, CLI setup application service, PATH setup flow) — 211 tests, 211 passed, 0 failed.
- Unit tests cover every Homebrew prefix (`/opt/homebrew`, `/usr/local`, linuxbrew), the linked-bin probe and its `bin`-only restriction, a non-Homebrew path, a partial `Cellar` name, and Windows backslash normalization; button label, enabled state, PATH-repair reachability, and both warning texts are covered for Settings and the Setup Wizard.

## Known limitation

Unity classifies a `<prefix>/bin/uloop` as Homebrew-managed when the sibling `<prefix>/Cellar/uloop` directory exists. A binary installed with `ULOOP_INSTALL_DIR=<prefix>/bin` on a machine that also has an unlinked `uloop` keg is therefore misclassified. The dispatcher avoids this by resolving the symlink; Unity's .NET profile has no symlink API, so the check cannot be made exact here.
