### PR TITLE
fix: report real InvocationCount on AlreadyActive outcomes

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -42,8 +42,8 @@ a domain reload it reports zero patched methods, which is exactly when an
 
 Each `Active` row's `InvocationCount` counts calls into the patched body since that patch
 was applied. Reloading the same source with no edits after a fully applied reload (a run
-with no Skipped or Failed outcomes) reports `AlreadyActive` and keeps
-the count; re-running after a real edit replaces the patch and resets it to zero. While Unity is
+with no Skipped or Failed outcomes) reports `AlreadyActive` and the row carries
+the live `InvocationCount`; re-running after a real edit replaces the patch and resets it to zero. While Unity is
 paused — including while a pause-point hit holds the game — the player loop does not
 advance, so game-driven calls stop and the count freezes; calls you make yourself (for
 example through `uloop execute-dynamic-code`) still increment it. A frozen count during a
@@ -63,7 +63,7 @@ Re-running on the same method after a real edit replaces its previous patch;
 `ActivePatchTotal` tracks the ledger across runs. Reloading a file whose source is
 unchanged since the last fully applied reload (a run with no Skipped or Failed
 outcomes) is a no-op: each still-active method is reported
-as `AlreadyActive`, the existing patch stays in place, and `InvocationCount` is preserved.
+as `AlreadyActive`, the existing patch stays in place, and the row carries the live `InvocationCount`.
 Edit the file and reload again to apply new changes.
 
 ## Scope and limits
@@ -354,7 +354,7 @@ cached dispatch can bypass a hot-reload patch too.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last fully applied reload (a run with no Skipped or Failed outcomes), so the existing patch was left in place and `InvocationCount` was preserved. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last fully applied reload (a run with no Skipped or Failed outcomes), so the existing patch was left in place and the row carries the live `InvocationCount`. `InvocationCount` is meaningful on `Active` rows and `AlreadyActive` apply rows (calls since the current patch was applied); it is `0` on other apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
 - `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods at risk of being already JIT-inlined into existing callers — those marked `[AggressiveInlining]`, plus (only when Code Optimization is Release) those with tiny pre-patch bodies — meaning the change may not show at those call sites, the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `AddedFields` (array): source-level names ("Type.field") of fields this reload added; their values live outside the compiled type until 'uloop compile'.

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -42,8 +42,8 @@ a domain reload it reports zero patched methods, which is exactly when an
 
 Each `Active` row's `InvocationCount` counts calls into the patched body since that patch
 was applied. Reloading the same source with no edits after a fully applied reload (a run
-with no Skipped or Failed outcomes) reports `AlreadyActive` and keeps
-the count; re-running after a real edit replaces the patch and resets it to zero. While Unity is
+with no Skipped or Failed outcomes) reports `AlreadyActive` and the row carries
+the live `InvocationCount`; re-running after a real edit replaces the patch and resets it to zero. While Unity is
 paused — including while a pause-point hit holds the game — the player loop does not
 advance, so game-driven calls stop and the count freezes; calls you make yourself (for
 example through `uloop execute-dynamic-code`) still increment it. A frozen count during a
@@ -63,7 +63,7 @@ Re-running on the same method after a real edit replaces its previous patch;
 `ActivePatchTotal` tracks the ledger across runs. Reloading a file whose source is
 unchanged since the last fully applied reload (a run with no Skipped or Failed
 outcomes) is a no-op: each still-active method is reported
-as `AlreadyActive`, the existing patch stays in place, and `InvocationCount` is preserved.
+as `AlreadyActive`, the existing patch stays in place, and the row carries the live `InvocationCount`.
 Edit the file and reload again to apply new changes.
 
 ## Scope and limits
@@ -354,7 +354,7 @@ cached dispatch can bypass a hot-reload patch too.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last fully applied reload (a run with no Skipped or Failed outcomes), so the existing patch was left in place and `InvocationCount` was preserved. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last fully applied reload (a run with no Skipped or Failed outcomes), so the existing patch was left in place and the row carries the live `InvocationCount`. `InvocationCount` is meaningful on `Active` rows and `AlreadyActive` apply rows (calls since the current patch was applied); it is `0` on other apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
 - `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods at risk of being already JIT-inlined into existing callers — those marked `[AggressiveInlining]`, plus (only when Code Optimization is Release) those with tiny pre-patch bodies — meaning the change may not show at those call sites, the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `AddedFields` (array): source-level names ("Type.field") of fields this reload added; their values live outside the compiled type until 'uloop compile'.

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -662,7 +662,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: an AlreadyActive apply row for an unregistered MethodKey stays at 0, matching
-        /// GetCount's unknown-key behavior (including Added-member labels).
+        /// GetCount's unknown-key behavior.
         /// </summary>
         [Test]
         public void BuildApplyResponse_AlreadyActiveUnregisteredKey_ReportsZero()

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -628,6 +628,95 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: an AlreadyActive apply row copies the live InvocationCount for a registered
+        /// MethodKey so the response does not force testers to run --status.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_AlreadyActiveRegisteredKey_CopiesLiveInvocationCount()
+        {
+            const string methodKey = "HotReloadToolTests.AlreadyActiveCounted.Method()";
+            HotReloadInvocationRegistry.Increment(methodKey);
+            HotReloadInvocationRegistry.Increment(methodKey);
+            HotReloadInvocationRegistry.Increment(methodKey);
+            try
+            {
+                HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                    new List<HotReloadMethodOutcome>
+                    {
+                        HotReloadMethodOutcome.AlreadyActive(methodKey, "Assets/A.cs")
+                    },
+                    new List<string>(),
+                    patchedTotal: 0,
+                    activePatchTotal: 1);
+
+                HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+                Assert.That(response.Methods.Count, Is.EqualTo(1));
+                Assert.That(response.Methods[0].InvocationCount, Is.EqualTo(3L));
+            }
+            finally
+            {
+                HotReloadInvocationRegistry.Remove(methodKey);
+            }
+        }
+
+        /// <summary>
+        /// What: an AlreadyActive apply row for an unregistered MethodKey stays at 0, matching
+        /// GetCount's unknown-key behavior (including Added-member labels).
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_AlreadyActiveUnregisteredKey_ReportsZero()
+        {
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>
+                {
+                    HotReloadMethodOutcome.AlreadyActive(
+                        "HotReloadToolTests.AlreadyActiveUnknown.Method()",
+                        "Assets/A.cs")
+                },
+                new List<string>(),
+                patchedTotal: 0,
+                activePatchTotal: 1);
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+            Assert.That(response.Methods.Count, Is.EqualTo(1));
+            Assert.That(response.Methods[0].InvocationCount, Is.EqualTo(0L));
+        }
+
+        /// <summary>
+        /// What: a Patched apply row stays at InvocationCount 0 even when the same MethodKey
+        /// has a live registry count.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_Patched_KeepsInvocationCountZero()
+        {
+            const string methodKey = "HotReloadToolTests.PatchedCounted.Method()";
+            HotReloadInvocationRegistry.Increment(methodKey);
+            try
+            {
+                HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                    new List<HotReloadMethodOutcome>
+                    {
+                        HotReloadMethodOutcome.Patched(methodKey, "Assets/A.cs")
+                    },
+                    new List<string>(),
+                    patchedTotal: 1,
+                    activePatchTotal: 1);
+
+                HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+                Assert.That(response.Methods.Count, Is.EqualTo(1));
+                Assert.That(response.Methods[0].Kind, Is.EqualTo(nameof(HotReloadMethodOutcomeKind.Patched)));
+                Assert.That(response.Methods[0].InvocationCount, Is.EqualTo(0L));
+            }
+            finally
+            {
+                HotReloadInvocationRegistry.Remove(methodKey);
+            }
+        }
+
+        /// <summary>
         /// What: a mixed Skipped+AlreadyActive run uses the no-patch message that names both kinds.
         /// </summary>
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -43,7 +43,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         /// <summary>
         /// How many times this patched method body has run since the current patch was applied.
-        /// Populated on --status; 0 for apply/revert outcomes.
+        /// Populated on --status Active rows and AlreadyActive apply rows; 0 for other
+        /// apply/revert outcomes.
         /// </summary>
         public long InvocationCount { get; set; }
 
@@ -218,6 +219,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         Method = outcome.Method,
                         Reason = outcome.Reason ?? string.Empty,
                         FilePath = outcome.FilePath ?? string.Empty,
+                        InvocationCount = outcome.Kind == HotReloadMethodOutcomeKind.AlreadyActive
+                            ? HotReloadInvocationRegistry.GetCount(outcome.Method)
+                            : 0L,
                         LifecycleNote = outcome.LifecycleNote ?? string.Empty
                     });
             }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -42,8 +42,8 @@ a domain reload it reports zero patched methods, which is exactly when an
 
 Each `Active` row's `InvocationCount` counts calls into the patched body since that patch
 was applied. Reloading the same source with no edits after a fully applied reload (a run
-with no Skipped or Failed outcomes) reports `AlreadyActive` and keeps
-the count; re-running after a real edit replaces the patch and resets it to zero. While Unity is
+with no Skipped or Failed outcomes) reports `AlreadyActive` and the row carries
+the live `InvocationCount`; re-running after a real edit replaces the patch and resets it to zero. While Unity is
 paused — including while a pause-point hit holds the game — the player loop does not
 advance, so game-driven calls stop and the count freezes; calls you make yourself (for
 example through `uloop execute-dynamic-code`) still increment it. A frozen count during a
@@ -63,7 +63,7 @@ Re-running on the same method after a real edit replaces its previous patch;
 `ActivePatchTotal` tracks the ledger across runs. Reloading a file whose source is
 unchanged since the last fully applied reload (a run with no Skipped or Failed
 outcomes) is a no-op: each still-active method is reported
-as `AlreadyActive`, the existing patch stays in place, and `InvocationCount` is preserved.
+as `AlreadyActive`, the existing patch stays in place, and the row carries the live `InvocationCount`.
 Edit the file and reload again to apply new changes.
 
 ## Scope and limits
@@ -354,7 +354,7 @@ cached dispatch can bypass a hot-reload patch too.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last fully applied reload (a run with no Skipped or Failed outcomes), so the existing patch was left in place and `InvocationCount` was preserved. `InvocationCount` is meaningful on `Active` rows (calls since the current patch was applied); it is `0` on apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
+- `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last fully applied reload (a run with no Skipped or Failed outcomes), so the existing patch was left in place and the row carries the live `InvocationCount`. `InvocationCount` is meaningful on `Active` rows and `AlreadyActive` apply rows (calls since the current patch was applied); it is `0` on other apply/revert outcomes. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`); empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
 - `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods at risk of being already JIT-inlined into existing callers — those marked `[AggressiveInlining]`, plus (only when Code Optimization is Release) those with tiny pre-patch bodies — meaning the change may not show at those call sites, the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits"
 - `PatchedTotal` (number): Methods patched in this run
 - `AddedFields` (array): source-level names ("Type.field") of fields this reload added; their values live outside the compiled type until 'uloop compile'.


### PR DESCRIPTION
## Summary
- An `AlreadyActive` apply row now shows the live `InvocationCount` instead of always reporting 0.
- Other apply and revert rows stay at 0. Unregistered keys, including added-member labels, also stay at 0.

## User Impact
- Before: the `AlreadyActive` reason said the existing patch kept its `InvocationCount`, but the same row always showed 0, so testers had to run `--status` to confirm the count.
- After: the apply row itself carries the live count, matching `--status` Active rows.

## Changes
- `BuildApplyResponse` fills `InvocationCount` from the invocation registry only for `AlreadyActive` outcomes.
- The hot-reload skill now states that an `AlreadyActive` row carries the live `InvocationCount`.

## Verification
- `dist/darwin-arm64/uloop compile` — ErrorCount 0
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value 'io\.github\.hatayama\.UnityCliLoop\.Tests\.Editor\.HotReload'` — 398 passed / 0 failed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

