### PR TITLE
fix: warn when a hot reload run deactivates previously active patches

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberRegistryTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberRegistryTests.cs
@@ -78,6 +78,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: ListActiveMethodKeys returns registered keys for that path only.
+        /// </summary>
+        [Test]
+        public void ListActiveMethodKeys_ReturnsKeysForThatPathOnly()
+        {
+            MethodInfo shim = RequireExistingCaller();
+            const string methodKey = "Host.AddedPing(System.Int32)";
+            HotReloadAddedMemberRegistry.BeginFileGeneration(FileOne);
+            HotReloadAddedMemberRegistry.Register(FileOne, methodKey, shim, FileOne);
+
+            IReadOnlyList<string> listedOne = HotReloadAddedMemberRegistry.ListActiveMethodKeys(FileOne);
+            IReadOnlyList<string> listedTwo = HotReloadAddedMemberRegistry.ListActiveMethodKeys(FileTwo);
+            Assert.That(listedOne, Is.EqualTo(new[] { methodKey }));
+            Assert.That(listedTwo, Is.Empty);
+        }
+
+        /// <summary>
         /// What: Clear removes every file's added members.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMethodApplyFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMethodApplyFixture.cs
@@ -9,6 +9,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     public class HotReloadAddedMethodApplyFixture
     {
         [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Unrelated(int value)
+        {
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public int ExistingCaller(int value)
         {
             return value;

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2610,8 +2610,136 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     "Per-file clear must drop AddedPing on re-apply.");
             }
 
+            AssertNoDeactivatedPatchesWarning(second);
             HotReloadAddedMethodApplyFixture host = new HotReloadAddedMethodApplyFixture();
             Assert.That(host.ExistingCaller(3), Is.EqualTo(13));
+        }
+
+        /// <summary>
+        /// What: after an added method applies, a later run that only breaks that added body
+        /// leaves the registry entry in place when nothing else is applied.
+        /// </summary>
+        [Test]
+        public async Task Run_BrokenAddedMethodAfterSuccess_ObservesRegistryWhenNothingElseApplies()
+        {
+            string fixturePath = ResolveAddedMethodApplyFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("BrokenAddedAfterSuccess1.cs", WithWorkingAddedPing(onDisk)),
+                CancellationToken.None);
+            AssertHasAdded(first, "AddedPing");
+            Assert.That(CountAddedMembersContaining("AddedPing"), Is.EqualTo(1));
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("BrokenAddedAfterSuccess2.cs", WithBrokenAddedPing(onDisk)),
+                CancellationToken.None);
+
+            int remaining = CountAddedMembersContaining("AddedPing");
+            Assert.That(
+                remaining,
+                Is.EqualTo(1),
+                "Observation: AddedPing remaining=" + remaining
+                + " ActivePatchTotal=" + second.ActivePatchTotal
+                + "\n" + FormatOutcomes(second));
+            Assert.That(second.ActivePatchTotal, Is.EqualTo(2));
+            AssertNoDeactivatedPatchesWarning(second);
+        }
+
+        /// <summary>
+        /// What: after an added method applies, a later run that breaks that added body while
+        /// still patching an unrelated method drops the added member and warns with its label.
+        /// </summary>
+        [Test]
+        public async Task Run_BrokenAddedMethodAfterSuccess_ObservesRegistryWhenUnrelatedStillPatches()
+        {
+            string fixturePath = ResolveAddedMethodApplyFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("BrokenAddedUnrelated1.cs", WithWorkingAddedPing(onDisk)),
+                CancellationToken.None);
+            AssertHasAdded(first, "AddedPing");
+            Assert.That(CountAddedMembersContaining("AddedPing"), Is.EqualTo(1));
+
+            string later = WithBrokenAddedPing(onDisk).Replace(
+                "        public int Unrelated(int value)\n        {\n            return value;\n        }",
+                "        public int Unrelated(int value)\n        {\n            return value + 1;\n        }",
+                StringComparison.Ordinal);
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("BrokenAddedUnrelated2.cs", later),
+                CancellationToken.None);
+
+            int remaining = CountAddedMembersContaining("AddedPing");
+            Assert.That(
+                remaining,
+                Is.EqualTo(0),
+                "Observation: AddedPing remaining=" + remaining
+                + " ActivePatchTotal=" + second.ActivePatchTotal
+                + "\n" + FormatOutcomes(second));
+            Assert.That(
+                second.Warnings,
+                Does.Contain(ExpectedDeactivatedPatchesWarning(AddedPingMethodLabel())),
+                FormatOutcomes(second) + "\n" + string.Join("\n", second.Warnings));
+        }
+
+        /// <summary>
+        /// What: a successful re-apply of the same added method re-registers it, so the
+        /// deactivated-patches warning is not emitted.
+        /// </summary>
+        [Test]
+        public async Task Run_ReapplyWorkingAddedMethod_DoesNotWarnDeactivatedPatches()
+        {
+            string fixturePath = ResolveAddedMethodApplyFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = WithWorkingAddedPing(onDisk);
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("ReapplyWorkingAdded1.cs", edited),
+                CancellationToken.None);
+            AssertHasAdded(first, "AddedPing");
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("ReapplyWorkingAdded2.cs", edited),
+                CancellationToken.None);
+            AssertHasAdded(second, "AddedPing");
+            AssertNoDeactivatedPatchesWarning(second);
+        }
+
+        /// <summary>
+        /// What: two added methods deactivated in one run are listed in ordinal order,
+        /// comma-space separated, in the deactivated-patches warning.
+        /// </summary>
+        [Test]
+        public async Task Run_BrokenAddedMethodsAfterSuccess_WarnsOrdinalJoinedLabels()
+        {
+            string fixturePath = ResolveAddedMethodApplyFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("BrokenAddedMulti1.cs", WithWorkingAddedPingAndPong(onDisk)),
+                CancellationToken.None);
+            AssertHasAdded(first, "AddedPing");
+            AssertHasAdded(first, "AddedPong");
+
+            string later = WithBrokenAddedPingAndPong(onDisk).Replace(
+                "        public int Unrelated(int value)\n        {\n            return value;\n        }",
+                "        public int Unrelated(int value)\n        {\n            return value + 1;\n        }",
+                StringComparison.Ordinal);
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("BrokenAddedMulti2.cs", later),
+                CancellationToken.None);
+
+            string expected = ExpectedDeactivatedPatchesWarning(
+                AddedPingMethodLabel() + ", " + AddedPongMethodLabel());
+            Assert.That(
+                second.Warnings,
+                Does.Contain(expected),
+                FormatOutcomes(second) + "\n" + string.Join("\n", second.Warnings));
         }
 
         /// <summary>
@@ -3425,6 +3553,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     "All-unchanged re-apply must drop AddedPing from the added-member ledger.");
             }
 
+            AssertNoDeactivatedPatchesWarning(second);
             Assert.That(host.ExistingCaller(3), Is.EqualTo(3));
         }
 
@@ -3990,6 +4119,79 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CallerMethodKey = callerMethodKey,
                 TargetMethodKey = targetMethodKey
             };
+        }
+
+        private static string WithWorkingAddedPing(string onDisk)
+        {
+            return onDisk.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedPing(value);\n        }\n\n"
+                + "        public int AddedPing(int value)\n        {\n            return value + 1;\n        }",
+                StringComparison.Ordinal);
+        }
+
+        private static string WithBrokenAddedPing(string onDisk)
+        {
+            return onDisk.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedPing(value);\n        }\n\n"
+                + "        public int AddedPing(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }",
+                StringComparison.Ordinal);
+        }
+
+        private static string WithWorkingAddedPingAndPong(string onDisk)
+        {
+            return onDisk.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedPing(value) + AddedPong(value);\n        }\n\n"
+                + "        public int AddedPing(int value)\n        {\n            return value + 1;\n        }\n\n"
+                + "        public int AddedPong(int value)\n        {\n            return value + 2;\n        }",
+                StringComparison.Ordinal);
+        }
+
+        private static string WithBrokenAddedPingAndPong(string onDisk)
+        {
+            return onDisk.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedPing(value) + AddedPong(value);\n        }\n\n"
+                + "        public int AddedPing(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }\n\n"
+                + "        public int AddedPong(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }",
+                StringComparison.Ordinal);
+        }
+
+        private static string AddedPingMethodLabel()
+        {
+            return HotReloadPatcher.FormatMethodKeyParts(
+                typeof(HotReloadAddedMethodApplyFixture).FullName,
+                "AddedPing",
+                new[] { "System.Int32" },
+                0);
+        }
+
+        private static string AddedPongMethodLabel()
+        {
+            return HotReloadPatcher.FormatMethodKeyParts(
+                typeof(HotReloadAddedMethodApplyFixture).FullName,
+                "AddedPong",
+                new[] { "System.Int32" },
+                0);
+        }
+
+        private static string ExpectedDeactivatedPatchesWarning(string joinedLabels)
+        {
+            return string.Format(HotReloadConstants.DeactivatedPatchesWarningFormat, joinedLabels);
+        }
+
+        private static void AssertNoDeactivatedPatchesWarning(HotReloadOrchestratorResult result)
+        {
+            string prefix = "This run deactivated previously active patches:";
+            foreach (string warning in result.Warnings)
+            {
+                Assert.That(
+                    warning,
+                    Does.Not.StartWith(prefix),
+                    FormatOutcomes(result) + "\n" + string.Join("\n", result.Warnings));
+            }
         }
 
         private static string WithSameFileReturnTypeChange(string onDisk)

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2740,6 +2740,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: after an added method applies, a later run that skips it as virtual while
+        /// still patching an unrelated method warns with the added method's label.
+        /// </summary>
+        [Test]
+        public async Task Run_VirtualAddedMethodAfterSuccess_WarnsDeactivatedPatches()
+        {
+            string fixturePath = ResolveAddedMethodApplyFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("VirtualAddedAfterSuccess1.cs", WithWorkingAddedPing(onDisk)),
+                CancellationToken.None);
+            AssertHasAdded(first, "AddedPing");
+
+            string later = WithVirtualAddedPing(onDisk).Replace(
+                "        public int Unrelated(int value)\n        {\n            return value;\n        }",
+                "        public int Unrelated(int value)\n        {\n            return value + 1;\n        }",
+                StringComparison.Ordinal);
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("VirtualAddedAfterSuccess2.cs", later),
+                CancellationToken.None);
+
+            AssertDeactivatedPatchesWarningsEqual(
+                second,
+                ExpectedDeactivatedPatchesWarning(AddedPingMethodLabel()));
+        }
+
+        /// <summary>
         /// What: a return-type change whose compiled callers all live in the edited file applies
         /// as Added plus a Patched caller, and the caller returns the new method's value.
         /// </summary>
@@ -4179,6 +4208,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
                 "        public int ExistingCaller(int value)\n        {\n            return AddedPing(value);\n        }\n\n"
                 + "        public int AddedPing(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }",
+                StringComparison.Ordinal);
+        }
+
+        private static string WithVirtualAddedPing(string onDisk)
+        {
+            return onDisk.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedPing(value);\n        }\n\n"
+                + "        public virtual int AddedPing(int value)\n        {\n            return value + 1;\n        }",
                 StringComparison.Ordinal);
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2679,10 +2679,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Observation: AddedPing remaining=" + remaining
                 + " ActivePatchTotal=" + second.ActivePatchTotal
                 + "\n" + FormatOutcomes(second));
-            Assert.That(
-                second.Warnings,
-                Does.Contain(ExpectedDeactivatedPatchesWarning(AddedPingMethodLabel())),
-                FormatOutcomes(second) + "\n" + string.Join("\n", second.Warnings));
+            AssertDeactivatedPatchesWarningsEqual(
+                second,
+                ExpectedDeactivatedPatchesWarning(AddedPingMethodLabel()));
         }
 
         /// <summary>
@@ -2734,12 +2733,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 WriteEditedSource("BrokenAddedMulti2.cs", later),
                 CancellationToken.None);
 
-            string expected = ExpectedDeactivatedPatchesWarning(
-                AddedPingMethodLabel() + ", " + AddedPongMethodLabel());
-            Assert.That(
-                second.Warnings,
-                Does.Contain(expected),
-                FormatOutcomes(second) + "\n" + string.Join("\n", second.Warnings));
+            AssertDeactivatedPatchesWarningsEqual(
+                second,
+                ExpectedDeactivatedPatchesWarning(
+                    AddedPingMethodLabel() + ", " + AddedPongMethodLabel()));
         }
 
         /// <summary>
@@ -2816,6 +2813,52 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.EqualTo(1),
                 "The earlier replacement must stay in the added-member registry.");
             Assert.That(second.ActivePatchTotal, Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// What: after a return-type replacement applies, a later run that gates it and
+        /// applies an unrelated method warns with the replacement label.
+        /// </summary>
+        [Test]
+        public async Task Run_ReturnTypeChange_GatedReplacementDeactivatedByUnrelatedApply_Warns()
+        {
+            string fixturePath = ResolveSignatureChangeAlreadyActiveFixturePath();
+            string applied = WithSameFileReturnTypeChange(File.ReadAllText(fixturePath));
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeGatedDeactivate1.cs", applied),
+                CancellationToken.None);
+            AssertNoFileLevelFailure(first);
+            AssertHasAdded(first, nameof(HotReloadSignatureChangeAlreadyActiveFixture.Target));
+
+            string later = applied
+                .Replace(
+                    "        public int MarkerHp { get; set; }",
+                    "        public int MarkerHp;",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "            return (int)Target(value);\n        }",
+                    "            MarkerHp = value;\n            return (int)Target(value);\n        }",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "        public int Unrelated(int value)\n        {\n            return value;\n        }",
+                    "        public int Unrelated(int value)\n        {\n            return value + 1;\n        }",
+                    StringComparison.Ordinal);
+            Assert.That(later, Is.Not.EqualTo(applied));
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeGatedDeactivate2.cs", later),
+                CancellationToken.None);
+
+            string expectedLabel = HotReloadPatcher.FormatMethodKeyParts(
+                typeof(HotReloadSignatureChangeAlreadyActiveFixture).FullName,
+                nameof(HotReloadSignatureChangeAlreadyActiveFixture.Target),
+                new[] { "System.Int32" },
+                0);
+            AssertDeactivatedPatchesWarningsEqual(
+                second,
+                ExpectedDeactivatedPatchesWarning(expectedLabel));
         }
 
         /// <summary>
@@ -4143,9 +4186,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             return onDisk.Replace(
                 "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
-                "        public int ExistingCaller(int value)\n        {\n            return AddedPing(value) + AddedPong(value);\n        }\n\n"
-                + "        public int AddedPing(int value)\n        {\n            return value + 1;\n        }\n\n"
-                + "        public int AddedPong(int value)\n        {\n            return value + 2;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedPong(value) + AddedPing(value);\n        }\n\n"
+                + "        public int AddedPong(int value)\n        {\n            return value + 2;\n        }\n\n"
+                + "        public int AddedPing(int value)\n        {\n            return value + 1;\n        }",
                 StringComparison.Ordinal);
         }
 
@@ -4153,9 +4196,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             return onDisk.Replace(
                 "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
-                "        public int ExistingCaller(int value)\n        {\n            return AddedPing(value) + AddedPong(value);\n        }\n\n"
-                + "        public int AddedPing(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }\n\n"
-                + "        public int AddedPong(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedPong(value) + AddedPing(value);\n        }\n\n"
+                + "        public int AddedPong(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }\n\n"
+                + "        public int AddedPing(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }",
                 StringComparison.Ordinal);
         }
 
@@ -4182,16 +4225,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return string.Format(HotReloadConstants.DeactivatedPatchesWarningFormat, joinedLabels);
         }
 
+        private static string DeactivatedPatchesWarningPrefix()
+        {
+            string format = HotReloadConstants.DeactivatedPatchesWarningFormat;
+            int placeholderIndex = format.IndexOf("{0}", StringComparison.Ordinal);
+            Assert.That(placeholderIndex, Is.GreaterThanOrEqualTo(0));
+            return format.Substring(0, placeholderIndex);
+        }
+
+        private static List<string> FilterDeactivatedPatchesWarnings(IReadOnlyList<string> warnings)
+        {
+            string prefix = DeactivatedPatchesWarningPrefix();
+            List<string> filtered = new List<string>();
+            foreach (string warning in warnings)
+            {
+                if (warning.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    filtered.Add(warning);
+                }
+            }
+
+            return filtered;
+        }
+
+        private static void AssertDeactivatedPatchesWarningsEqual(
+            HotReloadOrchestratorResult result,
+            params string[] expectedWarnings)
+        {
+            Assert.That(
+                FilterDeactivatedPatchesWarnings(result.Warnings),
+                Is.EqualTo(expectedWarnings),
+                FormatOutcomes(result) + "\n" + string.Join("\n", result.Warnings));
+        }
+
         private static void AssertNoDeactivatedPatchesWarning(HotReloadOrchestratorResult result)
         {
-            string prefix = "This run deactivated previously active patches:";
-            foreach (string warning in result.Warnings)
-            {
-                Assert.That(
-                    warning,
-                    Does.Not.StartWith(prefix),
-                    FormatOutcomes(result) + "\n" + string.Join("\n", result.Warnings));
-            }
+            AssertDeactivatedPatchesWarningsEqual(result);
         }
 
         private static string WithSameFileReturnTypeChange(string onDisk)

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeAlreadyActiveFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeAlreadyActiveFixture.cs
@@ -11,6 +11,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public int MarkerHp { get; set; }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Unrelated(int value)
+        {
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public int Target(int value)
         {
             return value;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAddedMemberRegistry.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAddedMemberRegistry.cs
@@ -61,6 +61,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return generation.Members.ContainsKey(methodKey);
         }
 
+        public static IReadOnlyList<string> ListActiveMethodKeys(string projectRelativePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+            if (!GenerationsByPath.TryGetValue(projectRelativePath, out FileGeneration generation))
+            {
+                return Array.Empty<string>();
+            }
+
+            List<string> keys = new List<string>(generation.Members.Count);
+            foreach (string methodKey in generation.Members.Keys)
+            {
+                keys.Add(methodKey);
+            }
+
+            return keys;
+        }
+
         public static int Count
         {
             get

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -90,6 +90,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string SignatureChangeCoverageLostFailureFormat =
             "Isolation excluded compiled callers of '{0}'; applying the rest would leave those callers on the old version. Run 'uloop compile'.";
 
+        public const string DeactivatedPatchesWarningFormat =
+            "This run deactivated previously active patches: {0}. They reverted to the compiled behavior; "
+            + "edit and reload again to re-apply them, or run 'uloop compile'.";
+
         // Wire value for TransformWorkerRemovedMemberDto.kind.
         // Keep in sync with RemovedMemberKinds in TransformWorker~/TransformWorker.cs.
         public const string RemovedMemberKindMethod = "method";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -450,7 +450,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 warnings,
                 snapshotLabels,
                 projectRelativePath,
-                workerOutput);
+                workerOutput,
+                outcomes);
             return new HotReloadFileProcessResult(
                 outcomes,
                 warnings,
@@ -2473,6 +2474,34 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return labels;
         }
 
+        // Why union Skipped labels: a still-declared added method can leave the first-pass
+        // entries when the worker skips it (virtual, generic, interface). Why not Failed:
+        // a Failed added method is always a first-pass added entry.
+        private static HashSet<string> CollectStillDeclaredAddedLabels(
+            TransformWorkerOutputDto workerOutput,
+            IReadOnlyList<HotReloadMethodOutcome> outcomes)
+        {
+            HashSet<string> labels = CollectAddedEntryLabels(workerOutput);
+            if (outcomes == null)
+            {
+                return labels;
+            }
+
+            foreach (HotReloadMethodOutcome outcome in outcomes)
+            {
+                if (outcome == null
+                    || outcome.Kind != HotReloadMethodOutcomeKind.Skipped
+                    || string.IsNullOrEmpty(outcome.Method))
+                {
+                    continue;
+                }
+
+                labels.Add(outcome.Method);
+            }
+
+            return labels;
+        }
+
         private static bool IsUnexpectedDeactivation(
             string label,
             HashSet<string> currentLabels,
@@ -2485,14 +2514,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> warnings,
             HashSet<string> snapshotLabels,
             string projectRelativePath,
-            TransformWorkerOutputDto workerOutput)
+            TransformWorkerOutputDto workerOutput,
+            IReadOnlyList<HotReloadMethodOutcome> outcomes)
         {
             Debug.Assert(warnings != null, "warnings must not be null.");
             Debug.Assert(snapshotLabels != null, "snapshotLabels must not be null.");
             Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
 
             HashSet<string> currentLabels = CollectActiveLabelsForFile(projectRelativePath);
-            HashSet<string> stillDeclaredAdded = CollectAddedEntryLabels(workerOutput);
+            HashSet<string> stillDeclaredAdded = CollectStillDeclaredAddedLabels(workerOutput, outcomes);
             List<string> deactivated = new List<string>();
             foreach (string label in snapshotLabels)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -165,6 +165,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return new HotReloadFileProcessResult(outcomes, warnings, 0);
             }
 
+            // Why snapshot at this file's apply entry: multi-file runs process files
+            // sequentially, and RevertUnchangedPatches / BeginFileGeneration mutate ledgers
+            // after the worker. The worker itself does not.
+            HashSet<string> snapshotLabels = CollectActiveLabelsForFile(projectRelativePath);
+            List<string> unchangedRevertedLabels = new List<string>();
+            TransformWorkerOutputDto workerOutputForDeactivation = null;
+            try
+            {
+
             string[] defines = compilationAssembly.defines ?? Array.Empty<string>();
             string[] referencePaths = BuildWorkerReferencePaths(compilationAssembly, targetDllPath);
 
@@ -196,6 +205,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             TransformWorkerOutputDto workerOutput = workerResult.Output;
+            workerOutputForDeactivation = workerOutput;
             string[] addedFieldNames = workerOutput.addedFieldNames;
             // Why after the worker: const-only / empty files have no patch candidates, so the
             // missing-baseline warning was pure noise (FB E). Emit only when the worker saw at
@@ -256,7 +266,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why before the empty-entries return: all-unchanged runs exit there, and those are
             // exactly the runs that must peel leftover patches so behavior converges to compiled IL.
             await MainThreadSwitcher.SwitchToMainThread(ct);
-            RevertUnchangedPatches(assemblyName, unchangedMethods);
+            unchangedRevertedLabels = RevertUnchangedPatches(assemblyName, unchangedMethods);
 
             SignatureChangeGateResult gateResult = await TryApplySignatureChangeGateAsync(
                 projectRoot,
@@ -446,17 +456,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 unchangedMethodCount,
                 retargetedPausePointIds,
                 addedFieldNames);
+            }
+            finally
+            {
+                AppendDeactivatedPatchesWarning(
+                    warnings,
+                    snapshotLabels,
+                    projectRelativePath,
+                    unchangedRevertedLabels,
+                    workerOutputForDeactivation);
+            }
         }
 
         // Peels leftover Harmony patches when the source again matches the verified baseline.
         // Resolve failures are silent: unchanged identities already matched compile-time IL.
-        private static void RevertUnchangedPatches(
+        private static List<string> RevertUnchangedPatches(
             string assemblyName,
             TransformWorkerUnchangedMethodDto[] unchangedMethods)
         {
             Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
             Debug.Assert(unchangedMethods != null, "unchangedMethods must not be null.");
 
+            List<string> revertedLabels = new List<string>();
             for (int index = 0; index < unchangedMethods.Length; index++)
             {
                 TransformWorkerUnchangedMethodDto unchanged = unchangedMethods[index];
@@ -482,8 +503,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                HotReloadPatcher.Revert(matchResult.Method);
+                if (HotReloadPatcher.Revert(matchResult.Method))
+                {
+                    revertedLabels.Add(HotReloadPatcher.FormatMethodKey(matchResult.Method));
+                }
             }
+
+            return revertedLabels;
         }
 
         private static HotReloadMethodOutcome ApplyEntry(
@@ -2408,6 +2434,184 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return contentPathOverride;
+        }
+
+        private static HashSet<string> CollectActiveLabelsForFile(string projectRelativePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+            HashSet<string> labels = new HashSet<string>(StringComparer.Ordinal);
+            IReadOnlyList<string> addedKeys =
+                HotReloadAddedMemberRegistry.ListActiveMethodKeys(projectRelativePath);
+            for (int index = 0; index < addedKeys.Count; index++)
+            {
+                labels.Add(addedKeys[index]);
+            }
+
+            IReadOnlyList<string> patchedKeys = HotReloadPatcher.ListActiveMethodKeys(projectRelativePath);
+            for (int index = 0; index < patchedKeys.Count; index++)
+            {
+                labels.Add(patchedKeys[index]);
+            }
+
+            return labels;
+        }
+
+        private static HashSet<string> CollectAddedEntryLabels(TransformWorkerOutputDto workerOutput)
+        {
+            HashSet<string> labels = new HashSet<string>(StringComparer.Ordinal);
+            if (workerOutput == null || workerOutput.entries == null)
+            {
+                return labels;
+            }
+
+            foreach (TransformWorkerEntryDto entry in workerOutput.entries)
+            {
+                if (entry == null || entry.patchKind != HotReloadConstants.PatchKindAddedMethod)
+                {
+                    continue;
+                }
+
+                labels.Add(
+                    HotReloadPatcher.FormatMethodKeyParts(
+                        entry.typeMetadataName,
+                        entry.methodName,
+                        entry.parameterTypeFullNames ?? Array.Empty<string>(),
+                        entry.genericArity));
+            }
+
+            return labels;
+        }
+
+        private static HashSet<string> CollectRemovedSignatureLabels(TransformWorkerOutputDto workerOutput)
+        {
+            HashSet<string> labels = new HashSet<string>(StringComparer.Ordinal);
+            if (workerOutput == null || workerOutput.removedMethodSignatures == null)
+            {
+                return labels;
+            }
+
+            foreach (TransformWorkerRemovedMethodSignatureDto signature in workerOutput.removedMethodSignatures)
+            {
+                if (signature == null
+                    || string.IsNullOrEmpty(signature.typeMetadataName)
+                    || string.IsNullOrEmpty(signature.methodName))
+                {
+                    continue;
+                }
+
+                labels.Add(
+                    HotReloadPatcher.FormatMethodKeyParts(
+                        signature.typeMetadataName,
+                        signature.methodName,
+                        signature.parameterTypeFullNames ?? Array.Empty<string>(),
+                        signature.genericArity));
+            }
+
+            return labels;
+        }
+
+        private static bool LabelMatchesRemovedMemberName(
+            string label,
+            TransformWorkerOutputDto workerOutput)
+        {
+            if (workerOutput == null || workerOutput.removedMembers == null)
+            {
+                return false;
+            }
+
+            foreach (TransformWorkerRemovedMemberDto removed in workerOutput.removedMembers)
+            {
+                if (removed == null || string.IsNullOrEmpty(removed.name))
+                {
+                    continue;
+                }
+
+                if (label.IndexOf("." + removed.name + "(", StringComparison.Ordinal) >= 0
+                    || label.IndexOf("." + removed.name + "`", StringComparison.Ordinal) >= 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsUnexpectedDeactivation(
+            string label,
+            HashSet<string> currentLabels,
+            HashSet<string> unchangedRevertedLabels,
+            HashSet<string> removedSignatureLabels,
+            HashSet<string> stillDeclaredAddedLabels,
+            TransformWorkerOutputDto workerOutput)
+        {
+            if (currentLabels.Contains(label))
+            {
+                return false;
+            }
+
+            if (unchangedRevertedLabels.Contains(label))
+            {
+                return false;
+            }
+
+            if (removedSignatureLabels.Contains(label))
+            {
+                return false;
+            }
+
+            if (LabelMatchesRemovedMemberName(label, workerOutput))
+            {
+                return false;
+            }
+
+            return stillDeclaredAddedLabels.Contains(label);
+        }
+
+        private static void AppendDeactivatedPatchesWarning(
+            List<string> warnings,
+            HashSet<string> snapshotLabels,
+            string projectRelativePath,
+            IReadOnlyList<string> unchangedRevertedLabels,
+            TransformWorkerOutputDto workerOutput)
+        {
+            Debug.Assert(warnings != null, "warnings must not be null.");
+            Debug.Assert(snapshotLabels != null, "snapshotLabels must not be null.");
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+            Debug.Assert(unchangedRevertedLabels != null, "unchangedRevertedLabels must not be null.");
+
+            HashSet<string> currentLabels = CollectActiveLabelsForFile(projectRelativePath);
+            HashSet<string> stillDeclaredAdded = CollectAddedEntryLabels(workerOutput);
+            HashSet<string> unchangedReverted = new HashSet<string>(
+                unchangedRevertedLabels,
+                StringComparer.Ordinal);
+            HashSet<string> removedSignatures = CollectRemovedSignatureLabels(workerOutput);
+            List<string> deactivated = new List<string>();
+            foreach (string label in snapshotLabels)
+            {
+                if (!IsUnexpectedDeactivation(
+                    label,
+                    currentLabels,
+                    unchangedReverted,
+                    removedSignatures,
+                    stillDeclaredAdded,
+                    workerOutput))
+                {
+                    continue;
+                }
+
+                deactivated.Add(label);
+            }
+
+            if (deactivated.Count == 0)
+            {
+                return;
+            }
+
+            deactivated.Sort(string.CompareOrdinal);
+            warnings.Add(
+                string.Format(
+                    HotReloadConstants.DeactivatedPatchesWarningFormat,
+                    string.Join(", ", deactivated)));
         }
 
         private static string ToProjectRelativeScriptPath(string path)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -169,10 +169,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // sequentially, and RevertUnchangedPatches / BeginFileGeneration mutate ledgers
             // after the worker. The worker itself does not.
             HashSet<string> snapshotLabels = CollectActiveLabelsForFile(projectRelativePath);
-            List<string> unchangedRevertedLabels = new List<string>();
-            TransformWorkerOutputDto workerOutputForDeactivation = null;
-            try
-            {
 
             string[] defines = compilationAssembly.defines ?? Array.Empty<string>();
             string[] referencePaths = BuildWorkerReferencePaths(compilationAssembly, targetDllPath);
@@ -205,7 +201,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             TransformWorkerOutputDto workerOutput = workerResult.Output;
-            workerOutputForDeactivation = workerOutput;
             string[] addedFieldNames = workerOutput.addedFieldNames;
             // Why after the worker: const-only / empty files have no patch candidates, so the
             // missing-baseline warning was pure noise (FB E). Emit only when the worker saw at
@@ -266,7 +261,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why before the empty-entries return: all-unchanged runs exit there, and those are
             // exactly the runs that must peel leftover patches so behavior converges to compiled IL.
             await MainThreadSwitcher.SwitchToMainThread(ct);
-            unchangedRevertedLabels = RevertUnchangedPatches(assemblyName, unchangedMethods);
+            RevertUnchangedPatches(assemblyName, unchangedMethods);
 
             SignatureChangeGateResult gateResult = await TryApplySignatureChangeGateAsync(
                 projectRoot,
@@ -447,6 +442,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
             }
 
+            // Why only this return: a still-declared added method is a first-pass entry, so
+            // empty-entries BeginFileGeneration only clears members the source no longer
+            // declares. The warning is only meaningful on the apply path that can drop a
+            // still-declared added member by not re-Registering it.
+            AppendDeactivatedPatchesWarning(
+                warnings,
+                snapshotLabels,
+                projectRelativePath,
+                workerOutput);
             return new HotReloadFileProcessResult(
                 outcomes,
                 warnings,
@@ -456,28 +460,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 unchangedMethodCount,
                 retargetedPausePointIds,
                 addedFieldNames);
-            }
-            finally
-            {
-                AppendDeactivatedPatchesWarning(
-                    warnings,
-                    snapshotLabels,
-                    projectRelativePath,
-                    unchangedRevertedLabels,
-                    workerOutputForDeactivation);
-            }
         }
 
         // Peels leftover Harmony patches when the source again matches the verified baseline.
         // Resolve failures are silent: unchanged identities already matched compile-time IL.
-        private static List<string> RevertUnchangedPatches(
+        private static void RevertUnchangedPatches(
             string assemblyName,
             TransformWorkerUnchangedMethodDto[] unchangedMethods)
         {
             Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
             Debug.Assert(unchangedMethods != null, "unchangedMethods must not be null.");
 
-            List<string> revertedLabels = new List<string>();
             for (int index = 0; index < unchangedMethods.Length; index++)
             {
                 TransformWorkerUnchangedMethodDto unchanged = unchangedMethods[index];
@@ -503,13 +496,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                if (HotReloadPatcher.Revert(matchResult.Method))
-                {
-                    revertedLabels.Add(HotReloadPatcher.FormatMethodKey(matchResult.Method));
-                }
+                HotReloadPatcher.Revert(matchResult.Method);
             }
-
-            return revertedLabels;
         }
 
         private static HotReloadMethodOutcome ApplyEntry(
@@ -2456,6 +2444,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return labels;
         }
 
+        // Why first-pass added entries: a return-type replacement is both an added entry and
+        // a removed signature with the same label, so subtracting removals would swallow the
+        // warning. Convergence is quiet because dropping the declaration also drops the entry.
         private static HashSet<string> CollectAddedEntryLabels(TransformWorkerOutputDto workerOutput)
         {
             HashSet<string> labels = new HashSet<string>(StringComparer.Ordinal);
@@ -2482,119 +2473,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return labels;
         }
 
-        private static HashSet<string> CollectRemovedSignatureLabels(TransformWorkerOutputDto workerOutput)
-        {
-            HashSet<string> labels = new HashSet<string>(StringComparer.Ordinal);
-            if (workerOutput == null || workerOutput.removedMethodSignatures == null)
-            {
-                return labels;
-            }
-
-            foreach (TransformWorkerRemovedMethodSignatureDto signature in workerOutput.removedMethodSignatures)
-            {
-                if (signature == null
-                    || string.IsNullOrEmpty(signature.typeMetadataName)
-                    || string.IsNullOrEmpty(signature.methodName))
-                {
-                    continue;
-                }
-
-                labels.Add(
-                    HotReloadPatcher.FormatMethodKeyParts(
-                        signature.typeMetadataName,
-                        signature.methodName,
-                        signature.parameterTypeFullNames ?? Array.Empty<string>(),
-                        signature.genericArity));
-            }
-
-            return labels;
-        }
-
-        private static bool LabelMatchesRemovedMemberName(
-            string label,
-            TransformWorkerOutputDto workerOutput)
-        {
-            if (workerOutput == null || workerOutput.removedMembers == null)
-            {
-                return false;
-            }
-
-            foreach (TransformWorkerRemovedMemberDto removed in workerOutput.removedMembers)
-            {
-                if (removed == null || string.IsNullOrEmpty(removed.name))
-                {
-                    continue;
-                }
-
-                if (label.IndexOf("." + removed.name + "(", StringComparison.Ordinal) >= 0
-                    || label.IndexOf("." + removed.name + "`", StringComparison.Ordinal) >= 0)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
         private static bool IsUnexpectedDeactivation(
             string label,
             HashSet<string> currentLabels,
-            HashSet<string> unchangedRevertedLabels,
-            HashSet<string> removedSignatureLabels,
-            HashSet<string> stillDeclaredAddedLabels,
-            TransformWorkerOutputDto workerOutput)
+            HashSet<string> stillDeclaredAddedLabels)
         {
-            if (currentLabels.Contains(label))
-            {
-                return false;
-            }
-
-            if (unchangedRevertedLabels.Contains(label))
-            {
-                return false;
-            }
-
-            if (removedSignatureLabels.Contains(label))
-            {
-                return false;
-            }
-
-            if (LabelMatchesRemovedMemberName(label, workerOutput))
-            {
-                return false;
-            }
-
-            return stillDeclaredAddedLabels.Contains(label);
+            return !currentLabels.Contains(label) && stillDeclaredAddedLabels.Contains(label);
         }
 
         private static void AppendDeactivatedPatchesWarning(
             List<string> warnings,
             HashSet<string> snapshotLabels,
             string projectRelativePath,
-            IReadOnlyList<string> unchangedRevertedLabels,
             TransformWorkerOutputDto workerOutput)
         {
             Debug.Assert(warnings != null, "warnings must not be null.");
             Debug.Assert(snapshotLabels != null, "snapshotLabels must not be null.");
             Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
-            Debug.Assert(unchangedRevertedLabels != null, "unchangedRevertedLabels must not be null.");
 
             HashSet<string> currentLabels = CollectActiveLabelsForFile(projectRelativePath);
             HashSet<string> stillDeclaredAdded = CollectAddedEntryLabels(workerOutput);
-            HashSet<string> unchangedReverted = new HashSet<string>(
-                unchangedRevertedLabels,
-                StringComparer.Ordinal);
-            HashSet<string> removedSignatures = CollectRemovedSignatureLabels(workerOutput);
             List<string> deactivated = new List<string>();
             foreach (string label in snapshotLabels)
             {
-                if (!IsUnexpectedDeactivation(
-                    label,
-                    currentLabels,
-                    unchangedReverted,
-                    removedSignatures,
-                    stillDeclaredAdded,
-                    workerOutput))
+                if (!IsUnexpectedDeactivation(label, currentLabels, stillDeclaredAdded))
                 {
                     continue;
                 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -316,6 +316,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return patches;
         }
 
+        // Why projectRelativePath, not DescribeActivePatches FilePath filtering by callers:
+        // FilePathByMethod is written with the orchestrator's project-relative path.
+        public static IReadOnlyList<string> ListActiveMethodKeys(string projectRelativePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+            List<string> keys = new List<string>();
+            foreach (KeyValuePair<MethodBase, string> pair in FilePathByMethod)
+            {
+                if (!string.Equals(pair.Value, projectRelativePath, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                keys.Add(FormatMethodKey(pair.Key));
+            }
+
+            return keys;
+        }
+
         // What: status / counter key from a resolved MethodBase (apply outcomes use the same
         // helper after Resolve so --status rows match Patched Methods[].Method).
         // Why parameter ToString (+ generic arity): MethodBase ledger entries distinguish


### PR DESCRIPTION
## Summary
- A later hot reload can drop a previously applied added method or return-type replacement while the source still declares it, and the response used to stay silent.
- The run now warns with the deactivated method labels and tells the agent to edit and reload again, or compile.

## User Impact
- Before: breaking an added method, gating a return-type replacement, or skipping a still-declared added method as virtual while still patching something else could silently restore compiled behavior.
- After: that case reports a warning listing the deactivated labels. Removing the method from source, reverting unchanged methods, or successfully re-applying the same added method does not warn.

## Changes
- Snapshot active patch and added-member labels at each file's apply entry.
- Warn when a label left the ledger and this run still declares it as a first-pass added entry or a Skipped outcome.
- Emit the warning on the apply-path return only.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → ErrorCount 0, WarningCount 0
- HotReload EditMode suite → 386 passed / 0 failed
- Repository CI does not run on PRs targeting the integration branch; local compile + this EditMode suite is the merge gate.
