### PR TITLE
fix: explain re-apply when unchanged source follows a non-baseline run

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1736,6 +1736,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "The second reload must not replace the patch; InvocationCount stays at the pre-reload value.");
             Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(115));
             Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(2L));
+            AssertNoUnchangedSourceNonBaselineWarning(second);
         }
 
         /// <summary>
@@ -1807,6 +1808,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertHasPatched(second, nameof(HotReloadE2EFixture.ComputeWithPrivate));
             AssertHasFailed(second, nameof(HotReloadE2EFixture.CallsMissingHelper));
             AssertNoAlreadyActive(second);
+            AssertHasUnchangedSourceNonBaselineWarning(second);
         }
 
         /// <summary>
@@ -1856,6 +1858,75 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertHasSkipped(third, nameof(HotReloadE2EFixture.ComputeWithPrivate), "base");
             AssertHasPatched(third, nameof(HotReloadE2EFixture.SumGrid));
             AssertNoAlreadyActive(third);
+            AssertHasUnchangedSourceNonBaselineWarning(third);
+        }
+
+        /// <summary>
+        /// What: an unchanged reload after a Skipped-only (empty-entries) run emits the
+        /// non-baseline warning, so all-Skipped files still record a hash.
+        /// </summary>
+        [Test]
+        public async Task Run_AllSkippedThenIdenticalReload_WarnsUnchangedSourceNonBaseline()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "AllSkippedThenIdenticalReload.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return base.BaseSeed() + delta;\n        }"));
+
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+            AssertNoFileLevelFailure(first);
+            AssertHasSkipped(first, nameof(HotReloadE2EFixture.ComputeWithPrivate), "base");
+            Assert.That(first.PatchedTotal, Is.EqualTo(0));
+            AssertNoUnchangedSourceNonBaselineWarning(first);
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+            AssertNoFileLevelFailure(second);
+            AssertHasSkipped(second, nameof(HotReloadE2EFixture.ComputeWithPrivate), "base");
+            AssertNoAlreadyActive(second);
+            AssertHasUnchangedSourceNonBaselineWarning(second);
+        }
+
+        /// <summary>
+        /// What: changing the source after a non-baseline run does not emit the unchanged-source
+        /// warning, because the probe hash no longer matches the recorded non-baseline entry.
+        /// </summary>
+        [Test]
+        public async Task Run_NonBaselineThenChangedSource_DoesNotWarnUnchangedSourceNonBaseline()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string skippedPath = WriteEditedSource(
+                "NonBaselineThenChanged1.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return base.BaseSeed() + delta;\n        }"));
+            string changedPath = WriteEditedSource(
+                "NonBaselineThenChanged2.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }"));
+
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                skippedPath,
+                CancellationToken.None);
+            AssertNoFileLevelFailure(first);
+            AssertHasSkipped(first, nameof(HotReloadE2EFixture.ComputeWithPrivate), "base");
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                changedPath,
+                CancellationToken.None);
+            AssertNoFileLevelFailure(second);
+            AssertHasPatched(second, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+            AssertNoUnchangedSourceNonBaselineWarning(second);
         }
 
         /// <summary>
@@ -4240,6 +4311,45 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     outcome.Kind,
                     Is.Not.EqualTo(HotReloadMethodOutcomeKind.AlreadyActive),
                     "Did not expect AlreadyActive.\n" + FormatOutcomes(result));
+            }
+        }
+
+        private static string FormatUnchangedSourceNonBaselineWarning()
+        {
+            return string.Format(
+                HotReloadConstants.UnchangedSourceNonBaselineWarningFormat,
+                "Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs");
+        }
+
+        private static void AssertHasUnchangedSourceNonBaselineWarning(HotReloadOrchestratorResult result)
+        {
+            string expected = FormatUnchangedSourceNonBaselineWarning();
+            int matchCount = 0;
+            foreach (string warning in result.Warnings)
+            {
+                if (string.Equals(warning, expected, StringComparison.Ordinal))
+                {
+                    matchCount++;
+                }
+            }
+
+            Assert.That(
+                matchCount,
+                Is.EqualTo(1),
+                "Expected exactly one unchanged-source non-baseline warning.\n"
+                + string.Join("\n", result.Warnings));
+        }
+
+        private static void AssertNoUnchangedSourceNonBaselineWarning(HotReloadOrchestratorResult result)
+        {
+            string expected = FormatUnchangedSourceNonBaselineWarning();
+            foreach (string warning in result.Warnings)
+            {
+                Assert.That(
+                    warning,
+                    Is.Not.EqualTo(expected),
+                    "Did not expect the unchanged-source non-baseline warning.\n"
+                    + string.Join("\n", result.Warnings));
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAppliedSourceLedger.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAppliedSourceLedger.cs
@@ -8,46 +8,64 @@ using UnityEngine;
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// In-memory ledger of the last successfully applied hot-reload source hash per file.
-    /// Domain reload drops this table on purpose: Harmony patches and the shim registry
-    /// disappear at the same time, so a persisted hash would short-circuit a reload whose
-    /// patches are already gone.
+    /// Decision for an unchanged-source probe against the applied-source ledger.
+    /// </summary>
+    internal enum HotReloadUnchangedSourceDecision
+    {
+        NotUnchanged,
+        ShortCircuited,
+        ReapplyNonBaseline
+    }
+
+    /// <summary>
+    /// In-memory ledger of the last hot-reload source hash per file, plus whether that
+    /// run was fully applied. Domain reload drops this table on purpose: Harmony patches
+    /// and the shim registry disappear at the same time, so a persisted hash would
+    /// short-circuit a reload whose patches are already gone.
+    /// Why the flag: a non-baseline entry (Skipped or Failed in the last run) must not
+    /// short-circuit; it exists only so an identical reload can explain why it re-applies.
     /// </summary>
     internal static class HotReloadAppliedSourceLedger
     {
-        private static readonly Dictionary<string, string> ContentHashByProjectRelativePath =
-            new Dictionary<string, string>(StringComparer.Ordinal);
+        private static readonly Dictionary<string, (string Hash, bool IsFullyApplied)>
+            EntryByProjectRelativePath =
+                new Dictionary<string, (string Hash, bool IsFullyApplied)>(StringComparer.Ordinal);
 
-        public static void Record(string projectRelativePath, string contentHash)
+        public static void Record(
+            string projectRelativePath,
+            string sourceContentSha256,
+            bool isFullyApplied)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
-            Debug.Assert(!string.IsNullOrEmpty(contentHash), "contentHash must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(sourceContentSha256), "sourceContentSha256 must not be empty.");
 
-            ContentHashByProjectRelativePath[projectRelativePath] = contentHash;
+            EntryByProjectRelativePath[projectRelativePath] = (sourceContentSha256, isFullyApplied);
         }
 
-        public static string TryGetHash(string projectRelativePath)
+        public static (string Hash, bool IsFullyApplied)? TryGet(string projectRelativePath)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
 
-            if (!ContentHashByProjectRelativePath.TryGetValue(projectRelativePath, out string contentHash))
+            if (!EntryByProjectRelativePath.TryGetValue(
+                    projectRelativePath,
+                    out (string Hash, bool IsFullyApplied) entry))
             {
                 return null;
             }
 
-            return contentHash;
+            return entry;
         }
 
         public static void Clear(string projectRelativePath)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
 
-            ContentHashByProjectRelativePath.Remove(projectRelativePath);
+            EntryByProjectRelativePath.Remove(projectRelativePath);
         }
 
         public static void ClearAll()
         {
-            ContentHashByProjectRelativePath.Clear();
+            EntryByProjectRelativePath.Clear();
         }
 
         public static string ComputeContentHash(byte[] bytes)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -198,6 +198,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             "Source is unchanged since the last applied hot reload; the existing patch stays active "
             + "and keeps its InvocationCount. Edit and reload again to apply new changes.";
 
+        // Format: project-relative path of the source that matched a non-baseline ledger entry.
+        public const string UnchangedSourceNonBaselineWarningFormat =
+            "Source of '{0}' is unchanged since the last reload, but that run had Skipped or Failed "
+            + "outcomes, so it is not a fully applied baseline. All editable methods were processed "
+            + "again and unresolved Skipped reasons are re-reported.";
+
         // Format: number of AlreadyActive method outcomes in this run.
         public const string AlreadyActiveApplyMessageFormat =
             "Hot reload found no source changes since the last applied reload. {0} patch(es) stay "

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -201,8 +201,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Format: project-relative path of the source that matched a non-baseline ledger entry.
         public const string UnchangedSourceNonBaselineWarningFormat =
             "Source of '{0}' is unchanged since the last reload, but that run had Skipped or Failed "
-            + "outcomes, so it is not a fully applied baseline. All editable methods were processed "
-            + "again and unresolved Skipped reasons are re-reported.";
+            + "outcomes, so it is not a fully applied baseline. Hot reload processes all editable "
+            + "methods again instead of reporting AlreadyActive, and unresolved Skipped reasons are "
+            + "re-reported.";
 
         // Format: number of AlreadyActive method outcomes in this run.
         public const string AlreadyActiveApplyMessageFormat =

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -51,8 +51,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int unchangedTotal = 0;
             // Why after the file loop (not inside ProcessFileAsync): duplicate paths in one
             // run must still apply twice; recording mid-run would short-circuit the second copy.
-            Dictionary<string, string> appliedSourceHashByPath =
-                new Dictionary<string, string>(StringComparer.Ordinal);
+            Dictionary<string, (string Hash, bool IsFullyApplied)> appliedSourceHashByPath =
+                new Dictionary<string, (string Hash, bool IsFullyApplied)>(StringComparer.Ordinal);
 
             for (int index = 0; index < files.Count; index++)
             {
@@ -89,9 +89,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     fileResult.Outcomes);
             }
 
-            foreach (KeyValuePair<string, string> pair in appliedSourceHashByPath)
+            foreach (KeyValuePair<string, (string Hash, bool IsFullyApplied)> pair in appliedSourceHashByPath)
             {
-                HotReloadAppliedSourceLedger.Record(pair.Key, pair.Value);
+                HotReloadAppliedSourceLedger.Record(pair.Key, pair.Value.Hash, pair.Value.IsFullyApplied);
             }
 
             if (inlineRiskMethodLabels.Count > 0)
@@ -179,13 +179,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return new HotReloadFileProcessResult(outcomes, warnings, 0);
             }
 
-            if (TryShortCircuitUnchangedAppliedSource(
-                    workerSourcePath,
-                    projectRelativePath,
-                    assemblyResolvePath,
-                    outcomes))
+            HotReloadUnchangedSourceDecision unchangedDecision = TryShortCircuitUnchangedAppliedSource(
+                workerSourcePath,
+                projectRelativePath,
+                assemblyResolvePath,
+                outcomes);
+            if (unchangedDecision == HotReloadUnchangedSourceDecision.ShortCircuited)
             {
                 return new HotReloadFileProcessResult(outcomes, warnings, 0);
+            }
+
+            if (unchangedDecision == HotReloadUnchangedSourceDecision.ReapplyNonBaseline)
+            {
+                warnings.Add(
+                    string.Format(
+                        HotReloadConstants.UnchangedSourceNonBaselineWarningFormat,
+                        projectRelativePath));
             }
 
             // Why snapshot at this file's apply entry: multi-file runs process files
@@ -321,7 +330,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     outcomes,
                     warnings,
                     0,
-                    unchangedMethodCount: unchangedMethodCount);
+                    unchangedMethodCount: unchangedMethodCount,
+                    sourceContentSha256: workerOutput.sourceContentSha256);
             }
 
             outcomes.AddRange(gateResult.SkippedOutcomes);
@@ -341,7 +351,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         suppressedPausePointIds,
                         new List<string>(),
                         unchangedMethodCount,
-                        retargetedPausePointIds);
+                        retargetedPausePointIds,
+                        addedFieldNames: null,
+                        sourceContentSha256: workerOutput.sourceContentSha256);
                 }
 
                 entriesToPatch = gateResult.Isolation.RetryEntries;
@@ -361,7 +373,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     outcomes,
                     warnings,
                     0,
-                    unchangedMethodCount: unchangedMethodCount);
+                    unchangedMethodCount: unchangedMethodCount,
+                    sourceContentSha256: workerOutput.sourceContentSha256);
             }
             else
             {
@@ -385,7 +398,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         outcomes,
                         warnings,
                         0,
-                        unchangedMethodCount: unchangedMethodCount);
+                        unchangedMethodCount: unchangedMethodCount,
+                        sourceContentSha256: workerOutput.sourceContentSha256);
                 }
 
                 outcomes.AddRange(firstCompile.Outcomes);
@@ -398,7 +412,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         suppressedPausePointIds,
                         new List<string>(),
                         unchangedMethodCount,
-                        retargetedPausePointIds);
+                        retargetedPausePointIds,
+                        addedFieldNames: null,
+                        sourceContentSha256: workerOutput.sourceContentSha256);
                 }
 
                 entriesToPatch = firstCompile.EntriesToPatch;
@@ -427,7 +443,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         outcomes,
                         warnings,
                         0,
-                        unchangedMethodCount: unchangedMethodCount);
+                        unchangedMethodCount: unchangedMethodCount,
+                        sourceContentSha256: workerOutput.sourceContentSha256);
                 }
             }
 
@@ -2449,11 +2466,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return contentPathOverride;
         }
 
-        // What: skip worker/shim/patch when this file's source still matches the last applied
-        // run and at least one patch from that run is still active.
-        // Why Clear on the miss path: a later Failed run or revert can leave the hash pointing
-        // at a different live patch set; the next reload must not inherit that stale hash.
-        private static bool TryShortCircuitUnchangedAppliedSource(
+        // What: decide whether an unchanged source should short-circuit, re-apply with a
+        // non-baseline warning, or fall through as a normal changed/unknown source.
+        // Why Clear on the miss and non-baseline paths: a later Failed run or revert can leave
+        // the hash pointing at a different live patch set; the next reload must not inherit
+        // that stale hash. Non-baseline matches still Clear; Stage/Record writes the same
+        // hash+flag back so the next identical reload warns again.
+        private static HotReloadUnchangedSourceDecision TryShortCircuitUnchangedAppliedSource(
             string workerSourcePath,
             string projectRelativePath,
             string assemblyResolvePath,
@@ -2470,30 +2489,36 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string fullWorkerSourcePath = Path.GetFullPath(workerSourcePath);
             if (!File.Exists(fullWorkerSourcePath))
             {
-                return false;
+                return HotReloadUnchangedSourceDecision.NotUnchanged;
             }
 
             byte[] probeBytes = File.ReadAllBytes(fullWorkerSourcePath);
             string probeHash = HotReloadAppliedSourceLedger.ComputeContentHash(probeBytes);
             HashSet<string> activeLabels = CollectActiveLabelsForFile(projectRelativePath);
-            string recordedHash = HotReloadAppliedSourceLedger.TryGetHash(projectRelativePath);
-            if (recordedHash == null
-                || !string.Equals(probeHash, recordedHash, StringComparison.Ordinal)
-                || activeLabels.Count == 0)
+            (string Hash, bool IsFullyApplied)? recorded = HotReloadAppliedSourceLedger.TryGet(projectRelativePath);
+            if (recorded == null
+                || !string.Equals(probeHash, recorded.Value.Hash, StringComparison.Ordinal)
+                || (recorded.Value.IsFullyApplied && activeLabels.Count == 0))
             {
                 HotReloadAppliedSourceLedger.Clear(projectRelativePath);
-                return false;
+                return HotReloadUnchangedSourceDecision.NotUnchanged;
             }
 
-            List<string> sortedLabels = new List<string>(activeLabels);
-            sortedLabels.Sort(StringComparer.Ordinal);
-            for (int index = 0; index < sortedLabels.Count; index++)
+            if (recorded.Value.IsFullyApplied)
             {
-                outcomes.Add(
-                    HotReloadMethodOutcome.AlreadyActive(sortedLabels[index], assemblyResolvePath));
+                List<string> sortedLabels = new List<string>(activeLabels);
+                sortedLabels.Sort(StringComparer.Ordinal);
+                for (int index = 0; index < sortedLabels.Count; index++)
+                {
+                    outcomes.Add(
+                        HotReloadMethodOutcome.AlreadyActive(sortedLabels[index], assemblyResolvePath));
+                }
+
+                return HotReloadUnchangedSourceDecision.ShortCircuited;
             }
 
-            return true;
+            HotReloadAppliedSourceLedger.Clear(projectRelativePath);
+            return HotReloadUnchangedSourceDecision.ReapplyNonBaseline;
         }
 
         // Why worker hash (not the orchestrator probe): the worker re-reads the file in another
@@ -2501,7 +2526,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Why last occurrence wins: duplicate paths in one run apply twice; only the last
         // qualifying hash is recorded so the next run short-circuits against what actually landed.
         private static void StageAppliedSourceHash(
-            Dictionary<string, string> appliedSourceHashByPath,
+            Dictionary<string, (string Hash, bool IsFullyApplied)> appliedSourceHashByPath,
             string projectRelativePath,
             string sourceContentSha256,
             IReadOnlyList<HotReloadMethodOutcome> outcomes)
@@ -2510,41 +2535,61 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
             Debug.Assert(outcomes != null, "outcomes must not be null.");
 
-            if (!ShouldRecordAppliedSource(sourceContentSha256, outcomes))
+            (string Hash, bool IsFullyApplied)? record = DecideAppliedSourceRecord(
+                sourceContentSha256,
+                outcomes);
+            if (record == null)
             {
                 appliedSourceHashByPath.Remove(projectRelativePath);
                 return;
             }
 
-            appliedSourceHashByPath[projectRelativePath] = sourceContentSha256;
+            appliedSourceHashByPath[projectRelativePath] = record.Value;
         }
 
-        private static bool ShouldRecordAppliedSource(
+        // Why not record "everything that is not fully applied": deleting an added method and
+        // converging to compiled IL yields empty outcomes on the empty-entries path. Recording
+        // that as non-baseline would make the next identical reload claim a prior Skipped/Failed
+        // that never happened.
+        private static (string Hash, bool IsFullyApplied)? DecideAppliedSourceRecord(
             string sourceContentSha256,
             IReadOnlyList<HotReloadMethodOutcome> outcomes)
         {
             if (string.IsNullOrEmpty(sourceContentSha256) || outcomes.Count == 0)
             {
-                return false;
+                return null;
             }
 
-            bool hasPatchedOrAdded = false;
+            bool hasSkippedOrFailed = false;
+            bool allPatchedOrAdded = true;
             for (int index = 0; index < outcomes.Count; index++)
             {
                 HotReloadMethodOutcomeKind kind = outcomes[index].Kind;
-                if (kind != HotReloadMethodOutcomeKind.Patched
-                    && kind != HotReloadMethodOutcomeKind.Added)
+                if (kind == HotReloadMethodOutcomeKind.Patched
+                    || kind == HotReloadMethodOutcomeKind.Added)
                 {
-                    // Why not record Skipped: that method's previous patch may still be live,
-                    // so recording would let the next identical reload report AlreadyActive and
-                    // hide the skip reason.
-                    return false;
+                    continue;
                 }
 
-                hasPatchedOrAdded = true;
+                allPatchedOrAdded = false;
+                if (kind == HotReloadMethodOutcomeKind.Skipped
+                    || kind == HotReloadMethodOutcomeKind.Failed)
+                {
+                    hasSkippedOrFailed = true;
+                }
             }
 
-            return hasPatchedOrAdded;
+            if (allPatchedOrAdded)
+            {
+                return (sourceContentSha256, true);
+            }
+
+            if (hasSkippedOrFailed)
+            {
+                return (sourceContentSha256, false);
+            }
+
+            return null;
         }
 
         private static HashSet<string> CollectActiveLabelsForFile(string projectRelativePath)


### PR DESCRIPTION
## Summary
- An unchanged reload after a run that had Skipped or Failed outcomes now explains why every editable method was processed again.
- Fully applied reloads still short-circuit to AlreadyActive and do not show this warning.

## User Impact
- Before: a second reload of the same source after a partial apply silently re-patched and re-reported the same Skipped/Failed rows, with no indication that this was expected.
- After: that second reload includes a warning that the previous run was not a fully applied baseline, so unresolved Skipped reasons are re-reported on purpose.

## Changes
- The applied-source ledger now stores whether the last recorded run was fully applied.
- A non-baseline hash is recorded only when the run had at least one Skipped or Failed outcome, and that entry never short-circuits.
- Worker-success early returns now propagate the source hash so all-Skipped (empty-entries) runs can record a non-baseline entry.

## Verification
- `dist/darwin-arm64/uloop compile` — ErrorCount 0
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value 'io\.github\.hatayama\.UnityCliLoop\.Tests\.Editor\.HotReload'` — 395 passed / 0 failed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

