### PR TITLE
fix: stop false outside-body drift warnings for using directives and added properties

### DIFF
--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -840,6 +840,171 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 result.Output.declarationDriftWarnings,
                 Has.Some.Contain("Edits outside method bodies"),
                 "Non-const field initializer edits must still emit the outside-body warning.");
+            AssertContainsOutsideMethodBodyDriftWarning(result, "NonConstFieldInitializerDrift.cs");
+        }
+
+        /// <summary>
+        /// What: adding a using directive plus a method-body edit does not emit the
+        /// outside-method-body drift warning, and the body edit is still Patched.
+        /// </summary>
+        [Test]
+        public async Task Run_UsingDirectiveOnlyPlusBodyEdit_DoesNotEmitOutsideBodyWarning()
+        {
+            const string fileName = "UsingDirectiveOnlyPlusBodyEdit.cs";
+            string onDisk = File.ReadAllText(ResolveE2EFixturePath());
+            string editedSource = onDisk.Replace(
+                "using UnityEngine;\n",
+                "using UnityEngine;\nusing System.Text;\n",
+                StringComparison.Ordinal);
+            editedSource = editedSource.Replace(
+                "return _secret + delta;",
+                "return _secret + delta + 1;",
+                StringComparison.Ordinal);
+            Assert.That(editedSource, Is.Not.EqualTo(onDisk), "Precondition: using and body must differ.");
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string sourcePath = Path.Combine(directory, fileName);
+            File.WriteAllText(sourcePath, editedSource);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                ResolveE2EFixtureProjectRelativePath(),
+                snapshotSource: onDisk);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
+
+            bool foundCompute = false;
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                if (entry.methodName == nameof(HotReloadE2EFixture.ComputeWithPrivate))
+                {
+                    foundCompute = true;
+                    break;
+                }
+            }
+
+            Assert.That(foundCompute, Is.True, "Body edit must still emit a Patched ComputeWithPrivate entry.");
+        }
+
+        private const string ExpectedAddedPropertySkipReason =
+            "Added properties are out of scope for hot reload; the compiled assembly has no such member. "
+            + "Use a 'const' or a plain added field for the value, or run 'uloop compile'.";
+
+        private const string ExpectedExplicitAccessorSkipReason =
+            "Property setter, init, or indexer accessors are out of scope for v1; "
+            + "run 'uloop compile' to apply accessor edits.";
+
+        /// <summary>
+        /// What: adding a get-accessor property plus a method-body edit skips the getter with
+        /// the added-property reason and does not emit the outside-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Run_AddedExpressionBodiedPropertyPlusBodyEdit_SkipsGetterWithoutOutsideBodyWarning()
+        {
+            const string fileName = "AddedExpressionBodiedPropertyDrift.cs";
+            TransformWorkerClientResult result = await RunWorkerOnEditedE2ECopyAsync(
+                fileName,
+                editedSource =>
+                {
+                    string next = editedSource.Replace(
+                        "        public int Counter;",
+                        "        public int AddedProbe => 7;\n\n        public int Counter;",
+                        StringComparison.Ordinal);
+                    return next.Replace(
+                        "return _secret + delta;",
+                        "return _secret + delta + 1;",
+                        StringComparison.Ordinal);
+                });
+
+            AssertSkippedContains(result, "get_AddedProbe", ExpectedAddedPropertySkipReason);
+            AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
+            AssertPatchedComputeWithPrivate(result);
+        }
+
+        /// <summary>
+        /// What: adding a setter-only property plus a method-body edit skips the setter with
+        /// the explicit-accessor reason and does not emit the outside-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Run_AddedSetterOnlyPropertyPlusBodyEdit_SkipsSetterWithoutOutsideBodyWarning()
+        {
+            const string fileName = "AddedSetterOnlyPropertyDrift.cs";
+            TransformWorkerClientResult result = await RunWorkerOnEditedE2ECopyAsync(
+                fileName,
+                editedSource =>
+                {
+                    string next = editedSource.Replace(
+                        "        public int Counter;",
+                        "        public int AddedSetterOnly { set { } }\n\n        public int Counter;",
+                        StringComparison.Ordinal);
+                    return next.Replace(
+                        "return _secret + delta;",
+                        "return _secret + delta + 1;",
+                        StringComparison.Ordinal);
+                });
+
+            AssertSkippedContains(result, "set_AddedSetterOnly", ExpectedExplicitAccessorSkipReason);
+            AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
+            AssertPatchedComputeWithPrivate(result);
+        }
+
+        /// <summary>
+        /// What: adding an auto-property emits no skip row, so the outside-body drift warning
+        /// remains the only signal that the new member was not applied.
+        /// </summary>
+        [Test]
+        public async Task Run_AddedAutoPropertyPlusBodyEdit_EmitsOutsideBodyWarningWithoutSkipRow()
+        {
+            const string fileName = "AddedAutoPropertyDrift.cs";
+            TransformWorkerClientResult result = await RunWorkerOnEditedE2ECopyAsync(
+                fileName,
+                editedSource =>
+                {
+                    string next = editedSource.Replace(
+                        "        public int Counter;",
+                        "        public int AddedAuto { get; set; }\n\n        public int Counter;",
+                        StringComparison.Ordinal);
+                    return next.Replace(
+                        "return _secret + delta;",
+                        "return _secret + delta + 1;",
+                        StringComparison.Ordinal);
+                });
+
+            AssertSkippedDoesNotContain(result, "AddedAuto");
+            AssertContainsOutsideMethodBodyDriftWarning(result, fileName);
+            AssertPatchedComputeWithPrivate(result);
+        }
+
+        /// <summary>
+        /// What: rewriting an existing property getter body still emits that getter as Patched
+        /// and does not emit the outside-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Run_ExistingPropertyGetterBodyEdit_KeepsPatchedGetterWithoutOutsideBodyWarning()
+        {
+            const string fileName = "ExistingPropertyGetterBodyEdit.cs";
+            TransformWorkerClientResult result = await RunWorkerOnEditedE2ECopyAsync(
+                fileName,
+                editedSource => editedSource.Replace(
+                    "get { return _secret; }",
+                    "get { return _secret + 1; }",
+                    StringComparison.Ordinal));
+
+            bool foundGetter = false;
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                if (entry.methodName == "get_ExplicitBodyGetter")
+                {
+                    foundGetter = true;
+                    break;
+                }
+            }
+
+            Assert.That(foundGetter, Is.True, "Existing getter body edit must stay Patched.");
+            AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
         }
 
         /// <summary>
@@ -1737,6 +1902,46 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             return result;
+        }
+
+        private static async Task<TransformWorkerClientResult> RunWorkerOnEditedE2ECopyAsync(
+            string fileName,
+            Func<string, string> edit)
+        {
+            string onDisk = File.ReadAllText(ResolveE2EFixturePath());
+            string editedSource = edit(onDisk);
+            Assert.That(editedSource, Is.Not.EqualTo(onDisk), "Precondition: snapshot must differ.");
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string sourcePath = Path.Combine(directory, fileName);
+            File.WriteAllText(sourcePath, editedSource);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                ResolveE2EFixtureProjectRelativePath(),
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            return result;
+        }
+
+        private static void AssertPatchedComputeWithPrivate(TransformWorkerClientResult result)
+        {
+            bool foundCompute = false;
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                if (entry.methodName == nameof(HotReloadE2EFixture.ComputeWithPrivate))
+                {
+                    foundCompute = true;
+                    break;
+                }
+            }
+
+            Assert.That(
+                foundCompute,
+                Is.True,
+                "Body edit must still emit a Patched ComputeWithPrivate entry.");
         }
 
         private static void AssertDoesNotContainOutsideMethodBodyDriftWarning(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -1008,6 +1008,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: editing only the getter of an existing getter+setter property still emits the
+        /// setter skip row and does not emit outside-body drift. Pins the snapshot ContainsKey
+        /// guard so an existing property is not stripped from the current tree alone.
+        /// </summary>
+        [Test]
+        public async Task Run_ExistingGetterAndSetterProperty_GetterBodyEdit_SkipsSetterWithoutOutsideBodyWarning()
+        {
+            const string fileName = "ExistingGetterAndSetterPropertyGetterEdit.cs";
+            string onDisk = File.ReadAllText(ResolveShapeFixturePath());
+            string editedSource = onDisk.Replace(
+                "get { return _value; }",
+                "get { return _value + 1; }",
+                StringComparison.Ordinal);
+            Assert.That(editedSource, Is.Not.EqualTo(onDisk), "Precondition: getter body must differ.");
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string sourcePath = Path.Combine(directory, fileName);
+            File.WriteAllText(sourcePath, editedSource);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                ResolveShapeFixtureProjectRelativePath(),
+                snapshotSource: onDisk);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertSkippedContains(result, "set_Value", ExpectedExplicitAccessorSkipReason);
+            AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
+        }
+
+        /// <summary>
         /// What: a snapshot that duplicates a method key falls back to no-baseline behavior
         /// (same entries as a null snapshot, empty unchangedMethods) and sets
         /// baselineDisabledByDuplicateKeys so the orchestrator can warn.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -368,7 +368,8 @@ public static class TransformWorkerProgram
                 hasBaseline ? snapshotPropertyMap : null,
                 hasBaseline ? snapshotIndexerMap : null,
                 hasBaseline ? plainCurrentPropertyMap : null,
-                hasBaseline ? plainCurrentIndexerMap : null);
+                hasBaseline ? plainCurrentIndexerMap : null,
+                addedMethodCatalog);
             AppendUnsupportedMemberKindSkips(
                 typeDeclaration,
                 typeMetadataNameFromSyntax,
@@ -446,19 +447,6 @@ public static class TransformWorkerProgram
             addedFieldCatalog,
             skipped);
 
-        if (hasBaseline && baselineSnapshotRoot != null)
-        {
-            // Why after classification: added/removed method and field declarations must be
-            // stripped before AreEquivalent, or every addition would fire "not applied".
-            AppendOutsideMethodBodyDriftWarningIfNeeded(
-                baselineSnapshotRoot,
-                plainRoot,
-                Path.GetFileName(input.SourcePath),
-                declarationDriftWarnings,
-                addedMethodCatalog,
-                addedFieldCatalog);
-        }
-
         foreach (TypeEmitState typeState in typeEmitStates)
         {
             EmitQueuedMethods(
@@ -505,6 +493,20 @@ public static class TransformWorkerProgram
                 shimTypeCounter = nextShimTypeCounter;
                 globalShimMethodCounter = nextGlobalShimMethodCounter;
             }
+        }
+
+        if (hasBaseline && baselineSnapshotRoot != null)
+        {
+            // Why after property emit: added-property syntax keys are registered when a skip
+            // row is written. Running the drift check first would miss those keys and keep
+            // the false outside-body warning for added properties that already have a row.
+            AppendOutsideMethodBodyDriftWarningIfNeeded(
+                baselineSnapshotRoot,
+                plainRoot,
+                Path.GetFileName(input.SourcePath),
+                declarationDriftWarnings,
+                addedMethodCatalog,
+                addedFieldCatalog);
         }
 
         bool hasAccessorDelegates = false;
@@ -1403,11 +1405,13 @@ public static class TransformWorkerProgram
         StripHandledMemberDeclarationsRewriter stripSnapshot =
             new StripHandledMemberDeclarationsRewriter(
                 snapshotKeys,
+                Array.Empty<string>(),
                 Array.Empty<string>());
         StripHandledMemberDeclarationsRewriter stripCurrent =
             new StripHandledMemberDeclarationsRewriter(
                 currentKeys,
-                addedMethodCatalog.AddedTypeSyntaxKeys);
+                addedMethodCatalog.AddedTypeSyntaxKeys,
+                addedMethodCatalog.AddedPropertySyntaxKeys);
         StripMethodBodiesRewriter bodyStripper = new StripMethodBodiesRewriter();
         SyntaxNode strippedSnapshot = bodyStripper.Visit(stripSnapshot.Visit(snapshotRoot));
         SyntaxNode strippedCurrent = bodyStripper.Visit(stripCurrent.Visit(currentRoot));
@@ -1422,14 +1426,19 @@ public static class TransformWorkerProgram
     {
         private readonly HashSet<string> _syntaxKeysToStrip;
         private readonly HashSet<string> _typeSyntaxKeysToStrip;
+        private readonly HashSet<string> _propertySyntaxKeysToStrip;
 
         public StripHandledMemberDeclarationsRewriter(
             IReadOnlyCollection<string> syntaxKeysToStrip,
-            IReadOnlyCollection<string> typeSyntaxKeysToStrip)
+            IReadOnlyCollection<string> typeSyntaxKeysToStrip,
+            IReadOnlyCollection<string> propertySyntaxKeysToStrip)
         {
             _syntaxKeysToStrip = new HashSet<string>(syntaxKeysToStrip, StringComparer.Ordinal);
             _typeSyntaxKeysToStrip = new HashSet<string>(
                 typeSyntaxKeysToStrip ?? Array.Empty<string>(),
+                StringComparer.Ordinal);
+            _propertySyntaxKeysToStrip = new HashSet<string>(
+                propertySyntaxKeysToStrip ?? Array.Empty<string>(),
                 StringComparer.Ordinal);
         }
 
@@ -1497,6 +1506,25 @@ public static class TransformWorkerProgram
             return base.VisitMethodDeclaration(node);
         }
 
+        public override SyntaxNode VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+        {
+            TypeDeclarationSyntax typeDeclaration = node.Parent as TypeDeclarationSyntax;
+            if (typeDeclaration == null)
+            {
+                return base.VisitPropertyDeclaration(node);
+            }
+
+            string syntaxKey = BuildSyntaxPropertyKey(
+                BuildTypeMetadataNameFromSyntax(typeDeclaration),
+                node);
+            if (_propertySyntaxKeysToStrip.Contains(syntaxKey))
+            {
+                return null;
+            }
+
+            return base.VisitPropertyDeclaration(node);
+        }
+
         public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)
         {
             TypeDeclarationSyntax typeDeclaration = node.Parent as TypeDeclarationSyntax;
@@ -1533,6 +1561,14 @@ public static class TransformWorkerProgram
 
     private sealed class StripMethodBodiesRewriter : CSharpSyntaxRewriter
     {
+        // Using directives never change patched behavior: CollectUsingsForType copies the edited
+        // file's usings into every shim, so comparing them here only produces false drift warnings
+        // for using-only edits. extern alias declarations stay compared (not copied into shims).
+        public override SyntaxNode VisitUsingDirective(UsingDirectiveSyntax node)
+        {
+            return null;
+        }
+
         public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
         {
             MethodDeclarationSyntax visited = (MethodDeclarationSyntax)base.VisitMethodDeclaration(node);
@@ -1722,7 +1758,8 @@ public static class TransformWorkerProgram
         Dictionary<string, PropertyDeclarationSyntax> snapshotPropertyMap,
         Dictionary<string, IndexerDeclarationSyntax> snapshotIndexerMap,
         Dictionary<string, PropertyDeclarationSyntax> plainCurrentPropertyMap,
-        Dictionary<string, IndexerDeclarationSyntax> plainCurrentIndexerMap)
+        Dictionary<string, IndexerDeclarationSyntax> plainCurrentIndexerMap,
+        AddedMethodCatalog addedMethodCatalog)
     {
         foreach (MemberDeclarationSyntax member in typeDeclaration.Members)
         {
@@ -1747,7 +1784,10 @@ public static class TransformWorkerProgram
                 AppendExplicitAccessorSkipsForProperty(
                     propertyDeclaration,
                     semanticModel.GetDeclaredSymbol(propertyDeclaration),
-                    skipped);
+                    skipped,
+                    typeMetadataNameFromSyntax,
+                    snapshotPropertyMap,
+                    addedMethodCatalog);
                 continue;
             }
 
@@ -1770,7 +1810,10 @@ public static class TransformWorkerProgram
                 AppendExplicitAccessorSkipsForProperty(
                     indexerDeclaration,
                     semanticModel.GetDeclaredSymbol(indexerDeclaration),
-                    skipped);
+                    skipped,
+                    typeMetadataNameFromSyntax,
+                    snapshotPropertyMap,
+                    addedMethodCatalog);
             }
         }
     }
@@ -1778,7 +1821,10 @@ public static class TransformWorkerProgram
     private static void AppendExplicitAccessorSkipsForProperty(
         BasePropertyDeclarationSyntax propertyDeclaration,
         IPropertySymbol propertySymbol,
-        List<WorkerSkipped> skipped)
+        List<WorkerSkipped> skipped,
+        string typeMetadataNameFromSyntax,
+        Dictionary<string, PropertyDeclarationSyntax> snapshotPropertyMap,
+        AddedMethodCatalog addedMethodCatalog)
     {
         if (propertySymbol == null)
         {
@@ -1798,6 +1844,7 @@ public static class TransformWorkerProgram
             return;
         }
 
+        bool emittedSkip = false;
         foreach (AccessorDeclarationSyntax accessor in propertyDeclaration.AccessorList.Accessors)
         {
             if (accessor.IsKind(SyntaxKind.GetAccessorDeclaration))
@@ -1822,6 +1869,22 @@ public static class TransformWorkerProgram
                 Method = FormatMethodLabel(accessorMethod),
                 Reason = ExplicitAccessorSkipReason
             });
+            emittedSkip = true;
+        }
+
+        PropertyDeclarationSyntax namedProperty = propertyDeclaration as PropertyDeclarationSyntax;
+        if (!emittedSkip
+            || namedProperty == null
+            || snapshotPropertyMap == null
+            || addedMethodCatalog == null)
+        {
+            return;
+        }
+
+        string propertyKey = BuildSyntaxPropertyKey(typeMetadataNameFromSyntax, namedProperty);
+        if (!snapshotPropertyMap.ContainsKey(propertyKey))
+        {
+            addedMethodCatalog.AddAddedPropertySyntaxKey(propertyKey);
         }
     }
 
@@ -2150,6 +2213,7 @@ public static class TransformWorkerProgram
                     Method = FormatMethodLabel(getterSymbol),
                     Reason = AddedMethodSkipReasons.AddedProperty
                 });
+                addedMethodCatalog.AddAddedPropertySyntaxKey(addedPropertyKey);
                 return (currentShimType, shimTypeCounter, globalShimMethodCounter);
             }
         }
@@ -7932,11 +7996,14 @@ internal sealed class AddedMethodCatalog
     private readonly HashSet<string> _classifiedAddedKeys = new HashSet<string>(StringComparer.Ordinal);
     private readonly HashSet<string> _addedSyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
     private readonly HashSet<string> _addedTypeSyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
+    private readonly HashSet<string> _addedPropertySyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
     private readonly HashSet<string> _removedSyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
 
     public IReadOnlyCollection<string> AddedSyntaxKeys => _addedSyntaxKeys;
 
     public IReadOnlyCollection<string> AddedTypeSyntaxKeys => _addedTypeSyntaxKeys;
+
+    public IReadOnlyCollection<string> AddedPropertySyntaxKeys => _addedPropertySyntaxKeys;
 
     public IReadOnlyCollection<string> RemovedSyntaxKeys => _removedSyntaxKeys;
 
@@ -7974,6 +8041,14 @@ internal sealed class AddedMethodCatalog
         if (typeSyntaxKey != null)
         {
             _addedTypeSyntaxKeys.Add(typeSyntaxKey);
+        }
+    }
+
+    public void AddAddedPropertySyntaxKey(string propertySyntaxKey)
+    {
+        if (propertySyntaxKey != null)
+        {
+            _addedPropertySyntaxKeys.Add(propertySyntaxKey);
         }
     }
 


### PR DESCRIPTION
## Summary
- Hot reload no longer warns about "edits outside method bodies" when the only extra change is a using directive, or when an added property already has its own skip row.

## User Impact
- Adding or removing a `using` while editing a method body produced a false drift warning even though patched bodies already pick up the edited file's usings.
- Adding a property with a getter or explicit accessor produced both a skip row and the same drift warning, so the warning looked like a second, unexplained failure.
- Adding an auto-property (`{ get; set; }`) still warns, because that case has no skip row and the warning is the only signal.

## Changes
- Drift comparison strips using directives from both trees.
- Added properties that emit a skip row are stripped from the comparison after those rows are registered.
- Auto-properties are left in the comparison so their warning stays.

## Verification
- `uloop compile`: Error 0 / Warning 0 on this run (the known HotReload fixture CS0067 / CS0414 pair did not appear on this incremental compile).
- Red: using-only + body edit failed until usings were stripped; added getter and setter-only properties failed until their skip rows suppressed the warning; auto-property and existing getter-body controls stayed green.
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value HotReload`: 428/428 passed (baseline 423 + 5 new tests).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

