### PR TITLE
fix: include generic arity in signature-change gate method keys

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerFixture.cs
@@ -86,6 +86,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             return await AsyncSelfRecursive(remaining - 1);
         }
+
+        public static int CalledFromGenericArityCaller()
+        {
+            return 5;
+        }
+
+        public static int Caller(int value)
+        {
+            return value;
+        }
+
+        public static int Caller<T>(int value)
+        {
+            CalledFromGenericArityCaller();
+            return value;
+        }
     }
 
     /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs
@@ -34,7 +34,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
                 FixtureTypeMetadataName,
                 nameof(HotReloadCallSiteScannerFixture.CalledFromOrdinaryMethod),
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                0);
 
             Assert.That(hits.Count, Is.EqualTo(1));
             Assert.That(
@@ -54,7 +55,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
                 FixtureTypeMetadataName,
                 nameof(HotReloadCallSiteScannerFixture.NeverCalled),
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                0);
 
             Assert.That(hits, Is.Empty);
         }
@@ -68,7 +70,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
                 FixtureTypeMetadataName,
                 nameof(HotReloadCallSiteScannerFixture.CalledOnlyViaDelegate),
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                0);
 
             Assert.That(hits.Count, Is.EqualTo(1));
             Assert.That(
@@ -86,7 +89,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
                 FixtureTypeMetadataName,
                 nameof(HotReloadCallSiteScannerFixture.CalledFromAsyncMethod),
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                0);
 
             Assert.That(hits.Count, Is.EqualTo(1));
             Assert.That(
@@ -106,7 +110,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
                 GenericHostTypeMetadataName,
                 nameof(GenericHost<int>.Target),
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                0);
 
             Assert.That(hits.Count, Is.EqualTo(1));
             Assert.That(
@@ -123,7 +128,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
                 FixtureTypeMetadataName,
                 nameof(HotReloadCallSiteScannerFixture.GenericMethodTarget),
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                1);
 
             List<string> keys = hits.ConvertAll(hit => hit.CallerMethodKey);
             Assert.That(keys, Does.Contain(FixtureTypeMetadataName + "::CallGenericMethodTarget()"));
@@ -140,7 +146,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
                 FixtureTypeMetadataName,
                 nameof(HotReloadCallSiteScannerFixture.SelfRecursive),
-                new[] { "System.Int32" });
+                new[] { "System.Int32" },
+                0);
 
             Assert.That(hits, Is.Empty);
         }
@@ -166,12 +173,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         assemblyName,
                         FixtureTypeMetadataName,
                         nameof(HotReloadCallSiteScannerFixture.CalledFromOrdinaryMethod),
-                        Array.Empty<string>()),
+                        Array.Empty<string>(),
+                        0),
                     new HotReloadCallSiteScanner.CompiledMethodIdentity(
                         assemblyName,
                         FixtureTypeMetadataName,
                         nameof(HotReloadCallSiteScannerFixture.CalledOnlyViaDelegate),
-                        Array.Empty<string>())
+                        Array.Empty<string>(),
+                        0)
                 });
 
             Assert.That(hits.Count, Is.EqualTo(2));
@@ -201,6 +210,28 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a generic Caller&lt;T&gt;(int) call site uses a different method key than
+        /// the non-generic Caller(int), so arity collisions cannot cover the wrong caller.
+        /// </summary>
+        [Test]
+        public void FindCallSites_GenericArityCaller_KeyDiffersFromNonGenericCaller()
+        {
+            List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
+                FixtureTypeMetadataName,
+                nameof(HotReloadCallSiteScannerFixture.CalledFromGenericArityCaller),
+                Array.Empty<string>(),
+                0);
+
+            Assert.That(hits.Count, Is.EqualTo(1));
+            Assert.That(
+                hits[0].CallerMethodKey,
+                Is.EqualTo(FixtureTypeMetadataName + "::Caller`1(System.Int32)"));
+            Assert.That(
+                hits[0].CallerMethodKey,
+                Is.Not.EqualTo(FixtureTypeMetadataName + "::Caller(System.Int32)"));
+        }
+
+        /// <summary>
         /// What: an async method awaiting itself is not reported after logical-owner resolution.
         /// </summary>
         [Test]
@@ -209,7 +240,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
                 FixtureTypeMetadataName,
                 nameof(HotReloadCallSiteScannerFixture.AsyncSelfRecursive),
-                new[] { "System.Int32" });
+                new[] { "System.Int32" },
+                0);
 
             Assert.That(hits, Is.Empty);
         }
@@ -217,7 +249,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private static List<HotReloadCallSiteScanner.CallSiteHit> FindHits(
             string typeMetadataName,
             string methodName,
-            string[] parameterTypeFullNames)
+            string[] parameterTypeFullNames,
+            int genericArity)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string rawAssemblyName = CompilationPipeline.GetAssemblyNameFromScriptPath(
@@ -229,7 +262,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     assemblyName,
                     typeMetadataName,
                     methodName,
-                    parameterTypeFullNames);
+                    parameterTypeFullNames,
+                    genericArity);
 
             return HotReloadCallSiteScanner.FindCallSites(
                 projectRoot,

--- a/Assets/Tests/Editor/HotReload/HotReloadMethodMatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadMethodMatcherTests.cs
@@ -25,7 +25,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 TestAssemblyName,
                 FixtureTypeMetadataName,
                 nameof(HotReloadCoreFixture.Add),
-                new[] { "System.Int32", "System.Int32" });
+                new[] { "System.Int32", "System.Int32" },
+                0);
 
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(result.Method, Is.Not.Null);
@@ -48,7 +49,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 TestAssemblyName,
                 FixtureTypeMetadataName,
                 nameof(HotReloadCoreFixture.Add),
-                new[] { "System.Int32", "System.Int32", "System.Int32" });
+                new[] { "System.Int32", "System.Int32", "System.Int32" },
+                0);
 
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(result.Method.GetParameters().Length, Is.EqualTo(3));
@@ -69,7 +71,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 TestAssemblyName,
                 FixtureTypeMetadataName,
                 nameof(HotReloadCoreFixture.Add),
-                new[] { "System.String", "System.Int32" });
+                new[] { "System.String", "System.Int32" },
+                0);
 
             Assert.That(result.Success, Is.False);
             Assert.That(result.FailureReason, Is.EqualTo(HotReloadMethodMatchFailureReason.MethodNotFound));
@@ -85,7 +88,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 TestAssemblyName,
                 FixtureTypeMetadataName,
                 nameof(HotReloadCoreFixture.StaticPing),
-                new string[0]);
+                new string[0],
+                0);
 
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(result.Method.IsStatic, Is.True);

--- a/Assets/Tests/Editor/HotReload/HotReloadMethodMatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadMethodMatcherTests.cs
@@ -97,6 +97,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: Resolve distinguishes Caller(int) from Caller&lt;T&gt;(int) by generic arity
+        /// so an unchanged generic row cannot resolve to the non-generic sibling.
+        /// </summary>
+        [Test]
+        public void Resolve_SameNameAndParameters_SelectsByGenericArity()
+        {
+            const string typeMetadataName =
+                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                + ".HotReloadSignatureChangeGenericCallerFixture";
+            string[] parameterTypeFullNames = { "System.Int32" };
+
+            HotReloadMethodMatchResult nonGeneric = HotReloadMethodMatcher.Resolve(
+                TestAssemblyName,
+                typeMetadataName,
+                nameof(HotReloadSignatureChangeGenericCallerFixture.Caller),
+                parameterTypeFullNames,
+                0);
+            HotReloadMethodMatchResult generic = HotReloadMethodMatcher.Resolve(
+                TestAssemblyName,
+                typeMetadataName,
+                nameof(HotReloadSignatureChangeGenericCallerFixture.Caller),
+                parameterTypeFullNames,
+                1);
+
+            Assert.That(nonGeneric.Success, Is.True, nonGeneric.ErrorMessage);
+            Assert.That(generic.Success, Is.True, generic.ErrorMessage);
+
+            MethodInfo nonGenericMethod = (MethodInfo)nonGeneric.Method;
+            MethodInfo genericMethod = (MethodInfo)generic.Method;
+            Assert.That(nonGenericMethod.IsGenericMethod, Is.False);
+            Assert.That(genericMethod.IsGenericMethodDefinition, Is.True);
+            Assert.That(genericMethod.GetGenericArguments().Length, Is.EqualTo(1));
+            Assert.That(nonGeneric.Method, Is.Not.EqualTo(generic.Method));
+        }
+
+        /// <summary>
         /// What: a mismatched Mvid against a loaded assembly fails with StaleAssembly without
         /// resolving a method from a stale token.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2286,7 +2286,91 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 result,
                 nameof(HotReloadSignatureChangeGenericCallerFixture.Target),
                 "The return type of");
-            AssertHasPatched(result, nameof(HotReloadSignatureChangeGenericCallerFixture.Caller));
+            string expectedCallerLabel = HotReloadPatcher.FormatMethodKeyParts(
+                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                + ".HotReloadSignatureChangeGenericCallerFixture",
+                "Caller",
+                new[] { "System.Int32" },
+                genericArity: 0);
+            AssertHasPatched(result, expectedCallerLabel);
+        }
+
+        /// <summary>
+        /// What: an unchanged compiled Caller&lt;T&gt;(int) must not revert a live patch on
+        /// Caller(int) when a later shim-compile failure skips isolation (patch-preservation path).
+        /// </summary>
+        [Test]
+        public async Task Run_UnchangedGenericCaller_DoesNotRevertPatchedNonGenericSibling()
+        {
+            string fixturePath = ResolveSignatureChangeGenericCallerFixturePath();
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string targetDllPath = Path.Combine(
+                projectRoot,
+                HotReloadConstants.ScriptAssembliesRelativeDirectory,
+                "UnityCLILoop.Tests.Editor.HotReload"
+                + HotReloadConstants.CompiledAssemblyExtension);
+            Assert.That(
+                HotReloadSourceBaseline.LoadVerifiedSnapshotSource(
+                    "Assets/Tests/Editor/HotReload/HotReloadSignatureChangeGenericCallerFixture.cs",
+                    targetDllPath),
+                Is.Not.Null,
+                "Verified snapshot must resolve so Caller<T> is listed as unchanged.");
+
+            string onDisk = File.ReadAllText(fixturePath);
+            string patchedSource = onDisk.Replace(
+                "        public int Caller(int value)\n        {\n            return value;\n        }",
+                "        public int Caller(int value)\n        {\n            return value + 1;\n        }",
+                StringComparison.Ordinal);
+            Assert.That(patchedSource, Is.Not.EqualTo(onDisk));
+
+            HotReloadOrchestratorResult patched = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("GenericCallerPatchThenPreserve1.cs", patchedSource),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(patched);
+            string expectedCallerLabel = HotReloadPatcher.FormatMethodKeyParts(
+                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                + ".HotReloadSignatureChangeGenericCallerFixture",
+                "Caller",
+                new[] { "System.Int32" },
+                genericArity: 0);
+            AssertHasPatched(patched, expectedCallerLabel);
+
+            HotReloadSignatureChangeGenericCallerFixture fixture =
+                new HotReloadSignatureChangeGenericCallerFixture();
+            Assert.That(fixture.Caller(5), Is.EqualTo(6));
+
+            string uncompilableSource = onDisk.Replace(
+                "        public int Caller(int value)\n        {\n            return value;\n        }",
+                "        public int Caller(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }",
+                StringComparison.Ordinal);
+            Assert.That(uncompilableSource, Is.Not.EqualTo(onDisk));
+
+            HotReloadOrchestratorResult failed = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("GenericCallerPatchThenPreserve2.cs", uncompilableSource),
+                CancellationToken.None);
+
+            bool callerFailed = false;
+            foreach (HotReloadMethodOutcome outcome in failed.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
+                    && outcome.Method == expectedCallerLabel)
+                {
+                    callerFailed = true;
+                }
+            }
+
+            Assert.That(
+                callerFailed,
+                Is.True,
+                "Run2 must fail the non-generic Caller on the isolation-skip path.\n"
+                + FormatOutcomes(failed));
+            Assert.That(
+                fixture.Caller(5),
+                Is.EqualTo(6),
+                "Unchanged Caller<T> must not peel the live Caller(int) patch.");
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2257,6 +2257,39 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a compiled generic Caller&lt;T&gt;(int) that calls Target is not covered by an
+        /// edited non-generic Caller(int), so the return-type change is skipped.
+        /// </summary>
+        [Test]
+        public async Task Run_ReturnTypeChange_GenericArityCaller_SkipsReplacement()
+        {
+            string fixturePath = ResolveSignatureChangeGenericCallerFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = onDisk
+                .Replace(
+                    "        public int Target(int value)\n        {\n            return value;\n        }",
+                    "        public long Target(int value)\n        {\n            return value + 1L;\n        }",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "        public int Caller(int value)\n        {\n            return value;\n        }",
+                    "        public int Caller(int value)\n        {\n            return value + 1;\n        }",
+                    StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeGenericCaller.cs", edited),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasSkipped(
+                result,
+                nameof(HotReloadSignatureChangeGenericCallerFixture.Target),
+                "The return type of");
+            AssertHasPatched(result, nameof(HotReloadSignatureChangeGenericCallerFixture.Caller));
+        }
+
+        /// <summary>
         /// What: deleting a same-file helper that called Target does not gate Target's return-type
         /// change when no other compiled caller remains.
         /// </summary>
@@ -2827,6 +2860,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 File.Exists(path),
                 Is.True,
                 "Signature-change helper-delete fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string ResolveSignatureChangeGenericCallerFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadSignatureChangeGenericCallerFixture.cs");
+            Assert.That(
+                File.Exists(path),
+                Is.True,
+                "Signature-change generic-caller fixture source missing: " + path);
             return Path.GetFullPath(path);
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeGenericCallerFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeGenericCallerFixture.cs
@@ -1,0 +1,30 @@
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled host where a generic Caller&lt;T&gt;(int) invokes Target and a non-generic
+    /// Caller(int) shares the name and parameter list. Used to prove the gate does not
+    /// treat an edited non-generic Caller as covering the generic compiled caller.
+    /// </summary>
+    public class HotReloadSignatureChangeGenericCallerFixture
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Target(int value)
+        {
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Caller(int value)
+        {
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Caller<T>(int value)
+        {
+            return Target(value);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeGenericCallerFixture.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeGenericCallerFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06e59297646db450197ab9ee44deba85
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs
@@ -18,7 +18,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal static class HotReloadCallSiteScanner
     {
         /// <summary>
-        /// Identity of a compiled method to search for (assembly + type + name + parameter types).
+        /// Identity of a compiled method to search for (assembly + type + name + arity + parameter types).
         /// </summary>
         public readonly struct CompiledMethodIdentity
         {
@@ -26,22 +26,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public readonly string TypeMetadataName;
             public readonly string MethodName;
             public readonly string[] ParameterTypeFullNames;
+            public readonly int GenericArity;
 
             public CompiledMethodIdentity(
                 string assemblyName,
                 string typeMetadataName,
                 string methodName,
-                string[] parameterTypeFullNames)
+                string[] parameterTypeFullNames,
+                int genericArity)
             {
                 Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
                 Debug.Assert(!string.IsNullOrEmpty(typeMetadataName), "typeMetadataName must not be null or empty.");
                 Debug.Assert(!string.IsNullOrEmpty(methodName), "methodName must not be null or empty.");
                 Debug.Assert(parameterTypeFullNames != null, "parameterTypeFullNames must not be null.");
+                Debug.Assert(genericArity >= 0, "genericArity must not be negative.");
 
                 AssemblyName = assemblyName;
                 TypeMetadataName = typeMetadataName;
                 MethodName = methodName;
                 ParameterTypeFullNames = parameterTypeFullNames;
+                GenericArity = genericArity;
             }
         }
 
@@ -273,7 +277,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         methodReference,
                         target.TypeMetadataName,
                         target.MethodName,
-                        target.ParameterTypeFullNames))
+                        target.ParameterTypeFullNames,
+                        target.GenericArity))
                 {
                     return (true, target);
                 }
@@ -296,14 +301,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 caller,
                 target.TypeMetadataName,
                 target.MethodName,
-                target.ParameterTypeFullNames);
+                target.ParameterTypeFullNames,
+                target.GenericArity);
         }
 
         private static bool MatchesIdentity(
             MethodReference methodReference,
             string typeMetadataName,
             string methodName,
-            string[] parameterTypeFullNames)
+            string[] parameterTypeFullNames,
+            int genericArity)
         {
             MethodReference openMethod = methodReference.GetElementMethod();
             if (openMethod.DeclaringType == null)
@@ -320,6 +327,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             if (openMethod.Name != methodName)
+            {
+                return false;
+            }
+
+            // Why compare arity: Caller(int) and Caller<T>(int) share name and parameters.
+            // Treating them as the same identity fail-opens the signature-change gate.
+            if (openMethod.GenericParameters.Count != genericArity)
             {
                 return false;
             }
@@ -427,17 +441,40 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // Keep in sync with TransformWorkerProgram.BuildMethodKey (out-of-process worker)
             // and HotReloadOrchestrator.BuildMethodKey (Unity package side).
+            // Why arity suffix: Caller(int) and Caller<T>(int) must not share a wire key.
             return new CallSiteHit
             {
                 CallerAssemblyName = assemblyName,
                 CallerTypeMetadataName = typeMetadataName,
                 CallerMethodName = caller.Name,
                 CallerParameterTypeFullNames = parameterTypeFullNames,
-                CallerMethodKey = typeMetadataName + "::" + caller.Name + "("
-                    + string.Join(",", parameterTypeFullNames) + ")",
-                TargetMethodKey = target.TypeMetadataName + "::" + target.MethodName + "("
-                    + string.Join(",", target.ParameterTypeFullNames) + ")"
+                CallerMethodKey = FormatWireMethodKey(
+                    typeMetadataName,
+                    caller.Name,
+                    parameterTypeFullNames,
+                    caller.GenericParameters.Count),
+                TargetMethodKey = FormatWireMethodKey(
+                    target.TypeMetadataName,
+                    target.MethodName,
+                    target.ParameterTypeFullNames,
+                    target.GenericArity)
             };
+        }
+
+        private static string FormatWireMethodKey(
+            string typeMetadataName,
+            string methodName,
+            string[] parameterTypeFullNames,
+            int genericArity)
+        {
+            string nameWithArity = methodName;
+            if (genericArity > 0)
+            {
+                nameWithArity = methodName + "`" + genericArity.ToString();
+            }
+
+            return typeMetadataName + "::" + nameWithArity + "("
+                + string.Join(",", parameterTypeFullNames) + ")";
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadMethodMatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadMethodMatcher.cs
@@ -17,19 +17,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         /// <summary>
         /// Resolves <paramref name="methodName"/> on <paramref name="typeMetadataName"/> inside
-        /// <paramref name="assemblyName"/> whose parameters match
-        /// <paramref name="parameterTypeFullNames"/> exactly (Cecil FullName, no <c>this</c>).
+        /// <paramref name="assemblyName"/> whose parameters and generic arity match
+        /// <paramref name="parameterTypeFullNames"/> and <paramref name="genericArity"/>
+        /// exactly (Cecil FullName, no <c>this</c>).
         /// </summary>
         public static HotReloadMethodMatchResult Resolve(
             string assemblyName,
             string typeMetadataName,
             string methodName,
-            string[] parameterTypeFullNames)
+            string[] parameterTypeFullNames,
+            int genericArity)
         {
             Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
             Debug.Assert(!string.IsNullOrEmpty(typeMetadataName), "typeMetadataName must not be null or empty.");
             Debug.Assert(!string.IsNullOrEmpty(methodName), "methodName must not be null or empty.");
             Debug.Assert(parameterTypeFullNames != null, "parameterTypeFullNames must not be null.");
+            Debug.Assert(genericArity >= 0, "genericArity must not be negative.");
 
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string dllPath = Path.Combine(
@@ -56,7 +59,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     $"Type '{typeMetadataName}' was not found in assembly '{assemblyName}'.");
             }
 
-            MethodDefinition methodDefinition = FindMatchingMethod(typeDefinition, methodName, parameterTypeFullNames);
+            MethodDefinition methodDefinition = FindMatchingMethod(
+                typeDefinition,
+                methodName,
+                parameterTypeFullNames,
+                genericArity);
             if (methodDefinition == null)
             {
                 return HotReloadMethodMatchResult.Failure(
@@ -72,11 +79,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static MethodDefinition FindMatchingMethod(
             TypeDefinition typeDefinition,
             string methodName,
-            string[] parameterTypeFullNames)
+            string[] parameterTypeFullNames,
+            int genericArity)
         {
             foreach (MethodDefinition candidate in typeDefinition.Methods)
             {
                 if (candidate.Name != methodName)
+                {
+                    continue;
+                }
+
+                if (candidate.GenericParameters.Count != genericArity)
                 {
                     continue;
                 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -433,11 +433,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
+                // Why arity 0: unchanged DTO has no genericArity field. A miss skips revert
+                // (fail-safe) instead of matching a same-name non-generic sibling.
                 HotReloadMethodMatchResult matchResult = HotReloadMethodMatcher.Resolve(
                     assemblyName,
                     unchanged.typeMetadataName,
                     unchanged.methodName,
-                    unchanged.parameterTypeFullNames);
+                    unchanged.parameterTypeFullNames,
+                    0);
                 if (!matchResult.Success)
                 {
                     continue;
@@ -461,13 +464,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string[] parameterTypeFullNames = entry.parameterTypeFullNames ?? Array.Empty<string>();
             // Pre-Resolve label: same shape as --status (params + nested '+' normalization).
             // After Resolve, prefer FormatMethodKey(MethodBase) so reflection ToString() wins.
-            // Why genericArity 0: TransformWorkerEntryDto has no arity field; open generics are
-            // rare here, and Resolve replaces this label with FormatMethodKey(MethodBase).
             string methodLabel = HotReloadPatcher.FormatMethodKeyParts(
                 entry.typeMetadataName,
                 entry.methodName,
                 parameterTypeFullNames,
-                genericArity: 0);
+                entry.genericArity);
 
             if (entry.patchKind == HotReloadConstants.PatchKindAddedMethod)
             {
@@ -497,7 +498,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 assemblyName,
                 entry.typeMetadataName,
                 entry.methodName,
-                parameterTypeFullNames);
+                parameterTypeFullNames,
+                entry.genericArity);
             if (!matchResult.Success)
             {
                 return HotReloadMethodOutcome.Failed(methodLabel, matchResult.ErrorMessage, filePath);
@@ -965,20 +967,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         // Keep in sync with TransformWorkerProgram.BuildMethodKey (out-of-process worker side)
         // and HotReloadCallSiteScanner.CreateHit.
+        // Why arity suffix: Caller(int) and Caller<T>(int) must not share a wire key.
+        // Arity 0 keeps the bare name so existing non-generic keys stay stable.
         private static string BuildMethodKey(TransformWorkerEntryDto entry)
         {
             return BuildMethodKeyParts(
                 entry.typeMetadataName,
                 entry.methodName,
-                entry.parameterTypeFullNames);
+                entry.parameterTypeFullNames,
+                entry.genericArity);
         }
 
         private static string BuildMethodKeyParts(
             string typeMetadataName,
             string methodName,
-            string[] parameterTypeFullNames)
+            string[] parameterTypeFullNames,
+            int genericArity)
         {
-            return typeMetadataName + "::" + methodName + "("
+            string nameWithArity = methodName;
+            if (genericArity > 0)
+            {
+                nameWithArity = methodName + "`" + genericArity.ToString();
+            }
+
+            return typeMetadataName + "::" + nameWithArity + "("
                 + string.Join(",", parameterTypeFullNames ?? Array.Empty<string>()) + ")";
         }
 
@@ -1129,12 +1141,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<HotReloadMethodOutcome> failedMethodOutcomes = new List<HotReloadMethodOutcome>();
             foreach (TransformWorkerEntryDto failedEntry in attribution.FailedEntries)
             {
-                // Why genericArity 0: TransformWorkerEntryDto has no arity field (see ApplyEntry).
                 string methodLabel = HotReloadPatcher.FormatMethodKeyParts(
                     failedEntry.typeMetadataName,
                     failedEntry.methodName,
                     failedEntry.parameterTypeFullNames ?? Array.Empty<string>(),
-                    genericArity: 0);
+                    failedEntry.genericArity);
                 List<string> entryErrorMessages = attribution.ErrorMessagesByEntry[failedEntry];
                 failedMethodOutcomes.Add(
                     HotReloadMethodOutcome.Failed(
@@ -1261,7 +1272,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     caller.typeMetadataName,
                     caller.methodName,
                     caller.parameterTypeFullNames ?? Array.Empty<string>(),
-                    genericArity: 0);
+                    caller.genericArity);
                 skippedCallerOutcomes.Add(
                     HotReloadMethodOutcome.Skipped(
                         methodLabel,
@@ -1345,7 +1356,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         soleEntry.typeMetadataName,
                         soleEntry.methodName,
                         soleEntry.parameterTypeFullNames ?? Array.Empty<string>(),
-                        genericArity: 0);
+                        soleEntry.genericArity);
                 }
 
                 return ShimFirstCompileResult.Failed(
@@ -1481,7 +1492,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     assemblyName,
                     entry.typeMetadataName,
                     entry.methodName,
-                    entry.parameterTypeFullNames);
+                    entry.parameterTypeFullNames,
+                    entry.genericArity);
             }
 
             foreach (TransformWorkerRemovedMethodSignatureDto signature in removedSignatures)
@@ -1492,7 +1504,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     assemblyName,
                     signature.typeMetadataName,
                     signature.methodName,
-                    signature.parameterTypeFullNames);
+                    signature.parameterTypeFullNames,
+                    signature.genericArity);
             }
 
             return targets.ToArray();
@@ -1504,9 +1517,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string assemblyName,
             string typeMetadataName,
             string methodName,
-            string[] parameterTypeFullNames)
+            string[] parameterTypeFullNames,
+            int genericArity)
         {
-            string methodKey = BuildMethodKeyParts(typeMetadataName, methodName, parameterTypeFullNames);
+            string methodKey = BuildMethodKeyParts(
+                typeMetadataName,
+                methodName,
+                parameterTypeFullNames,
+                genericArity);
             if (!seenKeys.Add(methodKey))
             {
                 return;
@@ -1517,7 +1535,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     assemblyName,
                     typeMetadataName,
                     methodName,
-                    parameterTypeFullNames ?? Array.Empty<string>()));
+                    parameterTypeFullNames ?? Array.Empty<string>(),
+                    genericArity));
         }
 
         private static HashSet<string> CollectCoveredMethodKeys(
@@ -1541,7 +1560,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     BuildMethodKeyParts(
                         target.TypeMetadataName,
                         target.MethodName,
-                        target.ParameterTypeFullNames));
+                        target.ParameterTypeFullNames,
+                        target.GenericArity));
             }
 
             return coveredKeys;
@@ -1585,7 +1605,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 string methodKey = BuildMethodKeyParts(
                     signature.typeMetadataName,
                     signature.methodName,
-                    signature.parameterTypeFullNames);
+                    signature.parameterTypeFullNames,
+                    signature.genericArity);
                 if (!uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> callers)
                     || callers.Count == 0)
                 {
@@ -1657,7 +1678,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     BuildMethodKeyParts(
                         target.TypeMetadataName,
                         target.MethodName,
-                        target.ParameterTypeFullNames));
+                        target.ParameterTypeFullNames,
+                        target.GenericArity));
             }
 
             return keys;
@@ -1692,7 +1714,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     entry.typeMetadataName,
                     entry.methodName,
                     entry.parameterTypeFullNames ?? Array.Empty<string>(),
-                    genericArity: 0);
+                    entry.genericArity);
                 outcomes.Add(
                     HotReloadMethodOutcome.Skipped(
                         methodLabel,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -433,14 +433,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                // Why arity 0: unchanged DTO has no genericArity field. A miss skips revert
-                // (fail-safe) instead of matching a same-name non-generic sibling.
+                // Why pass unchanged.genericArity: Caller(int) and Caller<T>(int) share name
+                // and parameters. Arity 0 would resolve the generic unchanged row to the
+                // non-generic sibling and peel its live patch.
                 HotReloadMethodMatchResult matchResult = HotReloadMethodMatcher.Resolve(
                     assemblyName,
                     unchanged.typeMetadataName,
                     unchanged.methodName,
                     unchanged.parameterTypeFullNames,
-                    0);
+                    unchanged.genericArity);
                 if (!matchResult.Success)
                 {
                     continue;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -79,6 +79,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string typeMetadataName;
         public string methodName;
         public string[] parameterTypeFullNames;
+
+        // Open generic arity. 0 for non-generic methods so existing keys stay unchanged.
+        public int genericArity;
     }
 
     [Serializable]
@@ -103,6 +106,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string typeMetadataName;
         public string methodName;
         public string[] parameterTypeFullNames;
+
+        // Open generic arity. 0 for non-generic methods so existing keys stay unchanged.
+        public int genericArity;
+
         public string shimTypeName;
         public string shimMethodName;
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -98,6 +98,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string typeMetadataName;
         public string methodName;
         public string[] parameterTypeFullNames;
+
+        // Open generic arity. 0 for non-generic methods so existing keys stay unchanged.
+        public int genericArity;
     }
 
     [Serializable]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -117,9 +117,22 @@ public static class TransformWorkerProgram
 
     // Keep in sync with HotReloadOrchestrator.BuildMethodKey (Unity package side)
     // and HotReloadCallSiteScanner.CreateHit.
-    private static string BuildMethodKey(string typeMetadataName, string methodName, string[] parameterTypeFullNames)
+    // Why arity suffix: Caller(int) and Caller<T>(int) must not share a wire key.
+    // Arity 0 keeps the bare name so existing non-generic keys stay stable.
+    private static string BuildMethodKey(
+        string typeMetadataName,
+        string methodName,
+        string[] parameterTypeFullNames,
+        int genericArity)
     {
-        return typeMetadataName + "::" + methodName + "(" + string.Join(",", parameterTypeFullNames ?? Array.Empty<string>()) + ")";
+        string nameWithArity = methodName;
+        if (genericArity > 0)
+        {
+            nameWithArity = methodName + "`" + genericArity.ToString(CultureInfo.InvariantCulture);
+        }
+
+        return typeMetadataName + "::" + nameWithArity + "("
+            + string.Join(",", parameterTypeFullNames ?? Array.Empty<string>()) + ")";
     }
 
     private static WorkerOutput TransformFile(WorkerInput input)
@@ -1470,7 +1483,8 @@ public static class TransformWorkerProgram
         string methodKey = BuildMethodKey(
             CecilTypeNames.ToMetadataName(typeSymbol),
             getterSymbol.Name,
-            parameterTypeFullNames);
+            parameterTypeFullNames,
+            getterSymbol.Arity);
         if (input.ExcludedMethodKeys.Contains(methodKey))
         {
             return (currentShimType, shimTypeCounter, globalShimMethodCounter);
@@ -1583,6 +1597,7 @@ public static class TransformWorkerProgram
             TypeMetadataName = CecilTypeNames.ToMetadataName(typeSymbol),
             MethodName = getterSymbol.Name,
             ParameterTypeFullNames = parameterTypeFullNames,
+            GenericArity = getterSymbol.Arity,
             ShimTypeName = currentShimType.ShimTypeName,
             ShimMethodName = shimMethodName,
             PatchKind = decision.PatchKind,
@@ -2281,7 +2296,8 @@ public static class TransformWorkerProgram
             string methodKey = BuildMethodKey(
                 CecilTypeNames.ToMetadataName(typeState.TypeSymbol),
                 methodSymbol.Name,
-                parameterTypeFullNames);
+                parameterTypeFullNames,
+                methodSymbol.Arity);
             // Why skip explicit-interface methods: compiled GetMembers(simpleName) does not
             // see them (metadata name is Interface.Method), so they would be misclassified as
             // Added and skip the unchanged/baseline path.
@@ -2425,7 +2441,8 @@ public static class TransformWorkerProgram
                     removedMethodSignatures,
                     typeState.TypeSymbol,
                     methodSymbol.Name,
-                    parameterTypeFullNames);
+                    parameterTypeFullNames,
+                    methodSymbol.Arity);
             }
 
             if (isAddedMethod)
@@ -2511,6 +2528,7 @@ public static class TransformWorkerProgram
                 TypeMetadataName = CecilTypeNames.ToMetadataName(typeState.TypeSymbol),
                 MethodName = queued.MethodSymbol.Name,
                 ParameterTypeFullNames = queued.ParameterTypeFullNames,
+                GenericArity = queued.MethodSymbol.Arity,
                 ShimTypeName = queued.ShimType.ShimTypeName,
                 ShimMethodName = queued.ShimMethodName,
                 PatchKind = queued.Decision.PatchKind,
@@ -2620,7 +2638,8 @@ public static class TransformWorkerProgram
                     removedMethodSignatures,
                     typeState.TypeSymbol,
                     compiledMethod.Name,
-                    parameterTypeFullNames);
+                    parameterTypeFullNames,
+                    compiledMethod.Arity);
             }
         }
     }
@@ -2640,6 +2659,7 @@ public static class TransformWorkerProgram
             if (sourceMethod == null
                 || sourceMethod.MethodKind != MethodKind.Ordinary
                 || sourceMethod.Name != compiledMethod.Name
+                || sourceMethod.Arity != compiledMethod.Arity
                 || sourceMethod.IsStatic != compiledMethod.IsStatic
                 || sourceMethod.Parameters.Length != compiledParameterTypeFullNames.Length)
             {
@@ -2687,13 +2707,15 @@ public static class TransformWorkerProgram
         List<WorkerRemovedMethodSignature> removedMethodSignatures,
         INamedTypeSymbol sourceType,
         string methodName,
-        string[] parameterTypeFullNames)
+        string[] parameterTypeFullNames,
+        int genericArity)
     {
         string typeMetadataName = CecilTypeNames.ToMetadataName(sourceType);
         foreach (WorkerRemovedMethodSignature existing in removedMethodSignatures)
         {
             if (existing.TypeMetadataName == typeMetadataName
                 && existing.MethodName == methodName
+                && existing.GenericArity == genericArity
                 && ParameterTypeFullNamesEqual(existing.ParameterTypeFullNames, parameterTypeFullNames))
             {
                 return;
@@ -2704,7 +2726,8 @@ public static class TransformWorkerProgram
         {
             TypeMetadataName = typeMetadataName,
             MethodName = methodName,
-            ParameterTypeFullNames = parameterTypeFullNames
+            ParameterTypeFullNames = parameterTypeFullNames,
+            GenericArity = genericArity
         });
     }
 
@@ -3103,8 +3126,10 @@ public static class TransformWorkerProgram
             .ToArray();
         foreach (ISymbol member in compiledType.GetMembers(sourceMethod.Name))
         {
+            // Why compare Arity: Caller(int) and Caller<T>(int) must not share a compiled match.
             if (member is not IMethodSymbol compiledMethod
                 || compiledMethod.MethodKind != MethodKind.Ordinary
+                || compiledMethod.Arity != sourceMethod.Arity
                 || compiledMethod.IsStatic != sourceMethod.IsStatic
                 || compiledMethod.Parameters.Length != sourceParameterTypeFullNames.Length)
             {
@@ -4164,7 +4189,8 @@ public static class TransformWorkerProgram
         return BuildMethodKey(
             CecilTypeNames.ToMetadataName(methodSymbol.ContainingType),
             methodSymbol.Name,
-            parameterTypeFullNames);
+            parameterTypeFullNames,
+            methodSymbol.Arity);
     }
 
     private static MethodDeclarationSyntax RewriteMethodBody(
@@ -7448,6 +7474,8 @@ internal sealed class WorkerRemovedMethodSignature
     public string MethodName { get; set; }
 
     public string[] ParameterTypeFullNames { get; set; }
+
+    public int GenericArity { get; set; }
 }
 
 internal enum CompiledMethodMatch
@@ -7481,6 +7509,8 @@ internal sealed class WorkerEntry
     public string MethodName { get; set; }
 
     public string[] ParameterTypeFullNames { get; set; }
+
+    public int GenericArity { get; set; }
 
     public string ShimTypeName { get; set; }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -1503,7 +1503,8 @@ public static class TransformWorkerProgram
                 {
                     TypeMetadataName = CecilTypeNames.ToMetadataName(typeSymbol),
                     MethodName = getterSymbol.Name,
-                    ParameterTypeFullNames = parameterTypeFullNames
+                    ParameterTypeFullNames = parameterTypeFullNames,
+                    GenericArity = getterSymbol.Arity
                 });
                 return (currentShimType, shimTypeCounter, globalShimMethodCounter);
             }
@@ -2365,7 +2366,8 @@ public static class TransformWorkerProgram
                     {
                         TypeMetadataName = CecilTypeNames.ToMetadataName(typeState.TypeSymbol),
                         MethodName = methodSymbol.Name,
-                        ParameterTypeFullNames = parameterTypeFullNames
+                        ParameterTypeFullNames = parameterTypeFullNames,
+                        GenericArity = methodSymbol.Arity
                     });
                     continue;
                 }
@@ -7500,6 +7502,8 @@ internal sealed class WorkerUnchangedMethod
     public string MethodName { get; set; }
 
     public string[] ParameterTypeFullNames { get; set; }
+
+    public int GenericArity { get; set; }
 }
 
 internal sealed class WorkerEntry


### PR DESCRIPTION
## Summary
- Hot reload no longer treats a generic method and a same-name non-generic method as the same caller when deciding whether a signature change is safe.

## User Impact
- Before: editing a non-generic `Caller(int)` could hide a compiled `Caller<T>(int)` that still invoked the old method, so a return-type change was applied even though live compiled callers remained.
- After: those two methods use distinct keys (`Caller(int)` vs `Caller\`1(int)`). The signature-change gate skips the replacement when the generic compiled caller is still present.

## Changes
- Wire method keys now include generic arity (`\`N`) when arity is greater than 0. Non-generic keys stay unchanged.
- The call-site scanner, worker catalog keys, removed-signature identities, and method matcher all use that same identity.
- Added scanner and end-to-end coverage for the generic-vs-non-generic caller collision.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` — 0 errors
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "HotReload"` — 302/302 passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

