### PR TITLE
feat: skip methods touching a compiled field whose type changed

### DIFF
--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -39,6 +39,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string FieldTypeChangedReason =
             "Field 'PublicSeed' has a different type in the compiled assembly. Run 'uloop compile'.";
 
+        private const string FieldModifiersChangedReason =
+            "Field 'PublicSeed' changed its static or const modifier in the compiled assembly. Run 'uloop compile'.";
+
         /// <summary>
         /// What: a field present only in the edited source is rewritten to the store, an existing
         /// field stays a real field access, and a snapshot-only field is reported removed.
@@ -733,9 +736,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task Skip_FieldTypeChangedIncompatible_SkipsReaderAndWriter_LeavesUntouchedMethod()
         {
-            await AssertFieldTypeChangeSkipsTouchingMethodsAsync(
+            await AssertCompiledFieldDeclarationChangeSkipsTouchingMethodsAsync(
                 "public string PublicSeed = \"x\";",
-                "FieldTypeChangedIncompatible.cs");
+                "FieldTypeChangedIncompatible.cs",
+                FieldTypeChangedReason);
         }
 
         /// <summary>
@@ -745,14 +749,55 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task Skip_FieldTypeChangedIntToLong_SkipsReaderAndWriter_LeavesUntouchedMethod()
         {
-            await AssertFieldTypeChangeSkipsTouchingMethodsAsync(
+            await AssertCompiledFieldDeclarationChangeSkipsTouchingMethodsAsync(
                 "public long PublicSeed = 3;",
-                "FieldTypeChangedIntToLong.cs");
+                "FieldTypeChangedIntToLong.cs",
+                FieldTypeChangedReason);
         }
 
-        private static async Task AssertFieldTypeChangeSkipsTouchingMethodsAsync(
+        /// <summary>
+        /// What: changing a compiled instance field to static skips readers and writers with
+        /// FieldModifiersChanged and does not emit the added-field Inspector warning.
+        /// </summary>
+        [Test]
+        public async Task Skip_FieldModifiersChangedToStatic_SkipsReaderAndWriter_LeavesUntouchedMethod()
+        {
+            await AssertCompiledFieldDeclarationChangeSkipsTouchingMethodsAsync(
+                "[SerializeField] public static int PublicSeed = 3;",
+                "FieldModifiersChangedToStatic.cs",
+                FieldModifiersChangedReason);
+        }
+
+        /// <summary>
+        /// What: changing a compiled instance field to const skips readers and writers with
+        /// FieldModifiersChanged, covering the implicit static bit, without an Inspector warning.
+        /// </summary>
+        [Test]
+        public async Task Skip_FieldModifiersChangedToConst_SkipsReaderAndWriter_LeavesUntouchedMethod()
+        {
+            await AssertCompiledFieldDeclarationChangeSkipsTouchingMethodsAsync(
+                "[SerializeField] public const int PublicSeed = 3;",
+                "FieldModifiersChangedToConst.cs",
+                FieldModifiersChangedReason);
+        }
+
+        /// <summary>
+        /// What: a [SerializeField] compiled field whose type changes is skipped with
+        /// FieldTypeChanged and does not emit the added-field Inspector warning.
+        /// </summary>
+        [Test]
+        public async Task Skip_FieldTypeChangedSerializeField_SkipsWithoutInspectorWarning()
+        {
+            await AssertCompiledFieldDeclarationChangeSkipsTouchingMethodsAsync(
+                "[SerializeField] public long PublicSeed = 3;",
+                "FieldTypeChangedSerializeField.cs",
+                FieldTypeChangedReason);
+        }
+
+        private static async Task AssertCompiledFieldDeclarationChangeSkipsTouchingMethodsAsync(
             string replacementFieldDeclaration,
-            string editedFileName)
+            string editedFileName,
+            string expectedSkipReason)
         {
             string onDisk = File.ReadAllText(ResolveHostPath());
             string edited = onDisk.Replace(
@@ -779,12 +824,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HostProjectRelativePath,
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), FieldTypeChangedReason);
-            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingFail), FieldTypeChangedReason);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), expectedSkipReason);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingFail), expectedSkipReason);
             Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingValue)), Is.Not.Null);
             Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller)), Is.Null);
             Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingFail)), Is.Null);
             Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
+            AssertHasNoAddedFieldSerializeWarning(result);
         }
 
         private static async Task<TransformWorkerClientResult> RunWorkerOnSourceAsync(
@@ -930,6 +976,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Expected skip for '" + methodNameFragment + "' with reason containing '"
                 + reasonFragment + "'. Skipped="
                 + FormatSkipped(result.Output.skipped));
+        }
+
+        private static void AssertHasNoAddedFieldSerializeWarning(TransformWorkerClientResult result)
+        {
+            foreach (string warning in result.Output.declarationDriftWarnings)
+            {
+                if (warning != null && warning.Contains("will not appear in the Inspector"))
+                {
+                    Assert.Fail(
+                        "Declaration-changed compiled fields must not emit the added-field "
+                        + "Inspector warning. Warnings="
+                        + string.Join("\n", result.Output.declarationDriftWarnings));
+                }
+            }
         }
 
         private static string FormatSkipped(TransformWorkerSkippedDto[] skipped)

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -30,6 +30,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string ExistingCallerOriginal =
             "        public int ExistingCaller(int value)\n        {\n            return value;\n        }";
 
+        private const string ExistingFailOriginal =
+            "        public int ExistingFail(int value)\n        {\n            return value;\n        }";
+
+        private const string ExistingValueOriginal =
+            "        public int ExistingValue()\n        {\n            return 1;\n        }";
+
+        private const string FieldTypeChangedReason =
+            "Field 'PublicSeed' has a different type in the compiled assembly. Run 'uloop compile'.";
+
         /// <summary>
         /// What: a field present only in the edited source is rewritten to the store, an existing
         /// field stays a real field access, and a snapshot-only field is reported removed.
@@ -715,6 +724,67 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             Assert.That(foundWarning, Is.True, "SerializeField added fields must warn about Inspector visibility.");
+        }
+
+        /// <summary>
+        /// What: changing a compiled field to an incompatible type skips the reader and writer
+        /// with FieldTypeChanged, while a method that does not touch the field still applies.
+        /// </summary>
+        [Test]
+        public async Task Skip_FieldTypeChangedIncompatible_SkipsReaderAndWriter_LeavesUntouchedMethod()
+        {
+            await AssertFieldTypeChangeSkipsTouchingMethodsAsync(
+                "public string PublicSeed = \"x\";",
+                "FieldTypeChangedIncompatible.cs");
+        }
+
+        /// <summary>
+        /// What: changing a compiled int field to long also skips readers and writers, so the
+        /// implicit conversion cannot apply against the old compiled storage.
+        /// </summary>
+        [Test]
+        public async Task Skip_FieldTypeChangedIntToLong_SkipsReaderAndWriter_LeavesUntouchedMethod()
+        {
+            await AssertFieldTypeChangeSkipsTouchingMethodsAsync(
+                "public long PublicSeed = 3;",
+                "FieldTypeChangedIntToLong.cs");
+        }
+
+        private static async Task AssertFieldTypeChangeSkipsTouchingMethodsAsync(
+            string replacementFieldDeclaration,
+            string editedFileName)
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int PublicSeed = 3;",
+                "        " + replacementFieldDeclaration,
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return PublicSeed.GetHashCode() + value;\n        }",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                ExistingFailOriginal,
+                "        public int ExistingFail(int value)\n        {\n"
+                + "            PublicSeed = value;\n            return value;\n        }",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                ExistingValueOriginal,
+                "        public int ExistingValue()\n        {\n            return 2;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited(editedFileName, edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), FieldTypeChangedReason);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingFail), FieldTypeChangedReason);
+            Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingValue)), Is.Not.Null);
+            Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller)), Is.Null);
+            Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingFail)), Is.Null);
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
         }
 
         private static async Task<TransformWorkerClientResult> RunWorkerOnSourceAsync(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -3154,8 +3154,8 @@ public static class TransformWorkerProgram
     }
 
     /// <summary>
-    /// What: matches a source field to a compiled field by name, static, and const, then
-    /// reports a type change separately so callers can skip instead of rewriting storage.
+    /// What: matches a source field to a compiled field by name, then reports type or
+    /// static/const drift separately so callers can skip instead of rewriting storage.
     /// </summary>
     private static CompiledFieldMatch MatchCompiledField(
         INamedTypeSymbol compiledType,
@@ -3163,11 +3163,17 @@ public static class TransformWorkerProgram
     {
         foreach (ISymbol member in compiledType.GetMembers(sourceField.Name))
         {
-            if (member is not IFieldSymbol compiledField
-                || compiledField.IsStatic != sourceField.IsStatic
-                || compiledField.IsConst != sourceField.IsConst)
+            if (member is not IFieldSymbol compiledField)
             {
                 continue;
+            }
+
+            // Why return here: C# field names are unique in a type, so a modifier
+            // mismatch is the compiled field, not a miss that should become a store.
+            if (compiledField.IsStatic != sourceField.IsStatic
+                || compiledField.IsConst != sourceField.IsConst)
+            {
+                return CompiledFieldMatch.FieldModifiersChanged;
             }
 
             if (CecilTypeNames.ToCecilFullName(compiledField.Type)
@@ -3180,6 +3186,35 @@ public static class TransformWorkerProgram
         }
 
         return CompiledFieldMatch.NotFound;
+    }
+
+    private static bool IsCompiledFieldDeclarationChange(CompiledFieldMatch fieldMatch)
+    {
+        return fieldMatch == CompiledFieldMatch.FieldTypeChanged
+            || fieldMatch == CompiledFieldMatch.FieldModifiersChanged;
+    }
+
+    private static string TryFormatCompiledFieldDeclarationChangeReason(
+        CompiledFieldMatch fieldMatch,
+        string fieldName)
+    {
+        if (fieldMatch == CompiledFieldMatch.FieldTypeChanged)
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                AddedFieldSkipReasons.FieldTypeChanged,
+                fieldName);
+        }
+
+        if (fieldMatch == CompiledFieldMatch.FieldModifiersChanged)
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                AddedFieldSkipReasons.FieldModifiersChanged,
+                fieldName);
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -3220,7 +3255,7 @@ public static class TransformWorkerProgram
                     fieldSymbol,
                     addedFieldCatalog,
                     declarationDriftWarnings,
-                    fieldMatch == CompiledFieldMatch.FieldTypeChanged);
+                    fieldMatch);
             }
         }
     }
@@ -3234,7 +3269,7 @@ public static class TransformWorkerProgram
         IFieldSymbol fieldSymbol,
         AddedFieldCatalog addedFieldCatalog,
         List<string> declarationDriftWarnings,
-        bool fieldTypeChanged)
+        CompiledFieldMatch fieldMatch)
     {
         string syntaxKey = BuildSyntaxFieldKey(typeState.TypeMetadataNameFromSyntax, fieldSymbol.Name);
         string fieldKey = FormatAddedFieldStoreKey(
@@ -3243,7 +3278,8 @@ public static class TransformWorkerProgram
         addedFieldCatalog.MarkClassifiedAdded(fieldKey);
         addedFieldCatalog.AddAddedSyntaxKey(syntaxKey);
 
-        if (!fieldTypeChanged && FieldHasSerializationAttribute(fieldDeclaration))
+        if (!IsCompiledFieldDeclarationChange(fieldMatch)
+            && FieldHasSerializationAttribute(fieldDeclaration))
         {
             declarationDriftWarnings.Add(
                 string.Format(
@@ -3264,14 +3300,14 @@ public static class TransformWorkerProgram
             Initializer = variable.Initializer != null ? variable.Initializer.Value : null
         };
 
-        if (fieldTypeChanged)
+        string declarationChangeReason = TryFormatCompiledFieldDeclarationChangeReason(
+            fieldMatch,
+            fieldSymbol.Name);
+        if (declarationChangeReason != null)
         {
-            // Why not RegisterStore: rewriting to the side table would hide the type
-            // change and leave compiled callers on the old field.
-            binding.UnavailableReason = string.Format(
-                CultureInfo.InvariantCulture,
-                AddedFieldSkipReasons.FieldTypeChanged,
-                fieldSymbol.Name);
+            // Why not RegisterStore: rewriting to the side table would hide the
+            // declaration change and leave compiled callers on the old field.
+            binding.UnavailableReason = declarationChangeReason;
             addedFieldCatalog.RegisterUnavailable(binding);
             return;
         }
@@ -3449,8 +3485,9 @@ public static class TransformWorkerProgram
 
         if (symbol is IFieldSymbol fieldSymbol)
         {
-            // Why map FieldTypeChanged to added: the compiled field still has the old type,
-            // so treating it as a direct shim reference would bind the old storage.
+            // Why map any non-Matched result to added: FieldTypeChanged and
+            // FieldModifiersChanged still name the compiled field, so treating
+            // them as a direct shim reference would bind the old storage.
             return MatchCompiledField(compiledType, fieldSymbol) != CompiledFieldMatch.Matched;
         }
 
@@ -3560,7 +3597,7 @@ public static class TransformWorkerProgram
                 continue;
             }
 
-            IFieldSymbol field = TryGetFieldSymbol(semanticModel, node);
+            IFieldSymbol field = TryGetFieldSymbolOrCandidate(semanticModel, node);
             if (field == null)
             {
                 continue;
@@ -3905,6 +3942,34 @@ public static class TransformWorkerProgram
 
         ISymbol symbol = semanticModel.GetSymbolInfo(node).Symbol;
         return symbol as IFieldSymbol;
+    }
+
+    private static IFieldSymbol TryGetFieldSymbolOrCandidate(
+        SemanticModel semanticModel,
+        SyntaxNode node)
+    {
+        IFieldSymbol field = TryGetFieldSymbol(semanticModel, node);
+        if (field != null)
+        {
+            return field;
+        }
+
+        if (node == null)
+        {
+            return null;
+        }
+
+        // Why candidates: assigning to a const (or other illegal field use) still
+        // names that field, but GetSymbolInfo leaves it in CandidateSymbols.
+        foreach (ISymbol candidate in semanticModel.GetSymbolInfo(node).CandidateSymbols)
+        {
+            if (candidate is IFieldSymbol candidateField)
+            {
+                return candidateField;
+            }
+        }
+
+        return null;
     }
 
     internal static string FormatAddedFieldKeyFromSymbol(IFieldSymbol fieldSymbol)
@@ -7210,6 +7275,9 @@ internal static class AddedFieldSkipReasons
     public const string FieldTypeChanged =
         "Field '{0}' has a different type in the compiled assembly. Run 'uloop compile'.";
 
+    public const string FieldModifiersChanged =
+        "Field '{0}' changed its static or const modifier in the compiled assembly. Run 'uloop compile'.";
+
     public const string SerializeWarningFormat =
         "Added field '{0}' has a serialization attribute, so it will not appear in the Inspector "
         + "or serialize until 'uloop compile'.";
@@ -7393,7 +7461,8 @@ internal enum CompiledFieldMatch
 {
     NotFound,
     Matched,
-    FieldTypeChanged
+    FieldTypeChanged,
+    FieldModifiersChanged
 }
 
 internal sealed class WorkerUnchangedMethod

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -3153,19 +3153,33 @@ public static class TransformWorkerProgram
             && compiledMethod.ReturnsByRefReadonly == sourceMethod.ReturnsByRefReadonly;
     }
 
-    private static bool CompiledTypeHasField(INamedTypeSymbol compiledType, IFieldSymbol sourceField)
+    /// <summary>
+    /// What: matches a source field to a compiled field by name, static, and const, then
+    /// reports a type change separately so callers can skip instead of rewriting storage.
+    /// </summary>
+    private static CompiledFieldMatch MatchCompiledField(
+        INamedTypeSymbol compiledType,
+        IFieldSymbol sourceField)
     {
         foreach (ISymbol member in compiledType.GetMembers(sourceField.Name))
         {
-            if (member is IFieldSymbol compiledField
-                && compiledField.IsStatic == sourceField.IsStatic
-                && compiledField.IsConst == sourceField.IsConst)
+            if (member is not IFieldSymbol compiledField
+                || compiledField.IsStatic != sourceField.IsStatic
+                || compiledField.IsConst != sourceField.IsConst)
             {
-                return true;
+                continue;
             }
+
+            if (CecilTypeNames.ToCecilFullName(compiledField.Type)
+                == CecilTypeNames.ToCecilFullName(sourceField.Type))
+            {
+                return CompiledFieldMatch.Matched;
+            }
+
+            return CompiledFieldMatch.FieldTypeChanged;
         }
 
-        return false;
+        return CompiledFieldMatch.NotFound;
     }
 
     /// <summary>
@@ -3186,7 +3200,13 @@ public static class TransformWorkerProgram
             foreach (VariableDeclaratorSyntax variable in fieldDeclaration.Declaration.Variables)
             {
                 IFieldSymbol fieldSymbol = semanticModel.GetDeclaredSymbol(variable) as IFieldSymbol;
-                if (fieldSymbol == null || CompiledTypeHasField(compiledType, fieldSymbol))
+                if (fieldSymbol == null)
+                {
+                    continue;
+                }
+
+                CompiledFieldMatch fieldMatch = MatchCompiledField(compiledType, fieldSymbol);
+                if (fieldMatch == CompiledFieldMatch.Matched)
                 {
                     continue;
                 }
@@ -3199,7 +3219,8 @@ public static class TransformWorkerProgram
                     variable,
                     fieldSymbol,
                     addedFieldCatalog,
-                    declarationDriftWarnings);
+                    declarationDriftWarnings,
+                    fieldMatch == CompiledFieldMatch.FieldTypeChanged);
             }
         }
     }
@@ -3212,7 +3233,8 @@ public static class TransformWorkerProgram
         VariableDeclaratorSyntax variable,
         IFieldSymbol fieldSymbol,
         AddedFieldCatalog addedFieldCatalog,
-        List<string> declarationDriftWarnings)
+        List<string> declarationDriftWarnings,
+        bool fieldTypeChanged)
     {
         string syntaxKey = BuildSyntaxFieldKey(typeState.TypeMetadataNameFromSyntax, fieldSymbol.Name);
         string fieldKey = FormatAddedFieldStoreKey(
@@ -3221,7 +3243,7 @@ public static class TransformWorkerProgram
         addedFieldCatalog.MarkClassifiedAdded(fieldKey);
         addedFieldCatalog.AddAddedSyntaxKey(syntaxKey);
 
-        if (FieldHasSerializationAttribute(fieldDeclaration))
+        if (!fieldTypeChanged && FieldHasSerializationAttribute(fieldDeclaration))
         {
             declarationDriftWarnings.Add(
                 string.Format(
@@ -3241,6 +3263,18 @@ public static class TransformWorkerProgram
             ConstantValue = fieldSymbol.HasConstantValue ? fieldSymbol.ConstantValue : null,
             Initializer = variable.Initializer != null ? variable.Initializer.Value : null
         };
+
+        if (fieldTypeChanged)
+        {
+            // Why not RegisterStore: rewriting to the side table would hide the type
+            // change and leave compiled callers on the old field.
+            binding.UnavailableReason = string.Format(
+                CultureInfo.InvariantCulture,
+                AddedFieldSkipReasons.FieldTypeChanged,
+                fieldSymbol.Name);
+            addedFieldCatalog.RegisterUnavailable(binding);
+            return;
+        }
 
         binding.UnavailableReason = EvaluateAddedFieldAvailability(
             typeState.TypeSymbol,
@@ -3415,7 +3449,9 @@ public static class TransformWorkerProgram
 
         if (symbol is IFieldSymbol fieldSymbol)
         {
-            return !CompiledTypeHasField(compiledType, fieldSymbol);
+            // Why map FieldTypeChanged to added: the compiled field still has the old type,
+            // so treating it as a direct shim reference would bind the old storage.
+            return MatchCompiledField(compiledType, fieldSymbol) != CompiledFieldMatch.Matched;
         }
 
         if (symbol is IMethodSymbol methodSymbol && methodSymbol.MethodKind == MethodKind.Ordinary)
@@ -7171,6 +7207,9 @@ internal static class AddedFieldSkipReasons
     public const string UnavailableAddedField =
         "Uses an added field that hot reload cannot emit. Run 'uloop compile'.";
 
+    public const string FieldTypeChanged =
+        "Field '{0}' has a different type in the compiled assembly. Run 'uloop compile'.";
+
     public const string SerializeWarningFormat =
         "Added field '{0}' has a serialization attribute, so it will not appear in the Inspector "
         + "or serialize until 'uloop compile'.";
@@ -7348,6 +7387,13 @@ internal enum CompiledMethodMatch
     NotFound,
     Matched,
     ReturnTypeChanged
+}
+
+internal enum CompiledFieldMatch
+{
+    NotFound,
+    Matched,
+    FieldTypeChanged
 }
 
 internal sealed class WorkerUnchangedMethod


### PR DESCRIPTION
## Summary
- Hot reload now skips methods that read or write a compiled field whose type changed, instead of failing with a raw compile error or silently applying against the old storage.
- Methods in the same edit that do not touch that field still apply.

## User Impact
- Before: changing a field type could surface as CS0029, or worse apply quietly when the new type converted from the old one (`int` to `long`), leaving compiled callers on the previous type.
- After: those readers and writers are skipped with `Field '{name}' has a different type in the compiled assembly. Run 'uloop compile'.`

## Changes
- Replace the compiled-field name/static/const matcher with a three-way result (`NotFound` / `Matched` / `FieldTypeChanged`).
- Type-changed fields go through the added-field catalog as unavailable and are not rewritten to the side table.
- Same-file shim member lookup treats a type-changed field as not the compiled field, so the shim cannot bind the old storage.
- Worker tests cover an incompatible type change and `int` to `long`; an untouched method still becomes an entry.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Success, 0 errors
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "HotReload"` → 297/297 Passed
- Repo CI does not run on PRs targeting `feature/hot-reload`; this local suite is the gate.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

