### PR TITLE
fix: explain shim compile failures caused by same-run skipped members

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1245,14 +1245,61 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "DescribeValue",
                 genericSkipReason);
             string fixturePath = ResolveE2EFixturePath();
-            // Why also edit ComputeWithPrivate: a single failing entry skips isolation and
-            // returns Compose without AppendNotes. A second healthy entry forces the
-            // BuildFailedMethodOutcomes path that this test protects.
+            // Why also edit ComputeWithPrivate: this test protects the isolation path
+            // (BuildFailedMethodOutcomes). The single-entry fallback is covered separately.
             string editedPath = WriteEditedSource(
                 "AddedGenericCaller.cs",
                 BuildFixtureSource(
                     computeWithPrivateMethod:
                     "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }",
+                    callsMissingHelperMethod:
+                    "public int CallsMissingHelper(int value)\n        {\n            return DescribeValue(value);\n        }\n\n"
+                    + "        private int DescribeValue<T>(T value)\n        {\n            return 42;\n        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            string failedReason = null;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
+                    && outcome.Method.Contains(nameof(HotReloadE2EFixture.CallsMissingHelper)))
+                {
+                    failedReason = outcome.Reason;
+                    break;
+                }
+            }
+
+            Assert.That(
+                failedReason,
+                Is.Not.Null,
+                "Expected CallsMissingHelper to fail shim compile.\n" + FormatOutcomes(result));
+            string[] reasonLines = failedReason.Replace("\r\n", "\n").Split('\n');
+            Assert.That(reasonLines[reasonLines.Length - 1], Is.EqualTo(expectedLastLine));
+        }
+
+        /// <summary>
+        /// What: editing only the caller of an added generic method (single shim entry) still
+        /// ends the Failed reason with the skipped-member note.
+        /// </summary>
+        [Test]
+        public async Task Run_SingleEditedCallerOfAddedGeneric_FailsWithSkippedMemberNote()
+        {
+            const string genericSkipReason =
+                "Added generic methods are skipped; hot reload cannot emit a typed shim for them. "
+                + "Run 'uloop compile'.";
+            string expectedLastLine = string.Format(
+                HotReloadConstants.SkippedMemberCompileFailureNoteFormat,
+                "DescribeValue",
+                genericSkipReason);
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "AddedGenericCallerSingleEntry.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
                     callsMissingHelperMethod:
                     "public int CallsMissingHelper(int value)\n        {\n            return DescribeValue(value);\n        }\n\n"
                     + "        private int DescribeValue<T>(T value)\n        {\n            return 42;\n        }"));

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1231,6 +1231,57 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a caller that invokes an added generic method fails shim compile, and the
+        /// Failed reason's last line is the skipped-member note for that generic add.
+        /// </summary>
+        [Test]
+        public async Task Run_EditedCallerOfAddedGeneric_FailsWithSkippedMemberNote()
+        {
+            const string genericSkipReason =
+                "Added generic methods are skipped; hot reload cannot emit a typed shim for them. "
+                + "Run 'uloop compile'.";
+            string expectedLastLine = string.Format(
+                HotReloadConstants.SkippedMemberCompileFailureNoteFormat,
+                "DescribeValue",
+                genericSkipReason);
+            string fixturePath = ResolveE2EFixturePath();
+            // Why also edit ComputeWithPrivate: a single failing entry skips isolation and
+            // returns Compose without AppendNotes. A second healthy entry forces the
+            // BuildFailedMethodOutcomes path that this test protects.
+            string editedPath = WriteEditedSource(
+                "AddedGenericCaller.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }",
+                    callsMissingHelperMethod:
+                    "public int CallsMissingHelper(int value)\n        {\n            return DescribeValue(value);\n        }\n\n"
+                    + "        private int DescribeValue<T>(T value)\n        {\n            return 42;\n        }"));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            string failedReason = null;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
+                    && outcome.Method.Contains(nameof(HotReloadE2EFixture.CallsMissingHelper)))
+                {
+                    failedReason = outcome.Reason;
+                    break;
+                }
+            }
+
+            Assert.That(
+                failedReason,
+                Is.Not.Null,
+                "Expected CallsMissingHelper to fail shim compile.\n" + FormatOutcomes(result));
+            string[] reasonLines = failedReason.Replace("\r\n", "\n").Split('\n');
+            Assert.That(reasonLines[reasonLines.Length - 1], Is.EqualTo(expectedLastLine));
+        }
+
+        /// <summary>
         /// What: editing a const value emits a drift warning naming both values while the run
         /// itself stays successful (methods still patch).
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadSkippedMemberCompileNoteTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSkippedMemberCompileNoteTests.cs
@@ -1,0 +1,165 @@
+using System;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Verifies unresolved-member extraction and skipped-member notes for shim compile failures.
+    /// </summary>
+    public sealed class HotReloadSkippedMemberCompileNoteTests
+    {
+        private const string Surface11Cs1061 =
+            "CS1061: 'TetrisGameController' does not contain a definition for 'DescribeValue' and no accessible extension method 'DescribeValue' accepting a first argument of type 'TetrisGameController' could be found (are you missing a using directive or an assembly reference?) (line 95)";
+
+        private const string Surface11SkippedMethod =
+            "Tetris.Presentation.TetrisGameController.DescribeValue`1(T)";
+
+        private const string Surface11SkippedReason =
+            "Added generic methods are skipped; hot reload cannot emit a typed shim for them. Run 'uloop compile'.";
+
+        private const string ExpectedSkippedMemberNote =
+            "'DescribeValue' was skipped by this hot reload run, which is why this compile failed: "
+            + "Added generic methods are skipped; hot reload cannot emit a typed shim for them. Run 'uloop compile'.";
+
+        /// <summary>
+        /// What: the surface-11 CS1061 line yields the unresolved member name DescribeValue.
+        /// </summary>
+        [Test]
+        public void ExtractUnresolvedMemberNames_Surface11Cs1061_ReturnsDescribeValue()
+        {
+            string[] names = HotReloadSkippedMemberCompileNote.ExtractUnresolvedMemberNames(
+                new[] { Surface11Cs1061 });
+
+            Assert.That(names, Is.EqualTo(new[] { "DescribeValue" }));
+        }
+
+        /// <summary>
+        /// What: CS0117 uses the same definition-for quote as CS1061.
+        /// </summary>
+        [Test]
+        public void ExtractUnresolvedMemberNames_Cs0117_ReturnsQuotedMemberName()
+        {
+            string[] names = HotReloadSkippedMemberCompileNote.ExtractUnresolvedMemberNames(
+                new[]
+                {
+                    "CS0117: 'Host' does not contain a definition for 'MissingHelper'"
+                });
+
+            Assert.That(names, Is.EqualTo(new[] { "MissingHelper" }));
+        }
+
+        /// <summary>
+        /// What: CS0103 yields the quoted name from The name 'X' does not exist.
+        /// </summary>
+        [Test]
+        public void ExtractUnresolvedMemberNames_Cs0103_ReturnsQuotedName()
+        {
+            string[] names = HotReloadSkippedMemberCompileNote.ExtractUnresolvedMemberNames(
+                new[]
+                {
+                    "CS0103: The name 'MissingHelperAddedByEdit' does not exist in the current context"
+                });
+
+            Assert.That(names, Is.EqualTo(new[] { "MissingHelperAddedByEdit" }));
+        }
+
+        /// <summary>
+        /// What: duplicate unresolved names from several diagnostics are returned once, in first-seen order.
+        /// </summary>
+        [Test]
+        public void ExtractUnresolvedMemberNames_DuplicateNames_ReturnsEachNameOnce()
+        {
+            string[] names = HotReloadSkippedMemberCompileNote.ExtractUnresolvedMemberNames(
+                new[]
+                {
+                    Surface11Cs1061,
+                    "CS0103: The name 'DescribeValue' does not exist in the current context",
+                    "CS0117: 'Host' does not contain a definition for 'OtherMissing'"
+                });
+
+            Assert.That(names, Is.EqualTo(new[] { "DescribeValue", "OtherMissing" }));
+        }
+
+        /// <summary>
+        /// What: lines that are not CS1061/CS0117/CS0103 prefixes are ignored.
+        /// </summary>
+        [Test]
+        public void ExtractUnresolvedMemberNames_UnrelatedDiagnostic_ReturnsEmpty()
+        {
+            string[] names = HotReloadSkippedMemberCompileNote.ExtractUnresolvedMemberNames(
+                new[]
+                {
+                    "CS0229: Ambiguity between 'A.DescribeValue' and 'B.DescribeValue'",
+                    "hint: CS1061: 'Host' does not contain a definition for 'DescribeValue'"
+                });
+
+            Assert.That(names, Is.EqualTo(Array.Empty<string>()));
+        }
+
+        /// <summary>
+        /// What: the surface-11 generic skip row matches DescribeValue and returns that reason.
+        /// </summary>
+        [Test]
+        public void FindSkippedMemberNote_Surface11GenericSkip_ReturnsReason()
+        {
+            TransformWorkerSkippedDto[] skipped =
+            {
+                new TransformWorkerSkippedDto
+                {
+                    method = Surface11SkippedMethod,
+                    reason = Surface11SkippedReason
+                }
+            };
+
+            string note = HotReloadSkippedMemberCompileNote.FindSkippedMemberNote("DescribeValue", skipped);
+
+            Assert.That(note, Is.EqualTo(Surface11SkippedReason));
+        }
+
+        /// <summary>
+        /// What: a skipped method whose simple name does not match returns null.
+        /// </summary>
+        [Test]
+        public void FindSkippedMemberNote_WhenNoSimpleNameMatches_ReturnsNull()
+        {
+            TransformWorkerSkippedDto[] skipped =
+            {
+                new TransformWorkerSkippedDto
+                {
+                    method = Surface11SkippedMethod,
+                    reason = Surface11SkippedReason
+                }
+            };
+
+            string note = HotReloadSkippedMemberCompileNote.FindSkippedMemberNote("BuildDiagnosticLine", skipped);
+
+            Assert.That(note, Is.Null);
+        }
+
+        /// <summary>
+        /// What: the skipped-member note format plus the surface-11 reason is an exact full line.
+        /// </summary>
+        [Test]
+        public void SkippedMemberCompileFailureNote_Surface11_MatchesFullText()
+        {
+            TransformWorkerSkippedDto[] skipped =
+            {
+                new TransformWorkerSkippedDto
+                {
+                    method = Surface11SkippedMethod,
+                    reason = Surface11SkippedReason
+                }
+            };
+            string reason = HotReloadSkippedMemberCompileNote.FindSkippedMemberNote("DescribeValue", skipped);
+            string note = string.Format(
+                HotReloadConstants.SkippedMemberCompileFailureNoteFormat,
+                "DescribeValue",
+                reason);
+
+            Assert.That(note, Is.EqualTo(ExpectedSkippedMemberNote));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSkippedMemberCompileNoteTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSkippedMemberCompileNoteTests.cs
@@ -140,6 +140,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a skipped label whose parameter type contains dots still matches the simple name.
+        /// </summary>
+        [Test]
+        public void FindSkippedMemberNote_WhenParameterTypeIsQualified_UsesMethodSimpleName()
+        {
+            TransformWorkerSkippedDto[] skipped =
+            {
+                new TransformWorkerSkippedDto
+                {
+                    method = "Ns.Type.DescribeValue(System.Int32)",
+                    reason = Surface11SkippedReason
+                }
+            };
+
+            string note = HotReloadSkippedMemberCompileNote.FindSkippedMemberNote("DescribeValue", skipped);
+
+            Assert.That(note, Is.EqualTo(Surface11SkippedReason));
+        }
+
+        /// <summary>
         /// What: the skipped-member note format plus the surface-11 reason is an exact full line.
         /// </summary>
         [Test]
@@ -160,6 +180,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 reason);
 
             Assert.That(note, Is.EqualTo(ExpectedSkippedMemberNote));
+        }
+
+        /// <summary>
+        /// What: AppendNotes appends the skipped-member note after the composed shim-compile hints.
+        /// </summary>
+        [Test]
+        public void AppendNotes_Surface11Cs1061_AppendsFullNoteAfterComposeHints()
+        {
+            TransformWorkerSkippedDto[] skipped =
+            {
+                new TransformWorkerSkippedDto
+                {
+                    method = Surface11SkippedMethod,
+                    reason = Surface11SkippedReason
+                }
+            };
+            string composed = HotReloadShimCompiler.ComposeShimCompileFailureMessage(
+                new[] { Surface11Cs1061 });
+            string expected = composed + "\n" + ExpectedSkippedMemberNote;
+
+            string message = HotReloadSkippedMemberCompileNote.AppendNotes(
+                composed,
+                new[] { Surface11Cs1061 },
+                skipped);
+
+            Assert.That(message, Is.EqualTo(expected));
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadSkippedMemberCompileNoteTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSkippedMemberCompileNoteTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16d6902f584b04c23a26c7b0a761de0c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -100,6 +100,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string MissingUsingCompileHint =
             "This can mean a missing using or global using (hot reload collects global usings from the edited file's assembly).";
 
+        // Why a separate line after Compose: CS1061/CS0117/CS0103 name the missing member, but
+        // not that this same run skipped it (generic add, etc.). Agents otherwise treat the
+        // compile error as the root cause.
+        public const string SkippedMemberCompileFailureNoteFormat =
+            "'{0}' was skipped by this hot reload run, which is why this compile failed: {1}";
+
         // Wire value for TransformWorkerEntryDto.patchKind when the worker rewrote inaccessible
         // accesses into accessor delegates.
         public const string PatchKindDelegation = "delegation";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -1432,10 +1432,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         soleEntry.genericArity);
                 }
 
+                List<string> fallbackErrorMessages = new List<string>(compileResult.Errors.Count);
+                for (int errorIndex = 0; errorIndex < compileResult.Errors.Count; errorIndex++)
+                {
+                    fallbackErrorMessages.Add(compileResult.Errors[errorIndex].Message);
+                }
+
                 return ShimFirstCompileResult.Failed(
                     HotReloadMethodOutcome.Failed(
                         failureMethodLabel,
-                        compileResult.ErrorMessage,
+                        HotReloadSkippedMemberCompileNote.AppendNotes(
+                            compileResult.ErrorMessage,
+                            fallbackErrorMessages,
+                            workerOutput.skipped),
                         assemblyResolvePath));
             }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -1098,7 +1098,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             List<HotReloadMethodOutcome> failedMethodOutcomes =
-                BuildFailedMethodOutcomes(attribution, assemblyResolvePath);
+                BuildFailedMethodOutcomes(attribution, assemblyResolvePath, workerOutput.skipped);
             IsolationExclusions exclusions = BuildIsolationExclusions(
                 attribution.FailedEntries,
                 workerOutput.entries);
@@ -1204,7 +1204,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static List<HotReloadMethodOutcome> BuildFailedMethodOutcomes(
             ShimCompileErrorAttribution attribution,
-            string assemblyResolvePath)
+            string assemblyResolvePath,
+            TransformWorkerSkippedDto[] skipped)
         {
             List<HotReloadMethodOutcome> failedMethodOutcomes = new List<HotReloadMethodOutcome>();
             foreach (TransformWorkerEntryDto failedEntry in attribution.FailedEntries)
@@ -1215,10 +1216,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     failedEntry.parameterTypeFullNames ?? Array.Empty<string>(),
                     failedEntry.genericArity);
                 List<string> entryErrorMessages = attribution.ErrorMessagesByEntry[failedEntry];
+                string composedMessage = HotReloadShimCompiler.ComposeShimCompileFailureMessage(entryErrorMessages);
                 failedMethodOutcomes.Add(
                     HotReloadMethodOutcome.Failed(
                         methodLabel,
-                        HotReloadShimCompiler.ComposeShimCompileFailureMessage(entryErrorMessages),
+                        HotReloadSkippedMemberCompileNote.AppendNotes(
+                            composedMessage,
+                            entryErrorMessages,
+                            skipped),
                         assemblyResolvePath));
             }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSkippedMemberCompileNote.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSkippedMemberCompileNote.cs
@@ -132,22 +132,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static string ExtractSimpleMethodName(string methodLabel)
         {
-            int lastDot = methodLabel.LastIndexOf('.');
-            int start = lastDot >= 0 ? lastDot + 1 : 0;
-            int end = methodLabel.Length;
-            int backtick = methodLabel.IndexOf('`', start);
+            // Why clip before ` or (: a qualified parameter type such as System.String
+            // contains dots that must not become the simple-name start.
+            int nameEnd = methodLabel.Length;
+            int backtick = methodLabel.IndexOf('`');
             if (backtick >= 0)
             {
-                end = backtick;
+                nameEnd = backtick;
             }
 
-            int paren = methodLabel.IndexOf('(', start);
-            if (paren >= 0 && paren < end)
+            int paren = methodLabel.IndexOf('(');
+            if (paren >= 0 && paren < nameEnd)
             {
-                end = paren;
+                nameEnd = paren;
             }
 
-            return methodLabel.Substring(start, end - start);
+            int lastDot = nameEnd > 0 ? methodLabel.LastIndexOf('.', nameEnd - 1) : -1;
+            int start = lastDot >= 0 ? lastDot + 1 : 0;
+            return methodLabel.Substring(start, nameEnd - start);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSkippedMemberCompileNote.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSkippedMemberCompileNote.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Extracts unresolved member names from shim compile errors and matches them to
+    /// skipped rows from the same hot-reload run.
+    /// </summary>
+    internal static class HotReloadSkippedMemberCompileNote
+    {
+        private const string Cs1061Prefix = "CS1061:";
+        private const string Cs0117Prefix = "CS0117:";
+        private const string Cs0103Prefix = "CS0103:";
+        private const string DefinitionForMarker = "does not contain a definition for '";
+        private const string NameMarker = "The name '";
+
+        internal static string[] ExtractUnresolvedMemberNames(IReadOnlyList<string> errorMessages)
+        {
+            Debug.Assert(errorMessages != null, "errorMessages must not be null.");
+
+            HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
+            List<string> names = new List<string>();
+            for (int index = 0; index < errorMessages.Count; index++)
+            {
+                string error = errorMessages[index];
+                if (string.IsNullOrEmpty(error))
+                {
+                    continue;
+                }
+
+                string name = ExtractNameFromDiagnostic(error);
+                if (name == null || !seen.Add(name))
+                {
+                    continue;
+                }
+
+                names.Add(name);
+            }
+
+            return names.ToArray();
+        }
+
+        internal static string FindSkippedMemberNote(string unresolvedName, TransformWorkerSkippedDto[] skipped)
+        {
+            Debug.Assert(unresolvedName != null, "unresolvedName must not be null.");
+
+            if (skipped == null)
+            {
+                return null;
+            }
+
+            for (int index = 0; index < skipped.Length; index++)
+            {
+                TransformWorkerSkippedDto row = skipped[index];
+                if (row == null || string.IsNullOrEmpty(row.method))
+                {
+                    continue;
+                }
+
+                string simpleName = ExtractSimpleMethodName(row.method);
+                if (string.Equals(simpleName, unresolvedName, StringComparison.Ordinal))
+                {
+                    return row.reason;
+                }
+            }
+
+            return null;
+        }
+
+        internal static string AppendNotes(
+            string composedMessage,
+            IReadOnlyList<string> errorMessages,
+            TransformWorkerSkippedDto[] skipped)
+        {
+            Debug.Assert(composedMessage != null, "composedMessage must not be null.");
+
+            string[] unresolvedNames = ExtractUnresolvedMemberNames(errorMessages);
+            string message = composedMessage;
+            for (int index = 0; index < unresolvedNames.Length; index++)
+            {
+                string unresolvedName = unresolvedNames[index];
+                string reason = FindSkippedMemberNote(unresolvedName, skipped);
+                if (reason == null)
+                {
+                    continue;
+                }
+
+                message += "\n" + string.Format(
+                    HotReloadConstants.SkippedMemberCompileFailureNoteFormat,
+                    unresolvedName,
+                    reason);
+            }
+
+            return message;
+        }
+
+        private static string ExtractNameFromDiagnostic(string error)
+        {
+            if (error.StartsWith(Cs1061Prefix, StringComparison.Ordinal)
+                || error.StartsWith(Cs0117Prefix, StringComparison.Ordinal))
+            {
+                return ExtractQuotedNameAfter(error, DefinitionForMarker);
+            }
+
+            if (error.StartsWith(Cs0103Prefix, StringComparison.Ordinal))
+            {
+                return ExtractQuotedNameAfter(error, NameMarker);
+            }
+
+            return null;
+        }
+
+        private static string ExtractQuotedNameAfter(string error, string marker)
+        {
+            int markerIndex = error.IndexOf(marker, StringComparison.Ordinal);
+            if (markerIndex < 0)
+            {
+                return null;
+            }
+
+            int nameStart = markerIndex + marker.Length;
+            int nameEnd = error.IndexOf('\'', nameStart);
+            if (nameEnd <= nameStart)
+            {
+                return null;
+            }
+
+            return error.Substring(nameStart, nameEnd - nameStart);
+        }
+
+        private static string ExtractSimpleMethodName(string methodLabel)
+        {
+            int lastDot = methodLabel.LastIndexOf('.');
+            int start = lastDot >= 0 ? lastDot + 1 : 0;
+            int end = methodLabel.Length;
+            int backtick = methodLabel.IndexOf('`', start);
+            if (backtick >= 0)
+            {
+                end = backtick;
+            }
+
+            int paren = methodLabel.IndexOf('(', start);
+            if (paren >= 0 && paren < end)
+            {
+                end = paren;
+            }
+
+            return methodLabel.Substring(start, end - start);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSkippedMemberCompileNote.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSkippedMemberCompileNote.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd89295d2c7a34f10863f33b33e6f8cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- When a hot-reload shim compile fails because this same run skipped a member (for example an added generic method), the Failed reason now names that skip.
- Agents can see the skipped member and its skip reason instead of treating CS1061/CS0117/CS0103 as the root cause.

## User Impact
- Before: adding a generic method next to a same-named non-generic method produced a Failed compile line that only said the type had no such member.
- After: that Failed line ends with a note that the skipped member is why the compile failed, including the original skip reason.

## Changes
- Extract unresolved names from CS1061, CS0117, and CS0103 prefixes and match them to this run's skipped method labels.
- Append one note per matched name after the existing shim-compile hints.

## Verification
- `uloop compile` → Success true, ErrorCount 0
- New unit tests `HotReloadSkippedMemberCompileNoteTests` → TestCount 8, PassedCount 8, FailedCount 0
- HotReload EditMode namespace → TestCount 352, PassedCount 352, FailedCount 0
- Live repro: added `DescribeValue(int)` plus `DescribeValue<T>` and called both from an existing method. Failed `BuildLine()` reason ended with:
  `'DescribeValue' was skipped by this hot reload run, which is why this compile failed: Added generic methods are skipped; hot reload cannot emit a typed shim for them. Run 'uloop compile'.`
  The live host used CS0117 (static type) rather than CS1061; both prefixes are covered. Temporary host deleted; `uloop hot-reload --revert-all` ClearedCount 1; compile Success true.

## Notes
- Repository CI does not run on pull requests targeting `feature/hot-reload` (`pull_request.branches` is `main` / `v3-beta` only). Local EditMode evidence above is the merge gate for this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

