### PR TITLE
fix: disclose the dual --line basis and compiled spans in pause-point responses

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftTests.cs
@@ -27,7 +27,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string HotReloadCompiledLineMapWarning =
             "'Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftFixture.cs' has active "
             + "hot-reload patches. For methods this reload did not patch, --line resolves against "
-            + "the last compiled source, not the edited file. Verify ResolvedMethod and "
+            + "the last compiled source, not the edited file. Methods currently patched by hot "
+            + "reload resolve against the edited file instead. Verify ResolvedMethod and "
             + "ResolvedLineText, or run 'uloop compile' and re-enable.";
 
         private const string CompiledSnapshotSentinel = "SENTINEL_COMPILED_LINE_TEXT";
@@ -100,7 +101,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: the same top-of-file insert still retargets a patched method onto the
-        /// hot-reload body and does not emit the compiled-line-map warning.
+        /// hot-reload body, emits the edited-file line-basis warning, and does not emit
+        /// the compiled-line-map warning.
         /// </summary>
         [Test]
         public async Task Enable_PatchedMethodAfterTopOfFileInsert_DoesNotWarnAboutCompiledLineMap()
@@ -124,6 +126,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(enable.RetargetedToHotReloadPatch, Is.True);
             Assert.That(enable.ResolvedMethod, Does.Contain(nameof(HotReloadPausePointLineDriftFixture.PatchTarget)));
             Assert.That(enable.Warning ?? string.Empty, Does.Not.Contain("has active hot-reload patches"));
+
+            HotReloadShimMethodLookup patchedEntry = FindPatchedShimEntry();
+            string expectedWarning = PausePointUseCase.MergeWarnings(
+                PausePointUseCase.MergeWarnings(
+                    PausePointUseCase.CreateEnableWarning(),
+                    PausePointUseCase.BuildRetargetedToHotReloadPatchWarningOrEmpty(
+                        true,
+                        enable.ResolvedMethod,
+                        editedPatchLine,
+                        patchedEntry.SourceStartLine,
+                        patchedEntry.SourceEndLine)),
+                SourcePausePointConstants.SmallMethodInliningRiskWarning);
+            Assert.That(enable.Warning, Is.EqualTo(expectedWarning));
         }
 
         /// <summary>
@@ -241,6 +256,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(enable.Success, Is.True, enable.Message + " / " + enable.RecommendedNextAction);
             Assert.That(enable.RetargetedToHotReloadPatch, Is.True);
             return enable;
+        }
+
+        private static HotReloadShimMethodLookup FindPatchedShimEntry()
+        {
+            Func<string, HotReloadShimFileLookup> getLookup =
+                HotReloadPausePointCoordination.GetShimLookupForFile;
+            Assert.That(getLookup, Is.Not.Null);
+            HotReloadShimFileLookup lookup = getLookup(FixtureProjectRelativePath);
+            Assert.That(lookup, Is.Not.Null);
+            Assert.That(lookup.Methods, Is.Not.Null);
+
+            HotReloadShimMethodLookup patchedEntry = null;
+            foreach (HotReloadShimMethodLookup method in lookup.Methods)
+            {
+                if (method.OriginalMethod != null
+                    && method.OriginalMethod.Name == nameof(HotReloadPausePointLineDriftFixture.PatchTarget))
+                {
+                    patchedEntry = method;
+                    break;
+                }
+            }
+
+            Assert.That(patchedEntry, Is.Not.Null);
+            Assert.That(patchedEntry.SourceStartLine, Is.GreaterThan(0));
+            Assert.That(patchedEntry.SourceEndLine, Is.GreaterThanOrEqualTo(patchedEntry.SourceStartLine));
+            return patchedEntry;
         }
 
         private static string BuildSentinelSnapshot(string sentinel, int lineCount)

--- a/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
+++ b/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Reflection;
 
 using NUnit.Framework;
 
@@ -21,6 +22,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             "Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs";
 
         private const int UnresolvableLine = 999999;
+
+        private const string GenericPatchedMethodsUseEditedFileSentence =
+            "Methods currently patched by hot reload resolve against the edited file instead";
 
         [SetUp]
         public void SetUp()
@@ -381,8 +385,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
-        /// What: nearby compiled spans are formatted as a suffix on a resolve-failure message.
+        /// What: the PDB-unavailable helper interpolates method name and requested line.
         /// </summary>
+        [Test]
+        public void BuildPatchedMethodPdbUnavailableWarningOrEmpty_WhenUnavailable_ReturnsFormattedWarning()
+        {
+            string warning = PausePointUseCase.BuildPatchedMethodPdbUnavailableWarningOrEmpty(
+                true,
+                "Example.Run",
+                42);
+
+            Assert.That(
+                warning,
+                Is.EqualTo(
+                    string.Format(
+                        SourcePausePointConstants.HotReloadPatchedMethodPdbUnavailableWarningFormat,
+                        "Example.Run",
+                        42)));
+        }
+
+        /// <summary>
+        /// What: the PDB-unavailable helper stays silent when the shim PDB is present.
+        /// </summary>
+        [Test]
+        public void BuildPatchedMethodPdbUnavailableWarningOrEmpty_WhenAvailable_ReturnsEmpty()
+        {
+            string warning = PausePointUseCase.BuildPatchedMethodPdbUnavailableWarningOrEmpty(
+                false,
+                "Example.Run",
+                42);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
         [Test]
         public void AppendNearbyCompiledMethodsSuffix_WhenNearbyMethodsExist_AppendsFormattedSpans()
         {
@@ -505,6 +539,111 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
         }
 
+        /// <summary>
+        /// What: a line inside a patched method with no shim PDB is a distinct Kind, not
+        /// NotInPatchedMethod.
+        /// </summary>
+        [Test]
+        public void ShimResolve_WhenLineIsInPatchedMethodButPdbBytesAreMissing_ReturnsPatchedMethodPdbUnavailable()
+        {
+            SourcePausePointShimResolution resolution = SourcePausePointShimResolver.Resolve(
+                CreatePdbUnavailableLookup(CompiledLineDriftProbeMethod(), 10),
+                ResolveFailureFile,
+                10);
+
+            Assert.That(
+                resolution.Kind,
+                Is.EqualTo(SourcePausePointShimResolveKind.PatchedMethodPdbUnavailable));
+            Assert.That(
+                resolution.MethodDisplayName,
+                Is.EqualTo("PausePointCompiledLineMapWarningTests.CompiledLineDriftProbe"));
+        }
+
+        /// <summary>
+        /// What: a patched method whose shim lookup has no PDB bytes falls through to compiled
+        /// resolve and emits the dedicated warning instead of the generic edited-file sentence.
+        /// </summary>
+        [Test]
+        public void Enable_WhenPatchedMethodHasNoPdbBytes_EmitsDedicatedWarningOnSuccess()
+        {
+            string absolutePath = Path.Combine(
+                UnityCliLoopPathResolver.GetProjectRoot(),
+                ResolveFailureFile);
+            string diskSource = File.ReadAllText(absolutePath);
+            int requestedLine = FindLineNumberContaining(
+                diskSource,
+                "compiled-line-drift" + "-probe-unique") + 1;
+            Assert.That(requestedLine, Is.GreaterThan(1));
+
+            Func<string, HotReloadShimFileLookup> previous =
+                HotReloadPausePointCoordination.GetShimLookupForFile;
+            try
+            {
+                HotReloadPausePointCoordination.GetShimLookupForFile =
+                    _ => CreatePdbUnavailableLookup(CompiledLineDriftProbeMethod(), requestedLine);
+                PausePointResponse response = new PausePointUseCase().Enable(new EnablePausePointSchema
+                {
+                    File = ResolveFailureFile,
+                    Line = requestedLine,
+                    TimeoutSeconds = 30,
+                    Mode = UloopPausePointCaptureMode.SingleShot
+                });
+
+                Assert.That(
+                    response.Success,
+                    Is.True,
+                    response.ErrorCode + " / " + response.Message + " / " + response.RecommendedNextAction);
+                Assert.That(response.RetargetedToHotReloadPatch, Is.False);
+                string dedicatedWarning = string.Format(
+                    SourcePausePointConstants.HotReloadPatchedMethodPdbUnavailableWarningFormat,
+                    "PausePointCompiledLineMapWarningTests.CompiledLineDriftProbe",
+                    requestedLine);
+                string expectedWarning = PausePointUseCase.MergeWarnings(
+                    PausePointUseCase.MergeWarnings(
+                        PausePointUseCase.CreateEnableWarning(),
+                        dedicatedWarning),
+                    SourcePausePointConstants.SmallMethodInliningRiskWarning);
+                Assert.That(response.Warning, Is.EqualTo(expectedWarning));
+                Assert.That(response.Warning, Does.Not.Contain(GenericPatchedMethodsUseEditedFileSentence));
+            }
+            finally
+            {
+                HotReloadPausePointCoordination.GetShimLookupForFile = previous;
+            }
+        }
+
+        /// <summary>
+        /// What: resolve failure inside a patched method with no shim PDB uses the dedicated
+        /// warning, not the generic compiled-line-map failure sentence.
+        /// </summary>
+        [Test]
+        public void Enable_WhenPatchedMethodHasNoPdbBytes_EmitsDedicatedWarningOnResolveFailure()
+        {
+            Func<string, HotReloadShimFileLookup> previous =
+                HotReloadPausePointCoordination.GetShimLookupForFile;
+            try
+            {
+                HotReloadPausePointCoordination.GetShimLookupForFile =
+                    _ => CreatePdbUnavailableLookup(CompiledLineDriftProbeMethod(), UnresolvableLine);
+                PausePointResponse response = EnableUnresolvableLine();
+
+                Assert.That(response.Success, Is.False);
+                Assert.That(response.ErrorCode, Is.EqualTo(SourcePausePointConstants.ErrorCodeResolveFailed));
+                Assert.That(
+                    response.Warning,
+                    Is.EqualTo(
+                        string.Format(
+                            SourcePausePointConstants.HotReloadPatchedMethodPdbUnavailableWarningFormat,
+                            "PausePointCompiledLineMapWarningTests.CompiledLineDriftProbe",
+                            UnresolvableLine)));
+                Assert.That(response.Warning, Does.Not.Contain(GenericPatchedMethodsUseEditedFileSentence));
+            }
+            finally
+            {
+                HotReloadPausePointCoordination.GetShimLookupForFile = previous;
+            }
+        }
+
         internal static int CompiledLineDriftProbe()
         {
             // compiled-line-drift-probe-unique
@@ -534,6 +673,33 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 TimeoutSeconds = 30,
                 Mode = UloopPausePointCaptureMode.SingleShot
             });
+        }
+
+        private static HotReloadShimFileLookup CreatePdbUnavailableLookup(MethodBase patchedMethod, int line)
+        {
+            HotReloadShimMethodLookup[] methods =
+            {
+                new HotReloadShimMethodLookup(
+                    patchedMethod,
+                    patchedMethod,
+                    false,
+                    line,
+                    line)
+            };
+            return new HotReloadShimFileLookup(
+                Array.Empty<byte>(),
+                null,
+                null,
+                methods);
+        }
+
+        private static MethodBase CompiledLineDriftProbeMethod()
+        {
+            MethodBase method = typeof(PausePointCompiledLineMapWarningTests).GetMethod(
+                nameof(CompiledLineDriftProbe),
+                BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.That(method, Is.Not.Null);
+            return method;
         }
 
         private sealed class FakePausePointPauseController : IUloopPausePointPauseController

--- a/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
+++ b/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
@@ -417,6 +417,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(warning, Is.EqualTo(string.Empty));
         }
+
+        /// <summary>
+        /// What: nearby compiled spans are formatted as a suffix on a resolve-failure message.
+        /// </summary>
         [Test]
         public void AppendNearbyCompiledMethodsSuffix_WhenNearbyMethodsExist_AppendsFormattedSpans()
         {

--- a/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
+++ b/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
@@ -238,12 +238,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     response.Success,
                     Is.True,
                     response.ErrorCode + " / " + response.Message + " / " + response.RecommendedNextAction);
+                SourcePausePointResolveResult spanResult = SourcePausePointResolver.Resolve(
+                    ResolveFailureFile,
+                    response.ResolvedLine);
+                Assert.That(spanResult.Success, Is.True, spanResult.ErrorMessage);
+                Assert.That(spanResult.Resolution.CompiledMethodStartLine, Is.GreaterThan(0));
+                Assert.That(spanResult.Resolution.CompiledMethodEndLine, Is.GreaterThan(0));
                 string expectedDrift = string.Format(
                     SourcePausePointConstants.HotReloadCompiledLineMapLineDriftWarningFormat,
                     ResolveFailureFile,
                     response.ResolvedLine,
                     "return 0;",
                     "return 424242;");
+                expectedDrift = PausePointUseCase.AppendCompiledMethodSpanToDriftWarningOrUnchanged(
+                    expectedDrift,
+                    response.ResolvedMethod,
+                    spanResult.Resolution.CompiledMethodStartLine,
+                    spanResult.Resolution.CompiledMethodEndLine);
                 string expectedWarning = PausePointUseCase.MergeWarnings(
                     PausePointUseCase.MergeWarnings(
                         PausePointUseCase.MergeWarnings(
@@ -261,6 +272,189 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 HotReloadPausePointCoordination.GetShimLookupForFile = previousLookup;
                 HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = previousSnapshot;
             }
+        }
+
+        /// <summary>
+        /// What: a known compiled span is appended to a non-empty drift warning.
+        /// </summary>
+        [Test]
+        public void AppendCompiledMethodSpanToDriftWarningOrUnchanged_WhenSpanIsKnown_AppendsSpanSentence()
+        {
+            string drift = string.Format(
+                SourcePausePointConstants.HotReloadCompiledLineMapLineDriftWarningFormat,
+                ForwardSlashFile,
+                17,
+                "return 1;",
+                "return 2;");
+
+            string warning = PausePointUseCase.AppendCompiledMethodSpanToDriftWarningOrUnchanged(
+                drift,
+                "Example.Run",
+                8,
+                11);
+
+            Assert.That(
+                warning,
+                Is.EqualTo(
+                    drift + string.Format(
+                        SourcePausePointConstants.HotReloadCompiledMethodSpanInLastCompiledSourceFormat,
+                        "Example.Run",
+                        8,
+                        11)));
+        }
+
+        /// <summary>
+        /// What: an unknown (0,0) compiled span leaves the drift warning unchanged.
+        /// </summary>
+        [Test]
+        public void AppendCompiledMethodSpanToDriftWarningOrUnchanged_WhenSpanIsUnknown_LeavesWarningUnchanged()
+        {
+            string drift = string.Format(
+                SourcePausePointConstants.HotReloadCompiledLineMapLineDriftWarningFormat,
+                ForwardSlashFile,
+                17,
+                "return 1;",
+                "return 2;");
+
+            string warning = PausePointUseCase.AppendCompiledMethodSpanToDriftWarningOrUnchanged(
+                drift,
+                "Example.Run",
+                0,
+                0);
+
+            Assert.That(warning, Is.EqualTo(drift));
+        }
+
+        /// <summary>
+        /// What: an empty drift warning stays empty even when a compiled span is known.
+        /// </summary>
+        [Test]
+        public void AppendCompiledMethodSpanToDriftWarningOrUnchanged_WhenDriftIsEmpty_ReturnsEmpty()
+        {
+            string warning = PausePointUseCase.AppendCompiledMethodSpanToDriftWarningOrUnchanged(
+                string.Empty,
+                "Example.Run",
+                8,
+                11);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: retarget warning interpolates resolved method, requested line, and edited span.
+        /// </summary>
+        [Test]
+        public void BuildRetargetedToHotReloadPatchWarningOrEmpty_WhenRetargeted_ReturnsFormattedWarning()
+        {
+            string warning = PausePointUseCase.BuildRetargetedToHotReloadPatchWarningOrEmpty(
+                true,
+                "Example.Run",
+                42,
+                10,
+                20);
+
+            Assert.That(
+                warning,
+                Is.EqualTo(
+                    string.Format(
+                        SourcePausePointConstants.HotReloadRetargetedToEditedFileWarningFormat,
+                        "Example.Run",
+                        42,
+                        10,
+                        20)));
+        }
+
+        /// <summary>
+        /// What: the retarget helper stays silent when the marker did not retarget.
+        /// </summary>
+        [Test]
+        public void BuildRetargetedToHotReloadPatchWarningOrEmpty_WhenNotRetargeted_ReturnsEmpty()
+        {
+            string warning = PausePointUseCase.BuildRetargetedToHotReloadPatchWarningOrEmpty(
+                false,
+                "Example.Run",
+                42,
+                10,
+                20);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: nearby compiled spans are formatted as a suffix on a resolve-failure message.
+        /// </summary>
+        [Test]
+        public void AppendNearbyCompiledMethodsSuffix_WhenNearbyMethodsExist_AppendsFormattedSpans()
+        {
+            string errorMessage = "No sequence point found on or after line 9999 in 'file'.";
+            SourcePausePointNearbyCompiledMethod[] nearby =
+            {
+                new SourcePausePointNearbyCompiledMethod("CompiledMethodSpanFixture.Target", 8, 11),
+                new SourcePausePointNearbyCompiledMethod("CompiledMethodSpanFixture.OtherMethod", 15, 18)
+            };
+
+            string message = PausePointUseCase.AppendNearbyCompiledMethodsSuffix(errorMessage, nearby);
+
+            Assert.That(
+                message,
+                Is.EqualTo(
+                    errorMessage
+                    + SourcePausePointConstants.NearbyCompiledMethodsPrefix
+                    + "'CompiledMethodSpanFixture.Target' spans lines 8-11"
+                    + "; "
+                    + "'CompiledMethodSpanFixture.OtherMethod' spans lines 15-18"
+                    + "."));
+        }
+
+        /// <summary>
+        /// What: an empty nearby list leaves the resolve-failure message unchanged.
+        /// </summary>
+        [Test]
+        public void AppendNearbyCompiledMethodsSuffix_WhenNearbyListIsEmpty_LeavesMessageUnchanged()
+        {
+            string errorMessage = "No sequence point found on or after line 9999 in 'file'.";
+
+            string message = PausePointUseCase.AppendNearbyCompiledMethodsSuffix(
+                errorMessage,
+                Array.Empty<SourcePausePointNearbyCompiledMethod>());
+
+            Assert.That(message, Is.EqualTo(errorMessage));
+        }
+
+        /// <summary>
+        /// What: enable resolve-failure on a real PDB fixture appends the nearest compiled
+        /// method span from that file.
+        /// </summary>
+        [Test]
+        public void Enable_WhenResolveFails_AppendsNearbyCompiledMethodSpans()
+        {
+            const string file =
+                "Assets/Tests/Editor/SourcePausePointResolver/Fixtures/CompiledMethodSpanFixture.cs";
+            SourcePausePointResolveResult otherMethod = SourcePausePointResolver.Resolve(file, 16);
+            Assert.That(otherMethod.Success, Is.True, otherMethod.ErrorMessage);
+            Assert.That(otherMethod.Resolution.CompiledMethodStartLine, Is.GreaterThan(0));
+            Assert.That(otherMethod.Resolution.CompiledMethodEndLine, Is.GreaterThan(0));
+
+            PausePointResponse response = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = file,
+                Line = 9999,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.SingleShot
+            });
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.ErrorCode, Is.EqualTo(SourcePausePointConstants.ErrorCodeResolveFailed));
+            string expectedMessage =
+                "No sequence point found on or after line 9999 in '" + file + "'."
+                + SourcePausePointConstants.NearbyCompiledMethodsPrefix
+                + string.Format(
+                    SourcePausePointConstants.NearbyCompiledMethodSpanFormat,
+                    "CompiledMethodSpanFixture.OtherMethod",
+                    otherMethod.Resolution.CompiledMethodStartLine,
+                    otherMethod.Resolution.CompiledMethodEndLine)
+                + ".";
+            Assert.That(response.Message, Is.EqualTo(expectedMessage));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/NearbyContainingMethodsFixture.cs
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/NearbyContainingMethodsFixture.cs
@@ -1,0 +1,12 @@
+// FROZEN FIXTURE: content and line numbers are asserted by SourcePausePointResolverTests.
+// Do not reformat or edit this file; add a new fixture file instead.
+namespace io.github.hatayama.UnityCliLoop.Tests.SourcePausePointResolverFixtures
+{
+    internal sealed class NearbyContainingMethodsFixture
+    {
+        public int Host(int value)
+        {
+            System.Func<int, int> first = x => x + 1; System.Func<int, int> second = y => y + 2; System.Func<int, int> third = z => z + 3; return first(value) + second(value) + third(value);
+        }
+    }
+}

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/NearbyContainingMethodsFixture.cs.meta
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/NearbyContainingMethodsFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9eda16fde99884964b319e3ae29942e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointResolverTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointResolverTests.cs
@@ -194,5 +194,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result.Success, Is.False);
             Assert.That(result.FailureReason, Is.EqualTo(SourcePausePointResolveFailureReason.NoSequencePointOnOrAfterLine));
         }
+
+        /// <summary>
+        /// What: a line past every sequence point in the file lists the last compiled method
+        /// span in that document as nearby recovery material.
+        /// </summary>
+        [Test]
+        public void Resolve_WhenLineIsBeyondAllSequencePoints_IncludesNearbyCompiledMethodSpans()
+        {
+            string file = FixturesDirectory + "CompiledMethodSpanFixture.cs";
+            SourcePausePointResolveResult otherMethod = SourcePausePointResolver.Resolve(file, 16);
+            Assert.That(otherMethod.Success, Is.True, otherMethod.ErrorMessage);
+
+            SourcePausePointResolveResult result = SourcePausePointResolver.Resolve(file, 9999);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.FailureReason, Is.EqualTo(SourcePausePointResolveFailureReason.NoSequencePointOnOrAfterLine));
+            Assert.That(result.NearbyCompiledMethods.Count, Is.EqualTo(1));
+            Assert.That(
+                result.NearbyCompiledMethods[0].DisplayName,
+                Is.EqualTo("CompiledMethodSpanFixture.OtherMethod"));
+            Assert.That(
+                result.NearbyCompiledMethods[0].StartLine,
+                Is.EqualTo(otherMethod.Resolution.CompiledMethodStartLine));
+            Assert.That(
+                result.NearbyCompiledMethods[0].EndLine,
+                Is.EqualTo(otherMethod.Resolution.CompiledMethodEndLine));
+        }
     }
 }

--- a/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointResolverTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointResolverTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 
 using NUnit.Framework;
@@ -220,6 +221,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 result.NearbyCompiledMethods[0].EndLine,
                 Is.EqualTo(otherMethod.Resolution.CompiledMethodEndLine));
+        }
+
+        /// <summary>
+        /// What: when three or more compiled methods contain the requested line, nearby
+        /// recovery material is capped at two.
+        /// </summary>
+        [Test]
+        public void FindNearbyCompiledMethods_WhenMoreThanTwoMethodsContainTheLine_ReturnsAtMostTwo()
+        {
+            const int line = 9;
+            string file = FixturesDirectory + "NearbyContainingMethodsFixture.cs";
+
+            IReadOnlyList<SourcePausePointNearbyCompiledMethod> nearby =
+                SourcePausePointResolver.FindNearbyCompiledMethodsInFile(file, line);
+
+            Assert.That(
+                nearby.Count,
+                Is.EqualTo(2),
+                string.Join(", ", nearby.Select(method => method.DisplayName)));
+            Assert.That(nearby[0].StartLine, Is.LessThanOrEqualTo(line));
+            Assert.That(nearby[0].EndLine, Is.GreaterThanOrEqualTo(line));
+            Assert.That(nearby[1].StartLine, Is.LessThanOrEqualTo(line));
+            Assert.That(nearby[1].EndLine, Is.GreaterThanOrEqualTo(line));
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -485,6 +485,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             string normalizedFile = SourcePausePointPathNormalizer.ToForwardSlashes(parameters.File);
             string id = BuildSourcePausePointId(parameters.File, parameters.Line);
+            string patchedMethodPdbUnavailableWarning = string.Empty;
 
             HotReloadShimFileLookup shimLookup =
                 HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(normalizedFile);
@@ -536,7 +537,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         "Pick a line with an executable statement inside the edited method body.");
                 }
 
-                // NotInPatchedMethod: fall through to the compiled ScriptAssemblies resolver.
+                patchedMethodPdbUnavailableWarning = BuildPatchedMethodPdbUnavailableWarningOrEmpty(
+                    shimResolution.Kind == SourcePausePointShimResolveKind.PatchedMethodPdbUnavailable,
+                    shimResolution.MethodDisplayName,
+                    parameters.Line);
+                // NotInPatchedMethod and PatchedMethodPdbUnavailable: fall through to the
+                // compiled ScriptAssemblies resolver. The latter still uses the compiled line
+                // map; only the warning text differs.
             }
 
             SourcePausePointResolveResult resolveResult = SourcePausePointResolver.Resolve(parameters.File, parameters.Line);
@@ -555,9 +562,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         resolveResult.NearbyCompiledMethods),
                     SourcePausePointConstants.ErrorCodeResolveFailed,
                     recommendedNextAction);
-                response.Warning = BuildCompiledLineMapResolveFailureWarningOrEmpty(
-                    hasActiveHotReloadPatches,
-                    parameters.File);
+                response.Warning = ChooseCompiledLineMapWarning(
+                    patchedMethodPdbUnavailableWarning,
+                    BuildCompiledLineMapResolveFailureWarningOrEmpty(
+                        hasActiveHotReloadPatches,
+                        parameters.File));
                 return response;
             }
 
@@ -592,7 +601,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 retargetedToHotReloadPatch: false,
                 hasActiveHotReloadPatches: shimLookup != null,
                 compiledMethodStartLine: resolveResult.Resolution.CompiledMethodStartLine,
-                compiledMethodEndLine: resolveResult.Resolution.CompiledMethodEndLine);
+                compiledMethodEndLine: resolveResult.Resolution.CompiledMethodEndLine,
+                patchedMethodPdbUnavailableWarning: patchedMethodPdbUnavailableWarning);
         }
 
         private static PausePointResponse FinishEnableBySourceLocation(
@@ -607,7 +617,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int editedMethodStartLine = 0,
             int editedMethodEndLine = 0,
             int compiledMethodStartLine = 0,
-            int compiledMethodEndLine = 0)
+            int compiledMethodEndLine = 0,
+            string patchedMethodPdbUnavailableWarning = "")
         {
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(
                 id,
@@ -645,9 +656,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     editedMethodStartLine,
                     editedMethodEndLine));
             bool compareCompiledLineDrift = hasActiveHotReloadPatches && !retargetedToHotReloadPatch;
-            string compiledLineMapWarning = BuildCompiledLineMapWarningOrEmpty(
-                compareCompiledLineDrift,
-                parameters.File);
+            string compiledLineMapWarning = ChooseCompiledLineMapWarning(
+                patchedMethodPdbUnavailableWarning,
+                BuildCompiledLineMapWarningOrEmpty(
+                    compareCompiledLineDrift,
+                    parameters.File));
             enableWarning = MergeWarnings(enableWarning, compiledLineMapWarning);
             if (compareCompiledLineDrift)
             {
@@ -992,6 +1005,36 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return SourcePausePointSourceLineReader.ReadLineTextFromSource(
                 File.ReadAllText(absoluteFilePath),
                 resolvedLine);
+        }
+
+        internal static string BuildPatchedMethodPdbUnavailableWarningOrEmpty(
+            bool patchedMethodPdbUnavailable,
+            string methodDisplayName,
+            int requestedLine)
+        {
+            if (!patchedMethodPdbUnavailable)
+            {
+                return string.Empty;
+            }
+
+            Debug.Assert(!string.IsNullOrEmpty(methodDisplayName), "methodDisplayName must not be empty.");
+            Debug.Assert(requestedLine > 0, "requestedLine must be a positive 1-based line number.");
+            return string.Format(
+                SourcePausePointConstants.HotReloadPatchedMethodPdbUnavailableWarningFormat,
+                methodDisplayName,
+                requestedLine);
+        }
+
+        private static string ChooseCompiledLineMapWarning(
+            string patchedMethodPdbUnavailableWarning,
+            string genericCompiledLineMapWarning)
+        {
+            if (!string.IsNullOrEmpty(patchedMethodPdbUnavailableWarning))
+            {
+                return patchedMethodPdbUnavailableWarning;
+            }
+
+            return genericCompiledLineMapWarning;
         }
 
         internal static string BuildCompiledLineMapWarningOrEmpty(bool hasActiveHotReloadPatches, string file)

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -513,8 +513,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         };
                     }
 
-                    // Shim resolutions carry no end line, so the span degenerates to the single
-                    // resolved line.
+                    // Why the same resolved line twice: shim sequence points do not expose an
+                    // end line distinct from the hit line. Edited method span is passed separately.
                     return FinishEnableBySourceLocation(
                         id,
                         parameters,
@@ -523,7 +523,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         shimResolution.MethodDisplayName,
                         shimPatchResult,
                         retargetedToHotReloadPatch: true,
-                        hasActiveHotReloadPatches: true);
+                        hasActiveHotReloadPatches: true,
+                        editedMethodStartLine: shimResolution.SourceStartLine,
+                        editedMethodEndLine: shimResolution.SourceEndLine);
                 }
 
                 if (shimResolution.Kind == SourcePausePointShimResolveKind.NoStatementInPatchedMethod)
@@ -548,7 +550,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     ? SourcePausePointConstants.HotReloadCompiledLineMapResolveFailureNextAction
                     : SourcePausePointConstants.ResolveFailedRecommendedNextAction;
                 PausePointResponse response = CreateValidationFailure(
-                    resolveResult.ErrorMessage,
+                    AppendNearbyCompiledMethodsSuffix(
+                        resolveResult.ErrorMessage,
+                        resolveResult.NearbyCompiledMethods),
                     SourcePausePointConstants.ErrorCodeResolveFailed,
                     recommendedNextAction);
                 response.Warning = BuildCompiledLineMapResolveFailureWarningOrEmpty(
@@ -586,7 +590,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 resolveResult.Resolution.MethodDisplayName,
                 patchResult,
                 retargetedToHotReloadPatch: false,
-                hasActiveHotReloadPatches: shimLookup != null);
+                hasActiveHotReloadPatches: shimLookup != null,
+                compiledMethodStartLine: resolveResult.Resolution.CompiledMethodStartLine,
+                compiledMethodEndLine: resolveResult.Resolution.CompiledMethodEndLine);
         }
 
         private static PausePointResponse FinishEnableBySourceLocation(
@@ -597,7 +603,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string resolvedMethod,
             SourcePausePointPatchResult patchResult,
             bool retargetedToHotReloadPatch,
-            bool hasActiveHotReloadPatches)
+            bool hasActiveHotReloadPatches,
+            int editedMethodStartLine = 0,
+            int editedMethodEndLine = 0,
+            int compiledMethodStartLine = 0,
+            int compiledMethodEndLine = 0)
         {
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(
                 id,
@@ -626,6 +636,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             response.ResolvedMethod = resolvedMethod;
             response.SnapshotTiming = SourcePausePointConstants.PreLineSnapshotTimingNote;
             string enableWarning = CreateEnableWarning();
+            enableWarning = MergeWarnings(
+                enableWarning,
+                BuildRetargetedToHotReloadPatchWarningOrEmpty(
+                    retargetedToHotReloadPatch,
+                    resolvedMethod,
+                    parameters.Line,
+                    editedMethodStartLine,
+                    editedMethodEndLine));
             bool compareCompiledLineDrift = hasActiveHotReloadPatches && !retargetedToHotReloadPatch;
             string compiledLineMapWarning = BuildCompiledLineMapWarningOrEmpty(
                 compareCompiledLineDrift,
@@ -639,6 +657,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     editedLineText,
                     parameters.File,
                     resolvedLine);
+                driftWarning = AppendCompiledMethodSpanToDriftWarningOrUnchanged(
+                    driftWarning,
+                    resolvedMethod,
+                    compiledMethodStartLine,
+                    compiledMethodEndLine);
                 enableWarning = MergeWarnings(enableWarning, driftWarning);
                 if (driftWarning.Length > 0)
                 {
@@ -884,6 +907,72 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 resolvedLine,
                 compiledTrimmed,
                 editedTrimmed);
+        }
+
+        internal static string AppendCompiledMethodSpanToDriftWarningOrUnchanged(
+            string driftWarning,
+            string resolvedMethod,
+            int compiledMethodStartLine,
+            int compiledMethodEndLine)
+        {
+            if (string.IsNullOrEmpty(driftWarning)
+                || compiledMethodStartLine <= 0
+                || compiledMethodEndLine <= 0)
+            {
+                return driftWarning ?? string.Empty;
+            }
+
+            return driftWarning + string.Format(
+                SourcePausePointConstants.HotReloadCompiledMethodSpanInLastCompiledSourceFormat,
+                resolvedMethod,
+                compiledMethodStartLine,
+                compiledMethodEndLine);
+        }
+
+        internal static string BuildRetargetedToHotReloadPatchWarningOrEmpty(
+            bool retargetedToHotReloadPatch,
+            string resolvedMethod,
+            int requestedLine,
+            int editedMethodStartLine,
+            int editedMethodEndLine)
+        {
+            if (!retargetedToHotReloadPatch)
+            {
+                return string.Empty;
+            }
+
+            return string.Format(
+                SourcePausePointConstants.HotReloadRetargetedToEditedFileWarningFormat,
+                resolvedMethod,
+                requestedLine,
+                editedMethodStartLine,
+                editedMethodEndLine);
+        }
+
+        internal static string AppendNearbyCompiledMethodsSuffix(
+            string errorMessage,
+            IReadOnlyList<SourcePausePointNearbyCompiledMethod> nearbyCompiledMethods)
+        {
+            if (nearbyCompiledMethods == null || nearbyCompiledMethods.Count == 0)
+            {
+                return errorMessage;
+            }
+
+            List<string> parts = new List<string>();
+            foreach (SourcePausePointNearbyCompiledMethod nearby in nearbyCompiledMethods)
+            {
+                parts.Add(
+                    string.Format(
+                        SourcePausePointConstants.NearbyCompiledMethodSpanFormat,
+                        nearby.DisplayName,
+                        nearby.StartLine,
+                        nearby.EndLine));
+            }
+
+            return errorMessage
+                + SourcePausePointConstants.NearbyCompiledMethodsPrefix
+                + string.Join("; ", parts)
+                + ".";
         }
 
         private static string ReadEditedLineTextOrEmpty(string requestedFile, int resolvedLine)

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -235,6 +235,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public const string NearbyCompiledMethodSpanFormat = "'{0}' spans lines {1}-{2}";
 
+        // Format: patched method display name, requested line.
+        // Why a dedicated string: a patched method with no shim PDB still falls through to the
+        // compiled line map, so the generic "patched methods use the edited file" sentence would
+        // be a lie on that path.
+        public const string HotReloadPatchedMethodPdbUnavailableWarningFormat =
+            "--line {1} falls inside hot-reload patched method '{0}', but this patch has no debug "
+            + "symbols. Line numbers are therefore resolved against the last compiled source, not "
+            + "the edited file. Run 'uloop compile' and re-enable.";
+
         // Format: resolved method display name, requested line, edited start line, edited end line.
         public const string HotReloadRetargetedToEditedFileWarningFormat =
             "--line {1} was resolved against the edited file because it falls inside hot-reload "

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -183,7 +183,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // file. Agents otherwise arm a different method with no signal (FB9).
         public const string HotReloadCompiledLineMapWarningFormat =
             "'{0}' has active hot-reload patches. For methods this reload did not patch, --line "
-            + "resolves against the last compiled source, not the edited file. Verify "
+            + "resolves against the last compiled source, not the edited file. Methods currently "
+            + "patched by hot reload resolve against the edited file instead. Verify "
             + "ResolvedMethod and ResolvedLineText, or run 'uloop compile' and re-enable.";
 
         // Why a separate failure string: resolve failure leaves ResolvedMethod and
@@ -191,7 +192,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string HotReloadCompiledLineMapResolveFailureWarningFormat =
             "'{0}' has active hot-reload patches. --line resolves against the last compiled source, "
             + "not the edited file, so a line number taken from the edited file can miss or fail to "
-            + "resolve. Recompute the line against the last compiled source, or run 'uloop compile' "
+            + "resolve. Methods currently patched by hot reload resolve against the edited file instead. "
+            + "Recompute the line against the last compiled source, or run 'uloop compile' "
             + "and re-enable.";
 
         public const string HotReloadCompiledLineMapResolveFailureNextAction =
@@ -212,8 +214,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string HotReloadPatchedLineOutsidePatchedBodyMessageFormat =
             "'{0}.{1}' is currently hot-reload patched and line {2} does not fall inside any "
             + "hot-reload patched method's current body, so the marker cannot be placed reliably. "
-            + "Line numbers are resolved against the last compiled source, so a line number taken "
-            + "from the edited file can land inside a different method after edits shift lines. "
+            + "Patched methods resolve against the edited file; methods this reload did not patch "
+            + "resolve against the last compiled source. "
             + "Either the compiled line map for this file is stale, or the method's active patch "
             + "belongs to a superseded hot-reload generation.";
 
@@ -223,6 +225,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public const string HotReloadPatchedCompiledMethodSpanFormat =
             " In the last compiled source, '{0}.{1}' spans lines {2}-{3}.";
+
+        // Format: resolved method display name, compiled start line, compiled end line.
+        public const string HotReloadCompiledMethodSpanInLastCompiledSourceFormat =
+            " In the last compiled source, '{0}' spans lines {1}-{2}.";
+
+        public const string NearbyCompiledMethodsPrefix =
+            " Nearby methods in the last compiled source: ";
+
+        public const string NearbyCompiledMethodSpanFormat = "'{0}' spans lines {1}-{2}";
+
+        // Format: resolved method display name, requested line, edited start line, edited end line.
+        public const string HotReloadRetargetedToEditedFileWarningFormat =
+            "--line {1} was resolved against the edited file because it falls inside hot-reload "
+            + "patched method '{0}' (edited lines {2}-{3}). Methods not patched by hot reload "
+            + "resolve against the last compiled source instead. If you meant a different method, "
+            + "verify ResolvedMethod, or pass a line outside patched methods' edited spans.";
 
         // Format: declaring type name, added-field count, comma-separated simple field names.
         public const string HotReloadAddedFieldsNotCapturedWarningFormat =

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolveResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolveResult.cs
@@ -1,7 +1,29 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
+    /// <summary>
+    /// One compiled-PDB method span used to recover from a file:line resolve failure.
+    /// </summary>
+    internal sealed class SourcePausePointNearbyCompiledMethod
+    {
+        public string DisplayName { get; }
+        public int StartLine { get; }
+        public int EndLine { get; }
+
+        public SourcePausePointNearbyCompiledMethod(string displayName, int startLine, int endLine)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(displayName), "displayName must not be empty.");
+            Debug.Assert(startLine > 0, "startLine must be a positive 1-based line number.");
+            Debug.Assert(endLine >= startLine, "endLine must be on or after startLine.");
+            DisplayName = displayName;
+            StartLine = startLine;
+            EndLine = endLine;
+        }
+    }
+
     /// <summary>
     /// Outcome of a file:line resolve attempt. Never thrown; failures are carried as data
     /// so callers can report a specific reason instead of an exception.
@@ -12,29 +34,45 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public SourcePausePointResolveFailureReason FailureReason { get; }
         public string ErrorMessage { get; }
         public SourcePausePointResolution Resolution { get; }
+        public IReadOnlyList<SourcePausePointNearbyCompiledMethod> NearbyCompiledMethods { get; }
 
         private SourcePausePointResolveResult(
             bool success,
             SourcePausePointResolveFailureReason failureReason,
             string errorMessage,
-            SourcePausePointResolution resolution)
+            SourcePausePointResolution resolution,
+            IReadOnlyList<SourcePausePointNearbyCompiledMethod> nearbyCompiledMethods)
         {
             Success = success;
             FailureReason = failureReason;
             ErrorMessage = errorMessage;
             Resolution = resolution;
+            NearbyCompiledMethods = nearbyCompiledMethods;
         }
 
         public static SourcePausePointResolveResult SuccessResult(SourcePausePointResolution resolution)
         {
             Debug.Assert(resolution != null, "resolution must not be null for a success result.");
-            return new SourcePausePointResolveResult(true, SourcePausePointResolveFailureReason.None, string.Empty, resolution);
+            return new SourcePausePointResolveResult(
+                true,
+                SourcePausePointResolveFailureReason.None,
+                string.Empty,
+                resolution,
+                Array.Empty<SourcePausePointNearbyCompiledMethod>());
         }
 
-        public static SourcePausePointResolveResult Failure(SourcePausePointResolveFailureReason reason, string errorMessage)
+        public static SourcePausePointResolveResult Failure(
+            SourcePausePointResolveFailureReason reason,
+            string errorMessage,
+            IReadOnlyList<SourcePausePointNearbyCompiledMethod> nearbyCompiledMethods = null)
         {
             Debug.Assert(reason != SourcePausePointResolveFailureReason.None, "Failure requires a specific reason.");
-            return new SourcePausePointResolveResult(false, reason, errorMessage, null);
+            return new SourcePausePointResolveResult(
+                false,
+                reason,
+                errorMessage,
+                null,
+                nearbyCompiledMethods ?? Array.Empty<SourcePausePointNearbyCompiledMethod>());
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs
@@ -210,6 +210,51 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return (startLine, endLine);
         }
 
+        // Why a file:line entry: the resolver test assembly cannot take a Cecil
+        // ModuleDefinition dependency, but TakeAtMostTwo only runs on this walk.
+        internal static IReadOnlyList<SourcePausePointNearbyCompiledMethod> FindNearbyCompiledMethodsInFile(
+            string projectRelativeFilePath,
+            int line)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativeFilePath), "projectRelativeFilePath must not be null or empty.");
+            Debug.Assert(line > 0, "line must be a positive 1-based line number.");
+
+            string normalizedInputPath = SourcePausePointPathNormalizer.ToForwardSlashes(projectRelativeFilePath);
+            string rawAssemblyName = CompilationPipeline.GetAssemblyNameFromScriptPath(normalizedInputPath);
+            if (string.IsNullOrEmpty(rawAssemblyName))
+            {
+                return Array.Empty<SourcePausePointNearbyCompiledMethod>();
+            }
+
+            string assemblyName = Path.GetFileNameWithoutExtension(rawAssemblyName);
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string dllPath = Path.Combine(
+                projectRoot,
+                SourcePausePointConstants.ScriptAssembliesRelativeDirectory,
+                assemblyName + SourcePausePointConstants.CompiledAssemblyExtension);
+            string pdbPath = Path.Combine(
+                projectRoot,
+                SourcePausePointConstants.ScriptAssembliesRelativeDirectory,
+                assemblyName + SourcePausePointConstants.DebugSymbolsExtension);
+            if (!File.Exists(dllPath) || !File.Exists(pdbPath))
+            {
+                return Array.Empty<SourcePausePointNearbyCompiledMethod>();
+            }
+
+            using FileStream dllStream = File.Open(dllPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using FileStream pdbStream = File.Open(pdbPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            ReaderParameters readerParameters = new ReaderParameters
+            {
+                InMemory = true,
+                ReadSymbols = true,
+                SymbolReaderProvider = new PortablePdbReaderProvider(),
+                SymbolStream = pdbStream
+            };
+            using AssemblyDefinition assemblyDefinition =
+                AssemblyDefinition.ReadAssembly(dllStream, readerParameters);
+            return FindNearbyCompiledMethods(assemblyDefinition.MainModule, normalizedInputPath, line);
+        }
+
         // Why a separate walk from FindClosestSequencePointOnOrAfterLine: that search only
         // looks forward, so a miss past the last statement would otherwise leave the caller
         // with no compiled span to retarget against.

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs
@@ -86,9 +86,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (method == null)
             {
+                IReadOnlyList<SourcePausePointNearbyCompiledMethod> nearbyCompiledMethods =
+                    FindNearbyCompiledMethods(assemblyDefinition.MainModule, normalizedInputPath, line);
                 return SourcePausePointResolveResult.Failure(
                     SourcePausePointResolveFailureReason.NoSequencePointOnOrAfterLine,
-                    $"No sequence point found on or after line {line} in '{originalInputPath}'.");
+                    $"No sequence point found on or after line {line} in '{originalInputPath}'.",
+                    nearbyCompiledMethods);
             }
 
             int instructionIndex = FindInstructionIndex(method.Body.Instructions, sequencePoint.Offset);
@@ -205,6 +208,102 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return (startLine, endLine);
+        }
+
+        // Why a separate walk from FindClosestSequencePointOnOrAfterLine: that search only
+        // looks forward, so a miss past the last statement would otherwise leave the caller
+        // with no compiled span to retarget against.
+        internal static IReadOnlyList<SourcePausePointNearbyCompiledMethod> FindNearbyCompiledMethods(
+            ModuleDefinition module,
+            string normalizedInputPath,
+            int line)
+        {
+            Debug.Assert(module != null, "module must not be null.");
+            Debug.Assert(!string.IsNullOrEmpty(normalizedInputPath), "normalizedInputPath must not be empty.");
+            Debug.Assert(line > 0, "line must be a positive 1-based line number.");
+
+            List<SourcePausePointNearbyCompiledMethod> containing = new List<SourcePausePointNearbyCompiledMethod>();
+            SourcePausePointNearbyCompiledMethod nearestBefore = null;
+            SourcePausePointNearbyCompiledMethod nearestAfter = null;
+
+            foreach (MethodDefinition method in EnumerateMethodsInModule(module))
+            {
+                SourcePausePointNearbyCompiledMethod candidate =
+                    TryCreateNearbyCompiledMethod(method, normalizedInputPath);
+                if (candidate == null)
+                {
+                    continue;
+                }
+
+                if (candidate.StartLine <= line && line <= candidate.EndLine)
+                {
+                    containing.Add(candidate);
+                    continue;
+                }
+
+                if (candidate.EndLine < line
+                    && (nearestBefore == null || candidate.EndLine > nearestBefore.EndLine))
+                {
+                    nearestBefore = candidate;
+                }
+
+                if (candidate.StartLine > line
+                    && (nearestAfter == null || candidate.StartLine < nearestAfter.StartLine))
+                {
+                    nearestAfter = candidate;
+                }
+            }
+
+            if (containing.Count > 0)
+            {
+                return TakeAtMostTwo(containing);
+            }
+
+            List<SourcePausePointNearbyCompiledMethod> nearby = new List<SourcePausePointNearbyCompiledMethod>();
+            if (nearestBefore != null)
+            {
+                nearby.Add(nearestBefore);
+            }
+
+            if (nearestAfter != null)
+            {
+                nearby.Add(nearestAfter);
+            }
+
+            return nearby;
+        }
+
+        private static SourcePausePointNearbyCompiledMethod TryCreateNearbyCompiledMethod(
+            MethodDefinition method,
+            string normalizedInputPath)
+        {
+            if (!method.HasBody)
+            {
+                return null;
+            }
+
+            (int startLine, int endLine) = CollectCompiledMethodSpan(method, normalizedInputPath);
+            if (startLine <= 0 || endLine <= 0)
+            {
+                return null;
+            }
+
+            string typeName = method.DeclaringType != null ? method.DeclaringType.Name : "?";
+            return new SourcePausePointNearbyCompiledMethod(
+                typeName + "." + method.Name,
+                startLine,
+                endLine);
+        }
+
+        private static IReadOnlyList<SourcePausePointNearbyCompiledMethod> TakeAtMostTwo(
+            List<SourcePausePointNearbyCompiledMethod> methods)
+        {
+            if (methods.Count <= 2)
+            {
+                return methods;
+            }
+
+            return new[] { methods[0], methods[1] };
         }
 
         // Shared with SourcePausePointShimResolver so shim-assembly sequence-point walks use the

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolution.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolution.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -118,6 +119,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameters: null,
                 instanceFromFirstArgument: false,
                 methodDisplayName: null,
+                errorMessage: null,
+                sourceStartLine: 0,
+                sourceEndLine: 0);
+        }
+
+        public static SourcePausePointShimResolution PatchedMethodPdbUnavailable(MethodBase logicalOwner)
+        {
+            Debug.Assert(logicalOwner != null, "logicalOwner must not be null.");
+            string typeName = logicalOwner.DeclaringType != null ? logicalOwner.DeclaringType.Name : "?";
+            return new SourcePausePointShimResolution(
+                SourcePausePointShimResolveKind.PatchedMethodPdbUnavailable,
+                targetMethod: null,
+                logicalOwner,
+                donorShim: null,
+                instructionIndex: -1,
+                resolvedLine: 0,
+                locals: null,
+                parameters: null,
+                instanceFromFirstArgument: false,
+                typeName + "." + logicalOwner.Name,
                 errorMessage: null,
                 sourceStartLine: 0,
                 sourceEndLine: 0);

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolution.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolution.cs
@@ -19,6 +19,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool InstanceFromFirstArgument { get; }
         public string MethodDisplayName { get; }
         public string ErrorMessage { get; }
+        public int SourceStartLine { get; }
+        public int SourceEndLine { get; }
 
         private SourcePausePointShimResolution(
             SourcePausePointShimResolveKind kind,
@@ -31,7 +33,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             IReadOnlyList<SourcePausePointParameter> parameters,
             bool instanceFromFirstArgument,
             string methodDisplayName,
-            string errorMessage)
+            string errorMessage,
+            int sourceStartLine,
+            int sourceEndLine)
         {
             Kind = kind;
             TargetMethod = targetMethod;
@@ -44,6 +48,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             InstanceFromFirstArgument = instanceFromFirstArgument;
             MethodDisplayName = methodDisplayName;
             ErrorMessage = errorMessage;
+            SourceStartLine = sourceStartLine;
+            SourceEndLine = sourceEndLine;
         }
 
         public static SourcePausePointShimResolution TransplantChainJoin(
@@ -52,7 +58,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int instructionIndex,
             int resolvedLine,
             IReadOnlyList<SourcePausePointLocalVariable> locals,
-            IReadOnlyList<SourcePausePointParameter> parameters)
+            IReadOnlyList<SourcePausePointParameter> parameters,
+            int sourceStartLine,
+            int sourceEndLine)
         {
             return new SourcePausePointShimResolution(
                 SourcePausePointShimResolveKind.TransplantChainJoin,
@@ -65,7 +73,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameters,
                 instanceFromFirstArgument: false,
                 originalMethod.ToString(),
-                errorMessage: null);
+                errorMessage: null,
+                sourceStartLine,
+                sourceEndLine);
         }
 
         public static SourcePausePointShimResolution ShimDirect(
@@ -75,7 +85,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int resolvedLine,
             IReadOnlyList<SourcePausePointLocalVariable> locals,
             IReadOnlyList<SourcePausePointParameter> parameters,
-            bool instanceFromFirstArgument)
+            bool instanceFromFirstArgument,
+            int sourceStartLine,
+            int sourceEndLine)
         {
             return new SourcePausePointShimResolution(
                 SourcePausePointShimResolveKind.ShimDirect,
@@ -88,7 +100,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameters,
                 instanceFromFirstArgument,
                 logicalOwner.ToString(),
-                errorMessage: null);
+                errorMessage: null,
+                sourceStartLine,
+                sourceEndLine);
         }
 
         public static SourcePausePointShimResolution NotInPatchedMethod()
@@ -104,7 +118,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameters: null,
                 instanceFromFirstArgument: false,
                 methodDisplayName: null,
-                errorMessage: null);
+                errorMessage: null,
+                sourceStartLine: 0,
+                sourceEndLine: 0);
         }
 
         public static SourcePausePointShimResolution NoStatementInPatchedMethod(
@@ -122,7 +138,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameters: null,
                 instanceFromFirstArgument: false,
                 logicalOwner.ToString(),
-                errorMessage);
+                errorMessage,
+                sourceStartLine: 0,
+                sourceEndLine: 0);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolveKind.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolveKind.cs
@@ -8,6 +8,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         TransplantChainJoin,
         ShimDirect,
         NotInPatchedMethod,
+        PatchedMethodPdbUnavailable,
         NoStatementInPatchedMethod
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolver.cs
@@ -31,11 +31,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return SourcePausePointShimResolution.NotInPatchedMethod();
             }
 
-            // Why bail before Cecil: fallback compile backends can omit PDB bytes; ReadSymbols
-            // against an empty stream throws and would abort the whole enable call.
+            // Why a distinct Kind: fallback compile backends can omit PDB bytes; ReadSymbols
+            // against an empty stream throws. Enable still falls through to the compiled
+            // resolver, but must not claim patched methods resolve against the edited file.
             if (lookup.PdbBytes == null || lookup.PdbBytes.Length == 0)
             {
-                return SourcePausePointShimResolution.NotInPatchedMethod();
+                return SourcePausePointShimResolution.PatchedMethodPdbUnavailable(methodEntry.OriginalMethod);
             }
 
             using MemoryStream assemblyStream = new MemoryStream(lookup.AssemblyBytes, writable: false);

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointShimResolver.cs
@@ -106,7 +106,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     instructionIndex,
                     sequencePoint.StartLine,
                     locals,
-                    parameters);
+                    parameters,
+                    methodEntry.SourceStartLine,
+                    methodEntry.SourceEndLine);
             }
 
             MethodBase targetMethod =
@@ -127,7 +129,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 sequencePoint.StartLine,
                 locals,
                 shimParameters,
-                instanceFromFirstArgument);
+                instanceFromFirstArgument,
+                methodEntry.SourceStartLine,
+                methodEntry.SourceEndLine);
         }
 
         private static HotReloadShimMethodLookup FindMethodEntryForLine(


### PR DESCRIPTION
## Summary
- Pause-point enable now says which line map it used: the edited file for a hot-reload patched method, or the last compiled source for everything else.
- Drift warnings and resolve failures include compiled method spans so you can retarget `--line` without guessing.

## User Impact
- Before: enabling on a patched method stayed silent, compiled-line-map warnings implied every method used the compiled map, and a miss past the last statement gave no nearby spans.
- After: a retargeted enable names the patched method and its edited span; unpatched drift warnings append the compiled span when it is known; a resolve failure lists nearby compiled methods (at most two) with their spans.

## Changes
- Shim resolution carries the edited method span and emit a retarget warning when that path arms the marker.
- Dual-basis wording is added to the compiled-line-map and outside-patched-body strings.
- Resolve failure collects nearby compiled PDB spans and appends them to the error message.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` — Success, ErrorCount 0
- `PausePointCompiledLineMapWarningTests` — 19 Passed
- `SourcePausePointResolverTests` — 14 Passed
- `HotReloadPausePointLineDriftTests` — 5 Passed
- `SourcePausePointPatcherTests` — 29 Passed
- `HotReloadPausePointContractTests` — 21 Passed
- `PausePointAddedFieldWarningTests` — 2 Passed
- `PausePointTests` — 92 Passed
- `HotReloadPausePointE2ETests|PausePointStatusResponseContractTests` — 5 Passed
- Repository GHA does not run on pull requests targeting `feature/hot-reload` (workflows are gated to `main` / `v3-beta`)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

