### PR TITLE
refactor: JSON-RPC busy and update-required errors decode through typed fields

### DIFF
--- a/Assets/Tests/Editor/ServerBusyErrorContractTests.cs
+++ b/Assets/Tests/Editor/ServerBusyErrorContractTests.cs
@@ -1,0 +1,98 @@
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Freezes the server_busy JSON-RPC error.data frame that the Go CLI decodes into a typed struct.
+    /// </summary>
+    public sealed class ServerBusyErrorContractTests
+    {
+        private const string SharedContractPath = "tests/contracts/server_busy_error_contract.json";
+
+        /// <summary>
+        /// Verifies ServerBusyErrorData still emits the frozen error.data field shape the Go CLI decodes.
+        /// </summary>
+        [Test]
+        public void ServerBusyErrorData_WhenSerialized_MatchesSharedErrorDataFieldShape()
+        {
+            JObject expected = ReadSharedErrorDataFieldShape();
+            ServerBusyErrorData errorData = new ServerBusyErrorData(
+                runningToolName: "compile",
+                requestedToolName: "get-logs",
+                isPlaying: true,
+                isPaused: false,
+                message: "Unity is busy running 'compile'. Retry 'get-logs' after the running tool completes.",
+                secondsSinceLastMainThreadTick: 1.5,
+                isCompiling: true,
+                isUpdating: false);
+            string json = JsonConvert.SerializeObject(
+                errorData,
+                Formatting.None,
+                UnityCliLoopJsonResponseSerializerSettings.Settings);
+            JObject actualData = JObject.Parse(json);
+            JObject actual = NormalizeFieldShape(actualData);
+
+            Assert.That(JToken.DeepEquals(actual, expected), Is.True, $"Expected {expected} but got {actual}");
+            Assert.That(actualData.Value<string>("type"), Is.EqualTo("server_busy"));
+            Assert.That(actualData.Value<string>("runningToolName"), Is.EqualTo("compile"));
+            Assert.That(actualData.Value<string>("requestedToolName"), Is.EqualTo("get-logs"));
+        }
+
+        private static JObject ReadSharedErrorDataFieldShape()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string json = File.ReadAllText(Path.Combine(projectRoot, SharedContractPath));
+            JObject contract = JObject.Parse(json);
+            return NormalizeFieldShape((JObject)contract["errorData"]!);
+        }
+
+        private static JObject NormalizeFieldShape(JObject value)
+        {
+            JObject shape = new();
+            foreach (JProperty property in value.Properties())
+            {
+                shape[property.Name] = NormalizeTokenFieldShape(property.Value);
+            }
+            return shape;
+        }
+
+        private static JToken NormalizeTokenFieldShape(JToken value)
+        {
+            if (value is JObject objectValue)
+            {
+                return NormalizeFieldShape(objectValue);
+            }
+
+            if (value is JArray arrayValue)
+            {
+                JArray arrayShape = new();
+                if (arrayValue.Count > 0)
+                {
+                    arrayShape.Add(NormalizeTokenFieldShape(arrayValue[0]));
+                }
+                return arrayShape;
+            }
+
+            return new JValue(NormalizeScalarType(value.Type));
+        }
+
+        private static string NormalizeScalarType(JTokenType type)
+        {
+            return type switch
+            {
+                JTokenType.Boolean => "boolean",
+                JTokenType.Float => "number",
+                JTokenType.Integer => "number",
+                JTokenType.Null => "null",
+                JTokenType.String => "string",
+                _ => "unknown"
+            };
+        }
+    }
+}

--- a/Assets/Tests/Editor/ServerBusyErrorContractTests.cs.meta
+++ b/Assets/Tests/Editor/ServerBusyErrorContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 467cbf5d0719748f8bf9174732fbc396
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/cli/common/clicore/tool_readiness.go
+++ b/cli/common/clicore/tool_readiness.go
@@ -108,15 +108,7 @@ func IsReadinessCLIUpdateRequiredError(err error) bool {
 		return false
 	}
 
-	var data any
-	if json.Unmarshal(rpcErr.Data, &data) != nil {
-		return false
-	}
-	typedData, ok := data.(map[string]any)
-	if !ok {
-		return false
-	}
-	return clierrors.RPCDataType(typedData) == "cli_update_required"
+	return clierrors.RPCDataType(rpcErr.Data) == "cli_update_required"
 }
 
 func ProbeToolReadinessSequence(ctx context.Context, projectRoot string) error {

--- a/cli/common/errors/busy_editor_state.go
+++ b/cli/common/errors/busy_editor_state.go
@@ -2,17 +2,17 @@ package clierrors
 
 const unityServerBusyResponsivenessStallThresholdSeconds = 5.0
 
-func unityServerBusyNextActions(data map[string]any) []string {
+func unityServerBusyNextActions(data serverBusyErrorData) []string {
 	actions := []string{
 		"Wait for the running Unity command to complete.",
 		"Retry the command after Unity reports it is no longer busy.",
 	}
 
-	if rpcBoolData(data, "isCompiling") {
+	if optionalTrueBool(data.IsCompiling) {
 		actions = append(
 			[]string{"Unity is compiling scripts; wait for compilation to finish before retrying."},
 			actions...)
-	} else if rpcBoolData(data, "isUpdating") {
+	} else if optionalTrueBool(data.IsUpdating) {
 		actions = append(
 			[]string{"Unity is importing assets; wait for the asset database update to finish before retrying."},
 			actions...)
@@ -21,15 +21,15 @@ func unityServerBusyNextActions(data map[string]any) []string {
 	// Why only runningToolName == "compile": attach recovery requires a local pending
 	// record from this client's own COMPILE_WAIT_TIMEOUT. Editor-state "unity-compile"
 	// busy and other clients' compiles must not promise reattach.
-	if rpcStringData(data, "runningToolName") == "compile" {
+	if data.RunningToolName == "compile" {
 		actions = append(
 			actions,
 			"A compile can take several minutes on large projects. Wait for it to finish, then retry. If your own `uloop compile` previously failed with COMPILE_WAIT_TIMEOUT, re-running `uloop compile` reattaches to that compile instead of starting a new one.",
 		)
 	}
 
-	if stallSeconds, ok := rpcFloatData(data, "secondsSinceLastMainThreadTick"); ok &&
-		stallSeconds >= unityServerBusyResponsivenessStallThresholdSeconds {
+	if data.SecondsSinceLastMainThreadTick != nil &&
+		*data.SecondsSinceLastMainThreadTick >= unityServerBusyResponsivenessStallThresholdSeconds {
 		actions = append(
 			actions,
 			"Run a light command such as `uloop get-logs --max-count 1` to check whether Unity is still responsive before treating this as a freeze.")
@@ -38,18 +38,14 @@ func unityServerBusyNextActions(data map[string]any) []string {
 	return actions
 }
 
-func unityServerBusyEditorActivitySummary(data map[string]any) map[string]any {
-	if data == nil {
-		return nil
-	}
-
+func unityServerBusyEditorActivitySummary(data serverBusyErrorData) map[string]any {
 	summary := map[string]any{}
-	copyOptionalBoolField(summary, data, "isCompiling")
-	copyOptionalBoolField(summary, data, "isUpdating")
-	copyOptionalBoolField(summary, data, "isPlaying")
-	copyOptionalBoolField(summary, data, "isPaused")
-	if stallSeconds, ok := rpcFloatData(data, "secondsSinceLastMainThreadTick"); ok {
-		summary["secondsSinceLastMainThreadTick"] = stallSeconds
+	copyOptionalTrueBool(summary, "isCompiling", data.IsCompiling)
+	copyOptionalTrueBool(summary, "isUpdating", data.IsUpdating)
+	copyOptionalTrueBool(summary, "isPlaying", data.IsPlaying)
+	copyOptionalTrueBool(summary, "isPaused", data.IsPaused)
+	if data.SecondsSinceLastMainThreadTick != nil {
+		summary["secondsSinceLastMainThreadTick"] = *data.SecondsSinceLastMainThreadTick
 	}
 	if len(summary) == 0 {
 		return nil
@@ -57,20 +53,13 @@ func unityServerBusyEditorActivitySummary(data map[string]any) map[string]any {
 	return summary
 }
 
-func rpcBoolData(data map[string]any, key string) bool {
-	value, ok := data[key].(bool)
-	return ok && value
+func optionalTrueBool(value *bool) bool {
+	return value != nil && *value
 }
 
-func rpcFloatData(data map[string]any, key string) (float64, bool) {
-	value, ok := data[key].(float64)
-	return value, ok
-}
-
-func copyOptionalBoolField(destination map[string]any, source map[string]any, key string) {
-	value, ok := source[key].(bool)
-	if !ok || !value {
+func copyOptionalTrueBool(destination map[string]any, key string, value *bool) {
+	if value == nil || !*value {
 		return
 	}
-	destination[key] = value
+	destination[key] = true
 }

--- a/cli/common/errors/busy_editor_state_test.go
+++ b/cli/common/errors/busy_editor_state_test.go
@@ -1,12 +1,14 @@
 package clierrors
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 // Verifies compiling busy payloads surface script-compile guidance in NextActions.
 func TestUnityServerBusyNextActions_WhenCompiling_IncludesCompileGuidance(t *testing.T) {
-	data := map[string]any{
-		"isCompiling": true,
-	}
+	isCompiling := true
+	data := serverBusyErrorData{IsCompiling: &isCompiling}
 
 	actions := unityServerBusyNextActions(data)
 	if len(actions) < 3 {
@@ -20,9 +22,7 @@ func TestUnityServerBusyNextActions_WhenCompiling_IncludesCompileGuidance(t *tes
 // Verifies a busy compile tool adds reattach guidance that only applies after the
 // caller's own COMPILE_WAIT_TIMEOUT (not for unrelated clients or unity-compile).
 func TestUnityServerBusyNextActions_WhenRunningCompileTool_IncludesReattachGuidance(t *testing.T) {
-	data := map[string]any{
-		"runningToolName": "compile",
-	}
+	data := serverBusyErrorData{RunningToolName: "compile"}
 
 	actions := unityServerBusyNextActions(data)
 	expected := "A compile can take several minutes on large projects. Wait for it to finish, then retry. If your own `uloop compile` previously failed with COMPILE_WAIT_TIMEOUT, re-running `uloop compile` reattaches to that compile instead of starting a new one."
@@ -40,9 +40,10 @@ func TestUnityServerBusyNextActions_WhenRunningCompileTool_IncludesReattachGuida
 
 // Verifies editor-state unity-compile busy does not promise uloop compile reattach.
 func TestUnityServerBusyNextActions_WhenRunningUnityCompile_OmitsReattachGuidance(t *testing.T) {
-	data := map[string]any{
-		"runningToolName": "unity-compile",
-		"isCompiling":     true,
+	isCompiling := true
+	data := serverBusyErrorData{
+		RunningToolName: "unity-compile",
+		IsCompiling:     &isCompiling,
 	}
 
 	actions := unityServerBusyNextActions(data)
@@ -55,9 +56,8 @@ func TestUnityServerBusyNextActions_WhenRunningUnityCompile_OmitsReattachGuidanc
 
 // Verifies stalled main-thread ticks add a lightweight responsiveness check action.
 func TestUnityServerBusyNextActions_WhenMainThreadStalled_IncludesResponsivenessCheck(t *testing.T) {
-	data := map[string]any{
-		"secondsSinceLastMainThreadTick": 12.0,
-	}
+	stallSeconds := 12.0
+	data := serverBusyErrorData{SecondsSinceLastMainThreadTick: &stallSeconds}
 
 	actions := unityServerBusyNextActions(data)
 	found := false
@@ -74,11 +74,8 @@ func TestUnityServerBusyNextActions_WhenMainThreadStalled_IncludesResponsiveness
 
 // Verifies editor activity summaries copy only populated busy-state fields.
 func TestUnityServerBusyEditorActivitySummary_CopiesKnownFields(t *testing.T) {
-	data := map[string]any{
-		"isCompiling":                    true,
-		"isUpdating":                     false,
-		"secondsSinceLastMainThreadTick": 1.5,
-	}
+	data := decodeServerBusyErrorData(json.RawMessage(
+		`{"isCompiling":true,"isUpdating":false,"secondsSinceLastMainThreadTick":1.5}`))
 
 	summary := unityServerBusyEditorActivitySummary(data)
 	if summary["isCompiling"] != true {

--- a/cli/common/errors/busy_status.go
+++ b/cli/common/errors/busy_status.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 )
 
-func unityServerBusyMessage(fallback string, data map[string]any, requestedCommand string) string {
-	runningToolName := rpcStringData(data, "runningToolName")
-	requestedToolName := firstNonEmpty(rpcStringData(data, "requestedToolName"), requestedCommand)
+func unityServerBusyMessage(fallback string, data serverBusyErrorData, requestedCommand string) string {
+	runningToolName := data.RunningToolName
+	requestedToolName := firstNonEmpty(data.RequestedToolName, requestedCommand)
 	if runningToolName == "" || requestedToolName == "" {
 		return fallback
 	}
@@ -17,12 +17,4 @@ func unityServerBusyMessage(fallback string, data map[string]any, requestedComma
 		requestedToolName,
 		runningToolName,
 		runningToolName)
-}
-
-func rpcStringData(data map[string]any, key string) string {
-	value, ok := data[key].(string)
-	if !ok {
-		return ""
-	}
-	return value
 }

--- a/cli/common/errors/cli_update_required_error_contract_test.go
+++ b/cli/common/errors/cli_update_required_error_contract_test.go
@@ -34,6 +34,34 @@ func TestClassifyError_WhenCliUpdateRequiredContractFixture_ClassifiesAsCLIUpdat
 	}
 }
 
+// Verifies the shared cli_update_required error.data fixture decodes into every typed struct field.
+func TestDecodeCliUpdateRequiredErrorData_WhenContractFixture_ReadsEveryField(t *testing.T) {
+	contract := readCliUpdateRequiredErrorContract(t)
+
+	decoded := decodeCliUpdateRequiredErrorData(contract.ErrorData)
+	if decoded.Type != "cli_update_required" {
+		t.Fatalf("type mismatch: %#v", decoded)
+	}
+	if decoded.Message != "Install matching uloop CLI and Unity package versions, then retry the original command." {
+		t.Fatalf("message mismatch: %#v", decoded)
+	}
+	if decoded.CurrentCliVersion != "3.0.0-beta.5" {
+		t.Fatalf("currentCliVersion mismatch: %#v", decoded)
+	}
+	if decoded.CurrentProtocolVersion == nil || *decoded.CurrentProtocolVersion != 1 {
+		t.Fatalf("currentProtocolVersion mismatch: %#v", decoded)
+	}
+	if decoded.RequiredProtocolVersion != 3 {
+		t.Fatalf("requiredProtocolVersion mismatch: %#v", decoded)
+	}
+	if decoded.UpdateCommand != "uloop update" {
+		t.Fatalf("updateCommand mismatch: %#v", decoded)
+	}
+	if !decoded.RetryableAfterUpdate {
+		t.Fatalf("retryableAfterUpdate mismatch: %#v", decoded)
+	}
+}
+
 func readCliUpdateRequiredErrorContract(t *testing.T) cliUpdateRequiredErrorContractFile {
 	t.Helper()
 

--- a/cli/common/errors/error_envelope.go
+++ b/cli/common/errors/error_envelope.go
@@ -144,7 +144,7 @@ func responseTimeoutAfterAcceptError(err error, context ErrorContext) CLIError {
 func unityServerBusyError(
 	rpcErr *unityipc.RPCError,
 	details map[string]any,
-	data map[string]any,
+	data serverBusyErrorData,
 	context ErrorContext,
 ) CLIError {
 	if editorActivity := unityServerBusyEditorActivitySummary(data); editorActivity != nil {
@@ -164,7 +164,7 @@ func unityServerBusyError(
 	}
 }
 
-func cliUpdateRequiredError(rpcErr *unityipc.RPCError, details map[string]any, data map[string]any, context ErrorContext) CLIError {
+func cliUpdateRequiredError(rpcErr *unityipc.RPCError, details map[string]any, data cliUpdateRequiredErrorData, context ErrorContext) CLIError {
 	return CLIError{
 		ErrorCode:   ErrorCodeCLIUpdateRequired,
 		Phase:       errorPhaseUnityRPC,
@@ -178,11 +178,10 @@ func cliUpdateRequiredError(rpcErr *unityipc.RPCError, details map[string]any, d
 	}
 }
 
-func cliUpdateRequiredNextActions(data map[string]any) []string {
-	updateCommand, _ := data["updateCommand"].(string)
+func cliUpdateRequiredNextActions(data cliUpdateRequiredErrorData) []string {
 	actions := []string{}
-	if updateCommand != "" {
-		actions = append(actions, "Run `"+updateCommand+"`.")
+	if data.UpdateCommand != "" {
+		actions = append(actions, "Run `"+data.UpdateCommand+"`.")
 	} else if cliProtocolMismatchIsNewer(data) {
 		actions = append(actions, "Update the Unity package to a version that supports this CLI protocol, or install the CLI from the same release as the package.")
 	} else {
@@ -192,15 +191,8 @@ func cliUpdateRequiredNextActions(data map[string]any) []string {
 	return actions
 }
 
-func cliProtocolMismatchIsNewer(data map[string]any) bool {
-	currentProtocolVersion, currentOk := protocolVersionFromRPCData(data, "currentProtocolVersion")
-	requiredProtocolVersion, requiredOk := protocolVersionFromRPCData(data, "requiredProtocolVersion")
-	return currentOk && requiredOk && currentProtocolVersion > requiredProtocolVersion
-}
-
-func protocolVersionFromRPCData(data map[string]any, key string) (float64, bool) {
-	value, ok := data[key].(float64)
-	return value, ok
+func cliProtocolMismatchIsNewer(data cliUpdateRequiredErrorData) bool {
+	return data.CurrentProtocolVersion != nil && *data.CurrentProtocolVersion > data.RequiredProtocolVersion
 }
 
 func disconnectedAfterAcceptError(err error, context ErrorContext) CLIError {

--- a/cli/common/errors/error_envelope_classification.go
+++ b/cli/common/errors/error_envelope_classification.go
@@ -137,35 +137,34 @@ func refusedConnectionAttemptCLIError(err *unityipc.ConnectionAttemptError, cont
 }
 
 func classifyRPCError(rpcErr *unityipc.RPCError, context ErrorContext) CLIError {
-	details, decodedData := rpcErrorDetails(rpcErr)
-	switch RPCDataType(decodedData) {
+	details := rpcErrorDetails(rpcErr)
+	switch RPCDataType(rpcErr.Data) {
 	case "cli_update_required":
-		return cliUpdateRequiredError(rpcErr, details, decodedData, context)
+		return cliUpdateRequiredError(rpcErr, details, decodeCliUpdateRequiredErrorData(rpcErr.Data), context)
 	case "server_busy":
-		return unityServerBusyError(rpcErr, details, decodedData, context)
+		return unityServerBusyError(rpcErr, details, decodeServerBusyErrorData(rpcErr.Data), context)
 	default:
 		return genericRPCError(rpcErr, details, context)
 	}
 }
 
-func rpcErrorDetails(rpcErr *unityipc.RPCError) (map[string]any, map[string]any) {
+func rpcErrorDetails(rpcErr *unityipc.RPCError) map[string]any {
 	details := map[string]any{
 		"Code":    rpcErr.Code,
 		"Message": rpcErr.Message,
 	}
 	if len(rpcErr.Data) == 0 {
-		return details, nil
+		return details
 	}
 
 	var data any
 	if json.Unmarshal(rpcErr.Data, &data) != nil {
 		details["Data"] = string(rpcErr.Data)
-		return details, nil
+		return details
 	}
 
 	details["Data"] = data
-	decodedData, _ := data.(map[string]any)
-	return details, decodedData
+	return details
 }
 
 func genericRPCError(rpcErr *unityipc.RPCError, details map[string]any, context ErrorContext) CLIError {
@@ -182,15 +181,4 @@ func genericRPCError(rpcErr *unityipc.RPCError, details map[string]any, context 
 		},
 		Details: details,
 	}
-}
-
-func RPCDataType(data map[string]any) string {
-	if data == nil {
-		return ""
-	}
-	value, ok := data["type"].(string)
-	if !ok {
-		return ""
-	}
-	return value
 }

--- a/cli/common/errors/rpc_error_data.go
+++ b/cli/common/errors/rpc_error_data.go
@@ -1,0 +1,52 @@
+package clierrors
+
+import "encoding/json"
+
+// Mirrors Packages/src/Editor/Infrastructure/Api/ServerBusyErrorData.cs public properties.
+type serverBusyErrorData struct {
+	Type                           string   `json:"type"`
+	Message                        string   `json:"message"`
+	RunningToolName                string   `json:"runningToolName"`
+	RequestedToolName              string   `json:"requestedToolName"`
+	IsPlaying                      *bool    `json:"isPlaying"`
+	IsPaused                       *bool    `json:"isPaused"`
+	IsCompiling                    *bool    `json:"isCompiling"`
+	IsUpdating                     *bool    `json:"isUpdating"`
+	SecondsSinceLastMainThreadTick *float64 `json:"secondsSinceLastMainThreadTick"`
+}
+
+// Mirrors Packages/src/Editor/Infrastructure/Api/CliUpdateRequiredErrorData.cs public properties.
+type cliUpdateRequiredErrorData struct {
+	Type                    string `json:"type"`
+	Message                 string `json:"message"`
+	CurrentCliVersion       string `json:"currentCliVersion"`
+	CurrentProtocolVersion  *int   `json:"currentProtocolVersion"`
+	RequiredProtocolVersion int    `json:"requiredProtocolVersion"`
+	UpdateCommand           string `json:"updateCommand"`
+	RetryableAfterUpdate    bool   `json:"retryableAfterUpdate"`
+}
+
+func decodeServerBusyErrorData(data json.RawMessage) serverBusyErrorData {
+	var decoded serverBusyErrorData
+	// Why ignore: keep the previous missing-key = zero-value fallback. A type mismatch
+	// on one field used to zero only that field via map assertions; failing closed to
+	// the zero struct is the typed equivalent and avoids inventing per-field recovery.
+	_ = json.Unmarshal(data, &decoded)
+	return decoded
+}
+
+func decodeCliUpdateRequiredErrorData(data json.RawMessage) cliUpdateRequiredErrorData {
+	var decoded cliUpdateRequiredErrorData
+	// Why ignore: keep the previous missing-key = zero-value fallback.
+	_ = json.Unmarshal(data, &decoded)
+	return decoded
+}
+
+func RPCDataType(data json.RawMessage) string {
+	var typed struct {
+		Type string `json:"type"`
+	}
+	// Why ignore: empty or unknown payloads classify as no type, matching a map key miss.
+	_ = json.Unmarshal(data, &typed)
+	return typed.Type
+}

--- a/cli/common/errors/server_busy_error_contract_test.go
+++ b/cli/common/errors/server_busy_error_contract_test.go
@@ -1,0 +1,67 @@
+package clierrors
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+const serverBusyErrorContractPath = "tests/contracts/server_busy_error_contract.json"
+
+type serverBusyErrorContractFile struct {
+	Comment   string          `json:"comment"`
+	ErrorData json.RawMessage `json:"errorData"`
+}
+
+// Verifies the shared server_busy error.data fixture decodes into every typed struct field.
+func TestDecodeServerBusyErrorData_WhenContractFixture_ReadsEveryField(t *testing.T) {
+	contract := readServerBusyErrorContract(t)
+
+	decoded := decodeServerBusyErrorData(contract.ErrorData)
+	if decoded.Type != "server_busy" {
+		t.Fatalf("type mismatch: %#v", decoded)
+	}
+	if decoded.Message != "Unity is busy running 'compile'. Retry 'get-logs' after the running tool completes." {
+		t.Fatalf("message mismatch: %#v", decoded)
+	}
+	if decoded.RunningToolName != "compile" {
+		t.Fatalf("runningToolName mismatch: %#v", decoded)
+	}
+	if decoded.RequestedToolName != "get-logs" {
+		t.Fatalf("requestedToolName mismatch: %#v", decoded)
+	}
+	if decoded.IsPlaying == nil || !*decoded.IsPlaying {
+		t.Fatalf("isPlaying mismatch: %#v", decoded)
+	}
+	if decoded.IsPaused == nil || *decoded.IsPaused {
+		t.Fatalf("isPaused mismatch: %#v", decoded)
+	}
+	if decoded.IsCompiling == nil || !*decoded.IsCompiling {
+		t.Fatalf("isCompiling mismatch: %#v", decoded)
+	}
+	if decoded.IsUpdating == nil || *decoded.IsUpdating {
+		t.Fatalf("isUpdating mismatch: %#v", decoded)
+	}
+	if decoded.SecondsSinceLastMainThreadTick == nil || *decoded.SecondsSinceLastMainThreadTick != 1.5 {
+		t.Fatalf("secondsSinceLastMainThreadTick mismatch: %#v", decoded)
+	}
+}
+
+func readServerBusyErrorContract(t *testing.T) serverBusyErrorContractFile {
+	t.Helper()
+
+	path := findRepoRelativeFile(t, serverBusyErrorContractPath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read server_busy error contract: %v", err)
+	}
+
+	var contract serverBusyErrorContractFile
+	if err := json.Unmarshal(data, &contract); err != nil {
+		t.Fatalf("failed to unmarshal server_busy error contract: %v", err)
+	}
+	if len(contract.ErrorData) == 0 {
+		t.Fatal("server_busy error contract must include errorData")
+	}
+	return contract
+}

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "ecf51866b120f7d37a14c9f4ed1e794ddb4679f0"
+  "sharedInputsHash": "5bd2292f47253444170d8959b2007537a27fc544"
 }

--- a/cli/project-runner/internal/projectrunner/connection_retry.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry.go
@@ -2,7 +2,6 @@ package projectrunner
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -362,11 +361,7 @@ func isUnityServerBusyRPCError(err error) bool {
 	if !errors.As(err, &rpcErr) {
 		return false
 	}
-	decodedData := map[string]any{}
-	if len(rpcErr.Data) > 0 {
-		_ = json.Unmarshal(rpcErr.Data, &decodedData)
-	}
-	return clierrors.RPCDataType(decodedData) == "server_busy"
+	return clierrors.RPCDataType(rpcErr.Data) == "server_busy"
 }
 
 func connectionRetryFocusReasonForError(

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "33a95319d839821334a53655cda951dd2684b929"
+  "sharedInputsHash": "ae7c402a7868c66f60413de924c8a29adbd66995"
 }

--- a/tests/contracts/server_busy_error_contract.json
+++ b/tests/contracts/server_busy_error_contract.json
@@ -1,0 +1,14 @@
+{
+  "comment": "Representative server_busy error.data payload with every ServerBusyErrorData field present. Go and C# contract tests decode this same frame.",
+  "errorData": {
+    "type": "server_busy",
+    "message": "Unity is busy running 'compile'. Retry 'get-logs' after the running tool completes.",
+    "runningToolName": "compile",
+    "requestedToolName": "get-logs",
+    "isPlaying": true,
+    "isPaused": false,
+    "isCompiling": true,
+    "isUpdating": false,
+    "secondsSinceLastMainThreadTick": 1.5
+  }
+}


### PR DESCRIPTION
## Summary
- The CLI now decodes Unity `server_busy` and `cli_update_required` JSON-RPC error data through typed structs that mirror the C# DTOs, so a field rename or typo fails at compile time instead of silently dropping the value.

## User Impact
- Before: Go read these payloads with string-key map lookups. A C# property rename or a key typo still compiled on both sides and broke busy / CLI-update classification with no build failure.
- After: The same fields are typed. Envelope output for existing payloads stays byte-identical; only the receive-side decode path changed.

## Changes
- Added `serverBusyErrorData` and `cliUpdateRequiredErrorData` in `cli/common/errors`, with JSON tags matching the C# property names.
- Replaced untyped reads in busy editor-state / status, error-envelope classification, tool readiness, and connection retry. `RPCDataType` now takes `json.RawMessage`.
- Shared contract fixture `tests/contracts/server_busy_error_contract.json` plus matching Go and C# contract tests.
- Stamped dispatcher and project-runner shared release inputs.

Closes #2042

## Verification
- `cd cli/common && go test ./errors/ ./clicore/` — pass
- `cd cli/common && go test ./...` — pass
- `cd cli/project-runner && go test ./internal/projectrunner/` — pass (`ok ... 14.727s`)
- `scripts/check-go-cli.sh` — exit 0 (fmt / vet / lint / tests / rebuild)
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>` — `Success: true`, `ErrorCount: 0`, `WarningCount: 0`
- `dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --filter-type regex --filter-value ServerBusyErrorContractTests` — `Status: Passed`, `TestCount: 1`, `PassedCount: 1`, `FailedCount: 0`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

