### PR TITLE
feat: Hot reload now reports constructor, operator, and event-accessor edits as skipped

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -68,8 +68,8 @@ when edited (with a verified baseline, unchanged members of those kinds produce
 no row). Finalizers and `interface` members (including default interface
 implementations) are never scanned: **edits** to them produce **no per-method
 entry at all** and are silently not applied — use `uloop compile` for those.
-(**Adding** one of these member kinds is different: the addition is detected and
-reported as `Skipped`, per the next section.)
+Adding a constructor, operator, or explicit event accessor is reported as
+`Skipped` as well, same as an edit to an existing one.
 
 ### Added methods and fields
 
@@ -105,11 +105,12 @@ compiled source) removes it from the ledger on that run. Deleting a *compiled*
 member is reported in `Warnings`, but its IL remains callable from unedited code
 until `uloop compile`.
 
-Adding a type (`class`, `struct`, `enum`, `record`), a property, an event, an
-indexer, a constructor, or an operator is still out of scope. These additions
-are not reported per member — no `Skipped` row names them; at most they
-surface as outside-body drift in `Warnings`. Treat silence as "not applied"
-and land them with `uloop compile`.
+Adding a constructor, operator, or explicit event accessor is still out of
+scope and is reported as `Skipped`, same as edits to them. Adding a type
+(`class`, `struct`, `enum`, `record`), a property, or an indexer is still out
+of scope. These additions are not reported per member — no `Skipped` row
+names them; at most they surface as outside-body drift in `Warnings`. Treat
+silence as "not applied" and land them with `uloop compile`.
 
 Outside method bodies, only member additions (previous section) take effect.
 Every other declaration edit — changing a `const` value, a compiled field's

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -63,11 +63,13 @@ ledger across runs.
 ## Scope and limits
 
 Only ordinary method declarations and property getters with a body are patched.
-Constructors, finalizers, operators, event accessors, and `interface` members
-(including default interface implementations) are never scanned: **edits** to them
-produce **no per-method entry at all** and are silently not applied — use
-`uloop compile` for those. (**Adding** one of these member kinds is different:
-the addition is detected and reported as `Skipped`, per the next section.)
+Constructors, operators, and explicit event accessors are reported as `Skipped`
+when edited (with a verified baseline, unchanged members of those kinds produce
+no row). Finalizers and `interface` members (including default interface
+implementations) are never scanned: **edits** to them produce **no per-method
+entry at all** and are silently not applied — use `uloop compile` for those.
+(**Adding** one of these member kinds is different: the addition is detected and
+reported as `Skipped`, per the next section.)
 
 ### Added methods and fields
 
@@ -236,6 +238,7 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
 | Property setter, init, or indexer accessor with an explicit body | Accessor patching covers getters only; `uloop compile` applies setter/init/indexer edits |
+| Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Out of scope for v1; `uloop compile` applies these edits |
 | Method raises, invokes, or reads a field-like event (anything beyond `+=`/`-=`) | C# only allows `+=`/`-=` on an event outside its declaring type, so the raising body cannot compile from the shim assembly |
 
 ### Failed — flips `Success` to `false`

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -68,8 +68,8 @@ when edited (with a verified baseline, unchanged members of those kinds produce
 no row). Finalizers and `interface` members (including default interface
 implementations) are never scanned: **edits** to them produce **no per-method
 entry at all** and are silently not applied — use `uloop compile` for those.
-(**Adding** one of these member kinds is different: the addition is detected and
-reported as `Skipped`, per the next section.)
+Adding a constructor, operator, or explicit event accessor is reported as
+`Skipped` as well, same as an edit to an existing one.
 
 ### Added methods and fields
 
@@ -105,11 +105,12 @@ compiled source) removes it from the ledger on that run. Deleting a *compiled*
 member is reported in `Warnings`, but its IL remains callable from unedited code
 until `uloop compile`.
 
-Adding a type (`class`, `struct`, `enum`, `record`), a property, an event, an
-indexer, a constructor, or an operator is still out of scope. These additions
-are not reported per member — no `Skipped` row names them; at most they
-surface as outside-body drift in `Warnings`. Treat silence as "not applied"
-and land them with `uloop compile`.
+Adding a constructor, operator, or explicit event accessor is still out of
+scope and is reported as `Skipped`, same as edits to them. Adding a type
+(`class`, `struct`, `enum`, `record`), a property, or an indexer is still out
+of scope. These additions are not reported per member — no `Skipped` row
+names them; at most they surface as outside-body drift in `Warnings`. Treat
+silence as "not applied" and land them with `uloop compile`.
 
 Outside method bodies, only member additions (previous section) take effect.
 Every other declaration edit — changing a `const` value, a compiled field's

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -63,11 +63,13 @@ ledger across runs.
 ## Scope and limits
 
 Only ordinary method declarations and property getters with a body are patched.
-Constructors, finalizers, operators, event accessors, and `interface` members
-(including default interface implementations) are never scanned: **edits** to them
-produce **no per-method entry at all** and are silently not applied — use
-`uloop compile` for those. (**Adding** one of these member kinds is different:
-the addition is detected and reported as `Skipped`, per the next section.)
+Constructors, operators, and explicit event accessors are reported as `Skipped`
+when edited (with a verified baseline, unchanged members of those kinds produce
+no row). Finalizers and `interface` members (including default interface
+implementations) are never scanned: **edits** to them produce **no per-method
+entry at all** and are silently not applied — use `uloop compile` for those.
+(**Adding** one of these member kinds is different: the addition is detected and
+reported as `Skipped`, per the next section.)
 
 ### Added methods and fields
 
@@ -236,6 +238,7 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
 | Property setter, init, or indexer accessor with an explicit body | Accessor patching covers getters only; `uloop compile` applies setter/init/indexer edits |
+| Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Out of scope for v1; `uloop compile` applies these edits |
 | Method raises, invokes, or reads a field-like event (anything beyond `+=`/`-=`) | C# only allows `+=`/`-=` on an event outside its declaring type, so the raising body cannot compile from the shim assembly |
 
 ### Failed — flips `Success` to `false`

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -550,6 +550,54 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: editing an instance constructor reports it as Skipped with the unsupported-member
+        /// reason and leaves Success true.
+        /// </summary>
+        [Test]
+        public async Task Run_EditedInstanceConstructor_IsSkippedAndSuccessStaysTrue()
+        {
+            string fixturePath = ResolveUnsupportedKindFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string editedSource = onDisk.Replace(
+                "Marker = 11;",
+                "Marker = 111;",
+                StringComparison.Ordinal);
+            Assert.That(editedSource, Is.Not.EqualTo(onDisk), "Precondition: constructor body must differ.");
+
+            string editedPath = WriteEditedSource("UnsupportedKindCtor.cs", editedSource);
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                contentPathOverride: editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+
+            const string expectedReason =
+                "Constructors, operators, and event accessors are out of scope for v1; "
+                + "run 'uloop compile' to apply these edits.";
+            AssertHasSkipped(result, ".ctor()", expectedReason);
+
+            bool foundUneditedOverload = false;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Skipped
+                    && outcome.Reason == expectedReason
+                    && outcome.Method.Contains(".ctor(System.Int32)"))
+                {
+                    foundUneditedOverload = true;
+                }
+            }
+
+            Assert.That(
+                foundUneditedOverload,
+                Is.False,
+                "Unedited constructor overload must not be Skipped; got: " + FormatOutcomes(result));
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+            Assert.That(response.Success, Is.True, "Skipped constructors must not flip Success.");
+        }
+
+        /// <summary>
         /// What: editing a static expression-bodied property getter patches runtime reads,
         /// --status lists the Active get_ row, and RevertAll restores the compiled literal.
         /// </summary>
@@ -3777,6 +3825,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "HotReload",
                 "HotReloadAddedMemberHost.cs");
             Assert.That(File.Exists(path), Is.True, "Added-member host source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string ResolveUnsupportedKindFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadUnsupportedMemberKindFixtures.cs");
+            Assert.That(File.Exists(path), Is.True, "Unsupported-kind fixture source missing: " + path);
             return Path.GetFullPath(path);
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadUnsupportedMemberKindFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadUnsupportedMemberKindFixtures.cs
@@ -1,0 +1,142 @@
+using System;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled types for worker tests that assert ctor/operator/event-accessor Skipped rows
+    /// and the local-function parent-method pin. Unique assignment tokens are replaced in
+    /// snapshots; do not reuse them across types.
+    /// </summary>
+    public sealed class HotReloadUnsupportedKindCtorFixture
+    {
+        public int Marker;
+
+        public HotReloadUnsupportedKindCtorFixture()
+        {
+            Marker = 11;
+        }
+
+        public HotReloadUnsupportedKindCtorFixture(int value)
+        {
+            Marker = value;
+        }
+
+        public int Read()
+        {
+            return Marker;
+        }
+    }
+
+    public sealed class HotReloadUnsupportedKindStaticCtorEdited
+    {
+        public static int Marker;
+
+        static HotReloadUnsupportedKindStaticCtorEdited()
+        {
+            Marker = 21;
+        }
+
+        public static int Read()
+        {
+            return Marker;
+        }
+    }
+
+    public sealed class HotReloadUnsupportedKindStaticCtorUnedited
+    {
+        public static int Marker;
+
+        static HotReloadUnsupportedKindStaticCtorUnedited()
+        {
+            Marker = 22;
+        }
+
+        public static int Read()
+        {
+            return Marker;
+        }
+    }
+
+    public sealed class HotReloadUnsupportedKindOperatorFixture
+    {
+        public int Marker;
+
+        public static HotReloadUnsupportedKindOperatorFixture operator +(
+            HotReloadUnsupportedKindOperatorFixture left,
+            HotReloadUnsupportedKindOperatorFixture right)
+        {
+            left.Marker = 31;
+            return left;
+        }
+
+        public static HotReloadUnsupportedKindOperatorFixture operator -(
+            HotReloadUnsupportedKindOperatorFixture left,
+            HotReloadUnsupportedKindOperatorFixture right)
+        {
+            left.Marker = 32;
+            return left;
+        }
+
+        public int Read()
+        {
+            return Marker;
+        }
+    }
+
+    public sealed class HotReloadUnsupportedKindConversionFixture
+    {
+        public int Marker;
+
+        public static implicit operator int(HotReloadUnsupportedKindConversionFixture value)
+        {
+            value.Marker = 41;
+            return value.Marker;
+        }
+
+        public static explicit operator long(HotReloadUnsupportedKindConversionFixture value)
+        {
+            value.Marker = 42;
+            return value.Marker;
+        }
+
+        public int Read()
+        {
+            return Marker;
+        }
+    }
+
+    public sealed class HotReloadUnsupportedKindEventFixture
+    {
+        public int Marker;
+
+        public event Action Edited
+        {
+            add { Marker = 51; }
+            remove { }
+        }
+
+        public event Action Unedited
+        {
+            add { Marker = 52; }
+            remove { }
+        }
+
+        public int Read()
+        {
+            return Marker;
+        }
+    }
+
+    public sealed class HotReloadLocalFunctionParentFixture
+    {
+        public int Compute(int x)
+        {
+            int Local()
+            {
+                return 41;
+            }
+
+            return Local() + x;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadUnsupportedMemberKindFixtures.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadUnsupportedMemberKindFixtures.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 357ab0b7aad6346748daa616995b5247
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -1404,7 +1404,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: editing one explicit event accessor reports that accessor as Skipped and omits
+        /// What: editing one explicit event accessor reports that event's add and remove as
+        /// Skipped (member-level equivalence, same granularity as property accessors) and omits
         /// accessors of an unedited event in the same type.
         /// </summary>
         [Test]
@@ -1418,6 +1419,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertSkippedContains(
                 result,
                 "add_Edited",
+                ExpectedUnsupportedMemberKindSkipReason);
+            AssertSkippedContains(
+                result,
+                "remove_Edited",
                 ExpectedUnsupportedMemberKindSkipReason);
             AssertSkippedDoesNotContain(result, "add_Unedited");
             AssertSkippedDoesNotContain(result, "remove_Unedited");

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -1429,6 +1429,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: adding an instance constructor that is absent from the verified snapshot
+        /// reports that .ctor as Skipped with the unsupported-member reason (same path as an
+        /// edit) and omits unedited overloads already in the snapshot.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_AddedInstanceCtor_IsSkipped()
+        {
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                "UnsupportedKindAddedInstanceCtor.cs",
+                "            Marker = value;\n        }",
+                "            Marker = value;\n        }\n\n"
+                + "        public HotReloadUnsupportedKindCtorFixture(int a, int b)\n"
+                + "        {\n"
+                + "            Marker = a + b;\n"
+                + "        }");
+
+            AssertSkippedContains(
+                result,
+                "HotReloadUnsupportedKindCtorFixture..ctor(System.Int32,System.Int32)",
+                ExpectedUnsupportedMemberKindSkipReason);
+            AssertSkippedDoesNotContain(result, ".ctor()");
+            AssertSkippedDoesNotContain(result, ".ctor(System.Int32)");
+        }
+
+        /// <summary>
         /// What: editing only a local function body emits the parent method as a patch entry,
         /// not Skipped, and does not emit a separate local-function row.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -1323,6 +1323,198 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Does.Contain("Awake is a one-shot lifecycle method"));
         }
 
+        private const string ExpectedUnsupportedMemberKindSkipReason =
+            "Constructors, operators, and event accessors are out of scope for v1; "
+            + "run 'uloop compile' to apply these edits.";
+
+        /// <summary>
+        /// What: editing one instance constructor reports that .ctor as Skipped and omits an
+        /// unedited overload in the same type.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_InstanceCtor_SkipsEditedOmitsUnedited()
+        {
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                "UnsupportedKindInstanceCtor.cs",
+                "Marker = 11;",
+                "Marker = 111;");
+
+            AssertSkippedContains(
+                result,
+                ".ctor()",
+                ExpectedUnsupportedMemberKindSkipReason);
+            AssertSkippedDoesNotContain(result, ".ctor(System.Int32)");
+        }
+
+        /// <summary>
+        /// What: editing one type's static constructor reports that .cctor as Skipped and omits
+        /// an unedited static constructor on a sibling type in the same file.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_StaticCtor_SkipsEditedOmitsUnedited()
+        {
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                "UnsupportedKindStaticCtor.cs",
+                "Marker = 21;",
+                "Marker = 211;");
+
+            AssertSkippedContains(
+                result,
+                "HotReloadUnsupportedKindStaticCtorEdited..cctor()",
+                ExpectedUnsupportedMemberKindSkipReason);
+            AssertSkippedDoesNotContain(result, "HotReloadUnsupportedKindStaticCtorUnedited");
+        }
+
+        /// <summary>
+        /// What: editing one operator reports that operator as Skipped and omits an unedited
+        /// operator in the same type.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_Operator_SkipsEditedOmitsUnedited()
+        {
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                "UnsupportedKindOperator.cs",
+                "left.Marker = 31;",
+                "left.Marker = 311;");
+
+            AssertSkippedContains(
+                result,
+                "op_Addition",
+                ExpectedUnsupportedMemberKindSkipReason);
+            AssertSkippedDoesNotContain(result, "op_Subtraction");
+        }
+
+        /// <summary>
+        /// What: editing one conversion operator reports that conversion as Skipped and omits an
+        /// unedited conversion in the same type.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_ConversionOperator_SkipsEditedOmitsUnedited()
+        {
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                "UnsupportedKindConversion.cs",
+                "value.Marker = 41;",
+                "value.Marker = 411;");
+
+            AssertSkippedContains(
+                result,
+                "op_Implicit",
+                ExpectedUnsupportedMemberKindSkipReason);
+            AssertSkippedDoesNotContain(result, "op_Explicit");
+        }
+
+        /// <summary>
+        /// What: editing one explicit event accessor reports that accessor as Skipped and omits
+        /// accessors of an unedited event in the same type.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_EventAccessor_SkipsEditedOmitsUnedited()
+        {
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                "UnsupportedKindEventAccessor.cs",
+                "Marker = 51;",
+                "Marker = 511;");
+
+            AssertSkippedContains(
+                result,
+                "add_Edited",
+                ExpectedUnsupportedMemberKindSkipReason);
+            AssertSkippedDoesNotContain(result, "add_Unedited");
+            AssertSkippedDoesNotContain(result, "remove_Unedited");
+        }
+
+        /// <summary>
+        /// What: editing only a local function body emits the parent method as a patch entry,
+        /// not Skipped, and does not emit a separate local-function row.
+        /// </summary>
+        [Test]
+        public async Task Run_LocalFunction_EmitsParentMethodOnly()
+        {
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                "LocalFunctionParent.cs",
+                "return 41;",
+                "return 42;");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.entries, Is.Not.Null);
+            Assert.That(
+                result.Output.entries.Length,
+                Is.EqualTo(1),
+                "Local-function body edits must emit exactly one parent-method entry; got: "
+                + FormatEntryMethodNames(result.Output.entries)
+                + "; skipped="
+                + FormatSkippedMethodNames(result.Output.skipped));
+            Assert.That(result.Output.entries[0].methodName, Is.EqualTo("Compute"));
+            AssertSkippedDoesNotContain(result, "Compute");
+            AssertSkippedDoesNotContain(result, "Local");
+        }
+
+        private static async Task<TransformWorkerClientResult> RunWorkerOnUnsupportedKindEditAsync(
+            string fileName,
+            string originalFragment,
+            string editedFragment)
+        {
+            string fixturePath = ResolveUnsupportedKindFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string currentSource = onDisk.Replace(
+                originalFragment,
+                editedFragment,
+                StringComparison.Ordinal);
+            Assert.That(currentSource, Is.Not.EqualTo(onDisk), "Precondition: snapshot must differ.");
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string sourcePath = Path.Combine(directory, fileName);
+            File.WriteAllText(sourcePath, currentSource);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                ResolveUnsupportedKindFixtureProjectRelativePath(),
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            return result;
+        }
+
+        private static void AssertSkippedContains(
+            TransformWorkerClientResult result,
+            string methodFragment,
+            string expectedReason)
+        {
+            Assert.That(result.Output.skipped, Is.Not.Null, "Expected a skipped list from the worker.");
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                if (skipped.method != null
+                    && skipped.method.Contains(methodFragment)
+                    && skipped.reason == expectedReason)
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail(
+                "Expected skip containing '" + methodFragment + "' with the unsupported-member reason; got: "
+                + FormatSkippedMethodNames(result.Output.skipped));
+        }
+
+        private static void AssertSkippedDoesNotContain(
+            TransformWorkerClientResult result,
+            string methodFragment)
+        {
+            if (result.Output.skipped == null)
+            {
+                return;
+            }
+
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                Assert.That(
+                    skipped.method,
+                    Does.Not.Contain(methodFragment),
+                    "Unedited member '" + methodFragment + "' must not appear in skipped; got: "
+                    + FormatSkippedMethodNames(result.Output.skipped));
+            }
+        }
+
         private static async Task<TransformWorkerEntryDto> RunWorkerAndFindEntryAsync(
             string source,
             string fileName,
@@ -1523,6 +1715,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private static string ResolveE2EFixtureProjectRelativePath()
         {
             return "Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs";
+        }
+
+        private static string ResolveUnsupportedKindFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadUnsupportedMemberKindFixtures.cs");
+            Assert.That(File.Exists(path), Is.True, "Unsupported-kind fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string ResolveUnsupportedKindFixtureProjectRelativePath()
+        {
+            return "Assets/Tests/Editor/HotReload/HotReloadUnsupportedMemberKindFixtures.cs";
         }
 
         private static string ResolveShapeFixturePath()

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -68,8 +68,8 @@ when edited (with a verified baseline, unchanged members of those kinds produce
 no row). Finalizers and `interface` members (including default interface
 implementations) are never scanned: **edits** to them produce **no per-method
 entry at all** and are silently not applied — use `uloop compile` for those.
-(**Adding** one of these member kinds is different: the addition is detected and
-reported as `Skipped`, per the next section.)
+Adding a constructor, operator, or explicit event accessor is reported as
+`Skipped` as well, same as an edit to an existing one.
 
 ### Added methods and fields
 
@@ -105,11 +105,12 @@ compiled source) removes it from the ledger on that run. Deleting a *compiled*
 member is reported in `Warnings`, but its IL remains callable from unedited code
 until `uloop compile`.
 
-Adding a type (`class`, `struct`, `enum`, `record`), a property, an event, an
-indexer, a constructor, or an operator is still out of scope. These additions
-are not reported per member — no `Skipped` row names them; at most they
-surface as outside-body drift in `Warnings`. Treat silence as "not applied"
-and land them with `uloop compile`.
+Adding a constructor, operator, or explicit event accessor is still out of
+scope and is reported as `Skipped`, same as edits to them. Adding a type
+(`class`, `struct`, `enum`, `record`), a property, or an indexer is still out
+of scope. These additions are not reported per member — no `Skipped` row
+names them; at most they surface as outside-body drift in `Warnings`. Treat
+silence as "not applied" and land them with `uloop compile`.
 
 Outside method bodies, only member additions (previous section) take effect.
 Every other declaration edit — changing a `const` value, a compiled field's

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -63,11 +63,13 @@ ledger across runs.
 ## Scope and limits
 
 Only ordinary method declarations and property getters with a body are patched.
-Constructors, finalizers, operators, event accessors, and `interface` members
-(including default interface implementations) are never scanned: **edits** to them
-produce **no per-method entry at all** and are silently not applied — use
-`uloop compile` for those. (**Adding** one of these member kinds is different:
-the addition is detected and reported as `Skipped`, per the next section.)
+Constructors, operators, and explicit event accessors are reported as `Skipped`
+when edited (with a verified baseline, unchanged members of those kinds produce
+no row). Finalizers and `interface` members (including default interface
+implementations) are never scanned: **edits** to them produce **no per-method
+entry at all** and are silently not applied — use `uloop compile` for those.
+(**Adding** one of these member kinds is different: the addition is detected and
+reported as `Skipped`, per the next section.)
 
 ### Added methods and fields
 
@@ -236,6 +238,7 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
 | Property setter, init, or indexer accessor with an explicit body | Accessor patching covers getters only; `uloop compile` applies setter/init/indexer edits |
+| Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Out of scope for v1; `uloop compile` applies these edits |
 | Method raises, invokes, or reads a field-like event (anything beyond `+=`/`-=`) | C# only allows `+=`/`-=` on an event outside its declaring type, so the raising body cannot compile from the shim assembly |
 
 ### Failed — flips `Success` to `false`

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -278,8 +278,14 @@ public static class TransformWorkerProgram
         Dictionary<string, MethodDeclarationSyntax> plainCurrentMethodMap = null;
         Dictionary<string, PropertyDeclarationSyntax> snapshotPropertyMap = null;
         Dictionary<string, IndexerDeclarationSyntax> snapshotIndexerMap = null;
+        Dictionary<string, ConstructorDeclarationSyntax> snapshotConstructorMap = null;
+        Dictionary<string, MemberDeclarationSyntax> snapshotOperatorMap = null;
+        Dictionary<string, EventDeclarationSyntax> snapshotEventMap = null;
         Dictionary<string, PropertyDeclarationSyntax> plainCurrentPropertyMap = null;
         Dictionary<string, IndexerDeclarationSyntax> plainCurrentIndexerMap = null;
+        Dictionary<string, ConstructorDeclarationSyntax> plainCurrentConstructorMap = null;
+        Dictionary<string, MemberDeclarationSyntax> plainCurrentOperatorMap = null;
+        Dictionary<string, EventDeclarationSyntax> plainCurrentEventMap = null;
         CompilationUnitSyntax baselineSnapshotRoot = null;
         // Null disables comparison; empty string is a real (empty) baseline text.
         if (input.SnapshotSource != null)
@@ -302,8 +308,14 @@ public static class TransformWorkerProgram
                 // gating for this file; method-level baseline matching still applies.
                 snapshotPropertyMap = BuildSyntaxPropertyMapOrNull(baselineSnapshotRoot);
                 snapshotIndexerMap = BuildSyntaxIndexerMapOrNull(baselineSnapshotRoot);
+                snapshotConstructorMap = BuildSyntaxConstructorMapOrNull(baselineSnapshotRoot);
+                snapshotOperatorMap = BuildSyntaxOperatorMapOrNull(baselineSnapshotRoot);
+                snapshotEventMap = BuildSyntaxEventMapOrNull(baselineSnapshotRoot);
                 plainCurrentPropertyMap = BuildSyntaxPropertyMapOrNull(plainRoot);
                 plainCurrentIndexerMap = BuildSyntaxIndexerMapOrNull(plainRoot);
+                plainCurrentConstructorMap = BuildSyntaxConstructorMapOrNull(plainRoot);
+                plainCurrentOperatorMap = BuildSyntaxOperatorMapOrNull(plainRoot);
+                plainCurrentEventMap = BuildSyntaxEventMapOrNull(plainRoot);
             }
             else
             {
@@ -347,6 +359,17 @@ public static class TransformWorkerProgram
                 hasBaseline ? snapshotIndexerMap : null,
                 hasBaseline ? plainCurrentPropertyMap : null,
                 hasBaseline ? plainCurrentIndexerMap : null);
+            AppendUnsupportedMemberKindSkips(
+                typeDeclaration,
+                typeMetadataNameFromSyntax,
+                semanticModel,
+                skipped,
+                hasBaseline ? snapshotConstructorMap : null,
+                hasBaseline ? snapshotOperatorMap : null,
+                hasBaseline ? snapshotEventMap : null,
+                hasBaseline ? plainCurrentConstructorMap : null,
+                hasBaseline ? plainCurrentOperatorMap : null,
+                hasBaseline ? plainCurrentEventMap : null);
 
             TypeEmitState typeState = new TypeEmitState
             {
@@ -898,6 +921,10 @@ public static class TransformWorkerProgram
         "Property setter, init, or indexer accessors are out of scope for v1; "
         + "run 'uloop compile' to apply accessor edits.";
 
+    private const string UnsupportedMemberKindSkipReason =
+        "Constructors, operators, and event accessors are out of scope for v1; "
+        + "run 'uloop compile' to apply these edits.";
+
     private const string OutsideMethodBodyDriftWarningFormat =
         "Edits outside method bodies in {0} (fields, initializers, or attributes) are not applied by hot reload; run uloop compile to pick them up.";
 
@@ -1049,6 +1076,76 @@ public static class TransformWorkerProgram
         return typeMetadataName + "::this(" + string.Join(",", parameterKeys) + ")";
     }
 
+    private static string BuildSyntaxConstructorKey(
+        string typeMetadataName,
+        ConstructorDeclarationSyntax constructorDeclaration)
+    {
+        List<string> parameterKeys = new List<string>();
+        if (constructorDeclaration.ParameterList != null)
+        {
+            foreach (ParameterSyntax parameter in constructorDeclaration.ParameterList.Parameters)
+            {
+                parameterKeys.Add(BuildSyntaxParameterTypeKey(parameter));
+            }
+        }
+
+        string name = constructorDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword)
+            ? ".cctor"
+            : ".ctor";
+        return typeMetadataName + "::" + name + "(" + string.Join(",", parameterKeys) + ")";
+    }
+
+    private static string BuildSyntaxOperatorKey(
+        string typeMetadataName,
+        OperatorDeclarationSyntax operatorDeclaration)
+    {
+        List<string> parameterKeys = new List<string>();
+        if (operatorDeclaration.ParameterList != null)
+        {
+            foreach (ParameterSyntax parameter in operatorDeclaration.ParameterList.Parameters)
+            {
+                parameterKeys.Add(BuildSyntaxParameterTypeKey(parameter));
+            }
+        }
+
+        return typeMetadataName + "::" + operatorDeclaration.OperatorToken.ValueText
+            + "(" + string.Join(",", parameterKeys) + ")";
+    }
+
+    private static string BuildSyntaxConversionOperatorKey(
+        string typeMetadataName,
+        ConversionOperatorDeclarationSyntax conversionDeclaration)
+    {
+        List<string> parameterKeys = new List<string>();
+        if (conversionDeclaration.ParameterList != null)
+        {
+            foreach (ParameterSyntax parameter in conversionDeclaration.ParameterList.Parameters)
+            {
+                parameterKeys.Add(BuildSyntaxParameterTypeKey(parameter));
+            }
+        }
+
+        string targetType = conversionDeclaration.Type != null
+            ? conversionDeclaration.Type.NormalizeWhitespace().ToString()
+            : string.Empty;
+        return typeMetadataName + "::" + conversionDeclaration.ImplicitOrExplicitKeyword.ValueText
+            + "->" + targetType + "(" + string.Join(",", parameterKeys) + ")";
+    }
+
+    private static string BuildSyntaxEventKey(
+        string typeMetadataName,
+        EventDeclarationSyntax eventDeclaration)
+    {
+        string name = eventDeclaration.Identifier.Text;
+        if (eventDeclaration.ExplicitInterfaceSpecifier != null)
+        {
+            name = eventDeclaration.ExplicitInterfaceSpecifier.Name.NormalizeWhitespace().ToString()
+                + "." + name;
+        }
+
+        return typeMetadataName + "::" + name;
+    }
+
     private static Dictionary<string, MethodDeclarationSyntax> BuildSyntaxMethodMapOrNull(
         CompilationUnitSyntax root)
     {
@@ -1136,6 +1233,99 @@ public static class TransformWorkerProgram
                 }
 
                 map[key] = indexerDeclaration;
+            }
+        }
+
+        return map;
+    }
+
+    private static Dictionary<string, ConstructorDeclarationSyntax> BuildSyntaxConstructorMapOrNull(
+        CompilationUnitSyntax root)
+    {
+        Dictionary<string, ConstructorDeclarationSyntax> map =
+            new Dictionary<string, ConstructorDeclarationSyntax>();
+        foreach (TypeDeclarationSyntax typeDeclaration in EnumerateTypeDeclarations(root))
+        {
+            string typeMetadataName = BuildTypeMetadataNameFromSyntax(typeDeclaration);
+            foreach (ConstructorDeclarationSyntax constructorDeclaration in typeDeclaration.Members
+                .OfType<ConstructorDeclarationSyntax>())
+            {
+                string key = BuildSyntaxConstructorKey(typeMetadataName, constructorDeclaration);
+                if (map.ContainsKey(key))
+                {
+                    return null;
+                }
+
+                map[key] = constructorDeclaration;
+            }
+        }
+
+        return map;
+    }
+
+    private static Dictionary<string, MemberDeclarationSyntax> BuildSyntaxOperatorMapOrNull(
+        CompilationUnitSyntax root)
+    {
+        Dictionary<string, MemberDeclarationSyntax> map =
+            new Dictionary<string, MemberDeclarationSyntax>();
+        foreach (TypeDeclarationSyntax typeDeclaration in EnumerateTypeDeclarations(root))
+        {
+            string typeMetadataName = BuildTypeMetadataNameFromSyntax(typeDeclaration);
+            foreach (MemberDeclarationSyntax member in typeDeclaration.Members)
+            {
+                string key = TryBuildSyntaxOperatorMemberKey(typeMetadataName, member);
+                if (key == null)
+                {
+                    continue;
+                }
+
+                if (map.ContainsKey(key))
+                {
+                    return null;
+                }
+
+                map[key] = member;
+            }
+        }
+
+        return map;
+    }
+
+    private static string TryBuildSyntaxOperatorMemberKey(
+        string typeMetadataName,
+        MemberDeclarationSyntax member)
+    {
+        if (member is OperatorDeclarationSyntax operatorDeclaration)
+        {
+            return BuildSyntaxOperatorKey(typeMetadataName, operatorDeclaration);
+        }
+
+        if (member is ConversionOperatorDeclarationSyntax conversionDeclaration)
+        {
+            return BuildSyntaxConversionOperatorKey(typeMetadataName, conversionDeclaration);
+        }
+
+        return null;
+    }
+
+    private static Dictionary<string, EventDeclarationSyntax> BuildSyntaxEventMapOrNull(
+        CompilationUnitSyntax root)
+    {
+        Dictionary<string, EventDeclarationSyntax> map =
+            new Dictionary<string, EventDeclarationSyntax>();
+        foreach (TypeDeclarationSyntax typeDeclaration in EnumerateTypeDeclarations(root))
+        {
+            string typeMetadataName = BuildTypeMetadataNameFromSyntax(typeDeclaration);
+            foreach (EventDeclarationSyntax eventDeclaration in typeDeclaration.Members
+                .OfType<EventDeclarationSyntax>())
+            {
+                string key = BuildSyntaxEventKey(typeMetadataName, eventDeclaration);
+                if (map.ContainsKey(key))
+                {
+                    return null;
+                }
+
+                map[key] = eventDeclaration;
             }
         }
 
@@ -1577,6 +1767,184 @@ public static class TransformWorkerProgram
         }
 
         return null;
+    }
+
+    // What: reports instance/static constructors, operators, conversion operators, and
+    // explicit event accessors as Skipped. Unchanged members matching a verified snapshot
+    // are omitted. Field-like events and finalizers are not listed.
+    private static void AppendUnsupportedMemberKindSkips(
+        TypeDeclarationSyntax typeDeclaration,
+        string typeMetadataNameFromSyntax,
+        SemanticModel semanticModel,
+        List<WorkerSkipped> skipped,
+        Dictionary<string, ConstructorDeclarationSyntax> snapshotConstructorMap,
+        Dictionary<string, MemberDeclarationSyntax> snapshotOperatorMap,
+        Dictionary<string, EventDeclarationSyntax> snapshotEventMap,
+        Dictionary<string, ConstructorDeclarationSyntax> plainCurrentConstructorMap,
+        Dictionary<string, MemberDeclarationSyntax> plainCurrentOperatorMap,
+        Dictionary<string, EventDeclarationSyntax> plainCurrentEventMap)
+    {
+        AppendConstructorSkips(
+            typeDeclaration,
+            typeMetadataNameFromSyntax,
+            semanticModel,
+            skipped,
+            snapshotConstructorMap,
+            plainCurrentConstructorMap);
+        AppendOperatorSkips(
+            typeDeclaration,
+            typeMetadataNameFromSyntax,
+            semanticModel,
+            skipped,
+            snapshotOperatorMap,
+            plainCurrentOperatorMap);
+        AppendEventAccessorSkips(
+            typeDeclaration,
+            typeMetadataNameFromSyntax,
+            semanticModel,
+            skipped,
+            snapshotEventMap,
+            plainCurrentEventMap);
+    }
+
+    private static void AppendConstructorSkips(
+        TypeDeclarationSyntax typeDeclaration,
+        string typeMetadataNameFromSyntax,
+        SemanticModel semanticModel,
+        List<WorkerSkipped> skipped,
+        Dictionary<string, ConstructorDeclarationSyntax> snapshotConstructorMap,
+        Dictionary<string, ConstructorDeclarationSyntax> plainCurrentConstructorMap)
+    {
+        foreach (ConstructorDeclarationSyntax constructorDeclaration in typeDeclaration.Members
+            .OfType<ConstructorDeclarationSyntax>())
+        {
+            string constructorKey = BuildSyntaxConstructorKey(
+                typeMetadataNameFromSyntax,
+                constructorDeclaration);
+            if (snapshotConstructorMap != null
+                && plainCurrentConstructorMap != null
+                && snapshotConstructorMap.TryGetValue(
+                    constructorKey,
+                    out ConstructorDeclarationSyntax snapshotConstructor)
+                && plainCurrentConstructorMap.TryGetValue(
+                    constructorKey,
+                    out ConstructorDeclarationSyntax plainConstructor)
+                && SyntaxFactory.AreEquivalent(snapshotConstructor, plainConstructor, topLevel: false))
+            {
+                continue;
+            }
+
+            IMethodSymbol methodSymbol = semanticModel.GetDeclaredSymbol(constructorDeclaration);
+            AppendUnsupportedKindSkip(skipped, methodSymbol);
+        }
+    }
+
+    private static void AppendOperatorSkips(
+        TypeDeclarationSyntax typeDeclaration,
+        string typeMetadataNameFromSyntax,
+        SemanticModel semanticModel,
+        List<WorkerSkipped> skipped,
+        Dictionary<string, MemberDeclarationSyntax> snapshotOperatorMap,
+        Dictionary<string, MemberDeclarationSyntax> plainCurrentOperatorMap)
+    {
+        foreach (MemberDeclarationSyntax member in typeDeclaration.Members)
+        {
+            string operatorKey = TryBuildSyntaxOperatorMemberKey(typeMetadataNameFromSyntax, member);
+            if (operatorKey == null)
+            {
+                continue;
+            }
+
+            if (snapshotOperatorMap != null
+                && plainCurrentOperatorMap != null
+                && snapshotOperatorMap.TryGetValue(operatorKey, out MemberDeclarationSyntax snapshotOperator)
+                && plainCurrentOperatorMap.TryGetValue(operatorKey, out MemberDeclarationSyntax plainOperator)
+                && SyntaxFactory.AreEquivalent(snapshotOperator, plainOperator, topLevel: false))
+            {
+                continue;
+            }
+
+            IMethodSymbol methodSymbol = semanticModel.GetDeclaredSymbol(member) as IMethodSymbol;
+            AppendUnsupportedKindSkip(skipped, methodSymbol);
+        }
+    }
+
+    private static void AppendEventAccessorSkips(
+        TypeDeclarationSyntax typeDeclaration,
+        string typeMetadataNameFromSyntax,
+        SemanticModel semanticModel,
+        List<WorkerSkipped> skipped,
+        Dictionary<string, EventDeclarationSyntax> snapshotEventMap,
+        Dictionary<string, EventDeclarationSyntax> plainCurrentEventMap)
+    {
+        foreach (EventDeclarationSyntax eventDeclaration in typeDeclaration.Members
+            .OfType<EventDeclarationSyntax>())
+        {
+            string eventKey = BuildSyntaxEventKey(typeMetadataNameFromSyntax, eventDeclaration);
+            if (snapshotEventMap != null
+                && plainCurrentEventMap != null
+                && snapshotEventMap.TryGetValue(eventKey, out EventDeclarationSyntax snapshotEvent)
+                && plainCurrentEventMap.TryGetValue(eventKey, out EventDeclarationSyntax plainEvent)
+                && SyntaxFactory.AreEquivalent(snapshotEvent, plainEvent, topLevel: false))
+            {
+                continue;
+            }
+
+            IEventSymbol eventSymbol = semanticModel.GetDeclaredSymbol(eventDeclaration);
+            if (eventSymbol == null)
+            {
+                continue;
+            }
+
+            AppendEventAccessorSkipIfExplicit(skipped, eventDeclaration, SyntaxKind.AddAccessorDeclaration, eventSymbol.AddMethod);
+            AppendEventAccessorSkipIfExplicit(
+                skipped,
+                eventDeclaration,
+                SyntaxKind.RemoveAccessorDeclaration,
+                eventSymbol.RemoveMethod);
+        }
+    }
+
+    private static void AppendEventAccessorSkipIfExplicit(
+        List<WorkerSkipped> skipped,
+        EventDeclarationSyntax eventDeclaration,
+        SyntaxKind accessorKind,
+        IMethodSymbol accessorMethod)
+    {
+        if (accessorMethod == null || eventDeclaration.AccessorList == null)
+        {
+            return;
+        }
+
+        foreach (AccessorDeclarationSyntax accessor in eventDeclaration.AccessorList.Accessors)
+        {
+            if (accessor.Kind() != accessorKind)
+            {
+                continue;
+            }
+
+            if (accessor.Body == null && accessor.ExpressionBody == null)
+            {
+                return;
+            }
+
+            AppendUnsupportedKindSkip(skipped, accessorMethod);
+            return;
+        }
+    }
+
+    private static void AppendUnsupportedKindSkip(List<WorkerSkipped> skipped, IMethodSymbol methodSymbol)
+    {
+        if (methodSymbol == null)
+        {
+            return;
+        }
+
+        skipped.Add(new WorkerSkipped
+        {
+            Method = FormatMethodLabel(methodSymbol),
+            Reason = UnsupportedMemberKindSkipReason
+        });
     }
 
     // What: emit a get_<Name> entry / unchanged row / skip for one property with a getter body.


### PR DESCRIPTION
## Summary
- Hot reload now reports edits to constructors, operators, conversion operators, and explicit event accessors as `Skipped`, instead of returning `Success` with no per-method row.

## User Impact
- Before: editing a constructor, operator, or explicit event accessor looked like a successful no-op. The change was not applied and not listed.
- After: the edited member appears as `Skipped` with a reason that points at `uloop compile`. Unchanged members of those kinds stay off the list when a verified baseline is present. Finalizers stay never-scanned. Field-like events are unchanged.

Closes #2113

## Changes
- Transform worker reports these kinds with the same baseline gating as explicit property/indexer accessors.
- Method labels keep the existing `FormatMethodLabel` shape (`.ctor` / `.cctor` / `op_*` / `add_*`).
- `StripMethodBodiesRewriter` is unchanged; a Skipped row plus the generic outside-body drift warning can both appear, matching the existing setter behavior.
- Local-function body edits still emit the parent method as a patch entry (pinned by test).

## Verification
- EditMode: `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload` → **363 passed / 0 failed**.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

