### PR TITLE
ci: run the complexity and dead-code workflows on PRs targeting any branch

### DIFF
--- a/.github/workflows/code-complexity.yml
+++ b/.github/workflows/code-complexity.yml
@@ -2,7 +2,6 @@ name: Code Complexity
 
 on:
   pull_request:
-    branches: [ main, v3-beta ]
     paths:
       - 'cli/**/*.go'
       - 'cli/.go-version'

--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -2,7 +2,6 @@ name: Dead Code
 
 on:
   pull_request:
-    branches: [ main, v3-beta ]
     paths:
       - 'Packages/src/**/*.cs'
       - 'tools/UnityCliLoop.DeadCodeScanner/**'


### PR DESCRIPTION
## Summary
- Complexity Report and Dead Code Gate now run on pull requests targeting any branch, not only `main` and `v3-beta`.
- Feature-branch PRs can no longer skip these gates because of a target-branch filter.

## User Impact
- Before, PRs into a feature or integration branch skipped both workflows even when their paths matched, so unused members and complexity findings could merge without a GitHub check.
- After, any PR whose paths match still gets Complexity Report (advisory; fail-on-exceeded stays off) and Dead Code Gate (already enforcing).

## Changes
- Remove `pull_request.branches` from `.github/workflows/code-complexity.yml` and `.github/workflows/dead-code.yml`.
- Keep existing `paths:` filters.
- Leave `CODE_COMPLEXITY_FAIL_ON_EXCEEDED: 'false'` unchanged.

## Verification
- `go test ./internal/architecture -run 'TestWorkflowActions|TestPullRequestWorkflow' -count=1` in `cli/release-automation`: pass.
- Confirmed `CODE_COMPLEXITY_FAIL_ON_EXCEEDED: 'false'` remains in `code-complexity.yml`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

