### PR TITLE
fix: report removed or kind-changed compiled properties and events

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -104,8 +104,10 @@ member is reported in `Warnings`, but its IL remains callable from unedited code
 until `uloop compile`.
 
 Adding a type (`class`, `struct`, `enum`, `record`), a property, an event, an
-indexer, a constructor, or an operator is still out of scope and reported as
-`Skipped`; land those with `uloop compile`.
+indexer, a constructor, or an operator is still out of scope. These additions
+are not reported per member — no `Skipped` row names them; at most they
+surface as outside-body drift in `Warnings`. Treat silence as "not applied"
+and land them with `uloop compile`.
 
 Outside method bodies, only member additions (previous section) take effect.
 Every other declaration edit — changing a `const` value, a compiled field's

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -104,8 +104,10 @@ member is reported in `Warnings`, but its IL remains callable from unedited code
 until `uloop compile`.
 
 Adding a type (`class`, `struct`, `enum`, `record`), a property, an event, an
-indexer, a constructor, or an operator is still out of scope and reported as
-`Skipped`; land those with `uloop compile`.
+indexer, a constructor, or an operator is still out of scope. These additions
+are not reported per member — no `Skipped` row names them; at most they
+surface as outside-body drift in `Warnings`. Treat silence as "not applied"
+and land them with `uloop compile`.
 
 Outside method bodies, only member additions (previous section) take effect.
 Every other declaration edit — changing a `const` value, a compiled field's

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
@@ -104,15 +104,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
     }
 
+    public interface IHotReloadFieldKindChangeMarker
+    {
+        int ExplicitHp { get; }
+    }
+
     /// <summary>
     /// Compiled host with an auto-property and an event so a same-name field declaration
     /// can be classified against live compiled members instead of a side-table store.
     /// </summary>
-    public class HotReloadFieldKindChangeFixture
+    public class HotReloadFieldKindChangeFixture : IHotReloadFieldKindChangeMarker
     {
         public int Hp { get; set; }
 
         public event Action ScoreChanged;
+
+        int IHotReloadFieldKindChangeMarker.ExplicitHp
+        {
+            get { return 0; }
+        }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void ClearScoreChanged()

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberPartialHost.Other.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberPartialHost.Other.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
@@ -8,6 +9,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     /// </summary>
     public partial class HotReloadAddedMemberPartialHost
     {
+        public int PartialOtherProperty { get; set; }
+
+        public event Action PartialOtherEvent;
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         public int PartialOtherFile()
         {

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -3841,8 +3841,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     {
         private int _secret = 10;
         " + tuningConst + @"
+        private int? Score { get; set; }
+        private int Value { get; set; }
 
         public int SecretForAssert => _secret;
+
+        public HotReloadE2EFixture Current
+        {
+            get { return this; }
+        }
 
         " + explicitAccessors + @"
 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1432,6 +1432,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: replacing compiled property Hp with a field surfaces the named warning on
+        /// HotReloadOrchestratorResult.Warnings, not only the worker DTO.
+        /// </summary>
+        [Test]
+        public async Task Run_PropertyRewrittenAsField_WarnsOnOrchestratorResult()
+        {
+            string fixturePath = ResolveAddedMemberHostPath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = onDisk.Replace(
+                "        public int Hp { get; set; }",
+                "        public int Hp;",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            string editedPath = WriteEditedSource("OrchestratorPropertyKindChange.cs", edited);
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            string expectedWarning = string.Format(
+                "Compiled property '{0}' was removed or redeclared as a different member kind in the edited source; the compiled member stays until 'uloop compile'.",
+                typeof(HotReloadFieldKindChangeFixture).FullName + ".Hp");
+            Assert.That(
+                result.Warnings,
+                Does.Contain(expectedWarning),
+                string.Join("\n", result.Warnings));
+        }
+
+        /// <summary>
         /// What: a file declaring a field-like event hot-reloads its subscriber and handler methods
         /// (no CS0229 from the publicized backing field) — the edited subscriber body (net two
         /// subscriptions via += / -=) must actually apply (HandledCount == 10, not the original
@@ -3841,6 +3872,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     {
         private int _secret = 10;
         " + tuningConst + @"
+        // Why keep these compiled properties: omitting them makes property-removed
+        // warnings fire and breaks exact Warnings.Count asserts in this template.
         private int? Score { get; set; }
         private int Value { get; set; }
 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -45,6 +45,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string MemberKindChangedReasonFormat =
             "Field '{0}' is declared as a property or an event in the compiled assembly. Run 'uloop compile'.";
 
+        private const string CompiledPropertyOrEventWarningFormat =
+            "Compiled property or event '{0}' was removed or redeclared as a different member kind in the edited source; the compiled member stays until 'uloop compile'.";
+
         private const string FieldKindChangeProjectRelativePath =
             "Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs";
 
@@ -837,6 +840,83 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "EventRewrittenAsField.cs");
         }
 
+        /// <summary>
+        /// What: replacing compiled property Hp with a field warns even when no method body
+        /// is edited (FB9 E-1 kind change).
+        /// </summary>
+        [Test]
+        public async Task Warn_PropertyRewrittenAsField_WithoutTouchingBodies()
+        {
+            await AssertCompiledPropertyOrEventWarningAsync(
+                "        public int Hp { get; set; }",
+                "        public int Hp;",
+                "Hp",
+                "WarnPropertyRewrittenAsField.cs");
+        }
+
+        /// <summary>
+        /// What: replacing compiled event ScoreChanged with a field warns even when no method
+        /// body is edited (FB11 E kind change).
+        /// </summary>
+        [Test]
+        public async Task Warn_EventRewrittenAsField_WithoutTouchingBodies()
+        {
+            await AssertCompiledPropertyOrEventWarningAsync(
+                "        public event Action ScoreChanged;",
+                "        public int ScoreChanged;",
+                "ScoreChanged",
+                "WarnEventRewrittenAsField.cs");
+        }
+
+        /// <summary>
+        /// What: deleting compiled property Hp without touching a method body still names it
+        /// in the compiled property-or-event warning.
+        /// </summary>
+        [Test]
+        public async Task Warn_CompiledPropertyRemoved_WithoutTouchingBodies()
+        {
+            await AssertCompiledPropertyOrEventWarningAsync(
+                "        public int Hp { get; set; }\n",
+                string.Empty,
+                "Hp",
+                "WarnPropertyRemoved.cs");
+        }
+
+        /// <summary>
+        /// What: deleting compiled event ScoreChanged without touching a method body still
+        /// names it in the compiled property-or-event warning.
+        /// </summary>
+        [Test]
+        public async Task Warn_CompiledEventRemoved_WithoutTouchingBodies()
+        {
+            await AssertCompiledPropertyOrEventWarningAsync(
+                "        public event Action ScoreChanged;\n",
+                string.Empty,
+                "ScoreChanged",
+                "WarnEventRemoved.cs");
+        }
+
+        /// <summary>
+        /// What: adding an event does not emit the compiled property-or-event warning and
+        /// does not add an individual Skipped row for that event (SKILL discrepancy kept).
+        /// </summary>
+        [Test]
+        public async Task Classify_AddedEvent_DoesNotWarnOrSkipTheEvent()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public event Action ScoreChanged;",
+                "        public event Action ScoreChanged;\n        public event Action ExtraScore;",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedEventNoCompiledKindWarning.cs", edited),
+                FieldKindChangeProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasNoCompiledPropertyOrEventWarning(result, "ExtraScore");
+            AssertHasNoSkipContaining(result, "ExtraScore");
+        }
+
         private static async Task AssertCompiledFieldDeclarationChangeSkipsTouchingMethodsAsync(
             string replacementFieldDeclaration,
             string editedFileName,
@@ -916,6 +996,82 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(FindEntry(result, nameof(HotReloadFieldKindChangeFixture.WriteKind)), Is.Null);
             Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
             AssertHasNoAddedFieldSerializeWarning(result);
+        }
+
+        private static async Task AssertCompiledPropertyOrEventWarningAsync(
+            string compiledMemberDeclaration,
+            string replacementDeclaration,
+            string memberName,
+            string editedFileName)
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            Assert.That(onDisk, Does.Contain(compiledMemberDeclaration));
+            string edited = onDisk.Replace(
+                compiledMemberDeclaration,
+                replacementDeclaration,
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited(editedFileName, edited),
+                FieldKindChangeProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            string expectedWarning = string.Format(
+                CompiledPropertyOrEventWarningFormat,
+                memberName);
+            AssertHasDeclarationDriftWarning(result, expectedWarning);
+        }
+
+        private static void AssertHasDeclarationDriftWarning(
+            TransformWorkerClientResult result,
+            string expectedWarning)
+        {
+            string[] warnings = result.Output.declarationDriftWarnings ?? Array.Empty<string>();
+            foreach (string warning in warnings)
+            {
+                if (warning == expectedWarning)
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail(
+                "Expected declaration drift warning '" + expectedWarning + "'. Warnings="
+                + string.Join("\n", warnings));
+        }
+
+        private static void AssertHasNoCompiledPropertyOrEventWarning(
+            TransformWorkerClientResult result,
+            string memberName)
+        {
+            string unexpected = string.Format(CompiledPropertyOrEventWarningFormat, memberName);
+            string[] warnings = result.Output.declarationDriftWarnings ?? Array.Empty<string>();
+            foreach (string warning in warnings)
+            {
+                if (warning == unexpected)
+                {
+                    Assert.Fail(
+                        "Added event must not emit the compiled property-or-event warning. Warnings="
+                        + string.Join("\n", warnings));
+                }
+            }
+        }
+
+        private static void AssertHasNoSkipContaining(
+            TransformWorkerClientResult result,
+            string methodNameFragment)
+        {
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                if (skipped.method != null
+                    && skipped.method.Contains(methodNameFragment, StringComparison.Ordinal))
+                {
+                    Assert.Fail(
+                        "Added event must not produce a Skipped row. Skipped="
+                        + FormatSkipped(result.Output.skipped));
+                }
+            }
         }
 
         private static async Task<TransformWorkerClientResult> RunWorkerOnSourceAsync(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -45,8 +45,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string MemberKindChangedReasonFormat =
             "Field '{0}' is declared as a property or an event in the compiled assembly. Run 'uloop compile'.";
 
-        private const string CompiledPropertyOrEventWarningFormat =
-            "Compiled property or event '{0}' was removed or redeclared as a different member kind in the edited source; the compiled member stays until 'uloop compile'.";
+        private const string CompiledPropertyWarningFormat =
+            "Compiled property '{0}' was removed or redeclared as a different member kind in the edited source; the compiled member stays until 'uloop compile'.";
+
+        private const string CompiledEventWarningFormat =
+            "Compiled event '{0}' was removed or redeclared as a different member kind in the edited source; the compiled member stays until 'uloop compile'.";
 
         private const string FieldKindChangeProjectRelativePath =
             "Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs";
@@ -850,6 +853,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             await AssertCompiledPropertyOrEventWarningAsync(
                 "        public int Hp { get; set; }",
                 "        public int Hp;",
+                CompiledPropertyWarningFormat,
                 "Hp",
                 "WarnPropertyRewrittenAsField.cs");
         }
@@ -864,6 +868,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             await AssertCompiledPropertyOrEventWarningAsync(
                 "        public event Action ScoreChanged;",
                 "        public int ScoreChanged;",
+                CompiledEventWarningFormat,
                 "ScoreChanged",
                 "WarnEventRewrittenAsField.cs");
         }
@@ -878,13 +883,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             await AssertCompiledPropertyOrEventWarningAsync(
                 "        public int Hp { get; set; }\n",
                 string.Empty,
+                CompiledPropertyWarningFormat,
                 "Hp",
                 "WarnPropertyRemoved.cs");
         }
 
         /// <summary>
         /// What: deleting compiled event ScoreChanged without touching a method body still
-        /// names it in the compiled property-or-event warning.
+        /// names it in the compiled event warning. Declaration deletion leaves a dangling
+        /// reference in ClearScoreChanged; a binding-error skip row from that leftover
+        /// call is noise, not the behavior under test.
         /// </summary>
         [Test]
         public async Task Warn_CompiledEventRemoved_WithoutTouchingBodies()
@@ -892,6 +900,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             await AssertCompiledPropertyOrEventWarningAsync(
                 "        public event Action ScoreChanged;\n",
                 string.Empty,
+                CompiledEventWarningFormat,
                 "ScoreChanged",
                 "WarnEventRemoved.cs");
         }
@@ -913,8 +922,70 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 FieldKindChangeProjectRelativePath,
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            AssertHasNoCompiledPropertyOrEventWarning(result, "ExtraScore");
+            AssertHasNoCompiledKindChangeWarningForMember(result, "ExtraScore");
             AssertHasNoSkipContaining(result, "ExtraScore");
+        }
+
+        /// <summary>
+        /// What: adding a property does not emit the compiled property warning and does
+        /// not add an individual Skipped row for that property (SKILL discrepancy kept).
+        /// </summary>
+        [Test]
+        public async Task Classify_AddedProperty_DoesNotWarnOrSkipTheProperty()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int Hp { get; set; }",
+                "        public int Hp { get; set; }\n        public int ExtraHp { get; set; }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedPropertyNoCompiledKindWarning.cs", edited),
+                FieldKindChangeProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasNoCompiledKindChangeWarningForMember(result, "ExtraHp");
+            AssertHasNoSkipContaining(result, "ExtraHp");
+        }
+
+        /// <summary>
+        /// What: a property declared only on the other file of a partial type does not
+        /// produce a compiled-property-removed warning when this file is hot-reloaded.
+        /// </summary>
+        [Test]
+        public async Task Warn_PartialOtherFilePropertyOrEvent_DoesNotWarnAsRemoved()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int PartialKept()\n        {\n            return 1;\n        }",
+                "        public int PartialKept()\n        {\n            return 11;\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("PartialOtherFilePropertyNoFalseWarning.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasNoCompiledKindChangeWarningForMember(result, "PartialOtherProperty");
+            AssertHasNoCompiledKindChangeWarningForMember(result, "PartialOtherEvent");
+        }
+
+        /// <summary>
+        /// What: keeping a compiled explicit-interface property declaration while editing
+        /// another method does not emit a compiled-property-removed warning.
+        /// </summary>
+        [Test]
+        public async Task Warn_ExplicitInterfacePropertyKept_DoesNotWarnAsRemoved()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                FieldKindChangeUntouchedOriginal,
+                "        public int UntouchedKind()\n        {\n            return 2;\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("ExplicitInterfacePropertyKept.cs", edited),
+                FieldKindChangeProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasNoCompiledKindChangeWarningForMember(result, "ExplicitHp");
         }
 
         private static async Task AssertCompiledFieldDeclarationChangeSkipsTouchingMethodsAsync(
@@ -1001,6 +1072,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private static async Task AssertCompiledPropertyOrEventWarningAsync(
             string compiledMemberDeclaration,
             string replacementDeclaration,
+            string warningFormat,
             string memberName,
             string editedFileName)
         {
@@ -1018,8 +1090,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             string expectedWarning = string.Format(
-                CompiledPropertyOrEventWarningFormat,
-                memberName);
+                warningFormat,
+                typeof(HotReloadFieldKindChangeFixture).FullName + "." + memberName);
             AssertHasDeclarationDriftWarning(result, expectedWarning);
         }
 
@@ -1041,18 +1113,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + string.Join("\n", warnings));
         }
 
-        private static void AssertHasNoCompiledPropertyOrEventWarning(
+        private static void AssertHasNoCompiledKindChangeWarningForMember(
             TransformWorkerClientResult result,
             string memberName)
         {
-            string unexpected = string.Format(CompiledPropertyOrEventWarningFormat, memberName);
             string[] warnings = result.Output.declarationDriftWarnings ?? Array.Empty<string>();
             foreach (string warning in warnings)
             {
-                if (warning == unexpected)
+                if (warning == null)
+                {
+                    continue;
+                }
+
+                bool isKindChange = warning.StartsWith("Compiled property '", StringComparison.Ordinal)
+                    || warning.StartsWith("Compiled event '", StringComparison.Ordinal);
+                if (isKindChange && warning.Contains(memberName, StringComparison.Ordinal))
                 {
                     Assert.Fail(
-                        "Added event must not emit the compiled property-or-event warning. Warnings="
+                        "Member '" + memberName + "' must not emit a compiled kind-change warning. Warnings="
                         + string.Join("\n", warnings));
                 }
             }
@@ -1060,15 +1138,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private static void AssertHasNoSkipContaining(
             TransformWorkerClientResult result,
-            string methodNameFragment)
+            string fragment)
         {
             foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
             {
-                if (skipped.method != null
-                    && skipped.method.Contains(methodNameFragment, StringComparison.Ordinal))
+                bool methodHit = skipped.method != null
+                    && skipped.method.Contains(fragment, StringComparison.Ordinal);
+                bool reasonHit = skipped.reason != null
+                    && skipped.reason.Contains(fragment, StringComparison.Ordinal);
+                if (methodHit || reasonHit)
                 {
                     Assert.Fail(
-                        "Added event must not produce a Skipped row. Skipped="
+                        "Fragment '" + fragment + "' must not appear in a Skipped row. Skipped="
                         + FormatSkipped(result.Output.skipped));
                 }
             }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -104,8 +104,10 @@ member is reported in `Warnings`, but its IL remains callable from unedited code
 until `uloop compile`.
 
 Adding a type (`class`, `struct`, `enum`, `record`), a property, an event, an
-indexer, a constructor, or an operator is still out of scope and reported as
-`Skipped`; land those with `uloop compile`.
+indexer, a constructor, or an operator is still out of scope. These additions
+are not reported per member — no `Skipped` row names them; at most they
+surface as outside-body drift in `Warnings`. Treat silence as "not applied"
+and land them with `uloop compile`.
 
 Outside method bodies, only member additions (previous section) take effect.
 Every other declaration edit — changing a `const` value, a compiled field's

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -762,8 +762,11 @@ public static class TransformWorkerProgram
         return Convert.ToString(value, CultureInfo.InvariantCulture);
     }
 
-    private const string CompiledPropertyOrEventKindChangeWarningFormat =
-        "Compiled property or event '{0}' was removed or redeclared as a different member kind in the edited source; the compiled member stays until 'uloop compile'.";
+    private const string CompiledPropertyKindChangeWarningFormat =
+        "Compiled property '{0}' was removed or redeclared as a different member kind in the edited source; the compiled member stays until 'uloop compile'.";
+
+    private const string CompiledEventKindChangeWarningFormat =
+        "Compiled event '{0}' was removed or redeclared as a different member kind in the edited source; the compiled member stays until 'uloop compile'.";
 
     /// <summary>
     /// What: names compiled properties and events that the edited source deleted or
@@ -784,6 +787,16 @@ public static class TransformWorkerProgram
         foreach (BaseTypeDeclarationSyntax typeDeclaration
             in root.DescendantNodes().OfType<BaseTypeDeclarationSyntax>())
         {
+            // Why syntax PartialKeyword: the worker compilation sees only this file. A
+            // compiled property or event declared in another partial file is absent from
+            // the source symbol and would look permanently removed. Locations cannot be
+            // used — metadata symbols have no source locations.
+            if (typeDeclaration is TypeDeclarationSyntax typedDeclaration
+                && typedDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword))
+            {
+                continue;
+            }
+
             INamedTypeSymbol sourceType = semanticModel.GetDeclaredSymbol(typeDeclaration);
             if (sourceType == null)
             {
@@ -814,37 +827,42 @@ public static class TransformWorkerProgram
     {
         foreach (ISymbol compiledMember in compiledType.GetMembers())
         {
-            string missingName = TryGetMissingCompiledPropertyOrEventName(compiledMember, sourceType);
-            if (missingName == null)
+            string warning = TryFormatMissingCompiledPropertyOrEventWarning(compiledMember, sourceType);
+            if (warning == null)
             {
                 continue;
             }
 
-            warnings.Add(
-                string.Format(
-                    CultureInfo.InvariantCulture,
-                    CompiledPropertyOrEventKindChangeWarningFormat,
-                    missingName));
+            warnings.Add(warning);
         }
     }
 
-    private static string TryGetMissingCompiledPropertyOrEventName(
+    private static string TryFormatMissingCompiledPropertyOrEventWarning(
         ISymbol compiledMember,
         INamedTypeSymbol sourceType)
     {
+        // Why still check IsImplicitlyDeclared: source-compiled symbols can be implicit.
+        // Metadata symbols from the PE almost always report false, so this is best-effort
+        // and does not filter compiler-generated members out of the compiled assembly.
         if (compiledMember is IPropertySymbol property
             && !property.IsIndexer
             && !property.IsImplicitlyDeclared
             && !SourceDeclaresProperty(sourceType, property.Name))
         {
-            return property.Name;
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                CompiledPropertyKindChangeWarningFormat,
+                sourceType.ToDisplayString() + "." + property.Name);
         }
 
         if (compiledMember is IEventSymbol compiledEvent
             && !compiledEvent.IsImplicitlyDeclared
             && !SourceDeclaresEvent(sourceType, compiledEvent.Name))
         {
-            return compiledEvent.Name;
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                CompiledEventKindChangeWarningFormat,
+                sourceType.ToDisplayString() + "." + compiledEvent.Name);
         }
 
         return null;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -262,6 +262,13 @@ public static class TransformWorkerProgram
             root,
             semanticModel,
             targetTypesAssemblySymbol);
+        // Why here: a compiled property/event can disappear or change kind with no
+        // touched body, so the generic outside-body warning would bury the name.
+        AppendCompiledPropertyOrEventKindChangeWarnings(
+            root,
+            semanticModel,
+            targetTypesAssemblySymbol,
+            declarationDriftWarnings);
 
         // Syntax-key maps for edited-method detection. Distinct from BuildMethodKey (Cecil names):
         // same-file old/new comparison only needs syntax keys to stay consistent with each other.
@@ -753,6 +760,120 @@ public static class TransformWorkerProgram
         }
 
         return Convert.ToString(value, CultureInfo.InvariantCulture);
+    }
+
+    private const string CompiledPropertyOrEventKindChangeWarningFormat =
+        "Compiled property or event '{0}' was removed or redeclared as a different member kind in the edited source; the compiled member stays until 'uloop compile'.";
+
+    /// <summary>
+    /// What: names compiled properties and events that the edited source deleted or
+    /// redeclared as another member kind, even when no method body changed.
+    /// </summary>
+    private static void AppendCompiledPropertyOrEventKindChangeWarnings(
+        CompilationUnitSyntax root,
+        SemanticModel semanticModel,
+        IAssemblySymbol targetTypesAssemblySymbol,
+        List<string> warnings)
+    {
+        if (targetTypesAssemblySymbol == null)
+        {
+            return;
+        }
+
+        HashSet<string> seenTypeMetadataNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (BaseTypeDeclarationSyntax typeDeclaration
+            in root.DescendantNodes().OfType<BaseTypeDeclarationSyntax>())
+        {
+            INamedTypeSymbol sourceType = semanticModel.GetDeclaredSymbol(typeDeclaration);
+            if (sourceType == null)
+            {
+                continue;
+            }
+
+            string typeMetadataName = ToReflectionMetadataName(sourceType);
+            if (!seenTypeMetadataNames.Add(typeMetadataName))
+            {
+                continue;
+            }
+
+            INamedTypeSymbol compiledType = targetTypesAssemblySymbol.GetTypeByMetadataName(
+                typeMetadataName);
+            if (compiledType == null)
+            {
+                continue;
+            }
+
+            AppendMissingCompiledPropertyOrEventWarnings(compiledType, sourceType, warnings);
+        }
+    }
+
+    private static void AppendMissingCompiledPropertyOrEventWarnings(
+        INamedTypeSymbol compiledType,
+        INamedTypeSymbol sourceType,
+        List<string> warnings)
+    {
+        foreach (ISymbol compiledMember in compiledType.GetMembers())
+        {
+            string missingName = TryGetMissingCompiledPropertyOrEventName(compiledMember, sourceType);
+            if (missingName == null)
+            {
+                continue;
+            }
+
+            warnings.Add(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    CompiledPropertyOrEventKindChangeWarningFormat,
+                    missingName));
+        }
+    }
+
+    private static string TryGetMissingCompiledPropertyOrEventName(
+        ISymbol compiledMember,
+        INamedTypeSymbol sourceType)
+    {
+        if (compiledMember is IPropertySymbol property
+            && !property.IsIndexer
+            && !property.IsImplicitlyDeclared
+            && !SourceDeclaresProperty(sourceType, property.Name))
+        {
+            return property.Name;
+        }
+
+        if (compiledMember is IEventSymbol compiledEvent
+            && !compiledEvent.IsImplicitlyDeclared
+            && !SourceDeclaresEvent(sourceType, compiledEvent.Name))
+        {
+            return compiledEvent.Name;
+        }
+
+        return null;
+    }
+
+    private static bool SourceDeclaresProperty(INamedTypeSymbol sourceType, string name)
+    {
+        foreach (ISymbol member in sourceType.GetMembers(name))
+        {
+            if (member is IPropertySymbol property && !property.IsIndexer)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool SourceDeclaresEvent(INamedTypeSymbol sourceType, string name)
+    {
+        foreach (ISymbol member in sourceType.GetMembers(name))
+        {
+            if (member is IEventSymbol)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private const string ExplicitAccessorSkipReason =


### PR DESCRIPTION
## Summary
- Hot reload now names a compiled property or event that the edited source deleted or redeclared as a different member kind, even when no method body changed.
- Added types, properties, events, indexers, constructors, and operators stay out of scope. The skill no longer claims those additions appear as per-member `Skipped` rows.

## User Impact
- Before: changing a property or event to a field, or deleting one, only showed up as a generic outside-body warning (or not at all if you did not touch a method). The compiled member kept running.
- After: `Warnings` names the member and its type. Silence on an added property or event still means it was not applied — land it with `uloop compile`.

## Changes
- Property warning (verbatim): `Compiled property '{0}' was removed or redeclared as a different member kind in the edited source; the compiled member stays until 'uloop compile'.`
- Event warning (verbatim): `Compiled event '{0}' was removed or redeclared as a different member kind in the edited source; the compiled member stays until 'uloop compile'.`
- `{0}` is the type-qualified name (`Type.Member`), same shape as const-drift.
- Emitted from the compiled assembly for both deletion and kind change, whether or not a method body was edited. Partial types are skipped so other-file declarations are not reported as removed.
- Added property/event behavior is unchanged: no new per-member `Skipped` row.
- Skill wording updated to match that silence.

## Scope
This PR does not name a compiled indexer that disappeared, a property or event that kept its kind but changed accessibility, type, or static, or a type that was deleted entirely. Those stay outside the named warning. Indexer deletion is the same failure class but was not in the reported feedback and is left for a later change.

## Verification
- `dist/darwin-arm64/uloop compile` → `Success: true`, `ErrorCount: 0`
- Review-fix tests (kind change, deletion, added property/event, partial other-file, explicit-interface, orchestrator hop) plus related asserts → Passed
- `uloop run-tests --filter-type regex --filter-value "HotReload"` → **337/337** Passed
- Repository CI does not run on pull requests targeting `feature/hot-reload`.
