### PR TITLE
feat: explain callers re-patched to satisfy a signature-change gate

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -154,6 +154,7 @@ applies them together without `uloop compile`.
 Call sites inside methods that the same edit removes or
 re-signatures do not gate: those compiled bodies are already stale, and anything
 still reaching them stays on the consistent old behavior.
+If an earlier reload already patched the compiled call sites, a later signature change applies without editing the callers; the response then carries a warning naming the call sites this run re-applied on the new signature.
 
 Renaming a method or changing its parameter list follows the delete rules rather
 than the gate: the new signature is an ordinary added method, the old one is

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -154,6 +154,7 @@ applies them together without `uloop compile`.
 Call sites inside methods that the same edit removes or
 re-signatures do not gate: those compiled bodies are already stale, and anything
 still reaching them stays on the consistent old behavior.
+If an earlier reload already patched the compiled call sites, a later signature change applies without editing the callers; the response then carries a warning naming the call sites this run re-applied on the new signature.
 
 Renaming a method or changing its parameter list follows the delete rules rather
 than the gate: the new signature is an ordinary added method, the old one is

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -3277,6 +3277,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertHasAdded(result, nameof(HotReloadSignatureChangeSameFileFixture.Target));
             AssertHasPatched(result, nameof(HotReloadSignatureChangeSameFileFixture.ExistingCaller));
             Assert.That(result.ActivePatchTotal, Is.EqualTo(2));
+            Assert.That(
+                CountWarningsContaining(
+                    result.Warnings,
+                    "applied because its compiled call sites were already hot-reload patched"),
+                Is.EqualTo(0),
+                "A never-active caller edited in the same run must not emit the re-patched notice.\n"
+                + string.Join("\n", result.Warnings));
 
             HotReloadSignatureChangeSameFileFixture host = new HotReloadSignatureChangeSameFileFixture();
             Assert.That(host.ExistingCaller(3), Is.EqualTo(4));
@@ -3718,6 +3725,153 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 matchingWarningCount,
                 Is.EqualTo(1),
                 "Expected exactly one re-patched notice.\n" + string.Join("\n", second.Warnings));
+        }
+
+        /// <summary>
+        /// What: a gated skip of Target plus an already-patched sibling that this run stops
+        /// calling Target does not emit an applied re-patched notice for the skipped change.
+        /// </summary>
+        [Test]
+        public async Task Run_ReturnTypeChange_GatedTargetAndSweptNonCaller_OmitsRepatchedNotice()
+        {
+            string fixturePath = ResolveSignatureChangeTwoCallerFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string callerEdited = onDisk.Replace(
+                "        public long CallerBeta(int value)\n        {\n            return Target(value);\n        }",
+                "        public long CallerBeta(int value)\n        {\n            return Target(value) + 1L;\n        }",
+                StringComparison.Ordinal);
+            Assert.That(callerEdited, Is.Not.EqualTo(onDisk));
+
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeGatedSwept1.cs", callerEdited),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(first);
+            AssertHasPatched(first, nameof(HotReloadSignatureChangeTwoCallerFixture.CallerBeta));
+
+            string mixed = callerEdited
+                .Replace(
+                    "        public int Target(int value)\n        {\n            return value;\n        }",
+                    "        public long Target(int value)\n        {\n            return value + 1L;\n        }",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "        public long CallerBeta(int value)\n        {\n            return Target(value) + 1L;\n        }",
+                    "        public long CallerBeta(int value)\n        {\n            return value;\n        }",
+                    StringComparison.Ordinal);
+            Assert.That(mixed, Is.Not.EqualTo(callerEdited));
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeGatedSwept2.cs", mixed),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(second);
+            AssertHasSkipped(
+                second,
+                nameof(HotReloadSignatureChangeTwoCallerFixture.Target),
+                "The return type of");
+            Assert.That(
+                CountWarningsContaining(
+                    second.Warnings,
+                    "applied because its compiled call sites were already hot-reload patched"),
+                Is.EqualTo(0),
+                "A gated skip must not emit an applied re-patched notice.\n"
+                + string.Join("\n", second.Warnings));
+        }
+
+        /// <summary>
+        /// What: two already-patched callers of the same old signature produce one
+        /// re-patched notice that names both callers.
+        /// </summary>
+        [Test]
+        public async Task Run_ReturnTypeChange_TwoAlreadyPatchedCallers_EmitsOneAggregatedNotice()
+        {
+            string fixturePath = ResolveSignatureChangeTwoCallerFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string callersEdited = onDisk
+                .Replace(
+                    "        public long CallerAlpha(int value)\n        {\n            return Target(value);\n        }",
+                    "        public long CallerAlpha(int value)\n        {\n            return Target(value) + 1L;\n        }",
+                    StringComparison.Ordinal)
+                .Replace(
+                    "        public long CallerBeta(int value)\n        {\n            return Target(value);\n        }",
+                    "        public long CallerBeta(int value)\n        {\n            return Target(value) + 1L;\n        }",
+                    StringComparison.Ordinal);
+            Assert.That(callersEdited, Is.Not.EqualTo(onDisk));
+
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeTwoPatchedCallers1.cs", callersEdited),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(first);
+            AssertHasPatched(first, nameof(HotReloadSignatureChangeTwoCallerFixture.CallerAlpha));
+            AssertHasPatched(first, nameof(HotReloadSignatureChangeTwoCallerFixture.CallerBeta));
+
+            string signatureEdited = callersEdited.Replace(
+                "        public int Target(int value)\n        {\n            return value;\n        }",
+                "        public long Target(int value)\n        {\n            return value + 1L;\n        }",
+                StringComparison.Ordinal);
+            Assert.That(signatureEdited, Is.Not.EqualTo(callersEdited));
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeTwoPatchedCallers2.cs", signatureEdited),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(second);
+            AssertHasAdded(second, nameof(HotReloadSignatureChangeTwoCallerFixture.Target));
+            AssertHasPatched(second, nameof(HotReloadSignatureChangeTwoCallerFixture.CallerAlpha));
+            AssertHasPatched(second, nameof(HotReloadSignatureChangeTwoCallerFixture.CallerBeta));
+
+            string expectedOldSignature =
+                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                + ".HotReloadSignatureChangeTwoCallerFixture::Target(System.Int32)";
+            string expectedCallerLabels = string.Join(
+                ", ",
+                new[]
+                {
+                    HotReloadPatcher.FormatMethodKeyParts(
+                        typeof(HotReloadSignatureChangeTwoCallerFixture).FullName,
+                        nameof(HotReloadSignatureChangeTwoCallerFixture.CallerAlpha),
+                        new[] { "System.Int32" },
+                        0),
+                    HotReloadPatcher.FormatMethodKeyParts(
+                        typeof(HotReloadSignatureChangeTwoCallerFixture).FullName,
+                        nameof(HotReloadSignatureChangeTwoCallerFixture.CallerBeta),
+                        new[] { "System.Int32" },
+                        0)
+                });
+            string expectedWarning = string.Format(
+                HotReloadConstants.SignatureChangeCallersRepatchedNoticeFormat,
+                expectedOldSignature,
+                expectedCallerLabels);
+            int matchingWarningCount = 0;
+            int noticeCount = 0;
+            foreach (string warning in second.Warnings)
+            {
+                if (warning.Contains("applied because its compiled call sites were already hot-reload patched"))
+                {
+                    noticeCount++;
+                }
+
+                if (string.Equals(warning, expectedWarning, StringComparison.Ordinal))
+                {
+                    matchingWarningCount++;
+                }
+            }
+
+            Assert.That(
+                noticeCount,
+                Is.EqualTo(1),
+                "Expected exactly one re-patched notice for one old signature.\n"
+                + string.Join("\n", second.Warnings));
+            Assert.That(
+                matchingWarningCount,
+                Is.EqualTo(1),
+                "Expected the aggregated notice to name both callers.\n"
+                + string.Join("\n", second.Warnings));
         }
 
         /// <summary>
@@ -4990,6 +5144,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 File.Exists(path),
                 Is.True,
                 "Signature-change same-file fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string ResolveSignatureChangeTwoCallerFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadSignatureChangeTwoCallerFixture.cs");
+            Assert.That(
+                File.Exists(path),
+                Is.True,
+                "Signature-change two-caller fixture source missing: " + path);
             return Path.GetFullPath(path);
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -3646,6 +3646,78 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.EqualTo(0),
                 "A gated (not applied) replacement must not appear as a removed member.\n"
                 + string.Join("\n", result.Warnings));
+            Assert.That(
+                CountWarningsContaining(
+                    result.Warnings,
+                    "applied because its compiled call sites were already hot-reload patched"),
+                Is.EqualTo(0),
+                "A never-patched caller must keep the gate skip and must not emit the re-patched notice.\n"
+                + string.Join("\n", result.Warnings));
+        }
+
+        /// <summary>
+        /// What: after a caller body patch, a later signature-only change applies and names
+        /// that already-patched caller in the re-patched notice.
+        /// </summary>
+        [Test]
+        public async Task Run_ReturnTypeChange_AlreadyPatchedCaller_EmitsRepatchedNotice()
+        {
+            string fixturePath = ResolveSignatureChangeUnchangedCallerFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string callerEdited = onDisk.Replace(
+                "        public long StoreTarget(int value)\n        {\n            return Target(value);\n        }",
+                "        public long StoreTarget(int value)\n        {\n            return Target(value) + 1L;\n        }",
+                StringComparison.Ordinal);
+            Assert.That(callerEdited, Is.Not.EqualTo(onDisk));
+
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeAlreadyPatchedCaller1.cs", callerEdited),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(first);
+            AssertHasPatched(first, nameof(HotReloadSignatureChangeUnchangedCallerFixture.StoreTarget));
+
+            string signatureEdited = callerEdited.Replace(
+                "        public int Target(int value)\n        {\n            return value;\n        }",
+                "        public long Target(int value)\n        {\n            return value + 1L;\n        }",
+                StringComparison.Ordinal);
+            Assert.That(signatureEdited, Is.Not.EqualTo(callerEdited));
+
+            HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeAlreadyPatchedCaller2.cs", signatureEdited),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(second);
+            AssertHasAdded(second, nameof(HotReloadSignatureChangeUnchangedCallerFixture.Target));
+            AssertHasPatched(second, nameof(HotReloadSignatureChangeUnchangedCallerFixture.StoreTarget));
+
+            string expectedOldSignature =
+                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                + ".HotReloadSignatureChangeUnchangedCallerFixture::Target(System.Int32)";
+            string expectedCallerLabel = HotReloadPatcher.FormatMethodKeyParts(
+                typeof(HotReloadSignatureChangeUnchangedCallerFixture).FullName,
+                nameof(HotReloadSignatureChangeUnchangedCallerFixture.StoreTarget),
+                new[] { "System.Int32" },
+                0);
+            string expectedWarning = string.Format(
+                HotReloadConstants.SignatureChangeCallersRepatchedNoticeFormat,
+                expectedOldSignature,
+                expectedCallerLabel);
+            int matchingWarningCount = 0;
+            foreach (string warning in second.Warnings)
+            {
+                if (string.Equals(warning, expectedWarning, StringComparison.Ordinal))
+                {
+                    matchingWarningCount++;
+                }
+            }
+
+            Assert.That(
+                matchingWarningCount,
+                Is.EqualTo(1),
+                "Expected exactly one re-patched notice.\n" + string.Join("\n", second.Warnings));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeTwoCallerFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeTwoCallerFixture.cs
@@ -1,0 +1,29 @@
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled host with two same-file callers of one target, so a mixed
+    /// never-patched / already-patched caller run can share one fixture.
+    /// </summary>
+    public class HotReloadSignatureChangeTwoCallerFixture
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Target(int value)
+        {
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public long CallerAlpha(int value)
+        {
+            return Target(value);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public long CallerBeta(int value)
+        {
+            return Target(value);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeTwoCallerFixture.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeTwoCallerFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac00e3c53798e4050a69690c3531f907
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -87,6 +87,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string StaleSignatureCallersWarningFormat =
             "Compiled call sites of the removed signature '{0}' are not patched by this hot reload: {1}. They keep the previous behavior until 'uloop compile'.";
 
+        public const string SignatureChangeCallersRepatchedNoticeFormat =
+            "Signature change '{0}' applied because its compiled call sites were already hot-reload patched; this run re-applied them on the new signature: {1}.";
+
         public const string SignatureChangeCoverageLostFailureFormat =
             "Isolation excluded compiled callers of '{0}'; applying the rest would leave those callers on the old version. Run 'uloop compile'.";
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -491,6 +491,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         unchangedMethodCount: unchangedMethodCount,
                         sourceContentSha256: workerOutput.sourceContentSha256);
                 }
+
+                AppendSignatureChangeCallersRepatchedWarnings(
+                    warnings,
+                    entriesToPatch,
+                    gateResult.Hits,
+                    snapshotLabels);
             }
 
             // Harmony Patch/Unpatch and method resolution against loaded modules require main thread.
@@ -2108,6 +2114,99 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return warnings;
+        }
+
+        // Why only already-patched callers: a caller the user edited this run is obvious in
+        // Methods. The non-obvious case is a caller that was already patched at run start and
+        // was re-entered only to satisfy the signature-change gate. Known limits: an
+        // already-patched caller that is also edited this run is over-reported (the text is
+        // still true); a caller that stayed Skipped and drifted is missed; constructed
+        // generics can miss when the label space differs from the wire key (same constraint
+        // as IsActiveMember).
+        private static void AppendSignatureChangeCallersRepatchedWarnings(
+            List<string> warnings,
+            TransformWorkerEntryDto[] entriesToPatch,
+            IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits,
+            HashSet<string> snapshotLabels)
+        {
+            Debug.Assert(warnings != null, "warnings must not be null.");
+            Debug.Assert(entriesToPatch != null, "entriesToPatch must not be null.");
+            Debug.Assert(hits != null, "hits must not be null.");
+            Debug.Assert(snapshotLabels != null, "snapshotLabels must not be null.");
+
+            HashSet<string> entryKeys = new HashSet<string>(StringComparer.Ordinal);
+            foreach (TransformWorkerEntryDto entry in entriesToPatch)
+            {
+                entryKeys.Add(BuildMethodKey(entry));
+            }
+
+            Dictionary<string, List<string>> callerLabelsByOldSignature =
+                new Dictionary<string, List<string>>(StringComparer.Ordinal);
+            foreach (HotReloadCallSiteScanner.CallSiteHit hit in hits)
+            {
+                if (hit == null || !entryKeys.Contains(hit.CallerMethodKey))
+                {
+                    continue;
+                }
+
+                string callerLabel = FormatCallSiteCallerLabel(hit);
+                if (!snapshotLabels.Contains(callerLabel))
+                {
+                    continue;
+                }
+
+                if (!callerLabelsByOldSignature.TryGetValue(
+                    hit.TargetMethodKey,
+                    out List<string> callerLabels))
+                {
+                    callerLabels = new List<string>();
+                    callerLabelsByOldSignature.Add(hit.TargetMethodKey, callerLabels);
+                }
+
+                if (!callerLabels.Contains(callerLabel))
+                {
+                    callerLabels.Add(callerLabel);
+                }
+            }
+
+            foreach (KeyValuePair<string, List<string>> pair in callerLabelsByOldSignature)
+            {
+                warnings.Add(
+                    string.Format(
+                        HotReloadConstants.SignatureChangeCallersRepatchedNoticeFormat,
+                        pair.Key,
+                        string.Join(", ", pair.Value)));
+            }
+        }
+
+        private static string FormatCallSiteCallerLabel(HotReloadCallSiteScanner.CallSiteHit hit)
+        {
+            Debug.Assert(hit != null, "hit must not be null.");
+            return HotReloadPatcher.FormatMethodKeyParts(
+                hit.CallerTypeMetadataName,
+                hit.CallerMethodName,
+                hit.CallerParameterTypeFullNames ?? Array.Empty<string>(),
+                ReadGenericArityFromWireMethodKey(hit.CallerMethodKey, hit.CallerMethodName));
+        }
+
+        private static int ReadGenericArityFromWireMethodKey(string methodKey, string methodName)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(methodKey), "methodKey must not be null or empty.");
+            Debug.Assert(!string.IsNullOrEmpty(methodName), "methodName must not be null or empty.");
+
+            string arityPrefix = "::" + methodName + "`";
+            int arityPrefixIndex = methodKey.IndexOf(arityPrefix, StringComparison.Ordinal);
+            if (arityPrefixIndex < 0)
+            {
+                return 0;
+            }
+
+            int arityStart = arityPrefixIndex + arityPrefix.Length;
+            int arityEnd = methodKey.IndexOf('(', arityStart);
+            Debug.Assert(arityEnd > arityStart, "wire method key arity must precede '('.");
+            return int.Parse(
+                methodKey.Substring(arityStart, arityEnd - arityStart),
+                CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -2116,13 +2116,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return warnings;
         }
 
-        // Why only already-patched callers: a caller the user edited this run is obvious in
-        // Methods. The non-obvious case is a caller that was already patched at run start and
-        // was re-entered only to satisfy the signature-change gate. Known limits: an
-        // already-patched caller that is also edited this run is over-reported (the text is
-        // still true); a caller that stayed Skipped and drifted is missed; constructed
-        // generics can miss when the label space differs from the wire key (same constraint
-        // as IsActiveMember).
+        // Why only already-patched callers of applied replacements: a caller the user
+        // edited this run is obvious in Methods. The non-obvious case is a caller that
+        // was already patched at run start and was re-entered only to satisfy the
+        // signature-change gate. Hits still list gated replacements and rename/param
+        // removals, so restrict to replacements that remain in the apply set. Known
+        // limits: an already-patched caller that is also edited this run is
+        // over-reported (the text is still true); a caller that stayed Skipped and
+        // drifted is missed; constructed generics can miss when the label space differs
+        // from the wire key (same constraint as IsActiveMember).
         private static void AppendSignatureChangeCallersRepatchedWarnings(
             List<string> warnings,
             TransformWorkerEntryDto[] entriesToPatch,
@@ -2135,16 +2137,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(snapshotLabels != null, "snapshotLabels must not be null.");
 
             HashSet<string> entryKeys = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<string> appliedReplacementKeys = new HashSet<string>(StringComparer.Ordinal);
             foreach (TransformWorkerEntryDto entry in entriesToPatch)
             {
-                entryKeys.Add(BuildMethodKey(entry));
+                string methodKey = BuildMethodKey(entry);
+                entryKeys.Add(methodKey);
+                if (entry.replacesCompiledMethod)
+                {
+                    appliedReplacementKeys.Add(methodKey);
+                }
             }
 
             Dictionary<string, List<string>> callerLabelsByOldSignature =
                 new Dictionary<string, List<string>>(StringComparer.Ordinal);
             foreach (HotReloadCallSiteScanner.CallSiteHit hit in hits)
             {
-                if (hit == null || !entryKeys.Contains(hit.CallerMethodKey))
+                if (hit == null
+                    || !appliedReplacementKeys.Contains(hit.TargetMethodKey)
+                    || !entryKeys.Contains(hit.CallerMethodKey))
                 {
                     continue;
                 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -154,6 +154,7 @@ applies them together without `uloop compile`.
 Call sites inside methods that the same edit removes or
 re-signatures do not gate: those compiled bodies are already stale, and anything
 still reaching them stays on the consistent old behavior.
+If an earlier reload already patched the compiled call sites, a later signature change applies without editing the callers; the response then carries a warning naming the call sites this run re-applied on the new signature.
 
 Renaming a method or changing its parameter list follows the delete rules rather
 than the gate: the new signature is an ordinary added method, the old one is


### PR DESCRIPTION
## Summary
- A later signature change can apply without editing callers when an earlier reload already patched those compiled call sites.
- The response now includes a warning that names the call sites this run re-applied on the new signature, so Applied no longer looks unexplained next to a prior Skipped.
- Skill text documents the same Applied-side notice.

## Test plan
- [ ] Edit a caller body, reload, then change only the callee signature and reload: the second run applies and lists the already-patched caller in the new warning.
- [ ] Change a signature while its same-file caller has never been patched: the run stays Skipped with the existing gate wording and does not emit the new warning.
- [ ] Confirm generated skill copies include the new sentence.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

