### PR TITLE
fix: skip re-patching on identical re-reload and report AlreadyActive

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -41,7 +41,8 @@ a domain reload it reports zero patched methods, which is exactly when an
 `ActivePatchTotal` remembered from an earlier response has gone stale.
 
 Each `Active` row's `InvocationCount` counts calls into the patched body since that patch
-was applied; re-running hot reload on the same method resets it to zero. While Unity is
+was applied. Reloading the same source with no edits reports `AlreadyActive` and keeps
+the count; re-running after a real edit replaces the patch and resets it to zero. While Unity is
 paused — including while a pause-point hit holds the game — the player loop does not
 advance, so game-driven calls stop and the count freezes; calls you make yourself (for
 example through `uloop execute-dynamic-code`) still increment it. A frozen count during a
@@ -57,8 +58,11 @@ game, and only then read `InvocationCount` as a reachability signal.
 3. Compiles the shims against publicized reference copies, loads the result into the Editor domain, and binds every shim type's accessor delegates (`__BindAccessors`) before any patch is applied.
 4. Patches each original method with a Harmony transpiler (ID `io.github.hatayama.uloop.hot-reload`) in one of two shapes: transplant copies the shim's IL into the original method, while delegation rewrites the original to forward its arguments to the shim, which runs as normally compiled code.
 
-Re-running on the same method replaces its previous patch; `ActivePatchTotal` tracks the
-ledger across runs.
+Re-running on the same method after a real edit replaces its previous patch;
+`ActivePatchTotal` tracks the ledger across runs. Reloading a file whose source is
+unchanged since the last successful apply is a no-op: each still-active method is reported
+as `AlreadyActive`, the existing patch stays in place, and `InvocationCount` is preserved.
+Edit the file and reload again to apply new changes.
 
 ## Scope and limits
 
@@ -348,7 +352,7 @@ cached dispatch can bypass a hot-reload patch too.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, or `Added` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last successfully applied reload, so the existing patch was left in place and `InvocationCount` was preserved. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
 - `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods at risk of being already JIT-inlined into existing callers — those marked `[AggressiveInlining]`, plus (only when Code Optimization is Release) those with tiny pre-patch bodies — meaning the change may not show at those call sites, the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `AddedFields` (array): source-level names ("Type.field") of fields this reload added; their values live outside the compiled type until 'uloop compile'.

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -41,7 +41,8 @@ a domain reload it reports zero patched methods, which is exactly when an
 `ActivePatchTotal` remembered from an earlier response has gone stale.
 
 Each `Active` row's `InvocationCount` counts calls into the patched body since that patch
-was applied. Reloading the same source with no edits reports `AlreadyActive` and keeps
+was applied. Reloading the same source with no edits after a fully applied reload (a run
+with no Skipped or Failed outcomes) reports `AlreadyActive` and keeps
 the count; re-running after a real edit replaces the patch and resets it to zero. While Unity is
 paused — including while a pause-point hit holds the game — the player loop does not
 advance, so game-driven calls stop and the count freezes; calls you make yourself (for
@@ -60,7 +61,8 @@ game, and only then read `InvocationCount` as a reachability signal.
 
 Re-running on the same method after a real edit replaces its previous patch;
 `ActivePatchTotal` tracks the ledger across runs. Reloading a file whose source is
-unchanged since the last successful apply is a no-op: each still-active method is reported
+unchanged since the last fully applied reload (a run with no Skipped or Failed
+outcomes) is a no-op: each still-active method is reported
 as `AlreadyActive`, the existing patch stays in place, and `InvocationCount` is preserved.
 Edit the file and reload again to apply new changes.
 
@@ -352,7 +354,7 @@ cached dispatch can bypass a hot-reload patch too.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last successfully applied reload, so the existing patch was left in place and `InvocationCount` was preserved. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last fully applied reload (a run with no Skipped or Failed outcomes), so the existing patch was left in place and `InvocationCount` was preserved. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
 - `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods at risk of being already JIT-inlined into existing callers — those marked `[AggressiveInlining]`, plus (only when Code Optimization is Release) those with tiny pre-patch bodies — meaning the change may not show at those call sites, the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `AddedFields` (array): source-level names ("Type.field") of fields this reload added; their values live outside the compiled type until 'uloop compile'.

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -41,7 +41,8 @@ a domain reload it reports zero patched methods, which is exactly when an
 `ActivePatchTotal` remembered from an earlier response has gone stale.
 
 Each `Active` row's `InvocationCount` counts calls into the patched body since that patch
-was applied; re-running hot reload on the same method resets it to zero. While Unity is
+was applied. Reloading the same source with no edits reports `AlreadyActive` and keeps
+the count; re-running after a real edit replaces the patch and resets it to zero. While Unity is
 paused — including while a pause-point hit holds the game — the player loop does not
 advance, so game-driven calls stop and the count freezes; calls you make yourself (for
 example through `uloop execute-dynamic-code`) still increment it. A frozen count during a
@@ -57,8 +58,11 @@ game, and only then read `InvocationCount` as a reachability signal.
 3. Compiles the shims against publicized reference copies, loads the result into the Editor domain, and binds every shim type's accessor delegates (`__BindAccessors`) before any patch is applied.
 4. Patches each original method with a Harmony transpiler (ID `io.github.hatayama.uloop.hot-reload`) in one of two shapes: transplant copies the shim's IL into the original method, while delegation rewrites the original to forward its arguments to the shim, which runs as normally compiled code.
 
-Re-running on the same method replaces its previous patch; `ActivePatchTotal` tracks the
-ledger across runs.
+Re-running on the same method after a real edit replaces its previous patch;
+`ActivePatchTotal` tracks the ledger across runs. Reloading a file whose source is
+unchanged since the last successful apply is a no-op: each still-active method is reported
+as `AlreadyActive`, the existing patch stays in place, and `InvocationCount` is preserved.
+Edit the file and reload again to apply new changes.
 
 ## Scope and limits
 
@@ -348,7 +352,7 @@ cached dispatch can bypass a hot-reload patch too.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, or `Added` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last successfully applied reload, so the existing patch was left in place and `InvocationCount` was preserved. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
 - `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods at risk of being already JIT-inlined into existing callers — those marked `[AggressiveInlining]`, plus (only when Code Optimization is Release) those with tiny pre-patch bodies — meaning the change may not show at those call sites, the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `AddedFields` (array): source-level names ("Type.field") of fields this reload added; their values live outside the compiled type until 'uloop compile'.

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -41,7 +41,8 @@ a domain reload it reports zero patched methods, which is exactly when an
 `ActivePatchTotal` remembered from an earlier response has gone stale.
 
 Each `Active` row's `InvocationCount` counts calls into the patched body since that patch
-was applied. Reloading the same source with no edits reports `AlreadyActive` and keeps
+was applied. Reloading the same source with no edits after a fully applied reload (a run
+with no Skipped or Failed outcomes) reports `AlreadyActive` and keeps
 the count; re-running after a real edit replaces the patch and resets it to zero. While Unity is
 paused — including while a pause-point hit holds the game — the player loop does not
 advance, so game-driven calls stop and the count freezes; calls you make yourself (for
@@ -60,7 +61,8 @@ game, and only then read `InvocationCount` as a reachability signal.
 
 Re-running on the same method after a real edit replaces its previous patch;
 `ActivePatchTotal` tracks the ledger across runs. Reloading a file whose source is
-unchanged since the last successful apply is a no-op: each still-active method is reported
+unchanged since the last fully applied reload (a run with no Skipped or Failed
+outcomes) is a no-op: each still-active method is reported
 as `AlreadyActive`, the existing patch stays in place, and `InvocationCount` is preserved.
 Edit the file and reload again to apply new changes.
 
@@ -352,7 +354,7 @@ cached dispatch can bypass a hot-reload patch too.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last successfully applied reload, so the existing patch was left in place and `InvocationCount` was preserved. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last fully applied reload (a run with no Skipped or Failed outcomes), so the existing patch was left in place and `InvocationCount` was preserved. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
 - `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods at risk of being already JIT-inlined into existing callers — those marked `[AggressiveInlining]`, plus (only when Code Optimization is Release) those with tiny pre-patch bodies — meaning the change may not show at those call sites, the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `AddedFields` (array): source-level names ("Type.field") of fields this reload added; their values live outside the compiled type until 'uloop compile'.

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1810,6 +1810,55 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a later run that Skips a previously patched method while still Patching a
+        /// sibling is not recorded, so an identical third reload re-reports the Skip instead of
+        /// AlreadyActive.
+        /// </summary>
+        [Test]
+        public async Task Run_SkippedMixThenIdenticalReload_DoesNotShortCircuitAndRereportsSkipped()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string firstSource = BuildFixtureSource(
+                computeWithPrivateMethod:
+                "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }",
+                sumGridMethod:
+                "public int SumGrid(int[,] grid)\n        {\n            return 42;\n        }");
+            string skippedMixSource = BuildFixtureSource(
+                computeWithPrivateMethod:
+                "public int ComputeWithPrivate(int delta)\n        {\n            return base.BaseSeed() + delta;\n        }",
+                sumGridMethod:
+                "public int SumGrid(int[,] grid)\n        {\n            return 42;\n        }");
+            string firstPath = WriteEditedSource("SkippedMixThenIdentical1.cs", firstSource);
+            string skippedMixPath = WriteEditedSource("SkippedMixThenIdentical2.cs", skippedMixSource);
+
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                firstPath,
+                CancellationToken.None);
+            AssertNoFileLevelFailure(first);
+            AssertHasPatched(first, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+            AssertHasPatched(first, nameof(HotReloadE2EFixture.SumGrid));
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                skippedMixPath,
+                CancellationToken.None);
+            AssertNoFileLevelFailure(second);
+            AssertHasSkipped(second, nameof(HotReloadE2EFixture.ComputeWithPrivate), "base");
+            AssertHasPatched(second, nameof(HotReloadE2EFixture.SumGrid));
+            AssertNoAlreadyActive(second);
+
+            HotReloadOrchestratorResult third = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                skippedMixPath,
+                CancellationToken.None);
+            AssertNoFileLevelFailure(third);
+            AssertHasSkipped(third, nameof(HotReloadE2EFixture.ComputeWithPrivate), "base");
+            AssertHasPatched(third, nameof(HotReloadE2EFixture.SumGrid));
+            AssertNoAlreadyActive(third);
+        }
+
+        /// <summary>
         /// What: --revert-all clears the applied-source ledger, so reloading the same edited
         /// source afterwards patches again instead of reporting AlreadyActive.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -1692,6 +1693,159 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: reloading the same edited source a second time reports AlreadyActive and
+        /// leaves the existing Harmony patch in place so InvocationCount is preserved.
+        /// </summary>
+        [Test]
+        public async Task Run_IdenticalSourceSecondReload_ReportsAlreadyActiveAndKeepsInvocationCount()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "IdenticalSourceSecondReload.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }"));
+
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(first);
+            AssertHasPatched(first, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(115));
+
+            MethodInfo computeMethod = typeof(HotReloadE2EFixture).GetMethod(
+                nameof(HotReloadE2EFixture.ComputeWithPrivate));
+            Assert.That(computeMethod, Is.Not.Null);
+            string methodKey = HotReloadPatcher.FormatMethodKey(computeMethod);
+            Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(1L));
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(second);
+            AssertHasAlreadyActive(second, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+            Assert.That(second.PatchedTotal, Is.EqualTo(0));
+            Assert.That(
+                HotReloadInvocationRegistry.GetCount(methodKey),
+                Is.EqualTo(1L),
+                "The second reload must not replace the patch; InvocationCount stays at the pre-reload value.");
+            Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(115));
+            Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(2L));
+        }
+
+        /// <summary>
+        /// What: after a patch, reloading the compiled on-disk baseline still peels that patch
+        /// (the revert-to-compiled path is not swallowed by the identical-source short-circuit).
+        /// </summary>
+        [Test]
+        public async Task Run_RevertToCompiledBaseline_PeelsPatchAndDoesNotReportAlreadyActive()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "RevertBaselineNotAlreadyActive.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }"));
+
+            HotReloadOrchestratorResult patched = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(patched);
+            AssertHasPatched(patched, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(115));
+
+            HotReloadOrchestratorResult reverted = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                contentPathOverride: null,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(reverted);
+            Assert.That(reverted.Methods, Is.Empty, FormatOutcomes(reverted));
+            AssertNoAlreadyActive(reverted);
+            Assert.That(reverted.UnchangedTotal, Is.GreaterThan(0));
+            Assert.That(reverted.ActivePatchTotal, Is.EqualTo(0));
+            Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(15));
+        }
+
+        /// <summary>
+        /// What: a run that reports Failed does not short-circuit a later identical reload, so
+        /// the same Failed outcome is reported again instead of AlreadyActive.
+        /// </summary>
+        [Test]
+        public async Task Run_FailedMixThenIdenticalReload_DoesNotShortCircuitAndRereportsFailed()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "FailedMixThenIdenticalReload.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }",
+                    callsMissingHelperMethod:
+                    "public int CallsMissingHelper(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }"));
+
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertHasPatched(first, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+            AssertHasFailed(first, nameof(HotReloadE2EFixture.CallsMissingHelper));
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertHasPatched(second, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+            AssertHasFailed(second, nameof(HotReloadE2EFixture.CallsMissingHelper));
+            AssertNoAlreadyActive(second);
+        }
+
+        /// <summary>
+        /// What: --revert-all clears the applied-source ledger, so reloading the same edited
+        /// source afterwards patches again instead of reporting AlreadyActive.
+        /// </summary>
+        [Test]
+        public async Task Run_RevertAllThenIdenticalSource_DoesNotShortCircuit()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "RevertAllThenIdenticalSource.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }"));
+
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(first);
+            AssertHasPatched(first, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+
+            HotReloadPatcher.RevertAll();
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(second);
+            AssertHasPatched(second, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+            AssertNoAlreadyActive(second);
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(115));
+        }
+
+        /// <summary>
         /// What: a const-only source with no verified snapshot does not emit the
         /// "No verified source snapshot" warning (no patch candidates → no noise).
         /// </summary>
@@ -2407,7 +2561,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: adding a field and reading/writing it from edited bodies stores values per
-        /// instance, and a second apply keeps the stored values.
+        /// instance, and a second identical apply reports AlreadyActive while keeping the values.
         /// </summary>
         [Test]
         public async Task Run_AddedField_AppliesThroughStoreAndKeepsValuesOnReapply()
@@ -2437,7 +2591,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 WriteEditedSource("AddedFieldApplyE2EReapply.cs", edited),
                 CancellationToken.None);
             AssertNoFileLevelFailure(second);
-            AssertHasPatched(second, nameof(HotReloadAddedFieldApplyFixture.ReadAdded));
+            AssertHasAlreadyActive(second, nameof(HotReloadAddedFieldApplyFixture.ReadAdded));
+            AssertHasAlreadyActive(second, nameof(HotReloadAddedFieldApplyFixture.WriteAdded));
             Assert.That(firstHost.ReadAdded(), Is.EqualTo(10));
             Assert.That(secondHost.ReadAdded(), Is.EqualTo(20));
         }
@@ -2685,8 +2840,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a successful re-apply of the same added method re-registers it, so the
-        /// deactivated-patches warning is not emitted.
+        /// What: a successful identical re-apply of an added method reports AlreadyActive and
+        /// does not emit the deactivated-patches warning.
         /// </summary>
         [Test]
         public async Task Run_ReapplyWorkingAddedMethod_DoesNotWarnDeactivatedPatches()
@@ -2704,7 +2859,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 new[] { fixturePath },
                 WriteEditedSource("ReapplyWorkingAdded2.cs", edited),
                 CancellationToken.None);
-            AssertHasAdded(second, "AddedPing");
+            AssertHasAlreadyActive(second, "AddedPing");
             AssertNoDeactivatedPatchesWarning(second);
         }
 
@@ -3033,8 +3188,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: re-applying the same same-file return-type change does not double the added-member
-        /// registry or ActivePatchTotal.
+        /// What: re-applying the same same-file return-type change reports AlreadyActive and
+        /// does not double the added-member registry or ActivePatchTotal.
         /// </summary>
         [Test]
         public async Task Run_ReturnTypeChange_Reapply_DoesNotDoubleRegistry()
@@ -3058,7 +3213,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 WriteEditedSource("SignatureChangeReapply2.cs", edited),
                 CancellationToken.None);
             AssertNoFileLevelFailure(second);
-            AssertHasAdded(second, nameof(HotReloadSignatureChangeSameFileFixture.Target));
+            AssertHasAlreadyActive(second, nameof(HotReloadSignatureChangeSameFileFixture.Target));
             Assert.That(second.ActivePatchTotal, Is.EqualTo(2));
             Assert.That(
                 CountAddedMembersContaining(nameof(HotReloadSignatureChangeSameFileFixture.Target)),
@@ -3994,6 +4149,49 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             Assert.Fail("Expected Patched outcome for " + methodName + ".\n" + FormatOutcomes(result));
+        }
+
+        private static void AssertHasAlreadyActive(HotReloadOrchestratorResult result, string methodName)
+        {
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.AlreadyActive
+                    && outcome.Method.Contains(methodName))
+                {
+                    Assert.That(
+                        outcome.Reason,
+                        Is.EqualTo(HotReloadConstants.AlreadyActiveReason));
+                    return;
+                }
+            }
+
+            Assert.Fail(
+                "Expected AlreadyActive outcome for " + methodName + ".\n" + FormatOutcomes(result));
+        }
+
+        private static void AssertHasFailed(HotReloadOrchestratorResult result, string methodName)
+        {
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
+                    && outcome.Method.Contains(methodName))
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail("Expected Failed outcome for " + methodName + ".\n" + FormatOutcomes(result));
+        }
+
+        private static void AssertNoAlreadyActive(HotReloadOrchestratorResult result)
+        {
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                Assert.That(
+                    outcome.Kind,
+                    Is.Not.EqualTo(HotReloadMethodOutcomeKind.AlreadyActive),
+                    "Did not expect AlreadyActive.\n" + FormatOutcomes(result));
+            }
         }
 
         private static int CountOccurrences(string text, string token)

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
@@ -302,7 +302,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: an expired armed marker is reported once on the next hot-reload of its owner
-        /// and does not re-warn on a later apply of the same method (pending-drain + detach).
+        /// and does not re-warn on a later identical apply (AlreadyActive no-op; pending-drain
+        /// already detached the expire event).
         /// </summary>
         [Test]
         public async Task HotReload_AfterExpire_WarnsOnceAndDoesNotRepeat()
@@ -939,7 +940,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.False,
                 FormatHotReloadOutcomes(result));
             Assert.That(
-                result.Methods.Any(m => m.Kind == HotReloadMethodOutcomeKind.Patched),
+                result.Methods.Any(m =>
+                    m.Kind == HotReloadMethodOutcomeKind.Patched
+                    || m.Kind == HotReloadMethodOutcomeKind.AlreadyActive),
                 Is.True,
                 FormatHotReloadOutcomes(result));
             return HotReloadTool.BuildApplyResponse(result);

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -392,7 +392,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a skipped-only run keeps the existing "See Methods for Skipped reasons." message.
+        /// What: a skipped-only run uses the no-patch message that also names AlreadyActive.
         /// </summary>
         [Test]
         public void BuildApplyResponse_SkippedOnly_KeepsExistingSkippedMessage()
@@ -410,7 +410,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(
                 response.Message,
-                Is.EqualTo("Hot reload finished with no methods patched. See Methods for Skipped reasons."));
+                Is.EqualTo(HotReloadConstants.NoMethodsPatchedSeeSkippedOrAlreadyActiveMessage));
         }
 
         /// <summary>
@@ -498,8 +498,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 skippedOnly.Message,
                 Is.EqualTo(
-                    "Hot reload finished with no methods patched. See Methods for Skipped reasons. "
-                    + "1 warning(s). See Warnings."));
+                    HotReloadConstants.NoMethodsPatchedSeeSkippedOrAlreadyActiveMessage
+                    + " 1 warning(s). See Warnings."));
 
             HotReloadResponse applied = HotReloadTool.BuildApplyResponse(
                 new HotReloadOrchestratorResult(
@@ -593,6 +593,61 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.EqualTo(
                     "Hot reload applied. PatchedTotal=1, ActivePatchTotal=1. "
                     + "See Methods for Skipped reasons."));
+        }
+
+        /// <summary>
+        /// What: an all-AlreadyActive run serializes Kind as AlreadyActive and uses the dedicated
+        /// no-change message, without counting those rows in PatchedTotal.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_AllAlreadyActive_SetsKindAndDedicatedMessage()
+        {
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>
+                {
+                    HotReloadMethodOutcome.AlreadyActive("Type.MethodA", "Assets/A.cs"),
+                    HotReloadMethodOutcome.AlreadyActive("Type.MethodB", "Assets/A.cs")
+                },
+                new List<string>(),
+                patchedTotal: 0,
+                activePatchTotal: 2);
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(response.PatchedTotal, Is.EqualTo(0));
+            Assert.That(response.Methods.Count, Is.EqualTo(2));
+            Assert.That(response.Methods[0].Kind, Is.EqualTo(nameof(HotReloadMethodOutcomeKind.AlreadyActive)));
+            Assert.That(response.Methods[1].Kind, Is.EqualTo(nameof(HotReloadMethodOutcomeKind.AlreadyActive)));
+            Assert.That(
+                response.Methods[0].Reason,
+                Is.EqualTo(HotReloadConstants.AlreadyActiveReason));
+            Assert.That(
+                response.Message,
+                Is.EqualTo(string.Format(HotReloadConstants.AlreadyActiveApplyMessageFormat, 2)));
+        }
+
+        /// <summary>
+        /// What: a mixed Skipped+AlreadyActive run uses the no-patch message that names both kinds.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_SkippedAndAlreadyActive_UsesSharedNoPatchMessage()
+        {
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>
+                {
+                    HotReloadMethodOutcome.Skipped("T.Skip", "reason", "file.cs"),
+                    HotReloadMethodOutcome.AlreadyActive("Type.Method", "Assets/A.cs")
+                },
+                new List<string>(),
+                patchedTotal: 0,
+                activePatchTotal: 1);
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+            Assert.That(
+                response.Message,
+                Is.EqualTo(HotReloadConstants.NoMethodsPatchedSeeSkippedOrAlreadyActiveMessage));
         }
 
         private sealed class FakePausePointPauseController : IUloopPausePointPauseController

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAppliedSourceLedger.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAppliedSourceLedger.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// In-memory ledger of the last successfully applied hot-reload source hash per file.
+    /// Domain reload drops this table on purpose: Harmony patches and the shim registry
+    /// disappear at the same time, so a persisted hash would short-circuit a reload whose
+    /// patches are already gone.
+    /// </summary>
+    internal static class HotReloadAppliedSourceLedger
+    {
+        private static readonly Dictionary<string, string> ContentHashByProjectRelativePath =
+            new Dictionary<string, string>(StringComparer.Ordinal);
+
+        public static void Record(string projectRelativePath, string contentHash)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(contentHash), "contentHash must not be empty.");
+
+            ContentHashByProjectRelativePath[projectRelativePath] = contentHash;
+        }
+
+        public static string TryGetHash(string projectRelativePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+
+            if (!ContentHashByProjectRelativePath.TryGetValue(projectRelativePath, out string contentHash))
+            {
+                return null;
+            }
+
+            return contentHash;
+        }
+
+        public static void Clear(string projectRelativePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+
+            ContentHashByProjectRelativePath.Remove(projectRelativePath);
+        }
+
+        public static void ClearAll()
+        {
+            ContentHashByProjectRelativePath.Clear();
+        }
+
+        public static string ComputeContentHash(byte[] bytes)
+        {
+            Debug.Assert(bytes != null, "bytes must not be null.");
+
+            using SHA256 sha256 = SHA256.Create();
+            byte[] hash = sha256.ComputeHash(bytes);
+            StringBuilder builder = new StringBuilder(hash.Length * 2);
+            for (int index = 0; index < hash.Length; index++)
+            {
+                builder.Append(hash[index].ToString("x2"));
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAppliedSourceLedger.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAppliedSourceLedger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e36ee5eaabc9a46c48515ba873c721c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -193,5 +193,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Format: count of Methods entries that carry a LifecycleNote.
         public const string LifecycleNotesAggregatedMessageFormat =
             "{0} patched method(s) have one-shot lifecycle notes; see Methods[].LifecycleNote.";
+
+        public const string AlreadyActiveReason =
+            "Source is unchanged since the last applied hot reload; the existing patch stays active "
+            + "and keeps its InvocationCount. Edit and reload again to apply new changes.";
+
+        // Format: number of AlreadyActive method outcomes in this run.
+        public const string AlreadyActiveApplyMessageFormat =
+            "Hot reload found no source changes since the last applied reload. {0} patches stay "
+            + "active with their InvocationCount preserved. Edit and reload again to apply new changes.";
+
+        public const string NoMethodsPatchedSeeSkippedOrAlreadyActiveMessage =
+            "Hot reload finished with no methods patched. See Methods for Skipped and AlreadyActive reasons.";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -200,7 +200,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         // Format: number of AlreadyActive method outcomes in this run.
         public const string AlreadyActiveApplyMessageFormat =
-            "Hot reload found no source changes since the last applied reload. {0} patches stay "
+            "Hot reload found no source changes since the last applied reload. {0} patch(es) stay "
             + "active with their InvocationCount preserved. Edit and reload again to apply new changes.";
 
         public const string NoMethodsPatchedSeeSkippedOrAlreadyActiveMessage =

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -49,6 +49,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> addedFields = new List<string>();
             int patchedTotal = 0;
             int unchangedTotal = 0;
+            // Why after the file loop (not inside ProcessFileAsync): duplicate paths in one
+            // run must still apply twice; recording mid-run would short-circuit the second copy.
+            Dictionary<string, string> appliedSourceHashByPath =
+                new Dictionary<string, string>(StringComparer.Ordinal);
 
             for (int index = 0; index < files.Count; index++)
             {
@@ -78,6 +82,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 patchedTotal += fileResult.PatchedCount;
                 unchangedTotal += fileResult.UnchangedMethodCount;
                 addedFields.AddRange(fileResult.AddedFieldNames);
+                StageAppliedSourceHash(
+                    appliedSourceHashByPath,
+                    ToProjectRelativeScriptPath(filePath),
+                    fileResult.SourceContentSha256,
+                    fileResult.Outcomes);
+            }
+
+            foreach (KeyValuePair<string, string> pair in appliedSourceHashByPath)
+            {
+                HotReloadAppliedSourceLedger.Record(pair.Key, pair.Value);
             }
 
             if (inlineRiskMethodLabels.Count > 0)
@@ -162,6 +176,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (mvidGuardError != null)
             {
                 outcomes.Add(HotReloadMethodOutcome.Failed("(file)", mvidGuardError, assemblyResolvePath));
+                return new HotReloadFileProcessResult(outcomes, warnings, 0);
+            }
+
+            if (TryShortCircuitUnchangedAppliedSource(
+                    workerSourcePath,
+                    projectRelativePath,
+                    assemblyResolvePath,
+                    outcomes))
+            {
                 return new HotReloadFileProcessResult(outcomes, warnings, 0);
             }
 
@@ -460,7 +483,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 inlineRiskMethodLabels,
                 unchangedMethodCount,
                 retargetedPausePointIds,
-                addedFieldNames);
+                addedFieldNames,
+                workerOutput.sourceContentSha256);
         }
 
         // Peels leftover Harmony patches when the source again matches the verified baseline.
@@ -2425,6 +2449,96 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return contentPathOverride;
         }
 
+        // What: skip worker/shim/patch when this file's source still matches the last applied
+        // run and at least one patch from that run is still active.
+        // Why Clear on the miss path: a later Failed run or revert can leave the hash pointing
+        // at a different live patch set; the next reload must not inherit that stale hash.
+        private static bool TryShortCircuitUnchangedAppliedSource(
+            string workerSourcePath,
+            string projectRelativePath,
+            string assemblyResolvePath,
+            List<HotReloadMethodOutcome> outcomes)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(workerSourcePath), "workerSourcePath must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+            Debug.Assert(outcomes != null, "outcomes must not be null.");
+
+            byte[] probeBytes = File.ReadAllBytes(Path.GetFullPath(workerSourcePath));
+            string probeHash = HotReloadAppliedSourceLedger.ComputeContentHash(probeBytes);
+            HashSet<string> activeLabels = CollectActiveLabelsForFile(projectRelativePath);
+            string recordedHash = HotReloadAppliedSourceLedger.TryGetHash(projectRelativePath);
+            if (recordedHash == null
+                || !string.Equals(probeHash, recordedHash, StringComparison.Ordinal)
+                || activeLabels.Count == 0)
+            {
+                HotReloadAppliedSourceLedger.Clear(projectRelativePath);
+                return false;
+            }
+
+            List<string> sortedLabels = new List<string>(activeLabels);
+            sortedLabels.Sort(StringComparer.Ordinal);
+            for (int index = 0; index < sortedLabels.Count; index++)
+            {
+                outcomes.Add(
+                    HotReloadMethodOutcome.AlreadyActive(sortedLabels[index], assemblyResolvePath));
+            }
+
+            return true;
+        }
+
+        // Why worker hash (not the orchestrator probe): the worker re-reads the file in another
+        // process, so the bytes it compiled can differ from the probe if the file changed mid-run.
+        // Why last occurrence wins: duplicate paths in one run apply twice; only the last
+        // qualifying hash is recorded so the next run short-circuits against what actually landed.
+        private static void StageAppliedSourceHash(
+            Dictionary<string, string> appliedSourceHashByPath,
+            string projectRelativePath,
+            string sourceContentSha256,
+            IReadOnlyList<HotReloadMethodOutcome> outcomes)
+        {
+            Debug.Assert(appliedSourceHashByPath != null, "appliedSourceHashByPath must not be null.");
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+            Debug.Assert(outcomes != null, "outcomes must not be null.");
+
+            if (!ShouldRecordAppliedSource(sourceContentSha256, outcomes))
+            {
+                appliedSourceHashByPath.Remove(projectRelativePath);
+                return;
+            }
+
+            appliedSourceHashByPath[projectRelativePath] = sourceContentSha256;
+        }
+
+        private static bool ShouldRecordAppliedSource(
+            string sourceContentSha256,
+            IReadOnlyList<HotReloadMethodOutcome> outcomes)
+        {
+            if (string.IsNullOrEmpty(sourceContentSha256))
+            {
+                return false;
+            }
+
+            bool hasFailed = false;
+            bool hasPatchedOrAdded = false;
+            for (int index = 0; index < outcomes.Count; index++)
+            {
+                HotReloadMethodOutcomeKind kind = outcomes[index].Kind;
+                if (kind == HotReloadMethodOutcomeKind.Failed)
+                {
+                    hasFailed = true;
+                    break;
+                }
+
+                if (kind == HotReloadMethodOutcomeKind.Patched
+                    || kind == HotReloadMethodOutcomeKind.Added)
+                {
+                    hasPatchedOrAdded = true;
+                }
+            }
+
+            return !hasFailed && hasPatchedOrAdded;
+        }
+
         private static HashSet<string> CollectActiveLabelsForFile(string projectRelativePath)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
@@ -2579,6 +2693,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public List<string> InlineRiskMethodLabels { get; }
             public int UnchangedMethodCount { get; }
             public string[] AddedFieldNames { get; }
+            public string SourceContentSha256 { get; }
 
             public HotReloadFileProcessResult(
                 List<HotReloadMethodOutcome> outcomes,
@@ -2588,7 +2703,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 List<string> inlineRiskMethodLabels = null,
                 int unchangedMethodCount = 0,
                 List<string> retargetedPausePointIds = null,
-                string[] addedFieldNames = null)
+                string[] addedFieldNames = null,
+                string sourceContentSha256 = null)
             {
                 Outcomes = outcomes;
                 Warnings = warnings;
@@ -2598,6 +2714,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 UnchangedMethodCount = unchangedMethodCount;
                 RetargetedPausePointIds = retargetedPausePointIds ?? new List<string>();
                 AddedFieldNames = addedFieldNames ?? Array.Empty<string>();
+                SourceContentSha256 = sourceContentSha256;
             }
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -2463,7 +2463,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
             Debug.Assert(outcomes != null, "outcomes must not be null.");
 
-            byte[] probeBytes = File.ReadAllBytes(Path.GetFullPath(workerSourcePath));
+            // Why Exists (not ReadAllBytes first): a missing file after a successful apply
+            // used to surface as a file-level Failed from the worker. Reading unconditionally
+            // would throw and abort the whole RunAsync. Why not Clear: this path does not
+            // mutate patches, so the ledger still describes the live patch set.
+            string fullWorkerSourcePath = Path.GetFullPath(workerSourcePath);
+            if (!File.Exists(fullWorkerSourcePath))
+            {
+                return false;
+            }
+
+            byte[] probeBytes = File.ReadAllBytes(fullWorkerSourcePath);
             string probeHash = HotReloadAppliedSourceLedger.ComputeContentHash(probeBytes);
             HashSet<string> activeLabels = CollectActiveLabelsForFile(projectRelativePath);
             string recordedHash = HotReloadAppliedSourceLedger.TryGetHash(projectRelativePath);
@@ -2513,30 +2523,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string sourceContentSha256,
             IReadOnlyList<HotReloadMethodOutcome> outcomes)
         {
-            if (string.IsNullOrEmpty(sourceContentSha256))
+            if (string.IsNullOrEmpty(sourceContentSha256) || outcomes.Count == 0)
             {
                 return false;
             }
 
-            bool hasFailed = false;
             bool hasPatchedOrAdded = false;
             for (int index = 0; index < outcomes.Count; index++)
             {
                 HotReloadMethodOutcomeKind kind = outcomes[index].Kind;
-                if (kind == HotReloadMethodOutcomeKind.Failed)
+                if (kind != HotReloadMethodOutcomeKind.Patched
+                    && kind != HotReloadMethodOutcomeKind.Added)
                 {
-                    hasFailed = true;
-                    break;
+                    // Why not record Skipped: that method's previous patch may still be live,
+                    // so recording would let the next identical reload report AlreadyActive and
+                    // hide the skip reason.
+                    return false;
                 }
 
-                if (kind == HotReloadMethodOutcomeKind.Patched
-                    || kind == HotReloadMethodOutcomeKind.Added)
-                {
-                    hasPatchedOrAdded = true;
-                }
+                hasPatchedOrAdded = true;
             }
 
-            return !hasFailed && hasPatchedOrAdded;
+            return hasPatchedOrAdded;
         }
 
         private static HashSet<string> CollectActiveLabelsForFile(string projectRelativePath)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
@@ -39,7 +39,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     }
 
     /// <summary>
-    /// Per-method outcome: Patched, Skipped, Failed, or Added.
+    /// Per-method outcome: Patched, Skipped, Failed, Added, or AlreadyActive.
     /// </summary>
     internal sealed class HotReloadMethodOutcome
     {
@@ -108,6 +108,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 filePath,
                 lifecycleNote);
         }
+
+        public static HotReloadMethodOutcome AlreadyActive(string method, string filePath)
+        {
+            return new HotReloadMethodOutcome(
+                HotReloadMethodOutcomeKind.AlreadyActive,
+                method,
+                HotReloadConstants.AlreadyActiveReason,
+                filePath,
+                string.Empty);
+        }
     }
 
     internal enum HotReloadMethodOutcomeKind
@@ -115,6 +125,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         Patched = 0,
         Skipped = 1,
         Failed = 2,
-        Added = 3
+        Added = 3,
+        AlreadyActive = 4
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -225,7 +225,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
-        /// Removes every hot-reload patch owned by this patcher and clears the ledger.
+        /// Removes every hot-reload patch owned by this patcher and clears the patch,
+        /// added-member, and applied-source ledgers.
         /// </summary>
         public static void RevertAll()
         {
@@ -243,6 +244,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             TransplantLocalsByMethod.Clear();
             TransplantPreambleLengthByMethod.Clear();
             HotReloadInvocationRegistry.Clear();
+            HotReloadAppliedSourceLedger.ClearAll();
             _pendingShimMethod = null;
             _pendingOriginalMethod = null;
             HarmonyInstance.UnpatchAll(HotReloadConstants.HarmonyId);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -338,9 +338,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 message = "Hot reload found no patchable method bodies in the given files; nothing was changed. "
                     + "Hot reload only replaces existing ordinary method bodies; use uloop compile for other edits.";
             }
+            else if (AreAllOutcomesAlreadyActive(result))
+            {
+                message = string.Format(
+                    HotReloadConstants.AlreadyActiveApplyMessageFormat,
+                    result.Methods.Count);
+            }
             else if (result.PatchedTotal == 0 && addedCount == 0)
             {
-                message = "Hot reload finished with no methods patched. See Methods for Skipped reasons.";
+                message = HotReloadConstants.NoMethodsPatchedSeeSkippedOrAlreadyActiveMessage;
             }
             else
             {
@@ -382,6 +388,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return AppendWarningCount(message, warningCount);
+        }
+
+        private static bool AreAllOutcomesAlreadyActive(HotReloadOrchestratorResult result)
+        {
+            if (result.Methods.Count == 0)
+            {
+                return false;
+            }
+
+            for (int index = 0; index < result.Methods.Count; index++)
+            {
+                if (result.Methods[index].Kind != HotReloadMethodOutcomeKind.AlreadyActive)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private static bool HasSkippedOutcome(HotReloadOrchestratorResult result)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -41,7 +41,8 @@ a domain reload it reports zero patched methods, which is exactly when an
 `ActivePatchTotal` remembered from an earlier response has gone stale.
 
 Each `Active` row's `InvocationCount` counts calls into the patched body since that patch
-was applied; re-running hot reload on the same method resets it to zero. While Unity is
+was applied. Reloading the same source with no edits reports `AlreadyActive` and keeps
+the count; re-running after a real edit replaces the patch and resets it to zero. While Unity is
 paused — including while a pause-point hit holds the game — the player loop does not
 advance, so game-driven calls stop and the count freezes; calls you make yourself (for
 example through `uloop execute-dynamic-code`) still increment it. A frozen count during a
@@ -57,8 +58,11 @@ game, and only then read `InvocationCount` as a reachability signal.
 3. Compiles the shims against publicized reference copies, loads the result into the Editor domain, and binds every shim type's accessor delegates (`__BindAccessors`) before any patch is applied.
 4. Patches each original method with a Harmony transpiler (ID `io.github.hatayama.uloop.hot-reload`) in one of two shapes: transplant copies the shim's IL into the original method, while delegation rewrites the original to forward its arguments to the shim, which runs as normally compiled code.
 
-Re-running on the same method replaces its previous patch; `ActivePatchTotal` tracks the
-ledger across runs.
+Re-running on the same method after a real edit replaces its previous patch;
+`ActivePatchTotal` tracks the ledger across runs. Reloading a file whose source is
+unchanged since the last successful apply is a no-op: each still-active method is reported
+as `AlreadyActive`, the existing patch stays in place, and `InvocationCount` is preserved.
+Edit the file and reload again to apply new changes.
 
 ## Scope and limits
 
@@ -348,7 +352,7 @@ cached dispatch can bypass a hot-reload patch too.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, or `Added` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last successfully applied reload, so the existing patch was left in place and `InvocationCount` was preserved. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
 - `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods at risk of being already JIT-inlined into existing callers — those marked `[AggressiveInlining]`, plus (only when Code Optimization is Release) those with tiny pre-patch bodies — meaning the change may not show at those call sites, the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `AddedFields` (array): source-level names ("Type.field") of fields this reload added; their values live outside the compiled type until 'uloop compile'.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -41,7 +41,8 @@ a domain reload it reports zero patched methods, which is exactly when an
 `ActivePatchTotal` remembered from an earlier response has gone stale.
 
 Each `Active` row's `InvocationCount` counts calls into the patched body since that patch
-was applied. Reloading the same source with no edits reports `AlreadyActive` and keeps
+was applied. Reloading the same source with no edits after a fully applied reload (a run
+with no Skipped or Failed outcomes) reports `AlreadyActive` and keeps
 the count; re-running after a real edit replaces the patch and resets it to zero. While Unity is
 paused — including while a pause-point hit holds the game — the player loop does not
 advance, so game-driven calls stop and the count freezes; calls you make yourself (for
@@ -60,7 +61,8 @@ game, and only then read `InvocationCount` as a reachability signal.
 
 Re-running on the same method after a real edit replaces its previous patch;
 `ActivePatchTotal` tracks the ledger across runs. Reloading a file whose source is
-unchanged since the last successful apply is a no-op: each still-active method is reported
+unchanged since the last fully applied reload (a run with no Skipped or Failed
+outcomes) is a no-op: each still-active method is reported
 as `AlreadyActive`, the existing patch stays in place, and `InvocationCount` is preserved.
 Edit the file and reload again to apply new changes.
 
@@ -352,7 +354,7 @@ cached dispatch can bypass a hot-reload patch too.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last successfully applied reload, so the existing patch was left in place and `InvocationCount` was preserved. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last fully applied reload (a run with no Skipped or Failed outcomes), so the existing patch was left in place and `InvocationCount` was preserved. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
 - `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods at risk of being already JIT-inlined into existing callers — those marked `[AggressiveInlining]`, plus (only when Code Optimization is Release) those with tiny pre-patch bodies — meaning the change may not show at those call sites, the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `AddedFields` (array): source-level names ("Type.field") of fields this reload added; their values live outside the compiled type until 'uloop compile'.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -75,6 +75,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Compiled identities of methods that left the edited file (or whose return type changed).
         // Null/omitted deserializes as empty after client coalesce.
         public TransformWorkerRemovedMethodSignatureDto[] removedMethodSignatures;
+
+        // SHA-256 (lowercase hex) of the raw source bytes the worker actually read.
+        // Null/omitted when the worker returned before reading the file.
+        public string sourceContentSha256;
     }
 
     [Serializable]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -12,6 +12,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.Loader;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -159,9 +160,17 @@ public static class TransformWorkerProgram
         }
 
         string sourceText;
+        string sourceContentSha256;
         try
         {
-            sourceText = File.ReadAllText(input.SourcePath, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            byte[] sourceBytes = File.ReadAllBytes(input.SourcePath);
+            sourceContentSha256 = ComputeSourceContentSha256(sourceBytes);
+            using MemoryStream memoryStream = new MemoryStream(sourceBytes, writable: false);
+            using StreamReader reader = new StreamReader(
+                memoryStream,
+                Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: true);
+            sourceText = reader.ReadToEnd();
         }
         catch (Exception exception)
         {
@@ -522,8 +531,23 @@ public static class TransformWorkerProgram
             RemovedMethodSignatures = removedMethodSignatures.ToArray(),
             HasAccessorDelegates = hasAccessorDelegates,
             HasAddedFieldRewrites = addedFieldCatalog.HasStoreRewrites,
-            AddedFieldNames = addedFieldCatalog.ListRewrittenAddedFieldDisplayNames()
+            AddedFieldNames = addedFieldCatalog.ListRewrittenAddedFieldDisplayNames(),
+            SourceContentSha256 = sourceContentSha256
         };
+    }
+
+    // Keep in sync with HotReloadAppliedSourceLedger.ComputeContentHash (lowercase hex SHA-256).
+    private static string ComputeSourceContentSha256(byte[] bytes)
+    {
+        using SHA256 sha256 = SHA256.Create();
+        byte[] hash = sha256.ComputeHash(bytes);
+        StringBuilder builder = new StringBuilder(hash.Length * 2);
+        for (int index = 0; index < hash.Length; index++)
+        {
+            builder.Append(hash[index].ToString("x2"));
+        }
+
+        return builder.ToString();
     }
 
     /// <summary>
@@ -8244,6 +8268,9 @@ internal sealed class WorkerOutput
 
     // Keep in sync with TransformWorkerOutputDto.addedFieldNames.
     public string[] AddedFieldNames { get; set; }
+
+    // Keep in sync with TransformWorkerOutputDto.sourceContentSha256.
+    public string SourceContentSha256 { get; set; }
 }
 
 internal sealed class WorkerRemovedMember


### PR DESCRIPTION
## Summary
- Reloading a file with no source changes now reports `AlreadyActive` instead of looking like a fresh apply.
- Existing patches stay in place, so `InvocationCount` is preserved until you actually edit and reload.

## User Impact
- Before: running `uloop hot-reload` twice on the same unchanged file re-patched every method, reset each `InvocationCount` to 0, and printed the same "Hot reload applied" message. Testers could not tell a no-op from a real apply and had to check `--status`.
- After: the second run reports `AlreadyActive`, keeps the live patch and its count, and tells you to edit before reloading again. `--revert-all` still peels patches and allows a later identical reload to apply for real.

## Changes
- Track the last successfully applied source hash per file (in-memory; domain reload clears it with the patches).
- Hash is SHA-256 of the bytes the transform worker actually read, not the orchestrator's probe read.
- Short-circuit only when that hash still matches and at least one patch for the file is still active. A run that reports any `Failed` outcome is not recorded.
- Record those hashes at the end of `RunAsync`, not inside per-file processing, so duplicate paths in one command still apply twice (existing documented behavior). Cross-run identical reloads still short-circuit.
- Ledger invalidation on revert: `HotReloadPatcher.RevertAll` calls `ClearAll` (covers `--revert-all` / `ExecuteRevertAll`, and EditMode test teardown). `RevertUnchangedPatches` and apply-failure rollback are unchanged.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` — ErrorCount 0, WarningCount 2 (pre-existing fixture warnings, no increase).
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value 'io\.github\.hatayama\.UnityCliLoop\.Tests\.Editor\.HotReload' --project-path "$(git rev-parse --show-toplevel)"` — 392 passed, 0 failed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

