### PR TITLE
fix: warn when the empty-entries path deactivates added members

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2962,7 +2962,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + "\n" + FormatOutcomes(second));
             AssertDeactivatedPatchesWarningsEqual(
                 second,
-                ExpectedDeactivatedPatchesWarning(AddedPingMethodLabel()));
+                ExpectedDeactivatedAddedMembersWarning(AddedPingMethodLabel()));
         }
 
         /// <summary>
@@ -3016,7 +3016,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             AssertDeactivatedPatchesWarningsEqual(
                 second,
-                ExpectedDeactivatedPatchesWarning(
+                ExpectedDeactivatedAddedMembersWarning(
                     AddedPingMethodLabel() + ", " + AddedPongMethodLabel()));
         }
 
@@ -3046,7 +3046,55 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             AssertDeactivatedPatchesWarningsEqual(
                 second,
-                ExpectedDeactivatedPatchesWarning(AddedPingMethodLabel()));
+                ExpectedDeactivatedAddedMembersWarning(AddedPingMethodLabel()));
+        }
+
+        /// <summary>
+        /// What: after an added method applies, a later run that skips every method as virtual
+        /// (empty entries) still warns with the added-member deactivation wording.
+        /// </summary>
+        [Test]
+        public async Task Run_VirtualAddedMethodAfterSuccess_EmptyEntries_WarnsDeactivatedAddedMembers()
+        {
+            string fixturePath = ResolveAddedMethodApplyFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("VirtualAddedEmptyEntries1.cs", WithWorkingAddedPing(onDisk)),
+                CancellationToken.None);
+            AssertHasAdded(first, "AddedPing");
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("VirtualAddedEmptyEntries2.cs", WithVirtualAddedPing(onDisk)),
+                CancellationToken.None);
+
+            AssertDeactivatedPatchesWarningsEqual(
+                second,
+                ExpectedDeactivatedAddedMembersWarning(AddedPingMethodLabel()));
+        }
+
+        /// <summary>
+        /// What: deleting a previously added method and restoring its caller does not emit
+        /// the added-member deactivation warning (intentional convergence).
+        /// </summary>
+        [Test]
+        public async Task Run_DeleteAddedMethodAndRestoreCaller_DoesNotWarnDeactivatedAddedMembers()
+        {
+            string fixturePath = ResolveAddedMethodApplyFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("DeleteAddedRestoreCaller1.cs", WithWorkingAddedPing(onDisk)),
+                CancellationToken.None);
+            AssertHasAdded(first, "AddedPing");
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("DeleteAddedRestoreCaller2.cs", onDisk),
+                CancellationToken.None);
+
+            AssertNoDeactivatedPatchesWarning(second);
         }
 
         /// <summary>
@@ -3168,7 +3216,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 0);
             AssertDeactivatedPatchesWarningsEqual(
                 second,
-                ExpectedDeactivatedPatchesWarning(expectedLabel));
+                ExpectedDeactivatedAddedMembersWarning(expectedLabel));
         }
 
         /// <summary>
@@ -4705,14 +4753,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 0);
         }
 
-        private static string ExpectedDeactivatedPatchesWarning(string joinedLabels)
+        private static string ExpectedDeactivatedAddedMembersWarning(string joinedLabels)
         {
-            return string.Format(HotReloadConstants.DeactivatedPatchesWarningFormat, joinedLabels);
+            return string.Format(HotReloadConstants.DeactivatedAddedMembersWarningFormat, joinedLabels);
         }
 
-        private static string DeactivatedPatchesWarningPrefix()
+        private static bool IsDeactivatedPatchesWarning(string warning)
         {
-            string format = HotReloadConstants.DeactivatedPatchesWarningFormat;
+            return warning.StartsWith(
+                    DeactivatedWarningPrefix(HotReloadConstants.DeactivatedPatchesWarningFormat),
+                    StringComparison.Ordinal)
+                || warning.StartsWith(
+                    DeactivatedWarningPrefix(HotReloadConstants.DeactivatedAddedMembersWarningFormat),
+                    StringComparison.Ordinal);
+        }
+
+        private static string DeactivatedWarningPrefix(string format)
+        {
             int placeholderIndex = format.IndexOf("{0}", StringComparison.Ordinal);
             Assert.That(placeholderIndex, Is.GreaterThanOrEqualTo(0));
             return format.Substring(0, placeholderIndex);
@@ -4720,11 +4777,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private static List<string> FilterDeactivatedPatchesWarnings(IReadOnlyList<string> warnings)
         {
-            string prefix = DeactivatedPatchesWarningPrefix();
             List<string> filtered = new List<string>();
             foreach (string warning in warnings)
             {
-                if (warning.StartsWith(prefix, StringComparison.Ordinal))
+                if (IsDeactivatedPatchesWarning(warning))
                 {
                     filtered.Add(warning);
                 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -94,6 +94,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             "This run deactivated previously active patches: {0}. They reverted to the compiled behavior; "
             + "edit and reload again to re-apply them, or run 'uloop compile'.";
 
+        public const string DeactivatedAddedMembersWarningFormat =
+            "This run deactivated previously active added members: {0}. They are no longer registered, but patches this run left active may still reach their previous shim bodies. Edit and reload again to re-apply them, or run 'uloop compile'.";
+
         // Wire value for TransformWorkerRemovedMemberDto.kind.
         // Keep in sync with RemovedMemberKinds in TransformWorker~/TransformWorker.cs.
         public const string RemovedMemberKindMethod = "method";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -201,6 +201,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // sequentially, and RevertUnchangedPatches / BeginFileGeneration mutate ledgers
             // after the worker. The worker itself does not.
             HashSet<string> snapshotLabels = CollectActiveLabelsForFile(projectRelativePath);
+            HashSet<string> snapshotAddedLabels = new HashSet<string>(
+                HotReloadAddedMemberRegistry.ListActiveMethodKeys(projectRelativePath),
+                StringComparer.Ordinal);
 
             string[] defines = compilationAssembly.defines ?? Array.Empty<string>();
             string[] referencePaths = BuildWorkerReferencePaths(compilationAssembly, targetDllPath);
@@ -369,6 +372,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // clearing — same as leaving existing Harmony patches in place when apply does
                 // not succeed.
                 HotReloadAddedMemberRegistry.BeginFileGeneration(projectRelativePath);
+                // Why after the clear: a still-declared added method can be worker-skipped
+                // (virtual/generic), leaving entries empty while the registry drop is real.
+                AppendDeactivatedPatchesWarning(
+                    warnings,
+                    snapshotLabels,
+                    snapshotAddedLabels,
+                    projectRelativePath,
+                    workerOutput,
+                    outcomes);
                 return new HotReloadFileProcessResult(
                     outcomes,
                     warnings,
@@ -482,13 +494,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
             }
 
-            // Why only this return: a still-declared added method is a first-pass entry, so
-            // empty-entries BeginFileGeneration only clears members the source no longer
-            // declares. The warning is only meaningful on the apply path that can drop a
-            // still-declared added member by not re-Registering it.
+            // Why here as well as the empty-entries return: apply can drop a still-declared
+            // added member by not re-Registering it after BeginFileGeneration.
             AppendDeactivatedPatchesWarning(
                 warnings,
                 snapshotLabels,
+                snapshotAddedLabels,
                 projectRelativePath,
                 workerOutput,
                 outcomes);
@@ -2750,17 +2761,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static void AppendDeactivatedPatchesWarning(
             List<string> warnings,
             HashSet<string> snapshotLabels,
+            HashSet<string> snapshotAddedLabels,
             string projectRelativePath,
             TransformWorkerOutputDto workerOutput,
             IReadOnlyList<HotReloadMethodOutcome> outcomes)
         {
             Debug.Assert(warnings != null, "warnings must not be null.");
             Debug.Assert(snapshotLabels != null, "snapshotLabels must not be null.");
+            Debug.Assert(snapshotAddedLabels != null, "snapshotAddedLabels must not be null.");
             Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
 
             HashSet<string> currentLabels = CollectActiveLabelsForFile(projectRelativePath);
             HashSet<string> stillDeclaredAdded = CollectStillDeclaredAddedLabels(workerOutput, outcomes);
-            List<string> deactivated = new List<string>();
+            List<string> deactivatedAdded = new List<string>();
+            List<string> deactivatedPatches = new List<string>();
             foreach (string label in snapshotLabels)
             {
                 if (!IsUnexpectedDeactivation(label, currentLabels, stillDeclaredAdded))
@@ -2768,19 +2782,38 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                deactivated.Add(label);
+                if (snapshotAddedLabels.Contains(label))
+                {
+                    deactivatedAdded.Add(label);
+                }
+                else
+                {
+                    deactivatedPatches.Add(label);
+                }
             }
 
-            if (deactivated.Count == 0)
+            AppendDeactivatedWarningLine(
+                warnings,
+                deactivatedAdded,
+                HotReloadConstants.DeactivatedAddedMembersWarningFormat);
+            AppendDeactivatedWarningLine(
+                warnings,
+                deactivatedPatches,
+                HotReloadConstants.DeactivatedPatchesWarningFormat);
+        }
+
+        private static void AppendDeactivatedWarningLine(
+            List<string> warnings,
+            List<string> labels,
+            string format)
+        {
+            if (labels.Count == 0)
             {
                 return;
             }
 
-            deactivated.Sort(string.CompareOrdinal);
-            warnings.Add(
-                string.Format(
-                    HotReloadConstants.DeactivatedPatchesWarningFormat,
-                    string.Join(", ", deactivated)));
+            labels.Sort(string.CompareOrdinal);
+            warnings.Add(string.Format(format, string.Join(", ", labels)));
         }
 
         private static string ToProjectRelativeScriptPath(string path)


### PR DESCRIPTION
## Summary
- Hot reload now warns when the empty-entries path deactivates previously active added members.
- That warning no longer claims added members "reverted to the compiled behavior".

## User Impact
- Before: making a previously applied added method virtual (or otherwise skipping every method in the file) cleared it from the registry with no warning. The generic deactivation text also said added members reverted to compiled IL, which they cannot do; leftover patches may still call the old shim body.
- After: those runs report `This run deactivated previously active added members: ... They are no longer registered, but patches this run left active may still reach their previous shim bodies. ...`. Deleting an added method and restoring its caller stays silent (intentional convergence). Compiled-method deactivations keep the previous wording.

## Changes
- Snapshot added-member labels at run start, then split unexpected deactivations into added vs non-added warning lines.
- Call the same warning after `BeginFileGeneration` on the empty-entries path, not only after apply.

## Verification
- `uloop compile`: 0 errors. 2 warnings, both pre-existing unused-member warnings in fixture files (not introduced by this change).
- Red: `Run_VirtualAddedMethodAfterSuccess_EmptyEntries_WarnsDeactivatedAddedMembers` failed (missing added-member warning). `Run_DeleteAddedMethodAndRestoreCaller_DoesNotWarnDeactivatedAddedMembers` already passed.
- Green: both new tests passed. Existing added-deactivation tests now expect the new wording.
- Full HotReload EditMode assembly (`--filter-type assembly --filter-value UnityCLILoop.Tests.Editor.HotReload`): TestCount 402, PassedCount 402 (previous 400 plus the 2 new tests).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

