### PR TITLE
fix: report actual ClearedCount when clearing a pause point by id

### DIFF
--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -55,7 +55,7 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is 0 or 1 for `--id`, and the number of markers actually cleared for `--all`.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -55,7 +55,7 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is 0 or 1 for `--id`, and the number of markers actually cleared for `--all`.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/Assets/Tests/Editor/PausePointCaptureModeTests.cs
+++ b/Assets/Tests/Editor/PausePointCaptureModeTests.cs
@@ -116,7 +116,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.Enable("jump", 30, UloopPausePointCaptureMode.Continuous, 20);
             UloopPausePointRegistry.Hit("jump");
 
-            (UloopPausePointSnapshot snapshot, _) = UloopPausePointRegistry.Clear("jump");
+            (UloopPausePointSnapshot snapshot, _, _) = UloopPausePointRegistry.Clear("jump");
 
             Assert.That(snapshot.IsEnabled, Is.False);
             Assert.That(snapshot.CapturedVariableHistory, Has.Count.EqualTo(1));

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -315,7 +315,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies explicit clear prevents later marker hits from pausing Unity.
             UloopPausePointRegistry.Enable("jump", 30);
 
-            (UloopPausePointSnapshot snapshot, _) = UloopPausePointRegistry.Clear("jump");
+            (UloopPausePointSnapshot snapshot, _, _) = UloopPausePointRegistry.Clear("jump");
             UloopPausePoint.Pause("jump");
 
             Assert.That(snapshot.Status, Is.EqualTo(UloopPausePointStatus.Cleared));
@@ -330,7 +330,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.Enable("jump", 30);
             UloopPausePoint.Pause("jump");
 
-            (UloopPausePointSnapshot snapshot, _) = UloopPausePointRegistry.Clear("jump");
+            (UloopPausePointSnapshot snapshot, _, _) = UloopPausePointRegistry.Clear("jump");
 
             Assert.That(snapshot.Message, Is.EqualTo("Pause point was already hit (auto-disarmed); nothing to clear."));
             Assert.That(_pauseController.IsPaused, Is.False);
@@ -344,7 +344,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePoint.Pause("jump");
             Assert.That(_pauseController.IsPaused, Is.True);
 
-            (UloopPausePointSnapshot _, bool resumedFromPause) = UloopPausePointRegistry.Clear("jump");
+            (UloopPausePointSnapshot _, bool resumedFromPause, _) = UloopPausePointRegistry.Clear("jump");
 
             Assert.That(resumedFromPause, Is.True);
             Assert.That(_pauseController.IsPaused, Is.False);
@@ -357,7 +357,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.Enable("jump", 30);
             _pauseController.PauseExternally();
 
-            (UloopPausePointSnapshot _, bool resumedFromPause) = UloopPausePointRegistry.Clear("jump");
+            (UloopPausePointSnapshot _, bool resumedFromPause, _) = UloopPausePointRegistry.Clear("jump");
 
             Assert.That(resumedFromPause, Is.False);
             Assert.That(_pauseController.IsPaused, Is.True);
@@ -403,7 +403,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePoint.Pause("jump");
             _pauseController.ResumeExternally();
 
-            (UloopPausePointSnapshot _, bool resumedFromPause) = UloopPausePointRegistry.Clear("jump");
+            (UloopPausePointSnapshot _, bool resumedFromPause, _) = UloopPausePointRegistry.Clear("jump");
 
             Assert.That(resumedFromPause, Is.False);
             Assert.That(_pauseController.ResumeCount, Is.EqualTo(0));
@@ -602,7 +602,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.Enable("jump", 1);
             _nowUtc = _nowUtc.AddSeconds(2);
 
-            (UloopPausePointSnapshot snapshot, _) = UloopPausePointRegistry.Clear("jump");
+            (UloopPausePointSnapshot snapshot, _, _) = UloopPausePointRegistry.Clear("jump");
 
             Assert.That(snapshot.Message, Is.EqualTo("Pause point had already expired before being hit; nothing to clear."));
         }
@@ -614,9 +614,49 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.Enable("jump", 30);
             UloopPausePointRegistry.Clear("jump");
 
-            (UloopPausePointSnapshot snapshot, _) = UloopPausePointRegistry.Clear("jump");
+            (UloopPausePointSnapshot snapshot, _, _) = UloopPausePointRegistry.Clear("jump");
 
             Assert.That(snapshot.Message, Is.EqualTo("Pause point was already cleared."));
+        }
+
+        /// <summary>
+        /// Verifies Clear(id) reports 1 when an enabled marker that has been hit is actually cleared.
+        /// </summary>
+        [Test]
+        public void Clear_WhenHitMarkerIsCleared_ReportsClearedCountOne()
+        {
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+
+            (UloopPausePointSnapshot _, bool _, int clearedCount) = UloopPausePointRegistry.Clear("jump");
+
+            Assert.That(clearedCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// Verifies Clear(id) reports 0 for an id that was never enabled.
+        /// </summary>
+        [Test]
+        public void Clear_WhenIdIsUnknown_ReportsClearedCountZero()
+        {
+            (UloopPausePointSnapshot _, bool _, int clearedCount) = UloopPausePointRegistry.Clear("missing");
+
+            Assert.That(clearedCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies a second Clear(id) on the same marker reports 0 instead of recounting the first clear.
+        /// </summary>
+        [Test]
+        public void Clear_WhenSameIdClearedTwice_ReportsZeroOnSecondClear()
+        {
+            UloopPausePointRegistry.Enable("jump", 30);
+            (UloopPausePointSnapshot _, bool _, int firstClearedCount) = UloopPausePointRegistry.Clear("jump");
+
+            (UloopPausePointSnapshot _, bool _, int secondClearedCount) = UloopPausePointRegistry.Clear("jump");
+
+            Assert.That(firstClearedCount, Is.EqualTo(1));
+            Assert.That(secondClearedCount, Is.EqualTo(0));
         }
 
         [Test]
@@ -664,6 +704,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
 
             Assert.That(response.Warning, Is.Empty);
+        }
+
+        /// <summary>
+        /// Verifies clear-pause-point --id reports ClearedCount 1 through the public tool response path.
+        /// </summary>
+        [Test]
+        public async Task ClearPausePointTool_WhenClearingById_ReportsClearedCountOne()
+        {
+            UloopPausePointRegistry.Enable("jump", 30);
+
+            ClearPausePointTool tool = new();
+            JObject parameters = new() { ["id"] = "jump" };
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.ClearedCount, Is.EqualTo(1));
         }
 
         [Test]

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -659,6 +659,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(secondClearedCount, Is.EqualTo(0));
         }
 
+        /// <summary>
+        /// Verifies Clear(id) reports 1 when the first clear happens after the capture window expired.
+        /// </summary>
+        [Test]
+        public void Clear_WhenExpiredMarkerIsCleared_ReportsClearedCountOne()
+        {
+            UloopPausePointRegistry.Enable("jump", 1);
+            _nowUtc = _nowUtc.AddSeconds(2);
+
+            (UloopPausePointSnapshot _, bool _, int clearedCount) = UloopPausePointRegistry.Clear("jump");
+
+            Assert.That(clearedCount, Is.EqualTo(1));
+        }
+
         [Test]
         public async Task ClearAll_WhenNothingActive_ReportsNoActiveMessage()
         {
@@ -719,6 +733,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
 
             Assert.That(response.ClearedCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// Verifies clear-pause-point --id reports ClearedCount 0 on a no-op second clear through the public tool path.
+        /// </summary>
+        [Test]
+        public async Task ClearPausePointTool_WhenClearingSameIdTwice_ReportsClearedCountZeroOnSecondCall()
+        {
+            UloopPausePointRegistry.Enable("jump", 30);
+            ClearPausePointTool tool = new();
+            JObject parameters = new() { ["id"] = "jump" };
+            await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.ClearedCount, Is.EqualTo(0));
         }
 
         [Test]

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -55,7 +55,7 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is 0 or 1 for `--id`, and the number of markers actually cleared for `--all`.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -425,7 +425,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     "Pass --id with the id returned by enable-pause-point, or use --all to clear every marker.");
             }
 
-            (UloopPausePointSnapshot snapshot, bool resumedFromPause) = UloopPausePointRegistry.Clear(parameters.Id);
+            (UloopPausePointSnapshot snapshot, bool resumedFromPause, int clearedCount) =
+                UloopPausePointRegistry.Clear(parameters.Id);
             LogCleared(snapshot.Id, snapshot.StatusBeforeClear);
             if (snapshot.StatusBeforeClear == UloopPausePointStatus.Expired)
             {
@@ -439,6 +440,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // OnRegistryClearResolved. This keeps the direct-tool-call path in sync with the
             // Infrastructure CLI bridge's Clear path without duplicating the check here.
             PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
+            response.ClearedCount = clearedCount;
             if (resumedFromPause)
             {
                 response.Warning = SourcePausePointConstants.ClearResumedPlayModeWarning;

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -43,7 +43,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             // after the marker itself reports Cleared.
             // The CLI polling bridge only reports marker status; the resumed-from-pause side
             // effect is surfaced through the clear-pause-point tool response, not this path.
-            (UloopPausePointSnapshot snapshot, bool _) = UloopPausePointRegistry.Clear(id);
+            (UloopPausePointSnapshot snapshot, bool _, int _) = UloopPausePointRegistry.Clear(id);
             LogCleared(id, snapshot.StatusBeforeClear);
             if (snapshot.StatusBeforeClear == UloopPausePointStatus.Expired)
             {

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -99,7 +99,13 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             return entry.ToSnapshot(now, _pauseController);
         }
 
-        public static (UloopPausePointSnapshot Snapshot, bool ResumedFromPause) Clear(string id)
+        /// <summary>
+        /// Clears one marker. ClearedCount is 1 when this call actually transitions the entry
+        /// to Cleared (from Enabled, Hit, or Expired), and 0 for unknown ids or already-cleared
+        /// entries. Why not derive it from the snapshot: StatusBeforeClear survives a no-op
+        /// second clear, so snapshot-based counting would treat a no-op as 1.
+        /// </summary>
+        public static (UloopPausePointSnapshot Snapshot, bool ResumedFromPause, int ClearedCount) Clear(string id)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(id), "id must not be null or empty");
 
@@ -108,12 +114,13 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             DateTime now = NowUtc();
             if (!Entries.ContainsKey(id))
             {
-                return (UloopPausePointSnapshot.NotEnabled(id, _pauseController), false);
+                return (UloopPausePointSnapshot.NotEnabled(id, _pauseController), false, 0);
             }
 
             UloopPausePointEntry entry = Entries[id];
             // Resolve expiry first so a clear after the timeout reports "expired", not a normal clear.
             TryExpire(entry, now);
+            int clearedCount = entry.Status == UloopPausePointStatus.Cleared ? 0 : 1;
             string message = !entry.IsEnabled && entry.Status == UloopPausePointStatus.Hit
                 ? "Pause point was already hit (auto-disarmed); nothing to clear."
                 : entry.Status switch
@@ -137,7 +144,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             // window, so they are left untouched. (Client disconnect and expiry still resume
             // unconditionally: those paths must guarantee release even for a manual pause.)
             bool resumedFromPause = ResumeEditorPauseIfOwnedByPausePoint();
-            return (entry.ToSnapshot(now, _pauseController), resumedFromPause);
+            return (entry.ToSnapshot(now, _pauseController), resumedFromPause, clearedCount);
         }
 
         public static UloopPausePointClearAllResult ClearAll(

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -399,7 +399,7 @@
     },
     {
       "name": "clear-pause-point",
-      "description": "Clear one or all named UloopPausePoint.Pause markers",
+      "description": "Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is 0 or 1 for `--id`, and the number of markers actually cleared for `--all`.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "295ec74893fa0c1769e5db91a26cfd0dad0faca7"
+  "sharedInputsHash": "eaa2662c8a4fd990fbb1b6e6a1f70bc69248db91"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "5989ef6ca58cc94e57a76616180bc7adc2ef0c3e"
+  "sharedInputsHash": "ee98e98df168eb916dae7051859a8337d6753970"
 }


### PR DESCRIPTION
## Summary
- `clear-pause-point --id` now reports `ClearedCount` as 0 or 1, matching whether a marker was actually cleared
- `--all` still reports the number of markers cleared

## User Impact
- Before: clearing a single pause point by id always returned `ClearedCount: 0`, so the response looked like a no-op even when a marker was disarmed
- After: the first clear of an enabled, hit, or expired marker reports `1`; an unknown id or a second clear of the same id reports `0`

## Changes
- The pause-point registry now returns how many markers that `Clear(id)` call actually transitioned to Cleared
- The `--id` tool path copies that count onto the response after building it from the snapshot
- Skill text documents `ClearedCount` for `--id` and `--all`

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Success, ErrorCount 0
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value io.github.hatayama.UnityCliLoop.Tests.Editor.PausePointTests` → 89 Passed
- The original four ClearedCount tests plus two review follow-ups ran as their own filters and all Passed:
  - `Clear_WhenHitMarkerIsCleared_ReportsClearedCountOne`, `Clear_WhenIdIsUnknown_ReportsClearedCountZero`, `Clear_WhenSameIdClearedTwice_ReportsZeroOnSecondClear`, `ClearPausePointTool_WhenClearingById_ReportsClearedCountOne` (TestCount 4)
  - `Clear_WhenExpiredMarkerIsCleared_ReportsClearedCountOne`, `ClearPausePointTool_WhenClearingSameIdTwice_ReportsClearedCountZeroOnSecondCall` (TestCount 2)
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value io.github.hatayama.UnityCliLoop.Tests.Editor.PausePointCaptureModeTests` → 7 Passed
- This PR targets `feature/hot-reload`, so repository GitHub Actions do not run (`pull_request.branches` is `main` / `v3-beta` only)
