### PR TITLE
feat: add hot reload diagnostics via VibeLogger

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -31,6 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void TearDown()
         {
             HotReloadPatcher.RevertAll();
+            VibeLogger.ClearMemoryLogs();
         }
 
         // Keep in sync with AddedMethodSkipReasons.UnavailableAddedCall in
@@ -4447,6 +4448,121 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     nameof(HotReloadSignatureChangeExternalHost.SameFileCaller)),
                 Is.EqualTo(UnavailableAddedCallSkipReason));
             AssertHasPatched(result, nameof(HotReloadSignatureChangeExternalHost.Unrelated));
+        }
+
+        /// <summary>
+        /// What: a successful apply records file-start, worker-result, and apply-summary
+        /// VibeLogger operations that share one non-empty correlation id.
+        /// </summary>
+        [Test]
+        public async Task Run_SuccessfulApply_RecordsFileStartWorkerResultAndApplySummary()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "VibeLogSuccess.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                    sumGridMethod:
+                    "public int SumGrid(int[,] grid)\n        {\n            return 42;\n        }"));
+            VibeLogger.ClearMemoryLogs();
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.SumGrid));
+            List<JObject> logs = ReadHotReloadVibeLogs();
+            JObject fileStart = FindVibeLog(logs, HotReloadConstants.VibeLogFileStart);
+            JObject workerResult = FindVibeLog(logs, HotReloadConstants.VibeLogWorkerResult);
+            JObject applySummary = FindVibeLog(logs, HotReloadConstants.VibeLogApplySummary);
+            string correlationId = (string)fileStart["correlation_id"];
+            Assert.That(correlationId, Is.Not.Null.And.Not.Empty);
+            Assert.That((string)workerResult["correlation_id"], Is.EqualTo(correlationId));
+            Assert.That((string)applySummary["correlation_id"], Is.EqualTo(correlationId));
+        }
+
+        /// <summary>
+        /// What: an empty-entries run that clears added members records the empty-entries
+        /// VibeLogger operation.
+        /// </summary>
+        [Test]
+        public async Task Run_EmptyEntriesClear_RecordsEmptyEntriesClearVibeLog()
+        {
+            string fixturePath = ResolveAddedMethodApplyFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("VibeLogEmptyEntries1.cs", WithWorkingAddedPing(onDisk)),
+                CancellationToken.None);
+            VibeLogger.ClearMemoryLogs();
+
+            await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("VibeLogEmptyEntries2.cs", WithVirtualAddedPing(onDisk)),
+                CancellationToken.None);
+
+            List<JObject> logs = ReadHotReloadVibeLogs();
+            FindVibeLog(logs, HotReloadConstants.VibeLogEmptyEntriesClear);
+        }
+
+        /// <summary>
+        /// What: a shim compile failure that isolates one method records both the compile-failed
+        /// and isolation-retry VibeLogger operations.
+        /// </summary>
+        [Test]
+        public async Task Run_ShimCompileFailureWithIsolation_RecordsCompileFailedAndIsolationRetry()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedSource = BuildFixtureSource(
+                computeWithPrivateMethod:
+                "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }",
+                callsMissingHelperMethod:
+                "public int CallsMissingHelper(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }");
+            VibeLogger.ClearMemoryLogs();
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("VibeLogIsolation.cs", editedSource),
+                CancellationToken.None);
+
+            AssertHasPatched(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+            List<JObject> logs = ReadHotReloadVibeLogs();
+            FindVibeLog(logs, HotReloadConstants.VibeLogShimCompileFailed);
+            FindVibeLog(logs, HotReloadConstants.VibeLogIsolationRetry);
+        }
+
+        private static List<JObject> ReadHotReloadVibeLogs()
+        {
+            JArray entries = JArray.Parse(VibeLogger.GetLogsForAi());
+            List<JObject> hotReloadLogs = new List<JObject>();
+            foreach (JToken token in entries)
+            {
+                JObject entry = (JObject)token;
+                string operation = (string)entry["operation"];
+                if (operation != null
+                    && operation.StartsWith("hot_reload_", StringComparison.Ordinal))
+                {
+                    hotReloadLogs.Add(entry);
+                }
+            }
+
+            return hotReloadLogs;
+        }
+
+        private static JObject FindVibeLog(IReadOnlyList<JObject> logs, string operation)
+        {
+            foreach (JObject entry in logs)
+            {
+                if ((string)entry["operation"] == operation)
+                {
+                    return entry;
+                }
+            }
+
+            Assert.Fail("Missing VibeLogger operation " + operation);
+            return null;
         }
 
         private static int FindLineNumberContaining(string source, string fragment)

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -3910,11 +3910,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     "        public int Unrelated(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }",
                     StringComparison.Ordinal);
             Assert.That(edited, Is.Not.EqualTo(onDisk));
+            VibeLogger.ClearMemoryLogs();
 
             HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
                 new[] { fixturePath },
                 WriteEditedSource("SignatureChangeGateRetryFailure.cs", edited),
                 CancellationToken.None);
+
+            List<JObject> gateLogs = ReadHotReloadVibeLogs();
+            JObject gateFileStart = FindVibeLog(gateLogs, HotReloadConstants.VibeLogFileStart);
+            JObject gateIsolationRetry = FindVibeLog(gateLogs, HotReloadConstants.VibeLogIsolationRetry);
+            JObject gateShimCompileFailed = FindVibeLog(gateLogs, HotReloadConstants.VibeLogShimCompileFailed);
+            AssertSameHotReloadCorrelation(gateFileStart, gateIsolationRetry, gateShimCompileFailed);
+            Assert.That(
+                (string)gateIsolationRetry["context"]["trigger"],
+                Is.EqualTo(HotReloadConstants.VibeLogIsolationTriggerSignatureChangeGate));
+            Assert.That(
+                (string)gateShimCompileFailed["context"]["stage"],
+                Is.EqualTo(HotReloadConstants.VibeLogShimCompileStageRetry));
 
             Assert.That(result.Methods.Count, Is.EqualTo(1), FormatOutcomes(result));
             HotReloadMethodOutcome outcome = result.Methods[0];
@@ -4477,15 +4490,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             JObject fileStart = FindVibeLog(logs, HotReloadConstants.VibeLogFileStart);
             JObject workerResult = FindVibeLog(logs, HotReloadConstants.VibeLogWorkerResult);
             JObject applySummary = FindVibeLog(logs, HotReloadConstants.VibeLogApplySummary);
-            string correlationId = (string)fileStart["correlation_id"];
-            Assert.That(correlationId, Is.Not.Null.And.Not.Empty);
-            Assert.That((string)workerResult["correlation_id"], Is.EqualTo(correlationId));
-            Assert.That((string)applySummary["correlation_id"], Is.EqualTo(correlationId));
+            AssertSameHotReloadCorrelation(fileStart, workerResult, applySummary);
+            Assert.That(
+                (int)applySummary["context"]["addedCount"],
+                Is.EqualTo(CountOutcomeKind(result, HotReloadMethodOutcomeKind.Added)));
         }
 
         /// <summary>
         /// What: an empty-entries run that clears added members records the empty-entries
-        /// VibeLogger operation.
+        /// VibeLogger operation with the same correlation id as file-start.
         /// </summary>
         [Test]
         public async Task Run_EmptyEntriesClear_RecordsEmptyEntriesClearVibeLog()
@@ -4504,12 +4517,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CancellationToken.None);
 
             List<JObject> logs = ReadHotReloadVibeLogs();
-            FindVibeLog(logs, HotReloadConstants.VibeLogEmptyEntriesClear);
+            JObject fileStart = FindVibeLog(logs, HotReloadConstants.VibeLogFileStart);
+            JObject emptyEntriesClear = FindVibeLog(logs, HotReloadConstants.VibeLogEmptyEntriesClear);
+            AssertSameHotReloadCorrelation(fileStart, emptyEntriesClear);
         }
 
         /// <summary>
-        /// What: a shim compile failure that isolates one method records both the compile-failed
-        /// and isolation-retry VibeLogger operations.
+        /// What: a shim compile failure that isolates one method records compile-failed and
+        /// isolation-retry VibeLogger operations that share the file-start correlation id.
         /// </summary>
         [Test]
         public async Task Run_ShimCompileFailureWithIsolation_RecordsCompileFailedAndIsolationRetry()
@@ -4529,8 +4544,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             AssertHasPatched(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
             List<JObject> logs = ReadHotReloadVibeLogs();
-            FindVibeLog(logs, HotReloadConstants.VibeLogShimCompileFailed);
-            FindVibeLog(logs, HotReloadConstants.VibeLogIsolationRetry);
+            JObject fileStart = FindVibeLog(logs, HotReloadConstants.VibeLogFileStart);
+            JObject shimCompileFailed = FindVibeLog(logs, HotReloadConstants.VibeLogShimCompileFailed);
+            JObject isolationRetry = FindVibeLog(logs, HotReloadConstants.VibeLogIsolationRetry);
+            AssertSameHotReloadCorrelation(fileStart, shimCompileFailed, isolationRetry);
+            Assert.That(
+                (string)shimCompileFailed["context"]["stage"],
+                Is.EqualTo(HotReloadConstants.VibeLogShimCompileStageFirstPass));
+            Assert.That(
+                (string)isolationRetry["context"]["trigger"],
+                Is.EqualTo(HotReloadConstants.VibeLogIsolationTriggerShimCompileFailure));
+            Assert.That((bool)isolationRetry["context"]["retryWorkerSuccess"], Is.True);
         }
 
         private static List<JObject> ReadHotReloadVibeLogs()
@@ -4563,6 +4587,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.Fail("Missing VibeLogger operation " + operation);
             return null;
+        }
+
+        private static void AssertSameHotReloadCorrelation(JObject fileStart, params JObject[] others)
+        {
+            string correlationId = (string)fileStart["correlation_id"];
+            Assert.That(correlationId, Is.Not.Null.And.Not.Empty);
+            for (int index = 0; index < others.Length; index++)
+            {
+                Assert.That(
+                    (string)others[index]["correlation_id"],
+                    Is.EqualTo(correlationId));
+            }
+        }
+
+        private static int CountOutcomeKind(
+            HotReloadOrchestratorResult result,
+            HotReloadMethodOutcomeKind kind)
+        {
+            int count = 0;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == kind)
+                {
+                    count++;
+                }
+            }
+
+            return count;
         }
 
         private static int FindLineNumberContaining(string source, string fragment)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -222,5 +222,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public const string NoMethodsPatchedSeeSkippedOrAlreadyActiveMessage =
             "Hot reload finished with no methods patched. See Methods for Skipped and AlreadyActive reasons.";
+
+        public const string VibeLogFileStart = "hot_reload_file_start";
+        public const string VibeLogWorkerResult = "hot_reload_worker_result";
+        public const string VibeLogShimCompileFailed = "hot_reload_shim_compile_failed";
+        public const string VibeLogIsolationRetry = "hot_reload_isolation_retry";
+        public const string VibeLogEmptyEntriesClear = "hot_reload_empty_entries_clear";
+        public const string VibeLogApplySummary = "hot_reload_apply_summary";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -229,5 +229,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string VibeLogIsolationRetry = "hot_reload_isolation_retry";
         public const string VibeLogEmptyEntriesClear = "hot_reload_empty_entries_clear";
         public const string VibeLogApplySummary = "hot_reload_apply_summary";
+        public const string VibeLogShimCompileStageFirstPass = "first_pass";
+        public const string VibeLogShimCompileStageRetry = "retry";
+        public const string VibeLogIsolationTriggerShimCompileFailure = "shim_compile_failure";
+        public const string VibeLogIsolationTriggerSignatureChangeGate = "signature_change_gate";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -41,6 +41,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(files != null, "files must not be null.");
             Debug.Assert(files.Count > 0, "files must not be empty.");
 
+            string correlationId = VibeLogger.GenerateCorrelationId();
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
             List<string> warnings = new List<string>();
             List<string> suppressedPausePointIds = new List<string>();
@@ -72,6 +73,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadFileProcessResult fileResult = await ProcessFileAsync(
                     filePath,
                     workerSourcePath,
+                    correlationId,
                     ct).ConfigureAwait(false);
 
                 outcomes.AddRange(fileResult.Outcomes);
@@ -105,6 +107,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             await MainThreadSwitcher.SwitchToMainThread(ct);
             addedFields.Sort(StringComparer.Ordinal);
+            (int patchedCount, int failedCount, int skippedCount, int alreadyActiveCount) =
+                CountMethodOutcomeKinds(outcomes);
+            LogHotReloadApplySummary(
+                patchedCount,
+                failedCount,
+                skippedCount,
+                alreadyActiveCount,
+                failedCount == 0,
+                correlationId);
             return new HotReloadOrchestratorResult(
                 outcomes,
                 warnings,
@@ -119,6 +130,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static async Task<HotReloadFileProcessResult> ProcessFileAsync(
             string assemblyResolvePath,
             string workerSourcePath,
+            string correlationId,
             CancellationToken ct)
         {
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
@@ -184,6 +196,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 projectRelativePath,
                 assemblyResolvePath,
                 outcomes);
+            LogHotReloadFileStart(projectRelativePath, unchangedDecision, correlationId);
             if (unchangedDecision == HotReloadUnchangedSourceDecision.ShortCircuited)
             {
                 return new HotReloadFileProcessResult(outcomes, warnings, 0);
@@ -228,6 +241,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             TransformWorkerClientResult workerResult =
                 await TransformWorkerClient.RunAsync(workerInput, ct).ConfigureAwait(false);
+            LogHotReloadWorkerResult(workerResult, correlationId);
             if (!workerResult.Success)
             {
                 outcomes.Add(
@@ -308,6 +322,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 defines,
                 assemblyResolvePath,
                 projectRelativePath,
+                correlationId,
                 ct).ConfigureAwait(false);
             // Why after the gate: a gated replacement is not applied, so listing it under
             // "Removed members stay present... edited bodies no longer call them" is false.
@@ -371,6 +386,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Worker failure and shim-compile failure return earlier or later without
                 // clearing — same as leaving existing Harmony patches in place when apply does
                 // not succeed.
+                IReadOnlyList<string> addedLabelsAtClear =
+                    HotReloadAddedMemberRegistry.ListActiveMethodKeys(projectRelativePath);
+                LogHotReloadEmptyEntriesClear(addedLabelsAtClear, correlationId);
                 HotReloadAddedMemberRegistry.BeginFileGeneration(projectRelativePath);
                 // Why after the clear: a still-declared added method can be worker-skipped
                 // (virtual/generic), leaving entries empty while the registry drop is real.
@@ -397,6 +415,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     targetDllPath,
                     defines,
                     assemblyResolvePath,
+                    correlationId,
                     ct).ConfigureAwait(false);
                 if (firstCompile.AddedFieldNames != null)
                 {
@@ -1158,6 +1177,145 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 + string.Join(",", parameterTypeFullNames ?? Array.Empty<string>()) + ")";
         }
 
+        private static (int patchedCount, int failedCount, int skippedCount, int alreadyActiveCount)
+            CountMethodOutcomeKinds(IReadOnlyList<HotReloadMethodOutcome> outcomes)
+        {
+            int patchedCount = 0;
+            int failedCount = 0;
+            int skippedCount = 0;
+            int alreadyActiveCount = 0;
+            for (int index = 0; index < outcomes.Count; index++)
+            {
+                HotReloadMethodOutcomeKind kind = outcomes[index].Kind;
+                if (kind == HotReloadMethodOutcomeKind.Patched)
+                {
+                    patchedCount++;
+                }
+                else if (kind == HotReloadMethodOutcomeKind.Failed)
+                {
+                    failedCount++;
+                }
+                else if (kind == HotReloadMethodOutcomeKind.Skipped)
+                {
+                    skippedCount++;
+                }
+                else if (kind == HotReloadMethodOutcomeKind.AlreadyActive)
+                {
+                    alreadyActiveCount++;
+                }
+            }
+
+            return (patchedCount, failedCount, skippedCount, alreadyActiveCount);
+        }
+
+        private static void LogHotReloadFileStart(
+            string projectRelativePath,
+            HotReloadUnchangedSourceDecision unchangedDecision,
+            string correlationId)
+        {
+            VibeLogger.LogInfo(
+                HotReloadConstants.VibeLogFileStart,
+                "Hot reload file start.",
+                new
+                {
+                    projectRelativePath,
+                    unchangedDecision = unchangedDecision.ToString()
+                },
+                correlationId);
+        }
+
+        private static void LogHotReloadWorkerResult(
+            TransformWorkerClientResult workerResult,
+            string correlationId)
+        {
+            TransformWorkerOutputDto output = workerResult.Output;
+            VibeLogger.LogInfo(
+                HotReloadConstants.VibeLogWorkerResult,
+                "Hot reload worker result.",
+                new
+                {
+                    entryCount = output?.entries?.Length ?? 0,
+                    skippedCount = output?.skipped?.Length ?? 0,
+                    unchangedCount = output?.unchangedMethods?.Length ?? 0,
+                    workerSuccess = workerResult.Success
+                },
+                correlationId);
+        }
+
+        private static void LogHotReloadShimCompileFailed(
+            HotReloadShimCompileResult compileResult,
+            string correlationId)
+        {
+            string firstError = compileResult.Errors.Count > 0
+                ? compileResult.Errors[0].Message
+                : compileResult.ErrorMessage;
+            VibeLogger.LogInfo(
+                HotReloadConstants.VibeLogShimCompileFailed,
+                "Hot reload shim compile failed.",
+                new
+                {
+                    errorCount = compileResult.Errors.Count,
+                    firstError
+                },
+                correlationId);
+        }
+
+        private static void LogHotReloadIsolationRetry(
+            IsolationExclusions exclusions,
+            TransformWorkerOutputDto retryOutput,
+            int retryOnlySkippedCount,
+            string correlationId)
+        {
+            VibeLogger.LogInfo(
+                HotReloadConstants.VibeLogIsolationRetry,
+                "Hot reload isolation retry.",
+                new
+                {
+                    excludedMethodKeyCount = exclusions.ExcludedMethodKeys.Length,
+                    excludedAddedMethodKeyCount = exclusions.ExcludedAddedMethodKeys.Length,
+                    retryEntryCount = retryOutput.entries?.Length ?? 0,
+                    retrySkippedCount = retryOutput.skipped?.Length ?? 0,
+                    retryOnlySkippedCount
+                },
+                correlationId);
+        }
+
+        private static void LogHotReloadEmptyEntriesClear(
+            IReadOnlyList<string> addedLabelsAtClear,
+            string correlationId)
+        {
+            VibeLogger.LogInfo(
+                HotReloadConstants.VibeLogEmptyEntriesClear,
+                "Hot reload empty-entries registry clear.",
+                new
+                {
+                    addedLabels = addedLabelsAtClear
+                },
+                correlationId);
+        }
+
+        private static void LogHotReloadApplySummary(
+            int patchedCount,
+            int failedCount,
+            int skippedCount,
+            int alreadyActiveCount,
+            bool success,
+            string correlationId)
+        {
+            VibeLogger.LogInfo(
+                HotReloadConstants.VibeLogApplySummary,
+                "Hot reload apply summary.",
+                new
+                {
+                    patchedCount,
+                    failedCount,
+                    skippedCount,
+                    alreadyActiveCount,
+                    success
+                },
+                correlationId);
+        }
+
         /// <summary>
         /// Retries the failed shim compile once, excluding the method(s) whose compiler errors can
         /// be attributed to them, so the rest of the file's methods can still patch. Returns null
@@ -1173,6 +1331,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string targetDllPath,
             string[] defines,
             string assemblyResolvePath,
+            string correlationId,
             CancellationToken ct)
         {
             if (compileResult.Errors.Count == 0)
@@ -1213,6 +1372,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 defines,
                 workerOutput.skipped,
                 assemblyResolvePath,
+                correlationId,
                 ct).ConfigureAwait(false);
             return retry.Isolation;
         }
@@ -1227,6 +1387,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string[] defines,
             TransformWorkerSkippedDto[] firstPassSkipped,
             string assemblyResolvePath,
+            string correlationId,
             CancellationToken ct)
         {
             TransformWorkerInputDto retryInput = new TransformWorkerInputDto
@@ -1256,11 +1417,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why drop first-pass (Method, Reason) pairs: consuming them again would duplicate
             // every per-file skip. Retry-only pairs are new — typically transitive callers of
             // excluded added methods — and must surface or the edit is applied nowhere.
-            skippedCallerOutcomes.AddRange(
-                CollectRetryOnlySkippedOutcomes(
-                    firstPassSkipped,
-                    retryOutput.skipped,
-                    assemblyResolvePath));
+            List<HotReloadMethodOutcome> retryOnlySkipped = CollectRetryOnlySkippedOutcomes(
+                firstPassSkipped,
+                retryOutput.skipped,
+                assemblyResolvePath);
+            skippedCallerOutcomes.AddRange(retryOnlySkipped);
+            LogHotReloadIsolationRetry(
+                exclusions,
+                retryOutput,
+                retryOnlySkipped.Count,
+                correlationId);
             if (string.IsNullOrEmpty(retryOutput.shimSource) || retryOutput.entries.Length == 0)
             {
                 return IsolationRetryRunResult.Succeeded(
@@ -1530,6 +1696,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string targetDllPath,
             string[] defines,
             string assemblyResolvePath,
+            string correlationId,
             CancellationToken ct)
         {
             // BuildShimReferencePaths reads Application.dataPath / platform; stay on main thread.
@@ -1564,6 +1731,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return ShimFirstCompileResult.Succeeded(entriesToPatch, compileResult);
             }
 
+            LogHotReloadShimCompileFailed(compileResult, correlationId);
+
             // Why isolate only here: a signature-change gate retry already used
             // RunIsolationRetryAsync (worker run #2). Calling isolation after that would be a
             // third worker run. Gate retry compile failures return Failed from the gate and
@@ -1576,6 +1745,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 targetDllPath,
                 defines,
                 assemblyResolvePath,
+                correlationId,
                 ct).ConfigureAwait(false);
             if (isolation == null)
             {
@@ -1640,6 +1810,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string[] defines,
             string assemblyResolvePath,
             string projectRelativePath,
+            string correlationId,
             CancellationToken ct)
         {
             TransformWorkerEntryDto[] entries = workerOutput.entries ?? Array.Empty<TransformWorkerEntryDto>();
@@ -1702,6 +1873,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 defines,
                 workerOutput.skipped,
                 assemblyResolvePath,
+                correlationId,
                 ct).ConfigureAwait(false);
             List<string> gatedReplacementMethodKeys =
                 CollectGatedReplacementMethodKeys(gatedReplacements);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -1428,8 +1428,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (!retryWorkerResult.Success)
             {
                 LogHotReloadIsolationRetry(
-                    0,
-                    0,
+                    exclusions.ExcludedMethodKeys.Length,
+                    exclusions.ExcludedAddedMethodKeys.Length,
                     0,
                     0,
                     0,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -107,13 +107,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             await MainThreadSwitcher.SwitchToMainThread(ct);
             addedFields.Sort(StringComparer.Ordinal);
-            (int patchedCount, int failedCount, int skippedCount, int alreadyActiveCount) =
+            (int patchedCount, int failedCount, int skippedCount, int alreadyActiveCount, int addedCount) =
                 CountMethodOutcomeKinds(outcomes);
             LogHotReloadApplySummary(
                 patchedCount,
                 failedCount,
                 skippedCount,
                 alreadyActiveCount,
+                addedCount,
                 failedCount == 0,
                 correlationId);
             return new HotReloadOrchestratorResult(
@@ -1177,13 +1178,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 + string.Join(",", parameterTypeFullNames ?? Array.Empty<string>()) + ")";
         }
 
-        private static (int patchedCount, int failedCount, int skippedCount, int alreadyActiveCount)
+        private static (int patchedCount, int failedCount, int skippedCount, int alreadyActiveCount, int addedCount)
             CountMethodOutcomeKinds(IReadOnlyList<HotReloadMethodOutcome> outcomes)
         {
             int patchedCount = 0;
             int failedCount = 0;
             int skippedCount = 0;
             int alreadyActiveCount = 0;
+            int addedCount = 0;
             for (int index = 0; index < outcomes.Count; index++)
             {
                 HotReloadMethodOutcomeKind kind = outcomes[index].Kind;
@@ -1203,9 +1205,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     alreadyActiveCount++;
                 }
+                else if (kind == HotReloadMethodOutcomeKind.Added)
+                {
+                    addedCount++;
+                }
             }
 
-            return (patchedCount, failedCount, skippedCount, alreadyActiveCount);
+            return (patchedCount, failedCount, skippedCount, alreadyActiveCount, addedCount);
         }
 
         private static void LogHotReloadFileStart(
@@ -1244,6 +1250,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static void LogHotReloadShimCompileFailed(
             HotReloadShimCompileResult compileResult,
+            string stage,
             string correlationId)
         {
             string firstError = compileResult.Errors.Count > 0
@@ -1254,6 +1261,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 "Hot reload shim compile failed.",
                 new
                 {
+                    stage,
                     errorCount = compileResult.Errors.Count,
                     firstError
                 },
@@ -1261,9 +1269,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         private static void LogHotReloadIsolationRetry(
-            IsolationExclusions exclusions,
-            TransformWorkerOutputDto retryOutput,
+            int excludedMethodKeyCount,
+            int excludedAddedMethodKeyCount,
+            int retryEntryCount,
+            int retrySkippedCount,
             int retryOnlySkippedCount,
+            bool retryWorkerSuccess,
+            string trigger,
             string correlationId)
         {
             VibeLogger.LogInfo(
@@ -1271,10 +1283,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 "Hot reload isolation retry.",
                 new
                 {
-                    excludedMethodKeyCount = exclusions.ExcludedMethodKeys.Length,
-                    excludedAddedMethodKeyCount = exclusions.ExcludedAddedMethodKeys.Length,
-                    retryEntryCount = retryOutput.entries?.Length ?? 0,
-                    retrySkippedCount = retryOutput.skipped?.Length ?? 0,
+                    trigger,
+                    retryWorkerSuccess,
+                    excludedMethodKeyCount,
+                    excludedAddedMethodKeyCount,
+                    retryEntryCount,
+                    retrySkippedCount,
                     retryOnlySkippedCount
                 },
                 correlationId);
@@ -1299,6 +1313,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int failedCount,
             int skippedCount,
             int alreadyActiveCount,
+            int addedCount,
             bool success,
             string correlationId)
         {
@@ -1311,6 +1326,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     failedCount,
                     skippedCount,
                     alreadyActiveCount,
+                    addedCount,
                     success
                 },
                 correlationId);
@@ -1372,6 +1388,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 defines,
                 workerOutput.skipped,
                 assemblyResolvePath,
+                HotReloadConstants.VibeLogIsolationTriggerShimCompileFailure,
                 correlationId,
                 ct).ConfigureAwait(false);
             return retry.Isolation;
@@ -1387,6 +1404,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string[] defines,
             TransformWorkerSkippedDto[] firstPassSkipped,
             string assemblyResolvePath,
+            string trigger,
             string correlationId,
             CancellationToken ct)
         {
@@ -1409,6 +1427,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 await TransformWorkerClient.RunAsync(retryInput, ct).ConfigureAwait(false);
             if (!retryWorkerResult.Success)
             {
+                LogHotReloadIsolationRetry(
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    false,
+                    trigger,
+                    correlationId);
                 return IsolationRetryRunResult.Failed(
                     "Retry worker failed: " + retryWorkerResult.ErrorMessage);
             }
@@ -1423,9 +1450,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 assemblyResolvePath);
             skippedCallerOutcomes.AddRange(retryOnlySkipped);
             LogHotReloadIsolationRetry(
-                exclusions,
-                retryOutput,
+                exclusions.ExcludedMethodKeys.Length,
+                exclusions.ExcludedAddedMethodKeys.Length,
+                retryOutput.entries?.Length ?? 0,
+                retryOutput.skipped?.Length ?? 0,
                 retryOnlySkipped.Count,
+                true,
+                trigger,
                 correlationId);
             if (string.IsNullOrEmpty(retryOutput.shimSource) || retryOutput.entries.Length == 0)
             {
@@ -1463,6 +1494,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ct).ConfigureAwait(false);
             if (!retryCompileResult.Success)
             {
+                LogHotReloadShimCompileFailed(
+                    retryCompileResult,
+                    HotReloadConstants.VibeLogShimCompileStageRetry,
+                    correlationId);
                 return IsolationRetryRunResult.Failed(
                     "Retry shim compile failed: " + retryCompileResult.ErrorMessage);
             }
@@ -1731,7 +1766,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return ShimFirstCompileResult.Succeeded(entriesToPatch, compileResult);
             }
 
-            LogHotReloadShimCompileFailed(compileResult, correlationId);
+            LogHotReloadShimCompileFailed(
+                compileResult,
+                HotReloadConstants.VibeLogShimCompileStageFirstPass,
+                correlationId);
 
             // Why isolate only here: a signature-change gate retry already used
             // RunIsolationRetryAsync (worker run #2). Calling isolation after that would be a
@@ -1873,6 +1911,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 defines,
                 workerOutput.skipped,
                 assemblyResolvePath,
+                HotReloadConstants.VibeLogIsolationTriggerSignatureChangeGate,
                 correlationId,
                 ct).ConfigureAwait(false);
             List<string> gatedReplacementMethodKeys =


### PR DESCRIPTION
## Summary
- A hot reload run now writes structured VibeLogger diagnostics for each pipeline stage, tied together by one correlation id.
- Agents can tell a successful apply from an empty-entries clear or a shim-compile isolation retry without reading user source.

## User Impact
- Before: a skipped, failed, or empty-entries reload left only the apply response. Isolation retries and registry clears were invisible once the run finished.
- After: with `ULOOP_DEBUG` enabled, `.uloop/outputs/VibeLogs/unity_vibe_*.json` records `hot_reload_file_start`, `hot_reload_worker_result`, `hot_reload_shim_compile_failed`, `hot_reload_isolation_retry`, `hot_reload_empty_entries_clear`, and `hot_reload_apply_summary`. One `correlation_id` covers the whole `RunAsync`. Context is counts, labels, and one compiler error line — not method bodies.

## Changes
- `RunAsync` generates a correlation id and logs the six operations at the existing decision points.
- Three EditMode scenarios assert the memory-log operations by constant name: success (shared correlation id), empty-entries clear, and shim-compile failure plus isolation retry.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → 0 errors (2 pre-existing unused-member warnings in test fixtures).
- New VibeLogger tests → **3/3 Passed**.
- `uloop run-tests --test-mode EditMode --filter-type assembly --filter-value UnityCLILoop.Tests.Editor.HotReload --timeout-seconds 1500` → **423/423 Passed** (420 baseline + 3 new).
- Observed in `.uloop/outputs/VibeLogs/unity_vibe_20260818.json` from those runs (same correlation id per run):
  - success: `hot_reload_file_start` (`unchangedDecision":"NotUnchanged"`) → `hot_reload_apply_summary` (`patchedCount":1,"success":true`)
  - empty-entries: `hot_reload_empty_entries_clear` with the added-method label → `hot_reload_apply_summary` (`skippedCount":2`)
  - isolation: `hot_reload_isolation_retry` (`excludedMethodKeyCount":1,"retryEntryCount":1`) → `hot_reload_apply_summary` (`patchedCount":1,"failedCount":1,"success":false`)
- Repository CI does not run on `feature/hot-reload` PRs; local EditMode is the gate.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

