### PR TITLE
test: cover signature-change gate retry failure and scanner edge paths

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerFixture.cs
@@ -102,6 +102,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             CalledFromGenericArityCaller();
             return value;
         }
+
+        public static int CalledFromCrossAssembly()
+        {
+            return 6;
+        }
     }
 
     /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs
@@ -210,6 +210,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a caller in another project assembly that references the target DLL is
+        /// reported, so the scanner does not miss cross-assembly call sites.
+        /// </summary>
+        [Test]
+        public void FindCallSites_CrossAssemblyCaller_ReportsReferencedAssemblyHit()
+        {
+            List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
+                FixtureTypeMetadataName,
+                nameof(HotReloadCallSiteScannerFixture.CalledFromCrossAssembly),
+                Array.Empty<string>(),
+                0);
+
+            Assert.That(hits.Count, Is.EqualTo(1));
+            Assert.That(
+                hits[0].CallerAssemblyName,
+                Is.EqualTo("UnityCLILoop.Tests.Editor.HotReload.CallSiteCrossAssembly"));
+            Assert.That(
+                hits[0].CallerMethodKey,
+                Is.EqualTo(
+                    "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                    + ".HotReloadCallSiteCrossAssemblyCaller::Call()"));
+        }
+
+        /// <summary>
         /// What: a generic Caller&lt;T&gt;(int) call site uses a different method key than
         /// the non-generic Caller(int), so arity collisions cannot cover the wrong caller.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2466,6 +2466,144 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: the gate-retry FileFailed path (HotReloadOrchestrator ~267-278) reports a
+        /// single (signature-change-gate) Failed when an external caller gates a return-type
+        /// change and the isolation retry shim compile fails. This is not the coverage
+        /// recheck path (~349-370) covered by
+        /// Run_ReturnTypeChange_CallerShimCompileFailure_FailsCoverageRecheck.
+        /// </summary>
+        [Test]
+        public async Task Run_ReturnTypeChange_GateRetryShimCompileFailure_FailsFileWithoutApplying()
+        {
+            string fixturePath = ResolveSignatureChangeExternalHostPath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = onDisk
+                .Replace(
+                    "        public int Target(int value)\n        {\n            return value;\n        }",
+                    "        public long Target(int value)\n        {\n            return value + 1L;\n        }",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "        public int Unrelated(int value)\n        {\n            return value;\n        }",
+                    "        public int Unrelated(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }",
+                    StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeGateRetryFailure.cs", edited),
+                CancellationToken.None);
+
+            Assert.That(result.Methods.Count, Is.EqualTo(1), FormatOutcomes(result));
+            HotReloadMethodOutcome outcome = result.Methods[0];
+            Assert.That(outcome.Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Failed));
+            Assert.That(outcome.Method, Is.EqualTo("(signature-change-gate)"));
+            Assert.That(outcome.Reason, Does.Contain("Retry shim compile failed"));
+            Assert.That(
+                outcome.Reason.Contains("Isolation excluded compiled callers"),
+                Is.False,
+                "This path must not be the coverage-recheck failure.\n" + outcome.Reason);
+            foreach (HotReloadMethodOutcome methodOutcome in result.Methods)
+            {
+                Assert.That(
+                    methodOutcome.Kind,
+                    Is.Not.EqualTo(HotReloadMethodOutcomeKind.Added),
+                    FormatOutcomes(result));
+                Assert.That(
+                    methodOutcome.Kind,
+                    Is.Not.EqualTo(HotReloadMethodOutcomeKind.Patched),
+                    FormatOutcomes(result));
+            }
+        }
+
+        /// <summary>
+        /// What: one file can skip a gated return-type change and still apply a covered
+        /// replacement in the same run.
+        /// </summary>
+        [Test]
+        public async Task Run_ReturnTypeChange_MultipleReplacements_GatesOneAndAppliesTheOther()
+        {
+            string fixturePath = ResolveSignatureChangeMultiReplacementHostPath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = onDisk
+                .Replace(
+                    "        public int TargetGated(int value)\n        {\n            return value;\n        }",
+                    "        public long TargetGated(int value)\n        {\n            return value + 1L;\n        }",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "        public int TargetCovered(int value)\n        {\n            return value;\n        }",
+                    "        public long TargetCovered(int value)\n        {\n            return value + 1L;\n        }",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "            return TargetCovered(value);\n        }",
+                    "            return (int)TargetCovered(value);\n        }",
+                    StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeMultiReplacement.cs", edited),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasSkipped(
+                result,
+                nameof(HotReloadSignatureChangeMultiReplacementHost.TargetGated),
+                "The return type of");
+            AssertHasAdded(
+                result,
+                nameof(HotReloadSignatureChangeMultiReplacementHost.TargetCovered));
+            string expectedCallerLabel = HotReloadPatcher.FormatMethodKeyParts(
+                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                + ".HotReloadSignatureChangeMultiReplacementHost",
+                "CoveredCaller",
+                new[] { "System.Int32" },
+                genericArity: 0);
+            AssertHasPatched(result, expectedCallerLabel);
+        }
+
+        /// <summary>
+        /// What: changing ToDelete(int) to ToDelete(int, int) warns about the old compiled
+        /// signature's remaining caller and classifies the new signature as Added.
+        /// </summary>
+        [Test]
+        public async Task Run_ParameterChange_ExternalCaller_WarnsStaleSignatureAndAddsNewMethod()
+        {
+            string fixturePath = ResolveSignatureChangeExternalHostPath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = onDisk
+                .Replace(
+                    "        public int ToDelete(int value)\n        {\n            return value;\n        }",
+                    "        public int ToDelete(int value, int extra)\n        {\n            return value + extra;\n        }",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "        public int Unrelated(int value)\n        {\n            return value;\n        }",
+                    "        public int Unrelated(int value)\n        {\n            return value + 1;\n        }",
+                    StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            Assert.That(edited, Does.Contain("ToDelete(int value, int extra)"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeParamChange.cs", edited),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasAdded(result, nameof(HotReloadSignatureChangeExternalHost.ToDelete));
+            AssertHasPatched(result, nameof(HotReloadSignatureChangeExternalHost.Unrelated));
+            string expectedCallerKey =
+                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                + ".HotReloadSignatureChangeExternalCaller::CallDeleted(System.Int32)";
+            string expectedSignatureKey =
+                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                + ".HotReloadSignatureChangeExternalHost::ToDelete(System.Int32)";
+            string expectedWarning = string.Format(
+                HotReloadConstants.StaleSignatureCallersWarningFormat,
+                expectedSignatureKey,
+                expectedCallerKey);
+            Assert.That(result.Warnings, Does.Contain(expectedWarning), FormatOutcomes(result));
+        }
+
+        /// <summary>
         /// What: after applying an added method, a later hot-reload against the on-disk baseline
         /// (all-unchanged) clears that file's added-member ledger so --status and Play warnings
         /// do not keep counting it.
@@ -2959,6 +3097,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 File.Exists(path),
                 Is.True,
                 "Signature-change generic-caller fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string ResolveSignatureChangeMultiReplacementHostPath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadSignatureChangeMultiReplacementHost.cs");
+            Assert.That(
+                File.Exists(path),
+                Is.True,
+                "Signature-change multi-replacement host source missing: " + path);
             return Path.GetFullPath(path);
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2588,7 +2588,27 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CancellationToken.None);
 
             AssertNoFileLevelFailure(result);
-            AssertHasAdded(result, nameof(HotReloadSignatureChangeExternalHost.ToDelete));
+            string expectedAddedLabel = HotReloadPatcher.FormatMethodKeyParts(
+                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                + ".HotReloadSignatureChangeExternalHost",
+                "ToDelete",
+                new[] { "System.Int32", "System.Int32" },
+                genericArity: 0);
+            bool foundAddedNewSignature = false;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Added
+                    && outcome.Method == expectedAddedLabel)
+                {
+                    foundAddedNewSignature = true;
+                }
+            }
+
+            Assert.That(
+                foundAddedNewSignature,
+                Is.True,
+                "Parameter change must add ToDelete(int, int), not the old ToDelete(int).\n"
+                + FormatOutcomes(result));
             AssertHasPatched(result, nameof(HotReloadSignatureChangeExternalHost.Unrelated));
             string expectedCallerKey =
                 "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeMultiReplacementCaller.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeMultiReplacementCaller.cs
@@ -1,0 +1,16 @@
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled caller of TargetGated so that replacement stays uncovered in a multi-change run.
+    /// </summary>
+    public class HotReloadSignatureChangeMultiReplacementCaller
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int CallGated(int value)
+        {
+            return new HotReloadSignatureChangeMultiReplacementHost().TargetGated(value);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeMultiReplacementCaller.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeMultiReplacementCaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4287e3faca05640a097126decdb20342
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeMultiReplacementHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeMultiReplacementHost.cs
@@ -1,0 +1,29 @@
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled host with one replacement that has an external caller and one that is
+    /// only called from this file, so a single edit can gate one change and apply the other.
+    /// </summary>
+    public class HotReloadSignatureChangeMultiReplacementHost
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int TargetGated(int value)
+        {
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int TargetCovered(int value)
+        {
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int CoveredCaller(int value)
+        {
+            return TargetCovered(value);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeMultiReplacementHost.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeMultiReplacementHost.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bc392d2110a204efc92e32d39a93814d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReloadCallSiteCrossAssembly.meta
+++ b/Assets/Tests/Editor/HotReloadCallSiteCrossAssembly.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 573f69a889f2947829fd1fbc1ddbd310
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReloadCallSiteCrossAssembly/HotReloadCallSiteCrossAssemblyCaller.cs
+++ b/Assets/Tests/Editor/HotReloadCallSiteCrossAssembly/HotReloadCallSiteCrossAssemblyCaller.cs
@@ -1,0 +1,14 @@
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled caller in a separate assembly so the call-site scanner must follow
+    /// a project-assembly reference, not only the target assembly itself.
+    /// </summary>
+    public static class HotReloadCallSiteCrossAssemblyCaller
+    {
+        public static int Call()
+        {
+            return HotReloadCallSiteScannerFixture.CalledFromCrossAssembly();
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReloadCallSiteCrossAssembly/HotReloadCallSiteCrossAssemblyCaller.cs.meta
+++ b/Assets/Tests/Editor/HotReloadCallSiteCrossAssembly/HotReloadCallSiteCrossAssemblyCaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3996d2e0f1a4f474e9248ebe7a527c87
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReloadCallSiteCrossAssembly/UnityCLILoop.Tests.Editor.HotReload.CallSiteCrossAssembly.asmdef
+++ b/Assets/Tests/Editor/HotReloadCallSiteCrossAssembly/UnityCLILoop.Tests.Editor.HotReload.CallSiteCrossAssembly.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "UnityCLILoop.Tests.Editor.HotReload.CallSiteCrossAssembly",
+    "rootNamespace": "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload",
+    "references": [
+        "GUID:28ecd484b0cda4a278148b43a090fa74"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/Editor/HotReloadCallSiteCrossAssembly/UnityCLILoop.Tests.Editor.HotReload.CallSiteCrossAssembly.asmdef.meta
+++ b/Assets/Tests/Editor/HotReloadCallSiteCrossAssembly/UnityCLILoop.Tests.Editor.HotReload.CallSiteCrossAssembly.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fc86d7bfb642b4032b71b989e24c5fe8
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Signature-change hot reload now has regression tests for the remaining untested gate and scanner paths.

## User Impact
- No runtime behavior change. These tests lock down four cases that previously had no coverage: a failed gate retry, a file with one gated and one applied replacement, a caller in another assembly, and a parameter-list change that leaves the old compiled signature in use.

## Changes
- Gate-retry FileFailed path: external caller plus a remaining shim-compile failure reports a single `(signature-change-gate)` Failed and applies nothing.
- Multi-replacement fixture: `TargetGated` is skipped, `TargetCovered` is added, its same-file caller is patched.
- Cross-assembly scanner fixture: a separate Editor assembly that references the HotReload test DLL is reported as a call site.
- Parameter change: `ToDelete(int)` to `ToDelete(int, int)` warns about the old signature and adds the new method.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` — 0 errors
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "HotReload"` — 310/310 passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

