### PR TITLE
fix: surface skips dropped by shim isolation retry runs

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -33,6 +33,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadPatcher.RevertAll();
         }
 
+        // Keep in sync with AddedMethodSkipReasons.UnavailableAddedCall in
+        // Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs.
+        // That type lives in the Unity-ignored worker process and is not visible here.
+        private const string UnavailableAddedCallSkipReason =
+            "Calls an added method that hot reload cannot emit. Run 'uloop compile'.";
+
         /// <summary>
         /// What: the added-field store assembly is injected only when the store flag is set,
         /// matching the Harmony optional-reference pattern.
@@ -4178,6 +4184,90 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             HotReloadAddedMemberHost host = new HotReloadAddedMemberHost();
             Assert.That(host.ExistingValue(), Is.EqualTo(10));
+        }
+
+        /// <summary>
+        /// What: when isolation excludes a failed added method A and its direct added caller B,
+        /// the retry worker skip for transitive caller C (C calls B, not A) appears in the
+        /// response as Skipped with UnavailableAddedCall, while independent edited method D
+        /// still patches.
+        /// </summary>
+        [Test]
+        public async Task Run_IsolationRetry_ReportsTransitiveCallerOfExcludedAddedMethodAsSkipped()
+        {
+            string hostPath = ResolveAddedMemberHostPath();
+            string onDisk = File.ReadAllText(hostPath);
+            string edited = onDisk.Replace(
+                "        public int ExistingValue()\n        {\n            return 1;\n        }",
+                "        public int ExistingValue()\n        {\n            return 10;\n        }",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedHealthy(value);\n        }",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                "        public int ReadPrivateSeed()\n        {\n            return _privateSeed;\n        }",
+                "        public int ReadPrivateSeed()\n        {\n            return _privateSeed;\n        }\n\n"
+                + "        public int AddedBroken(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }\n\n"
+                + "        public int AddedHealthy(int value)\n        {\n            return AddedBroken(value);\n        }",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            string editedPath = WriteEditedSource("IsolationRetryTransitiveCaller.cs", edited);
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { hostPath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            Assert.That(
+                FindSkippedReason(result, nameof(HotReloadAddedMemberHost.ExistingCaller)),
+                Is.EqualTo(UnavailableAddedCallSkipReason));
+            AssertHasPatched(result, nameof(HotReloadAddedMemberHost.ExistingValue));
+        }
+
+        /// <summary>
+        /// What: a signature-change gate retry that excludes an added replacement and its
+        /// direct added caller still reports the transitive caller as Skipped with
+        /// UnavailableAddedCall, while an independent edited method still patches.
+        /// </summary>
+        [Test]
+        public async Task Run_SignatureChangeGateRetry_ReportsTransitiveCallerOfExcludedAddedMethodAsSkipped()
+        {
+            string fixturePath = ResolveSignatureChangeExternalHostPath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = onDisk
+                .Replace(
+                    "        public int Target(int value)\n        {\n            return value;\n        }",
+                    "        public long Target(int value)\n        {\n            return value + 1L;\n        }",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "            return Target(value);\n        }",
+                    "            return AddedBridge(value);\n        }",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "        public int Unrelated(int value)\n        {\n            return value;\n        }",
+                    "        public int Unrelated(int value)\n        {\n            return value + 1;\n        }",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "        public int ToDelete(int value)\n        {\n            return value;\n        }",
+                    "        public int ToDelete(int value)\n        {\n            return value;\n        }\n\n"
+                    + "        public int AddedBridge(int value)\n        {\n            return (int)Target(value);\n        }",
+                    StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeGateTransitiveCaller.cs", edited),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            Assert.That(
+                FindSkippedReason(
+                    result,
+                    nameof(HotReloadSignatureChangeExternalHost.SameFileCaller)),
+                Is.EqualTo(UnavailableAddedCallSkipReason));
+            AssertHasPatched(result, nameof(HotReloadSignatureChangeExternalHost.Unrelated));
         }
 
         private static int FindLineNumberContaining(string source, string fragment)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -1200,6 +1200,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 compilationAssembly,
                 targetDllPath,
                 defines,
+                workerOutput.skipped,
+                assemblyResolvePath,
                 ct).ConfigureAwait(false);
             return retry.Isolation;
         }
@@ -1212,6 +1214,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             UnityCompilationAssembly compilationAssembly,
             string targetDllPath,
             string[] defines,
+            TransformWorkerSkippedDto[] firstPassSkipped,
+            string assemblyResolvePath,
             CancellationToken ct)
         {
             TransformWorkerInputDto retryInput = new TransformWorkerInputDto
@@ -1237,9 +1241,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     "Retry worker failed: " + retryWorkerResult.ErrorMessage);
             }
 
-            // The first run already surfaced parseErrors / skipped / drift warnings; consuming
-            // them again would duplicate every per-file report.
             TransformWorkerOutputDto retryOutput = retryWorkerResult.Output;
+            // Why drop first-pass (Method, Reason) pairs: consuming them again would duplicate
+            // every per-file skip. Retry-only pairs are new — typically transitive callers of
+            // excluded added methods — and must surface or the edit is applied nowhere.
+            skippedCallerOutcomes.AddRange(
+                CollectRetryOnlySkippedOutcomes(
+                    firstPassSkipped,
+                    retryOutput.skipped,
+                    assemblyResolvePath));
             if (string.IsNullOrEmpty(retryOutput.shimSource) || retryOutput.entries.Length == 0)
             {
                 return IsolationRetryRunResult.Succeeded(
@@ -1287,6 +1297,61 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     retryOutput.entries,
                     retryCompileResult,
                     retryOutput.addedFieldNames));
+        }
+
+        /// <summary>
+        /// Converts retry-worker skips that are not already in the first-pass skipped list into
+        /// outcomes. Match is (Method, Reason) Ordinal equality so a method skipped for a new
+        /// reason on retry still surfaces.
+        /// </summary>
+        private static List<HotReloadMethodOutcome> CollectRetryOnlySkippedOutcomes(
+            TransformWorkerSkippedDto[] firstPassSkipped,
+            TransformWorkerSkippedDto[] retrySkipped,
+            string assemblyResolvePath)
+        {
+            List<HotReloadMethodOutcome> retryOnly = new List<HotReloadMethodOutcome>();
+            if (retrySkipped == null)
+            {
+                return retryOnly;
+            }
+
+            TransformWorkerSkippedDto[] baseline =
+                firstPassSkipped ?? Array.Empty<TransformWorkerSkippedDto>();
+            foreach (TransformWorkerSkippedDto retryRow in retrySkipped)
+            {
+                if (FirstPassContainsSkippedPair(baseline, retryRow))
+                {
+                    continue;
+                }
+
+                retryOnly.Add(
+                    HotReloadMethodOutcome.Skipped(
+                        retryRow.method ?? "(unknown)",
+                        retryRow.reason ?? string.Empty,
+                        assemblyResolvePath));
+            }
+
+            return retryOnly;
+        }
+
+        private static bool FirstPassContainsSkippedPair(
+            TransformWorkerSkippedDto[] firstPassSkipped,
+            TransformWorkerSkippedDto retryRow)
+        {
+            string retryMethod = retryRow.method ?? string.Empty;
+            string retryReason = retryRow.reason ?? string.Empty;
+            foreach (TransformWorkerSkippedDto firstPassRow in firstPassSkipped)
+            {
+                string firstMethod = firstPassRow.method ?? string.Empty;
+                string firstReason = firstPassRow.reason ?? string.Empty;
+                if (string.Equals(firstMethod, retryMethod, StringComparison.Ordinal)
+                    && string.Equals(firstReason, retryReason, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static List<HotReloadMethodOutcome> BuildFailedMethodOutcomes(
@@ -1624,6 +1689,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 compilationAssembly,
                 targetDllPath,
                 defines,
+                workerOutput.skipped,
+                assemblyResolvePath,
                 ct).ConfigureAwait(false);
             List<string> gatedReplacementMethodKeys =
                 CollectGatedReplacementMethodKeys(gatedReplacements);
@@ -1634,6 +1701,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     gatedReplacementMethodKeys);
             }
 
+            // Why merge here: gate consumption adds SkippedOutcomes only. Retry-only skips live
+            // on Isolation.SkippedCallerOutcomes and would drop again without this join.
+            skippedOutcomes.AddRange(retry.Isolation.SkippedCallerOutcomes);
             return SignatureChangeGateResult.Retried(
                 retry.Isolation,
                 skippedOutcomes,


### PR DESCRIPTION
## Summary
- Isolation retry no longer silently drops methods that the retry worker skipped for a new reason.
- Transitive callers of an excluded added method now appear as Skipped, with the same reason the worker already produced.

## User Impact
- Before: when shim compile isolation excluded an added method, a method that only called that added method through another added helper vanished from the hot reload response. The edit was not applied and nothing reported that it was skipped.
- After: that transitive caller is reported as Skipped (`Calls an added method that hot reload cannot emit. Run 'uloop compile'.`). Independent edited methods in the same file still patch.

## Changes
- Isolation retry keeps retry-worker skips whose `(Method, Reason)` pair was absent from the first pass, instead of discarding the whole retry skipped list.
- The signature-change gate retry path now joins those isolation skips into the gate skip outcomes, so the same drop cannot recur there.

## Verification
- `uloop compile`: 0 errors. 2 warnings, both pre-existing unused-member warnings in fixture files (not introduced by this change).
- Red: `Run_IsolationRetry_ReportsTransitiveCallerOfExcludedAddedMethodAsSkipped` and `Run_SignatureChangeGateRetry_ReportsTransitiveCallerOfExcludedAddedMethodAsSkipped` failed because `ExistingCaller` / `SameFileCaller` had no Skipped row (TestCount 2, FailedCount 2).
- Green: the same two tests passed after the merge (TestCount 2, PassedCount 2).
- Full HotReload EditMode assembly (`--filter-type assembly --filter-value UnityCLILoop.Tests.Editor.HotReload`): TestCount 400, PassedCount 400 (baseline 398 plus the 2 new tests).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

