### PR TITLE
fix: emit hot-reload line-map hint on pause-point resolve failure

### DIFF
--- a/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
+++ b/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
@@ -1,6 +1,10 @@
+using System;
+
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
@@ -12,10 +16,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     {
         private const string ForwardSlashFile = "Assets/Scripts/Example.cs";
 
+        private const string ResolveFailureFile =
+            "Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs";
+
+        private const int UnresolvableLine = 999999;
+
         private const string ExpectedWarning =
             "'Assets/Scripts/Example.cs' has active hot-reload patches. For methods this reload did not patch, --line "
             + "resolves against the last compiled source, not the edited file. Verify "
             + "ResolvedMethod and ResolvedLineText, or run 'uloop compile' and re-enable.";
+
+        private const string ExpectedResolveFailureWarning =
+            "'Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs' has active hot-reload patches. For methods this reload did not patch, --line "
+            + "resolves against the last compiled source, not the edited file. Verify "
+            + "ResolvedMethod and ResolvedLineText, or run 'uloop compile' and re-enable.";
+
+        [SetUp]
+        public void SetUp()
+        {
+            UloopPausePointRegistry.ConfigureForTests(new FakePausePointPauseController(), () => DateTime.UtcNow);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UloopPausePointRegistry.ResetForTests();
+        }
 
         /// <summary>
         /// Verifies an active-patch file produces the compiled-line-map warning with forward slashes.
@@ -48,6 +74,72 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string warning = PausePointUseCase.BuildCompiledLineMapWarningOrEmpty(false, ForwardSlashFile);
 
             Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// Verifies a resolve-failure enable response includes the compiled-line-map warning
+        /// only when GetShimLookupForFile returns a lookup for that file.
+        /// </summary>
+        [Test]
+        public void Enable_WhenResolveFailsAndFileHasActivePatches_IncludesCompiledLineMapWarning()
+        {
+            Func<string, HotReloadShimFileLookup> previous =
+                HotReloadPausePointCoordination.GetShimLookupForFile;
+            HotReloadShimFileLookup stubLookup = new HotReloadShimFileLookup(
+                Array.Empty<byte>(),
+                Array.Empty<byte>(),
+                null,
+                Array.Empty<HotReloadShimMethodLookup>());
+
+            try
+            {
+                HotReloadPausePointCoordination.GetShimLookupForFile = _ => stubLookup;
+                PausePointResponse withPatches = EnableUnresolvableLine();
+
+                Assert.That(withPatches.Success, Is.False);
+                Assert.That(withPatches.ErrorCode, Is.EqualTo(SourcePausePointConstants.ErrorCodeResolveFailed));
+                Assert.That(withPatches.Warning, Is.EqualTo(ExpectedResolveFailureWarning));
+
+                HotReloadPausePointCoordination.GetShimLookupForFile = _ => null;
+                PausePointResponse withoutPatches = EnableUnresolvableLine();
+
+                Assert.That(withoutPatches.Success, Is.False);
+                Assert.That(withoutPatches.ErrorCode, Is.EqualTo(SourcePausePointConstants.ErrorCodeResolveFailed));
+                Assert.That(withoutPatches.Warning, Is.EqualTo(string.Empty));
+            }
+            finally
+            {
+                HotReloadPausePointCoordination.GetShimLookupForFile = previous;
+            }
+        }
+
+        private static PausePointResponse EnableUnresolvableLine()
+        {
+            return new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = ResolveFailureFile,
+                Line = UnresolvableLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.SingleShot
+            });
+        }
+
+        private sealed class FakePausePointPauseController : IUloopPausePointPauseController
+        {
+            public int PauseCount { get; private set; }
+            public bool IsPlaying => true;
+            public bool IsPaused => PauseCount > 0;
+
+            public void Pause()
+            {
+                PauseCount++;
+            }
+
+            public void Resume()
+            {
+                // Why zero: Unity's isPaused is a bool; Option B Resume must fully clear pause.
+                PauseCount = 0;
+            }
         }
     }
 }

--- a/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
+++ b/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
@@ -1,0 +1,53 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies the compiled-line-map warning text for files that have active hot-reload patches.
+    /// </summary>
+    [TestFixture]
+    public sealed class PausePointCompiledLineMapWarningTests
+    {
+        private const string ForwardSlashFile = "Assets/Scripts/Example.cs";
+
+        private const string ExpectedWarning =
+            "'Assets/Scripts/Example.cs' has active hot-reload patches. For methods this reload did not patch, --line "
+            + "resolves against the last compiled source, not the edited file. Verify "
+            + "ResolvedMethod and ResolvedLineText, or run 'uloop compile' and re-enable.";
+
+        /// <summary>
+        /// Verifies an active-patch file produces the compiled-line-map warning with forward slashes.
+        /// </summary>
+        [Test]
+        public void BuildCompiledLineMapWarningOrEmpty_WhenPatchesAreActive_ReturnsFormattedWarning()
+        {
+            string warning = PausePointUseCase.BuildCompiledLineMapWarningOrEmpty(true, ForwardSlashFile);
+
+            Assert.That(warning, Is.EqualTo(ExpectedWarning));
+        }
+
+        /// <summary>
+        /// Verifies a backslash path is normalized before it is interpolated into the warning.
+        /// </summary>
+        [Test]
+        public void BuildCompiledLineMapWarningOrEmpty_WhenFileUsesBackslashes_NormalizesToForwardSlashes()
+        {
+            string warning = PausePointUseCase.BuildCompiledLineMapWarningOrEmpty(true, "Assets\\Scripts\\Example.cs");
+
+            Assert.That(warning, Is.EqualTo(ExpectedWarning));
+        }
+
+        /// <summary>
+        /// Verifies the helper stays silent when the file has no active hot-reload patches.
+        /// </summary>
+        [Test]
+        public void BuildCompiledLineMapWarningOrEmpty_WhenPatchesAreInactive_ReturnsEmpty()
+        {
+            string warning = PausePointUseCase.BuildCompiledLineMapWarningOrEmpty(false, ForwardSlashFile);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+    }
+}

--- a/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs.meta
+++ b/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f919a31b60b0408081979a9677e537d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -521,10 +521,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             SourcePausePointResolveResult resolveResult = SourcePausePointResolver.Resolve(parameters.File, parameters.Line);
             if (!resolveResult.Success)
             {
-                return CreateValidationFailure(
+                PausePointResponse response = CreateValidationFailure(
                     resolveResult.ErrorMessage,
                     SourcePausePointConstants.ErrorCodeResolveFailed,
                     SourcePausePointConstants.ResolveFailedRecommendedNextAction);
+                if (shimLookup != null)
+                {
+                    response.Warning = BuildCompiledLineMapWarningOrEmpty(true, parameters.File);
+                }
+
+                return response;
             }
 
             SourcePausePointPatchResult patchResult = SourcePausePointPatcher.Patch(
@@ -595,9 +601,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string enableWarning = CreateEnableWarning();
             if (hasActiveHotReloadPatches && !retargetedToHotReloadPatch)
             {
-                string compiledLineMapWarning = string.Format(
-                    SourcePausePointConstants.HotReloadCompiledLineMapWarningFormat,
-                    SourcePausePointPathNormalizer.ToForwardSlashes(parameters.File));
+                string compiledLineMapWarning = BuildCompiledLineMapWarningOrEmpty(true, parameters.File);
                 enableWarning = MergeWarnings(enableWarning, compiledLineMapWarning);
             }
 
@@ -766,6 +770,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return null;
+        }
+
+        // Why a shared helper: enable success already warned about compiled-line-map drift, but
+        // resolve failure returned an empty Warning, so agents lost the same hint when --line
+        // missed after a hot reload.
+        internal static string BuildCompiledLineMapWarningOrEmpty(bool hasActiveHotReloadPatches, string file)
+        {
+            if (!hasActiveHotReloadPatches)
+            {
+                return string.Empty;
+            }
+
+            return string.Format(
+                SourcePausePointConstants.HotReloadCompiledLineMapWarningFormat,
+                SourcePausePointPathNormalizer.ToForwardSlashes(file));
         }
 
         private static PausePointResponse CreateValidationFailure(

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -525,11 +525,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     resolveResult.ErrorMessage,
                     SourcePausePointConstants.ErrorCodeResolveFailed,
                     SourcePausePointConstants.ResolveFailedRecommendedNextAction);
-                if (shimLookup != null)
-                {
-                    response.Warning = BuildCompiledLineMapWarningOrEmpty(true, parameters.File);
-                }
-
+                response.Warning = BuildCompiledLineMapWarningOrEmpty(shimLookup != null, parameters.File);
                 return response;
             }
 
@@ -599,11 +595,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             response.ResolvedMethod = resolvedMethod;
             response.SnapshotTiming = SourcePausePointConstants.PreLineSnapshotTimingNote;
             string enableWarning = CreateEnableWarning();
-            if (hasActiveHotReloadPatches && !retargetedToHotReloadPatch)
-            {
-                string compiledLineMapWarning = BuildCompiledLineMapWarningOrEmpty(true, parameters.File);
-                enableWarning = MergeWarnings(enableWarning, compiledLineMapWarning);
-            }
+            string compiledLineMapWarning = BuildCompiledLineMapWarningOrEmpty(
+                hasActiveHotReloadPatches && !retargetedToHotReloadPatch,
+                parameters.File);
+            enableWarning = MergeWarnings(enableWarning, compiledLineMapWarning);
 
             response.Warning = MergeWarnings(enableWarning, patchResult.Warning);
             LogEnable(response.Id, response.ResolvedMethod, $"{parameters.File}:{response.ResolvedLine}", response.Mode, response.Warning);


### PR DESCRIPTION
## Summary
- When a pause point cannot resolve `--line` on a file that already has active hot-reload patches, the failure response now includes the compiled-line-map warning.
- Agents can see that `--line` is still mapped against the last compile, instead of getting an empty Warning.

## User Impact
- Before: resolve failure returned `Warning` empty even when the file had active hot-reload patches, so the same line-map hint already shown on success was missing on failure.
- After: that failure response carries the same compiled-line-map warning as a successful enable on an unpatched method.

## Changes
- Share `BuildCompiledLineMapWarningOrEmpty` between the enable success path and the resolve-failure path.
- Add unit tests for the helper: formatted warning, backslash normalization, and empty when no patches are active.

## Verification
- `uloop compile` → Success true, ErrorCount 0
- `uloop run-tests --filter-type regex --filter-value PausePointCompiledLineMapWarningTests` → TestCount 3, PassedCount 3, FailedCount 0
- `uloop run-tests --filter-type regex --filter-value` HotReload EditMode namespace → TestCount 344, PassedCount 344, FailedCount 0
- `uloop run-tests --filter-type regex --filter-value` Editor EditMode namespace → TestCount 2806, PassedCount 2798, FailedCount 0, SkippedCount 8 (suite Status Skipped / Success false because of those 8 skips; no failures)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

