### PR TITLE
fix: reduce misleading hot-reload warnings and unify method labels

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -136,7 +136,10 @@ another file — even one edited in the same run — or an *unedited* method in 
 same file (an implicit `int`→`long` widening can leave a caller's source
 untouched) would keep calling the old method silently, so the run reports the
 changed method and its edited callers as `Skipped` instead; land the change with
-`uloop compile`. When every uncovered caller is in the edited file itself, the `Skipped` reason says so: editing those callers' bodies and reloading again applies them together without `uloop compile`. Call sites inside methods that the same edit removes or
+`uloop compile`. When every uncovered caller is in the edited file itself, the
+`Skipped` reason says so: editing those callers' bodies and reloading again
+applies them together without `uloop compile`.
+Call sites inside methods that the same edit removes or
 re-signatures do not gate: those compiled bodies are already stale, and anything
 still reaching them stays on the consistent old behavior.
 

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -136,7 +136,7 @@ another file — even one edited in the same run — or an *unedited* method in 
 same file (an implicit `int`→`long` widening can leave a caller's source
 untouched) would keep calling the old method silently, so the run reports the
 changed method and its edited callers as `Skipped` instead; land the change with
-`uloop compile`. Call sites inside methods that the same edit removes or
+`uloop compile`. When every uncovered caller is in the edited file itself, the `Skipped` reason says so: editing those callers' bodies and reloading again applies them together without `uloop compile`. Call sites inside methods that the same edit removes or
 re-signatures do not gate: those compiled bodies are already stale, and anything
 still reaching them stays on the consistent old behavior.
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -136,7 +136,10 @@ another file — even one edited in the same run — or an *unedited* method in 
 same file (an implicit `int`→`long` widening can leave a caller's source
 untouched) would keep calling the old method silently, so the run reports the
 changed method and its edited callers as `Skipped` instead; land the change with
-`uloop compile`. When every uncovered caller is in the edited file itself, the `Skipped` reason says so: editing those callers' bodies and reloading again applies them together without `uloop compile`. Call sites inside methods that the same edit removes or
+`uloop compile`. When every uncovered caller is in the edited file itself, the
+`Skipped` reason says so: editing those callers' bodies and reloading again
+applies them together without `uloop compile`.
+Call sites inside methods that the same edit removes or
 re-signatures do not gate: those compiled bodies are already stale, and anything
 still reaching them stays on the consistent old behavior.
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -136,7 +136,7 @@ another file — even one edited in the same run — or an *unedited* method in 
 same file (an implicit `int`→`long` widening can leave a caller's source
 untouched) would keep calling the old method silently, so the run reports the
 changed method and its edited callers as `Skipped` instead; land the change with
-`uloop compile`. Call sites inside methods that the same edit removes or
+`uloop compile`. When every uncovered caller is in the edited file itself, the `Skipped` reason says so: editing those callers' bodies and reloading again applies them together without `uloop compile`. Call sites inside methods that the same edit removes or
 re-signatures do not gate: those compiled bodies are already stale, and anything
 still reaching them stays on the consistent old behavior.
 

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
@@ -316,6 +316,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     }
 
     /// <summary>
+    /// Nested interface host so skip labels can pin FormatMethodKeyParts for nested + generic
+    /// + multi-parameter methods.
+    /// </summary>
+    public class HotReloadMethodLabelNestedHost
+    {
+        public interface INestedGeneric
+        {
+            int GenericPing<T>(int left, string right) => 1;
+        }
+    }
+
+    /// <summary>
     /// Partial host so worker tests can prove deleted-method signatures are omitted on partials.
     /// </summary>
     public partial class HotReloadAddedMemberPartialHost

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2399,10 +2399,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CancellationToken.None);
 
             AssertNoFileLevelFailure(result);
+            string expectedExternalLabel =
+                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                + ".HotReloadSignatureChangeExternalHost.Target(System.Int32)";
+            string expectedExternalReason = string.Format(
+                HotReloadConstants.SignatureChangedGateSkipReasonFormat,
+                expectedExternalLabel);
             AssertHasSkipped(
                 result,
                 nameof(HotReloadSignatureChangeExternalHost.Target),
-                "The return type of");
+                expectedExternalReason);
+            Assert.That(
+                expectedExternalReason,
+                Does.Contain("Run 'uloop compile'."),
+                "Other-file uncovered callers keep the compile-only CTA.");
+            Assert.That(
+                expectedExternalReason,
+                Does.Not.Contain("Editing those callers' bodies in this file"),
+                "Other-file uncovered callers must not use the same-file insert.");
             AssertHasSkipped(
                 result,
                 nameof(HotReloadSignatureChangeExternalHost.SameFileCaller),
@@ -2537,7 +2551,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: an unchanged same-file caller that only needs an implicit int-to-long conversion
-        /// is not an apply entry, so the return-type change is skipped with the hot-reload wording.
+        /// is not an apply entry, so the return-type change is skipped with the same-file wording
+        /// and is not listed as a removed member.
         /// </summary>
         [Test]
         public async Task Run_ReturnTypeChange_UnchangedSameFileCaller_SkipsReplacement()
@@ -2559,12 +2574,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string expectedLabel =
                 "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
                 + ".HotReloadSignatureChangeUnchangedCallerFixture.Target(System.Int32)";
+            string expectedReason = string.Format(
+                HotReloadConstants.SignatureChangedGateSkipReasonSameFileCallersFormat,
+                expectedLabel);
             AssertHasSkipped(
                 result,
                 nameof(HotReloadSignatureChangeUnchangedCallerFixture.Target),
-                string.Format(
-                    HotReloadConstants.SignatureChangedGateSkipReasonFormat,
-                    expectedLabel));
+                expectedReason);
+            Assert.That(
+                expectedReason,
+                Does.Contain(
+                    "Editing those callers' bodies in this file and reloading again applies them together, or run 'uloop compile'."));
+            Assert.That(
+                CountWarningsContaining(result.Warnings, "Removed members stay present"),
+                Is.EqualTo(0),
+                "A gated (not applied) replacement must not appear as a removed member.\n"
+                + string.Join("\n", result.Warnings));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2405,16 +2405,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string expectedExternalReason = string.Format(
                 HotReloadConstants.SignatureChangedGateSkipReasonFormat,
                 expectedExternalLabel);
-            AssertHasSkipped(
+            string actualExternalReason = FindSkippedReason(
                 result,
-                nameof(HotReloadSignatureChangeExternalHost.Target),
-                expectedExternalReason);
+                nameof(HotReloadSignatureChangeExternalHost.Target));
+            Assert.That(actualExternalReason, Is.EqualTo(expectedExternalReason));
             Assert.That(
-                expectedExternalReason,
+                actualExternalReason,
                 Does.Contain("Run 'uloop compile'."),
                 "Other-file uncovered callers keep the compile-only CTA.");
             Assert.That(
-                expectedExternalReason,
+                actualExternalReason,
                 Does.Not.Contain("Editing those callers' bodies in this file"),
                 "Other-file uncovered callers must not use the same-file insert.");
             AssertHasSkipped(
@@ -2577,12 +2577,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string expectedReason = string.Format(
                 HotReloadConstants.SignatureChangedGateSkipReasonSameFileCallersFormat,
                 expectedLabel);
-            AssertHasSkipped(
+            string actualReason = FindSkippedReason(
                 result,
-                nameof(HotReloadSignatureChangeUnchangedCallerFixture.Target),
-                expectedReason);
+                nameof(HotReloadSignatureChangeUnchangedCallerFixture.Target));
+            Assert.That(actualReason, Is.EqualTo(expectedReason));
             Assert.That(
-                expectedReason,
+                actualReason,
                 Does.Contain(
                     "Editing those callers' bodies in this file and reloading again applies them together, or run 'uloop compile'."));
             Assert.That(
@@ -2590,6 +2590,70 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.EqualTo(0),
                 "A gated (not applied) replacement must not appear as a removed member.\n"
                 + string.Join("\n", result.Warnings));
+        }
+
+        /// <summary>
+        /// What: an uncovered caller on the same type whose method key is absent from the
+        /// edited file (other partial file, ctor, or unhandled member) is not same-file.
+        /// </summary>
+        [Test]
+        public void AreUncoveredCallersInEditedFile_SameTypeOtherPartialMethod_ReturnsFalse()
+        {
+            TransformWorkerEntryDto replacement = CreateReplacementEntry("Host", "Target");
+            bool sameFile = HotReloadOrchestrator.AreUncoveredCallersInEditedFile(
+                new[] { "Host::OtherFileCaller(System.Int32)" },
+                new[] { replacement },
+                Array.Empty<TransformWorkerUnchangedMethodDto>());
+
+            Assert.That(sameFile, Is.False);
+        }
+
+        /// <summary>
+        /// What: a gated same-name replacement does not suppress the removed-members warning
+        /// for a deleted Target on another type in the same file.
+        /// </summary>
+        [Test]
+        public async Task Run_ReturnTypeChange_SameNameDeletedOnOtherType_KeepsRemovedMembersWarning()
+        {
+            string fixturePath = ResolveSignatureChangeSameNameHostsPath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = onDisk.Replace(
+                "        public int Target(int value)\n        {\n            return value;\n        }\n\n"
+                + "        [MethodImpl(MethodImplOptions.NoInlining)]\n"
+                + "        public long Store",
+                "        public long Target(int value)\n        {\n            return value + 1L;\n        }\n\n"
+                + "        [MethodImpl(MethodImplOptions.NoInlining)]\n"
+                + "        public long Store",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                "    public class HotReloadSignatureChangeSameNameDeletedHost\n    {\n"
+                + "        [MethodImpl(MethodImplOptions.NoInlining)]\n"
+                + "        public int Target(int value)\n        {\n            return value;\n        }\n    }",
+                "    public class HotReloadSignatureChangeSameNameDeletedHost\n    {\n    }",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            Assert.That(edited, Does.Contain("HotReloadSignatureChangeSameNameDeletedHost"));
+            Assert.That(edited, Does.Not.Contain("return value;\n        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeSameNameDeleted.cs", edited),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasSkipped(
+                result,
+                nameof(HotReloadSignatureChangeSameNameGatedHost.Target),
+                "The return type of");
+            Assert.That(
+                CountWarningsContaining(result.Warnings, "Removed members stay present"),
+                Is.EqualTo(1),
+                "A same-name deletion on another type must still warn.\n"
+                + string.Join("\n", result.Warnings));
+            Assert.That(
+                result.Warnings,
+                Has.Some.Contain("Target"),
+                "The deleted same-name method must remain in the removed-members warning.");
         }
 
         /// <summary>
@@ -3304,6 +3368,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
         }
 
+        private static string FindSkippedReason(HotReloadOrchestratorResult result, string methodName)
+        {
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Skipped
+                    && outcome.Method.Contains(methodName)
+                    && outcome.Reason != null)
+                {
+                    return outcome.Reason;
+                }
+            }
+
+            Assert.Fail("Expected a Skipped outcome for " + methodName + ".\n" + FormatOutcomes(result));
+            return null;
+        }
+
         private static void AssertHasSkipped(
             HotReloadOrchestratorResult result,
             string methodName,
@@ -3438,6 +3518,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 File.Exists(path),
                 Is.True,
                 "Signature-change unchanged-caller fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string ResolveSignatureChangeSameNameHostsPath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadSignatureChangeSameNameHosts.cs");
+            Assert.That(
+                File.Exists(path),
+                Is.True,
+                "Signature-change same-name hosts source missing: " + path);
             return Path.GetFullPath(path);
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeSameNameHosts.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeSameNameHosts.cs
@@ -1,0 +1,35 @@
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled host whose Target return-type change is gated by an unchanged same-file caller.
+    /// </summary>
+    public class HotReloadSignatureChangeSameNameGatedHost
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Target(int value)
+        {
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public long Store(int value)
+        {
+            return Target(value);
+        }
+    }
+
+    /// <summary>
+    /// Same-file sibling type that also declares Target, so a deletion of this method
+    /// must not be suppressed when the gated replacement shares the simple name.
+    /// </summary>
+    public class HotReloadSignatureChangeSameNameDeletedHost
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Target(int value)
+        {
+            return value;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeSameNameHosts.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeSameNameHosts.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 10201a76709b145c68d186cd9f0ac97a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -409,6 +409,72 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a snapshot plus a return-type-only change does not fire the outside-body warning
+        /// because the replacement declaration is stripped from both trees.
+        /// </summary>
+        [Test]
+        public async Task Drift_ReturnTypeOnlyChange_WithSnapshot_DoesNotFireOutsideBodyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithExistingValueReturnTypeChange(onDisk);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("DriftReturnTypeOnlySnapshot.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.None.Contain("Edits outside method bodies"),
+                "Handled return-type change must not fire outside-body drift.\n"
+                + string.Join("\n", result.Output.declarationDriftWarnings ?? Array.Empty<string>()));
+        }
+
+        /// <summary>
+        /// What: the same return-type-only change without a verified snapshot never emits the
+        /// outside-body warning (comparison runs only when a baseline snapshot exists).
+        /// </summary>
+        [Test]
+        public async Task Drift_ReturnTypeOnlyChange_WithoutSnapshot_DoesNotFireOutsideBodyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithExistingValueReturnTypeChange(onDisk);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("DriftReturnTypeOnlyNoSnapshot.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: null);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.None.Contain("Edits outside method bodies"),
+                "No-snapshot return-type change must not fire outside-body drift.\n"
+                + string.Join("\n", result.Output.declarationDriftWarnings ?? Array.Empty<string>()));
+        }
+
+        /// <summary>
+        /// What: a snapshot plus a return-type change and a field-initializer edit still fires
+        /// the outside-body warning for the unhandled field drift.
+        /// </summary>
+        [Test]
+        public async Task Drift_ReturnTypeAndFieldInitializer_WithSnapshot_FiresOutsideBodyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithExistingValueReturnTypeChange(onDisk).Replace(
+                "public int PublicSeed = 3;",
+                "public int PublicSeed = 4;",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("DriftReturnTypeAndField.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.Some.Contain("Edits outside method bodies"),
+                "Field initializer drift must still fire after a handled return-type change is stripped.");
+        }
+
+        /// <summary>
         /// What: excluding an added method key still emits that added method so remaining callers
         /// can compile on isolation retry (G1).
         /// </summary>
@@ -922,6 +988,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             AssertHasSkip(result, "ExistingDefault", "Interface members are not patchable");
             Assert.That(FindEntry(result, "ExistingDefault"), Is.Null);
+            string expectedLabel = HotReloadPatcher.FormatMethodKeyParts(
+                typeof(IHotReloadAddedMemberDefault).FullName,
+                "ExistingDefault",
+                Array.Empty<string>(),
+                genericArity: 0);
+            Assert.That(
+                FindSkipMethod(result, "ExistingDefault"),
+                Is.EqualTo(expectedLabel),
+                "Skipped Methods[].Method must use the FormatMethodKeyParts label.");
         }
 
         /// <summary>
@@ -1304,6 +1379,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
         }
 
+        private static string WithExistingValueReturnTypeChange(string onDisk)
+        {
+            string edited = onDisk.Replace(
+                "        public int ExistingValue()\n        {\n            return 1;\n        }",
+                "        public long ExistingValue()\n        {\n            return 1L;\n        }",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            return edited;
+        }
+
         private static string WithHostMembers(string onDisk, string extraMembers)
         {
             Assert.That(onDisk, Does.Contain(HostCloseMarker));
@@ -1412,6 +1497,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Expected skip for '" + methodNameFragment + "' with reason containing '"
                 + reasonFragment + "'. Skipped="
                 + FormatSkipped(result.Output.skipped));
+        }
+
+        private static string FindSkipMethod(
+            TransformWorkerClientResult result,
+            string methodNameFragment)
+        {
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                if (skipped.method != null && skipped.method.Contains(methodNameFragment))
+                {
+                    return skipped.method;
+                }
+            }
+
+            return null;
         }
 
         private static string FindSkipReason(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -475,6 +475,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a return-type change plus an attribute on the same declaration still fires
+        /// the outside-body warning (the remaining declaration diff is not stripped).
+        /// </summary>
+        [Test]
+        public async Task Drift_ReturnTypeAndAttribute_WithSnapshot_FiresOutsideBodyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithExistingValueReturnTypeChange(onDisk).Replace(
+                "        public long ExistingValue()",
+                "        [System.Obsolete]\n        public long ExistingValue()",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("DriftReturnTypeAndAttribute.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.Some.Contain("Edits outside method bodies"),
+                "Attribute drift must still fire after a handled return-type change.");
+        }
+
+        /// <summary>
         /// What: excluding an added method key still emits that added method so remaining callers
         /// can compile on isolation retry (G1).
         /// </summary>
@@ -997,6 +1021,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 FindSkipMethod(result, "ExistingDefault"),
                 Is.EqualTo(expectedLabel),
                 "Skipped Methods[].Method must use the FormatMethodKeyParts label.");
+        }
+
+        /// <summary>
+        /// What: a worker skip on a nested generic multi-parameter method uses the same
+        /// Methods[].Method label as FormatMethodKeyParts.
+        /// </summary>
+        [Test]
+        public async Task Skip_NestedGenericMultiArg_UsesFormatMethodKeyPartsLabel()
+        {
+            const string projectRelativePath =
+                "Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs";
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "            int GenericPing<T>(int left, string right) => 1;",
+                "            int GenericPing<T>(int left, string right) => 2;",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("SkipNestedGenericLabel.cs", edited),
+                projectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            string expectedLabel = HotReloadPatcher.FormatMethodKeyParts(
+                typeof(HotReloadMethodLabelNestedHost.INestedGeneric).FullName,
+                "GenericPing",
+                new[] { "System.Int32", "System.String" },
+                genericArity: 1);
+            Assert.That(
+                FindSkipMethod(result, "GenericPing"),
+                Is.EqualTo(expectedLabel),
+                "Nested generic multi-arg skip labels must match FormatMethodKeyParts.");
+            AssertHasSkip(result, "GenericPing", "Interface members are not patchable");
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -72,6 +72,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string SignatureChangedGateSkipReasonFormat =
             "The return type of '{0}' changed, but this hot reload does not patch every compiled call site of the old method. Applying it would leave those call sites on the old version. Run 'uloop compile'.";
 
+        // Why drop the original trailing "Run 'uloop compile'.": the inserted sentence already
+        // ends with that CTA, and keeping both would duplicate it.
+        public const string SignatureChangedGateSkipReasonSameFileCallersFormat =
+            "The return type of '{0}' changed, but this hot reload does not patch every compiled call site of the old method. Applying it would leave those call sites on the old version. Editing those callers' bodies in this file and reloading again applies them together, or run 'uloop compile'.";
+
         public const string SignatureChangedGatedCallerSkipReason =
             "Calls a method whose signature change was not applied because unpatched compiled call sites remain; this caller was left unpatched too. Run 'uloop compile'.";
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -240,11 +240,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
             }
 
-            if (workerOutput.removedMembers != null && workerOutput.removedMembers.Length > 0)
-            {
-                warnings.Add(FormatRemovedMembersWarning(workerOutput.removedMembers));
-            }
-
             TransformWorkerUnchangedMethodDto[] unchangedMethods =
                 workerOutput.unchangedMethods ?? Array.Empty<TransformWorkerUnchangedMethodDto>();
             int unchangedMethodCount = unchangedMethods.Length;
@@ -264,6 +259,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 defines,
                 assemblyResolvePath,
                 ct).ConfigureAwait(false);
+            // Why after the gate: a gated replacement is not applied, so listing it under
+            // "Removed members stay present... edited bodies no longer call them" is false.
+            string removedMembersWarning = FormatRemovedMembersWarning(
+                workerOutput.removedMembers,
+                gateResult.GatedReplacementMethodNames);
+            if (removedMembersWarning != null)
+            {
+                warnings.Add(removedMembersWarning);
+            }
+
             if (gateResult.FileFailed)
             {
                 // Why not apply first-pass entries: a gate retry null means the replacement was
@@ -947,8 +952,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return false;
         }
 
-        private static string FormatRemovedMembersWarning(TransformWorkerRemovedMemberDto[] removedMembers)
+        private static string FormatRemovedMembersWarning(
+            TransformWorkerRemovedMemberDto[] removedMembers,
+            IReadOnlyCollection<string> gatedReplacementMethodNames)
         {
+            if (removedMembers == null || removedMembers.Length == 0)
+            {
+                return null;
+            }
+
+            HashSet<string> gatedNames = new HashSet<string>(
+                gatedReplacementMethodNames ?? Array.Empty<string>(),
+                StringComparer.Ordinal);
             List<string> names = new List<string>();
             HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
             foreach (TransformWorkerRemovedMemberDto removed in removedMembers)
@@ -958,7 +973,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
+                if (removed.kind == HotReloadConstants.RemovedMemberKindMethod
+                    && gatedNames.Contains(removed.name))
+                {
+                    continue;
+                }
+
                 names.Add(removed.name);
+            }
+
+            if (names.Count == 0)
+            {
+                return null;
             }
 
             return string.Format(
@@ -1431,8 +1457,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             IsolationExclusions exclusions = BuildIsolationExclusions(gatedReplacements, entries);
+            HashSet<string> editedFileTypeMetadataNames = CollectEditedFileTypeMetadataNames(
+                entries,
+                workerOutput.unchangedMethods ?? Array.Empty<TransformWorkerUnchangedMethodDto>());
             List<HotReloadMethodOutcome> skippedOutcomes = BuildGatedReplacementSkipOutcomes(
                 gatedReplacements,
+                uncoveredCallersByTarget,
+                hits,
+                editedFileTypeMetadataNames,
                 assemblyResolvePath);
             skippedOutcomes.AddRange(
                 BuildSkippedCallerOutcomes(
@@ -1449,17 +1481,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 targetDllPath,
                 defines,
                 ct).ConfigureAwait(false);
+            List<string> gatedReplacementMethodNames =
+                CollectGatedReplacementMethodNames(gatedReplacements);
             if (retry.Isolation == null)
             {
-                return SignatureChangeGateResult.Failed(retry.FailureMessage);
+                return SignatureChangeGateResult.Failed(retry.FailureMessage)
+                    .WithGatedReplacementMethodNames(gatedReplacementMethodNames);
             }
 
             return SignatureChangeGateResult.Retried(
-                retry.Isolation,
-                skippedOutcomes,
-                staleWarnings,
-                hits,
-                CollectScanTargetKeys(targets));
+                    retry.Isolation,
+                    skippedOutcomes,
+                    staleWarnings,
+                    hits,
+                    CollectScanTargetKeys(targets))
+                .WithGatedReplacementMethodNames(gatedReplacementMethodNames);
         }
 
         private static List<TransformWorkerEntryDto> CollectReplacementEntries(
@@ -1704,8 +1740,91 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return gated;
         }
 
+        private static List<string> CollectGatedReplacementMethodNames(
+            IReadOnlyList<TransformWorkerEntryDto> gatedReplacements)
+        {
+            List<string> names = new List<string>();
+            HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (TransformWorkerEntryDto entry in gatedReplacements)
+            {
+                if (entry == null || string.IsNullOrEmpty(entry.methodName) || !seen.Add(entry.methodName))
+                {
+                    continue;
+                }
+
+                names.Add(entry.methodName);
+            }
+
+            return names;
+        }
+
+        private static HashSet<string> CollectEditedFileTypeMetadataNames(
+            TransformWorkerEntryDto[] entries,
+            TransformWorkerUnchangedMethodDto[] unchangedMethods)
+        {
+            HashSet<string> typeNames = new HashSet<string>(StringComparer.Ordinal);
+            foreach (TransformWorkerEntryDto entry in entries)
+            {
+                if (!string.IsNullOrEmpty(entry.typeMetadataName))
+                {
+                    typeNames.Add(entry.typeMetadataName.Replace('/', '+'));
+                }
+            }
+
+            foreach (TransformWorkerUnchangedMethodDto unchanged in unchangedMethods)
+            {
+                if (!string.IsNullOrEmpty(unchanged.typeMetadataName))
+                {
+                    typeNames.Add(unchanged.typeMetadataName.Replace('/', '+'));
+                }
+            }
+
+            return typeNames;
+        }
+
+        private static bool AreAllUncoveredCallersInEditedFile(
+            string targetMethodKey,
+            IReadOnlyList<string> uncoveredCallerKeys,
+            IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits,
+            HashSet<string> editedFileTypeMetadataNames)
+        {
+            if (uncoveredCallerKeys == null || uncoveredCallerKeys.Count == 0)
+            {
+                return false;
+            }
+
+            foreach (string callerKey in uncoveredCallerKeys)
+            {
+                bool foundHit = false;
+                foreach (HotReloadCallSiteScanner.CallSiteHit hit in hits)
+                {
+                    if (hit.TargetMethodKey != targetMethodKey || hit.CallerMethodKey != callerKey)
+                    {
+                        continue;
+                    }
+
+                    foundHit = true;
+                    string callerType = (hit.CallerTypeMetadataName ?? string.Empty).Replace('/', '+');
+                    if (!editedFileTypeMetadataNames.Contains(callerType))
+                    {
+                        return false;
+                    }
+                }
+
+                if (!foundHit)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         private static List<HotReloadMethodOutcome> BuildGatedReplacementSkipOutcomes(
             IReadOnlyList<TransformWorkerEntryDto> gatedReplacements,
+            Dictionary<string, List<string>> uncoveredCallersByTarget,
+            IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits,
+            HashSet<string> editedFileTypeMetadataNames,
             string assemblyResolvePath)
         {
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
@@ -1716,12 +1835,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     entry.methodName,
                     entry.parameterTypeFullNames ?? Array.Empty<string>(),
                     entry.genericArity);
+                string methodKey = BuildMethodKey(entry);
+                string reasonFormat = HotReloadConstants.SignatureChangedGateSkipReasonFormat;
+                if (uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> uncoveredCallers)
+                    && AreAllUncoveredCallersInEditedFile(
+                        methodKey,
+                        uncoveredCallers,
+                        hits,
+                        editedFileTypeMetadataNames))
+                {
+                    reasonFormat = HotReloadConstants.SignatureChangedGateSkipReasonSameFileCallersFormat;
+                }
+
                 outcomes.Add(
                     HotReloadMethodOutcome.Skipped(
                         methodLabel,
-                        string.Format(
-                            HotReloadConstants.SignatureChangedGateSkipReasonFormat,
-                            methodLabel),
+                        string.Format(reasonFormat, methodLabel),
                         assemblyResolvePath));
             }
 
@@ -1867,6 +1996,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public List<string> Warnings { get; }
             public List<HotReloadCallSiteScanner.CallSiteHit> Hits { get; }
             public List<string> ScanTargetKeys { get; }
+            public List<string> GatedReplacementMethodNames { get; private set; }
 
             private SignatureChangeGateResult(
                 bool fileFailed,
@@ -1888,6 +2018,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Warnings = warnings ?? new List<string>();
                 Hits = hits ?? new List<HotReloadCallSiteScanner.CallSiteHit>();
                 ScanTargetKeys = scanTargetKeys ?? new List<string>();
+                GatedReplacementMethodNames = new List<string>();
+            }
+
+            public SignatureChangeGateResult WithGatedReplacementMethodNames(List<string> names)
+            {
+                GatedReplacementMethodNames = names ?? new List<string>();
+                return this;
             }
 
             public static SignatureChangeGateResult NoWork()

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -263,7 +263,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // "Removed members stay present... edited bodies no longer call them" is false.
             string removedMembersWarning = FormatRemovedMembersWarning(
                 workerOutput.removedMembers,
-                gateResult.GatedReplacementMethodNames);
+                workerOutput.removedMethodSignatures,
+                gateResult.GatedReplacementMethodKeys);
             if (removedMembersWarning != null)
             {
                 warnings.Add(removedMembersWarning);
@@ -954,15 +955,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static string FormatRemovedMembersWarning(
             TransformWorkerRemovedMemberDto[] removedMembers,
-            IReadOnlyCollection<string> gatedReplacementMethodNames)
+            TransformWorkerRemovedMethodSignatureDto[] removedMethodSignatures,
+            IReadOnlyCollection<string> gatedReplacementMethodKeys)
         {
             if (removedMembers == null || removedMembers.Length == 0)
             {
                 return null;
             }
 
-            HashSet<string> gatedNames = new HashSet<string>(
-                gatedReplacementMethodNames ?? Array.Empty<string>(),
+            HashSet<string> gatedKeys = new HashSet<string>(
+                gatedReplacementMethodKeys ?? Array.Empty<string>(),
                 StringComparer.Ordinal);
             List<string> names = new List<string>();
             HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
@@ -974,7 +976,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 if (removed.kind == HotReloadConstants.RemovedMemberKindMethod
-                    && gatedNames.Contains(removed.name))
+                    && ShouldSuppressGatedRemovedMethodName(
+                        removed.name,
+                        removedMethodSignatures,
+                        gatedKeys))
                 {
                     continue;
                 }
@@ -990,6 +995,42 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return string.Format(
                 HotReloadConstants.RemovedMembersWarningFormat,
                 string.Join(", ", names));
+        }
+
+        // Why signature keys, not simple names: a gated replacement and a real deletion can
+        // share a method name across types in the same file. Name-only suppression would
+        // drop the deletion warning (fail-open).
+        private static bool ShouldSuppressGatedRemovedMethodName(
+            string methodName,
+            TransformWorkerRemovedMethodSignatureDto[] removedMethodSignatures,
+            HashSet<string> gatedReplacementMethodKeys)
+        {
+            if (removedMethodSignatures == null)
+            {
+                return false;
+            }
+
+            bool sawSignature = false;
+            foreach (TransformWorkerRemovedMethodSignatureDto signature in removedMethodSignatures)
+            {
+                if (signature == null || signature.methodName != methodName)
+                {
+                    continue;
+                }
+
+                sawSignature = true;
+                string signatureKey = BuildMethodKeyParts(
+                    signature.typeMetadataName,
+                    signature.methodName,
+                    signature.parameterTypeFullNames,
+                    signature.genericArity);
+                if (!gatedReplacementMethodKeys.Contains(signatureKey))
+                {
+                    return false;
+                }
+            }
+
+            return sawSignature;
         }
 
         // Keep in sync with TransformWorkerProgram.BuildMethodKey (out-of-process worker side)
@@ -1457,14 +1498,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             IsolationExclusions exclusions = BuildIsolationExclusions(gatedReplacements, entries);
-            HashSet<string> editedFileTypeMetadataNames = CollectEditedFileTypeMetadataNames(
+            HashSet<string> editedFileMethodKeys = CollectEditedFileMethodKeys(
                 entries,
                 workerOutput.unchangedMethods ?? Array.Empty<TransformWorkerUnchangedMethodDto>());
             List<HotReloadMethodOutcome> skippedOutcomes = BuildGatedReplacementSkipOutcomes(
                 gatedReplacements,
                 uncoveredCallersByTarget,
-                hits,
-                editedFileTypeMetadataNames,
+                editedFileMethodKeys,
                 assemblyResolvePath);
             skippedOutcomes.AddRange(
                 BuildSkippedCallerOutcomes(
@@ -1481,21 +1521,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 targetDllPath,
                 defines,
                 ct).ConfigureAwait(false);
-            List<string> gatedReplacementMethodNames =
-                CollectGatedReplacementMethodNames(gatedReplacements);
+            List<string> gatedReplacementMethodKeys =
+                CollectGatedReplacementMethodKeys(gatedReplacements);
             if (retry.Isolation == null)
             {
-                return SignatureChangeGateResult.Failed(retry.FailureMessage)
-                    .WithGatedReplacementMethodNames(gatedReplacementMethodNames);
+                return SignatureChangeGateResult.Failed(
+                    retry.FailureMessage,
+                    gatedReplacementMethodKeys);
             }
 
             return SignatureChangeGateResult.Retried(
-                    retry.Isolation,
-                    skippedOutcomes,
-                    staleWarnings,
-                    hits,
-                    CollectScanTargetKeys(targets))
-                .WithGatedReplacementMethodNames(gatedReplacementMethodNames);
+                retry.Isolation,
+                skippedOutcomes,
+                staleWarnings,
+                hits,
+                CollectScanTargetKeys(targets),
+                gatedReplacementMethodKeys);
         }
 
         private static List<TransformWorkerEntryDto> CollectReplacementEntries(
@@ -1661,6 +1702,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
+        /// True when every uncovered caller key is an apply entry or unchanged method in the
+        /// edited file. A same-type caller that the worker did not see (other partial file,
+        /// ctor, or another assembly) must return false so the compile-only wording is used.
+        /// </summary>
+        internal static bool AreUncoveredCallersInEditedFile(
+            IReadOnlyList<string> uncoveredCallerKeys,
+            TransformWorkerEntryDto[] entries,
+            TransformWorkerUnchangedMethodDto[] unchangedMethods)
+        {
+            Debug.Assert(uncoveredCallerKeys != null, "uncoveredCallerKeys must not be null.");
+            Debug.Assert(entries != null, "entries must not be null.");
+            Debug.Assert(unchangedMethods != null, "unchangedMethods must not be null.");
+
+            return AreAllUncoveredCallersInEditedFile(
+                uncoveredCallerKeys,
+                CollectEditedFileMethodKeys(entries, unchangedMethods));
+        }
+
+        /// <summary>
         /// Rechecks scan hits against the final apply set. Returns replacement keys that would
         /// still have uncovered compiled callers after isolation or a gate retry shrank entries.
         /// </summary>
@@ -1740,78 +1800,55 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return gated;
         }
 
-        private static List<string> CollectGatedReplacementMethodNames(
+        private static List<string> CollectGatedReplacementMethodKeys(
             IReadOnlyList<TransformWorkerEntryDto> gatedReplacements)
         {
-            List<string> names = new List<string>();
+            List<string> keys = new List<string>();
             HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
             foreach (TransformWorkerEntryDto entry in gatedReplacements)
             {
-                if (entry == null || string.IsNullOrEmpty(entry.methodName) || !seen.Add(entry.methodName))
+                string methodKey = BuildMethodKey(entry);
+                if (!seen.Add(methodKey))
                 {
                     continue;
                 }
 
-                names.Add(entry.methodName);
+                keys.Add(methodKey);
             }
 
-            return names;
+            return keys;
         }
 
-        private static HashSet<string> CollectEditedFileTypeMetadataNames(
+        private static HashSet<string> CollectEditedFileMethodKeys(
             TransformWorkerEntryDto[] entries,
             TransformWorkerUnchangedMethodDto[] unchangedMethods)
         {
-            HashSet<string> typeNames = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<string> methodKeys = new HashSet<string>(StringComparer.Ordinal);
             foreach (TransformWorkerEntryDto entry in entries)
             {
-                if (!string.IsNullOrEmpty(entry.typeMetadataName))
-                {
-                    typeNames.Add(entry.typeMetadataName.Replace('/', '+'));
-                }
+                methodKeys.Add(BuildMethodKey(entry));
             }
 
             foreach (TransformWorkerUnchangedMethodDto unchanged in unchangedMethods)
             {
-                if (!string.IsNullOrEmpty(unchanged.typeMetadataName))
-                {
-                    typeNames.Add(unchanged.typeMetadataName.Replace('/', '+'));
-                }
+                methodKeys.Add(
+                    BuildMethodKeyParts(
+                        unchanged.typeMetadataName,
+                        unchanged.methodName,
+                        unchanged.parameterTypeFullNames,
+                        unchanged.genericArity));
             }
 
-            return typeNames;
+            return methodKeys;
         }
 
         private static bool AreAllUncoveredCallersInEditedFile(
-            string targetMethodKey,
             IReadOnlyList<string> uncoveredCallerKeys,
-            IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits,
-            HashSet<string> editedFileTypeMetadataNames)
+            HashSet<string> editedFileMethodKeys)
         {
-            if (uncoveredCallerKeys == null || uncoveredCallerKeys.Count == 0)
-            {
-                return false;
-            }
-
             foreach (string callerKey in uncoveredCallerKeys)
             {
-                bool foundHit = false;
-                foreach (HotReloadCallSiteScanner.CallSiteHit hit in hits)
-                {
-                    if (hit.TargetMethodKey != targetMethodKey || hit.CallerMethodKey != callerKey)
-                    {
-                        continue;
-                    }
-
-                    foundHit = true;
-                    string callerType = (hit.CallerTypeMetadataName ?? string.Empty).Replace('/', '+');
-                    if (!editedFileTypeMetadataNames.Contains(callerType))
-                    {
-                        return false;
-                    }
-                }
-
-                if (!foundHit)
+                if (!editedFileMethodKeys.Contains(callerKey))
                 {
                     return false;
                 }
@@ -1823,8 +1860,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static List<HotReloadMethodOutcome> BuildGatedReplacementSkipOutcomes(
             IReadOnlyList<TransformWorkerEntryDto> gatedReplacements,
             Dictionary<string, List<string>> uncoveredCallersByTarget,
-            IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits,
-            HashSet<string> editedFileTypeMetadataNames,
+            HashSet<string> editedFileMethodKeys,
             string assemblyResolvePath)
         {
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
@@ -1838,11 +1874,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 string methodKey = BuildMethodKey(entry);
                 string reasonFormat = HotReloadConstants.SignatureChangedGateSkipReasonFormat;
                 if (uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> uncoveredCallers)
-                    && AreAllUncoveredCallersInEditedFile(
-                        methodKey,
-                        uncoveredCallers,
-                        hits,
-                        editedFileTypeMetadataNames))
+                    && AreAllUncoveredCallersInEditedFile(uncoveredCallers, editedFileMethodKeys))
                 {
                     reasonFormat = HotReloadConstants.SignatureChangedGateSkipReasonSameFileCallersFormat;
                 }
@@ -1996,7 +2028,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public List<string> Warnings { get; }
             public List<HotReloadCallSiteScanner.CallSiteHit> Hits { get; }
             public List<string> ScanTargetKeys { get; }
-            public List<string> GatedReplacementMethodNames { get; private set; }
+            public List<string> GatedReplacementMethodKeys { get; }
 
             private SignatureChangeGateResult(
                 bool fileFailed,
@@ -2007,7 +2039,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 List<HotReloadMethodOutcome> skippedOutcomes,
                 List<string> warnings,
                 List<HotReloadCallSiteScanner.CallSiteHit> hits,
-                List<string> scanTargetKeys)
+                List<string> scanTargetKeys,
+                List<string> gatedReplacementMethodKeys)
             {
                 FileFailed = fileFailed;
                 FailureMessage = failureMessage;
@@ -2018,19 +2051,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Warnings = warnings ?? new List<string>();
                 Hits = hits ?? new List<HotReloadCallSiteScanner.CallSiteHit>();
                 ScanTargetKeys = scanTargetKeys ?? new List<string>();
-                GatedReplacementMethodNames = new List<string>();
-            }
-
-            public SignatureChangeGateResult WithGatedReplacementMethodNames(List<string> names)
-            {
-                GatedReplacementMethodNames = names ?? new List<string>();
-                return this;
+                GatedReplacementMethodKeys = gatedReplacementMethodKeys ?? new List<string>();
             }
 
             public static SignatureChangeGateResult NoWork()
             {
                 return new SignatureChangeGateResult(
-                    false, null, false, false, null, null, null, null, null);
+                    false, null, false, false, null, null, null, null, null, null);
             }
 
             public static SignatureChangeGateResult WarningsOnly(
@@ -2039,13 +2066,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 List<string> scanTargetKeys)
             {
                 return new SignatureChangeGateResult(
-                    false, null, false, true, null, null, warnings, hits, scanTargetKeys);
+                    false, null, false, true, null, null, warnings, hits, scanTargetKeys, null);
             }
 
-            public static SignatureChangeGateResult Failed(string failureMessage)
+            public static SignatureChangeGateResult Failed(
+                string failureMessage,
+                List<string> gatedReplacementMethodKeys)
             {
                 return new SignatureChangeGateResult(
-                    true, failureMessage, false, false, null, null, null, null, null);
+                    true,
+                    failureMessage,
+                    false,
+                    false,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    gatedReplacementMethodKeys);
             }
 
             public static SignatureChangeGateResult Retried(
@@ -2053,7 +2091,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 List<HotReloadMethodOutcome> skippedOutcomes,
                 List<string> warnings,
                 List<HotReloadCallSiteScanner.CallSiteHit> hits,
-                List<string> scanTargetKeys)
+                List<string> scanTargetKeys,
+                List<string> gatedReplacementMethodKeys)
             {
                 return new SignatureChangeGateResult(
                     false,
@@ -2064,7 +2103,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     skippedOutcomes,
                     warnings,
                     hits,
-                    scanTargetKeys);
+                    scanTargetKeys,
+                    gatedReplacementMethodKeys);
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -136,7 +136,10 @@ another file — even one edited in the same run — or an *unedited* method in 
 same file (an implicit `int`→`long` widening can leave a caller's source
 untouched) would keep calling the old method silently, so the run reports the
 changed method and its edited callers as `Skipped` instead; land the change with
-`uloop compile`. When every uncovered caller is in the edited file itself, the `Skipped` reason says so: editing those callers' bodies and reloading again applies them together without `uloop compile`. Call sites inside methods that the same edit removes or
+`uloop compile`. When every uncovered caller is in the edited file itself, the
+`Skipped` reason says so: editing those callers' bodies and reloading again
+applies them together without `uloop compile`.
+Call sites inside methods that the same edit removes or
 re-signatures do not gate: those compiled bodies are already stale, and anything
 still reaching them stays on the consistent old behavior.
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -136,7 +136,7 @@ another file — even one edited in the same run — or an *unedited* method in 
 same file (an implicit `int`→`long` widening can leave a caller's source
 untouched) would keep calling the old method silently, so the run reports the
 changed method and its edited callers as `Skipped` instead; land the change with
-`uloop compile`. Call sites inside methods that the same edit removes or
+`uloop compile`. When every uncovered caller is in the edited file itself, the `Skipped` reason says so: editing those callers' bodies and reloading again applies them together without `uloop compile`. Call sites inside methods that the same edit removes or
 re-signatures do not gate: those compiled bodies are already stale, and anything
 still reaching them stays on the consistent old behavior.
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -2466,8 +2466,10 @@ public static class TransformWorkerProgram
                 addedMethodCatalog.MarkClassifiedAdded(methodKey);
                 if (input.ExcludedAddedMethodKeys.Contains(methodKey))
                 {
-                    addedMethodCatalog.AddAddedSyntaxKey(
-                        BuildSyntaxMethodKey(typeState.TypeMetadataNameFromSyntax, methodDeclaration));
+                    RecordHandledAddedMethodSyntaxKey(
+                        addedMethodCatalog,
+                        BuildSyntaxMethodKey(typeState.TypeMetadataNameFromSyntax, methodDeclaration),
+                        replacesCompiledMethod);
                     continue;
                 }
             }
@@ -2498,7 +2500,10 @@ public static class TransformWorkerProgram
                 });
                 if (isAddedMethod)
                 {
-                    addedMethodCatalog.AddAddedSyntaxKey(syntaxMethodKey);
+                    RecordHandledAddedMethodSyntaxKey(
+                        addedMethodCatalog,
+                        syntaxMethodKey,
+                        replacesCompiledMethod);
                 }
 
                 continue;
@@ -2558,7 +2563,10 @@ public static class TransformWorkerProgram
                 {
                     // Why strip skipped added declarations: otherwise drift warns about
                     // fields/initializers for a method the skip reason already explained.
-                    addedMethodCatalog.AddAddedSyntaxKey(syntaxMethodKey);
+                    RecordHandledAddedMethodSyntaxKey(
+                        addedMethodCatalog,
+                        syntaxMethodKey,
+                        replacesCompiledMethod);
                 }
 
                 continue;
@@ -2613,7 +2621,10 @@ public static class TransformWorkerProgram
                         NamespaceName = shimType.NamespaceName,
                         IsStatic = methodSymbol.IsStatic
                     });
-                addedMethodCatalog.AddAddedSyntaxKey(syntaxMethodKey);
+                RecordHandledAddedMethodSyntaxKey(
+                    addedMethodCatalog,
+                    syntaxMethodKey,
+                    replacesCompiledMethod);
                 AppendUnityMessageWarningIfNeeded(
                     typeState.TypeSymbol,
                     methodSymbol,
@@ -2841,6 +2852,21 @@ public static class TransformWorkerProgram
         }
 
         return false;
+    }
+
+    // Why both sides: a return-type-only change keeps the same syntax key (name+params).
+    // Stripping only the current tree leaves the snapshot's old return type as unhandled
+    // outside-body drift even though the gate or Added row already reported it.
+    private static void RecordHandledAddedMethodSyntaxKey(
+        AddedMethodCatalog addedMethodCatalog,
+        string syntaxKey,
+        bool replacesCompiledMethod)
+    {
+        addedMethodCatalog.AddAddedSyntaxKey(syntaxKey);
+        if (replacesCompiledMethod)
+        {
+            addedMethodCatalog.AddRemovedSyntaxKey(syntaxKey);
+        }
     }
 
     private static void AddRemovedMethodName(List<WorkerRemovedMember> removedMembers, string name)
@@ -4428,9 +4454,39 @@ public static class TransformWorkerProgram
         return ShimMethodFactory.ToShimMethod(rewritten, methodSymbol);
     }
 
+    // Why FormatMethodKeyParts shape: Methods[].Method must use one label for every Kind.
+    // Roslyn FullyQualifiedFormat (global::, type arguments) was the Skipped-only outlier.
     private static string FormatMethodLabel(IMethodSymbol methodSymbol)
     {
-        return AccessorPlan.BuildMemberKey(methodSymbol);
+        string typeMetadataName = methodSymbol.ContainingType == null
+            ? string.Empty
+            : CecilTypeNames.ToMetadataName(methodSymbol.ContainingType).Replace('/', '+');
+        string[] parameterTypeFullNames = methodSymbol.Parameters
+            .Select(CecilTypeNames.ToParameterTypeFullName)
+            .ToArray();
+        StringBuilder builder = new StringBuilder();
+        builder.Append(typeMetadataName);
+        builder.Append('.');
+        builder.Append(methodSymbol.Name);
+        if (methodSymbol.Arity > 0)
+        {
+            builder.Append('`');
+            builder.Append(methodSymbol.Arity.ToString(CultureInfo.InvariantCulture));
+        }
+
+        builder.Append('(');
+        for (int index = 0; index < parameterTypeFullNames.Length; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(',');
+            }
+
+            builder.Append(parameterTypeFullNames[index].Replace('/', '+'));
+        }
+
+        builder.Append(')');
+        return builder.ToString();
     }
 
     private static List<UsingDirectiveSyntax> CollectUsingsForType(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -2469,7 +2469,9 @@ public static class TransformWorkerProgram
                     RecordHandledAddedMethodSyntaxKey(
                         addedMethodCatalog,
                         BuildSyntaxMethodKey(typeState.TypeMetadataNameFromSyntax, methodDeclaration),
-                        replacesCompiledMethod);
+                        replacesCompiledMethod,
+                        snapshotMethodMap,
+                        plainCurrentMethodMap);
                     continue;
                 }
             }
@@ -2503,7 +2505,9 @@ public static class TransformWorkerProgram
                     RecordHandledAddedMethodSyntaxKey(
                         addedMethodCatalog,
                         syntaxMethodKey,
-                        replacesCompiledMethod);
+                        replacesCompiledMethod,
+                        snapshotMethodMap,
+                        plainCurrentMethodMap);
                 }
 
                 continue;
@@ -2566,7 +2570,9 @@ public static class TransformWorkerProgram
                     RecordHandledAddedMethodSyntaxKey(
                         addedMethodCatalog,
                         syntaxMethodKey,
-                        replacesCompiledMethod);
+                        replacesCompiledMethod,
+                        snapshotMethodMap,
+                        plainCurrentMethodMap);
                 }
 
                 continue;
@@ -2624,7 +2630,9 @@ public static class TransformWorkerProgram
                 RecordHandledAddedMethodSyntaxKey(
                     addedMethodCatalog,
                     syntaxMethodKey,
-                    replacesCompiledMethod);
+                    replacesCompiledMethod,
+                    snapshotMethodMap,
+                    plainCurrentMethodMap);
                 AppendUnityMessageWarningIfNeeded(
                     typeState.TypeSymbol,
                     methodSymbol,
@@ -2854,19 +2862,58 @@ public static class TransformWorkerProgram
         return false;
     }
 
-    // Why both sides: a return-type-only change keeps the same syntax key (name+params).
-    // Stripping only the current tree leaves the snapshot's old return type as unhandled
-    // outside-body drift even though the gate or Added row already reported it.
+    // Why strip current always, snapshot only when equivalent: a return-type-only
+    // change keeps the same syntax key (name+params). Stripping only the current tree
+    // leaves the snapshot's old return type as unhandled outside-body drift. Stripping
+    // both unconditionally hid attribute/accessibility diffs that still need the warning.
     private static void RecordHandledAddedMethodSyntaxKey(
         AddedMethodCatalog addedMethodCatalog,
         string syntaxKey,
-        bool replacesCompiledMethod)
+        bool replacesCompiledMethod,
+        Dictionary<string, MethodDeclarationSyntax> snapshotMethodMap,
+        Dictionary<string, MethodDeclarationSyntax> plainCurrentMethodMap)
     {
         addedMethodCatalog.AddAddedSyntaxKey(syntaxKey);
-        if (replacesCompiledMethod)
+        if (!replacesCompiledMethod || snapshotMethodMap == null || plainCurrentMethodMap == null)
+        {
+            return;
+        }
+
+        snapshotMethodMap.TryGetValue(syntaxKey, out MethodDeclarationSyntax snapshotDecl);
+        plainCurrentMethodMap.TryGetValue(syntaxKey, out MethodDeclarationSyntax currentDecl);
+        if (AreDeclarationsEquivalentIgnoringBodyAndReturnType(snapshotDecl, currentDecl))
         {
             addedMethodCatalog.AddRemovedSyntaxKey(syntaxKey);
         }
+    }
+
+    private static bool AreDeclarationsEquivalentIgnoringBodyAndReturnType(
+        MethodDeclarationSyntax snapshotDecl,
+        MethodDeclarationSyntax currentDecl)
+    {
+        if (snapshotDecl == null || currentDecl == null)
+        {
+            return false;
+        }
+
+        MethodDeclarationSyntax normalizedSnapshot =
+            NormalizeDeclarationIgnoringBodyAndReturnType(snapshotDecl);
+        MethodDeclarationSyntax normalizedCurrent =
+            NormalizeDeclarationIgnoringBodyAndReturnType(currentDecl);
+        return SyntaxFactory.AreEquivalent(normalizedSnapshot, normalizedCurrent, topLevel: false);
+    }
+
+    private static MethodDeclarationSyntax NormalizeDeclarationIgnoringBodyAndReturnType(
+        MethodDeclarationSyntax method)
+    {
+        TypeSyntax placeholderReturn = SyntaxFactory.PredefinedType(
+            SyntaxFactory.Token(SyntaxKind.VoidKeyword));
+        return method
+            .WithReturnType(placeholderReturn)
+            .WithBody(null)
+            .WithExpressionBody(null)
+            .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+            .NormalizeWhitespace();
     }
 
     private static void AddRemovedMethodName(List<WorkerRemovedMember> removedMembers, string name)
@@ -4454,13 +4501,13 @@ public static class TransformWorkerProgram
         return ShimMethodFactory.ToShimMethod(rewritten, methodSymbol);
     }
 
+    // Keep in sync with HotReloadPatcher.FormatMethodKeyParts.
     // Why FormatMethodKeyParts shape: Methods[].Method must use one label for every Kind.
     // Roslyn FullyQualifiedFormat (global::, type arguments) was the Skipped-only outlier.
     private static string FormatMethodLabel(IMethodSymbol methodSymbol)
     {
-        string typeMetadataName = methodSymbol.ContainingType == null
-            ? string.Empty
-            : CecilTypeNames.ToMetadataName(methodSymbol.ContainingType).Replace('/', '+');
+        string typeMetadataName =
+            CecilTypeNames.ToMetadataName(methodSymbol.ContainingType).Replace('/', '+');
         string[] parameterTypeFullNames = methodSymbol.Parameters
             .Select(CecilTypeNames.ToParameterTypeFullName)
             .ToArray();


### PR DESCRIPTION
## Summary
- Hot reload no longer says a return-type change was "removed" when the signature gate skipped it, and no longer adds a generic outside-body warning for a return-type-only declaration diff.
- When every unpatched caller is a method in the edited file, the skip reason tells you to edit those callers and reload again. `Methods[].Method` uses one label shape for every Kind.

## User Impact
- Before: a gated return-type change still appeared under `Removed members stay present...`, and the same edit could also fire `Edits outside method bodies...`. Skip reasons always ended with compile-only wording. Skipped rows used a different method label than Patched/Added.
- After: a gated replacement is omitted from the removed-members warning only when every removed signature of that name is gated (a same-name deletion on another type still warns). A return-type-only change does not fire the outside-body warning; a remaining attribute or field-initializer change still does. Same-file wording requires every uncovered caller method key to be in the edited file. Skip labels match Patched/Added.

## Changes
- 4a / D2: emit the removed-members warning after the signature gate. Suppress a removed method name only when every `removedMethodSignatures` row of that name is in the gated method-key set.
- 4b / D3: strip the current replacement declaration always; strip the snapshot declaration only when body-removed, return-type-normalized trees are equivalent. Attribute or accessibility drift still fires outside-body.
- 4c / D1: same-file wording uses edited-file method keys (`entries` ∪ `unchangedMethods`), not type names. A same-type caller the worker did not see (other partial file, ctor) keeps `Run 'uloop compile'.`
- 4c combined reason (verbatim, same-file only): `The return type of '{0}' changed, but this hot reload does not patch every compiled call site of the old method. Applying it would leave those call sites on the old version. Editing those callers' bodies in this file and reloading again applies them together, or run 'uloop compile'.`
- 4d / D4: worker skip labels use the `FormatMethodKeyParts` shape. Nested + generic + multi-arg skip label is pinned. Accessor-plan keys are unchanged.
- D8: skill same-file sentence (verbatim): `When every uncovered caller is in the edited file itself, the `Skipped` reason says so: editing those callers' bodies and reloading again applies them together without `uloop compile`.` Generated `.claude/` / `.agents/` copies are in this PR.

## Verification
- `dist/darwin-arm64/uloop compile` → `Success: true`, `ErrorCount: 0`
- Discriminant tests (D1 method-key same-type miss, D2 same-name deletion warning, D3 return-type ± attribute/field, D4 nested generic label, D5 result-derived reasons) → Passed
- `uloop run-tests --filter-type regex --filter-value "HotReload"` → **344/344** Passed
- Repository CI does not run on pull requests targeting `feature/hot-reload`.
