### PR TITLE
fix: Rendering screenshots keep correct brightness in Linear color space

### DIFF
--- a/Assets/Tests/Editor/EditorWindowCaptureUtilityTests.cs
+++ b/Assets/Tests/Editor/EditorWindowCaptureUtilityTests.cs
@@ -45,5 +45,106 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(renderingImageInfo.RenderingImageSize, Is.EqualTo(gameViewSize));
             Assert.That(renderingImageInfo.ImageToInputOffsetY, Is.EqualTo(0));
         }
+
+        /// <summary>
+        /// Verifies that reading an sRGB Play Mode view RenderTexture in Linear color
+        /// space preserves sRGB brightness in the output bytes and flips vertically.
+        /// </summary>
+        [Test]
+        public void ReadPlayModeViewTexture_WithSrgbSourceInLinearColorSpace_PreservesBrightnessAndFlips()
+        {
+            Assert.That(QualitySettings.activeColorSpace, Is.EqualTo(ColorSpace.Linear));
+
+            const int SIZE = 4;
+            Texture2D source = new(SIZE, SIZE, TextureFormat.RGB24, false);
+            Color32 bottomColor = new(180, 60, 60, 255);
+            Color32 topColor = new(60, 60, 180, 255);
+            for (int y = 0; y < SIZE; y++)
+            {
+                Color32 rowColor = y < SIZE / 2 ? bottomColor : topColor;
+                for (int x = 0; x < SIZE; x++)
+                {
+                    source.SetPixel(x, y, rowColor);
+                }
+            }
+
+            source.Apply();
+
+            RenderTextureDescriptor descriptor = new(SIZE, SIZE, RenderTextureFormat.ARGB32, 0);
+            descriptor.sRGB = true;
+            RenderTexture sourceRt = RenderTexture.GetTemporary(descriptor);
+            Texture2D result = null;
+            try
+            {
+                Graphics.Blit(source, sourceRt);
+                result = EditorWindowCaptureUtility.ReadPlayModeViewTexture(sourceRt, 1.0f);
+                Color32 actualBottom = result.GetPixel(0, 0);
+                Color32 actualTop = result.GetPixel(0, SIZE - 1);
+                AssertColor32Near(actualBottom, topColor, 5);
+                AssertColor32Near(actualTop, bottomColor, 5);
+            }
+            finally
+            {
+                RenderTexture.ReleaseTemporary(sourceRt);
+                UnityEngine.Object.DestroyImmediate(source);
+                if (result != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(result);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Verifies that resolution scaling keeps sRGB brightness in Linear color space.
+        /// </summary>
+        [Test]
+        public void ReadPlayModeViewTexture_WithResolutionScaleInLinearColorSpace_PreservesBrightness()
+        {
+            Assert.That(QualitySettings.activeColorSpace, Is.EqualTo(ColorSpace.Linear));
+
+            const int SOURCE_SIZE = 8;
+            Color32 gray = new(128, 128, 128, 255);
+            Texture2D source = new(SOURCE_SIZE, SOURCE_SIZE, TextureFormat.RGB24, false);
+            for (int y = 0; y < SOURCE_SIZE; y++)
+            {
+                for (int x = 0; x < SOURCE_SIZE; x++)
+                {
+                    source.SetPixel(x, y, gray);
+                }
+            }
+
+            source.Apply();
+
+            RenderTextureDescriptor descriptor = new(SOURCE_SIZE, SOURCE_SIZE, RenderTextureFormat.ARGB32, 0);
+            descriptor.sRGB = true;
+            RenderTexture sourceRt = RenderTexture.GetTemporary(descriptor);
+            Texture2D result = null;
+            try
+            {
+                Graphics.Blit(source, sourceRt);
+                result = EditorWindowCaptureUtility.ReadPlayModeViewTexture(sourceRt, 0.5f);
+                Assert.That(result.width, Is.EqualTo(4));
+                Assert.That(result.height, Is.EqualTo(4));
+                Color32 actual = result.GetPixel(1, 1);
+                AssertColor32Near(actual, gray, 5);
+            }
+            finally
+            {
+                RenderTexture.ReleaseTemporary(sourceRt);
+                UnityEngine.Object.DestroyImmediate(source);
+                if (result != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(result);
+                }
+            }
+        }
+
+        private static void AssertColor32Near(Color32 actual, Color32 expected, int tolerance)
+        {
+            Assert.That(actual.r, Is.InRange(expected.r - tolerance, expected.r + tolerance));
+            Assert.That(actual.g, Is.InRange(expected.g - tolerance, expected.g + tolerance));
+            Assert.That(actual.b, Is.InRange(expected.b - tolerance, expected.b + tolerance));
+            Assert.That(actual.a, Is.InRange(expected.a - tolerance, expected.a + tolerance));
+        }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/EditorWindowCaptureUtility.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/EditorWindowCaptureUtility.cs
@@ -304,13 +304,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         // Reads and vertically flips the Play Mode view RT into a Texture2D (top-left origin).
-        private static Texture2D ReadPlayModeViewTexture(RenderTexture rt, float resolutionScale)
+        internal static Texture2D ReadPlayModeViewTexture(RenderTexture rt, float resolutionScale)
         {
             RenderTextureDescriptor flipDescriptor = new(rt.width, rt.height, rt.format, 0);
-            if (QualitySettings.activeColorSpace == ColorSpace.Linear)
-            {
-                flipDescriptor.sRGB = false;
-            }
+            // Why sRGB: Blit samples the source through sRGB decode in Linear color space, so the
+            // destination must re-encode on write; ReadPixels copies raw destination bytes into the
+            // PNG, which viewers interpret as sRGB. In Gamma color space this flag is ignored.
+            flipDescriptor.sRGB = true;
 
             // Capture the caller's active target before Blit: Blit leaves the destination
             // assigned to RenderTexture.active, so saving afterwards would "restore" the


### PR DESCRIPTION
## Summary
- Play Mode rendering screenshots in Linear color space now keep the same brightness as the Game view instead of looking too dark.

## User Impact
- Before: `uloop screenshot --capture-mode rendering` wrote linear-decoded bytes into the PNG. Image viewers treated those bytes as sRGB, so the capture looked much darker than the Game window.
- After: the flip destination re-encodes to sRGB on write, so the PNG matches what the Game view shows.

Closes #2127

## Changes
- The Play Mode view flip destination now uses `sRGB = true` so Blit's write path re-encodes after sRGB decode.
- Window capture is unchanged (already measured as correct).
- EditMode tests cover brightness preservation with and without resolution scaling, plus the vertical flip.

## Verification
- `uloop compile`: ErrorCount 0
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value "EditorWindowCaptureUtilityTests"`: TestCount 5, FailedCount 0
- E2E Play Mode captures of the SimulateMouse Demo scene:
  - rendering average luminance: 95.15
  - window (`Game`) average luminance: 84.90
  - ratio: 1.121 (within ±25%)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

