### PR TITLE
fix: stop claiming gated callers are outside the hot reload

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -134,10 +134,9 @@ another file — even one edited in the same run — or an *unedited* method in 
 same file (an implicit `int`→`long` widening can leave a caller's source
 untouched) would keep calling the old method silently, so the run reports the
 changed method and its edited callers as `Skipped` instead; land the change with
-`uloop compile`. Call sites inside methods
-that the same edit removes or re-signatures do not gate: those compiled bodies are
-already stale, and anything still reaching them stays on the consistent old
-behavior.
+`uloop compile`. Call sites inside methods that the same edit removes or
+re-signatures do not gate: those compiled bodies are already stale, and anything
+still reaching them stays on the consistent old behavior.
 
 Renaming a method or changing its parameter list follows the delete rules rather
 than the gate: the new signature is an ordinary added method, the old one is

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -129,19 +129,20 @@ it report `Patched`. Every added-member rule applies — same-file visibility, t
 Editor-session illusion, and the `virtual`/generic/interface exclusions.
 
 A gate protects compiled callers: the change applies only when every live compiled
-call site of the old signature is itself patched in the same run. A caller in
-another file — or an *unedited* method in the same file (an implicit `int`→`long`
-widening can leave a caller's source untouched) — would keep calling the old
-method silently, so the run reports the changed method and its edited callers as
-`Skipped` instead; land the change with `uloop compile`. Call sites inside methods
+call site of the old signature is patched by the same file's reload. A caller in
+another file — even one edited in the same run — or an *unedited* method in the
+same file (an implicit `int`→`long` widening can leave a caller's source
+untouched) would keep calling the old method silently, so the run reports the
+changed method and its edited callers as `Skipped` instead; land the change with
+`uloop compile`. Call sites inside methods
 that the same edit removes or re-signatures do not gate: those compiled bodies are
 already stale, and anything still reaching them stays on the consistent old
 behavior.
 
 Renaming a method or changing its parameter list follows the delete rules rather
 than the gate: the new signature is an ordinary added method, the old one is
-reported removed, and when compiled call sites of the old signature remain outside
-the run, a `Warnings` entry names each caller — those call sites keep the previous
+reported removed, and a `Warnings` entry names each compiled call site of the old
+signature that the reload leaves unpatched — those call sites keep the previous
 behavior until `uloop compile`. Deleting a method emits the same warning when
 compiled callers remain.
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -134,10 +134,9 @@ another file — even one edited in the same run — or an *unedited* method in 
 same file (an implicit `int`→`long` widening can leave a caller's source
 untouched) would keep calling the old method silently, so the run reports the
 changed method and its edited callers as `Skipped` instead; land the change with
-`uloop compile`. Call sites inside methods
-that the same edit removes or re-signatures do not gate: those compiled bodies are
-already stale, and anything still reaching them stays on the consistent old
-behavior.
+`uloop compile`. Call sites inside methods that the same edit removes or
+re-signatures do not gate: those compiled bodies are already stale, and anything
+still reaching them stays on the consistent old behavior.
 
 Renaming a method or changing its parameter list follows the delete rules rather
 than the gate: the new signature is an ordinary added method, the old one is

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -129,19 +129,20 @@ it report `Patched`. Every added-member rule applies — same-file visibility, t
 Editor-session illusion, and the `virtual`/generic/interface exclusions.
 
 A gate protects compiled callers: the change applies only when every live compiled
-call site of the old signature is itself patched in the same run. A caller in
-another file — or an *unedited* method in the same file (an implicit `int`→`long`
-widening can leave a caller's source untouched) — would keep calling the old
-method silently, so the run reports the changed method and its edited callers as
-`Skipped` instead; land the change with `uloop compile`. Call sites inside methods
+call site of the old signature is patched by the same file's reload. A caller in
+another file — even one edited in the same run — or an *unedited* method in the
+same file (an implicit `int`→`long` widening can leave a caller's source
+untouched) would keep calling the old method silently, so the run reports the
+changed method and its edited callers as `Skipped` instead; land the change with
+`uloop compile`. Call sites inside methods
 that the same edit removes or re-signatures do not gate: those compiled bodies are
 already stale, and anything still reaching them stays on the consistent old
 behavior.
 
 Renaming a method or changing its parameter list follows the delete rules rather
 than the gate: the new signature is an ordinary added method, the old one is
-reported removed, and when compiled call sites of the old signature remain outside
-the run, a `Warnings` entry names each caller — those call sites keep the previous
+reported removed, and a `Warnings` entry names each compiled call site of the old
+signature that the reload leaves unpatched — those call sites keep the previous
 behavior until `uloop compile`. Deleting a method emits the same warning when
 compiled callers remain.
 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -821,7 +821,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Reconstructed fixture source omits compiled members once.");
             int staleSignatureCount = CountWarningsContaining(
                 result.Warnings,
-                "Compiled code outside this hot reload still calls the removed signature");
+                "Compiled call sites of the removed signature");
             Assert.That(
                 result.Warnings.Count,
                 Is.EqualTo(3 + staleSignatureCount),
@@ -938,7 +938,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Duplicate file inputs each emit a removed-members warning.");
             int staleSignatureCount = CountWarningsContaining(
                 result.Warnings,
-                "Compiled code outside this hot reload still calls the removed signature");
+                "Compiled call sites of the removed signature");
             Assert.That(
                 result.Warnings.Count,
                 Is.EqualTo(5 + staleSignatureCount),

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -70,13 +70,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             + "Run 'uloop compile'.";
 
         public const string SignatureChangedGateSkipReasonFormat =
-            "The return type of '{0}' changed, but compiled code outside this hot reload still calls the old method. Applying it would leave those callers on the old version. Run 'uloop compile'.";
+            "The return type of '{0}' changed, but this hot reload does not patch every compiled call site of the old method. Applying it would leave those call sites on the old version. Run 'uloop compile'.";
 
         public const string SignatureChangedGatedCallerSkipReason =
-            "Calls a method whose signature change was not applied because compiled callers exist outside this hot reload; this caller was left unpatched. Run 'uloop compile'.";
+            "Calls a method whose signature change was not applied because unpatched compiled call sites remain; this caller was left unpatched too. Run 'uloop compile'.";
 
         public const string StaleSignatureCallersWarningFormat =
-            "Compiled code outside this hot reload still calls the removed signature '{0}': {1}. Those call sites keep the previous behavior until 'uloop compile'.";
+            "Compiled call sites of the removed signature '{0}' are not patched by this hot reload: {1}. They keep the previous behavior until 'uloop compile'.";
 
         public const string SignatureChangeCoverageLostFailureFormat =
             "Isolation excluded compiled callers of '{0}'; applying the rest would leave those callers on the old version. Run 'uloop compile'.";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -134,10 +134,9 @@ another file — even one edited in the same run — or an *unedited* method in 
 same file (an implicit `int`→`long` widening can leave a caller's source
 untouched) would keep calling the old method silently, so the run reports the
 changed method and its edited callers as `Skipped` instead; land the change with
-`uloop compile`. Call sites inside methods
-that the same edit removes or re-signatures do not gate: those compiled bodies are
-already stale, and anything still reaching them stays on the consistent old
-behavior.
+`uloop compile`. Call sites inside methods that the same edit removes or
+re-signatures do not gate: those compiled bodies are already stale, and anything
+still reaching them stays on the consistent old behavior.
 
 Renaming a method or changing its parameter list follows the delete rules rather
 than the gate: the new signature is an ordinary added method, the old one is

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -129,19 +129,20 @@ it report `Patched`. Every added-member rule applies — same-file visibility, t
 Editor-session illusion, and the `virtual`/generic/interface exclusions.
 
 A gate protects compiled callers: the change applies only when every live compiled
-call site of the old signature is itself patched in the same run. A caller in
-another file — or an *unedited* method in the same file (an implicit `int`→`long`
-widening can leave a caller's source untouched) — would keep calling the old
-method silently, so the run reports the changed method and its edited callers as
-`Skipped` instead; land the change with `uloop compile`. Call sites inside methods
+call site of the old signature is patched by the same file's reload. A caller in
+another file — even one edited in the same run — or an *unedited* method in the
+same file (an implicit `int`→`long` widening can leave a caller's source
+untouched) would keep calling the old method silently, so the run reports the
+changed method and its edited callers as `Skipped` instead; land the change with
+`uloop compile`. Call sites inside methods
 that the same edit removes or re-signatures do not gate: those compiled bodies are
 already stale, and anything still reaching them stays on the consistent old
 behavior.
 
 Renaming a method or changing its parameter list follows the delete rules rather
 than the gate: the new signature is an ordinary added method, the old one is
-reported removed, and when compiled call sites of the old signature remain outside
-the run, a `Warnings` entry names each caller — those call sites keep the previous
+reported removed, and a `Warnings` entry names each compiled call site of the old
+signature that the reload leaves unpatched — those call sites keep the previous
 behavior until `uloop compile`. Deleting a method emits the same warning when
 compiled callers remain.
 

--- a/scripts/regression-harness-hot-reload-signature-change.sh
+++ b/scripts/regression-harness-hot-reload-signature-change.sh
@@ -73,8 +73,8 @@ fi
 BASELINE_MARKER="[HotReloadSignatureChangeHarness] same=1;baseline"
 APPLIED_MARKER="[HotReloadSignatureChangeHarness] same=10;applied"
 PRISTINE_NEEDLE="Debug.Log(\"[HotReloadSignatureChangeHarness] same=\" + SameFileValue() + \";baseline\");"
-GATE_REASON="compiled code outside this hot reload still calls the old method"
-CALLER_REASON="this caller was left unpatched"
+GATE_REASON="this hot reload does not patch every compiled call site of the old method"
+CALLER_REASON="this caller was left unpatched too"
 
 # Why fail-fast on a dirty tree: a prior kill -9 can leave the patched members on disk;
 # backing that up would let the run PASS and then restore the dirty bytes.


### PR DESCRIPTION
## Summary
- Signature-change skip reasons and the stale-signature warning no longer claim that unpatched call sites sit "outside this hot reload".
- The hot-reload skill now describes the same per-file gate: a caller in another file stays unpatched even when that file is edited in the same run.

## User Impact
- Before: a return-type change gated because another compiled caller was not patched (including a caller in a different file of the same run) was described as "compiled code outside this hot reload".
- After: the skip and warning text say this hot reload does not patch every compiled call site, and the skill matches that boundary.

## Changes
- Replaced the three gate/warning constants in `HotReloadConstants` with the agreed wording.
- Updated hardcoded stale-warning prefixes in `HotReloadOrchestratorTests` and the `GATE_REASON` / `CALLER_REASON` substrings in the signature-change regression harness.
- Rewrote the skill gate and rename/parameter paragraphs so they no longer say "patched in the same run" or "outside the run". Regenerated `.claude/` and `.agents/` copies.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <repo>` → `Success: true` (`ErrorCount: 0`; pre-existing CS0414 on `HotReloadFieldKindChangeFixture.ScoreChanged`)
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "HotReload"` → `310/310` Passed
- `sh scripts/regression-harness-hot-reload-signature-change.sh` live → `PASS` (same-file apply + external caller gated + revert-all)
- `dist/darwin-arm64/uloop skills install --claude --agents` updated the two generated skill copies; `scripts/sync-tool-docs.sh` reported `default-tools.json is already up to date`
- Repository CI does not run on pull requests targeting `feature/hot-reload`; local compile + suite + live harness are the verification for this PR.
