### PR TITLE
fix: run no-tests asmdef diagnostics on the main thread

### DIFF
--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -463,6 +463,60 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.ClearedPausePointIds, Is.Null);
         }
 
+        /// <summary>
+        /// What: after cleanup resumes off-thread, no-tests diagnostics still run on the main thread.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenCleanupResumesOffThread_RunsNoTestsDiagnosticsOnMainThread()
+        {
+            RecordingNoTestsDiagnosticCapture diagnosticCapture = new RecordingNoTestsDiagnosticCapture();
+            StubTestExecutionService executionService = new StubTestExecutionService
+            {
+                NextResult = new SerializableTestResult
+                {
+                    success = false,
+                    status = RunTestsExecutionStatus.NoTestsFound,
+                    hasFailures = false,
+                    noTestsFound = true,
+                    noTestsFoundExplanation = RunTestsResponse.NoTestsFoundExplanationText,
+                    message = RunTestsResponse.NoTestsFoundMessage,
+                    completedAt = "2026-01-01T00:00:00.0000000Z",
+                    testCount = 0,
+                    passedCount = 0,
+                    failedCount = 0,
+                    skippedCount = 0,
+                    xmlPath = null
+                }
+            };
+            StubTestExecutionStateValidationService validationService =
+                new StubTestExecutionStateValidationService(ValidationResult.Success());
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                waitForTestRunnerCleanupAsync: ResumeCleanupOnThreadPoolAsync,
+                appendNoTestsDiagnostics: diagnosticCapture.Append);
+            RunTestsSchema parameters = new RunTestsSchema
+            {
+                TestMode = UnityCliLoopTestMode.EditMode,
+                FilterType = TestFilterType.all
+            };
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.NoTestsFound, Is.True);
+            Assert.That(diagnosticCapture.AppendCalled, Is.True);
+            Assert.That(diagnosticCapture.ObservedIsMainThread, Is.True);
+        }
+
+        private static async Task ResumeCleanupOnThreadPoolAsync(CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            // Why TimerDelay instead of Task.Run: EditMode guardrails forbid thread-pool tests
+            // that can stall the runner; this is the same timer resume production cleanup uses.
+            await TimerDelay.Wait(1, ct).ConfigureAwait(false);
+        }
+
         private static Task NoCleanupWait(CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
@@ -522,6 +576,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 ct.ThrowIfCancellationRequested();
                 WasCalled = true;
                 return Task.FromResult(NextResult);
+            }
+        }
+
+        private sealed class RecordingNoTestsDiagnosticCapture
+        {
+            public bool AppendCalled { get; private set; }
+            public bool ObservedIsMainThread { get; private set; }
+
+            public string Append(
+                string message,
+                bool noTestsFound,
+                UnityCliLoopTestMode testMode,
+                TestFilterType filterType)
+            {
+                AppendCalled = true;
+                ObservedIsMainThread = MainThreadSwitcher.IsMainThread;
+                return message;
             }
         }
     }

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -464,11 +464,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
-        /// What: after cleanup resumes off-thread, no-tests diagnostics still run on the main thread.
+        /// What: after cleanup is proven off-thread, no-tests diagnostics still run on the main thread.
         /// </summary>
         [Test]
         public async Task ExecuteAsync_WhenCleanupResumesOffThread_RunsNoTestsDiagnosticsOnMainThread()
         {
+            OffThreadCleanupResume cleanupResume = new OffThreadCleanupResume();
             RecordingNoTestsDiagnosticCapture diagnosticCapture = new RecordingNoTestsDiagnosticCapture();
             StubTestExecutionService executionService = new StubTestExecutionService
             {
@@ -494,7 +495,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new TestFilterCreationService(),
                 executionService,
                 validationService,
-                waitForTestRunnerCleanupAsync: ResumeCleanupOnThreadPoolAsync,
+                waitForTestRunnerCleanupAsync: cleanupResume.ResumeAsync,
                 appendNoTestsDiagnostics: diagnosticCapture.Append);
             RunTestsSchema parameters = new RunTestsSchema
             {
@@ -505,16 +506,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
 
             Assert.That(response.NoTestsFound, Is.True);
+            Assert.That(cleanupResume.ObservedIsMainThread, Is.False);
             Assert.That(diagnosticCapture.AppendCalled, Is.True);
             Assert.That(diagnosticCapture.ObservedIsMainThread, Is.True);
-        }
-
-        private static async Task ResumeCleanupOnThreadPoolAsync(CancellationToken ct)
-        {
-            ct.ThrowIfCancellationRequested();
-            // Why TimerDelay instead of Task.Run: EditMode guardrails forbid thread-pool tests
-            // that can stall the runner; this is the same timer resume production cleanup uses.
-            await TimerDelay.Wait(1, ct).ConfigureAwait(false);
         }
 
         private static Task NoCleanupWait(CancellationToken ct)
@@ -576,6 +570,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 ct.ThrowIfCancellationRequested();
                 WasCalled = true;
                 return Task.FromResult(NextResult);
+            }
+        }
+
+        /// <summary>
+        /// Test support type that resumes cleanup off-thread without Task.Run.
+        /// </summary>
+        private sealed class OffThreadCleanupResume
+        {
+            public bool ObservedIsMainThread { get; private set; }
+
+            public async Task ResumeAsync(CancellationToken ct)
+            {
+                ct.ThrowIfCancellationRequested();
+                // Why loop TimerDelay instead of Task.Run: EditMode guardrails
+                // forbid thread-pool tests that can stall the runner. A single
+                // Wait(1).ConfigureAwait(false) can complete before await and
+                // continue inline on the main thread; retry until a suspend
+                // actually resumes off-thread.
+                while (MainThreadSwitcher.IsMainThread)
+                {
+                    await TimerDelay.Wait(1, ct).ConfigureAwait(false);
+                }
+
+                ObservedIsMainThread = MainThreadSwitcher.IsMainThread;
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsNoTestsDiagnosticService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsNoTestsDiagnosticService.cs
@@ -33,6 +33,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return message;
             }
 
+            Debug.Assert(
+                MainThreadSwitcher.IsMainThread,
+                "No-tests asmdef diagnostics must run on the main thread because AssetDatabase.FindAssets is a Unity API.");
+
             RunTestsAsmdefInfo[] asmdefs = LoadProjectAsmdefs();
             RunTestsAsmdefDiagnosticFinding[] findings = Analyze(asmdefs, testMode);
             return AppendFindingsIfEligible(message, noTestsFound, findings);

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -18,7 +18,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly TestFilterCreationService _filterService;
         private readonly TestExecutionService _executionService;
         private readonly TestExecutionStateValidationService _validationService;
-        private readonly RunTestsNoTestsDiagnosticService _noTestsDiagnosticService;
+        private readonly Func<string, bool, UnityCliLoopTestMode, TestFilterType, string> _appendNoTestsDiagnostics;
         private readonly Func<string[]> _clearActivePausePoints;
         private readonly Func<CancellationToken, Task> _waitForTestRunnerCleanupAsync;
         private const int TestRunnerCleanupFallbackDelayMilliseconds = 3000;
@@ -36,7 +36,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             TestExecutionService executionService,
             TestExecutionStateValidationService validationService,
             Func<string[]> clearActivePausePoints = null,
-            Func<CancellationToken, Task> waitForTestRunnerCleanupAsync = null)
+            Func<CancellationToken, Task> waitForTestRunnerCleanupAsync = null,
+            Func<string, bool, UnityCliLoopTestMode, TestFilterType, string> appendNoTestsDiagnostics = null)
         {
             Debug.Assert(filterService != null, "filterService must not be null");
             Debug.Assert(executionService != null, "executionService must not be null");
@@ -44,7 +45,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _filterService = filterService;
             _executionService = executionService;
             _validationService = validationService;
-            _noTestsDiagnosticService = new RunTestsNoTestsDiagnosticService();
+            RunTestsNoTestsDiagnosticService noTestsDiagnosticService = new RunTestsNoTestsDiagnosticService();
+            _appendNoTestsDiagnostics = appendNoTestsDiagnostics
+                ?? ((string message, bool noTestsFound, UnityCliLoopTestMode testMode, TestFilterType filterType) =>
+                    noTestsDiagnosticService.AppendDiagnosticsIfNeeded(message, noTestsFound, testMode, filterType));
             _clearActivePausePoints = clearActivePausePoints ?? ClearActivePausePointsDefault;
             _waitForTestRunnerCleanupAsync = waitForTestRunnerCleanupAsync ?? WaitForTestRunnerCleanupAsync;
         }
@@ -161,9 +165,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 response.ClearedPausePointIds = clearedPausePointIds;
             }
+
+            // Why switch here: cleanup waits with ConfigureAwait(false), so this resume is
+            // off-thread. No-tests diagnostics call AssetDatabase.FindAssets, a Unity API.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
             response.Message = RunTestsNoTestsDiagnosticService.AppendDiagnosticsOrOriginalMessage(
                 response.Message,
-                () => _noTestsDiagnosticService.AppendDiagnosticsIfNeeded(
+                () => _appendNoTestsDiagnostics(
                     response.Message,
                     response.NoTestsFound,
                     parameters.TestMode,


### PR DESCRIPTION
## Summary
- `uloop run-tests` no longer turns a "no tests found" result into an internal error on Unity 6000.x.
- When Test Runner discovers zero tests, the command still returns the NoTestsFound response, including asmdef hints.

## User Impact
- Before: on Unity 6000.x, running `uloop run-tests` with no filter (`--filter-type all`) and zero matching tests failed as an internal JSON-RPC error (`UnityException: GetAllRegisteredPackages can only be called from the main thread`). Agents treated this as a broken Test Runner and stopped. The same command with an exact filter still returned NoTestsFound.
- After: the no-tests asmdef diagnostic path runs on the Unity main thread, so Unity 6000.x returns the normal NoTestsFound response instead of an internal error.
- This does not reproduce on Unity 2022.3: `AssetDatabase.FindAssets` there does not call `PackageInfo.GetAllRegisteredPackages()`, so the off-thread call is silent on the development Editor.

## Observed Unity 6000.3 error
```
UnityException: GetAllRegisteredPackages can only be called from the main thread.
```

Editor.log stack (project paths replaced):
```
AssetDatabaseSearching.FindEverywhere
PackageManagerUtilityInternal.GetAllVisiblePackages
PackageInfo.GetAllRegisteredPackages
AssetDatabase.FindAssets("t:AssemblyDefinitionAsset")
RunTestsNoTestsDiagnosticService.LoadProjectAsmdefs
RunTestsNoTestsDiagnosticService.AppendDiagnosticsIfNeeded
RunTestsNoTestsDiagnosticService.AppendDiagnosticsOrOriginalMessage
RunTestsUseCase.ExecuteAsync
<PROJECT_ROOT>/Packages/src/Editor/FirstPartyTools/RunTests/...
```

The catch around diagnostics recovers only `IOException` / `UnauthorizedAccessException`. This change does not widen that catch: it switches back to the main thread before diagnostics, matching the existing "off-thread resumes must switch back before any Unity API work" contract. The drop off the main thread came from `await WaitForTestRunnerCleanupAsync(...).ConfigureAwait(false)` after an earlier `SwitchToMainThread`.

## Changes
- Switch to the main thread immediately before appending no-tests asmdef diagnostics.
- Assert that diagnostics run on the main thread after the diagnostic gate and before `AssetDatabase.FindAssets`.
- Cover the cleanup `ConfigureAwait(false)` resume with an EditMode test that records `MainThreadSwitcher.IsMainThread` on the diagnostic hook.

## Verification
Repository GitHub Actions do not run on PRs targeting `feature/hot-reload`. Local evidence:

- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Success, ErrorCount 0, WarningCount 0
- Red: `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value "ExecuteAsync_WhenCleanupResumesOffThread_RunsNoTestsDiagnosticsOnMainThread"` → Failed 1 (Expected True, Got False) before the switch
- Green: same command → Passed 1
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value "RunTests"` → Passed 76 / 76


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

