### PR TITLE
feat: add trace-mode note and expired guidance to pause-point responses

### DIFF
--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -97,6 +97,8 @@ Choose the capture mode when enabling a pause point:
 - `continuous` pauses Unity on every hit and remains armed.
 - `trace` remains armed and records each hit without pausing Unity.
 - In every mode, `CapturedVariables` holds the latest hit and `CapturedVariableHistory` holds only strictly older frames, so with a single hit the history is empty (for `single-shot` it always is). When the latest-hit frame is excluded, `CapturedVariableHistoryNote` explains that the latest hit's variables are in `CapturedVariables`.
+- In trace mode, Status "Hit" does not mean Play Mode paused; the response carries a StatusNote saying the marker fired while the game kept running.
+- An Expired response carries a RecommendedNextAction: re-enable the pause point and raise --timeout-seconds (default 30) when setup takes longer than the timeout.
 - For an already-hit `continuous` or `trace` marker, `await-pause-point` waits for a **new** hit after the wait starts (`LastHitSequence` advancing). It does not return the stale hit that is already present. Read the current hit with `pause-point-status` instead. If await times out while waiting for that new hit, the error stays `PAUSE_POINT_WAIT_TIMEOUT` and `Details.Hint` tells you to pass `--resume-play` (or resume Play Mode) so another hit can occur. A freshly enabled marker (including `enable-pause-point --await`) has no prior hit, so the first hit satisfies the wait as before.
 
 `--max-history` defaults to 20 and accepts values from 1 through 100. When the limit is exceeded, the oldest frames are dropped and `HistoryDroppedCount` reports how many were removed. `pause-point-status` returns the current `Mode`, `MaxHistory`, history frames, and dropped count.

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -97,6 +97,8 @@ Choose the capture mode when enabling a pause point:
 - `continuous` pauses Unity on every hit and remains armed.
 - `trace` remains armed and records each hit without pausing Unity.
 - In every mode, `CapturedVariables` holds the latest hit and `CapturedVariableHistory` holds only strictly older frames, so with a single hit the history is empty (for `single-shot` it always is). When the latest-hit frame is excluded, `CapturedVariableHistoryNote` explains that the latest hit's variables are in `CapturedVariables`.
+- In trace mode, Status "Hit" does not mean Play Mode paused; the response carries a StatusNote saying the marker fired while the game kept running.
+- An Expired response carries a RecommendedNextAction: re-enable the pause point and raise --timeout-seconds (default 30) when setup takes longer than the timeout.
 - For an already-hit `continuous` or `trace` marker, `await-pause-point` waits for a **new** hit after the wait starts (`LastHitSequence` advancing). It does not return the stale hit that is already present. Read the current hit with `pause-point-status` instead. If await times out while waiting for that new hit, the error stays `PAUSE_POINT_WAIT_TIMEOUT` and `Details.Hint` tells you to pass `--resume-play` (or resume Play Mode) so another hit can occur. A freshly enabled marker (including `enable-pause-point --await`) has no prior hit, so the first hit satisfies the wait as before.
 
 `--max-history` defaults to 20 and accepts values from 1 through 100. When the limit is exceeded, the oldest frames are dropped and `HistoryDroppedCount` reports how many were removed. `pause-point-status` returns the current `Mode`, `MaxHistory`, history frames, and dropped count.

--- a/Assets/Tests/Editor/PausePointExpiredRecommendedNextActionTests.cs
+++ b/Assets/Tests/Editor/PausePointExpiredRecommendedNextActionTests.cs
@@ -1,0 +1,108 @@
+using System;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.Runtime;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies Expired responses fill RecommendedNextAction when the snapshot leaves it empty.
+    /// </summary>
+    [TestFixture]
+    public sealed class PausePointExpiredRecommendedNextActionTests
+    {
+        /// <summary>
+        /// What: PausePointResponse.FromSnapshot fills the expired next-action when the snapshot action is empty.
+        /// </summary>
+        [Test]
+        public void FromSnapshot_WhenExpiredAndActionEmpty_FillsExpiredRecommendedNextAction()
+        {
+            UloopPausePointSnapshot snapshot = CreateExpiredSnapshot(string.Empty);
+
+            PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
+
+            Assert.That(response.Status, Is.EqualTo(UloopPausePointStatus.Expired));
+            Assert.That(
+                response.RecommendedNextAction,
+                Is.EqualTo(SourcePausePointConstants.ExpiredRecommendedNextAction));
+        }
+
+        /// <summary>
+        /// What: PausePointStatusResponse.FromSnapshot fills the same expired next-action on the CLI bridge path.
+        /// </summary>
+        [Test]
+        public void StatusFromSnapshot_WhenExpiredAndActionEmpty_FillsExpiredRecommendedNextAction()
+        {
+            UloopPausePointSnapshot snapshot = CreateExpiredSnapshot(string.Empty);
+
+            PausePointStatusResponse response = PausePointStatusResponse.FromSnapshot(snapshot);
+
+            Assert.That(response.Status, Is.EqualTo(UloopPausePointStatus.Expired));
+            Assert.That(
+                response.RecommendedNextAction,
+                Is.EqualTo(SourcePausePointConstants.ExpiredRecommendedNextAction));
+        }
+
+        /// <summary>
+        /// What: a non-empty snapshot action is left unchanged so registry-expired wording stays intact.
+        /// </summary>
+        [Test]
+        public void FromSnapshot_WhenExpiredAndActionPresent_KeepsSnapshotAction()
+        {
+            const string existingAction =
+                "Clear this marker, then re-enable it with the same Id and TimeoutSeconds values.";
+            UloopPausePointSnapshot snapshot = CreateExpiredSnapshot(existingAction);
+
+            PausePointResponse toolResponse = PausePointResponse.FromSnapshot(snapshot);
+            PausePointStatusResponse statusResponse = PausePointStatusResponse.FromSnapshot(snapshot);
+
+            Assert.That(toolResponse.RecommendedNextAction, Is.EqualTo(existingAction));
+            Assert.That(statusResponse.RecommendedNextAction, Is.EqualTo(existingAction));
+        }
+
+        private static UloopPausePointSnapshot CreateExpiredSnapshot(string recommendedNextAction)
+        {
+            return new UloopPausePointSnapshot(
+                "jump",
+                UloopPausePointStatus.Expired,
+                false,
+                false,
+                0,
+                30,
+                UloopPausePointCaptureMode.SingleShot,
+                20,
+                15,
+                Array.Empty<UloopPausePointCapturedHistoryFrame>(),
+                0,
+                true,
+                "2026-06-03T00:00:00.0000000Z",
+                31000,
+                0,
+                1,
+                new UloopPausePointEditorStateSnapshot(
+                    true,
+                    false,
+                    UloopPausePointEditorStateCapturedAt.Current),
+                string.Empty,
+                string.Empty,
+                0,
+                0,
+                "Pause point expired.",
+                recommendedNextAction,
+                Array.Empty<UloopCapturedVariable>(),
+                false,
+                Array.Empty<string>(),
+                0,
+                string.Empty,
+                string.Empty,
+                false,
+                false,
+                null,
+                false,
+                0,
+                null);
+        }
+    }
+}

--- a/Assets/Tests/Editor/PausePointExpiredRecommendedNextActionTests.cs.meta
+++ b/Assets/Tests/Editor/PausePointExpiredRecommendedNextActionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4dbeb1493950b41ea8f00e6fcbaae77c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -97,6 +97,8 @@ Choose the capture mode when enabling a pause point:
 - `continuous` pauses Unity on every hit and remains armed.
 - `trace` remains armed and records each hit without pausing Unity.
 - In every mode, `CapturedVariables` holds the latest hit and `CapturedVariableHistory` holds only strictly older frames, so with a single hit the history is empty (for `single-shot` it always is). When the latest-hit frame is excluded, `CapturedVariableHistoryNote` explains that the latest hit's variables are in `CapturedVariables`.
+- In trace mode, Status "Hit" does not mean Play Mode paused; the response carries a StatusNote saying the marker fired while the game kept running.
+- An Expired response carries a RecommendedNextAction: re-enable the pause point and raise --timeout-seconds (default 30) when setup takes longer than the timeout.
 - For an already-hit `continuous` or `trace` marker, `await-pause-point` waits for a **new** hit after the wait starts (`LastHitSequence` advancing). It does not return the stale hit that is already present. Read the current hit with `pause-point-status` instead. If await times out while waiting for that new hit, the error stays `PAUSE_POINT_WAIT_TIMEOUT` and `Details.Hint` tells you to pass `--resume-play` (or resume Play Mode) so another hit can occur. A freshly enabled marker (including `enable-pause-point --await`) has no prior hit, so the first hit satisfies the wait as before.
 
 `--max-history` defaults to 20 and accepts values from 1 through 100. When the limit is exceeded, the oldest frames are dropped and `HistoryDroppedCount` reports how many were removed. `pause-point-status` returns the current `Mode`, `MaxHistory`, history frames, and dropped count.

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -152,10 +152,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Message = result.ClearedCount == 0
                     ? "No active pause points to clear."
                     : "Pause points cleared.",
-                    Warning = result.ResumedFromPause
-                        ? SourcePausePointConstants.ClearResumedPlayModeWarning
-                        : string.Empty
-                };
+                Warning = result.ResumedFromPause
+                    ? SourcePausePointConstants.ClearResumedPlayModeWarning
+                    : string.Empty
+            };
         }
 
         private static string ResolveExpiredRecommendedNextAction(string status, string recommendedNextAction)

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -123,7 +123,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 FirstHitSequence = snapshot.FirstHitSequence,
                 LastHitSequence = snapshot.LastHitSequence,
                 Message = snapshot.Message,
-                RecommendedNextAction = snapshot.RecommendedNextAction,
+                RecommendedNextAction = ResolveExpiredRecommendedNextAction(
+                    snapshot.Status,
+                    snapshot.RecommendedNextAction),
                 ClearedReason = snapshot.ClearedReason,
                 StatusBeforeClear = snapshot.StatusBeforeClear,
                 LateHitDiscardedAfterClear = snapshot.LateHitDiscardedAfterClear,
@@ -150,10 +152,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Message = result.ClearedCount == 0
                     ? "No active pause points to clear."
                     : "Pause points cleared.",
-                Warning = result.ResumedFromPause
-                    ? SourcePausePointConstants.ClearResumedPlayModeWarning
-                    : string.Empty
-            };
+                    Warning = result.ResumedFromPause
+                        ? SourcePausePointConstants.ClearResumedPlayModeWarning
+                        : string.Empty
+                };
+        }
+
+        private static string ResolveExpiredRecommendedNextAction(string status, string recommendedNextAction)
+        {
+            if (status == UloopPausePointStatus.Expired
+                && string.IsNullOrEmpty(recommendedNextAction))
+            {
+                return SourcePausePointConstants.ExpiredRecommendedNextAction;
+            }
+
+            return recommendedNextAction ?? string.Empty;
         }
     }
 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -156,6 +156,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             + "Note: the Debug setting reverts to the 'Code Optimization On Startup' preference "
             + "whenever the Editor restarts, including uloop launch -r.";
 
+        // Why fill when empty: some Expired snapshots reach the response with no next
+        // action, and agents then have no recovery for a timeout that fired during setup.
+        public const string ExpiredRecommendedNextAction =
+            "The pause point expired before it was hit. Re-enable it, and pass --timeout-seconds with a value larger than the default 30 if you need more setup time before triggering.";
+
         // Why: resolve failures have several distinct root causes (wrong path form, non-executable
         // line, stale PDBs after a Code Optimization switch); the skill troubleshooting reference
         // covers the patterns so this next-action stays short and stable.

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -187,7 +187,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 FirstHitSequence = snapshot.FirstHitSequence,
                 LastHitSequence = snapshot.LastHitSequence,
                 Message = snapshot.Message,
-                RecommendedNextAction = snapshot.RecommendedNextAction,
+                RecommendedNextAction = ResolveExpiredRecommendedNextAction(
+                    snapshot.Status,
+                    snapshot.RecommendedNextAction),
                 CapturedVariables = snapshot.CapturedVariables
                     .Select(PausePointStatusCapturedVariable.FromCapturedVariable)
                     .ToList(),
@@ -207,6 +209,22 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     ? null
                     : snapshot.ResolvedLineText
             };
+        }
+
+        // Why duplicate: this bridge must not reference the Editor-only PausePoint assembly.
+        // Keep in sync with SourcePausePointConstants.ExpiredRecommendedNextAction.
+        private const string ExpiredRecommendedNextAction =
+            "The pause point expired before it was hit. Re-enable it, and pass --timeout-seconds with a value larger than the default 30 if you need more setup time before triggering.";
+
+        private static string ResolveExpiredRecommendedNextAction(string status, string recommendedNextAction)
+        {
+            if (status == UloopPausePointStatus.Expired
+                && string.IsNullOrEmpty(recommendedNextAction))
+            {
+                return ExpiredRecommendedNextAction;
+            }
+
+            return recommendedNextAction ?? string.Empty;
         }
     }
 

--- a/cli/project-runner/internal/projectrunner/pause_point_enable.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable.go
@@ -411,6 +411,7 @@ func runPausePointWaitAfterEnable(
 		response.ResolvedMethod = enableFields.ResolvedMethod
 		response.SnapshotTiming = enableFields.SnapshotTiming
 		response = filterPausePointCapturedVariableHistory(response)
+		response = applyPausePointTraceStatusNote(response)
 		response = filterPausePointCapturedVariablesByName(response, options.capturedVariableNames)
 		response = applyPausePointCapturedVariablesMode(response, options.capturedVariablesMode)
 

--- a/cli/project-runner/internal/projectrunner/pause_point_enable_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable_test.go
@@ -214,6 +214,81 @@ func TestRunEnablePausePointCommandAwaitsAfterSuccessfulEnable(t *testing.T) {
 	}
 }
 
+// Verifies enable-pause-point --await stdout includes StatusNote on a trace-mode Hit.
+// Removing applyPausePointTraceStatusNote from the enable-await hit path makes this test Red.
+func TestRunEnablePausePointCommandIncludesStatusNoteOnTraceHit(t *testing.T) {
+	originalQuery := queryPausePointStatus
+	originalPoll := pausePointStatusPoll
+	originalFetch := fetchMatchingLogs
+	pausePointStatusPoll = time.Millisecond
+	t.Cleanup(func() {
+		queryPausePointStatus = originalQuery
+		pausePointStatusPoll = originalPoll
+		fetchMatchingLogs = originalFetch
+	})
+
+	statusResponses := []pausePointStatusResponse{
+		{Id: "jump", Status: pausePointStatusEnabled, IsEnabled: true},
+		{
+			Id:        "jump",
+			Status:    pausePointStatusHit,
+			Mode:      pausePointModeTrace,
+			IsEnabled: true,
+			IsHit:     true,
+			HitCount:  1,
+		},
+	}
+	statusCallCount := 0
+	queryPausePointStatus = func(ctx context.Context, connection unityipc.Connection, id string) (pausePointStatusResponse, error) {
+		response := statusResponses[statusCallCount]
+		statusCallCount++
+		return response, nil
+	}
+	fetchMatchingLogs = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		searchText string,
+		maxCount int,
+	) (pausePointMatchingLogsResult, error) {
+		return pausePointMatchingLogsResult{SearchText: searchText, Logs: []pausePointMatchingLog{}}, nil
+	}
+
+	listener := newLoopbackIpcListener(t)
+	enableRequests := make(chan map[string]any, 1)
+	serverErr := make(chan error, 1)
+	go serveSingleIPCResponse(
+		listener,
+		pausePointEnableCommandName,
+		enableRequests,
+		serverErr,
+		`{"Success":true,"Id":"jump","Status":"Enabled","IsEnabled":true,"TimeoutSeconds":30}`,
+	)
+
+	connection := unityipc.Connection{
+		Endpoint: unityipc.Endpoint{
+			Network: listener.Addr().Network(),
+			Address: listener.Addr().String(),
+		},
+		ProjectRoot: t.TempDir(),
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runEnablePausePointCommand(
+		context.Background(),
+		connection,
+		[]string{"--id", "jump", "--await"},
+		t.TempDir(),
+		&stdout,
+		&stderr)
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d with stderr %s", code, stderr.String())
+	}
+
+	assertStdoutHasPausePointTraceStatusNote(t, stdout.Bytes())
+}
+
 // Verifies file:line enable --await copies ResolvedLine / ResolvedLineText / ResolvedMethod /
 // SnapshotTiming from the enable response into the await hit payload.
 func TestRunEnablePausePointCommandAwaitPropagatesFileLineResolvedFields(t *testing.T) {

--- a/cli/project-runner/internal/projectrunner/pause_point_types.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_types.go
@@ -71,6 +71,11 @@ type pausePointStatusResponse struct {
 	// carries that hit. omitempty keeps the field off 0-hit and unfiltered responses.
 	CapturedVariableHistoryNote string `json:"CapturedVariableHistoryNote,omitempty"`
 
+	// StatusNote is set by the CLI, not Unity, when Mode is trace and Status is Hit.
+	// omitempty keeps the field off every other mode and status so the shared status
+	// contract fixture stays unchanged.
+	StatusNote string `json:"StatusNote,omitempty"`
+
 	// TriggerResult is set by the CLI, not Unity, only when --trigger was passed. It is omitted
 	// entirely otherwise, so callers that never use --trigger see no schema change at all.
 	TriggerResult *pausePointTriggerResult `json:"TriggerResult,omitempty"`

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -31,6 +31,9 @@ const (
 	// CapturedVariableHistory: repeating it would duplicate CapturedVariables.
 	pausePointCapturedVariableHistoryNote = "CapturedVariableHistory lists hits before the latest one; the latest hit's variables are in CapturedVariables."
 
+	// pausePointTraceStatusNote explains that a trace-mode Hit did not pause Play Mode.
+	pausePointTraceStatusNote = "Trace mode does not pause Play Mode; Status 'Hit' records that the marker fired while the game kept running."
+
 	// Mode strings mirror UloopPausePointCaptureMode on the Unity side. Await uses an allowlist
 	// (continuous/trace) for the new-hit baseline — never `Mode != "single-shot"` — so an empty
 	// Mode from an older package keeps the historical immediate-Hit success path.
@@ -124,6 +127,14 @@ func filterPausePointCapturedVariableHistory(response pausePointStatusResponse) 
 	return response
 }
 
+// applyPausePointTraceStatusNote records that a trace-mode Hit did not pause Play Mode.
+func applyPausePointTraceStatusNote(response pausePointStatusResponse) pausePointStatusResponse {
+	if response.Mode == pausePointModeTrace && response.Status == pausePointStatusHit {
+		response.StatusNote = pausePointTraceStatusNote
+	}
+	return response
+}
+
 func runWaitForPausePointCommand(
 	ctx context.Context,
 	connection unityipc.Connection,
@@ -192,6 +203,7 @@ func runPausePointStatusCommand(
 	}
 	response = normalizePausePointStatusResponse(response)
 	response = filterPausePointCapturedVariableHistory(response)
+	response = applyPausePointTraceStatusNote(response)
 	// Evaluated against the raw CapturedVariables, before the filters below can narrow or strip
 	// values, for the same reason as on the await path (runWaitForPausePoint): otherwise an --expect
 	// target not also requested via --captured-variable-names, or whose value names mode stripped,
@@ -247,6 +259,7 @@ func runWaitForPausePoint(
 		response.TriggerResult = triggerResult
 		response.ResumePlayResult = resumeResult
 		response = filterPausePointCapturedVariableHistory(response)
+		response = applyPausePointTraceStatusNote(response)
 		response = filterPausePointCapturedVariablesByName(response, options.capturedVariableNames)
 		response = applyPausePointCapturedVariablesMode(response, options.capturedVariablesMode)
 		// Best-effort: a hit must stay a success even if Unity is busy while paused.

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -1535,24 +1535,7 @@ func TestRunPausePointStatusIncludesStatusNoteOnTraceHit(t *testing.T) {
 		t.Fatalf("expected success, got %d with stderr %s", code, stderr.String())
 	}
 
-	var decoded map[string]json.RawMessage
-	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
-		t.Fatalf("stdout is not valid JSON: %v\n%s", err, stdout.String())
-	}
-
-	rawNote, ok := decoded["StatusNote"]
-	if !ok {
-		t.Fatalf("StatusNote missing from status JSON: %s", stdout.String())
-	}
-
-	var note string
-	if err := json.Unmarshal(rawNote, &note); err != nil {
-		t.Fatalf("unmarshal note failed: %v", err)
-	}
-	if note != pausePointTraceStatusNote {
-		t.Fatalf("StatusNote mismatch: got %#v, want %#v",
-			note, pausePointTraceStatusNote)
-	}
+	assertStdoutHasPausePointTraceStatusNote(t, stdout.Bytes())
 }
 
 // Verifies pause-point-status stdout omits StatusNote on a non-trace Hit.
@@ -1592,6 +1575,90 @@ func TestRunPausePointStatusOmitsStatusNoteOnContinuousHit(t *testing.T) {
 
 	if strings.Contains(stdout.String(), "StatusNote") {
 		t.Fatalf("continuous Hit status JSON must omit StatusNote: %s", stdout.String())
+	}
+}
+
+// Verifies await-pause-point stdout includes StatusNote on a trace-mode Hit.
+// Removing applyPausePointTraceStatusNote from the wait hit path makes this test Red.
+func TestRunWaitForPausePointCommandIncludesStatusNoteOnTraceHit(t *testing.T) {
+	originalExtend := extendPausePointExpiry
+	originalQuery := queryPausePointStatus
+	originalPoll := pausePointStatusPoll
+	pausePointStatusPoll = time.Millisecond
+	t.Cleanup(func() {
+		extendPausePointExpiry = originalExtend
+		queryPausePointStatus = originalQuery
+		pausePointStatusPoll = originalPoll
+	})
+
+	extendPausePointExpiry = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+		minimumRemainingSeconds int,
+	) (pausePointStatusResponse, error) {
+		return pausePointStatusResponse{Id: id, Status: pausePointStatusEnabled}, nil
+	}
+
+	statusResponses := []pausePointStatusResponse{
+		{Id: "jump", Status: pausePointStatusEnabled, IsEnabled: true},
+		{
+			Id:        "jump",
+			Status:    pausePointStatusHit,
+			Mode:      pausePointModeTrace,
+			IsEnabled: true,
+			IsHit:     true,
+			HitCount:  1,
+		},
+	}
+	statusCallCount := 0
+	queryPausePointStatus = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+	) (pausePointStatusResponse, error) {
+		response := statusResponses[statusCallCount]
+		statusCallCount++
+		return response, nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runWaitForPausePointCommand(
+		context.Background(),
+		unityipc.Connection{ProjectRoot: "/tmp/MyProject"},
+		[]string{"--id", "jump", "--timeout-seconds", "1"},
+		"",
+		&stdout,
+		&stderr)
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d with stderr %s", code, stderr.String())
+	}
+
+	assertStdoutHasPausePointTraceStatusNote(t, stdout.Bytes())
+}
+
+func assertStdoutHasPausePointTraceStatusNote(t *testing.T, stdout []byte) {
+	t.Helper()
+
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(stdout, &decoded); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", err, stdout)
+	}
+
+	rawNote, ok := decoded["StatusNote"]
+	if !ok {
+		t.Fatalf("StatusNote missing from JSON: %s", stdout)
+	}
+
+	var note string
+	if err := json.Unmarshal(rawNote, &note); err != nil {
+		t.Fatalf("unmarshal note failed: %v", err)
+	}
+	if note != pausePointTraceStatusNote {
+		t.Fatalf("StatusNote mismatch: got %#v, want %#v",
+			note, pausePointTraceStatusNote)
 	}
 }
 

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -981,6 +981,99 @@ func TestPausePointStatusResponseOmitsEmptyCapturedVariableHistoryNote(t *testin
 	}
 }
 
+// Verifies StatusNote is set only for a trace-mode Hit: other modes and statuses stay empty
+// so omitempty keeps the historical JSON shape.
+func TestApplyPausePointTraceStatusNote(t *testing.T) {
+	cases := []struct {
+		name     string
+		mode     string
+		status   string
+		wantNote string
+	}{
+		{
+			name:     "trace hit sets note",
+			mode:     pausePointModeTrace,
+			status:   pausePointStatusHit,
+			wantNote: pausePointTraceStatusNote,
+		},
+		{
+			name:     "continuous hit omits note",
+			mode:     pausePointModeContinuous,
+			status:   pausePointStatusHit,
+			wantNote: "",
+		},
+		{
+			name:     "trace enabled omits note",
+			mode:     pausePointModeTrace,
+			status:   pausePointStatusEnabled,
+			wantNote: "",
+		},
+		{
+			name:     "trace expired omits note",
+			mode:     pausePointModeTrace,
+			status:   pausePointStatusExpired,
+			wantNote: "",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			response := applyPausePointTraceStatusNote(pausePointStatusResponse{
+				Mode:   testCase.mode,
+				Status: testCase.status,
+			})
+			if response.StatusNote != testCase.wantNote {
+				t.Fatalf("StatusNote mismatch: got %#v, want %#v",
+					response.StatusNote, testCase.wantNote)
+			}
+		})
+	}
+}
+
+// Verifies a set StatusNote survives json.Marshal under that exact key.
+func TestPausePointStatusResponseIncludesStatusNote(t *testing.T) {
+	marshaled, err := json.Marshal(pausePointStatusResponse{
+		StatusNote: pausePointTraceStatusNote,
+	})
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(marshaled, &decoded); err != nil {
+		t.Fatalf("unmarshal envelope failed: %v", err)
+	}
+
+	rawNote, ok := decoded["StatusNote"]
+	if !ok {
+		t.Fatalf("StatusNote missing from JSON: %s", marshaled)
+	}
+
+	var note string
+	if err := json.Unmarshal(rawNote, &note); err != nil {
+		t.Fatalf("unmarshal note failed: %v", err)
+	}
+	if note != pausePointTraceStatusNote {
+		t.Fatalf("StatusNote mismatch: got %#v, want %#v", note, pausePointTraceStatusNote)
+	}
+}
+
+// Verifies an empty StatusNote is omitted from JSON so non-trace and non-Hit
+// responses keep the historical shape.
+func TestPausePointStatusResponseOmitsEmptyStatusNote(t *testing.T) {
+	marshaled, err := json.Marshal(pausePointStatusResponse{
+		Mode:   pausePointModeTrace,
+		Status: pausePointStatusHit,
+	})
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	if strings.Contains(string(marshaled), "StatusNote") {
+		t.Fatalf("empty StatusNote must be omitted from JSON: %s", marshaled)
+	}
+}
+
 // Verifies timeout errors include a deterministic diagnosis hint for common stuck states.
 func TestPausePointTimeoutErrorIncludesDiagnosisHint(t *testing.T) {
 	cases := []struct {
@@ -1402,6 +1495,103 @@ func TestRunPausePointStatusOmitsCapturedVariableHistoryNoteOnZeroHit(t *testing
 
 	if strings.Contains(stdout.String(), "CapturedVariableHistoryNote") {
 		t.Fatalf("0-hit status JSON must omit CapturedVariableHistoryNote: %s", stdout.String())
+	}
+}
+
+// Verifies pause-point-status stdout includes StatusNote when Unity reports a
+// trace-mode Hit. Removing applyPausePointTraceStatusNote from the status
+// command path makes this test Red.
+func TestRunPausePointStatusIncludesStatusNoteOnTraceHit(t *testing.T) {
+	originalQuery := queryPausePointStatus
+	defer func() {
+		queryPausePointStatus = originalQuery
+	}()
+
+	queryPausePointStatus = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+	) (pausePointStatusResponse, error) {
+		return pausePointStatusResponse{
+			Id:        id,
+			Status:    pausePointStatusHit,
+			Mode:      pausePointModeTrace,
+			IsEnabled: true,
+			IsHit:     true,
+			HitCount:  1,
+		}, nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runPausePointStatusCommand(
+		context.Background(),
+		unityipc.Connection{ProjectRoot: "/tmp/MyProject"},
+		[]string{"--id", "jump"},
+		&stdout,
+		&stderr)
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d with stderr %s", code, stderr.String())
+	}
+
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", err, stdout.String())
+	}
+
+	rawNote, ok := decoded["StatusNote"]
+	if !ok {
+		t.Fatalf("StatusNote missing from status JSON: %s", stdout.String())
+	}
+
+	var note string
+	if err := json.Unmarshal(rawNote, &note); err != nil {
+		t.Fatalf("unmarshal note failed: %v", err)
+	}
+	if note != pausePointTraceStatusNote {
+		t.Fatalf("StatusNote mismatch: got %#v, want %#v",
+			note, pausePointTraceStatusNote)
+	}
+}
+
+// Verifies pause-point-status stdout omits StatusNote on a non-trace Hit.
+func TestRunPausePointStatusOmitsStatusNoteOnContinuousHit(t *testing.T) {
+	originalQuery := queryPausePointStatus
+	defer func() {
+		queryPausePointStatus = originalQuery
+	}()
+
+	queryPausePointStatus = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+	) (pausePointStatusResponse, error) {
+		return pausePointStatusResponse{
+			Id:        id,
+			Status:    pausePointStatusHit,
+			Mode:      pausePointModeContinuous,
+			IsEnabled: true,
+			IsHit:     true,
+			HitCount:  1,
+		}, nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runPausePointStatusCommand(
+		context.Background(),
+		unityipc.Connection{ProjectRoot: "/tmp/MyProject"},
+		[]string{"--id", "jump"},
+		&stdout,
+		&stderr)
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d with stderr %s", code, stderr.String())
+	}
+
+	if strings.Contains(stdout.String(), "StatusNote") {
+		t.Fatalf("continuous Hit status JSON must omit StatusNote: %s", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- A trace-mode Hit now carries a `StatusNote` that the marker fired while Play Mode kept running.
- An Expired response with an empty next action now tells the caller to re-enable the marker and raise `--timeout-seconds` when setup takes longer than the default 30 seconds.

## User Impact
- Before: trace mode used the same Status `Hit` as a pausing marker, so it looked like Play Mode had stopped. Some Expired responses also left `RecommendedNextAction` empty, with no recovery for a timeout during setup.
- After: trace Hits include `StatusNote` explaining that the game kept running. Empty Expired actions are filled with the timeout-recovery sentence. A snapshot that already has a next action (including the registry-expired clear-and-re-enable text) is left unchanged.

## Changes
- CLI-only `StatusNote` (`omitempty`) is set when Mode is `trace` and Status is `Hit` on enable-await, wait, and status. It is not added to the shared status contract fixture.
- Tool and CLI-bridge snapshot mapping fill `RecommendedNextAction` only when Status is Expired and the snapshot action is empty.
- Pause-point skill documents both the trace note and the Expired recovery.

## Verification
- `scripts/check-go-cli.sh` → green (0 issues; project-runner tests passed).
- New Go StatusNote tests were compile-Red before the field/apply helper existed, then Green. Shared contract test still passes (StatusNote omitted when empty).
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → 0 errors (2 pre-existing unused-member warnings in test fixtures).
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value 'PausePoint'` → **327/327 Passed**.
- Repository CI does not run on `feature/hot-reload` PRs; local EditMode and `check-go-cli.sh` are the gate.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

