### PR TITLE
fix: stop false outside-body drift warnings for body-only edits

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadUnsupportedMemberKindFixtures.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadUnsupportedMemberKindFixtures.cs
@@ -127,6 +127,73 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
     }
 
+    /// <summary>
+    /// Expression-bodied constructor host. Token 61 is unique in this file.
+    /// </summary>
+    public sealed class HotReloadUnsupportedKindExpressionCtorFixture
+    {
+        public int Marker;
+
+        public HotReloadUnsupportedKindExpressionCtorFixture() => Marker = 61;
+
+        public int Read()
+        {
+            return Marker;
+        }
+    }
+
+    /// <summary>
+    /// Expression-bodied operator host. Token 71 is unique in this file.
+    /// </summary>
+    public sealed class HotReloadUnsupportedKindExpressionOperatorFixture
+    {
+        public int Marker;
+
+        public static int operator *(
+            HotReloadUnsupportedKindExpressionOperatorFixture left,
+            HotReloadUnsupportedKindExpressionOperatorFixture right) => left.Marker = 71;
+
+        public int Read()
+        {
+            return Marker;
+        }
+    }
+
+    /// <summary>
+    /// Expression-bodied conversion host. Token 81 is unique in this file.
+    /// </summary>
+    public sealed class HotReloadUnsupportedKindExpressionConversionFixture
+    {
+        public int Marker;
+
+        public static implicit operator bool(HotReloadUnsupportedKindExpressionConversionFixture value) =>
+            (value.Marker = 81) != 0;
+
+        public int Read()
+        {
+            return Marker;
+        }
+    }
+
+    /// <summary>
+    /// Expression-bodied event-accessor host. Tokens 91 / 92 are unique in this file.
+    /// </summary>
+    public sealed class HotReloadUnsupportedKindExpressionEventFixture
+    {
+        public int Marker;
+
+        public event Action ArrowEdited
+        {
+            add => Marker = 91;
+            remove => Marker = 92;
+        }
+
+        public int Read()
+        {
+            return Marker;
+        }
+    }
+
     public sealed class HotReloadLocalFunctionParentFixture
     {
         public int Compute(int x)

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -1327,6 +1327,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             "Constructors, operators, and event accessors are out of scope for v1; "
             + "run 'uloop compile' to apply these edits.";
 
+        // Keep in sync with OutsideMethodBodyDriftWarningFormat in
+        // Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs.
+        // That constant lives in the Unity-ignored worker process and is not visible here.
+        private const string OutsideMethodBodyDriftWarningFormat =
+            "Edits outside method bodies in {0} (fields, initializers, or attributes) are not applied by hot reload; run uloop compile to pick them up.";
+
         /// <summary>
         /// What: editing one instance constructor reports that .ctor as Skipped and omits an
         /// unedited overload in the same type.
@@ -1429,6 +1435,90 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a constructor body-only edit reports the ctor as Skipped and does not emit
+        /// the outside-method-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_InstanceCtorBodyOnly_DoesNotEmitOutsideBodyWarning()
+        {
+            const string fileName = "UnsupportedKindInstanceCtorBodyOnly.cs";
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                fileName,
+                "Marker = 11;",
+                "Marker = 111;");
+
+            AssertSkippedContains(
+                result,
+                ".ctor()",
+                ExpectedUnsupportedMemberKindSkipReason);
+            AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
+        }
+
+        /// <summary>
+        /// What: an operator body-only edit reports the operator as Skipped and does not emit
+        /// the outside-method-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_OperatorBodyOnly_DoesNotEmitOutsideBodyWarning()
+        {
+            const string fileName = "UnsupportedKindOperatorBodyOnly.cs";
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                fileName,
+                "left.Marker = 31;",
+                "left.Marker = 311;");
+
+            AssertSkippedContains(
+                result,
+                "op_Addition",
+                ExpectedUnsupportedMemberKindSkipReason);
+            AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
+        }
+
+        /// <summary>
+        /// What: a conversion-operator body-only edit reports the conversion as Skipped and
+        /// does not emit the outside-method-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_ConversionOperatorBodyOnly_DoesNotEmitOutsideBodyWarning()
+        {
+            const string fileName = "UnsupportedKindConversionBodyOnly.cs";
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                fileName,
+                "value.Marker = 41;",
+                "value.Marker = 411;");
+
+            AssertSkippedContains(
+                result,
+                "op_Implicit",
+                ExpectedUnsupportedMemberKindSkipReason);
+            AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
+        }
+
+        /// <summary>
+        /// What: an event-accessor body-only edit reports the edited accessors as Skipped and
+        /// does not emit the outside-method-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_EventAccessorBodyOnly_DoesNotEmitOutsideBodyWarning()
+        {
+            const string fileName = "UnsupportedKindEventAccessorBodyOnly.cs";
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                fileName,
+                "Marker = 51;",
+                "Marker = 511;");
+
+            AssertSkippedContains(
+                result,
+                "add_Edited",
+                ExpectedUnsupportedMemberKindSkipReason);
+            AssertSkippedContains(
+                result,
+                "remove_Edited",
+                ExpectedUnsupportedMemberKindSkipReason);
+            AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
+        }
+
+        /// <summary>
         /// What: adding an instance constructor that is absent from the verified snapshot
         /// reports that .ctor as Skipped with the unsupported-member reason (same path as an
         /// edit) and omits unedited overloads already in the snapshot.
@@ -1503,6 +1593,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             return result;
+        }
+
+        private static void AssertDoesNotContainOutsideMethodBodyDriftWarning(
+            TransformWorkerClientResult result,
+            string fileName)
+        {
+            string expectedWarning = string.Format(OutsideMethodBodyDriftWarningFormat, fileName);
+            string[] warnings = result.Output.declarationDriftWarnings ?? Array.Empty<string>();
+            Assert.That(
+                warnings,
+                Does.Not.Contain(expectedWarning),
+                "Body-only unsupported-kind edits must not emit the outside-body warning.\n"
+                + string.Join("\n", warnings));
         }
 
         private static void AssertSkippedContains(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -1519,6 +1519,150 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: an expression-bodied constructor body-only edit reports the ctor as Skipped
+        /// and does not emit the outside-method-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_ExpressionCtorBodyOnly_DoesNotEmitOutsideBodyWarning()
+        {
+            const string fileName = "UnsupportedKindExpressionCtorBodyOnly.cs";
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                fileName,
+                "Marker = 61;",
+                "Marker = 611;");
+
+            AssertSkippedContains(
+                result,
+                "HotReloadUnsupportedKindExpressionCtorFixture..ctor()",
+                ExpectedUnsupportedMemberKindSkipReason);
+            AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
+        }
+
+        /// <summary>
+        /// What: an expression-bodied operator body-only edit reports the operator as Skipped
+        /// and does not emit the outside-method-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_ExpressionOperatorBodyOnly_DoesNotEmitOutsideBodyWarning()
+        {
+            const string fileName = "UnsupportedKindExpressionOperatorBodyOnly.cs";
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                fileName,
+                "left.Marker = 71;",
+                "left.Marker = 711;");
+
+            AssertSkippedContains(
+                result,
+                "op_Multiply",
+                ExpectedUnsupportedMemberKindSkipReason);
+            AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
+        }
+
+        /// <summary>
+        /// What: an expression-bodied conversion body-only edit reports the conversion as
+        /// Skipped and does not emit the outside-method-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_ExpressionConversionBodyOnly_DoesNotEmitOutsideBodyWarning()
+        {
+            const string fileName = "UnsupportedKindExpressionConversionBodyOnly.cs";
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                fileName,
+                "(value.Marker = 81)",
+                "(value.Marker = 811)");
+
+            AssertSkippedContains(
+                result,
+                "HotReloadUnsupportedKindExpressionConversionFixture.op_Implicit",
+                ExpectedUnsupportedMemberKindSkipReason);
+            AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
+        }
+
+        /// <summary>
+        /// What: an expression-bodied event-accessor body-only edit reports the accessors as
+        /// Skipped and does not emit the outside-method-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_ExpressionEventAccessorBodyOnly_DoesNotEmitOutsideBodyWarning()
+        {
+            const string fileName = "UnsupportedKindExpressionEventAccessorBodyOnly.cs";
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                fileName,
+                "Marker = 91;",
+                "Marker = 911;");
+
+            AssertSkippedContains(
+                result,
+                "add_ArrowEdited",
+                ExpectedUnsupportedMemberKindSkipReason);
+            AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
+        }
+
+        /// <summary>
+        /// What: adding a constructor initializer (declaration-only) still emits the
+        /// outside-method-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_CtorInitializerEdit_EmitsOutsideBodyWarning()
+        {
+            const string fileName = "UnsupportedKindCtorInitializerDrift.cs";
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                fileName,
+                "        public HotReloadUnsupportedKindCtorFixture()\n        {",
+                "        public HotReloadUnsupportedKindCtorFixture() : this(0)\n        {");
+
+            AssertContainsOutsideMethodBodyDriftWarning(result, fileName);
+        }
+
+        /// <summary>
+        /// What: adding an attribute to an operator (declaration-only) still emits the
+        /// outside-method-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_OperatorAttributeEdit_EmitsOutsideBodyWarning()
+        {
+            const string fileName = "UnsupportedKindOperatorAttributeDrift.cs";
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                fileName,
+                "        public static HotReloadUnsupportedKindOperatorFixture operator +(",
+                "        [Obsolete]\n        public static HotReloadUnsupportedKindOperatorFixture operator +(");
+
+            AssertContainsOutsideMethodBodyDriftWarning(result, fileName);
+        }
+
+        /// <summary>
+        /// What: adding an attribute to a conversion operator (declaration-only) still emits
+        /// the outside-method-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_ConversionAttributeEdit_EmitsOutsideBodyWarning()
+        {
+            const string fileName = "UnsupportedKindConversionAttributeDrift.cs";
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                fileName,
+                "        public static implicit operator int(HotReloadUnsupportedKindConversionFixture value)",
+                "        [Obsolete]\n        public static implicit operator int(HotReloadUnsupportedKindConversionFixture value)");
+
+            AssertContainsOutsideMethodBodyDriftWarning(result, fileName);
+        }
+
+        /// <summary>
+        /// What: adding an attribute to an event (declaration-only) still emits the
+        /// outside-method-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Run_UnsupportedMemberKind_EventAttributeEdit_EmitsOutsideBodyWarning()
+        {
+            const string fileName = "UnsupportedKindEventAttributeDrift.cs";
+            TransformWorkerClientResult result = await RunWorkerOnUnsupportedKindEditAsync(
+                fileName,
+                "        public event Action Edited",
+                "        [Obsolete]\n        public event Action Edited");
+
+            AssertContainsOutsideMethodBodyDriftWarning(result, fileName);
+        }
+
+        /// <summary>
         /// What: adding an instance constructor that is absent from the verified snapshot
         /// reports that .ctor as Skipped with the unsupported-member reason (same path as an
         /// edit) and omits unedited overloads already in the snapshot.
@@ -1605,6 +1749,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 warnings,
                 Does.Not.Contain(expectedWarning),
                 "Body-only unsupported-kind edits must not emit the outside-body warning.\n"
+                + string.Join("\n", warnings));
+        }
+
+        private static void AssertContainsOutsideMethodBodyDriftWarning(
+            TransformWorkerClientResult result,
+            string fileName)
+        {
+            string expectedWarning = string.Format(OutsideMethodBodyDriftWarningFormat, fileName);
+            string[] warnings = result.Output.declarationDriftWarnings ?? Array.Empty<string>();
+            Assert.That(
+                warnings,
+                Does.Contain(expectedWarning),
+                "Declaration-only unsupported-kind edits must emit the outside-body warning.\n"
                 + string.Join("\n", warnings));
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -1573,6 +1573,81 @@ public static class TransformWorkerProgram
                 SyntaxFactory.AccessorList(SyntaxFactory.List(accessors)));
         }
 
+        // Why strip ctor/operator/event-accessor bodies: those members are reported as
+        // per-member Skipped, so a body-only edit must not also look like outside-body drift.
+        // Signature, attributes, and constructor initializers stay so those edits still warn.
+        public override SyntaxNode VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
+        {
+            ConstructorDeclarationSyntax visited =
+                (ConstructorDeclarationSyntax)base.VisitConstructorDeclaration(node);
+            if (visited.Body == null && visited.ExpressionBody == null)
+            {
+                return visited;
+            }
+
+            return visited
+                .WithExpressionBody(null)
+                .WithSemicolonToken(default(SyntaxToken))
+                .WithBody(SyntaxFactory.Block());
+        }
+
+        public override SyntaxNode VisitOperatorDeclaration(OperatorDeclarationSyntax node)
+        {
+            OperatorDeclarationSyntax visited = (OperatorDeclarationSyntax)base.VisitOperatorDeclaration(node);
+            if (visited.Body == null && visited.ExpressionBody == null)
+            {
+                return visited;
+            }
+
+            return visited
+                .WithExpressionBody(null)
+                .WithSemicolonToken(default(SyntaxToken))
+                .WithBody(SyntaxFactory.Block());
+        }
+
+        public override SyntaxNode VisitConversionOperatorDeclaration(ConversionOperatorDeclarationSyntax node)
+        {
+            ConversionOperatorDeclarationSyntax visited =
+                (ConversionOperatorDeclarationSyntax)base.VisitConversionOperatorDeclaration(node);
+            if (visited.Body == null && visited.ExpressionBody == null)
+            {
+                return visited;
+            }
+
+            return visited
+                .WithExpressionBody(null)
+                .WithSemicolonToken(default(SyntaxToken))
+                .WithBody(SyntaxFactory.Block());
+        }
+
+        public override SyntaxNode VisitEventDeclaration(EventDeclarationSyntax node)
+        {
+            EventDeclarationSyntax visited = (EventDeclarationSyntax)base.VisitEventDeclaration(node);
+            if (visited.AccessorList == null)
+            {
+                return visited;
+            }
+
+            List<AccessorDeclarationSyntax> accessors = new List<AccessorDeclarationSyntax>();
+            foreach (AccessorDeclarationSyntax accessor in visited.AccessorList.Accessors)
+            {
+                if (accessor.Body == null && accessor.ExpressionBody == null)
+                {
+                    accessors.Add(accessor);
+                    continue;
+                }
+
+                accessors.Add(
+                    accessor
+                        .WithExpressionBody(null)
+                        .WithSemicolonToken(default(SyntaxToken))
+                        .WithBody(SyntaxFactory.Block()));
+            }
+
+            return visited.WithAccessorList(
+                SyntaxFactory.AccessorList(SyntaxFactory.List(accessors)));
+        }
+
         // Why strip const initializers: const drift has its own warning with both values;
         // leaving EqualsValueClause here would also trip the generic outside-body warning.
         public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)


### PR DESCRIPTION
## Summary
- Constructor, operator, conversion-operator, and event-accessor body-only edits no longer raise a false outside-method-body drift warning.
- Those members still appear as Skipped. Field-initializer edits still warn.

## User Impact
- Before: editing only a constructor (or operator / event accessor) body reported the member as Skipped and also claimed "Edits outside method bodies (fields, initializers, or attributes)", which was not true.
- After: the body-only edit keeps the per-member Skipped row and omits that warning. Changing a field initializer still emits it.

## Changes
- `StripMethodBodiesRewriter` now replaces constructor, operator, conversion-operator, and event-accessor bodies / expression bodies with an empty block, the same way it already strips ordinary methods.
- Signatures, attributes, and constructor initializers are left in place so those edits still count as outside-body drift.

## Verification
- `uloop compile`: 0 errors / 0 warnings.
- Red: four body-only tests failed because the exact outside-body warning was present. `Run_WithNonConstFieldInitializerEdit_StillEmitsOutsideBodyWarning` already passed.
- Green: the same five tests passed (TestCount 5, PassedCount 5).
- Full HotReload EditMode assembly (`--filter-type assembly --filter-value UnityCLILoop.Tests.Editor.HotReload`): TestCount 406, PassedCount 406 (previous 402 plus the 4 new tests).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

