### PR TITLE
fix: treat a same-name compiled property or event as a field declaration change

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
@@ -97,6 +97,41 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     }
 
     /// <summary>
+    /// Compiled host with an auto-property and an event so a same-name field declaration
+    /// can be classified against live compiled members instead of a side-table store.
+    /// </summary>
+    public class HotReloadFieldKindChangeFixture
+    {
+        public int Hp { get; set; }
+
+        public event Action ScoreChanged;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void ClearScoreChanged()
+        {
+            ScoreChanged = null;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int UntouchedKind()
+        {
+            return 1;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int ReadKind(int value)
+        {
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int WriteKind(int value)
+        {
+            return value;
+        }
+    }
+
+    /// <summary>
     /// Compiled struct host so added-field tests can skip struct types against a real type.
     /// GetOrInit boxes struct receivers and would reinitialize on every access.
     /// </summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -42,6 +42,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string FieldModifiersChangedReason =
             "Field 'PublicSeed' changed its static or const modifier in the compiled assembly. Run 'uloop compile'.";
 
+        private const string MemberKindChangedReasonFormat =
+            "Field '{0}' is declared as a property or an event in the compiled assembly. Run 'uloop compile'.";
+
+        private const string FieldKindChangeProjectRelativePath =
+            "Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs";
+
+        private const string FieldKindChangeUntouchedOriginal =
+            "        public int UntouchedKind()\n        {\n            return 1;\n        }";
+
+        private const string FieldKindChangeReadOriginal =
+            "        public int ReadKind(int value)\n        {\n            return value;\n        }";
+
+        private const string FieldKindChangeWriteOriginal =
+            "        public int WriteKind(int value)\n        {\n            return value;\n        }";
+
         /// <summary>
         /// What: a field present only in the edited source is rewritten to the store, an existing
         /// field stays a real field access, and a snapshot-only field is reported removed.
@@ -794,6 +809,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 FieldTypeChangedReason);
         }
 
+        /// <summary>
+        /// What: rewriting a compiled auto-property Hp to a field skips readers and writers
+        /// instead of duplicating storage in the added-field side table.
+        /// </summary>
+        [Test]
+        public async Task Skip_PropertyRewrittenAsField_SkipsReaderAndWriter_LeavesUntouchedMethod()
+        {
+            await AssertCompiledMemberKindChangeSkipsTouchingMethodsAsync(
+                "        public int Hp { get; set; }",
+                "[SerializeField] public int Hp;",
+                "Hp",
+                "PropertyRewrittenAsField.cs");
+        }
+
+        /// <summary>
+        /// What: rewriting a compiled event ScoreChanged to a field skips readers and writers
+        /// instead of duplicating storage in the added-field side table.
+        /// </summary>
+        [Test]
+        public async Task Skip_EventRewrittenAsField_SkipsReaderAndWriter_LeavesUntouchedMethod()
+        {
+            await AssertCompiledMemberKindChangeSkipsTouchingMethodsAsync(
+                "        public event Action ScoreChanged;",
+                "[SerializeField] public int ScoreChanged;",
+                "ScoreChanged",
+                "EventRewrittenAsField.cs");
+        }
+
         private static async Task AssertCompiledFieldDeclarationChangeSkipsTouchingMethodsAsync(
             string replacementFieldDeclaration,
             string editedFileName,
@@ -829,6 +872,48 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingValue)), Is.Not.Null);
             Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller)), Is.Null);
             Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingFail)), Is.Null);
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
+            AssertHasNoAddedFieldSerializeWarning(result);
+        }
+
+        private static async Task AssertCompiledMemberKindChangeSkipsTouchingMethodsAsync(
+            string compiledMemberDeclaration,
+            string replacementFieldDeclaration,
+            string fieldName,
+            string editedFileName)
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            Assert.That(onDisk, Does.Contain(compiledMemberDeclaration));
+            string edited = onDisk.Replace(
+                compiledMemberDeclaration,
+                "        " + replacementFieldDeclaration,
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                FieldKindChangeReadOriginal,
+                "        public int ReadKind(int value)\n        {\n"
+                + "            return " + fieldName + " + value;\n        }",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                FieldKindChangeWriteOriginal,
+                "        public int WriteKind(int value)\n        {\n"
+                + "            " + fieldName + " = value;\n            return value;\n        }",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                FieldKindChangeUntouchedOriginal,
+                "        public int UntouchedKind()\n        {\n            return 2;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited(editedFileName, edited),
+                FieldKindChangeProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            string expectedSkipReason = string.Format(MemberKindChangedReasonFormat, fieldName);
+            AssertHasSkip(result, nameof(HotReloadFieldKindChangeFixture.ReadKind), expectedSkipReason);
+            AssertHasSkip(result, nameof(HotReloadFieldKindChangeFixture.WriteKind), expectedSkipReason);
+            Assert.That(FindEntry(result, nameof(HotReloadFieldKindChangeFixture.UntouchedKind)), Is.Not.Null);
+            Assert.That(FindEntry(result, nameof(HotReloadFieldKindChangeFixture.ReadKind)), Is.Null);
+            Assert.That(FindEntry(result, nameof(HotReloadFieldKindChangeFixture.WriteKind)), Is.Null);
             Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
             AssertHasNoAddedFieldSerializeWarning(result);
         }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -3181,8 +3181,9 @@ public static class TransformWorkerProgram
     }
 
     /// <summary>
-    /// What: matches a source field to a compiled field by name, then reports type or
-    /// static/const drift separately so callers can skip instead of rewriting storage.
+    /// What: matches a source field to a compiled member by name, then reports type,
+    /// static/const, or property/event kind drift so callers can skip instead of
+    /// rewriting storage.
     /// </summary>
     private static CompiledFieldMatch MatchCompiledField(
         INamedTypeSymbol compiledType,
@@ -3192,6 +3193,13 @@ public static class TransformWorkerProgram
         {
             if (member is not IFieldSymbol compiledField)
             {
+                // Why: a compiled property or event still owns this name. Treating the
+                // source field as added would duplicate storage in the side table.
+                if (member.Kind == SymbolKind.Property || member.Kind == SymbolKind.Event)
+                {
+                    return CompiledFieldMatch.MemberKindChanged;
+                }
+
                 continue;
             }
 
@@ -3218,7 +3226,8 @@ public static class TransformWorkerProgram
     private static bool IsCompiledFieldDeclarationChange(CompiledFieldMatch fieldMatch)
     {
         return fieldMatch == CompiledFieldMatch.FieldTypeChanged
-            || fieldMatch == CompiledFieldMatch.FieldModifiersChanged;
+            || fieldMatch == CompiledFieldMatch.FieldModifiersChanged
+            || fieldMatch == CompiledFieldMatch.MemberKindChanged;
     }
 
     private static string TryFormatCompiledFieldDeclarationChangeReason(
@@ -3238,6 +3247,14 @@ public static class TransformWorkerProgram
             return string.Format(
                 CultureInfo.InvariantCulture,
                 AddedFieldSkipReasons.FieldModifiersChanged,
+                fieldName);
+        }
+
+        if (fieldMatch == CompiledFieldMatch.MemberKindChanged)
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                AddedFieldSkipReasons.MemberKindChanged,
                 fieldName);
         }
 
@@ -3512,9 +3529,9 @@ public static class TransformWorkerProgram
 
         if (symbol is IFieldSymbol fieldSymbol)
         {
-            // Why map any non-Matched result to added: FieldTypeChanged and
-            // FieldModifiersChanged still name the compiled field, so treating
-            // them as a direct shim reference would bind the old storage.
+            // Why map any non-Matched result to added: FieldTypeChanged,
+            // FieldModifiersChanged, and MemberKindChanged still name compiled
+            // storage, so treating them as a direct shim reference would bind it.
             return MatchCompiledField(compiledType, fieldSymbol) != CompiledFieldMatch.Matched;
         }
 
@@ -7306,6 +7323,9 @@ internal static class AddedFieldSkipReasons
     public const string FieldModifiersChanged =
         "Field '{0}' changed its static or const modifier in the compiled assembly. Run 'uloop compile'.";
 
+    public const string MemberKindChanged =
+        "Field '{0}' is declared as a property or an event in the compiled assembly. Run 'uloop compile'.";
+
     public const string SerializeWarningFormat =
         "Added field '{0}' has a serialization attribute, so it will not appear in the Inspector "
         + "or serialize until 'uloop compile'.";
@@ -7492,7 +7512,8 @@ internal enum CompiledFieldMatch
     NotFound,
     Matched,
     FieldTypeChanged,
-    FieldModifiersChanged
+    FieldModifiersChanged,
+    MemberKindChanged
 }
 
 internal sealed class WorkerUnchangedMethod


### PR DESCRIPTION
## Summary
- Hot reload no longer treats a compiled auto-property or event rewritten as a field as a newly added field.

## User Impact
- Before: changing `Hp` from an auto-property (or an event) to a field silently created a side-table copy. Edited methods used the copy; Inspector, serialization, and unpatched code kept the original member.
- After: methods that read or write that field are skipped and tell you to run `uloop compile`.

## Changes
- Field matching now reports a member-kind change when the compiled type already has a property or event of the same name.
- Those fields take the same unavailable path as type and modifier drift, including suppressing the added-field Inspector warning.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` — 0 errors
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "HotReload"` — 306/306 passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

