### PR TITLE
docs: hot-reload troubleshooting and pause-point history notes

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -253,6 +253,10 @@ below) — raising is only expressible inside the declaring type, which a shim i
 
 ## When a patch reports `Patched` but behavior does not change
 
+Run `uloop get-logs` first. An exception thrown inside the patched body, or an
+error logged while the reload applied, appears there immediately and explains
+"Patched but no visible change" faster than any marker-based digging.
+
 `Patched` means the method body was replaced, not that the method ran. Before suspecting
 the patch, confirm the method is actually reached: arm `uloop enable-pause-point --mode
 trace` on a line inside the edited method body — it resolves against the patched body

--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -100,6 +100,12 @@ Choose the capture mode when enabling a pause point:
 
 `--max-history` defaults to 20 and accepts values from 1 through 100. When the limit is exceeded, the oldest frames are dropped and `HistoryDroppedCount` reports how many were removed. `pause-point-status` returns the current `Mode`, `MaxHistory`, history frames, and dropped count.
 
+Re-enabling the same `file:line` replaces the marker instead of updating it: the
+marker starts a new generation and the previous `CapturedVariableHistory` is
+discarded, so a re-enable never carries frames over. Read the history you still
+need with `pause-point-status` before re-enabling (for example before raising
+`--max-preview-elements` or changing the mode).
+
 To inspect value changes one Editor Step at a time, pair a `continuous` marker with a `control-play-mode --action Step` + `pause-point-status` loop — see [references/captured-variables.md](references/captured-variables.md) for the loop and its caveats.
 
 For multi-step verification, avoid repeating enable→await→clear cycles with the default single-shot mode: pass `--mode continuous` to `enable-pause-point`, or enable several file:line markers at once — markers are independent and can stay armed simultaneously.

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -253,6 +253,10 @@ below) — raising is only expressible inside the declaring type, which a shim i
 
 ## When a patch reports `Patched` but behavior does not change
 
+Run `uloop get-logs` first. An exception thrown inside the patched body, or an
+error logged while the reload applied, appears there immediately and explains
+"Patched but no visible change" faster than any marker-based digging.
+
 `Patched` means the method body was replaced, not that the method ran. Before suspecting
 the patch, confirm the method is actually reached: arm `uloop enable-pause-point --mode
 trace` on a line inside the edited method body — it resolves against the patched body

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -100,6 +100,12 @@ Choose the capture mode when enabling a pause point:
 
 `--max-history` defaults to 20 and accepts values from 1 through 100. When the limit is exceeded, the oldest frames are dropped and `HistoryDroppedCount` reports how many were removed. `pause-point-status` returns the current `Mode`, `MaxHistory`, history frames, and dropped count.
 
+Re-enabling the same `file:line` replaces the marker instead of updating it: the
+marker starts a new generation and the previous `CapturedVariableHistory` is
+discarded, so a re-enable never carries frames over. Read the history you still
+need with `pause-point-status` before re-enabling (for example before raising
+`--max-preview-elements` or changing the mode).
+
 To inspect value changes one Editor Step at a time, pair a `continuous` marker with a `control-play-mode --action Step` + `pause-point-status` loop — see [references/captured-variables.md](references/captured-variables.md) for the loop and its caveats.
 
 For multi-step verification, avoid repeating enable→await→clear cycles with the default single-shot mode: pass `--mode continuous` to `enable-pause-point`, or enable several file:line markers at once — markers are independent and can stay armed simultaneously.

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -100,6 +100,12 @@ Choose the capture mode when enabling a pause point:
 
 `--max-history` defaults to 20 and accepts values from 1 through 100. When the limit is exceeded, the oldest frames are dropped and `HistoryDroppedCount` reports how many were removed. `pause-point-status` returns the current `Mode`, `MaxHistory`, history frames, and dropped count.
 
+Re-enabling the same `file:line` replaces the marker instead of updating it: the
+marker starts a new generation and the previous `CapturedVariableHistory` is
+discarded, so a re-enable never carries frames over. Read the history you still
+need with `pause-point-status` before re-enabling (for example before raising
+`--max-preview-elements` or changing the mode).
+
 To inspect value changes one Editor Step at a time, pair a `continuous` marker with a `control-play-mode --action Step` + `pause-point-status` loop — see [references/captured-variables.md](references/captured-variables.md) for the loop and its caveats.
 
 For multi-step verification, avoid repeating enable→await→clear cycles with the default single-shot mode: pass `--mode continuous` to `enable-pause-point`, or enable several file:line markers at once — markers are independent and can stay armed simultaneously.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -253,6 +253,10 @@ below) — raising is only expressible inside the declaring type, which a shim i
 
 ## When a patch reports `Patched` but behavior does not change
 
+Run `uloop get-logs` first. An exception thrown inside the patched body, or an
+error logged while the reload applied, appears there immediately and explains
+"Patched but no visible change" faster than any marker-based digging.
+
 `Patched` means the method body was replaced, not that the method ran. Before suspecting
 the patch, confirm the method is actually reached: arm `uloop enable-pause-point --mode
 trace` on a line inside the edited method body — it resolves against the patched body


### PR DESCRIPTION
## Summary
- When a hot-reload row says `Patched` but nothing looks different, the skill now starts with `uloop get-logs` instead of marker-based digging.
- Re-enabling the same pause-point `file:line` is documented as a new generation that discards the previous `CapturedVariableHistory`.

## User Impact
- Before: "Patched but no change" sent you to pause-point reachability checks first, so a thrown exception or apply-time error in the console was easy to miss. Re-enabling a marker to raise `--max-preview-elements` or change mode looked like an in-place update and could drop history you still needed.
- After: get-logs is the first step for a silent `Patched` row. The pause-point skill says to read history with `pause-point-status` before re-enabling.

## Changes
- Hot-reload skill, new paragraph before the existing `Patched` means... text (verbatim): `Run `uloop get-logs` first. An exception thrown inside the patched body, or an error logged while the reload applied, appears there immediately and explains "Patched but no visible change" faster than any marker-based digging.`
- Pause-point skill, new paragraph after the `--max-history` paragraph (verbatim): `Re-enabling the same `file:line` replaces the marker instead of updating it: the marker starts a new generation and the previous `CapturedVariableHistory` is discarded, so a re-enable never carries frames over. Read the history you still need with `pause-point-status` before re-enabling (for example before raising `--max-preview-elements` or changing the mode).`
- Parameter tables are unchanged. Generated `.claude/` and `.agents/` copies are included.

## Verification
- Inserted paragraphs join (whitespace-normalized) to the supplied sentences exactly; wrap is ≤80 columns.
- `dist/darwin-arm64/uloop skills install --claude --agents` → Updated: 2 (hot-reload, pause-point) in both `.claude/skills` and `.agents/skills`.
- No C# or parameter-table change; `uloop compile` / `sync-tool-docs` not required.
- Repository CI does not run on pull requests targeting `feature/hot-reload`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

