### PR TITLE
fix: label already-active gated replacements instead of re-skipping them

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberRegistryTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberRegistryTests.cs
@@ -62,6 +62,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: IsActiveMember is true only for the registered path, not for the same
+        /// MethodKey on another file.
+        /// </summary>
+        [Test]
+        public void IsActiveMember_SameKeyDifferentPath_ReturnsFalse()
+        {
+            MethodInfo shim = RequireExistingCaller();
+            const string methodKey = "Host.AddedPing(System.Int32)";
+            HotReloadAddedMemberRegistry.BeginFileGeneration(FileOne);
+            HotReloadAddedMemberRegistry.Register(FileOne, methodKey, shim, FileOne);
+
+            Assert.That(HotReloadAddedMemberRegistry.IsActiveMember(FileOne, methodKey), Is.True);
+            Assert.That(HotReloadAddedMemberRegistry.IsActiveMember(FileTwo, methodKey), Is.False);
+        }
+
+        /// <summary>
         /// What: Clear removes every file's added members.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2638,6 +2638,80 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: after a same-file return-type change applies, a later run that skips the
+        /// covering caller still reports the replacement as already-active instead of a fresh
+        /// gate skip.
+        /// </summary>
+        [Test]
+        public async Task Run_ReturnTypeChange_LaterCallerSkip_ReportsAlreadyActiveReason()
+        {
+            string fixturePath = ResolveSignatureChangeAlreadyActiveFixturePath();
+            string applied = WithSameFileReturnTypeChange(File.ReadAllText(fixturePath));
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeAlreadyActive1.cs", applied),
+                CancellationToken.None);
+            AssertNoFileLevelFailure(first);
+            AssertHasAdded(first, nameof(HotReloadSignatureChangeAlreadyActiveFixture.Target));
+            AssertHasPatched(first, nameof(HotReloadSignatureChangeAlreadyActiveFixture.ExistingCaller));
+            Assert.That(
+                CountAddedMembersContaining(nameof(HotReloadSignatureChangeAlreadyActiveFixture.Target)),
+                Is.EqualTo(1));
+
+            string later = applied
+                .Replace(
+                    "        public int MarkerHp { get; set; }",
+                    "        public int MarkerHp;",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "            return (int)Target(value);\n        }",
+                    "            MarkerHp = value;\n            return (int)Target(value);\n        }",
+                    StringComparison.Ordinal);
+            Assert.That(later, Is.Not.EqualTo(applied));
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeAlreadyActive2.cs", later),
+                CancellationToken.None);
+            AssertNoFileLevelFailure(second);
+            string expectedLabel = HotReloadPatcher.FormatMethodKeyParts(
+                typeof(HotReloadSignatureChangeAlreadyActiveFixture).FullName,
+                nameof(HotReloadSignatureChangeAlreadyActiveFixture.Target),
+                new[] { "System.Int32" },
+                0);
+            string expectedReason = string.Format(
+                HotReloadConstants.SignatureChangedGateSkipReasonAlreadyActiveFormat,
+                expectedLabel);
+            Assert.That(FindSkippedReason(second, expectedLabel), Is.EqualTo(expectedReason));
+            Assert.That(
+                CountAddedMembersContaining(nameof(HotReloadSignatureChangeAlreadyActiveFixture.Target)),
+                Is.EqualTo(1),
+                "The earlier replacement must stay in the added-member registry.");
+            Assert.That(second.ActivePatchTotal, Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// What: a gated replacement's wire key keeps Cecil '/' and '::', so it cannot match
+        /// a registry MethodKey until FormatMethodKeyParts normalizes it.
+        /// </summary>
+        [Test]
+        public void FormatGatedReplacementRegistryKey_NestedType_DiffersFromWireKey()
+        {
+            TransformWorkerEntryDto entry = new TransformWorkerEntryDto
+            {
+                typeMetadataName = "Ns.Outer/Inner",
+                methodName = "Name",
+                parameterTypeFullNames = new[] { "System.Int32" },
+                genericArity = 0
+            };
+            string wireKey = "Ns.Outer/Inner::Name(System.Int32)";
+            string registryKey = HotReloadOrchestrator.FormatGatedReplacementRegistryKey(entry);
+
+            Assert.That(wireKey, Is.Not.EqualTo(registryKey));
+            Assert.That(registryKey, Is.EqualTo("Ns.Outer+Inner.Name(System.Int32)"));
+        }
+
+        /// <summary>
         /// What: a return-type change with a compiled caller in another class is skipped together
         /// with the same-file caller, while an unrelated body edit in the same file still patches.
         /// </summary>
@@ -3756,6 +3830,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 File.Exists(path),
                 Is.True,
                 "Signature-change same-file fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string ResolveSignatureChangeAlreadyActiveFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadSignatureChangeAlreadyActiveFixture.cs");
+            Assert.That(
+                File.Exists(path),
+                Is.True,
+                "Signature-change already-active fixture source missing: " + path);
             return Path.GetFullPath(path);
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2712,6 +2712,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: generic arity and extra parameter types reach the registry label, including
+        /// nested-type '+' normalization.
+        /// </summary>
+        [Test]
+        public void FormatGatedReplacementRegistryKey_NestedGenericMultiArg_MatchesRegistryLabel()
+        {
+            TransformWorkerEntryDto entry = new TransformWorkerEntryDto
+            {
+                typeMetadataName = "Ns.Outer/Inner",
+                methodName = "Name",
+                parameterTypeFullNames = new[] { "System.Int32", "System.String" },
+                genericArity = 1
+            };
+
+            Assert.That(
+                HotReloadOrchestrator.FormatGatedReplacementRegistryKey(entry),
+                Is.EqualTo("Ns.Outer+Inner.Name`1(System.Int32,System.String)"));
+        }
+
+        /// <summary>
         /// What: a return-type change with a compiled caller in another class is skipped together
         /// with the same-file caller, while an unrelated body edit in the same file still patches.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeAlreadyActiveFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeAlreadyActiveFixture.cs
@@ -1,0 +1,25 @@
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled host for the already-active gate sequence: a same-file return-type
+    /// change plus a property that a later run can rewrite to skip the caller.
+    /// </summary>
+    public class HotReloadSignatureChangeAlreadyActiveFixture
+    {
+        public int MarkerHp { get; set; }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Target(int value)
+        {
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int ExistingCaller(int value)
+        {
+            return Target(value);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeAlreadyActiveFixture.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeAlreadyActiveFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1fcdf0b7a52084b48b87b3dc5c1f1f13
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAddedMemberRegistry.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAddedMemberRegistry.cs
@@ -47,6 +47,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             GenerationsByPath.Clear();
         }
 
+        // Why path + key, not Describe(): identity is per file generation. A same
+        // MethodKey on another projectRelativePath is a different member.
+        public static bool IsActiveMember(string projectRelativePath, string methodKey)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(methodKey), "methodKey must not be empty.");
+            if (!GenerationsByPath.TryGetValue(projectRelativePath, out FileGeneration generation))
+            {
+                return false;
+            }
+
+            return generation.Members.ContainsKey(methodKey);
+        }
+
         public static int Count
         {
             get

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -77,6 +77,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string SignatureChangedGateSkipReasonSameFileCallersFormat =
             "The return type of '{0}' changed, but this hot reload does not patch every compiled call site of the old method. Applying it would leave those call sites on the old version. Editing those callers' bodies in this file and reloading again applies them together, or run 'uloop compile'.";
 
+        public const string SignatureChangedGateSkipReasonAlreadyActiveFormat =
+            "The return type of '{0}' changed against the last compile, and the replacement applied by an "
+            + "earlier hot reload is still active; this run left it unchanged. Run 'uloop compile' to make it permanent.";
+
         public const string SignatureChangedGatedCallerSkipReason =
             "Calls a method whose signature change was not applied because unpatched compiled call sites remain; this caller was left unpatched too. Run 'uloop compile'.";
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -267,6 +267,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 targetDllPath,
                 defines,
                 assemblyResolvePath,
+                projectRelativePath,
                 ct).ConfigureAwait(false);
             // Why after the gate: a gated replacement is not applied, so listing it under
             // "Removed members stay present... edited bodies no longer call them" is false.
@@ -1506,6 +1507,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string targetDllPath,
             string[] defines,
             string assemblyResolvePath,
+            string projectRelativePath,
             CancellationToken ct)
         {
             TransformWorkerEntryDto[] entries = workerOutput.entries ?? Array.Empty<TransformWorkerEntryDto>();
@@ -1550,7 +1552,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 gatedReplacements,
                 uncoveredCallersByTarget,
                 editedFileMethodKeys,
-                assemblyResolvePath);
+                assemblyResolvePath,
+                projectRelativePath);
             skippedOutcomes.AddRange(
                 BuildSkippedCallerOutcomes(
                     exclusions.CallerEntries,
@@ -1915,25 +1918,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 entry.genericArity);
         }
 
-        private static bool IsAddedMemberAlreadyActive(string methodLabel)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(methodLabel), "methodLabel must not be null or empty.");
-            foreach (HotReloadAddedMemberInfo added in HotReloadAddedMemberRegistry.Describe())
-            {
-                if (string.Equals(added.MethodKey, methodLabel, StringComparison.Ordinal))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
         private static List<HotReloadMethodOutcome> BuildGatedReplacementSkipOutcomes(
             IReadOnlyList<TransformWorkerEntryDto> gatedReplacements,
             Dictionary<string, List<string>> uncoveredCallersByTarget,
             HashSet<string> editedFileMethodKeys,
-            string assemblyResolvePath)
+            string assemblyResolvePath,
+            string projectRelativePath)
         {
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
             foreach (TransformWorkerEntryDto entry in gatedReplacements)
@@ -1941,9 +1931,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 string methodLabel = FormatGatedReplacementRegistryKey(entry);
                 string methodKey = BuildMethodKey(entry);
                 string reasonFormat = HotReloadConstants.SignatureChangedGateSkipReasonFormat;
-                // Why live Describe, not a run-start snapshot: BeginFileGeneration runs after
+                // Why live registry, not a run-start snapshot: BeginFileGeneration runs after
                 // this gate, so the previous apply's added members are still listed here.
-                if (IsAddedMemberAlreadyActive(methodLabel))
+                if (HotReloadAddedMemberRegistry.IsActiveMember(projectRelativePath, methodLabel))
                 {
                     reasonFormat = HotReloadConstants.SignatureChangedGateSkipReasonAlreadyActiveFormat;
                 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -1902,6 +1902,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return true;
         }
 
+        // Why FormatMethodKeyParts, not BuildMethodKey: registry MethodKey uses the display
+        // label ('+' nested separators, '.' before the name). The wire key keeps '/' and '::'
+        // and never matches Describe().
+        internal static string FormatGatedReplacementRegistryKey(TransformWorkerEntryDto entry)
+        {
+            Debug.Assert(entry != null, "entry must not be null.");
+            return HotReloadPatcher.FormatMethodKeyParts(
+                entry.typeMetadataName,
+                entry.methodName,
+                entry.parameterTypeFullNames ?? Array.Empty<string>(),
+                entry.genericArity);
+        }
+
+        private static bool IsAddedMemberAlreadyActive(string methodLabel)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(methodLabel), "methodLabel must not be null or empty.");
+            foreach (HotReloadAddedMemberInfo added in HotReloadAddedMemberRegistry.Describe())
+            {
+                if (string.Equals(added.MethodKey, methodLabel, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private static List<HotReloadMethodOutcome> BuildGatedReplacementSkipOutcomes(
             IReadOnlyList<TransformWorkerEntryDto> gatedReplacements,
             Dictionary<string, List<string>> uncoveredCallersByTarget,
@@ -1911,14 +1938,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
             foreach (TransformWorkerEntryDto entry in gatedReplacements)
             {
-                string methodLabel = HotReloadPatcher.FormatMethodKeyParts(
-                    entry.typeMetadataName,
-                    entry.methodName,
-                    entry.parameterTypeFullNames ?? Array.Empty<string>(),
-                    entry.genericArity);
+                string methodLabel = FormatGatedReplacementRegistryKey(entry);
                 string methodKey = BuildMethodKey(entry);
                 string reasonFormat = HotReloadConstants.SignatureChangedGateSkipReasonFormat;
-                if (uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> uncoveredCallers)
+                // Why live Describe, not a run-start snapshot: BeginFileGeneration runs after
+                // this gate, so the previous apply's added members are still listed here.
+                if (IsAddedMemberAlreadyActive(methodLabel))
+                {
+                    reasonFormat = HotReloadConstants.SignatureChangedGateSkipReasonAlreadyActiveFormat;
+                }
+                else if (uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> uncoveredCallers)
                     && AreAllUncoveredCallersInEditedFile(uncoveredCallers, editedFileMethodKeys))
                 {
                     reasonFormat = HotReloadConstants.SignatureChangedGateSkipReasonSameFileCallersFormat;


### PR DESCRIPTION
## Summary
- A later hot-reload run no longer describes an already-applied return-type replacement as a fresh skip that looks like the change was undone.
- The skip reason now says the earlier replacement is still active and this run left it unchanged.

## User Impact
- Before: after a return-type change applied, a later edit that skipped the covering caller reused the first-time gate wording (`this hot reload does not patch every compiled call site`). The response read as if the replacement had been cancelled, even though `--status` still showed it active.
- After: that row uses a dedicated already-active reason and tells the agent the earlier replacement is still in effect until `uloop compile`.

## Changes
- Gate skip outcomes check the added-member registry with the same display label used for `Methods[].Method` (`/` → `+`, `.` before the name). The wire key is not compared.
- First-time compile-only and same-file-caller wordings are unchanged when the replacement is not already active.
- Gated removed-name suppression is unchanged.

## Verification
- `uloop compile`: ErrorCount 0 / WarningCount 0
- EditMode HotReload suite: 377 passed / 0 failed
- New E2E: apply same-file return-type change, then skip the caller via a property-to-field rewrite; assert the already-active reason (full string) and that the registry still holds the replacement.
- New unit test: nested-type wire key (`Ns.Outer/Inner::Name(...)`) ≠ registry label (`Ns.Outer+Inner.Name(...)`).
- Registry is read live at gate time (file generation starts after the gate), so no run-start snapshot was required.

## Test plan
- [ ] Confirm a first-time gated return-type change still uses the compile-only or same-file wording
- [ ] Confirm a later run that skips the covering caller reports the already-active wording
- [ ] Confirm `--status` still lists the earlier replacement as Added


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

