### PR TITLE
feat: report the compiled method span when a pause point lands in a patched body

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -331,6 +331,7 @@ enforcing exclusivity, every patch transition re-targets them:
 - Enabling a new pause point on a currently patched method resolves against the patched
   body directly. `PAUSE_POINT_PATCHED_BY_HOT_RELOAD` is returned only when the line
   cannot be mapped onto it (a stale line map or a superseded generation).
+  When the compiled line range of the patched method is known, the failure message also reports it, so you can see how far the edited file's line numbers have shifted from the compiled source.
 - `uloop hot-reload --revert-all` (or reverting a method's patch) re-targets armed
   markers back onto the compiled body; a marker whose line no longer resolves there
   stays suppressed with a reason until `uloop compile` and a re-enable.

--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -190,6 +190,7 @@ armed on the edited code. Methods the reload did not patch are the opposite case
 requested line cannot be mapped onto the patched body — the file's line map is stale or
 the patch belongs to a superseded hot-reload generation. Pick a line inside the edited
 method body, run `uloop hot-reload --revert-all`, or run `uloop compile`, then retry.
+When the compiled line range of the patched method is known, the failure message also reports it, so you can see how far the edited file's line numbers have shifted from the compiled source.
 `SuppressedByHotReload: true` on a status response means a later hot-reload transition
 (apply, a newer generation, or revert) could not re-target the armed marker; the reason
 is in `SuppressedByHotReloadReason` and surfaced as the status `Warning`. The marker is

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -331,6 +331,7 @@ enforcing exclusivity, every patch transition re-targets them:
 - Enabling a new pause point on a currently patched method resolves against the patched
   body directly. `PAUSE_POINT_PATCHED_BY_HOT_RELOAD` is returned only when the line
   cannot be mapped onto it (a stale line map or a superseded generation).
+  When the compiled line range of the patched method is known, the failure message also reports it, so you can see how far the edited file's line numbers have shifted from the compiled source.
 - `uloop hot-reload --revert-all` (or reverting a method's patch) re-targets armed
   markers back onto the compiled body; a marker whose line no longer resolves there
   stays suppressed with a reason until `uloop compile` and a re-enable.

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -190,6 +190,7 @@ armed on the edited code. Methods the reload did not patch are the opposite case
 requested line cannot be mapped onto the patched body — the file's line map is stale or
 the patch belongs to a superseded hot-reload generation. Pick a line inside the edited
 method body, run `uloop hot-reload --revert-all`, or run `uloop compile`, then retry.
+When the compiled line range of the patched method is known, the failure message also reports it, so you can see how far the edited file's line numbers have shifted from the compiled source.
 `SuppressedByHotReload: true` on a status response means a later hot-reload transition
 (apply, a newer generation, or revert) could not re-target the armed marker; the reason
 is in `SuppressedByHotReloadReason` and surfaced as the status `Warning`. The marker is

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
@@ -664,6 +664,59 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a synthetic resolution with a compiled method span appends that span to the
+        /// patched-by-hot-reload failure message.
+        /// </summary>
+        [Test]
+        public void Patch_OnHotReloadedMethod_WithCompiledSpan_AppendsSpanSentence()
+        {
+            MethodInfo original = AccessTools.Method(
+                typeof(HotReloadPausePointContractFixture),
+                nameof(HotReloadPausePointContractFixture.ReplaceableCompute));
+            MethodInfo shim = AccessTools.Method(
+                typeof(HotReloadPausePointContractShims),
+                nameof(HotReloadPausePointContractShims.ReplaceableCompute__shim0));
+
+            Assert.That(
+                HotReloadPatcher.Apply(original, shim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
+                Is.True);
+
+            const int requestedLine = 42;
+            const int compiledStart = 10;
+            const int compiledEnd = 20;
+            SourcePausePointPatchResult result = SourcePausePointPatcher.Patch(
+                "contract-reject-on-patched-span",
+                BuildSyntheticResolution(
+                    original,
+                    instructionIndex: 5000,
+                    compiledMethodStartLine: compiledStart,
+                    compiledMethodEndLine: compiledEnd),
+                normalizedFile: "Assets/Tests/Editor/HotReload/HotReloadPausePointContractFixture.cs",
+                requestedLine: requestedLine);
+
+            string expectedMessage =
+                string.Format(
+                    SourcePausePointConstants.HotReloadPatchedLineOutsidePatchedBodyMessageFormat,
+                    nameof(HotReloadPausePointContractFixture),
+                    nameof(HotReloadPausePointContractFixture.ReplaceableCompute),
+                    requestedLine)
+                + string.Format(
+                    SourcePausePointConstants.HotReloadPatchedCompiledMethodSpanFormat,
+                    nameof(HotReloadPausePointContractFixture),
+                    nameof(HotReloadPausePointContractFixture.ReplaceableCompute),
+                    compiledStart,
+                    compiledEnd);
+            Assert.That(result.Success, Is.False);
+            Assert.That(
+                result.FailureReason,
+                Is.EqualTo(SourcePausePointPatchFailureReason.MethodPatchedByHotReload));
+            Assert.That(result.ErrorMessage, Is.EqualTo(expectedMessage));
+            Assert.That(
+                result.Hint,
+                Is.EqualTo(SourcePausePointConstants.HotReloadPatchedLineOutsidePatchedBodyNextAction));
+        }
+
+        /// <summary>
         /// What: enable on an unedited method in a hot-reloaded file still uses the compiled
         /// resolver (NotInPatchedMethod fallthrough) and hits.
         /// </summary>
@@ -832,7 +885,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private static SourcePausePointResolution BuildSyntheticResolution(
             MethodBase method,
-            int instructionIndex)
+            int instructionIndex,
+            int compiledMethodStartLine = 0,
+            int compiledMethodEndLine = 0)
         {
             return new SourcePausePointResolution(
                 method.Module.Assembly.GetName().Name,
@@ -845,6 +900,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 0,
                 1,
                 1,
+                compiledMethodStartLine,
+                compiledMethodEndLine,
                 Array.Empty<SourcePausePointLocalVariable>(),
                 Array.Empty<SourcePausePointParameter>());
         }

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -1456,6 +1456,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 resolution.IlOffset,
                 resolution.ResolvedLine,
                 resolution.ResolvedEndLine,
+                resolution.CompiledMethodStartLine,
+                resolution.CompiledMethodEndLine,
                 resolution.Locals,
                 resolution.Parameters);
         }

--- a/Assets/Tests/Editor/SourcePausePointPatcher/SourcePausePointPatcherTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointPatcher/SourcePausePointPatcherTests.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.Tests.SourcePausePointPatcherFixtures;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
@@ -21,17 +22,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private const string FixturesDirectory = "Assets/Tests/Editor/SourcePausePointPatcher/Fixtures/";
 
         private FakePausePointPauseController _pauseController;
+        private Func<MethodBase, MethodBase> _previousGetActiveShim;
 
         [SetUp]
         public void SetUp()
         {
             _pauseController = new FakePausePointPauseController();
             UloopPausePointRegistry.ConfigureForTests(_pauseController, () => DateTime.UtcNow);
+            _previousGetActiveShim = HotReloadPausePointCoordination.GetActiveShimForMethod;
         }
 
         [TearDown]
         public void TearDown()
         {
+            HotReloadPausePointCoordination.GetActiveShimForMethod = _previousGetActiveShim;
             SourcePausePointPatcher.UnpatchAll();
             UloopPausePointRegistry.ResetForTests();
         }
@@ -602,6 +606,75 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result.Hint, Is.Not.Empty);
         }
 
+        /// <summary>
+        /// What: a hot-reload patched method with no compiled span keeps the existing
+        /// patched-by-hot-reload failure message.
+        /// </summary>
+        [Test]
+        public void Patch_OnHotReloadedMethod_WithoutCompiledSpan_KeepsExistingMessage()
+        {
+            MethodBase method = typeof(PatcherStaticMethodFixture).GetMethod(nameof(PatcherStaticMethodFixture.Add));
+            HotReloadPausePointCoordination.GetActiveShimForMethod = _ => method;
+            const int requestedLine = 42;
+            SourcePausePointPatchResult result = SourcePausePointPatcher.Patch(
+                "patcher-hot-reload-no-span",
+                BuildSyntheticResolution(method),
+                requestedLine: requestedLine);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(
+                result.FailureReason,
+                Is.EqualTo(SourcePausePointPatchFailureReason.MethodPatchedByHotReload));
+            Assert.That(
+                result.ErrorMessage,
+                Is.EqualTo(
+                    string.Format(
+                        SourcePausePointConstants.HotReloadPatchedLineOutsidePatchedBodyMessageFormat,
+                        method.DeclaringType.Name,
+                        method.Name,
+                        requestedLine)));
+        }
+
+        /// <summary>
+        /// What: a hot-reload patched method with a compiled span appends that span to the
+        /// patched-by-hot-reload failure message.
+        /// </summary>
+        [Test]
+        public void Patch_OnHotReloadedMethod_WithCompiledSpan_AppendsSpanSentence()
+        {
+            MethodBase method = typeof(PatcherStaticMethodFixture).GetMethod(nameof(PatcherStaticMethodFixture.Add));
+            HotReloadPausePointCoordination.GetActiveShimForMethod = _ => method;
+            const int requestedLine = 42;
+            const int compiledStart = 10;
+            const int compiledEnd = 20;
+            SourcePausePointPatchResult result = SourcePausePointPatcher.Patch(
+                "patcher-hot-reload-span",
+                BuildSyntheticResolutionWithMvid(
+                    method,
+                    method.Module.ModuleVersionId.ToString(),
+                    compiledStart,
+                    compiledEnd),
+                requestedLine: requestedLine);
+
+            string expectedMessage =
+                string.Format(
+                    SourcePausePointConstants.HotReloadPatchedLineOutsidePatchedBodyMessageFormat,
+                    method.DeclaringType.Name,
+                    method.Name,
+                    requestedLine)
+                + string.Format(
+                    SourcePausePointConstants.HotReloadPatchedCompiledMethodSpanFormat,
+                    method.DeclaringType.Name,
+                    method.Name,
+                    compiledStart,
+                    compiledEnd);
+            Assert.That(result.Success, Is.False);
+            Assert.That(
+                result.FailureReason,
+                Is.EqualTo(SourcePausePointPatchFailureReason.MethodPatchedByHotReload));
+            Assert.That(result.ErrorMessage, Is.EqualTo(expectedMessage));
+        }
+
         // Builds a resolution good enough to reach SourcePausePointPatcher's patchability gate; the
         // instruction index and locals/parameters are never read because every case here fails before that.
         private static SourcePausePointResolution BuildSyntheticResolution(MethodBase method)
@@ -611,7 +684,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
         // Same as BuildSyntheticResolution but lets a test supply a deliberately wrong Mvid, to
         // exercise the stale-assembly gate without needing a second compiled assembly.
-        private static SourcePausePointResolution BuildSyntheticResolutionWithMvid(MethodBase method, string mvid)
+        private static SourcePausePointResolution BuildSyntheticResolutionWithMvid(
+            MethodBase method,
+            string mvid,
+            int compiledMethodStartLine = 0,
+            int compiledMethodEndLine = 0)
         {
             return new SourcePausePointResolution(
                 method.Module.Assembly.GetName().Name,
@@ -624,6 +701,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 0,
                 1,
                 1,
+                compiledMethodStartLine,
+                compiledMethodEndLine,
                 Array.Empty<SourcePausePointLocalVariable>(),
                 Array.Empty<SourcePausePointParameter>());
         }

--- a/Assets/Tests/Editor/SourcePausePointPatcher/UnityCLILoop.Tests.Editor.SourcePausePointPatcher.asmdef
+++ b/Assets/Tests/Editor/SourcePausePointPatcher/UnityCLILoop.Tests.Editor.SourcePausePointPatcher.asmdef
@@ -5,7 +5,8 @@
         "GUID:0acc523941302664db1f4e527237feb3",
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
         "GUID:94d8abc693f543a691a4645a5ff42e5c",
-        "GUID:527f26a36b5043c2bd4d4036d04cd76d"
+        "GUID:527f26a36b5043c2bd4d4036d04cd76d",
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
     ],
     "includePlatforms": [
         "Editor"

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/CompiledMethodSpanFixture.cs
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/CompiledMethodSpanFixture.cs
@@ -1,0 +1,19 @@
+// FROZEN FIXTURE: content and line numbers are asserted by SourcePausePointResolverTests.
+// Do not reformat or edit this file; add a new fixture file instead.
+namespace io.github.hatayama.UnityCliLoop.Tests.SourcePausePointResolverFixtures
+{
+    internal sealed class CompiledMethodSpanFixture
+    {
+        public int Target(int value)
+        {
+            int doubled = value * 2;
+            return doubled;
+        }
+
+        public int OtherMethod(int value)
+        {
+            int tripled = value * 3;
+            return tripled;
+        }
+    }
+}

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/CompiledMethodSpanFixture.cs.meta
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/CompiledMethodSpanFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4bfad656bb3124718bbd5e03142ee982
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointResolverTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointResolverTests.cs
@@ -154,6 +154,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result.Resolution.ResolvedEndLine, Is.EqualTo(13));
         }
 
+        /// <summary>
+        /// What: the compiled span covers only the resolved method, not a sibling method
+        /// in the same file.
+        /// </summary>
+        [Test]
+        public void Resolve_CompiledMethodSpan_PinsStartAndEndOfResolvedMethodOnly()
+        {
+            SourcePausePointResolveResult result = SourcePausePointResolver.Resolve(
+                FixturesDirectory + "CompiledMethodSpanFixture.cs", 9);
+
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.Resolution.ResolvedLine, Is.EqualTo(9));
+            Assert.That(result.Resolution.CompiledMethodStartLine, Is.EqualTo(8));
+            Assert.That(result.Resolution.CompiledMethodEndLine, Is.EqualTo(11));
+        }
+
         [Test]
         public void Resolve_WhenPathIsOutsideAnyScriptFolder_ReturnsScriptNotInAnyAssemblyFailure()
         {

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -190,6 +190,7 @@ armed on the edited code. Methods the reload did not patch are the opposite case
 requested line cannot be mapped onto the patched body — the file's line map is stale or
 the patch belongs to a superseded hot-reload generation. Pick a line inside the edited
 method body, run `uloop hot-reload --revert-all`, or run `uloop compile`, then retry.
+When the compiled line range of the patched method is known, the failure message also reports it, so you can see how far the edited file's line numbers have shifted from the compiled source.
 `SuppressedByHotReload: true` on a status response means a later hot-reload transition
 (apply, a newer generation, or revert) could not re-target the armed marker; the reason
 is in `SuppressedByHotReloadReason` and surfaced as the status `Warning`. The marker is

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -331,6 +331,7 @@ enforcing exclusivity, every patch transition re-targets them:
 - Enabling a new pause point on a currently patched method resolves against the patched
   body directly. `PAUSE_POINT_PATCHED_BY_HOT_RELOAD` is returned only when the line
   cannot be mapped onto it (a stale line map or a superseded generation).
+  When the compiled line range of the patched method is known, the failure message also reports it, so you can see how far the edited file's line numbers have shifted from the compiled source.
 - `uloop hot-reload --revert-all` (or reverting a method's patch) re-targets armed
   markers back onto the compiled body; a marker whose line no longer resolves there
   stays suppressed with a reason until `uloop compile` and a re-enable.

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -220,5 +220,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string HotReloadPatchedLineOutsidePatchedBodyNextAction =
             "Pick a line inside the edited method body, run 'uloop hot-reload --revert-all' to "
             + "restore compiled bodies, or run 'uloop compile' to realign line numbers.";
+
+        public const string HotReloadPatchedCompiledMethodSpanFormat =
+            " In the last compiled source, '{0}.{1}' spans lines {2}-{3}.";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -442,13 +442,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (patchedByHotReload)
             {
                 string typeName = method.DeclaringType != null ? method.DeclaringType.Name : "?";
-                return SourcePausePointPatchResult.Failure(
-                    SourcePausePointPatchFailureReason.MethodPatchedByHotReload,
-                    string.Format(
-                        SourcePausePointConstants.HotReloadPatchedLineOutsidePatchedBodyMessageFormat,
+                string errorMessage = string.Format(
+                    SourcePausePointConstants.HotReloadPatchedLineOutsidePatchedBodyMessageFormat,
+                    typeName,
+                    method.Name,
+                    requestedLine);
+                if (resolution.CompiledMethodStartLine > 0 && resolution.CompiledMethodEndLine > 0)
+                {
+                    errorMessage += string.Format(
+                        SourcePausePointConstants.HotReloadPatchedCompiledMethodSpanFormat,
                         typeName,
                         method.Name,
-                        requestedLine),
+                        resolution.CompiledMethodStartLine,
+                        resolution.CompiledMethodEndLine);
+                }
+
+                return SourcePausePointPatchResult.Failure(
+                    SourcePausePointPatchFailureReason.MethodPatchedByHotReload,
+                    errorMessage,
                     SourcePausePointConstants.HotReloadPatchedLineOutsidePatchedBodyNextAction);
             }
 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolution.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolution.cs
@@ -20,6 +20,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Sequence-point EndLine is internal transport for joining ResolvedLineText.
         // It is not a CLI response field.
         public int ResolvedEndLine { get; }
+        // Compiled method span is internal transport for the patched-by-hot-reload
+        // failure message. It is not a CLI response field.
+        public int CompiledMethodStartLine { get; }
+        public int CompiledMethodEndLine { get; }
         public IReadOnlyList<SourcePausePointLocalVariable> Locals { get; }
         public IReadOnlyList<SourcePausePointParameter> Parameters { get; }
 
@@ -34,6 +38,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int ilOffset,
             int resolvedLine,
             int resolvedEndLine,
+            int compiledMethodStartLine,
+            int compiledMethodEndLine,
             IReadOnlyList<SourcePausePointLocalVariable> locals,
             IReadOnlyList<SourcePausePointParameter> parameters)
         {
@@ -47,6 +53,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             IlOffset = ilOffset;
             ResolvedLine = resolvedLine;
             ResolvedEndLine = resolvedEndLine;
+            CompiledMethodStartLine = compiledMethodStartLine;
+            CompiledMethodEndLine = compiledMethodEndLine;
             Locals = locals;
             Parameters = parameters;
         }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs
@@ -96,6 +96,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             List<SourcePausePointLocalVariable> locals = CollectCapturableLocals(method, sequencePoint.Offset);
             List<SourcePausePointParameter> parameters = CollectParameters(method);
+            (int compiledMethodStartLine, int compiledMethodEndLine) = CollectCompiledMethodSpan(
+                method,
+                normalizedInputPath);
 
             SourcePausePointResolution resolution = new SourcePausePointResolution(
                 assemblyName,
@@ -108,6 +111,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 sequencePoint.Offset,
                 sequencePoint.StartLine,
                 sequencePoint.EndLine,
+                compiledMethodStartLine,
+                compiledMethodEndLine,
                 locals,
                 parameters);
 
@@ -154,6 +159,52 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return (bestMethod, bestSequencePoint);
+        }
+
+        // Why after bestMethod is chosen: the candidate loop walks every method in the
+        // document and also skips StartLine < requested line, so min/max there would be
+        // the whole file or a truncated body. Hidden points are 0xFEEFEE (16707566).
+        private static (int startLine, int endLine) CollectCompiledMethodSpan(
+            MethodDefinition method,
+            string normalizedInputPath)
+        {
+            Debug.Assert(method != null, "method must not be null.");
+            Debug.Assert(!string.IsNullOrEmpty(normalizedInputPath), "normalizedInputPath must not be empty.");
+
+            MethodDebugInformation debugInformation = method.DebugInformation;
+            if (debugInformation == null || !debugInformation.HasSequencePoints)
+            {
+                return (0, 0);
+            }
+
+            int startLine = 0;
+            int endLine = 0;
+            foreach (SequencePoint sequencePoint in debugInformation.SequencePoints)
+            {
+                if (sequencePoint.IsHidden)
+                {
+                    continue;
+                }
+
+                if (!SourcePausePointPathNormalizer.PathsReferToSameFile(
+                    sequencePoint.Document.Url,
+                    normalizedInputPath))
+                {
+                    continue;
+                }
+
+                if (startLine == 0 || sequencePoint.StartLine < startLine)
+                {
+                    startLine = sequencePoint.StartLine;
+                }
+
+                if (sequencePoint.EndLine > endLine)
+                {
+                    endLine = sequencePoint.EndLine;
+                }
+            }
+
+            return (startLine, endLine);
         }
 
         // Shared with SourcePausePointShimResolver so shim-assembly sequence-point walks use the

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -221,6 +221,7 @@ Wire details:
   a later patch transition restores the line or `uloop compile` runs. Enabling a new
   marker on a patched method is rejected with `PAUSE_POINT_PATCHED_BY_HOT_RELOAD` only
   when the line cannot be mapped onto the patched body.
+  When the compiled line range of the patched method is known, the failure message also reports it, so you can see how far the edited file's line numbers have shifted from the compiled source.
 
 ## Open Questions Tracked for Implementation
 


### PR DESCRIPTION
## Summary
- When `enable-pause-point --line` lands inside a hot-reload patched method and cannot be mapped onto the patched body, the failure message now includes that method's compiled source line range when it is known.
- The extra sentence is informational only. Recovery is still the existing next action (pick a line in the edited body, revert-all, or compile). It does not tell you to re-aim inside the compiled span.

## Test plan
- [ ] Enable a pause point on a stale line that resolves into a hot-reload patched method: the failure message ends with `In the last compiled source, 'Type.Method' spans lines N-M.`
- [ ] The same failure without a compiled span keeps the previous message and next action.
- [ ] Resolver coverage pins the span to the resolved method only, not a sibling method in the same file.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

