### PR TITLE
fix: make hot-reload skip reasons name callers and prefer reload-first recovery

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -149,7 +149,7 @@ same file (an implicit `int`→`long` widening can leave a caller's source
 untouched) would keep calling the old method silently, so the run reports the
 changed method and its edited callers as `Skipped` instead; land the change with
 `uloop compile`. When every uncovered caller is in the edited file itself, the
-`Skipped` reason says so: editing those callers' bodies and reloading again
+`Skipped` reason names those callers: editing their bodies and reloading again
 applies them together without `uloop compile`.
 Call sites inside methods that the same edit removes or
 re-signatures do not gate: those compiled bodies are already stale, and anything

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -149,7 +149,7 @@ same file (an implicit `int`→`long` widening can leave a caller's source
 untouched) would keep calling the old method silently, so the run reports the
 changed method and its edited callers as `Skipped` instead; land the change with
 `uloop compile`. When every uncovered caller is in the edited file itself, the
-`Skipped` reason says so: editing those callers' bodies and reloading again
+`Skipped` reason names those callers: editing their bodies and reloading again
 applies them together without `uloop compile`.
 Call sites inside methods that the same edit removes or
 re-signatures do not gate: those compiled bodies are already stale, and anything

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -3475,7 +3475,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Other-file uncovered callers keep the compile-only CTA.");
             Assert.That(
                 actualExternalReason,
-                Does.Not.Contain("Editing those callers' bodies in this file"),
+                Does.Not.Contain("Editing the bodies of"),
                 "Other-file uncovered callers must not use the same-file insert.");
             AssertHasSkipped(
                 result,
@@ -3613,6 +3613,126 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: shim-compile-failure isolation rewrites a two-hop UnavailableAddedCall chain
+        /// to IsolatedAddedMethodCallerSkipReason.
+        /// </summary>
+        [Test]
+        public void CollectRetryOnlySkippedOutcomes_ShimCompileFailure_RewritesTwoHopIndirectCallers()
+        {
+            TransformWorkerSkippedDto[] retrySkipped =
+            {
+                new TransformWorkerSkippedDto
+                {
+                    method = "Host.Mid()",
+                    methodKey = "Host::Mid()",
+                    reason = HotReloadConstants.UnavailableAddedCallSkipReason,
+                    calledAddedMethodKey = "Host::Broken()"
+                },
+                new TransformWorkerSkippedDto
+                {
+                    method = "Host.Outer()",
+                    methodKey = "Host::Outer()",
+                    reason = HotReloadConstants.UnavailableAddedCallSkipReason,
+                    calledAddedMethodKey = "Host::Mid()"
+                }
+            };
+
+            List<HotReloadMethodOutcome> outcomes = HotReloadOrchestrator.CollectRetryOnlySkippedOutcomes(
+                Array.Empty<TransformWorkerSkippedDto>(),
+                retrySkipped,
+                "test.dll",
+                HotReloadConstants.VibeLogIsolationTriggerShimCompileFailure,
+                new[] { "Host::Broken()" });
+
+            Assert.That(outcomes.Count, Is.EqualTo(2));
+            Assert.That(outcomes[0].Reason, Is.EqualTo(HotReloadConstants.IsolatedAddedMethodCallerSkipReason));
+            Assert.That(outcomes[1].Reason, Is.EqualTo(HotReloadConstants.IsolatedAddedMethodCallerSkipReason));
+        }
+
+        /// <summary>
+        /// What: signature-change-gate isolation leaves UnavailableAddedCall on the same two-hop
+        /// chain instead of rewriting it.
+        /// </summary>
+        [Test]
+        public void CollectRetryOnlySkippedOutcomes_SignatureChangeGate_LeavesUnavailableAddedCall()
+        {
+            TransformWorkerSkippedDto[] retrySkipped =
+            {
+                new TransformWorkerSkippedDto
+                {
+                    method = "Host.Mid()",
+                    methodKey = "Host::Mid()",
+                    reason = HotReloadConstants.UnavailableAddedCallSkipReason,
+                    calledAddedMethodKey = "Host::Broken()"
+                },
+                new TransformWorkerSkippedDto
+                {
+                    method = "Host.Outer()",
+                    methodKey = "Host::Outer()",
+                    reason = HotReloadConstants.UnavailableAddedCallSkipReason,
+                    calledAddedMethodKey = "Host::Mid()"
+                }
+            };
+
+            List<HotReloadMethodOutcome> outcomes = HotReloadOrchestrator.CollectRetryOnlySkippedOutcomes(
+                Array.Empty<TransformWorkerSkippedDto>(),
+                retrySkipped,
+                "test.dll",
+                HotReloadConstants.VibeLogIsolationTriggerSignatureChangeGate,
+                new[] { "Host::Broken()" });
+
+            Assert.That(outcomes.Count, Is.EqualTo(2));
+            Assert.That(outcomes[0].Reason, Is.EqualTo(HotReloadConstants.UnavailableAddedCallSkipReason));
+            Assert.That(outcomes[1].Reason, Is.EqualTo(HotReloadConstants.UnavailableAddedCallSkipReason));
+        }
+
+        /// <summary>
+        /// What: a retry skip whose calledAddedMethodKey is outside the excluded set stays
+        /// UnavailableAddedCall even on shim-compile-failure isolation.
+        /// </summary>
+        [Test]
+        public void CollectRetryOnlySkippedOutcomes_UnrelatedCalledKey_LeavesUnavailableAddedCall()
+        {
+            TransformWorkerSkippedDto[] retrySkipped =
+            {
+                new TransformWorkerSkippedDto
+                {
+                    method = "Host.Caller()",
+                    methodKey = "Host::Caller()",
+                    reason = HotReloadConstants.UnavailableAddedCallSkipReason,
+                    calledAddedMethodKey = "Host::Unrelated()"
+                }
+            };
+
+            List<HotReloadMethodOutcome> outcomes = HotReloadOrchestrator.CollectRetryOnlySkippedOutcomes(
+                Array.Empty<TransformWorkerSkippedDto>(),
+                retrySkipped,
+                "test.dll",
+                HotReloadConstants.VibeLogIsolationTriggerShimCompileFailure,
+                new[] { "Host::Broken()" });
+
+            Assert.That(outcomes.Count, Is.EqualTo(1));
+            Assert.That(outcomes[0].Reason, Is.EqualTo(HotReloadConstants.UnavailableAddedCallSkipReason));
+        }
+
+        /// <summary>
+        /// What: uncovered caller short names use Type.Caller order, last type segment only, and
+        /// replace nested '/' with '.'.
+        /// </summary>
+        [Test]
+        public void FormatUncoveredCallerShortNames_TwoCallers_JoinsLastTypeSegmentAndMethodInListOrder()
+        {
+            string names = HotReloadOrchestrator.FormatUncoveredCallerShortNames(
+                new[]
+                {
+                    "Ns.Host::AlphaCaller(System.Int32)",
+                    "Ns.Outer/Inner::BetaCaller(System.Int32)"
+                });
+
+            Assert.That(names, Is.EqualTo("Host.AlphaCaller, Inner.BetaCaller"));
+        }
+
+        /// <summary>
         /// What: an unchanged same-file caller that only needs an implicit int-to-long conversion
         /// is not an apply entry, so the return-type change is skipped with the same-file wording
         /// and is not listed as a removed member.
@@ -3639,7 +3759,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + ".HotReloadSignatureChangeUnchangedCallerFixture.Target(System.Int32)";
             string expectedReason = string.Format(
                 HotReloadConstants.SignatureChangedGateSkipReasonSameFileCallersFormat,
-                expectedLabel);
+                expectedLabel,
+                "HotReloadSignatureChangeUnchangedCallerFixture.StoreTarget");
             string actualReason = FindSkippedReason(
                 result,
                 nameof(HotReloadSignatureChangeUnchangedCallerFixture.Target));
@@ -3647,7 +3768,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 actualReason,
                 Does.Contain(
-                    "Editing those callers' bodies in this file and reloading again applies them together, or run 'uloop compile'."));
+                    "Editing the bodies of HotReloadSignatureChangeUnchangedCallerFixture.StoreTarget in this file and reloading again applies them together, or run 'uloop compile'."));
             Assert.That(
                 CountWarningsContaining(result.Warnings, "Removed members stay present"),
                 Is.EqualTo(0),
@@ -3660,6 +3781,43 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.EqualTo(0),
                 "A never-patched caller must keep the gate skip and must not emit the re-patched notice.\n"
                 + string.Join("\n", result.Warnings));
+        }
+
+        /// <summary>
+        /// What: a return-type change with two unchanged same-file callers names both short
+        /// caller names in the same-file skip reason, in scanner list order.
+        /// </summary>
+        [Test]
+        public async Task Run_ReturnTypeChange_TwoUnchangedSameFileCallers_NamesBothCallersInSkipReason()
+        {
+            string fixturePath = ResolveSignatureChangeTwoCallerFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = onDisk.Replace(
+                "        public int Target(int value)\n        {\n            return value;\n        }",
+                "        public long Target(int value)\n        {\n            return value + 1L;\n        }",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("SignatureChangeTwoUnchangedCallers.cs", edited),
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            string expectedLabel =
+                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                + ".HotReloadSignatureChangeTwoCallerFixture.Target(System.Int32)";
+            string expectedCallerNames =
+                "HotReloadSignatureChangeTwoCallerFixture.CallerAlpha, "
+                + "HotReloadSignatureChangeTwoCallerFixture.CallerBeta";
+            string expectedReason = string.Format(
+                HotReloadConstants.SignatureChangedGateSkipReasonSameFileCallersFormat,
+                expectedLabel,
+                expectedCallerNames);
+            string actualReason = FindSkippedReason(
+                result,
+                nameof(HotReloadSignatureChangeTwoCallerFixture.Target));
+            Assert.That(actualReason, Is.EqualTo(expectedReason));
         }
 
         /// <summary>
@@ -4641,8 +4799,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// <summary>
         /// What: when isolation excludes a failed added method A and its direct added caller B,
         /// the retry worker skip for transitive caller C (C calls B, not A) appears in the
-        /// response as Skipped with UnavailableAddedCall, while independent edited method D
-        /// still patches.
+        /// response as Skipped with IsolatedAddedMethodCallerSkipReason, while independent
+        /// edited method D still patches.
         /// </summary>
         [Test]
         public async Task Run_IsolationRetry_ReportsTransitiveCallerOfExcludedAddedMethodAsSkipped()
@@ -4674,7 +4832,49 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertNoFileLevelFailure(result);
             Assert.That(
                 FindSkippedReason(result, nameof(HotReloadAddedMemberHost.ExistingCaller)),
-                Is.EqualTo(UnavailableAddedCallSkipReason));
+                Is.EqualTo(HotReloadConstants.IsolatedAddedMethodCallerSkipReason));
+            AssertHasPatched(result, nameof(HotReloadAddedMemberHost.ExistingValue));
+        }
+
+        /// <summary>
+        /// What: a two-hop indirect caller chain of a failed added method is rewritten to
+        /// IsolatedAddedMethodCallerSkipReason on both hops.
+        /// </summary>
+        [Test]
+        public async Task Run_IsolationRetry_TwoHopIndirectCallers_UseIsolatedAddedMethodCallerSkipReason()
+        {
+            string hostPath = ResolveAddedMemberHostPath();
+            string onDisk = File.ReadAllText(hostPath);
+            string edited = onDisk.Replace(
+                "        public int ExistingValue()\n        {\n            return 1;\n        }",
+                "        public int ExistingValue()\n        {\n            return 10;\n        }",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                "        public int ExistingCaller(int value)\n        {\n            return value;\n        }",
+                "        public int ExistingCaller(int value)\n        {\n            return AddedOuter(value);\n        }",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                "        public int ReadPrivateSeed()\n        {\n            return _privateSeed;\n        }",
+                "        public int ReadPrivateSeed()\n        {\n            return _privateSeed;\n        }\n\n"
+                + "        public int AddedBroken(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }\n\n"
+                + "        public int AddedMid(int value)\n        {\n            return AddedBroken(value);\n        }\n\n"
+                + "        public int AddedOuter(int value)\n        {\n            return AddedMid(value);\n        }",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            string editedPath = WriteEditedSource("IsolationRetryTwoHopIndirectCallers.cs", edited);
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { hostPath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            Assert.That(
+                FindSkippedReason(result, "AddedOuter"),
+                Is.EqualTo(HotReloadConstants.IsolatedAddedMethodCallerSkipReason));
+            Assert.That(
+                FindSkippedReason(result, nameof(HotReloadAddedMemberHost.ExistingCaller)),
+                Is.EqualTo(HotReloadConstants.IsolatedAddedMethodCallerSkipReason));
             AssertHasPatched(result, nameof(HotReloadAddedMemberHost.ExistingValue));
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -67,7 +67,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // are not Failed (the compile error was in the added body) and must not stay silent.
         public const string IsolatedAddedMethodCallerSkipReason =
             "Calls an added method whose shim failed to compile; the caller was left unpatched. "
-            + "Run 'uloop compile'.";
+            + "Fix the compile error in the added method (see the Failed row in this response) and reload again, or run 'uloop compile'.";
+
+        // Keep in sync with AddedMethodSkipReasons.UnavailableAddedCall in TransformWorker.
+        public const string UnavailableAddedCallSkipReason =
+            "Calls an added method that hot reload cannot emit. Run 'uloop compile'.";
 
         public const string SignatureChangedGateSkipReasonFormat =
             "The return type of '{0}' changed, but this hot reload does not patch every compiled call site of the old method. Applying it would leave those call sites on the old version. Run 'uloop compile'.";
@@ -75,7 +79,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Why drop the original trailing "Run 'uloop compile'.": the inserted sentence already
         // ends with that CTA, and keeping both would duplicate it.
         public const string SignatureChangedGateSkipReasonSameFileCallersFormat =
-            "The return type of '{0}' changed, but this hot reload does not patch every compiled call site of the old method. Applying it would leave those call sites on the old version. Editing those callers' bodies in this file and reloading again applies them together, or run 'uloop compile'.";
+            "The return type of '{0}' changed, but this hot reload does not patch every compiled call site of the old method. Applying it would leave those call sites on the old version. Editing the bodies of {1} in this file and reloading again applies them together, or run 'uloop compile'.";
 
         public const string SignatureChangedGateSkipReasonAlreadyActiveFormat =
             "The return type of '{0}' changed against the last compile, and the replacement applied by an "

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -1466,7 +1466,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<HotReloadMethodOutcome> retryOnlySkipped = CollectRetryOnlySkippedOutcomes(
                 firstPassSkipped,
                 retryOutput.skipped,
-                assemblyResolvePath);
+                assemblyResolvePath,
+                trigger,
+                exclusions.ExcludedAddedMethodKeys);
             skippedCallerOutcomes.AddRange(retryOnlySkipped);
             LogHotReloadIsolationRetry(
                 exclusions.ExcludedMethodKeys.Length,
@@ -1533,12 +1535,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <summary>
         /// Converts retry-worker skips that are not already in the first-pass skipped list into
         /// outcomes. Match is (Method, Reason) Ordinal equality so a method skipped for a new
-        /// reason on retry still surfaces.
+        /// reason on retry still surfaces. Why rewrite only on shim-compile-failure isolation:
+        /// signature-change-gate retry must keep UnavailableAddedCall for indirect callers.
         /// </summary>
-        private static List<HotReloadMethodOutcome> CollectRetryOnlySkippedOutcomes(
+        internal static List<HotReloadMethodOutcome> CollectRetryOnlySkippedOutcomes(
             TransformWorkerSkippedDto[] firstPassSkipped,
             TransformWorkerSkippedDto[] retrySkipped,
-            string assemblyResolvePath)
+            string assemblyResolvePath,
+            string trigger,
+            IReadOnlyCollection<string> excludedAddedMethodKeys)
         {
             List<HotReloadMethodOutcome> retryOnly = new List<HotReloadMethodOutcome>();
             if (retrySkipped == null)
@@ -1548,6 +1553,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             TransformWorkerSkippedDto[] baseline =
                 firstPassSkipped ?? Array.Empty<TransformWorkerSkippedDto>();
+            List<TransformWorkerSkippedDto> retryOnlyRows = new List<TransformWorkerSkippedDto>();
             foreach (TransformWorkerSkippedDto retryRow in retrySkipped)
             {
                 if (FirstPassContainsSkippedPair(baseline, retryRow))
@@ -1555,6 +1561,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
+                retryOnlyRows.Add(retryRow);
+            }
+
+            if (string.Equals(
+                trigger,
+                HotReloadConstants.VibeLogIsolationTriggerShimCompileFailure,
+                StringComparison.Ordinal))
+            {
+                RewriteShimCompileFailureIndirectCallerReasons(retryOnlyRows, excludedAddedMethodKeys);
+            }
+
+            foreach (TransformWorkerSkippedDto retryRow in retryOnlyRows)
+            {
                 retryOnly.Add(
                     HotReloadMethodOutcome.Skipped(
                         retryRow.method ?? "(unknown)",
@@ -1563,6 +1582,52 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return retryOnly;
+        }
+
+        private static void RewriteShimCompileFailureIndirectCallerReasons(
+            List<TransformWorkerSkippedDto> retryOnlyRows,
+            IReadOnlyCollection<string> excludedAddedMethodKeys)
+        {
+            HashSet<string> reachable = new HashSet<string>(StringComparer.Ordinal);
+            if (excludedAddedMethodKeys != null)
+            {
+                foreach (string key in excludedAddedMethodKeys)
+                {
+                    if (!string.IsNullOrEmpty(key))
+                    {
+                        reachable.Add(key);
+                    }
+                }
+            }
+
+            bool progressed = true;
+            while (progressed)
+            {
+                progressed = false;
+                foreach (TransformWorkerSkippedDto row in retryOnlyRows)
+                {
+                    if (!string.Equals(
+                        row.reason,
+                        HotReloadConstants.UnavailableAddedCallSkipReason,
+                        StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    if (string.IsNullOrEmpty(row.calledAddedMethodKey)
+                        || !reachable.Contains(row.calledAddedMethodKey))
+                    {
+                        continue;
+                    }
+
+                    row.reason = HotReloadConstants.IsolatedAddedMethodCallerSkipReason;
+                    progressed = true;
+                    if (!string.IsNullOrEmpty(row.methodKey))
+                    {
+                        reachable.Add(row.methodKey);
+                    }
+                }
+            }
         }
 
         private static bool FirstPassContainsSkippedPair(
@@ -2400,27 +2465,82 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 string methodLabel = FormatGatedReplacementRegistryKey(entry);
                 string methodKey = BuildMethodKey(entry);
-                string reasonFormat = HotReloadConstants.SignatureChangedGateSkipReasonFormat;
+                string reason;
                 // Why live registry, not a run-start snapshot: BeginFileGeneration runs after
                 // this gate, so the previous apply's added members are still listed here.
                 if (HotReloadAddedMemberRegistry.IsActiveMember(projectRelativePath, methodLabel))
                 {
-                    reasonFormat = HotReloadConstants.SignatureChangedGateSkipReasonAlreadyActiveFormat;
+                    reason = string.Format(
+                        HotReloadConstants.SignatureChangedGateSkipReasonAlreadyActiveFormat,
+                        methodLabel);
                 }
                 else if (uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> uncoveredCallers)
                     && AreAllUncoveredCallersInEditedFile(uncoveredCallers, editedFileMethodKeys))
                 {
-                    reasonFormat = HotReloadConstants.SignatureChangedGateSkipReasonSameFileCallersFormat;
+                    reason = string.Format(
+                        HotReloadConstants.SignatureChangedGateSkipReasonSameFileCallersFormat,
+                        methodLabel,
+                        FormatUncoveredCallerShortNames(uncoveredCallers));
+                }
+                else
+                {
+                    reason = string.Format(
+                        HotReloadConstants.SignatureChangedGateSkipReasonFormat,
+                        methodLabel);
                 }
 
                 outcomes.Add(
                     HotReloadMethodOutcome.Skipped(
                         methodLabel,
-                        string.Format(reasonFormat, methodLabel),
+                        reason,
                         assemblyResolvePath));
             }
 
             return outcomes;
+        }
+
+        /// <summary>
+        /// Derives Type.Caller short names from wire keys (Ns.Type::Caller(params)), in list
+        /// order, de-duplicated. Nested type '/' is normalized to '.' and only the last type
+        /// segment is kept.
+        /// </summary>
+        internal static string FormatUncoveredCallerShortNames(IReadOnlyList<string> uncoveredCallers)
+        {
+            if (uncoveredCallers == null || uncoveredCallers.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            List<string> names = new List<string>();
+            HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (string wireKey in uncoveredCallers)
+            {
+                string shortName = FormatCallerShortName(wireKey);
+                if (string.IsNullOrEmpty(shortName) || !seen.Add(shortName))
+                {
+                    continue;
+                }
+
+                names.Add(shortName);
+            }
+
+            return string.Join(", ", names);
+        }
+
+        internal static string FormatCallerShortName(string wireKey)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(wireKey), "wireKey must not be empty.");
+            int separatorIndex = wireKey.IndexOf("::", StringComparison.Ordinal);
+            Debug.Assert(separatorIndex >= 0, "wireKey must contain '::'.");
+            string typePart = wireKey.Substring(0, separatorIndex).Replace('/', '.');
+            int lastDot = typePart.LastIndexOf('.');
+            string typeName = lastDot >= 0 ? typePart.Substring(lastDot + 1) : typePart;
+            string methodAndParams = wireKey.Substring(separatorIndex + 2);
+            int parenIndex = methodAndParams.IndexOf('(');
+            string methodName = parenIndex >= 0
+                ? methodAndParams.Substring(0, parenIndex)
+                : methodAndParams;
+            return typeName + "." + methodName;
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -149,7 +149,7 @@ same file (an implicit `int`→`long` widening can leave a caller's source
 untouched) would keep calling the old method silently, so the run reports the
 changed method and its edited callers as `Skipped` instead; land the change with
 `uloop compile`. When every uncovered caller is in the edited file itself, the
-`Skipped` reason says so: editing those callers' bodies and reloading again
+`Skipped` reason names those callers: editing their bodies and reloading again
 applies them together without `uloop compile`.
 Call sites inside methods that the same edit removes or
 re-signatures do not gate: those compiled bodies are already stale, and anything

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -149,5 +149,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public string method;
         public string reason;
+        // Wire key of the skipped method. Why: the isolation-retry closure must add this in
+        // the same format as calledAddedMethodKey and ExcludedAddedMethodKeys; `method` is the
+        // display label and would not match the next hop.
+        public string methodKey;
+        // Callee wire key. Set only when reason is UnavailableAddedCall.
+        public string calledAddedMethodKey;
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -2232,7 +2232,9 @@ public static class TransformWorkerProgram
             return (currentShimType, shimTypeCounter, globalShimMethodCounter);
         }
 
-        string addedCallSiteSkip = EvaluateAddedCallSiteSkipReason(
+        string addedCallSiteSkip;
+        string calledAddedMethodKey;
+        (addedCallSiteSkip, calledAddedMethodKey) = EvaluateAddedCallSiteSkipReason(
             getterBodyNode,
             semanticModel,
             addedMethodCatalog,
@@ -2242,7 +2244,11 @@ public static class TransformWorkerProgram
             skipped.Add(new WorkerSkipped
             {
                 Method = FormatMethodLabel(getterSymbol),
-                Reason = addedCallSiteSkip
+                Reason = addedCallSiteSkip,
+                CalledAddedMethodKey = calledAddedMethodKey,
+                MethodKey = calledAddedMethodKey == null
+                    ? null
+                    : BuildMethodKeyFromSymbol(getterSymbol)
             });
             return (currentShimType, shimTypeCounter, globalShimMethodCounter);
         }
@@ -3627,7 +3633,9 @@ public static class TransformWorkerProgram
                 {
                     SyntaxNode bodyNode =
                         (SyntaxNode)queued.MethodDeclaration.Body ?? queued.MethodDeclaration.ExpressionBody;
-                    string skipReason = EvaluateAddedCallSiteSkipReason(
+                    string skipReason;
+                    string calledAddedMethodKey;
+                    (skipReason, calledAddedMethodKey) = EvaluateAddedCallSiteSkipReason(
                         bodyNode,
                         semanticModel,
                         addedMethodCatalog,
@@ -3637,7 +3645,9 @@ public static class TransformWorkerProgram
                         skipped.Add(new WorkerSkipped
                         {
                             Method = FormatMethodLabel(queued.MethodSymbol),
-                            Reason = skipReason
+                            Reason = skipReason,
+                            CalledAddedMethodKey = calledAddedMethodKey,
+                            MethodKey = calledAddedMethodKey == null ? null : queued.MethodKey
                         });
                         if (queued.IsAddedMethod)
                         {
@@ -3658,7 +3668,7 @@ public static class TransformWorkerProgram
         while (progressed);
     }
 
-    private static string EvaluateAddedCallSiteSkipReason(
+    private static (string Reason, string CalledAddedMethodKey) EvaluateAddedCallSiteSkipReason(
         SyntaxNode bodyNode,
         SemanticModel semanticModel,
         AddedMethodCatalog addedMethodCatalog,
@@ -3666,7 +3676,7 @@ public static class TransformWorkerProgram
     {
         if (bodyNode == null)
         {
-            return null;
+            return (null, null);
         }
 
         foreach (InvocationExpressionSyntax invocation in bodyNode.DescendantNodesAndSelf()
@@ -3690,21 +3700,21 @@ public static class TransformWorkerProgram
             if (IsConditionalAccessReceiverSpine(invocation)
                 && addedMethodCatalog.IsClassifiedAdded(calledKey))
             {
-                return AddedMethodSkipReasons.ConditionalAccess;
+                return (AddedMethodSkipReasons.ConditionalAccess, null);
             }
 
             if (addedMethodCatalog.IsUnavailableAdded(calledKey))
             {
-                return AddedMethodSkipReasons.UnavailableAddedCall;
+                return (AddedMethodSkipReasons.UnavailableAddedCall, calledKey);
             }
         }
 
         if (BodyReferencesAddedMethodGroup(bodyNode, semanticModel, addedMethodCatalog))
         {
-            return AddedMethodSkipReasons.MethodGroupReference;
+            return (AddedMethodSkipReasons.MethodGroupReference, null);
         }
 
-        return EvaluateAddedFieldSkipReason(bodyNode, semanticModel, addedFieldCatalog);
+        return (EvaluateAddedFieldSkipReason(bodyNode, semanticModel, addedFieldCatalog), null);
     }
 
     private static bool BodyReferencesAddedMethodGroup(
@@ -8574,4 +8584,8 @@ internal sealed class WorkerSkipped
     public string Method { get; set; }
 
     public string Reason { get; set; }
+
+    public string MethodKey { get; set; }
+
+    public string CalledAddedMethodKey { get; set; }
 }


### PR DESCRIPTION
## Summary
- Skip reasons for added-method isolation now tell you to fix the compile error and reload, not only to compile
- Indirect callers of a failed added method get the same isolation reason instead of a generic "cannot emit" message
- A same-file return-type gate names the callers whose bodies still need an edit

## User Impact
- Before: a failed added-method shim told its callers to run `uloop compile`, and callers two hops away looked like an emit limitation. A same-file signature gate said "those callers" without naming them.
- After: isolation skips point at the Failed row and a reload-first recovery. Indirect callers of that failure use the same wording. Same-file gates list the caller names to edit.

## Changes
- Worker skipped rows carry the callee wire key (and the skipped method's wire key) when the reason is UnavailableAddedCall
- Shim-compile-failure isolation rewrites that chain to IsolatedAddedMethodCallerSkipReason; signature-change-gate isolation does not
- Same-file signature-gate skip format includes `{1}` as de-duplicated `Type.Caller` names

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Success, ErrorCount 0
- Updated and new skip-reason tests as their own regex filter → TestCount 10 Passed
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadOrchestratorTests` → 125 Passed
- This PR targets `feature/hot-reload`, so repository GitHub Actions do not run (`pull_request.branches` is `main` / `v3-beta` only)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

