### PR TITLE
refactor: split high-complexity project-runner and release-automation functions

### DIFF
--- a/cli/project-runner/internal/projectrunner/pause_point_captured_variable_names_filter_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_captured_variable_names_filter_test.go
@@ -27,77 +27,100 @@ func capturedVariableNamesFilterResponse() pausePointStatusResponse {
 // single-name selection, multi-name selection, a name with no match, and that it composes with
 // the --captured-variables mode (filter narrows first, then mode strips values).
 func TestFilterPausePointCapturedVariablesByName(t *testing.T) {
-	baseResponse := capturedVariableNamesFilterResponse
-
 	t.Run("single name keeps only the matching variable", func(t *testing.T) {
-		result := filterPausePointCapturedVariablesByName(baseResponse(), []string{"velocity"})
-		if len(result.CapturedVariables) != 1 || result.CapturedVariables[0].Name != "velocity" {
-			t.Fatalf("expected only velocity to survive: %#v", result.CapturedVariables)
-		}
-		if len(result.CapturedVariableHistory[0].CapturedVariables) != 1 {
-			t.Fatalf("expected history frame filtered to 1 entry: %#v", result.CapturedVariableHistory)
-		}
-		if result.CapturedVariableNameFilterNoMatch {
-			t.Fatal("expected CapturedVariableNameFilterNoMatch to be false when a match exists")
-		}
+		assertFilterKeepsSingleCapturedVariableName(t)
 	})
-
 	t.Run("multiple names keep all matching variables in order", func(t *testing.T) {
-		result := filterPausePointCapturedVariablesByName(baseResponse(), []string{"velocity", "this"})
-		if len(result.CapturedVariables) != 2 {
-			t.Fatalf("expected velocity and this to survive: %#v", result.CapturedVariables)
-		}
-		if result.CapturedVariables[0].Name != "velocity" || result.CapturedVariables[1].Name != "this" {
-			t.Fatalf("expected original order preserved: %#v", result.CapturedVariables)
-		}
+		assertFilterKeepsCapturedVariableNamesInOrder(t)
 	})
-
 	t.Run("no matching name empties the arrays and sets the no-match flag", func(t *testing.T) {
-		result := filterPausePointCapturedVariablesByName(baseResponse(), []string{"doesNotExist"})
-		if len(result.CapturedVariables) != 0 {
-			t.Fatalf("expected no captured variables to survive: %#v", result.CapturedVariables)
-		}
-		if len(result.CapturedVariableHistory[0].CapturedVariables) != 0 {
-			t.Fatalf("expected history frame emptied: %#v", result.CapturedVariableHistory)
-		}
-		if !result.CapturedVariableNameFilterNoMatch {
-			t.Fatal("expected CapturedVariableNameFilterNoMatch to be true when nothing matches")
-		}
-		const wantWarning = "No captured variable matched the requested names; the hit captured other variables. Check CapturedVariableNamesNotFound for the names that were absent."
-		if result.Warning != wantWarning {
-			t.Fatalf("expected human-readable Warning for no-match filter: %q", result.Warning)
-		}
+		assertFilterReportsNoMatchingCapturedVariableName(t)
 	})
-
 	t.Run("empty pre-filter snapshot keeps no-match flag but skips Warning", func(t *testing.T) {
-		// Verifies an unhit status (no variables yet) does not blame the requested names.
-		result := filterPausePointCapturedVariablesByName(pausePointStatusResponse{}, []string{"velocity"})
-		if !result.CapturedVariableNameFilterNoMatch {
-			t.Fatal("expected CapturedVariableNameFilterNoMatch to stay true on an empty snapshot")
-		}
-		if result.Warning != "" {
-			t.Fatalf("expected no Warning when the snapshot had no variables before filtering: %q", result.Warning)
-		}
+		assertFilterSkipsWarningOnEmptyPreFilterSnapshot(t)
 	})
-
 	t.Run("composes with captured-variables names mode: filter first, then strip values", func(t *testing.T) {
-		filtered := filterPausePointCapturedVariablesByName(baseResponse(), []string{"velocity"})
-		result := applyPausePointCapturedVariablesMode(filtered, pausePointCapturedVariablesModeNames)
-		if len(result.CapturedVariables) != 1 || result.CapturedVariables[0].Name != "velocity" {
-			t.Fatalf("expected only velocity to survive the filter: %#v", result.CapturedVariables)
-		}
-		if result.CapturedVariables[0].Value != nil {
-			t.Fatalf("expected Value stripped by names mode: %#v", result.CapturedVariables[0])
-		}
+		assertFilterComposesWithCapturedVariablesNamesMode(t)
 	})
-
 	t.Run("empty names list leaves the response unchanged", func(t *testing.T) {
-		original := baseResponse()
-		result := filterPausePointCapturedVariablesByName(original, nil)
-		if len(result.CapturedVariables) != len(original.CapturedVariables) {
-			t.Fatalf("expected response unchanged with no names filter: %#v", result.CapturedVariables)
-		}
+		assertFilterLeavesResponseUnchangedWhenNamesEmpty(t)
 	})
+}
+
+func assertFilterKeepsSingleCapturedVariableName(t *testing.T) {
+	t.Helper()
+	result := filterPausePointCapturedVariablesByName(capturedVariableNamesFilterResponse(), []string{"velocity"})
+	if len(result.CapturedVariables) != 1 || result.CapturedVariables[0].Name != "velocity" {
+		t.Fatalf("expected only velocity to survive: %#v", result.CapturedVariables)
+	}
+	if len(result.CapturedVariableHistory[0].CapturedVariables) != 1 {
+		t.Fatalf("expected history frame filtered to 1 entry: %#v", result.CapturedVariableHistory)
+	}
+	if result.CapturedVariableNameFilterNoMatch {
+		t.Fatal("expected CapturedVariableNameFilterNoMatch to be false when a match exists")
+	}
+}
+
+func assertFilterKeepsCapturedVariableNamesInOrder(t *testing.T) {
+	t.Helper()
+	result := filterPausePointCapturedVariablesByName(capturedVariableNamesFilterResponse(), []string{"velocity", "this"})
+	if len(result.CapturedVariables) != 2 {
+		t.Fatalf("expected velocity and this to survive: %#v", result.CapturedVariables)
+	}
+	if result.CapturedVariables[0].Name != "velocity" || result.CapturedVariables[1].Name != "this" {
+		t.Fatalf("expected original order preserved: %#v", result.CapturedVariables)
+	}
+}
+
+func assertFilterReportsNoMatchingCapturedVariableName(t *testing.T) {
+	t.Helper()
+	result := filterPausePointCapturedVariablesByName(capturedVariableNamesFilterResponse(), []string{"doesNotExist"})
+	if len(result.CapturedVariables) != 0 {
+		t.Fatalf("expected no captured variables to survive: %#v", result.CapturedVariables)
+	}
+	if len(result.CapturedVariableHistory[0].CapturedVariables) != 0 {
+		t.Fatalf("expected history frame emptied: %#v", result.CapturedVariableHistory)
+	}
+	if !result.CapturedVariableNameFilterNoMatch {
+		t.Fatal("expected CapturedVariableNameFilterNoMatch to be true when nothing matches")
+	}
+	const wantWarning = "No captured variable matched the requested names; the hit captured other variables. Check CapturedVariableNamesNotFound for the names that were absent."
+	if result.Warning != wantWarning {
+		t.Fatalf("expected human-readable Warning for no-match filter: %q", result.Warning)
+	}
+}
+
+func assertFilterSkipsWarningOnEmptyPreFilterSnapshot(t *testing.T) {
+	t.Helper()
+	// Verifies an unhit status (no variables yet) does not blame the requested names.
+	result := filterPausePointCapturedVariablesByName(pausePointStatusResponse{}, []string{"velocity"})
+	if !result.CapturedVariableNameFilterNoMatch {
+		t.Fatal("expected CapturedVariableNameFilterNoMatch to stay true on an empty snapshot")
+	}
+	if result.Warning != "" {
+		t.Fatalf("expected no Warning when the snapshot had no variables before filtering: %q", result.Warning)
+	}
+}
+
+func assertFilterComposesWithCapturedVariablesNamesMode(t *testing.T) {
+	t.Helper()
+	filtered := filterPausePointCapturedVariablesByName(capturedVariableNamesFilterResponse(), []string{"velocity"})
+	result := applyPausePointCapturedVariablesMode(filtered, pausePointCapturedVariablesModeNames)
+	if len(result.CapturedVariables) != 1 || result.CapturedVariables[0].Name != "velocity" {
+		t.Fatalf("expected only velocity to survive the filter: %#v", result.CapturedVariables)
+	}
+	if result.CapturedVariables[0].Value != nil {
+		t.Fatalf("expected Value stripped by names mode: %#v", result.CapturedVariables[0])
+	}
+}
+
+func assertFilterLeavesResponseUnchangedWhenNamesEmpty(t *testing.T) {
+	t.Helper()
+	original := capturedVariableNamesFilterResponse()
+	result := filterPausePointCapturedVariablesByName(original, nil)
+	if len(result.CapturedVariables) != len(original.CapturedVariables) {
+		t.Fatalf("expected response unchanged with no names filter: %#v", result.CapturedVariables)
+	}
 }
 
 // TestParsePausePointCapturedVariableNames verifies comma-splitting, whitespace trimming, and

--- a/cli/project-runner/internal/projectrunner/pause_point_resume_play_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_resume_play_test.go
@@ -501,87 +501,96 @@ func TestResumePlayModeForPausePointFromUnityBranches(t *testing.T) {
 	defer func() { sendControlPlayModeForPausePoint = originalSend }()
 
 	t.Run("Status transport failure", func(t *testing.T) {
-		actions := make([]string, 0, 1)
-		sendControlPlayModeForPausePoint = func(
-			ctx context.Context,
-			connection unityipc.Connection,
-			action string,
-		) (controlPlayModeToolResponse, error) {
-			actions = append(actions, action)
-			return controlPlayModeToolResponse{}, fmt.Errorf("boom")
-		}
-
-		result := resumePlayModeForPausePointFromUnity(context.Background(), unityipc.Connection{})
-		if result.WasPaused || result.Resumed || !strings.Contains(result.Error, "control-play-mode Status failed") {
-			t.Fatalf("result mismatch: %#v", result)
-		}
-		if len(actions) != 1 || actions[0] != "Status" {
-			t.Fatalf("expected only Status, got %#v", actions)
-		}
+		assertResumePlayModeFromUnityBranch(t, stubControlPlayModeStatusError("boom"), pausePointResumePlayResult{
+			Error: "control-play-mode Status failed: boom",
+		}, []string{"Status"})
 	})
 
 	t.Run("Status Success=false", func(t *testing.T) {
-		actions := make([]string, 0, 1)
-		sendControlPlayModeForPausePoint = func(
-			ctx context.Context,
-			connection unityipc.Connection,
-			action string,
-		) (controlPlayModeToolResponse, error) {
-			actions = append(actions, action)
-			return controlPlayModeToolResponse{Success: false, Message: "status denied"}, nil
-		}
-
-		result := resumePlayModeForPausePointFromUnity(context.Background(), unityipc.Connection{})
-		if result.WasPaused || result.Resumed || result.Error != "status denied" {
-			t.Fatalf("result mismatch: %#v", result)
-		}
-		if len(actions) != 1 || actions[0] != "Status" {
-			t.Fatalf("expected only Status, got %#v", actions)
-		}
+		assertResumePlayModeFromUnityBranch(t, stubControlPlayModeFixed(controlPlayModeToolResponse{
+			Success: false,
+			Message: "status denied",
+		}, nil), pausePointResumePlayResult{Error: "status denied"}, []string{"Status"})
 	})
 
 	t.Run("IsPaused=false skips Play", func(t *testing.T) {
-		actions := make([]string, 0, 1)
-		sendControlPlayModeForPausePoint = func(
-			ctx context.Context,
-			connection unityipc.Connection,
-			action string,
-		) (controlPlayModeToolResponse, error) {
-			actions = append(actions, action)
-			return controlPlayModeToolResponse{Success: true, IsPaused: false}, nil
-		}
-
-		result := resumePlayModeForPausePointFromUnity(context.Background(), unityipc.Connection{})
-		if result.WasPaused || result.Resumed || result.Error != "" {
-			t.Fatalf("result mismatch: %#v", result)
-		}
-		if len(actions) != 1 || actions[0] != "Status" {
-			t.Fatalf("expected only Status, got %#v", actions)
-		}
+		assertResumePlayModeFromUnityBranch(t, stubControlPlayModeFixed(controlPlayModeToolResponse{
+			Success:  true,
+			IsPaused: false,
+		}, nil), pausePointResumePlayResult{}, []string{"Status"})
 	})
 
 	t.Run("Play transport failure", func(t *testing.T) {
-		actions := make([]string, 0, 2)
-		sendControlPlayModeForPausePoint = func(
-			ctx context.Context,
-			connection unityipc.Connection,
-			action string,
-		) (controlPlayModeToolResponse, error) {
-			actions = append(actions, action)
-			if action == "Status" {
-				return controlPlayModeToolResponse{Success: true, IsPaused: true}, nil
-			}
-			return controlPlayModeToolResponse{}, fmt.Errorf("play boom")
-		}
-
-		result := resumePlayModeForPausePointFromUnity(context.Background(), unityipc.Connection{})
-		if !result.WasPaused || result.Resumed || !strings.Contains(result.Error, "control-play-mode Play failed") {
-			t.Fatalf("result mismatch: %#v", result)
-		}
-		if len(actions) != 2 || actions[0] != "Status" || actions[1] != "Play" {
-			t.Fatalf("expected Status then Play, got %#v", actions)
-		}
+		assertResumePlayModeFromUnityBranch(t, stubControlPlayModePlayError("play boom"), pausePointResumePlayResult{
+			WasPaused: true,
+			Error:     "control-play-mode Play failed: play boom",
+		}, []string{"Status", "Play"})
 	})
+}
+
+func stubControlPlayModeFixed(
+	response controlPlayModeToolResponse,
+	err error,
+) func(context.Context, unityipc.Connection, string) (controlPlayModeToolResponse, error) {
+	return func(
+		_ context.Context,
+		_ unityipc.Connection,
+		_ string,
+	) (controlPlayModeToolResponse, error) {
+		return response, err
+	}
+}
+
+func stubControlPlayModeStatusError(
+	message string,
+) func(context.Context, unityipc.Connection, string) (controlPlayModeToolResponse, error) {
+	return stubControlPlayModeFixed(controlPlayModeToolResponse{}, fmt.Errorf("%s", message))
+}
+
+func stubControlPlayModePlayError(
+	message string,
+) func(context.Context, unityipc.Connection, string) (controlPlayModeToolResponse, error) {
+	return func(
+		_ context.Context,
+		_ unityipc.Connection,
+		action string,
+	) (controlPlayModeToolResponse, error) {
+		if action == "Status" {
+			return controlPlayModeToolResponse{Success: true, IsPaused: true}, nil
+		}
+		return controlPlayModeToolResponse{}, fmt.Errorf("%s", message)
+	}
+}
+
+func assertResumePlayModeFromUnityBranch(
+	t *testing.T,
+	stub func(context.Context, unityipc.Connection, string) (controlPlayModeToolResponse, error),
+	want pausePointResumePlayResult,
+	wantActions []string,
+) {
+	t.Helper()
+	actions := make([]string, 0, len(wantActions))
+	sendControlPlayModeForPausePoint = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		action string,
+	) (controlPlayModeToolResponse, error) {
+		actions = append(actions, action)
+		return stub(ctx, connection, action)
+	}
+
+	result := resumePlayModeForPausePointFromUnity(context.Background(), unityipc.Connection{})
+	if result != want {
+		t.Fatalf("result mismatch: got %#v, want %#v", result, want)
+	}
+	if len(actions) != len(wantActions) {
+		t.Fatalf("expected actions %#v, got %#v", wantActions, actions)
+	}
+	for index, action := range wantActions {
+		if actions[index] != action {
+			t.Fatalf("expected actions %#v, got %#v", wantActions, actions)
+		}
+	}
 }
 
 // Verifies wait-start unarmed errors include the observed Cleared status and AwaitTimeoutAutoClear

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -346,55 +346,8 @@ func parseWaitForPausePointOptions(args []string) (waitForPausePointOptions, err
 		if err != nil {
 			return waitForPausePointOptions{}, err
 		}
-
-		switch name {
-		case PausePointIDFlagName:
-			options.id = value
-		case PausePointTimeoutFlagName:
-			timeoutSeconds, parseErr := parsePausePointTimeoutSeconds(value)
-			if parseErr != nil {
-				return waitForPausePointOptions{}, parseErr
-			}
-			options.timeoutSeconds = timeoutSeconds
-			options.timeout = time.Duration(timeoutSeconds) * time.Second
-		case PausePointLogsMaxCountFlagName:
-			maxCount, parseErr := strconv.Atoi(value)
-			if parseErr != nil || maxCount <= 0 {
-				return waitForPausePointOptions{}, clierrors.InvalidValueArgumentError(
-					"--"+PausePointLogsMaxCountFlagName, value, "positive integer")
-			}
-			options.matchingLogsMaxCount = maxCount
-		case tooldocs.PausePointCapturedVariablesFlagName:
-			mode, parseErr := parsePausePointCapturedVariablesMode(value)
-			if parseErr != nil {
-				return waitForPausePointOptions{}, parseErr
-			}
-			options.capturedVariablesMode = mode
-		case tooldocs.PausePointCapturedVariableNamesFlagName:
-			options.capturedVariableNames = parsePausePointCapturedVariableNames(value)
-		case tooldocs.PausePointExpectFlagName:
-			expectation, parseErr := parsePausePointExpectFlagValue(value)
-			if parseErr != nil {
-				return waitForPausePointOptions{}, parseErr
-			}
-			options.expectations = append(options.expectations, expectation)
-		case tooldocs.PausePointTriggerFlagName:
-			triggerCommand, triggerArgs, parseErr := parsePausePointTriggerCommand(clicore.PausePointAwaitCommandName, value)
-			if parseErr != nil {
-				return waitForPausePointOptions{}, parseErr
-			}
-			options.triggerCommand = triggerCommand
-			options.triggerArgs = triggerArgs
-		case tooldocs.PausePointResumePlayFlagName:
-			// --resume-play=true style is accepted; any other value is rejected so a typo cannot
-			// silently disable the resume step.
-			if value != "true" && value != "1" {
-				return waitForPausePointOptions{}, clierrors.InvalidValueArgumentError(
-					"--"+tooldocs.PausePointResumePlayFlagName, value, "boolean flag (pass with no value)")
-			}
-			options.resumePlay = true
-		default:
-			return waitForPausePointOptions{}, pausePointUnknownOptionError(clicore.PausePointAwaitCommandName, name)
+		if applyErr := applyWaitForPausePointFlag(&options, name, value); applyErr != nil {
+			return waitForPausePointOptions{}, applyErr
 		}
 
 		if consumedNext {

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_options.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_options.go
@@ -1,0 +1,98 @@
+package projectrunner
+
+import (
+	"strconv"
+	"time"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+	"github.com/hatayama/unity-cli-loop/common/tooldocs"
+)
+
+// applyWaitForPausePointFlag applies one named await-pause-point flag. Why a
+// helper: the per-flag validation stays with the flag it belongs to, so the
+// parser loop does not accumulate every branch into one cyclop finding.
+func applyWaitForPausePointFlag(options *waitForPausePointOptions, name string, value string) error {
+	switch name {
+	case PausePointIDFlagName:
+		options.id = value
+		return nil
+	case PausePointTimeoutFlagName:
+		return applyWaitForPausePointTimeout(options, value)
+	case PausePointLogsMaxCountFlagName:
+		return applyWaitForPausePointLogsMaxCount(options, value)
+	case tooldocs.PausePointCapturedVariablesFlagName:
+		return applyWaitForPausePointCapturedVariables(options, value)
+	case tooldocs.PausePointCapturedVariableNamesFlagName:
+		options.capturedVariableNames = parsePausePointCapturedVariableNames(value)
+		return nil
+	case tooldocs.PausePointExpectFlagName:
+		return applyWaitForPausePointExpect(options, value)
+	case tooldocs.PausePointTriggerFlagName:
+		return applyWaitForPausePointTrigger(options, value)
+	case tooldocs.PausePointResumePlayFlagName:
+		return applyWaitForPausePointResumePlayValue(options, value)
+	default:
+		return pausePointUnknownOptionError(clicore.PausePointAwaitCommandName, name)
+	}
+}
+
+func applyWaitForPausePointTimeout(options *waitForPausePointOptions, value string) error {
+	timeoutSeconds, parseErr := parsePausePointTimeoutSeconds(value)
+	if parseErr != nil {
+		return parseErr
+	}
+	options.timeoutSeconds = timeoutSeconds
+	options.timeout = time.Duration(timeoutSeconds) * time.Second
+	return nil
+}
+
+func applyWaitForPausePointLogsMaxCount(options *waitForPausePointOptions, value string) error {
+	maxCount, parseErr := strconv.Atoi(value)
+	if parseErr != nil || maxCount <= 0 {
+		return clierrors.InvalidValueArgumentError(
+			"--"+PausePointLogsMaxCountFlagName, value, "positive integer")
+	}
+	options.matchingLogsMaxCount = maxCount
+	return nil
+}
+
+func applyWaitForPausePointCapturedVariables(options *waitForPausePointOptions, value string) error {
+	mode, parseErr := parsePausePointCapturedVariablesMode(value)
+	if parseErr != nil {
+		return parseErr
+	}
+	options.capturedVariablesMode = mode
+	return nil
+}
+
+func applyWaitForPausePointExpect(options *waitForPausePointOptions, value string) error {
+	expectation, parseErr := parsePausePointExpectFlagValue(value)
+	if parseErr != nil {
+		return parseErr
+	}
+	options.expectations = append(options.expectations, expectation)
+	return nil
+}
+
+func applyWaitForPausePointTrigger(options *waitForPausePointOptions, value string) error {
+	triggerCommand, triggerArgs, parseErr := parsePausePointTriggerCommand(clicore.PausePointAwaitCommandName, value)
+	if parseErr != nil {
+		return parseErr
+	}
+	options.triggerCommand = triggerCommand
+	options.triggerArgs = triggerArgs
+	return nil
+}
+
+func applyWaitForPausePointResumePlayValue(options *waitForPausePointOptions, value string) error {
+	// --resume-play=true style is accepted; any other value is rejected so a typo cannot
+	// silently disable the resume step.
+	if value != "true" && value != "1" {
+		return clierrors.InvalidValueArgumentError(
+			"--"+tooldocs.PausePointResumePlayFlagName, value, "boolean flag (pass with no value)")
+	}
+	options.resumePlay = true
+	return nil
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_poll.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_poll.go
@@ -172,6 +172,20 @@ func pausePointUnarmedAtWaitStartSuffix(response pausePointStatusResponse, query
 	)
 }
 
+// pausePointWaitLoopState is the mutable snapshot the await poll loop updates
+// across ticks. Why a type: the timeout and poll-success paths both rewrite
+// the same fields, and passing them as a bag of locals kept waitForPausePointStatus
+// above the cyclop limit.
+type pausePointWaitLoopState struct {
+	lastResponse     pausePointStatusResponse
+	lastErr          error
+	triggerResult    *pausePointTriggerResult
+	hasResponse      bool
+	baselineSequence int
+	hasBaseline      bool
+	baselineDecided  bool
+}
+
 func waitForPausePointStatus(
 	ctx context.Context,
 	connection unityipc.Connection,
@@ -184,80 +198,109 @@ func waitForPausePointStatus(
 	waitContext, cancel := context.WithTimeout(ctx, options.timeout)
 	defer cancel()
 
-	lastResponse := pausePointStatusResponse{Id: options.id}
-	var lastErr error
-	var triggerResult *pausePointTriggerResult
-	hasResponse := false
+	state := pausePointWaitLoopState{
+		lastResponse:     pausePointStatusResponse{Id: options.id},
+		baselineSequence: baselineSequence,
+		hasBaseline:      hasBaseline,
+		baselineDecided:  baselineDecided,
+	}
 	triggerDone := triggerHandle.doneChannel()
 	ticker := time.NewTicker(pausePointStatusPoll)
 	defer ticker.Stop()
 	for {
 		response, err := queryPausePointStatus(waitContext, connection, options.id)
-		if err == nil {
-			lastResponse = response
-			hasResponse = true
-			// Why only once: a later Enabled→Hit transition is the await success itself
-			// (enable --await). Re-baselining on that first mid-wait Hit would demand a second
-			// sequence bump and never return.
-			if !baselineDecided {
-				baselineSequence, hasBaseline, baselineDecided = decidePausePointNewHitBaseline(
-					response, options.markerJustEnabled)
-			}
-			state := pausePointWaitStateForPolledStatus(response, baselineSequence, hasBaseline)
-			if state != "" {
-				return response, state, triggerResult, hasBaseline, nil
-			}
-		} else {
-			// Why abort: every poll dials again, so a connect the operating system refused
-			// permanently keeps failing for the whole --timeout and the refusal is reported only
-			// after that wait is spent.
-			if clierrors.IsPermanentConnectError(err) {
-				return lastResponse, "", triggerResult, hasBaseline, err
-			}
-			lastErr = err
+		waitState, done, pollErr := applyPausePointWaitPoll(&state, response, err, options.markerJustEnabled)
+		if done {
+			return state.lastResponse, waitState, state.triggerResult, state.hasBaseline, pollErr
 		}
 
 		select {
 		case <-waitContext.Done():
-			if ctx.Err() != nil {
-				return lastResponse, "", triggerResult, hasBaseline, ctx.Err()
-			}
-			finalResponse, finalState, hasFinalResponse, finalErr := queryPausePointStatusAtTimeout(
-				ctx, connection, options.id, baselineSequence, hasBaseline)
-			if hasFinalResponse {
-				lastResponse = finalResponse
-				hasResponse = true
-				if !baselineDecided {
-					baselineSequence, hasBaseline, _ = decidePausePointNewHitBaseline(
-						finalResponse, options.markerJustEnabled)
-					finalState = pausePointWaitStateForPolledStatus(finalResponse, baselineSequence, hasBaseline)
-				}
-				if finalState != "" {
-					return finalResponse, finalState, triggerResult, hasBaseline, nil
-				}
-			} else if lastErr == nil {
-				lastErr = finalErr
-			}
-			if hasResponse {
-				return lastResponse, pausePointWaitStateTimeout, triggerResult, hasBaseline, nil
-			}
-			if lastErr != nil {
-				return lastResponse, "", triggerResult, hasBaseline, fmt.Errorf("timed out waiting for pause point status: %w", lastErr)
-			}
-			return lastResponse, pausePointWaitStateTimeout, triggerResult, hasBaseline, nil
+			return finishPausePointWaitOnTimeout(ctx, connection, options, &state)
 		case result := <-triggerDone:
 			// Nil the channel so this case can never fire twice: the handle's channel holds a single
 			// buffered value, and the caller reuses the result received here instead of joining.
-			triggerResult = result
+			state.triggerResult = result
 			triggerDone = nil
 			if pausePointTriggerRejectedBeforeExecution(result) {
 				abortResponse, abortState := abortPausePointWaitAfterTriggerRejection(
-					ctx, connection, options.id, lastResponse, baselineSequence, hasBaseline)
-				return abortResponse, abortState, triggerResult, hasBaseline, nil
+					ctx, connection, options.id, state.lastResponse, state.baselineSequence, state.hasBaseline)
+				return abortResponse, abortState, state.triggerResult, state.hasBaseline, nil
 			}
 		case <-ticker.C:
 		}
 	}
+}
+
+// applyPausePointWaitPoll records one status query. Why abort on a permanent
+// connect error: every poll dials again, so a refused connect would otherwise
+// burn the whole --timeout before the refusal is reported.
+func applyPausePointWaitPoll(
+	state *pausePointWaitLoopState,
+	response pausePointStatusResponse,
+	err error,
+	markerJustEnabled bool,
+) (pausePointWaitState, bool, error) {
+	if err != nil {
+		if clierrors.IsPermanentConnectError(err) {
+			return "", true, err
+		}
+		state.lastErr = err
+		return "", false, nil
+	}
+
+	state.lastResponse = response
+	state.hasResponse = true
+	// Why only once: a later Enabled→Hit transition is the await success itself
+	// (enable --await). Re-baselining on that first mid-wait Hit would demand a second
+	// sequence bump and never return.
+	if !state.baselineDecided {
+		state.baselineSequence, state.hasBaseline, state.baselineDecided = decidePausePointNewHitBaseline(
+			response, markerJustEnabled)
+	}
+	waitState := pausePointWaitStateForPolledStatus(response, state.baselineSequence, state.hasBaseline)
+	if waitState != "" {
+		return waitState, true, nil
+	}
+	return "", false, nil
+}
+
+// finishPausePointWaitOnTimeout takes one last status probe after the wait
+// deadline. Why a helper: the deadline path has its own baseline and error
+// fallbacks, and leaving them inline kept waitForPausePointStatus over the
+// cyclop limit.
+func finishPausePointWaitOnTimeout(
+	ctx context.Context,
+	connection unityipc.Connection,
+	options waitForPausePointOptions,
+	state *pausePointWaitLoopState,
+) (pausePointStatusResponse, pausePointWaitState, *pausePointTriggerResult, bool, error) {
+	if ctx.Err() != nil {
+		return state.lastResponse, "", state.triggerResult, state.hasBaseline, ctx.Err()
+	}
+	finalResponse, finalState, hasFinalResponse, finalErr := queryPausePointStatusAtTimeout(
+		ctx, connection, options.id, state.baselineSequence, state.hasBaseline)
+	if hasFinalResponse {
+		state.lastResponse = finalResponse
+		state.hasResponse = true
+		if !state.baselineDecided {
+			state.baselineSequence, state.hasBaseline, _ = decidePausePointNewHitBaseline(
+				finalResponse, options.markerJustEnabled)
+			finalState = pausePointWaitStateForPolledStatus(finalResponse, state.baselineSequence, state.hasBaseline)
+		}
+		if finalState != "" {
+			return finalResponse, finalState, state.triggerResult, state.hasBaseline, nil
+		}
+	} else if state.lastErr == nil {
+		state.lastErr = finalErr
+	}
+	if state.hasResponse {
+		return state.lastResponse, pausePointWaitStateTimeout, state.triggerResult, state.hasBaseline, nil
+	}
+	if state.lastErr != nil {
+		return state.lastResponse, "", state.triggerResult, state.hasBaseline, fmt.Errorf("timed out waiting for pause point status: %w", state.lastErr)
+	}
+	return state.lastResponse, pausePointWaitStateTimeout, state.triggerResult, state.hasBaseline, nil
 }
 
 // abortPausePointWaitAfterTriggerRejection takes one last status reading before abandoning the

--- a/cli/release-automation/internal/automation/codeql_sarif_guard.go
+++ b/cli/release-automation/internal/automation/codeql_sarif_guard.go
@@ -122,38 +122,77 @@ func validateCodeQLSARIF(data []byte) (CodeQLSARIFValidationResult, error) {
 	return validateCodeQLSARIFQuality(run)
 }
 
+type codeQLQualityScan struct {
+	hasBuildlessCompletion bool
+	extractedFileCount     int
+	callTargets            int
+	knownTypes             int
+}
+
 func validateCodeQLSARIFQuality(run codeQLSARIFRun) (CodeQLSARIFValidationResult, error) {
-	invocation := run.Invocations[0]
-	hasBuildlessCompletion := false
-	extractedFileCount := 0
+	scan, err := scanCodeQLQualityNotifications(run.Invocations[0])
+	if err != nil {
+		return CodeQLSARIFValidationResult{}, err
+	}
+	if err := scan.rejectIfIncomplete(); err != nil {
+		return CodeQLSARIFValidationResult{}, err
+	}
+	if err := scan.rejectIfBelowApprovedFloor(); err != nil {
+		return CodeQLSARIFValidationResult{}, err
+	}
+	if err := rejectCodeQLLinesOfCodeBelowFloor(run); err != nil {
+		return CodeQLSARIFValidationResult{}, err
+	}
+	return CodeQLSARIFValidationResult{Warnings: scan.baselineDriftWarnings()}, nil
+}
+
+// scanCodeQLQualityNotifications reads the invocation diagnostics that prove
+// build-mode none completed and that extractor quality is present. Why a
+// helper: those three notification kinds are one scan, and leaving the loop
+// inline kept validateCodeQLSARIFQuality over the cyclop limit.
+func scanCodeQLQualityNotifications(invocation codeQLSARIFInvocation) (codeQLQualityScan, error) {
 	// CodeQL 2.26.0 emits the database-quality diagnostic only below its own 85% thresholds. The strict semantic-version check above freezes that behavior, so absence means both metrics are at least 85%, not that evidence was silently lost.
-	callTargets := 100
-	knownTypes := 100
+	scan := codeQLQualityScan{
+		callTargets: 100,
+		knownTypes:  100,
+	}
 	for _, notification := range invocation.ToolExecutionNotifications {
 		if notification.Descriptor.ID == codeQLBuildlessCompletionDiagnosticID && notification.Message.Text == codeQLBuildlessCompletionMessage {
-			hasBuildlessCompletion = true
+			scan.hasBuildlessCompletion = true
 		}
 		if notification.Descriptor.ID == codeQLExtractedFilesDiagnosticID {
-			extractedFileCount++
+			scan.extractedFileCount++
 		}
 		if notification.Descriptor.ID == codeQLQualityDiagnosticID {
 			parsedCallTargets, parsedKnownTypes, err := parseCodeQLQualityMetrics(notification.Message.Text)
 			if err != nil {
-				return CodeQLSARIFValidationResult{}, err
+				return codeQLQualityScan{}, err
 			}
-			callTargets = parsedCallTargets
-			knownTypes = parsedKnownTypes
+			scan.callTargets = parsedCallTargets
+			scan.knownTypes = parsedKnownTypes
 		}
 	}
-	if !hasBuildlessCompletion {
-		return CodeQLSARIFValidationResult{}, fmt.Errorf("CodeQL SARIF is missing build-mode none completion diagnostic")
+	return scan, nil
+}
+
+func (scan codeQLQualityScan) rejectIfIncomplete() error {
+	if !scan.hasBuildlessCompletion {
+		return fmt.Errorf("CodeQL SARIF is missing build-mode none completion diagnostic")
 	}
-	if extractedFileCount == 0 {
-		return CodeQLSARIFValidationResult{}, fmt.Errorf("CodeQL SARIF has no successfully extracted C# files")
+	if scan.extractedFileCount == 0 {
+		return fmt.Errorf("CodeQL SARIF has no successfully extracted C# files")
 	}
-	if callTargets < minimumCodeQLCallTargetPercentage || knownTypes < minimumCodeQLKnownTypePercentage {
-		return CodeQLSARIFValidationResult{}, fmt.Errorf("CodeQL database quality is below the approved floor: call targets %d%%, known types %d%%", callTargets, knownTypes)
+	return nil
+}
+
+func (scan codeQLQualityScan) rejectIfBelowApprovedFloor() error {
+	if scan.callTargets < minimumCodeQLCallTargetPercentage || scan.knownTypes < minimumCodeQLKnownTypePercentage {
+		return fmt.Errorf("CodeQL database quality is below the approved floor: call targets %d%%, known types %d%%", scan.callTargets, scan.knownTypes)
 	}
+	return nil
+}
+
+func rejectCodeQLLinesOfCodeBelowFloor(run codeQLSARIFRun) error {
 	linesOfCode := float64(0)
 	for _, metric := range run.Properties.MetricResults {
 		if metric.RuleID == codeQLLinesOfCodeMetricID {
@@ -161,13 +200,17 @@ func validateCodeQLSARIFQuality(run codeQLSARIFRun) (CodeQLSARIFValidationResult
 		}
 	}
 	if linesOfCode < float64(minimumCodeQLLinesOfCode) {
-		return CodeQLSARIFValidationResult{}, fmt.Errorf("CodeQL extracted lines of code %.0f is below the approved floor %d", linesOfCode, minimumCodeQLLinesOfCode)
+		return fmt.Errorf("CodeQL extracted lines of code %.0f is below the approved floor %d", linesOfCode, minimumCodeQLLinesOfCode)
 	}
+	return nil
+}
+
+func (scan codeQLQualityScan) baselineDriftWarnings() []string {
 	warnings := []string{}
-	if callTargets < baselineCodeQLCallTargetPercentage || knownTypes < baselineCodeQLKnownTypePercentage {
-		warnings = append(warnings, fmt.Sprintf("CodeQL database quality is below the 2026-07-15 PoC baseline: call targets %d%% (baseline %d%%), known types %d%% (baseline %d%%)", callTargets, baselineCodeQLCallTargetPercentage, knownTypes, baselineCodeQLKnownTypePercentage))
+	if scan.callTargets < baselineCodeQLCallTargetPercentage || scan.knownTypes < baselineCodeQLKnownTypePercentage {
+		warnings = append(warnings, fmt.Sprintf("CodeQL database quality is below the 2026-07-15 PoC baseline: call targets %d%% (baseline %d%%), known types %d%% (baseline %d%%)", scan.callTargets, baselineCodeQLCallTargetPercentage, scan.knownTypes, baselineCodeQLKnownTypePercentage))
 	}
-	return CodeQLSARIFValidationResult{Warnings: warnings}, nil
+	return warnings
 }
 
 func parseCodeQLQualityMetrics(message string) (int, int, error) {

--- a/cli/release-automation/internal/automation/homebrew_formula_update_test.go
+++ b/cli/release-automation/internal/automation/homebrew_formula_update_test.go
@@ -177,41 +177,8 @@ func TestUpdateHomebrewFormulaSkipsWithoutToken(t *testing.T) {
 // TestUpdateHomebrewFormulaCreatesFormulaWhenAbsent verifies a missing tap formula is created without sha.
 func TestUpdateHomebrewFormulaCreatesFormulaWhenAbsent(t *testing.T) {
 	t.Setenv(homebrewTapTokenEnvName, "tap-token")
-	formula, err := renderHomebrewFormula(homebrewFormulaData{
-		Version:     "3.0.0-beta.30",
-		Repository:  "hatayama/unity-cli-loop",
-		SHA256Arm64: testHomebrewArm64SHA256,
-		SHA256Amd64: testHomebrewAmd64SHA256,
-	})
-	if err != nil {
-		t.Fatalf("renderHomebrewFormula failed: %v", err)
-	}
-	encodedFormula := base64.StdEncoding.EncodeToString([]byte(formula))
-
-	var putArgs []string
-	deps := homebrewFormulaUpdateDeps{
-		runOutput: func(_ context.Context, extraEnv []string, name string, args ...string) (string, error) {
-			joined := strings.Join(args, " ")
-			switch {
-			case strings.Contains(joined, "release download") && strings.Contains(joined, homebrewDarwinArm64AssetName+".sha256"):
-				return testHomebrewArm64SHA256 + "  " + homebrewDarwinArm64AssetName + "\n", nil
-			case strings.Contains(joined, "release download") && strings.Contains(joined, homebrewDarwinAmd64AssetName+".sha256"):
-				return testHomebrewAmd64SHA256 + "  " + homebrewDarwinAmd64AssetName + "\n", nil
-			case strings.Contains(joined, "repos/hatayama/homebrew-tap/contents/"+homebrewFormulaPath):
-				if strings.Contains(joined, "-X PUT") {
-					putArgs = append([]string{}, args...)
-					return `{"content":{"sha":"new-sha"}}`, nil
-				}
-				if len(extraEnv) == 0 || !strings.Contains(strings.Join(extraEnv, "\n"), "GH_TOKEN=tap-token") {
-					t.Fatalf("expected tap token env on contents GET, got %v", extraEnv)
-				}
-				return "", errors.New("gh api failed: HTTP 404 Not Found")
-			default:
-				return "", errors.New("unexpected command: " + name + " " + joined)
-			}
-		},
-	}
-
+	encodedFormula := mustRenderHomebrewFormulaBase64(t)
+	putArgs := []string{}
 	code := runUpdateHomebrewFormulaWithDeps(
 		context.Background(),
 		&bytes.Buffer{},
@@ -221,8 +188,63 @@ func TestUpdateHomebrewFormulaCreatesFormulaWhenAbsent(t *testing.T) {
 			tag:        "dispatcher-v3.0.0-beta.30",
 			tapRepo:    "hatayama/homebrew-tap",
 		},
-		deps,
+		homebrewFormulaUpdateDeps{
+			runOutput: stubHomebrewCreateFormulaWhenAbsent(t, &putArgs),
+		},
 	)
+	assertHomebrewFormulaCreatedWithoutSHA(t, code, putArgs, encodedFormula)
+}
+
+func mustRenderHomebrewFormulaBase64(t *testing.T) string {
+	t.Helper()
+	formula, err := renderHomebrewFormula(homebrewFormulaData{
+		Version:     "3.0.0-beta.30",
+		Repository:  "hatayama/unity-cli-loop",
+		SHA256Arm64: testHomebrewArm64SHA256,
+		SHA256Amd64: testHomebrewAmd64SHA256,
+	})
+	if err != nil {
+		t.Fatalf("renderHomebrewFormula failed: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString([]byte(formula))
+}
+
+func stubHomebrewCreateFormulaWhenAbsent(
+	t *testing.T,
+	putArgs *[]string,
+) func(context.Context, []string, string, ...string) (string, error) {
+	t.Helper()
+	return func(_ context.Context, extraEnv []string, name string, args ...string) (string, error) {
+		joined := strings.Join(args, " ")
+		if output, handled, err := homebrewFormulaSHADownloadOutput(joined); handled {
+			return output, err
+		}
+		if !strings.Contains(joined, "repos/hatayama/homebrew-tap/contents/"+homebrewFormulaPath) {
+			return "", errors.New("unexpected command: " + name + " " + joined)
+		}
+		if strings.Contains(joined, "-X PUT") {
+			*putArgs = append([]string{}, args...)
+			return `{"content":{"sha":"new-sha"}}`, nil
+		}
+		if len(extraEnv) == 0 || !strings.Contains(strings.Join(extraEnv, "\n"), "GH_TOKEN=tap-token") {
+			t.Fatalf("expected tap token env on contents GET, got %v", extraEnv)
+		}
+		return "", errors.New("gh api failed: HTTP 404 Not Found")
+	}
+}
+
+func homebrewFormulaSHADownloadOutput(joined string) (string, bool, error) {
+	if strings.Contains(joined, "release download") && strings.Contains(joined, homebrewDarwinArm64AssetName+".sha256") {
+		return testHomebrewArm64SHA256 + "  " + homebrewDarwinArm64AssetName + "\n", true, nil
+	}
+	if strings.Contains(joined, "release download") && strings.Contains(joined, homebrewDarwinAmd64AssetName+".sha256") {
+		return testHomebrewAmd64SHA256 + "  " + homebrewDarwinAmd64AssetName + "\n", true, nil
+	}
+	return "", false, nil
+}
+
+func assertHomebrewFormulaCreatedWithoutSHA(t *testing.T, code int, putArgs []string, encodedFormula string) {
+	t.Helper()
 	if code != 0 {
 		t.Fatalf("exit code = %d", code)
 	}

--- a/cli/release-automation/internal/automation/release_pr_checks.go
+++ b/cli/release-automation/internal/automation/release_pr_checks.go
@@ -96,6 +96,27 @@ func runReleasePleasePRChecksWithDeps(ctx context.Context, stdout io.Writer, std
 		return 0
 	}
 
+	if code := prepareReleasePRForChecks(ctx, stdout, stderr, config, releasePR, deps); code != 0 {
+		return code
+	}
+	checkedHeadSHA, code := dispatchAndWatchReleasePRCheckWorkflows(ctx, stdout, stderr, config, releasePR, deps)
+	if code != 0 {
+		return code
+	}
+	return finalizeReleasePRChecks(ctx, stdout, stderr, config, releasePR, checkedHeadSHA, deps)
+}
+
+// prepareReleasePRForChecks clarifies the release PR body and marks it draft
+// before workflows run. Why a helper: find/dispatch/finalize are separate
+// stages, and leaving draft setup inline kept the orchestrator over cyclop.
+func prepareReleasePRForChecks(
+	ctx context.Context,
+	stdout io.Writer,
+	stderr io.Writer,
+	config releasePRCheckConfig,
+	releasePR releasePullRequest,
+	deps releasePRCheckDeps,
+) int {
 	bodyChanged, err := clarifyReleasePRCheckBody(ctx, config, releasePR, deps)
 	if err != nil {
 		writeReleasePRCheckLine(stderr, err)
@@ -111,14 +132,28 @@ func runReleasePleasePRChecksWithDeps(ctx context.Context, stdout io.Writer, std
 		return 1
 	}
 	writeReleasePRCheckLine(stdout, fmt.Sprintf("Marked release PR #%d as draft while checks run.", releasePR.Number))
+	return 0
+}
 
+// dispatchAndWatchReleasePRCheckWorkflows dispatches each required workflow
+// and waits for the same head SHA. Why reject mixed heads: a release-please
+// force-push between dispatches would otherwise let a mixed set of green runs
+// mark the PR ready.
+func dispatchAndWatchReleasePRCheckWorkflows(
+	ctx context.Context,
+	stdout io.Writer,
+	stderr io.Writer,
+	config releasePRCheckConfig,
+	releasePR releasePullRequest,
+	deps releasePRCheckDeps,
+) (string, int) {
 	dispatchedAt := deps.now().UTC().Truncate(time.Second)
 	for _, workflow := range config.workflows {
 		writeReleasePRCheckLine(stdout, fmt.Sprintf("Dispatching %s for release PR #%d: %s", workflow, releasePR.Number, releasePR.URL))
-		err = dispatchReleasePRCheckWorkflow(ctx, config, workflow, releasePR, deps)
+		err := dispatchReleasePRCheckWorkflow(ctx, config, workflow, releasePR, deps)
 		if err != nil {
 			writeReleasePRCheckLine(stderr, err)
-			return 1
+			return "", 1
 		}
 	}
 
@@ -128,19 +163,16 @@ func runReleasePleasePRChecksWithDeps(ctx context.Context, stdout io.Writer, std
 		run, err := findDispatchedReleasePRCheckRun(ctx, config, workflow, releasePR, dispatchedAt, deps)
 		if err != nil {
 			writeReleasePRCheckLine(stderr, err)
-			return 1
+			return "", 1
 		}
 
 		writeReleasePRCheckLine(stdout, fmt.Sprintf("Watching %s run %d for release PR #%d.", workflow, run.DatabaseID, releasePR.Number))
 		err = watchReleasePRCheckRun(ctx, config, run.DatabaseID, deps)
 		if err != nil {
 			writeReleasePRCheckLine(stderr, err)
-			return 1
+			return "", 1
 		}
 
-		// A release-please force-push between two dispatches would let each
-		// workflow validate a different commit, so a mixed set of green runs
-		// must not mark the PR ready.
 		if checkedHeadSHA == "" {
 			checkedHeadSHA = run.HeadSHA
 			checkedHeadWorkflow = workflow
@@ -150,11 +182,22 @@ func runReleasePleasePRChecksWithDeps(ctx context.Context, stdout io.Writer, std
 			writeReleasePRCheckLine(stderr, fmt.Errorf(
 				"release PR #%d checks ran on different heads: %s checked %s but %s checked %s",
 				releasePR.Number, checkedHeadWorkflow, checkedHeadSHA, workflow, run.HeadSHA))
-			return 1
+			return "", 1
 		}
 	}
+	return checkedHeadSHA, 0
+}
 
-	err = verifyReleasePRCheckHeadMatchesRun(ctx, config, releasePR, checkedHeadSHA, deps)
+func finalizeReleasePRChecks(
+	ctx context.Context,
+	stdout io.Writer,
+	stderr io.Writer,
+	config releasePRCheckConfig,
+	releasePR releasePullRequest,
+	checkedHeadSHA string,
+	deps releasePRCheckDeps,
+) int {
+	err := verifyReleasePRCheckHeadMatchesRun(ctx, config, releasePR, checkedHeadSHA, deps)
 	if err != nil {
 		writeReleasePRCheckLine(stderr, err)
 		return 1


### PR DESCRIPTION
## Summary
- Split the remaining high-complexity project-runner and release-automation functions so each stays at or below the cyclop limit of 15.
- Existing pause-point wait parsing, wait-poll outcomes, CodeQL SARIF quality checks, and release-please PR check orchestration keep the same errors and control flow.

## User Impact
- Before, seven Go functions in the project runner and release automation sat above the repository complexity limit, so later edits in those paths were harder to review safely.
- After, those functions are split by meaning (flag, poll stage, workflow stage, or test case) without changing command behavior.

## Changes
- Extract await-pause-point flag handlers and wait-poll timeout/success stages.
- Extract CodeQL quality notification scanning and release-please prepare/dispatch/finalize stages.
- Move dense test branches into helpers and lock exact resume-play error strings.

## Verification
- `scripts/check-go-cli.sh`: pass (format, lint, architecture, all Go module tests).
- `scripts/check-code-complexity.sh`: Go cyclop 0 issues across common, dispatcher, project-runner, and release-automation. Remaining CA1502 findings are the planned C# work (22), unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

