### PR TITLE
refactor: split high-complexity dispatcher functions below the cyclop threshold

### DIFF
--- a/cli/dispatcher/attestation/verifier.go
+++ b/cli/dispatcher/attestation/verifier.go
@@ -144,14 +144,8 @@ type SubjectsOptions struct {
 // against the specific asset they downloaded. Verify() still enforces artifact
 // binding for the installer script path.
 func VerifySubjects(trustedMaterial root.TrustedMaterial, opts SubjectsOptions) (map[string]string, error) {
-	if len(opts.BundleData) == 0 {
-		return nil, fmt.Errorf("%w: BundleData required", ErrVerificationFailed)
-	}
-	if !isHexCommitSHA(opts.ExpectedCommitSHA) {
-		return nil, fmt.Errorf("%w: ExpectedCommitSHA must be 40-char hex", ErrVerificationFailed)
-	}
-	if opts.Identity.Repository == "" || opts.Identity.WorkflowPath == "" || len(opts.Identity.Refs) == 0 {
-		return nil, fmt.Errorf("%w: Identity.Repository, WorkflowPath, and at least one Ref required", ErrVerificationFailed)
+	if err := opts.validate(); err != nil {
+		return nil, err
 	}
 
 	var b bundle.Bundle
@@ -183,6 +177,26 @@ func VerifySubjects(trustedMaterial root.TrustedMaterial, opts SubjectsOptions) 
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrVerificationFailed, err)
 	}
+	return extractVerifiedSubjects(result)
+}
+
+func (o SubjectsOptions) validate() error {
+	if len(o.BundleData) == 0 {
+		return fmt.Errorf("%w: BundleData required", ErrVerificationFailed)
+	}
+	if !isHexCommitSHA(o.ExpectedCommitSHA) {
+		return fmt.Errorf("%w: ExpectedCommitSHA must be 40-char hex", ErrVerificationFailed)
+	}
+	if o.Identity.Repository == "" || o.Identity.WorkflowPath == "" || len(o.Identity.Refs) == 0 {
+		return fmt.Errorf("%w: Identity.Repository, WorkflowPath, and at least one Ref required", ErrVerificationFailed)
+	}
+	return nil
+}
+
+// extractVerifiedSubjects maps verified in-toto subjects to lowercase sha256
+// hex digests. Why skip entries without sha256: callers compare those hashes
+// against downloaded assets, so an unhashed subject must not appear trusted.
+func extractVerifiedSubjects(result *verify.VerificationResult) (map[string]string, error) {
 	if result == nil || result.Statement == nil {
 		return nil, fmt.Errorf("%w: verified bundle had no statement", ErrVerificationFailed)
 	}

--- a/cli/dispatcher/attestation/verifier_test.go
+++ b/cli/dispatcher/attestation/verifier_test.go
@@ -146,10 +146,19 @@ func TestVerifySubjects_RejectsIncompleteOptions(t *testing.T) {
 			wantErrContains: "BundleData required",
 		},
 		{
-			name: "non hex commit",
+			name: "wrong length commit",
 			opts: SubjectsOptions{
 				BundleData:        f.bundle,
 				ExpectedCommitSHA: "not-a-40-char-hex-commit-sha",
+				Identity:          f.identity,
+			},
+			wantErrContains: "ExpectedCommitSHA must be 40-char hex",
+		},
+		{
+			name: "non hex commit",
+			opts: SubjectsOptions{
+				BundleData:        f.bundle,
+				ExpectedCommitSHA: strings.Repeat("g", 40),
 				Identity:          f.identity,
 			},
 			wantErrContains: "ExpectedCommitSHA must be 40-char hex",

--- a/cli/dispatcher/attestation/verifier_test.go
+++ b/cli/dispatcher/attestation/verifier_test.go
@@ -133,9 +133,9 @@ func TestVerifySubjects_RejectsIncompleteOptions(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name            string
-		opts            SubjectsOptions
-		wantErrContains string
+		name    string
+		opts    SubjectsOptions
+		wantErr string
 	}{
 		{
 			name: "empty bundle",
@@ -143,7 +143,7 @@ func TestVerifySubjects_RejectsIncompleteOptions(t *testing.T) {
 				ExpectedCommitSHA: f.commitSHA,
 				Identity:          f.identity,
 			},
-			wantErrContains: "BundleData required",
+			wantErr: "attestation verification failed: BundleData required",
 		},
 		{
 			name: "wrong length commit",
@@ -152,7 +152,7 @@ func TestVerifySubjects_RejectsIncompleteOptions(t *testing.T) {
 				ExpectedCommitSHA: "not-a-40-char-hex-commit-sha",
 				Identity:          f.identity,
 			},
-			wantErrContains: "ExpectedCommitSHA must be 40-char hex",
+			wantErr: "attestation verification failed: ExpectedCommitSHA must be 40-char hex",
 		},
 		{
 			name: "non hex commit",
@@ -161,7 +161,7 @@ func TestVerifySubjects_RejectsIncompleteOptions(t *testing.T) {
 				ExpectedCommitSHA: strings.Repeat("g", 40),
 				Identity:          f.identity,
 			},
-			wantErrContains: "ExpectedCommitSHA must be 40-char hex",
+			wantErr: "attestation verification failed: ExpectedCommitSHA must be 40-char hex",
 		},
 		{
 			name: "missing repository",
@@ -173,7 +173,7 @@ func TestVerifySubjects_RejectsIncompleteOptions(t *testing.T) {
 					Refs:         f.identity.Refs,
 				},
 			},
-			wantErrContains: "Identity.Repository, WorkflowPath, and at least one Ref required",
+			wantErr: "attestation verification failed: Identity.Repository, WorkflowPath, and at least one Ref required",
 		},
 		{
 			name: "missing workflow path",
@@ -185,7 +185,7 @@ func TestVerifySubjects_RejectsIncompleteOptions(t *testing.T) {
 					Refs:       f.identity.Refs,
 				},
 			},
-			wantErrContains: "Identity.Repository, WorkflowPath, and at least one Ref required",
+			wantErr: "attestation verification failed: Identity.Repository, WorkflowPath, and at least one Ref required",
 		},
 		{
 			name: "missing refs",
@@ -197,7 +197,7 @@ func TestVerifySubjects_RejectsIncompleteOptions(t *testing.T) {
 					WorkflowPath: f.identity.WorkflowPath,
 				},
 			},
-			wantErrContains: "Identity.Repository, WorkflowPath, and at least one Ref required",
+			wantErr: "attestation verification failed: Identity.Repository, WorkflowPath, and at least one Ref required",
 		},
 	}
 
@@ -210,8 +210,8 @@ func TestVerifySubjects_RejectsIncompleteOptions(t *testing.T) {
 			if !errors.Is(verifyErr, ErrVerificationFailed) {
 				t.Fatalf("expected ErrVerificationFailed, got %v", verifyErr)
 			}
-			if !strings.Contains(verifyErr.Error(), testCase.wantErrContains) {
-				t.Fatalf("error %q does not contain %q", verifyErr, testCase.wantErrContains)
+			if verifyErr.Error() != testCase.wantErr {
+				t.Fatalf("error = %q, want %q", verifyErr.Error(), testCase.wantErr)
 			}
 		})
 	}

--- a/cli/dispatcher/attestation/verifier_test.go
+++ b/cli/dispatcher/attestation/verifier_test.go
@@ -124,6 +124,90 @@ func TestVerifySubjects_CommitMismatchFailsClosed(t *testing.T) {
 	}
 }
 
+// Characterizes VerifySubjects fail-closed input checks that run before Sigstore verification.
+func TestVerifySubjects_RejectsIncompleteOptions(t *testing.T) {
+	f := loadHappyFixture(t)
+	trusted, err := LoadEmbeddedTrustedMaterial()
+	if err != nil {
+		t.Fatalf("load trusted root: %v", err)
+	}
+
+	testCases := []struct {
+		name            string
+		opts            SubjectsOptions
+		wantErrContains string
+	}{
+		{
+			name: "empty bundle",
+			opts: SubjectsOptions{
+				ExpectedCommitSHA: f.commitSHA,
+				Identity:          f.identity,
+			},
+			wantErrContains: "BundleData required",
+		},
+		{
+			name: "non hex commit",
+			opts: SubjectsOptions{
+				BundleData:        f.bundle,
+				ExpectedCommitSHA: "not-a-40-char-hex-commit-sha",
+				Identity:          f.identity,
+			},
+			wantErrContains: "ExpectedCommitSHA must be 40-char hex",
+		},
+		{
+			name: "missing repository",
+			opts: SubjectsOptions{
+				BundleData:        f.bundle,
+				ExpectedCommitSHA: f.commitSHA,
+				Identity: Identity{
+					WorkflowPath: f.identity.WorkflowPath,
+					Refs:         f.identity.Refs,
+				},
+			},
+			wantErrContains: "Identity.Repository, WorkflowPath, and at least one Ref required",
+		},
+		{
+			name: "missing workflow path",
+			opts: SubjectsOptions{
+				BundleData:        f.bundle,
+				ExpectedCommitSHA: f.commitSHA,
+				Identity: Identity{
+					Repository: f.identity.Repository,
+					Refs:       f.identity.Refs,
+				},
+			},
+			wantErrContains: "Identity.Repository, WorkflowPath, and at least one Ref required",
+		},
+		{
+			name: "missing refs",
+			opts: SubjectsOptions{
+				BundleData:        f.bundle,
+				ExpectedCommitSHA: f.commitSHA,
+				Identity: Identity{
+					Repository:   f.identity.Repository,
+					WorkflowPath: f.identity.WorkflowPath,
+				},
+			},
+			wantErrContains: "Identity.Repository, WorkflowPath, and at least one Ref required",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, verifyErr := VerifySubjects(trusted, testCase.opts)
+			if verifyErr == nil {
+				t.Fatal("expected incomplete options to fail")
+			}
+			if !errors.Is(verifyErr, ErrVerificationFailed) {
+				t.Fatalf("expected ErrVerificationFailed, got %v", verifyErr)
+			}
+			if !strings.Contains(verifyErr.Error(), testCase.wantErrContains) {
+				t.Fatalf("error %q does not contain %q", verifyErr, testCase.wantErrContains)
+			}
+		})
+	}
+}
+
 // Verifies VerifySubjects rejects bundles it cannot parse as Sigstore JSON.
 func TestVerifySubjects_MalformedBundleFailsClosed(t *testing.T) {
 	f := loadHappyFixture(t)

--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect.go
@@ -70,38 +70,74 @@ func detectV2DispatcherProject(projectRoot string) (dispatcherV2Project, error) 
 	if err != nil {
 		return dispatcherV2Project{}, err
 	}
-	packageVersion := lockEntry.Version
-	if found && sharedversion.IsValid(strings.TrimSpace(packageVersion)) {
-		if !isDispatcherV2PackageVersion(packageVersion) {
-			return dispatcherV2Project{}, nil
-		}
-		return dispatcherV2Project{IsV2: true, PackageVersion: packageVersion}, nil
+	if project, handled := detectV2DispatcherFromResolvedLockVersion(lockEntry, found); handled {
+		return project, nil
 	}
 
 	if isDispatcherFileDependency(manifestDependency) {
 		return detectV2DispatcherFileDependencyProject(projectRoot, manifestDependency)
 	}
 
-	if found && lockEntry.Source != dispatcherPackageLockSourceGit {
-		return dispatcherV2Project{}, nil
-	}
-	if !found && !isDispatcherGitPackageDependency(manifestDependency) {
+	if !shouldDetectV2FromPackageCache(found, lockEntry, manifestDependency) {
 		return dispatcherV2Project{}, nil
 	}
 
+	return detectV2DispatcherFromPackageCache(projectRoot, lockEntry, found)
+}
+
+// detectV2DispatcherFromResolvedLockVersion trusts packages-lock.json when Unity
+// already resolved a valid semver. Why not fall through: that lock version is
+// the entity Unity loads for registry/git packages.
+func detectV2DispatcherFromResolvedLockVersion(lockEntry dispatcherPackageLockEntry, found bool) (dispatcherV2Project, bool) {
+	packageVersion := lockEntry.Version
+	if !found || !sharedversion.IsValid(strings.TrimSpace(packageVersion)) {
+		return dispatcherV2Project{}, false
+	}
+	if !isDispatcherV2PackageVersion(packageVersion) {
+		return dispatcherV2Project{}, true
+	}
+	return dispatcherV2Project{IsV2: true, PackageVersion: packageVersion}, true
+}
+
+func shouldDetectV2FromPackageCache(found bool, lockEntry dispatcherPackageLockEntry, manifestDependency json.RawMessage) bool {
+	if found && lockEntry.Source != dispatcherPackageLockSourceGit {
+		return false
+	}
+	if !found && !isDispatcherGitPackageDependency(manifestDependency) {
+		return false
+	}
+	return true
+}
+
+func detectV2DispatcherFromPackageCache(projectRoot string, lockEntry dispatcherPackageLockEntry, found bool) (dispatcherV2Project, error) {
 	packageCacheEntries, err := dispatcherPackageCacheEntries(projectRoot)
 	if err != nil {
 		return dispatcherV2Project{}, err
 	}
-	if found && lockEntry.Source == dispatcherPackageLockSourceGit {
-		if version, ok := dispatcherPackageCacheVersionForHash(packageCacheEntries, lockEntry.Hash); ok {
-			if !isDispatcherV2PackageVersion(version) {
-				return dispatcherV2Project{}, nil
-			}
-			return dispatcherV2Project{IsV2: true, PackageVersion: version}, nil
-		}
+	if project, handled := detectV2DispatcherFromGitCacheHash(packageCacheEntries, lockEntry, found); handled {
+		return project, nil
 	}
+	return detectV2DispatcherFromDistinctCacheVersions(packageCacheEntries, projectRoot)
+}
 
+// detectV2DispatcherFromGitCacheHash binds a git lock hash to one PackageCache
+// generation. Why hash match first: multiple cached copies can coexist after
+// upgrades, and only the lock's hash identifies the loaded one.
+func detectV2DispatcherFromGitCacheHash(packageCacheEntries []dispatcherPackageCacheEntry, lockEntry dispatcherPackageLockEntry, found bool) (dispatcherV2Project, bool) {
+	if !found || lockEntry.Source != dispatcherPackageLockSourceGit {
+		return dispatcherV2Project{}, false
+	}
+	version, ok := dispatcherPackageCacheVersionForHash(packageCacheEntries, lockEntry.Hash)
+	if !ok {
+		return dispatcherV2Project{}, false
+	}
+	if !isDispatcherV2PackageVersion(version) {
+		return dispatcherV2Project{}, true
+	}
+	return dispatcherV2Project{IsV2: true, PackageVersion: version}, true
+}
+
+func detectV2DispatcherFromDistinctCacheVersions(packageCacheEntries []dispatcherPackageCacheEntry, projectRoot string) (dispatcherV2Project, error) {
 	packageVersions := dispatcherDistinctPackageCacheVersions(packageCacheEntries)
 	if len(packageVersions) == 0 {
 		return dispatcherV2Project{}, nil
@@ -117,7 +153,6 @@ func detectV2DispatcherProject(projectRoot string) (dispatcherV2Project, error) 
 			return dispatcherV2Project{}, fmt.Errorf("multiple package generations found in %s", filepath.Join(projectRoot, "Library", "PackageCache"))
 		}
 	}
-
 	return dispatcherV2Project{IsV2: true, PackageVersionCandidates: packageVersions}, nil
 }
 

--- a/cli/dispatcher/internal/dispatcher/launch_options.go
+++ b/cli/dispatcher/internal/dispatcher/launch_options.go
@@ -11,28 +11,57 @@ import (
 
 func applyLaunchOption(options *launchOptions, args []string, index int) (int, error) {
 	arg := args[index]
-	switch {
-	case arg == "-r" || arg == "--restart":
-		options.restart = true
-		return index, nil
-	case arg == "-q" || arg == "--quit":
-		options.quit = true
-		return index, nil
-	case arg == "-d" || arg == "--delete-recovery":
-		options.deleteRecovery = true
-		return index, nil
-	case arg == "--editor-version" || strings.HasPrefix(arg, "--editor-version="):
-		return applyLaunchEditorVersionOption(options, args, index)
-	case isUnsupportedLaunchHubOption(arg):
+	if next, handled, err := applyLaunchBooleanFlag(options, arg, index); handled {
+		return next, err
+	}
+	if next, handled, err := applyLaunchKeyedOption(options, args, index); handled {
+		return next, err
+	}
+	if isUnsupportedLaunchHubOption(arg) {
 		return index, unsupportedLaunchHubOptionError(arg)
-	case arg == "-p" || arg == "--platform" || strings.HasPrefix(arg, "--platform="):
-		return applyLaunchPlatformOption(options, args, index)
-	case arg == "--max-depth" || strings.HasPrefix(arg, "--max-depth="):
-		return applyLaunchMaxDepthOption(options, args, index)
-	case strings.HasPrefix(arg, "-"):
+	}
+	if strings.HasPrefix(arg, "-") {
 		return index, unknownLaunchOptionError(arg)
+	}
+	return applyLaunchProjectPathArgument(options, arg, index)
+}
+
+// applyLaunchBooleanFlag handles restart/quit/delete-recovery. Why a separate
+// helper: those flags share "set a bool and keep the current index" behavior,
+// and leaving them in applyLaunchOption kept the switch above the cyclop limit.
+func applyLaunchBooleanFlag(options *launchOptions, arg string, index int) (int, bool, error) {
+	switch arg {
+	case "-r", "--restart":
+		options.restart = true
+		return index, true, nil
+	case "-q", "--quit":
+		options.quit = true
+		return index, true, nil
+	case "-d", "--delete-recovery":
+		options.deleteRecovery = true
+		return index, true, nil
 	default:
-		return applyLaunchProjectPathArgument(options, arg, index)
+		return index, false, nil
+	}
+}
+
+// applyLaunchKeyedOption handles value-taking launch flags. Why not fold these
+// into applyLaunchBooleanFlag: equals-form and next-token consumption are
+// unique to keyed options.
+func applyLaunchKeyedOption(options *launchOptions, args []string, index int) (int, bool, error) {
+	arg := args[index]
+	switch {
+	case arg == "--editor-version" || strings.HasPrefix(arg, "--editor-version="):
+		next, err := applyLaunchEditorVersionOption(options, args, index)
+		return next, true, err
+	case arg == "-p" || arg == "--platform" || strings.HasPrefix(arg, "--platform="):
+		next, err := applyLaunchPlatformOption(options, args, index)
+		return next, true, err
+	case arg == "--max-depth" || strings.HasPrefix(arg, "--max-depth="):
+		next, err := applyLaunchMaxDepthOption(options, args, index)
+		return next, true, err
+	default:
+		return index, false, nil
 	}
 }
 

--- a/cli/dispatcher/internal/dispatcher/launch_test.go
+++ b/cli/dispatcher/internal/dispatcher/launch_test.go
@@ -207,6 +207,96 @@ func TestParseLaunchOptionsRejectsEmptyPlatformEqualsValue(t *testing.T) {
 	}
 }
 
+func TestApplyLaunchOptionCharacterizesTokenDispatch(t *testing.T) {
+	// Characterizes applyLaunchOption token families so extract-method refactors cannot change recognition or rejection.
+	testCases := []struct {
+		name             string
+		args             []string
+		seed             launchOptions
+		want             launchOptions
+		wantNext         int
+		wantErrSubstring string
+	}{
+		{name: "short restart", args: []string{"-r"}, want: launchOptions{restart: true}},
+		{name: "long restart", args: []string{"--restart"}, want: launchOptions{restart: true}},
+		{name: "short quit", args: []string{"-q"}, want: launchOptions{quit: true}},
+		{name: "long quit", args: []string{"--quit"}, want: launchOptions{quit: true}},
+		{name: "short delete recovery", args: []string{"-d"}, want: launchOptions{deleteRecovery: true}},
+		{name: "long delete recovery", args: []string{"--delete-recovery"}, want: launchOptions{deleteRecovery: true}},
+		{
+			name:     "editor version equals",
+			args:     []string{"--editor-version=6000.0.0f1"},
+			want:     launchOptions{editorVersion: "6000.0.0f1"},
+			wantNext: 0,
+		},
+		{
+			name:     "editor version separate",
+			args:     []string{"--editor-version", "6000.0.0f1"},
+			want:     launchOptions{editorVersion: "6000.0.0f1"},
+			wantNext: 1,
+		},
+		{
+			name:     "short platform",
+			args:     []string{"-p", "Android"},
+			want:     launchOptions{platform: "Android"},
+			wantNext: 1,
+		},
+		{
+			name:     "max depth equals",
+			args:     []string{"--max-depth=-1"},
+			want:     launchOptions{maxDepth: -1},
+			wantNext: 0,
+		},
+		{
+			name:     "project path",
+			args:     []string{"/tmp/project"},
+			want:     launchOptions{projectPath: "/tmp/project"},
+			wantNext: 0,
+		},
+		{
+			name:             "hub option",
+			args:             []string{"--add-unity-hub"},
+			wantErrSubstring: "Unity Hub registration",
+		},
+		{
+			name:             "unknown option",
+			args:             []string{"--bogus"},
+			wantErrSubstring: "Unknown launch option",
+		},
+		{
+			name:             "extra project path",
+			args:             []string{"/tmp/other"},
+			seed:             launchOptions{projectPath: "/tmp/first"},
+			wantErrSubstring: "Unexpected extra launch argument",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			options := testCase.seed
+			next, err := applyLaunchOption(&options, testCase.args, 0)
+			if testCase.wantErrSubstring != "" {
+				if err == nil {
+					t.Fatal("expected applyLaunchOption error")
+				}
+				if !strings.Contains(err.Error(), testCase.wantErrSubstring) {
+					t.Fatalf("error %q does not contain %q", err, testCase.wantErrSubstring)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("applyLaunchOption failed: %v", err)
+			}
+			if next != testCase.wantNext {
+				t.Fatalf("next index = %d, want %d", next, testCase.wantNext)
+			}
+			if options != testCase.want {
+				t.Fatalf("options = %#v, want %#v", options, testCase.want)
+			}
+		})
+	}
+}
+
 func TestReadUnityEditorVersion(t *testing.T) {
 	projectRoot := createLaunchTestProject(t)
 	projectSettings := filepath.Join(projectRoot, "ProjectSettings")

--- a/cli/dispatcher/internal/dispatcher/launch_test.go
+++ b/cli/dispatcher/internal/dispatcher/launch_test.go
@@ -210,12 +210,12 @@ func TestParseLaunchOptionsRejectsEmptyPlatformEqualsValue(t *testing.T) {
 func TestApplyLaunchOptionCharacterizesTokenDispatch(t *testing.T) {
 	// Characterizes applyLaunchOption token families so extract-method refactors cannot change recognition or rejection.
 	testCases := []struct {
-		name             string
-		args             []string
-		seed             launchOptions
-		want             launchOptions
-		wantNext         int
-		wantErrSubstring string
+		name     string
+		args     []string
+		seed     launchOptions
+		want     launchOptions
+		wantNext int
+		wantErr  string
 	}{
 		{name: "short restart", args: []string{"-r"}, want: launchOptions{restart: true}},
 		{name: "long restart", args: []string{"--restart"}, want: launchOptions{restart: true}},
@@ -254,20 +254,20 @@ func TestApplyLaunchOptionCharacterizesTokenDispatch(t *testing.T) {
 			wantNext: 0,
 		},
 		{
-			name:             "hub option",
-			args:             []string{"--add-unity-hub"},
-			wantErrSubstring: "Unity Hub registration",
+			name:    "hub option",
+			args:    []string{"--add-unity-hub"},
+			wantErr: "Native launch does not support Unity Hub registration options.",
 		},
 		{
-			name:             "unknown option",
-			args:             []string{"--bogus"},
-			wantErrSubstring: "Unknown launch option",
+			name:    "unknown option",
+			args:    []string{"--bogus"},
+			wantErr: "Unknown launch option: --bogus",
 		},
 		{
-			name:             "extra project path",
-			args:             []string{"/tmp/other"},
-			seed:             launchOptions{projectPath: "/tmp/first"},
-			wantErrSubstring: "Unexpected extra launch argument",
+			name:    "extra project path",
+			args:    []string{"/tmp/other"},
+			seed:    launchOptions{projectPath: "/tmp/first"},
+			wantErr: "Unexpected extra launch argument: /tmp/other",
 		},
 	}
 
@@ -275,12 +275,12 @@ func TestApplyLaunchOptionCharacterizesTokenDispatch(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			options := testCase.seed
 			next, err := applyLaunchOption(&options, testCase.args, 0)
-			if testCase.wantErrSubstring != "" {
+			if testCase.wantErr != "" {
 				if err == nil {
 					t.Fatal("expected applyLaunchOption error")
 				}
-				if !strings.Contains(err.Error(), testCase.wantErrSubstring) {
-					t.Fatalf("error %q does not contain %q", err, testCase.wantErrSubstring)
+				if err.Error() != testCase.wantErr {
+					t.Fatalf("error = %q, want %q", err.Error(), testCase.wantErr)
 				}
 				return
 			}

--- a/cli/dispatcher/internal/dispatcher/package.go
+++ b/cli/dispatcher/internal/dispatcher/package.go
@@ -248,59 +248,97 @@ func inspectPackageManifestStatus(content []byte) (packageManifestStatus, error)
 	}
 
 	status := packageManifestStatus{}
-	if rawDependencies, ok := root.values["dependencies"]; ok {
-		dependencies, depErr := parseOrderedJSONObjectBytes(rawDependencies)
-		if depErr != nil {
-			return packageManifestStatus{}, depErr
-		}
-		if rawVersion, found := dependencies.values[dispatcherUnityPackageName]; found {
-			var version string
-			if unmarshalErr := json.Unmarshal(rawVersion, &version); unmarshalErr != nil {
-				return packageManifestStatus{}, unmarshalErr
-			}
-			status.dependencyInstalled = true
-			status.dependencyVersion = version
-		}
+	if inspectErr := inspectPackageManifestDependency(root, &status); inspectErr != nil {
+		return packageManifestStatus{}, inspectErr
 	}
-
-	if rawRegistries, ok := root.values["scopedRegistries"]; ok {
-		elements, arrayErr := parseJSONRawArray(rawRegistries)
-		if arrayErr != nil {
-			return packageManifestStatus{}, arrayErr
-		}
-		for _, element := range elements {
-			entry, parseErr := parseOrderedJSONObjectBytes(element)
-			if parseErr != nil {
-				return packageManifestStatus{}, parseErr
-			}
-			urlRaw, hasURL := entry.values["url"]
-			if !hasURL {
-				continue
-			}
-			var url string
-			if unmarshalErr := json.Unmarshal(urlRaw, &url); unmarshalErr != nil {
-				return packageManifestStatus{}, unmarshalErr
-			}
-			if url != openUPMRegistryURL {
-				continue
-			}
-			rawScopes, hasScopes := entry.values["scopes"]
-			if !hasScopes {
-				continue
-			}
-			var scopes []string
-			if unmarshalErr := json.Unmarshal(rawScopes, &scopes); unmarshalErr != nil {
-				return packageManifestStatus{}, unmarshalErr
-			}
-			for _, scope := range scopes {
-				if scope == dispatcherUnityPackageName {
-					status.registryInstalled = true
-					break
-				}
-			}
-		}
+	if inspectErr := inspectPackageManifestOpenUPMRegistry(root, &status); inspectErr != nil {
+		return packageManifestStatus{}, inspectErr
 	}
 	return status, nil
+}
+
+func inspectPackageManifestDependency(root orderedJSONObject, status *packageManifestStatus) error {
+	rawDependencies, ok := root.values["dependencies"]
+	if !ok {
+		return nil
+	}
+	dependencies, depErr := parseOrderedJSONObjectBytes(rawDependencies)
+	if depErr != nil {
+		return depErr
+	}
+	rawVersion, found := dependencies.values[dispatcherUnityPackageName]
+	if !found {
+		return nil
+	}
+	version := ""
+	if unmarshalErr := json.Unmarshal(rawVersion, &version); unmarshalErr != nil {
+		return unmarshalErr
+	}
+	status.dependencyInstalled = true
+	status.dependencyVersion = version
+	return nil
+}
+
+func inspectPackageManifestOpenUPMRegistry(root orderedJSONObject, status *packageManifestStatus) error {
+	rawRegistries, ok := root.values["scopedRegistries"]
+	if !ok {
+		return nil
+	}
+	elements, arrayErr := parseJSONRawArray(rawRegistries)
+	if arrayErr != nil {
+		return arrayErr
+	}
+	installed, err := openUPMRegistryHasPackageScope(elements)
+	if err != nil {
+		return err
+	}
+	status.registryInstalled = installed
+	return nil
+}
+
+func openUPMRegistryHasPackageScope(elements []json.RawMessage) (bool, error) {
+	for _, element := range elements {
+		entry, parseErr := parseOrderedJSONObjectBytes(element)
+		if parseErr != nil {
+			return false, parseErr
+		}
+		hasScope, err := openUPMEntryHasPackageScope(entry)
+		if err != nil {
+			return false, err
+		}
+		if hasScope {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func openUPMEntryHasPackageScope(entry orderedJSONObject) (bool, error) {
+	urlRaw, hasURL := entry.values["url"]
+	if !hasURL {
+		return false, nil
+	}
+	url := ""
+	if unmarshalErr := json.Unmarshal(urlRaw, &url); unmarshalErr != nil {
+		return false, unmarshalErr
+	}
+	if url != openUPMRegistryURL {
+		return false, nil
+	}
+	rawScopes, hasScopes := entry.values["scopes"]
+	if !hasScopes {
+		return false, nil
+	}
+	scopes := []string{}
+	if unmarshalErr := json.Unmarshal(rawScopes, &scopes); unmarshalErr != nil {
+		return false, unmarshalErr
+	}
+	for _, scope := range scopes {
+		if scope == dispatcherUnityPackageName {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func writePackageManifestAtomically(manifestPath string, content []byte) error {

--- a/cli/dispatcher/internal/dispatcher/package.go
+++ b/cli/dispatcher/internal/dispatcher/package.go
@@ -297,6 +297,7 @@ func inspectPackageManifestOpenUPMRegistry(root orderedJSONObject, status *packa
 }
 
 func openUPMRegistryHasPackageScope(elements []json.RawMessage) (bool, error) {
+	found := false
 	for _, element := range elements {
 		entry, parseErr := parseOrderedJSONObjectBytes(element)
 		if parseErr != nil {
@@ -307,10 +308,13 @@ func openUPMRegistryHasPackageScope(elements []json.RawMessage) (bool, error) {
 			return false, err
 		}
 		if hasScope {
-			return true, nil
+			// Why not return here: the original scan kept walking later
+			// scopedRegistries entries so a trailing malformed object still
+			// failed status inspect. Early success would hide that parse error.
+			found = true
 		}
 	}
-	return false, nil
+	return found, nil
 }
 
 func openUPMEntryHasPackageScope(entry orderedJSONObject) (bool, error) {

--- a/cli/dispatcher/internal/dispatcher/package_manifest.go
+++ b/cli/dispatcher/internal/dispatcher/package_manifest.go
@@ -144,15 +144,7 @@ func insertDependencyAlphabetically(dependencies *orderedJSONObject, name string
 func updatePackageManifestScopedRegistries(root *orderedJSONObject, result *packageManifestMergeResult) error {
 	rawRegistries, hasRegistries := root.values["scopedRegistries"]
 	if !hasRegistries {
-		encoded, err := emitOpenUPMScopedRegistriesArray(1)
-		if err != nil {
-			return err
-		}
-		root.insertAfter("scopedRegistries", encoded, "dependencies")
-		result.Changed = true
-		result.RegistryAdded = true
-		result.ScopeAdded = true
-		return nil
+		return insertDefaultOpenUPMScopedRegistries(root, result)
 	}
 
 	elements, err := parseJSONRawArray(rawRegistries)
@@ -160,45 +152,84 @@ func updatePackageManifestScopedRegistries(root *orderedJSONObject, result *pack
 		return fmt.Errorf("scopedRegistries: %w", err)
 	}
 
+	openUPMIndex, parsedEntries, err := locateOpenUPMScopedRegistry(elements)
+	if err != nil {
+		return err
+	}
+	if openUPMIndex < 0 {
+		return appendOpenUPMScopedRegistry(root, elements, result)
+	}
+	return addMissingOpenUPMScopeToRegistry(root, elements, parsedEntries[openUPMIndex], openUPMIndex, result)
+}
+
+func insertDefaultOpenUPMScopedRegistries(root *orderedJSONObject, result *packageManifestMergeResult) error {
+	encoded, err := emitOpenUPMScopedRegistriesArray(1)
+	if err != nil {
+		return err
+	}
+	root.insertAfter("scopedRegistries", encoded, "dependencies")
+	result.Changed = true
+	result.RegistryAdded = true
+	result.ScopeAdded = true
+	return nil
+}
+
+func locateOpenUPMScopedRegistry(elements []json.RawMessage) (int, []orderedJSONObject, error) {
 	openUPMIndex := -1
 	parsedEntries := make([]orderedJSONObject, len(elements))
 	for index, element := range elements {
 		entry, parseErr := parseOrderedJSONObjectBytes(element)
 		if parseErr != nil {
-			return fmt.Errorf("scopedRegistries[%d]: %w", index, parseErr)
+			return -1, nil, fmt.Errorf("scopedRegistries[%d]: %w", index, parseErr)
 		}
 		parsedEntries[index] = entry
-		urlRaw, ok := entry.values["url"]
-		if !ok {
-			continue
+		matched, matchErr := isOpenUPMRegistryEntry(entry, index)
+		if matchErr != nil {
+			return -1, nil, matchErr
 		}
-		var url string
-		if err := json.Unmarshal(urlRaw, &url); err != nil {
-			return fmt.Errorf("scopedRegistries[%d].url: %w", index, err)
-		}
-		if url == openUPMRegistryURL {
+		if matched {
 			openUPMIndex = index
 		}
 	}
+	return openUPMIndex, parsedEntries, nil
+}
 
-	if openUPMIndex < 0 {
-		newEntry, err := buildOpenUPMRegistryEntry()
-		if err != nil {
-			return err
-		}
-		elements = append(elements, newEntry)
-		encoded, err := emitJSONRawArray(elements, 1)
-		if err != nil {
-			return err
-		}
-		root.values["scopedRegistries"] = encoded
-		result.Changed = true
-		result.RegistryAdded = true
-		result.ScopeAdded = true
-		return nil
+func isOpenUPMRegistryEntry(entry orderedJSONObject, index int) (bool, error) {
+	urlRaw, ok := entry.values["url"]
+	if !ok {
+		return false, nil
 	}
+	url := ""
+	if err := json.Unmarshal(urlRaw, &url); err != nil {
+		return false, fmt.Errorf("scopedRegistries[%d].url: %w", index, err)
+	}
+	return url == openUPMRegistryURL, nil
+}
 
-	entry := parsedEntries[openUPMIndex]
+func appendOpenUPMScopedRegistry(root *orderedJSONObject, elements []json.RawMessage, result *packageManifestMergeResult) error {
+	newEntry, err := buildOpenUPMRegistryEntry()
+	if err != nil {
+		return err
+	}
+	elements = append(elements, newEntry)
+	encoded, err := emitJSONRawArray(elements, 1)
+	if err != nil {
+		return err
+	}
+	root.values["scopedRegistries"] = encoded
+	result.Changed = true
+	result.RegistryAdded = true
+	result.ScopeAdded = true
+	return nil
+}
+
+func addMissingOpenUPMScopeToRegistry(
+	root *orderedJSONObject,
+	elements []json.RawMessage,
+	entry orderedJSONObject,
+	openUPMIndex int,
+	result *packageManifestMergeResult,
+) error {
 	scopesChanged, err := ensureOpenUPMScope(&entry)
 	if err != nil {
 		return err

--- a/cli/dispatcher/internal/dispatcher/package_test.go
+++ b/cli/dispatcher/internal/dispatcher/package_test.go
@@ -259,6 +259,131 @@ func TestPackageStatusReportsInstalledVersion(t *testing.T) {
 	}
 }
 
+func TestInspectPackageManifestStatusCharacterizesInstalledFlags(t *testing.T) {
+	// Characterizes inspectPackageManifestStatus dependency and OpenUPM-scope detection.
+	testCases := []struct {
+		name    string
+		content string
+		want    packageManifestStatus
+		wantErr bool
+	}{
+		{
+			name: "bare dependencies",
+			content: `{
+  "dependencies": {
+    "com.unity.modules.ai": "1.0.0"
+  }
+}
+`,
+			want: packageManifestStatus{},
+		},
+		{
+			name: "dependency without registry",
+			content: `{
+  "dependencies": {
+    "io.github.hatayama.uloopmcp": "1.2.3"
+  }
+}
+`,
+			want: packageManifestStatus{
+				dependencyInstalled: true,
+				dependencyVersion:   "1.2.3",
+			},
+		},
+		{
+			name: "openupm without package scope",
+			content: `{
+  "dependencies": {},
+  "scopedRegistries": [
+    {
+      "name": "package.openupm.com",
+      "url": "https://package.openupm.com",
+      "scopes": ["com.other.openupm"]
+    }
+  ]
+}
+`,
+			want: packageManifestStatus{},
+		},
+		{
+			name: "foreign registry only",
+			content: `{
+  "dependencies": {},
+  "scopedRegistries": [
+    {
+      "name": "Other",
+      "url": "https://example.invalid/registry",
+      "scopes": ["io.github.hatayama.uloopmcp"]
+    }
+  ]
+}
+`,
+			want: packageManifestStatus{},
+		},
+		{
+			name: "openupm scope without dependency",
+			content: `{
+  "dependencies": {},
+  "scopedRegistries": [
+    {
+      "name": "package.openupm.com",
+      "url": "https://package.openupm.com",
+      "scopes": ["io.github.hatayama.uloopmcp"]
+    }
+  ]
+}
+`,
+			want: packageManifestStatus{registryInstalled: true},
+		},
+		{
+			name:    "installed dependency and registry",
+			content: installedPackageManifest("1.2.3"),
+			want: packageManifestStatus{
+				registryInstalled:   true,
+				dependencyInstalled: true,
+				dependencyVersion:   "1.2.3",
+			},
+		},
+		{
+			name: "openupm entry missing url",
+			content: `{
+  "dependencies": {},
+  "scopedRegistries": [
+    {
+      "name": "package.openupm.com",
+      "scopes": ["io.github.hatayama.uloopmcp"]
+    }
+  ]
+}
+`,
+			want: packageManifestStatus{},
+		},
+		{
+			name:    "malformed json",
+			content: `{not json`,
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			status, err := inspectPackageManifestStatus([]byte(testCase.content))
+			if testCase.wantErr {
+				if err == nil {
+					t.Fatal("expected inspectPackageManifestStatus error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("inspectPackageManifestStatus failed: %v", err)
+			}
+			if status != testCase.want {
+				t.Fatalf("status = %#v, want %#v", status, testCase.want)
+			}
+		})
+	}
+}
+
 // Verifies an unknown package subcommand fails with guidance for valid subcommands.
 func TestPackageUnknownSubcommandFails(t *testing.T) {
 	t.Chdir(t.TempDir())

--- a/cli/dispatcher/internal/dispatcher/package_test.go
+++ b/cli/dispatcher/internal/dispatcher/package_test.go
@@ -262,10 +262,11 @@ func TestPackageStatusReportsInstalledVersion(t *testing.T) {
 func TestInspectPackageManifestStatusCharacterizesInstalledFlags(t *testing.T) {
 	// Characterizes inspectPackageManifestStatus dependency and OpenUPM-scope detection.
 	testCases := []struct {
-		name    string
-		content string
-		want    packageManifestStatus
-		wantErr bool
+		name        string
+		content     string
+		want        packageManifestStatus
+		wantErr     bool
+		wantErrText string
 	}{
 		{
 			name: "bare dependencies",
@@ -363,6 +364,23 @@ func TestInspectPackageManifestStatusCharacterizesInstalledFlags(t *testing.T) {
 			content: `{not json`,
 			wantErr: true,
 		},
+		{
+			name: "valid openupm followed by non object",
+			content: `{
+  "dependencies": {},
+  "scopedRegistries": [
+    {
+      "name": "package.openupm.com",
+      "url": "https://package.openupm.com",
+      "scopes": ["io.github.hatayama.uloopmcp"]
+    },
+    "not-an-object"
+  ]
+}
+`,
+			wantErr:     true,
+			wantErrText: "expected JSON object",
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -371,6 +389,9 @@ func TestInspectPackageManifestStatusCharacterizesInstalledFlags(t *testing.T) {
 			if testCase.wantErr {
 				if err == nil {
 					t.Fatal("expected inspectPackageManifestStatus error")
+				}
+				if testCase.wantErrText != "" && err.Error() != testCase.wantErrText {
+					t.Fatalf("error = %q, want %q", err.Error(), testCase.wantErrText)
 				}
 				return
 			}

--- a/cli/dispatcher/internal/dispatcher/run_dispatcher.go
+++ b/cli/dispatcher/internal/dispatcher/run_dispatcher.go
@@ -61,23 +61,49 @@ func runDispatcherWithDeps(ctx context.Context, args []string, stdout io.Writer,
 		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{})
 		return 1
 	}
-	if len(args) == 0 || clicore.IsHelpRequest(remainingArgs) || clicore.IsVersionRequest(remainingArgs) || clicore.IsVersionJSONRequest(remainingArgs) {
-		if startPath, workingDirectoryErr := os.Getwd(); workingDirectoryErr == nil {
-			if projectRoot, resolveErr := resolveDispatcherProjectRoot(startPath, projectPath, remainingArgs); resolveErr == nil {
-				if handled, code := tryRunDetectedDispatcherV2Project(ctx, projectRoot, args, stdout, stderr, deps); handled {
-					return code
-				}
-			}
-		}
-		if handled, code := tryHandleDispatcherInfoRequest(args, stdout); handled {
-			return code
-		}
+	if handled, code := tryHandleDispatcherHelpOrVersion(ctx, args, remainingArgs, projectPath, stdout, stderr, deps); handled {
+		return code
 	}
-
 	if shouldRunInDispatcherProcess(remainingArgs) {
 		return runDispatcherProcessCommandWithDeps(ctx, args, remainingArgs, projectPath, stdout, stderr, deps)
 	}
+	return runPinnedDispatcherProjectRunner(ctx, args, remainingArgs, projectPath, stdout, stderr, deps)
+}
 
+func tryHandleDispatcherHelpOrVersion(
+	ctx context.Context,
+	args []string,
+	remainingArgs []string,
+	projectPath string,
+	stdout io.Writer,
+	stderr io.Writer,
+	deps dispatcherRunDeps,
+) (bool, int) {
+	if len(args) != 0 && !clicore.IsHelpRequest(remainingArgs) && !clicore.IsVersionRequest(remainingArgs) && !clicore.IsVersionJSONRequest(remainingArgs) {
+		return false, 0
+	}
+	if startPath, workingDirectoryErr := os.Getwd(); workingDirectoryErr == nil {
+		if projectRoot, resolveErr := resolveDispatcherProjectRoot(startPath, projectPath, remainingArgs); resolveErr == nil {
+			if handled, code := tryRunDetectedDispatcherV2Project(ctx, projectRoot, args, stdout, stderr, deps); handled {
+				return true, code
+			}
+		}
+	}
+	if handled, code := tryHandleDispatcherInfoRequest(args, stdout); handled {
+		return true, code
+	}
+	return false, 0
+}
+
+func runPinnedDispatcherProjectRunner(
+	ctx context.Context,
+	args []string,
+	remainingArgs []string,
+	projectPath string,
+	stdout io.Writer,
+	stderr io.Writer,
+	deps dispatcherRunDeps,
+) int {
 	startPath, err := os.Getwd()
 	if err != nil {
 		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{})

--- a/cli/dispatcher/internal/uninstall/command_test.go
+++ b/cli/dispatcher/internal/uninstall/command_test.go
@@ -96,6 +96,15 @@ func TestPosixUninstallScriptRemovesShellPathBlocks(t *testing.T) {
 		t.Skip("POSIX uninstall script is not available on Windows")
 	}
 
+	home, installDir, targetPath := createPosixUninstallHome(t)
+	profilePaths := writePosixUninstallPathBlockProfiles(t, home, installDir)
+	runPosixUninstallCommand(t, home, installDir)
+	assertPosixUninstallRemovedBinary(t, targetPath)
+	assertPosixUninstallRemovedPathBlocks(t, profilePaths)
+}
+
+func createPosixUninstallHome(t *testing.T) (string, string, string) {
+	t.Helper()
 	home := t.TempDir()
 	installDir := filepath.Join(home, ".local", "bin")
 	if err := os.MkdirAll(installDir, 0o755); err != nil {
@@ -105,7 +114,11 @@ func TestPosixUninstallScriptRemovesShellPathBlocks(t *testing.T) {
 	if err := os.WriteFile(targetPath, []byte("binary"), 0o755); err != nil {
 		t.Fatalf("failed to create target binary: %v", err)
 	}
+	return home, installDir, targetPath
+}
 
+func writePosixUninstallPathBlockProfiles(t *testing.T, home string, installDir string) []string {
+	t.Helper()
 	profilePaths := []string{
 		filepath.Join(home, ".bash_profile"),
 		filepath.Join(home, ".zshrc"),
@@ -120,7 +133,11 @@ func TestPosixUninstallScriptRemovesShellPathBlocks(t *testing.T) {
 			t.Fatalf("failed to write profile: %v", err)
 		}
 	}
+	return profilePaths
+}
 
+func runPosixUninstallCommand(t *testing.T, home string, installDir string) {
+	t.Helper()
 	command, err := CommandForOS("darwin", Options{
 		InstallDir: installDir,
 		CurrentPID: 1234,
@@ -138,22 +155,31 @@ func TestPosixUninstallScriptRemovesShellPathBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POSIX uninstall failed: %v\n%s", err, output)
 	}
+}
+
+func assertPosixUninstallRemovedBinary(t *testing.T, targetPath string) {
+	t.Helper()
 	if _, err := os.Stat(targetPath); !os.IsNotExist(err) {
 		t.Fatalf("target binary should be removed, stat err=%v", err)
 	}
+}
 
+func assertPosixUninstallRemovedPathBlocks(t *testing.T, profilePaths []string) {
+	t.Helper()
 	for _, profilePath := range profilePaths {
-		profileContent, err := os.ReadFile(profilePath)
-		if err != nil {
-			t.Fatalf("failed to read profile: %v", err)
-		}
-		content := string(profileContent)
-		if strings.Contains(content, "# >>> uloop PATH >>>") || strings.Contains(content, "# <<< uloop PATH <<<") {
-			t.Fatalf("profile still contains uloop marker block:\n%s", content)
-		}
-		if !strings.Contains(content, "before\n") || !strings.Contains(content, "after\n") {
-			t.Fatalf("profile should preserve unrelated content:\n%s", content)
-		}
+		t.Run(filepath.Base(profilePath), func(t *testing.T) {
+			profileContent, err := os.ReadFile(profilePath)
+			if err != nil {
+				t.Fatalf("failed to read profile: %v", err)
+			}
+			content := string(profileContent)
+			if strings.Contains(content, "# >>> uloop PATH >>>") || strings.Contains(content, "# <<< uloop PATH <<<") {
+				t.Fatalf("profile still contains uloop marker block:\n%s", content)
+			}
+			if !strings.Contains(content, "before\n") || !strings.Contains(content, "after\n") {
+				t.Fatalf("profile should preserve unrelated content:\n%s", content)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Split dispatcher functions that exceeded the cyclomatic complexity limit of 15 so later PRs can turn the Code Complexity workflow into a failing check.
- Runtime behavior is unchanged: launch parsing, package manifest merge/status, attestation subject verification, and dispatcher routing keep the same results and messages.

## User Impact
- No user-visible CLI change. Commands, flags, errors, and install/uninstall scripts behave as before.
- The change prepares the repository to reject new complexity debt instead of only reporting it.

## Changes
- Extracted meaning-sized helpers from `VerifySubjects`, `detectV2DispatcherProject`, `applyLaunchOption`, `inspectPackageManifestStatus`, `updatePackageManifestScopedRegistries`, and `runDispatcherWithDeps`.
- Split `TestPosixUninstallScriptRemovesShellPathBlocks` into setup/assert helpers and per-profile subtests without dropping assertions.
- Added characterization tests for thin branches: VerifySubjects input validation, applyLaunchOption token dispatch, and inspectPackageManifestStatus installed-flag combinations.

## Coverage
| Function | How behavior is locked |
|---|---|
| `VerifySubjects` | Existing happy/fail-closed tests + new incomplete-options characterization |
| `detectV2DispatcherProject` | Existing dedicated detect suite (lock/cache/file/embedded/git-hash) |
| `applyLaunchOption` | Existing `parseLaunchOptions` tests + new token-dispatch characterization |
| `inspectPackageManifestStatus` | Existing `package status` tests + new installed-flag characterization |
| `updatePackageManifestScopedRegistries` | Existing `mergePackageManifest` suite (add/append/idempotent/order/CRLF) |
| `runDispatcherWithDeps` | Existing dispatcher routing, pin, help, version, and V2 tests |
| `TestPosixUninstallScriptRemovesShellPathBlocks` | Same test, helpers/subtests only |

## Verification
- `cd cli/dispatcher && golangci-lint run --config ../.golangci-complexity.yml ./...` → 0 issues
- `scripts/check-code-complexity.sh` → dispatcher Go findings 0; remaining findings are the planned PR-2/PR-3/PR-4/PR-5 set only
- `scripts/check-go-cli.sh` → format/lint/tests/rebuild passed
- New characterization tests ran with `-v` and all subtests passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

