### PR TITLE
refactor: reduce CA1502 complexity in first-party tool editor code

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemConfiguredUpdateApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemConfiguredUpdateApplier.cs
@@ -38,38 +38,52 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return ApplyOnExplicitUpdate(apply, targetUpdateType, ct);
             }
 
-            TaskCompletionSource<InputSimulationWaitOutcome> tcs =
-                new(TaskCreationOptions.RunContinuationsAsynchronously);
-            CancellationTokenRegistration registration = default;
-            int applyWaitState = ApplyWaitStateWaiting;
-            Action? callback = null;
-            InputSystemUpdateSubscription? subscription = null;
-
-            void TryDiscardForPause()
+            ConfiguredUpdateApplyWait wait = new()
             {
-                if (Interlocked.CompareExchange(
-                        ref applyWaitState,
-                        ApplyWaitStateFinishedWithoutApply,
-                        ApplyWaitStateWaiting) != ApplyWaitStateWaiting)
-                {
-                    return;
-                }
+                Apply = apply,
+                TargetUpdateType = targetUpdateType,
+                Completion = new TaskCompletionSource<InputSimulationWaitOutcome>(
+                    TaskCreationOptions.RunContinuationsAsynchronously)
+            };
+            wait.Subscription = new InputSystemUpdateSubscription(CreateConfiguredUpdateCallback(wait));
+            return await AwaitConfiguredUpdateResult(wait, ct).ConfigureAwait(false);
+        }
 
-                // Dispose before cleanup release so a queued edge cannot apply after resume.
-                subscription?.Dispose();
-                tcs.TrySetResult(InputSimulationWaitOutcome.Paused);
+        private sealed class ConfiguredUpdateApplyWait
+        {
+            public Action Apply = null!;
+            public InputUpdateType TargetUpdateType;
+            public TaskCompletionSource<InputSimulationWaitOutcome> Completion = null!;
+            public InputSystemUpdateSubscription? Subscription;
+            public int ApplyWaitState;
+        }
+
+        private static void TryDiscardConfiguredUpdateForPause(ConfiguredUpdateApplyWait wait)
+        {
+            if (Interlocked.CompareExchange(
+                    ref wait.ApplyWaitState,
+                    ApplyWaitStateFinishedWithoutApply,
+                    ApplyWaitStateWaiting) != ApplyWaitStateWaiting)
+            {
+                return;
             }
 
-            callback = () =>
+            // Dispose before cleanup release so a queued edge cannot apply after resume.
+            wait.Subscription?.Dispose();
+            wait.Completion.TrySetResult(InputSimulationWaitOutcome.Paused);
+        }
+
+        private static Action CreateConfiguredUpdateCallback(ConfiguredUpdateApplyWait wait)
+        {
+            return () =>
             {
-                Debug.Assert(callback != null, "callback must be assigned before subscription");
-                Debug.Assert(subscription != null, "subscription must be assigned before callback invocation");
+                Debug.Assert(wait.Subscription != null, "subscription must be assigned before callback invocation");
                 if (Interlocked.CompareExchange(
-                        ref applyWaitState,
+                        ref wait.ApplyWaitState,
                         ApplyWaitStateWaiting,
                         ApplyWaitStateWaiting) != ApplyWaitStateWaiting)
                 {
-                    subscription?.Dispose();
+                    wait.Subscription?.Dispose();
                     return;
                 }
 
@@ -77,39 +91,44 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // it after resume (that delayed apply is the Repro B / round-8 stale press).
                 if (InputSystemUpdateHelper.IsPaused())
                 {
-                    TryDiscardForPause();
+                    TryDiscardConfiguredUpdateForPause(wait);
                     return;
                 }
 
                 InputUpdateType currentUpdateType = InputState.currentUpdateType;
-                if (!InputUpdateTypeResolver.IsMatch(currentUpdateType, targetUpdateType))
+                if (!InputUpdateTypeResolver.IsMatch(currentUpdateType, wait.TargetUpdateType))
                 {
                     return;
                 }
 
                 if (Interlocked.CompareExchange(
-                        ref applyWaitState,
+                        ref wait.ApplyWaitState,
                         ApplyWaitStateApplying,
                         ApplyWaitStateWaiting) != ApplyWaitStateWaiting)
                 {
-                    subscription?.Dispose();
+                    wait.Subscription?.Dispose();
                     return;
                 }
 
-                subscription?.Dispose();
+                wait.Subscription?.Dispose();
                 try
                 {
-                    apply();
-                    tcs.TrySetResult(InputSimulationWaitOutcome.Completed);
+                    wait.Apply();
+                    wait.Completion.TrySetResult(InputSimulationWaitOutcome.Completed);
                 }
                 catch (Exception exception)
                 {
                     // Convert apply failures into the awaited task result so timeout paths never wait on an orphaned TCS.
-                    tcs.TrySetException(exception);
+                    wait.Completion.TrySetException(exception);
                 }
             };
+        }
 
-            subscription = new InputSystemUpdateSubscription(callback);
+        private static async Task<InputSimulationWaitOutcome> AwaitConfiguredUpdateResult(
+            ConfiguredUpdateApplyWait wait,
+            CancellationToken ct)
+        {
+            CancellationTokenRegistration registration = default;
             try
             {
                 if (ct.CanBeCanceled)
@@ -117,12 +136,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     registration = ct.Register(() =>
                     {
                         if (Interlocked.CompareExchange(
-                                ref applyWaitState,
+                                ref wait.ApplyWaitState,
                                 ApplyWaitStateFinishedWithoutApply,
                                 ApplyWaitStateWaiting) == ApplyWaitStateWaiting)
                         {
-                            subscription?.Dispose();
-                            tcs.TrySetCanceled(ct);
+                            wait.Subscription?.Dispose();
+                            wait.Completion.TrySetCanceled(ct);
                         }
                     });
                 }
@@ -133,37 +152,45 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     timeoutCts.Token);
                 // Why: onBeforeUpdate may not run while paused, so poll pause separately and
                 // dispose the subscription before any later resume can apply the queued edge.
-                _ = WatchForPauseDiscardAsync(TryDiscardForPause, timeoutCts.Token);
-                Task completedTask = await Task.WhenAny(tcs.Task, timeoutTask).ConfigureAwait(false);
+                _ = WatchForPauseDiscardAsync(() => TryDiscardConfiguredUpdateForPause(wait), timeoutCts.Token);
+                Task completedTask = await Task.WhenAny(wait.Completion.Task, timeoutTask).ConfigureAwait(false);
                 if (completedTask == timeoutTask)
                 {
-                    await timeoutTask.ConfigureAwait(false);
-                    // Why: cancel before scope-exit dispose so the pause watcher exits instead of polling a disposed token.
-                    timeoutCts.Cancel();
-                    if (Interlocked.CompareExchange(
-                            ref applyWaitState,
-                            ApplyWaitStateFinishedWithoutApply,
-                            ApplyWaitStateWaiting) == ApplyWaitStateWaiting)
-                    {
-                        subscription.Dispose();
-                        return InputSimulationWaitOutcome.TimedOut;
-                    }
-
-                    InputSimulationWaitOutcome appliedOutcome = await tcs.Task.ConfigureAwait(false);
-                    await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
-                    return appliedOutcome;
+                    return await FinishConfiguredUpdateTimeout(wait, timeoutTask, timeoutCts).ConfigureAwait(false);
                 }
 
                 timeoutCts.Cancel();
-                InputSimulationWaitOutcome outcome = await tcs.Task.ConfigureAwait(false);
+                InputSimulationWaitOutcome outcome = await wait.Completion.Task.ConfigureAwait(false);
                 await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
                 return outcome;
             }
             finally
             {
                 registration.Dispose();
-                subscription?.Dispose();
+                wait.Subscription?.Dispose();
             }
+        }
+
+        private static async Task<InputSimulationWaitOutcome> FinishConfiguredUpdateTimeout(
+            ConfiguredUpdateApplyWait wait,
+            Task timeoutTask,
+            CancellationTokenSource timeoutCts)
+        {
+            await timeoutTask.ConfigureAwait(false);
+            // Why: cancel before scope-exit dispose so the pause watcher exits instead of polling a disposed token.
+            timeoutCts.Cancel();
+            if (Interlocked.CompareExchange(
+                    ref wait.ApplyWaitState,
+                    ApplyWaitStateFinishedWithoutApply,
+                    ApplyWaitStateWaiting) == ApplyWaitStateWaiting)
+            {
+                wait.Subscription?.Dispose();
+                return InputSimulationWaitOutcome.TimedOut;
+            }
+
+            InputSimulationWaitOutcome appliedOutcome = await wait.Completion.Task.ConfigureAwait(false);
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
+            return appliedOutcome;
         }
 
         private static async Task WatchForPauseDiscardAsync(Action tryDiscardForPause, CancellationToken ct)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeLiteralHoister.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeLiteralHoister.cs
@@ -21,74 +21,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             while (index < source.Length)
             {
-                if (DynamicCodeLiteralSyntaxScanner.TryCopyInterpolatedStringLiteral(source, rewrittenSource, ref index))
+                if (TryCopyProtectedSyntax(source, rewrittenSource, scopeTracker, ref index))
                 {
                     continue;
                 }
 
-                if (DynamicCodeLiteralSyntaxScanner.TryCopyVerbatimStringLiteral(source, rewrittenSource, ref index))
+                if (TryCopyScopePunctuation(source, rewrittenSource, scopeTracker, ref index))
                 {
                     continue;
                 }
 
-                if (DynamicCodeLiteralSyntaxScanner.TryCopyCharLiteral(source, rewrittenSource, ref index))
-                {
-                    continue;
-                }
-
-                if (DynamicCodeLiteralSyntaxScanner.TryCopyLineComment(source, rewrittenSource, ref index))
-                {
-                    continue;
-                }
-
-                if (DynamicCodeLiteralSyntaxScanner.TryCopyBlockComment(source, rewrittenSource, ref index))
-                {
-                    continue;
-                }
-
-                if (scopeTracker.TryConsumeStaticLocalFunctionHeader(source, index, rewrittenSource, ref index))
-                {
-                    continue;
-                }
-
-                if (source[index] == '{')
-                {
-                    scopeTracker.OnOpenBrace();
-                    rewrittenSource.Append('{');
-                    index++;
-                    continue;
-                }
-
-                if (source[index] == '}')
-                {
-                    scopeTracker.OnCloseBrace();
-                    rewrittenSource.Append('}');
-                    index++;
-                    continue;
-                }
-
-                if (source[index] == ';')
-                {
-                    scopeTracker.OnSemicolon();
-                    rewrittenSource.Append(';');
-                    index++;
-                    continue;
-                }
-
-                if (scopeTracker.ShouldSuppressLiteralHoisting)
-                {
-                    if (DynamicCodeLiteralSyntaxScanner.TryCopyRegularStringLiteral(source, rewrittenSource, ref index))
-                    {
-                        continue;
-                    }
-                }
-                else if (TryHoistRegularStringLiteral(source, rewrittenSource, bindings, ref index))
-                {
-                    continue;
-                }
-
-                if (!scopeTracker.ShouldSuppressLiteralHoisting
-                    && TryHoistIntegerLiteral(source, rewrittenSource, bindings, ref index))
+                if (TryHoistOrCopyLiterals(source, rewrittenSource, bindings, scopeTracker, ref index))
                 {
                     continue;
                 }
@@ -108,6 +51,96 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 rewrittenSource.ToString(),
                 bindings,
                 declarationLines);
+        }
+
+        // Copies syntax that must stay verbatim (strings with interpolation/verbatim, comments,
+        // and static local-function headers). Why a helper: those scanners are one skip-list,
+        // and leaving them inline kept Rewrite over CA1502.
+        private static bool TryCopyProtectedSyntax(
+            string source,
+            StringBuilder rewrittenSource,
+            LiteralHoistScopeTracker scopeTracker,
+            ref int index)
+        {
+            if (DynamicCodeLiteralSyntaxScanner.TryCopyInterpolatedStringLiteral(source, rewrittenSource, ref index))
+            {
+                return true;
+            }
+
+            if (DynamicCodeLiteralSyntaxScanner.TryCopyVerbatimStringLiteral(source, rewrittenSource, ref index))
+            {
+                return true;
+            }
+
+            if (DynamicCodeLiteralSyntaxScanner.TryCopyCharLiteral(source, rewrittenSource, ref index))
+            {
+                return true;
+            }
+
+            if (DynamicCodeLiteralSyntaxScanner.TryCopyLineComment(source, rewrittenSource, ref index))
+            {
+                return true;
+            }
+
+            if (DynamicCodeLiteralSyntaxScanner.TryCopyBlockComment(source, rewrittenSource, ref index))
+            {
+                return true;
+            }
+
+            return scopeTracker.TryConsumeStaticLocalFunctionHeader(source, index, rewrittenSource, ref index);
+        }
+
+        private static bool TryCopyScopePunctuation(
+            string source,
+            StringBuilder rewrittenSource,
+            LiteralHoistScopeTracker scopeTracker,
+            ref int index)
+        {
+            if (source[index] == '{')
+            {
+                scopeTracker.OnOpenBrace();
+                rewrittenSource.Append('{');
+                index++;
+                return true;
+            }
+
+            if (source[index] == '}')
+            {
+                scopeTracker.OnCloseBrace();
+                rewrittenSource.Append('}');
+                index++;
+                return true;
+            }
+
+            if (source[index] == ';')
+            {
+                scopeTracker.OnSemicolon();
+                rewrittenSource.Append(';');
+                index++;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryHoistOrCopyLiterals(
+            string source,
+            StringBuilder rewrittenSource,
+            List<HoistedLiteralBinding> bindings,
+            LiteralHoistScopeTracker scopeTracker,
+            ref int index)
+        {
+            if (scopeTracker.ShouldSuppressLiteralHoisting)
+            {
+                return DynamicCodeLiteralSyntaxScanner.TryCopyRegularStringLiteral(source, rewrittenSource, ref index);
+            }
+
+            if (TryHoistRegularStringLiteral(source, rewrittenSource, bindings, ref index))
+            {
+                return true;
+            }
+
+            return TryHoistIntegerLiteral(source, rewrittenSource, bindings, ref index);
         }
 
         private static bool TryHoistRegularStringLiteral(

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCollectionPreviewSerializer.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCollectionPreviewSerializer.cs
@@ -122,43 +122,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (value is IEnumerable enumerable)
             {
-                if (!visited.Add(value))
-                {
-                    return new JValue("(circular)");
-                }
-
-                // Why: an array or dictionary whose elements/keys/values are all primitives/enums
-                // costs no further recursion budget once reached (each one resolves via the
-                // IsJsonPrimitive branch above regardless of depth), so gating it on remainingDepth
-                // here would degrade a nested field like "Board._cells" (a PieceType?[,]) to a bare
-                // type-name string purely because two field-access hops already spent the depth
-                // budget, not because previewing it is actually unsafe or unbounded.
-                bool isPrimitiveElementArray =
-                    value is Array primitiveElementArray && IsJsonPrimitiveElementType(primitiveElementArray.GetType().GetElementType());
-                bool isPrimitiveKeyValueDictionary =
-                    value is IDictionary && IsPrimitiveKeyValueDictionaryType(value.GetType());
-
-                if (remainingDepth <= 0 && !isPrimitiveElementArray && !isPrimitiveKeyValueDictionary)
-                {
-                    return new JValue(SafeToString(value));
-                }
-
-                if (value is IDictionary dictionary)
-                {
-                    return BuildDictionaryToken(dictionary, remainingDepth, maxElementCount, visited, ref truncated);
-                }
-
-                if (value is Array multidimensionalArray && multidimensionalArray.Rank > 1)
-                {
-                    return BuildMultidimensionalArrayToken(multidimensionalArray, remainingDepth, maxElementCount, visited, ref truncated);
-                }
-
-                if (value is ICollection)
-                {
-                    return BuildArrayToken(enumerable, remainingDepth, maxElementCount, visited, ref truncated);
-                }
-
-                return new JValue(SafeToString(value));
+                return BuildEnumerableToken(enumerable, remainingDepth, maxElementCount, visited, ref truncated);
             }
 
             if (!HasToStringOverride(value.GetType()))
@@ -333,14 +297,68 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Type-level counterpart of IsJsonPrimitive (plus string, which BuildToken also resolves
         // unconditionally above), used to recognize an array/dictionary whose elements will always
         // resolve regardless of remaining depth budget.
+        // Why a helper: the IEnumerable branch has its own circular-ref, depth-budget, and
+        // collection-kind decisions, and leaving them inline kept BuildToken over CA1502.
+        private static JToken BuildEnumerableToken(
+            IEnumerable enumerable, int remainingDepth, int maxElementCount, HashSet<object> visited, ref bool truncated)
+        {
+            if (!visited.Add(enumerable))
+            {
+                return new JValue("(circular)");
+            }
+
+            // Why: an array or dictionary whose elements/keys/values are all primitives/enums
+            // costs no further recursion budget once reached (each one resolves via the
+            // IsJsonPrimitive branch above regardless of depth), so gating it on remainingDepth
+            // here would degrade a nested field like "Board._cells" (a PieceType?[,]) to a bare
+            // type-name string purely because two field-access hops already spent the depth
+            // budget, not because previewing it is actually unsafe or unbounded.
+            bool isPrimitiveElementArray =
+                enumerable is Array primitiveElementArray && IsJsonPrimitiveElementType(primitiveElementArray.GetType().GetElementType());
+            bool isPrimitiveKeyValueDictionary =
+                enumerable is IDictionary && IsPrimitiveKeyValueDictionaryType(enumerable.GetType());
+
+            if (remainingDepth <= 0 && !isPrimitiveElementArray && !isPrimitiveKeyValueDictionary)
+            {
+                return new JValue(SafeToString(enumerable));
+            }
+
+            if (enumerable is IDictionary dictionary)
+            {
+                return BuildDictionaryToken(dictionary, remainingDepth, maxElementCount, visited, ref truncated);
+            }
+
+            if (enumerable is Array multidimensionalArray && multidimensionalArray.Rank > 1)
+            {
+                return BuildMultidimensionalArrayToken(multidimensionalArray, remainingDepth, maxElementCount, visited, ref truncated);
+            }
+
+            if (enumerable is ICollection)
+            {
+                return BuildArrayToken(enumerable, remainingDepth, maxElementCount, visited, ref truncated);
+            }
+
+            return new JValue(SafeToString(enumerable));
+        }
+
         private static bool IsJsonPrimitiveElementType(Type elementType)
         {
             Type underlyingType = Nullable.GetUnderlyingType(elementType) ?? elementType;
-            return underlyingType == typeof(bool)
-                || underlyingType == typeof(byte) || underlyingType == typeof(sbyte)
+            return IsJsonPrimitiveIntegerElementType(underlyingType)
+                || IsJsonPrimitiveNonIntegerElementType(underlyingType);
+        }
+
+        private static bool IsJsonPrimitiveIntegerElementType(Type underlyingType)
+        {
+            return underlyingType == typeof(byte) || underlyingType == typeof(sbyte)
                 || underlyingType == typeof(short) || underlyingType == typeof(ushort)
                 || underlyingType == typeof(int) || underlyingType == typeof(uint)
-                || underlyingType == typeof(long) || underlyingType == typeof(ulong)
+                || underlyingType == typeof(long) || underlyingType == typeof(ulong);
+        }
+
+        private static bool IsJsonPrimitiveNonIntegerElementType(Type underlyingType)
+        {
+            return underlyingType == typeof(bool)
                 || underlyingType == typeof(float) || underlyingType == typeof(double)
                 || underlyingType == typeof(decimal)
                 || underlyingType == typeof(char)

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -301,9 +301,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 try
                 {
-                    ScreenshotResponse overlayTimeout;
-                    (annotationOverlay, overlayTimeout) = await ShowAnnotationOverlayOrTimeoutAsync(
-                        request, annotationCapture, editorContext, correlationId, ct).ConfigureAwait(false);
+                    // Assign before any await so the inner finally still destroys the overlay
+                    // if WaitForRenderedFrameAsync throws after CreateAnnotationOverlay.
+                    annotationOverlay = CreateAnnotationOverlayIfNeeded(request, annotationCapture);
+                    ScreenshotResponse overlayTimeout = await WaitAfterShowingAnnotationOverlayAsync(
+                        annotationOverlay, editorContext, correlationId, ct).ConfigureAwait(false);
                     if (overlayTimeout != null)
                     {
                         return (null, default, overlayTimeout);
@@ -375,16 +377,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return null;
         }
 
-        private async Task<(GameObject overlay, ScreenshotResponse timeout)> ShowAnnotationOverlayOrTimeoutAsync(
+        private static GameObject CreateAnnotationOverlayIfNeeded(
             ScreenshotSchema request,
-            RenderingAnnotationCapture annotationCapture,
-            SynchronizationContext editorContext,
-            string correlationId,
-            CancellationToken ct)
+            RenderingAnnotationCapture annotationCapture)
         {
             if (!request.AnnotateElements && !request.AnnotateRaycastGrid)
             {
-                return (null, null);
+                return null;
             }
 
             List<UIElementInfo> overlayElements = new(annotationCapture.AnnotatedElements);
@@ -393,6 +392,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 overlayElements,
                 request.ResolutionScale);
             Canvas.ForceUpdateCanvases();
+            return annotationOverlay;
+        }
+
+        private async Task<ScreenshotResponse> WaitAfterShowingAnnotationOverlayAsync(
+            GameObject annotationOverlay,
+            SynchronizationContext editorContext,
+            string correlationId,
+            CancellationToken ct)
+        {
+            if (ReferenceEquals(annotationOverlay, null))
+            {
+                return null;
+            }
+
             // Chained CLI calls can read the previous GameView RT before overlay rendering catches up.
             PlayModeViewRenderWaitResult overlayWaitResult =
                 await PlayModeViewRenderWaiter.WaitForRenderedFrameAsync(
@@ -400,10 +413,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     ct).ConfigureAwait(false);
             if (overlayWaitResult == PlayModeViewRenderWaitResult.TicksStalled)
             {
-                return (annotationOverlay, CreateTimedOutResult(
+                return CreateTimedOutResult(
                     "annotation overlay render",
                     correlationId,
-                    new List<ScreenshotInfo>()));
+                    new List<ScreenshotInfo>());
             }
 
             if (overlayWaitResult == PlayModeViewRenderWaitResult.NotRendered)
@@ -415,7 +428,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
-            return (annotationOverlay, null);
+            return null;
         }
 
         private async Task<ScreenshotResponse> CaptureWindowsAsync(

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -66,197 +66,42 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 };
             }
 
-            List<UIElementInfo> annotatedElements = new();
-            List<UIElementInfo> physicsColliderElements = new();
-            List<RaycastLayerSummaryInfo> raycastLayerSummaries = new();
-            List<string> raycastLayerNamesChecked = new();
-            GameRenderingImageInfo? raycastGridRenderingInfo = null;
-
+            RenderingAnnotationCapture annotationCapture = new();
             if (request.AnnotateElements)
             {
-                annotatedElements = UIElementAnnotator.CollectInteractiveElements();
-                UIElementAnnotator.AssignLabels(annotatedElements);
+                annotationCapture.AnnotatedElements = UIElementAnnotator.CollectInteractiveElements();
+                UIElementAnnotator.AssignLabels(annotationCapture.AnnotatedElements);
             }
 
             if (request.AnnotateRaycastGrid)
             {
-                GameRenderingImageInfo renderingImageInfo;
-                bool gridInfoTimedOut;
-                (renderingImageInfo, gridInfoTimedOut) = await EditorWindowCaptureUtility.GetGameRenderingImageInfoAsync(
-                    UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
-                    ct).ConfigureAwait(false);
-                if (gridInfoTimedOut)
+                ScreenshotResponse timedOutGrid = await CollectRaycastGridAnnotationsAsync(
+                    request, annotationCapture, editorContext, correlationId, ct).ConfigureAwait(false);
+                if (timedOutGrid != null)
                 {
-                    return CreateTimedOutResult(
-                        "raycast grid rendering info capture",
-                        correlationId,
-                        new List<ScreenshotInfo>());
+                    return timedOutGrid;
                 }
-
-                await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
-
-                raycastGridRenderingInfo = renderingImageInfo;
-                RaycastLayerMaskResolution raycastLayerMaskResolution = ScreenshotParameterValidator.ResolveRaycastLayerMask(request);
-                List<RaycastLayerDefinition> availableLayerDefinitions = ScreenshotParameterValidator.GetAvailableLayerDefinitions();
-                int effectiveLayerMask = raycastLayerMaskResolution.HasLayerNames
-                    ? raycastLayerMaskResolution.Mask
-                    : Physics.DefaultRaycastLayers;
-
-                physicsColliderElements = RaycastGridAnnotator.CollectPhysicsColliderElements(
-                    renderingImageInfo.RenderingImageSize,
-                    renderingImageInfo.ImageToInputOffsetY,
-                    effectiveLayerMask);
-                raycastLayerSummaries = RaycastGridAnnotator.CollectRaycastLayerSummaries(
-                    renderingImageInfo.RenderingImageSize,
-                    renderingImageInfo.ImageToInputOffsetY);
-
-                Camera mainCamera = Camera.main;
-                int checkedLayerMask = mainCamera != null ? effectiveLayerMask & mainCamera.cullingMask : 0;
-                raycastLayerNamesChecked = RaycastLayerMaskResolver.CreateLayerNamesFromMask(
-                    checkedLayerMask,
-                    availableLayerDefinitions);
             }
 
             if (request.ElementsOnly)
             {
-                GameRenderingImageInfo elementsOnlyRenderingInfo;
-                if (raycastGridRenderingInfo.HasValue)
-                {
-                    elementsOnlyRenderingInfo = raycastGridRenderingInfo.Value;
-                }
-                else
-                {
-                    GameRenderingImageInfo measuredRenderingInfo;
-                    bool elementsOnlyInfoTimedOut;
-                    (measuredRenderingInfo, elementsOnlyInfoTimedOut) =
-                        await EditorWindowCaptureUtility.GetGameRenderingImageInfoAsync(
-                            UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
-                            ct).ConfigureAwait(false);
-                    if (elementsOnlyInfoTimedOut)
-                    {
-                        return CreateTimedOutResult(
-                            "elements-only rendering info capture",
-                            correlationId,
-                            new List<ScreenshotInfo>());
-                    }
-
-                    await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
-                    elementsOnlyRenderingInfo = measuredRenderingInfo;
-                }
-
-                return BuildElementsOnlyScreenshotInfo(
-                    annotatedElements,
-                    physicsColliderElements,
-                    raycastLayerSummaries,
-                    raycastLayerNamesChecked,
-                    request.ResolutionScale,
-                    elementsOnlyRenderingInfo);
+                return await CaptureElementsOnlyRenderingAsync(
+                    request, annotationCapture, editorContext, correlationId, ct).ConfigureAwait(false);
             }
 
-            GameObject annotationOverlay = null;
-            Texture2D texture;
-            GameRenderingImageInfo captureRenderingInfo;
-            bool captureTimedOut;
-
-            // Why SwitchTo before hide: SetActive/Canvas/RT clear are main-thread only. Keep this
-            // await outside try — nothing is hidden yet if cancellation throws here.
-            await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
-            (GameObject inputVisualizationOverlay, bool inputVisualizationWasActive) =
-                HideInputVisualizationOverlay();
-
-            try
+            (Texture2D texture, GameRenderingImageInfo captureRenderingInfo, ScreenshotResponse overlayTimeout) =
+                await CaptureTextureAfterHidingOverlaysAsync(
+                    request, annotationCapture, editorContext, correlationId, ct).ConfigureAwait(false);
+            if (overlayTimeout != null)
             {
-                // Why wait inside try: WaitFramesOrTimeoutAsync / SwitchTo throw OperationCanceledException
-                // on CLI disconnect; finally must still restore the overlay.
-                if (inputVisualizationWasActive)
-                {
-                    PlayModeViewRenderWaitResult hideWaitResult =
-                        await PlayModeViewRenderWaiter.WaitForRenderedFrameAsync(
-                            UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
-                            ct).ConfigureAwait(false);
-                    if (hideWaitResult == PlayModeViewRenderWaitResult.TicksStalled)
-                    {
-                        return CreateTimedOutResult(
-                            "input visualization overlay hide",
-                            correlationId,
-                            new List<ScreenshotInfo>());
-                    }
-
-                    if (hideWaitResult == PlayModeViewRenderWaitResult.NotRendered)
-                    {
-                        VibeLogger.LogWarning(
-                            "screenshot_render_wait_not_confirmed",
-                            "Timed out waiting for a Game camera render after hiding the input visualization overlay; continuing capture.",
-                            correlationId: correlationId);
-                    }
-
-                    await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
-                }
-
-                try
-                {
-                    if (request.AnnotateElements || request.AnnotateRaycastGrid)
-                    {
-                        List<UIElementInfo> overlayElements = new(annotatedElements);
-                        overlayElements.AddRange(physicsColliderElements);
-                        annotationOverlay = UIElementAnnotator.CreateAnnotationOverlay(
-                            overlayElements,
-                            request.ResolutionScale);
-                        Canvas.ForceUpdateCanvases();
-                        // Chained CLI calls can read the previous GameView RT before overlay rendering catches up.
-                        PlayModeViewRenderWaitResult overlayWaitResult =
-                            await PlayModeViewRenderWaiter.WaitForRenderedFrameAsync(
-                                UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
-                                ct).ConfigureAwait(false);
-                        if (overlayWaitResult == PlayModeViewRenderWaitResult.TicksStalled)
-                        {
-                            return CreateTimedOutResult(
-                                "annotation overlay render",
-                                correlationId,
-                                new List<ScreenshotInfo>());
-                        }
-
-                        if (overlayWaitResult == PlayModeViewRenderWaitResult.NotRendered)
-                        {
-                            VibeLogger.LogWarning(
-                                "screenshot_render_wait_not_confirmed",
-                                "Timed out waiting for a Game camera render after showing the annotation overlay; continuing capture.",
-                                correlationId: correlationId);
-                        }
-
-                        await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
-                    }
-
-                    (texture, captureRenderingInfo, captureTimedOut) = await EditorWindowCaptureUtility.CaptureGameRenderingAsync(
-                        request.ResolutionScale,
-                        raycastGridRenderingInfo,
-                        UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
-                        ct).ConfigureAwait(false);
-                    if (captureTimedOut)
-                    {
-                        return CreateTimedOutResult(
-                            "Play Mode view rendering capture",
-                            correlationId,
-                            new List<ScreenshotInfo>());
-                    }
-
-                    await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
-                }
-                finally
-                {
-                    DestroyAnnotationOverlay(annotationOverlay, editorContext);
-                }
-            }
-            finally
-            {
-                RestoreInputVisualizationOverlay(inputVisualizationOverlay, inputVisualizationWasActive, editorContext);
+                return overlayTimeout;
             }
 
             // Uses the settled capture-time size, not the pre-capture gameViewSize sample, so annotated
             // element coordinates stay consistent with the GameViewWidth/Height this response reports.
-            UIElementAnnotator.ConvertToSimCoordinates(annotatedElements, Mathf.RoundToInt(captureRenderingInfo.GameViewSize.y));
+            UIElementAnnotator.ConvertToSimCoordinates(annotationCapture.AnnotatedElements, Mathf.RoundToInt(captureRenderingInfo.GameViewSize.y));
             List<UIElementInfo> responseAnnotatedElements =
-                CreateResponseAnnotatedElements(annotatedElements, physicsColliderElements);
+                CreateResponseAnnotatedElements(annotationCapture.AnnotatedElements, annotationCapture.PhysicsColliderElements);
 
             if (texture == null)
             {
@@ -301,8 +146,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 };
                 ApplyRenderingCoordinateMetadata(info, captureRenderingInfo.GameViewSize, captureRenderingInfo.ImageToInputOffsetY);
                 info.AnnotatedElements = responseAnnotatedElements;
-                info.RaycastLayerSummaries = raycastLayerSummaries;
-                info.RaycastLayerNamesChecked = raycastLayerNamesChecked;
+                info.RaycastLayerSummaries = annotationCapture.RaycastLayerSummaries;
+                info.RaycastLayerNamesChecked = annotationCapture.RaycastLayerNamesChecked;
                 screenshots.Add(info);
             }
             catch (Exception ex)
@@ -324,12 +169,253 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 VibeLogger.LogInfo(
                     "screenshot_success",
                     $"Captured game rendering ({width}x{height})",
-                    new { CaptureMode = "rendering", ScreenshotCount = screenshots.Count, AnnotatedElements = annotatedElements.Count },
+                    new { CaptureMode = "rendering", ScreenshotCount = screenshots.Count, AnnotatedElements = annotationCapture.AnnotatedElements.Count },
                     correlationId: correlationId
                 );
             }
 
             return new ScreenshotResponse { Screenshots = screenshots };
+        }
+
+        private sealed class RenderingAnnotationCapture
+        {
+            public List<UIElementInfo> AnnotatedElements = new();
+            public List<UIElementInfo> PhysicsColliderElements = new();
+            public List<RaycastLayerSummaryInfo> RaycastLayerSummaries = new();
+            public List<string> RaycastLayerNamesChecked = new();
+            public GameRenderingImageInfo? RaycastGridRenderingInfo;
+        }
+
+        private async Task<ScreenshotResponse> CollectRaycastGridAnnotationsAsync(
+            ScreenshotSchema request,
+            RenderingAnnotationCapture annotationCapture,
+            SynchronizationContext editorContext,
+            string correlationId,
+            CancellationToken ct)
+        {
+            GameRenderingImageInfo renderingImageInfo;
+            bool gridInfoTimedOut;
+            (renderingImageInfo, gridInfoTimedOut) = await EditorWindowCaptureUtility.GetGameRenderingImageInfoAsync(
+                UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
+                ct).ConfigureAwait(false);
+            if (gridInfoTimedOut)
+            {
+                return CreateTimedOutResult(
+                    "raycast grid rendering info capture",
+                    correlationId,
+                    new List<ScreenshotInfo>());
+            }
+
+            await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+
+            annotationCapture.RaycastGridRenderingInfo = renderingImageInfo;
+            RaycastLayerMaskResolution raycastLayerMaskResolution = ScreenshotParameterValidator.ResolveRaycastLayerMask(request);
+            List<RaycastLayerDefinition> availableLayerDefinitions = ScreenshotParameterValidator.GetAvailableLayerDefinitions();
+            int effectiveLayerMask = raycastLayerMaskResolution.HasLayerNames
+                ? raycastLayerMaskResolution.Mask
+                : Physics.DefaultRaycastLayers;
+
+            annotationCapture.PhysicsColliderElements = RaycastGridAnnotator.CollectPhysicsColliderElements(
+                renderingImageInfo.RenderingImageSize,
+                renderingImageInfo.ImageToInputOffsetY,
+                effectiveLayerMask);
+            annotationCapture.RaycastLayerSummaries = RaycastGridAnnotator.CollectRaycastLayerSummaries(
+                renderingImageInfo.RenderingImageSize,
+                renderingImageInfo.ImageToInputOffsetY);
+
+            Camera mainCamera = Camera.main;
+            int checkedLayerMask = mainCamera != null ? effectiveLayerMask & mainCamera.cullingMask : 0;
+            annotationCapture.RaycastLayerNamesChecked = RaycastLayerMaskResolver.CreateLayerNamesFromMask(
+                checkedLayerMask,
+                availableLayerDefinitions);
+            return null;
+        }
+
+        private async Task<ScreenshotResponse> CaptureElementsOnlyRenderingAsync(
+            ScreenshotSchema request,
+            RenderingAnnotationCapture annotationCapture,
+            SynchronizationContext editorContext,
+            string correlationId,
+            CancellationToken ct)
+        {
+            GameRenderingImageInfo elementsOnlyRenderingInfo;
+            if (annotationCapture.RaycastGridRenderingInfo.HasValue)
+            {
+                elementsOnlyRenderingInfo = annotationCapture.RaycastGridRenderingInfo.Value;
+            }
+            else
+            {
+                GameRenderingImageInfo measuredRenderingInfo;
+                bool elementsOnlyInfoTimedOut;
+                (measuredRenderingInfo, elementsOnlyInfoTimedOut) =
+                    await EditorWindowCaptureUtility.GetGameRenderingImageInfoAsync(
+                        UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
+                        ct).ConfigureAwait(false);
+                if (elementsOnlyInfoTimedOut)
+                {
+                    return CreateTimedOutResult(
+                        "elements-only rendering info capture",
+                        correlationId,
+                        new List<ScreenshotInfo>());
+                }
+
+                await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+                elementsOnlyRenderingInfo = measuredRenderingInfo;
+            }
+
+            return BuildElementsOnlyScreenshotInfo(
+                annotationCapture.AnnotatedElements,
+                annotationCapture.PhysicsColliderElements,
+                annotationCapture.RaycastLayerSummaries,
+                annotationCapture.RaycastLayerNamesChecked,
+                request.ResolutionScale,
+                elementsOnlyRenderingInfo);
+        }
+
+        private async Task<(Texture2D texture, GameRenderingImageInfo captureRenderingInfo, ScreenshotResponse timeout)>
+            CaptureTextureAfterHidingOverlaysAsync(
+                ScreenshotSchema request,
+                RenderingAnnotationCapture annotationCapture,
+                SynchronizationContext editorContext,
+                string correlationId,
+                CancellationToken ct)
+        {
+            GameObject annotationOverlay = null;
+            Texture2D texture = null;
+            GameRenderingImageInfo captureRenderingInfo = default;
+
+            // Why SwitchTo before hide: SetActive/Canvas/RT clear are main-thread only. Keep this
+            // await outside try — nothing is hidden yet if cancellation throws here.
+            await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+            (GameObject inputVisualizationOverlay, bool inputVisualizationWasActive) =
+                HideInputVisualizationOverlay();
+
+            try
+            {
+                ScreenshotResponse hideTimeout = await WaitAfterHidingInputVisualizationAsync(
+                    inputVisualizationWasActive, editorContext, correlationId, ct).ConfigureAwait(false);
+                if (hideTimeout != null)
+                {
+                    return (null, default, hideTimeout);
+                }
+
+                try
+                {
+                    ScreenshotResponse overlayTimeout;
+                    (annotationOverlay, overlayTimeout) = await ShowAnnotationOverlayOrTimeoutAsync(
+                        request, annotationCapture, editorContext, correlationId, ct).ConfigureAwait(false);
+                    if (overlayTimeout != null)
+                    {
+                        return (null, default, overlayTimeout);
+                    }
+
+                    bool captureTimedOut;
+                    (texture, captureRenderingInfo, captureTimedOut) = await EditorWindowCaptureUtility.CaptureGameRenderingAsync(
+                        request.ResolutionScale,
+                        annotationCapture.RaycastGridRenderingInfo,
+                        UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
+                        ct).ConfigureAwait(false);
+                    if (captureTimedOut)
+                    {
+                        return (null, default, CreateTimedOutResult(
+                            "Play Mode view rendering capture",
+                            correlationId,
+                            new List<ScreenshotInfo>()));
+                    }
+
+                    await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+                }
+                finally
+                {
+                    DestroyAnnotationOverlay(annotationOverlay, editorContext);
+                }
+            }
+            finally
+            {
+                RestoreInputVisualizationOverlay(inputVisualizationOverlay, inputVisualizationWasActive, editorContext);
+            }
+
+            return (texture, captureRenderingInfo, null);
+        }
+
+        private async Task<ScreenshotResponse> WaitAfterHidingInputVisualizationAsync(
+            bool inputVisualizationWasActive,
+            SynchronizationContext editorContext,
+            string correlationId,
+            CancellationToken ct)
+        {
+            // Why wait inside try: WaitFramesOrTimeoutAsync / SwitchTo throw OperationCanceledException
+            // on CLI disconnect; finally must still restore the overlay.
+            if (!inputVisualizationWasActive)
+            {
+                return null;
+            }
+
+            PlayModeViewRenderWaitResult hideWaitResult =
+                await PlayModeViewRenderWaiter.WaitForRenderedFrameAsync(
+                    UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
+                    ct).ConfigureAwait(false);
+            if (hideWaitResult == PlayModeViewRenderWaitResult.TicksStalled)
+            {
+                return CreateTimedOutResult(
+                    "input visualization overlay hide",
+                    correlationId,
+                    new List<ScreenshotInfo>());
+            }
+
+            if (hideWaitResult == PlayModeViewRenderWaitResult.NotRendered)
+            {
+                VibeLogger.LogWarning(
+                    "screenshot_render_wait_not_confirmed",
+                    "Timed out waiting for a Game camera render after hiding the input visualization overlay; continuing capture.",
+                    correlationId: correlationId);
+            }
+
+            await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+            return null;
+        }
+
+        private async Task<(GameObject overlay, ScreenshotResponse timeout)> ShowAnnotationOverlayOrTimeoutAsync(
+            ScreenshotSchema request,
+            RenderingAnnotationCapture annotationCapture,
+            SynchronizationContext editorContext,
+            string correlationId,
+            CancellationToken ct)
+        {
+            if (!request.AnnotateElements && !request.AnnotateRaycastGrid)
+            {
+                return (null, null);
+            }
+
+            List<UIElementInfo> overlayElements = new(annotationCapture.AnnotatedElements);
+            overlayElements.AddRange(annotationCapture.PhysicsColliderElements);
+            GameObject annotationOverlay = UIElementAnnotator.CreateAnnotationOverlay(
+                overlayElements,
+                request.ResolutionScale);
+            Canvas.ForceUpdateCanvases();
+            // Chained CLI calls can read the previous GameView RT before overlay rendering catches up.
+            PlayModeViewRenderWaitResult overlayWaitResult =
+                await PlayModeViewRenderWaiter.WaitForRenderedFrameAsync(
+                    UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
+                    ct).ConfigureAwait(false);
+            if (overlayWaitResult == PlayModeViewRenderWaitResult.TicksStalled)
+            {
+                return (annotationOverlay, CreateTimedOutResult(
+                    "annotation overlay render",
+                    correlationId,
+                    new List<ScreenshotInfo>()));
+            }
+
+            if (overlayWaitResult == PlayModeViewRenderWaitResult.NotRendered)
+            {
+                VibeLogger.LogWarning(
+                    "screenshot_render_wait_not_confirmed",
+                    "Timed out waiting for a Game camera render after showing the annotation overlay; continuing capture.",
+                    correlationId: correlationId);
+            }
+
+            await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+            return (annotationOverlay, null);
         }
 
         private async Task<ScreenshotResponse> CaptureWindowsAsync(

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -97,6 +97,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return overlayTimeout;
             }
 
+            // Why switch after the helper: CaptureTextureAfterHidingOverlaysAsync ends on the
+            // editor context, but ConfigureAwait(false) resumes this method on a thread-pool
+            // thread. texture.width / EncodeToPNG / DestroyImmediate are main-thread only.
+            await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+
             // Uses the settled capture-time size, not the pre-capture gameViewSize sample, so annotated
             // element coordinates stay consistent with the GameViewWidth/Height this response reports.
             UIElementAnnotator.ConvertToSimCoordinates(annotationCapture.AnnotatedElements, Mathf.RoundToInt(captureRenderingInfo.GameViewSize.y));
@@ -299,6 +304,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return (null, default, hideTimeout);
                 }
 
+                // Why switch after the helper: when the overlay was active the helper awaited,
+                // so ConfigureAwait(false) resumes here off-main before CreateAnnotationOverlay
+                // (new GameObject / AddComponent / Canvas.ForceUpdateCanvases).
+                await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+
                 try
                 {
                     // Assign before any await so the inner finally still destroys the overlay
@@ -310,6 +320,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     {
                         return (null, default, overlayTimeout);
                     }
+
+                    // Why switch after the helper: the original entered CaptureGameRenderingAsync
+                    // on the main thread. ConfigureAwait(false) hops off-main after the overlay wait.
+                    await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
 
                     bool captureTimedOut;
                     (texture, captureRenderingInfo, captureTimedOut) = await EditorWindowCaptureUtility.CaptureGameRenderingAsync(

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputActionExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputActionExecutor.cs
@@ -19,27 +19,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal static async Task<SimulateKeyboardResponse> ExecutePress(
             Keyboard keyboard, Key key, float duration, CancellationToken ct)
         {
-            if (duration < 0f || float.IsNaN(duration) || float.IsInfinity(duration))
+            SimulateKeyboardResponse? invalidDuration = CreateInvalidPressDurationResponse(key, duration);
+            if (invalidDuration != null)
             {
-                return new SimulateKeyboardResponse
-                {
-                    Success = false,
-                    Message = $"Duration must be non-negative, got: {duration}",
-                    Action = UnityCliLoopKeyboardAction.Press.ToString(),
-                    KeyName = key.ToString()
-                };
-            }
-
-            if (duration > SimulateInputConstants.MaxDurationSeconds)
-            {
-                return new SimulateKeyboardResponse
-                {
-                    Success = false,
-                    Message =
-                        $"Duration must be {SimulateInputConstants.MaxDurationSeconds} seconds or less, got: {duration}. The unit is seconds, not milliseconds.",
-                    Action = UnityCliLoopKeyboardAction.Press.ToString(),
-                    KeyName = key.ToString()
-                };
+                return invalidDuration;
             }
 
             string keyName = key.ToString();
@@ -96,52 +79,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
             finally
             {
-                await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
-                InputSystem.onAfterUpdate -= pressEdgeMonitor;
-                if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
-                {
-                    KeyboardInputMainThreadCleanup.ScheduleTimedOutPressCleanup(
-                        keyboard,
-                        key,
-                        pressWasApplied);
-                }
-                else if (waitOutcome == InputSimulationWaitOutcome.Paused)
-                {
-                    // Why: ApplyOnNextConfiguredUpdate already disposed any pending press
-                    // subscription when it returned Paused. Release + latch-sync only after
-                    // that dispose — a live queued edge or a stale wasPressedThisFrame latch
-                    // (armed by edge monitoring even when apply never committed) would both
-                    // look like a re-press after resume.
-                    KeyboardInputMainThreadCleanup.ReleaseKeyStateImmediatelyAfterPauseInterruption(
-                        keyboard,
-                        key);
-
-                    KeyboardKeyState.UnregisterTransientKey(key);
-                    SimulateKeyboardOverlayState.ClearPress();
-                }
-                else if (pressWasApplied)
-                {
-                    InputSimulationWaitOutcome releaseOutcome =
-                        await KeyboardInputMainThreadCleanup.ReleaseKeyStateIfPossible(
-                            keyboard,
-                            key,
-                            CancellationToken.None).ConfigureAwait(false);
-                    if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
-                    {
-                        waitOutcome = InputSimulationWaitOutcome.TimedOut;
-                        KeyboardInputMainThreadCleanup.ScheduleTimedOutPressCleanup(keyboard, key, false);
-                    }
-                    else
-                    {
-                        KeyboardKeyState.UnregisterTransientKey(key);
-                        await KeyboardInputMainThreadCleanup.FinalizePressOverlay(ct).ConfigureAwait(false);
-                    }
-                }
-                else
-                {
-                    KeyboardKeyState.UnregisterTransientKey(key);
-                    SimulateKeyboardOverlayState.ClearPress();
-                }
+                waitOutcome = await CleanupPressWaitAsync(
+                    keyboard,
+                    key,
+                    pressWasApplied,
+                    waitOutcome,
+                    pressEdgeMonitor,
+                    ct).ConfigureAwait(false);
             }
 
             if (waitOutcome == InputSimulationWaitOutcome.Paused)
@@ -159,27 +103,109 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     keyName);
             }
 
-            string durationText = duration > 0f ? $" for {InputSimulationDurationFormatter.FormatSeconds(duration)}s" : "";
-            string edgeText;
-            if (pressEdgeObserved && pressHoldExtendedFrames > 0)
+            return BuildPressSuccessResponse(
+                keyName,
+                duration,
+                pressEdgeObserved,
+                pressHoldExtendedFrames,
+                edgeMissDiagnostics);
+        }
+
+        private static SimulateKeyboardResponse? CreateInvalidPressDurationResponse(Key key, float duration)
+        {
+            if (duration < 0f || float.IsNaN(duration) || float.IsInfinity(duration))
             {
-                edgeText =
-                    $" (release delayed {pressHoldExtendedFrames} frame(s) until wasPressedThisFrame was observed)";
-            }
-            else if (pressEdgeObserved)
-            {
-                edgeText = "";
-            }
-            else
-            {
-                edgeText =
-                    " (press edge was not observed via wasPressedThisFrame; gameplay polling may have missed it, so retry or verify with a focused log)" +
-                    PressEdgeDiagnosticsMessageFormatter.BuildSuffix(
-                        edgeMissDiagnostics.ConsumedByUpdateType,
-                        edgeMissDiagnostics.AnyDynamicUpdateObserved,
-                        edgeMissDiagnostics.KeyAlreadyPressedBeforeQueue);
+                return new SimulateKeyboardResponse
+                {
+                    Success = false,
+                    Message = $"Duration must be non-negative, got: {duration}",
+                    Action = UnityCliLoopKeyboardAction.Press.ToString(),
+                    KeyName = key.ToString()
+                };
             }
 
+            if (duration > SimulateInputConstants.MaxDurationSeconds)
+            {
+                return new SimulateKeyboardResponse
+                {
+                    Success = false,
+                    Message =
+                        $"Duration must be {SimulateInputConstants.MaxDurationSeconds} seconds or less, got: {duration}. The unit is seconds, not milliseconds.",
+                    Action = UnityCliLoopKeyboardAction.Press.ToString(),
+                    KeyName = key.ToString()
+                };
+            }
+
+            return null;
+        }
+
+        private static async Task<InputSimulationWaitOutcome> CleanupPressWaitAsync(
+            Keyboard keyboard,
+            Key key,
+            bool pressWasApplied,
+            InputSimulationWaitOutcome waitOutcome,
+            Action pressEdgeMonitor,
+            CancellationToken ct)
+        {
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
+            InputSystem.onAfterUpdate -= pressEdgeMonitor;
+            if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
+            {
+                KeyboardInputMainThreadCleanup.ScheduleTimedOutPressCleanup(
+                    keyboard,
+                    key,
+                    pressWasApplied);
+                return waitOutcome;
+            }
+
+            if (waitOutcome == InputSimulationWaitOutcome.Paused)
+            {
+                // Why: ApplyOnNextConfiguredUpdate already disposed any pending press
+                // subscription when it returned Paused. Release + latch-sync only after
+                // that dispose — a live queued edge or a stale wasPressedThisFrame latch
+                // (armed by edge monitoring even when apply never committed) would both
+                // look like a re-press after resume.
+                KeyboardInputMainThreadCleanup.ReleaseKeyStateImmediatelyAfterPauseInterruption(
+                    keyboard,
+                    key);
+
+                KeyboardKeyState.UnregisterTransientKey(key);
+                SimulateKeyboardOverlayState.ClearPress();
+                return waitOutcome;
+            }
+
+            if (!pressWasApplied)
+            {
+                KeyboardKeyState.UnregisterTransientKey(key);
+                SimulateKeyboardOverlayState.ClearPress();
+                return waitOutcome;
+            }
+
+            InputSimulationWaitOutcome releaseOutcome =
+                await KeyboardInputMainThreadCleanup.ReleaseKeyStateIfPossible(
+                    keyboard,
+                    key,
+                    CancellationToken.None).ConfigureAwait(false);
+            if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
+            {
+                KeyboardInputMainThreadCleanup.ScheduleTimedOutPressCleanup(keyboard, key, false);
+                return InputSimulationWaitOutcome.TimedOut;
+            }
+
+            KeyboardKeyState.UnregisterTransientKey(key);
+            await KeyboardInputMainThreadCleanup.FinalizePressOverlay(ct).ConfigureAwait(false);
+            return waitOutcome;
+        }
+
+        private static SimulateKeyboardResponse BuildPressSuccessResponse(
+            string keyName,
+            float duration,
+            bool pressEdgeObserved,
+            int pressHoldExtendedFrames,
+            PressEdgeMissDiagnostics edgeMissDiagnostics)
+        {
+            string durationText = duration > 0f ? $" for {InputSimulationDurationFormatter.FormatSeconds(duration)}s" : "";
+            string edgeText = BuildPressEdgeText(pressEdgeObserved, pressHoldExtendedFrames, edgeMissDiagnostics);
             return new SimulateKeyboardResponse
             {
                 Success = true,
@@ -192,6 +218,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 PressEdgeAnyDynamicUpdateObserved = pressEdgeObserved ? null : edgeMissDiagnostics.AnyDynamicUpdateObserved,
                 PressEdgeKeyAlreadyPressedBeforeQueue = pressEdgeObserved ? null : edgeMissDiagnostics.KeyAlreadyPressedBeforeQueue
             };
+        }
+
+        private static string BuildPressEdgeText(
+            bool pressEdgeObserved,
+            int pressHoldExtendedFrames,
+            PressEdgeMissDiagnostics edgeMissDiagnostics)
+        {
+            if (pressEdgeObserved && pressHoldExtendedFrames > 0)
+            {
+                return
+                    $" (release delayed {pressHoldExtendedFrames} frame(s) until wasPressedThisFrame was observed)";
+            }
+
+            if (pressEdgeObserved)
+            {
+                return "";
+            }
+
+            return
+                " (press edge was not observed via wasPressedThisFrame; gameplay polling may have missed it, so retry or verify with a focused log)" +
+                PressEdgeDiagnosticsMessageFormatter.BuildSuffix(
+                    edgeMissDiagnostics.ConsumedByUpdateType,
+                    edgeMissDiagnostics.AnyDynamicUpdateObserved,
+                    edgeMissDiagnostics.KeyAlreadyPressedBeforeQueue);
         }
 
         internal static async Task<SimulateKeyboardResponse> ExecuteKeyDown(

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOneShotDragExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOneShotDragExecutor.cs
@@ -70,9 +70,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             try
             {
-                // Why no ConfigureAwait(false): AnimateDragMotionOrAbortAsync ends on the main
-                // thread after SwitchToMainThread. ConfigureAwait(false) would hop off-main
-                // before OverlayState.Update / PlayDissipateAnimation.
                 SimulateMouseUiResponse? motionAbort = await AnimateDragMotionOrAbortAsync(
                     parameters,
                     pointerData,
@@ -83,7 +80,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     targetName,
                     DragInterruptedDuringMotionMessage,
                     cleanupScheduler,
-                    ct);
+                    ct).ConfigureAwait(false);
                 if (motionAbort != null)
                 {
                     return motionAbort;
@@ -93,6 +90,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 cleanupScheduler.ExecuteCleanupOnMainThread(() => MouseUiDragEventExecutor.FinalizeDrag(pointerData, target, explicitDropTarget));
             }
+
+            // Why switch after the helper: AnimateDragMotionOrAbortAsync ends on the main
+            // thread, but ConfigureAwait(false) can resume this method off-main before
+            // OverlayState.Update / PlayDissipateAnimation.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
 
             SimulateMouseUiOverlayState.Update(
                 MouseAction.Drag, inputEnd, inputStart, Handles.GetMainGameViewSize());
@@ -126,31 +128,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 "Drag stopped because Unity paused during Pause Point inspection. No draggable target was found at the start position, so no drag was initiated.";
             SimulateMouseUiOverlayState.Update(
                 MouseAction.Drag, inputStart, null, Handles.GetMainGameViewSize());
-            SimulateMouseUiResponse? expandAbort = await AbortDragOnOverlayOutcomeAsync(
+            SimulateMouseUiResponse? expandAbort = AbortDragOnOverlayOutcome(
                 await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false),
                 inputStart,
                 inputEnd,
                 null,
                 NoTargetInterruptedMessage,
-                cleanupScheduler,
-                ct);
+                cleanupScheduler);
             if (expandAbort != null)
             {
                 return expandAbort;
             }
 
-            SimulateMouseUiResponse? dissipateAbort = await AbortDragOnOverlayOutcomeAsync(
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+
+            SimulateMouseUiResponse? dissipateAbort = AbortDragOnOverlayOutcome(
                 await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false),
                 inputStart,
                 inputEnd,
                 null,
                 NoTargetInterruptedMessage,
-                cleanupScheduler,
-                ct);
+                cleanupScheduler);
             if (dissipateAbort != null)
             {
                 return dissipateAbort;
             }
+
+            await MainThreadSwitcher.SwitchToMainThread(ct);
 
             return new SimulateMouseUiResponse
             {
@@ -178,51 +182,58 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             MouseUiMainThreadCleanupScheduler cleanupScheduler,
             CancellationToken ct)
         {
-            SimulateMouseUiResponse? expandAbort = await AbortDragOnOverlayOutcomeAsync(
+            SimulateMouseUiResponse? expandAbort = AbortDragOnOverlayOutcome(
                 await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false),
                 inputStart,
                 inputEnd,
                 targetName,
                 interruptedMessage,
-                cleanupScheduler,
-                ct);
+                cleanupScheduler);
             if (expandAbort != null)
             {
                 return expandAbort;
             }
 
-            SimulateMouseUiResponse? dragAbort = await AbortDragOnOverlayOutcomeAsync(
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+
+            SimulateMouseUiResponse? dragAbort = AbortDragOnOverlayOutcome(
                 await MouseUiDragEventExecutor.InterpolateDragPosition(pointerData, target, screenEnd, parameters.DragSpeed, ct)
                     .ConfigureAwait(false),
                 inputStart,
                 inputEnd,
                 targetName,
                 interruptedMessage,
-                cleanupScheduler,
-                ct);
+                cleanupScheduler);
             if (dragAbort != null)
             {
                 return dragAbort;
             }
 
-            return await AbortDragOnOverlayOutcomeAsync(
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+
+            SimulateMouseUiResponse? settleAbort = AbortDragOnOverlayOutcome(
                 await MouseUiEditorFrameWaiter.WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false),
                 inputStart,
                 inputEnd,
                 targetName,
                 interruptedMessage,
-                cleanupScheduler,
-                ct);
+                cleanupScheduler);
+            if (settleAbort != null)
+            {
+                return settleAbort;
+            }
+
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+            return null;
         }
 
-        private static async Task<SimulateMouseUiResponse?> AbortDragOnOverlayOutcomeAsync(
+        private static SimulateMouseUiResponse? AbortDragOnOverlayOutcome(
             MouseUiFrameWaitOutcome outcome,
             Vector2 inputStart,
             Vector2 inputEnd,
             string? targetName,
             string interruptedMessage,
-            MouseUiMainThreadCleanupScheduler cleanupScheduler,
-            CancellationToken ct)
+            MouseUiMainThreadCleanupScheduler cleanupScheduler)
         {
             if (outcome == MouseUiFrameWaitOutcome.TimedOut)
             {
@@ -237,7 +248,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     MouseAction.Drag, inputStart, targetName, interruptedMessage);
             }
 
-            await MainThreadSwitcher.SwitchToMainThread(ct);
             return null;
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOneShotDragExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOneShotDragExecutor.cs
@@ -49,50 +49,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (target == null)
             {
-                SimulateMouseUiOverlayState.Update(
-                    MouseAction.Drag, inputStart, null, Handles.GetMainGameViewSize());
-                MouseUiFrameWaitOutcome noTargetExpandOutcome = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
-                if (noTargetExpandOutcome == MouseUiFrameWaitOutcome.TimedOut)
-                {
-                    cleanupScheduler.QueueOverlayClear();
-                    return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, null);
-                }
-                if (noTargetExpandOutcome == MouseUiFrameWaitOutcome.Paused)
-                {
-                    cleanupScheduler.QueueOverlayClear();
-                    return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                        MouseAction.Drag, inputStart, null,
-                        "Drag stopped because Unity paused during Pause Point inspection. No draggable target was found at the start position, so no drag was initiated.");
-                }
-                await MainThreadSwitcher.SwitchToMainThread(ct);
-
-                MouseUiFrameWaitOutcome noTargetDissipateOutcome = await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false);
-                if (noTargetDissipateOutcome == MouseUiFrameWaitOutcome.TimedOut)
-                {
-                    cleanupScheduler.QueueOverlayClear();
-                    return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, null);
-                }
-                if (noTargetDissipateOutcome == MouseUiFrameWaitOutcome.Paused)
-                {
-                    cleanupScheduler.QueueOverlayClear();
-                    return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                        MouseAction.Drag, inputStart, null,
-                        "Drag stopped because Unity paused during Pause Point inspection. No draggable target was found at the start position, so no drag was initiated.");
-                }
-                await MainThreadSwitcher.SwitchToMainThread(ct);
-
-                return new SimulateMouseUiResponse
-                {
-                    Success = false,
-                    Message = parameters.BypassRaycast
-                        ? $"TargetPath '{parameters.TargetPath}' has no drag handler."
-                        : $"No draggable UI element at ({inputStart.x:F1}, {inputStart.y:F1}). Use find-game-objects or screenshot to verify positions.",
-                    Action = MouseAction.Drag.ToString(),
-                    PositionX = inputStart.x,
-                    PositionY = inputStart.y,
-                    EndPositionX = inputEnd.x,
-                    EndPositionY = inputEnd.y
-                };
+                return await ExecuteNoTargetDragAsync(
+                    parameters, inputStart, inputEnd, cleanupScheduler, ct).ConfigureAwait(false);
             }
 
             // uGUI drag controls (ScrollRect, Slider) only respond to left-button drags
@@ -112,48 +70,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             try
             {
-                MouseUiFrameWaitOutcome expandOutcome = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
-                if (expandOutcome == MouseUiFrameWaitOutcome.TimedOut)
+                SimulateMouseUiResponse? motionAbort = await AnimateDragMotionOrAbortAsync(
+                    parameters,
+                    pointerData,
+                    target,
+                    inputStart,
+                    inputEnd,
+                    screenEnd,
+                    targetName,
+                    DragInterruptedDuringMotionMessage,
+                    cleanupScheduler,
+                    ct).ConfigureAwait(false);
+                if (motionAbort != null)
                 {
-                    cleanupScheduler.QueueOverlayClear();
-                    return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, targetName);
+                    return motionAbort;
                 }
-                if (expandOutcome == MouseUiFrameWaitOutcome.Paused)
-                {
-                    cleanupScheduler.QueueOverlayClear();
-                    return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                        MouseAction.Drag, inputStart, targetName, DragInterruptedDuringMotionMessage);
-                }
-                await MainThreadSwitcher.SwitchToMainThread(ct);
-
-                MouseUiFrameWaitOutcome dragOutcome = await MouseUiDragEventExecutor.InterpolateDragPosition(pointerData, target, screenEnd, parameters.DragSpeed, ct)
-                    .ConfigureAwait(false);
-                if (dragOutcome == MouseUiFrameWaitOutcome.TimedOut)
-                {
-                    cleanupScheduler.QueueOverlayClear();
-                    return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, targetName);
-                }
-                if (dragOutcome == MouseUiFrameWaitOutcome.Paused)
-                {
-                    cleanupScheduler.QueueOverlayClear();
-                    return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                        MouseAction.Drag, inputStart, targetName, DragInterruptedDuringMotionMessage);
-                }
-                await MainThreadSwitcher.SwitchToMainThread(ct);
-
-                MouseUiFrameWaitOutcome settleOutcome = await MouseUiEditorFrameWaiter.WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
-                if (settleOutcome == MouseUiFrameWaitOutcome.TimedOut)
-                {
-                    cleanupScheduler.QueueOverlayClear();
-                    return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, targetName);
-                }
-                if (settleOutcome == MouseUiFrameWaitOutcome.Paused)
-                {
-                    cleanupScheduler.QueueOverlayClear();
-                    return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                        MouseAction.Drag, inputStart, targetName, DragInterruptedDuringMotionMessage);
-                }
-                await MainThreadSwitcher.SwitchToMainThread(ct);
             }
             finally
             {
@@ -179,6 +110,132 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
             return MouseUiSimulationResponseFactory.CreateDragResult(parameters, inputStart, inputEnd, targetName);
+        }
+
+        private static async Task<SimulateMouseUiResponse> ExecuteNoTargetDragAsync(
+            MouseUiSimulationCommand parameters,
+            Vector2 inputStart,
+            Vector2 inputEnd,
+            MouseUiMainThreadCleanupScheduler cleanupScheduler,
+            CancellationToken ct)
+        {
+            const string NoTargetInterruptedMessage =
+                "Drag stopped because Unity paused during Pause Point inspection. No draggable target was found at the start position, so no drag was initiated.";
+            SimulateMouseUiOverlayState.Update(
+                MouseAction.Drag, inputStart, null, Handles.GetMainGameViewSize());
+            SimulateMouseUiResponse? expandAbort = await AbortDragOnOverlayOutcomeAsync(
+                await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false),
+                inputStart,
+                inputEnd,
+                null,
+                NoTargetInterruptedMessage,
+                cleanupScheduler,
+                ct).ConfigureAwait(false);
+            if (expandAbort != null)
+            {
+                return expandAbort;
+            }
+
+            SimulateMouseUiResponse? dissipateAbort = await AbortDragOnOverlayOutcomeAsync(
+                await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false),
+                inputStart,
+                inputEnd,
+                null,
+                NoTargetInterruptedMessage,
+                cleanupScheduler,
+                ct).ConfigureAwait(false);
+            if (dissipateAbort != null)
+            {
+                return dissipateAbort;
+            }
+
+            return new SimulateMouseUiResponse
+            {
+                Success = false,
+                Message = parameters.BypassRaycast
+                    ? $"TargetPath '{parameters.TargetPath}' has no drag handler."
+                    : $"No draggable UI element at ({inputStart.x:F1}, {inputStart.y:F1}). Use find-game-objects or screenshot to verify positions.",
+                Action = MouseAction.Drag.ToString(),
+                PositionX = inputStart.x,
+                PositionY = inputStart.y,
+                EndPositionX = inputEnd.x,
+                EndPositionY = inputEnd.y
+            };
+        }
+
+        private static async Task<SimulateMouseUiResponse?> AnimateDragMotionOrAbortAsync(
+            MouseUiSimulationCommand parameters,
+            PointerEventData pointerData,
+            GameObject target,
+            Vector2 inputStart,
+            Vector2 inputEnd,
+            Vector2 screenEnd,
+            string targetName,
+            string interruptedMessage,
+            MouseUiMainThreadCleanupScheduler cleanupScheduler,
+            CancellationToken ct)
+        {
+            SimulateMouseUiResponse? expandAbort = await AbortDragOnOverlayOutcomeAsync(
+                await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false),
+                inputStart,
+                inputEnd,
+                targetName,
+                interruptedMessage,
+                cleanupScheduler,
+                ct).ConfigureAwait(false);
+            if (expandAbort != null)
+            {
+                return expandAbort;
+            }
+
+            SimulateMouseUiResponse? dragAbort = await AbortDragOnOverlayOutcomeAsync(
+                await MouseUiDragEventExecutor.InterpolateDragPosition(pointerData, target, screenEnd, parameters.DragSpeed, ct)
+                    .ConfigureAwait(false),
+                inputStart,
+                inputEnd,
+                targetName,
+                interruptedMessage,
+                cleanupScheduler,
+                ct).ConfigureAwait(false);
+            if (dragAbort != null)
+            {
+                return dragAbort;
+            }
+
+            return await AbortDragOnOverlayOutcomeAsync(
+                await MouseUiEditorFrameWaiter.WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false),
+                inputStart,
+                inputEnd,
+                targetName,
+                interruptedMessage,
+                cleanupScheduler,
+                ct).ConfigureAwait(false);
+        }
+
+        private static async Task<SimulateMouseUiResponse?> AbortDragOnOverlayOutcomeAsync(
+            MouseUiFrameWaitOutcome outcome,
+            Vector2 inputStart,
+            Vector2 inputEnd,
+            string? targetName,
+            string interruptedMessage,
+            MouseUiMainThreadCleanupScheduler cleanupScheduler,
+            CancellationToken ct)
+        {
+            if (outcome == MouseUiFrameWaitOutcome.TimedOut)
+            {
+                cleanupScheduler.QueueOverlayClear();
+                return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, targetName);
+            }
+
+            if (outcome == MouseUiFrameWaitOutcome.Paused)
+            {
+                cleanupScheduler.QueueOverlayClear();
+                return MouseUiSimulationResponseFactory.CreateInterruptedResult(
+                    MouseAction.Drag, inputStart, targetName, interruptedMessage);
+            }
+
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+            return null;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOneShotDragExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOneShotDragExecutor.cs
@@ -70,6 +70,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             try
             {
+                // Why no ConfigureAwait(false): AnimateDragMotionOrAbortAsync ends on the main
+                // thread after SwitchToMainThread. ConfigureAwait(false) would hop off-main
+                // before OverlayState.Update / PlayDissipateAnimation.
                 SimulateMouseUiResponse? motionAbort = await AnimateDragMotionOrAbortAsync(
                     parameters,
                     pointerData,
@@ -80,7 +83,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     targetName,
                     DragInterruptedDuringMotionMessage,
                     cleanupScheduler,
-                    ct).ConfigureAwait(false);
+                    ct);
                 if (motionAbort != null)
                 {
                     return motionAbort;
@@ -130,7 +133,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 null,
                 NoTargetInterruptedMessage,
                 cleanupScheduler,
-                ct).ConfigureAwait(false);
+                ct);
             if (expandAbort != null)
             {
                 return expandAbort;
@@ -143,7 +146,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 null,
                 NoTargetInterruptedMessage,
                 cleanupScheduler,
-                ct).ConfigureAwait(false);
+                ct);
             if (dissipateAbort != null)
             {
                 return dissipateAbort;
@@ -182,7 +185,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 targetName,
                 interruptedMessage,
                 cleanupScheduler,
-                ct).ConfigureAwait(false);
+                ct);
             if (expandAbort != null)
             {
                 return expandAbort;
@@ -196,7 +199,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 targetName,
                 interruptedMessage,
                 cleanupScheduler,
-                ct).ConfigureAwait(false);
+                ct);
             if (dragAbort != null)
             {
                 return dragAbort;
@@ -209,7 +212,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 targetName,
                 interruptedMessage,
                 cleanupScheduler,
-                ct).ConfigureAwait(false);
+                ct);
         }
 
         private static async Task<SimulateMouseUiResponse?> AbortDragOnOverlayOutcomeAsync(

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs
@@ -147,11 +147,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             try
             {
-                // Why no ConfigureAwait(false): the helper already switched to the main thread
-                // on its last iteration. ConfigureAwait(false) here would resume off-main
-                // before PlayDissipateAnimation, which the inlined loop never did.
                 SimulateMouseUiResponse? holdAbort = await HoldLongPressOrAbortAsync(
-                    parameters.Duration, inputPos, targetName, cleanupScheduler, ct);
+                    parameters.Duration, inputPos, targetName, cleanupScheduler, ct).ConfigureAwait(false);
                 if (holdAbort != null)
                 {
                     return holdAbort;
@@ -166,6 +163,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         () => ExecuteEvents.Execute(resolvedTargets.Target!, pointerData, ExecuteEvents.pointerUpHandler));
                 }
             }
+
+            // Why switch after the helper: HoldLongPressOrAbortAsync ends on the main thread,
+            // but ConfigureAwait(false) can resume this method off-main before dissipate.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
 
             MouseUiFrameWaitOutcome dissipateOutcome = await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false);
             if (dissipateOutcome == MouseUiFrameWaitOutcome.TimedOut)

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs
@@ -147,8 +147,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             try
             {
+                // Why no ConfigureAwait(false): the helper already switched to the main thread
+                // on its last iteration. ConfigureAwait(false) here would resume off-main
+                // before PlayDissipateAnimation, which the inlined loop never did.
                 SimulateMouseUiResponse? holdAbort = await HoldLongPressOrAbortAsync(
-                    parameters.Duration, inputPos, targetName, cleanupScheduler, ct).ConfigureAwait(false);
+                    parameters.Duration, inputPos, targetName, cleanupScheduler, ct);
                 if (holdAbort != null)
                 {
                     return holdAbort;

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs
@@ -92,25 +92,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             MouseUiMainThreadCleanupScheduler cleanupScheduler,
             CancellationToken ct)
         {
-            if (parameters.Duration <= 0f || float.IsNaN(parameters.Duration) || float.IsInfinity(parameters.Duration))
+            SimulateMouseUiResponse? invalidDuration = CreateInvalidLongPressDurationResponse(parameters.Duration);
+            if (invalidDuration != null)
             {
-                return new SimulateMouseUiResponse
-                {
-                    Success = false,
-                    Message = $"Duration must be positive, got: {parameters.Duration}",
-                    Action = MouseAction.LongPress.ToString()
-                };
-            }
-
-            if (parameters.Duration > SimulateInputConstants.MaxDurationSeconds)
-            {
-                return new SimulateMouseUiResponse
-                {
-                    Success = false,
-                    Message =
-                        $"Duration must be {SimulateInputConstants.MaxDurationSeconds} seconds or less, got: {parameters.Duration}. The unit is seconds, not milliseconds.",
-                    Action = MouseAction.LongPress.ToString()
-                };
+                return invalidDuration;
             }
 
             Vector2 inputPos = new(parameters.X, parameters.Y);
@@ -162,30 +147,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             try
             {
-                // Hold for Duration seconds, updating elapsed time each frame for overlay display
-                float startTime = Time.realtimeSinceStartup;
-                float elapsed = 0f;
-                while (elapsed < parameters.Duration)
+                SimulateMouseUiResponse? holdAbort = await HoldLongPressOrAbortAsync(
+                    parameters.Duration, inputPos, targetName, cleanupScheduler, ct).ConfigureAwait(false);
+                if (holdAbort != null)
                 {
-                    SimulateMouseUiOverlayState.UpdateLongPressElapsed(elapsed);
-                    MouseUiFrameWaitOutcome frameOutcome = await MouseUiEditorFrameWaiter.WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
-                    if (frameOutcome == MouseUiFrameWaitOutcome.TimedOut)
-                    {
-                        cleanupScheduler.QueueOverlayClear();
-                        return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.LongPress, inputPos, null, targetName);
-                    }
-                    if (frameOutcome == MouseUiFrameWaitOutcome.Paused)
-                    {
-                        // Returning here still runs the finally below, which releases pointerUp early.
-                        cleanupScheduler.QueueOverlayClear();
-                        return MouseUiSimulationResponseFactory.CreateInterruptedResult(
-                            MouseAction.LongPress, inputPos, targetName,
-                            "Long-press pointerDown was already dispatched. Unity paused during Pause Point inspection while holding; pointerUp was released early and the press duration was cut short.");
-                    }
-                    await MainThreadSwitcher.SwitchToMainThread(ct);
-                    elapsed = Time.realtimeSinceStartup - startTime;
+                    return holdAbort;
                 }
-                SimulateMouseUiOverlayState.UpdateLongPressElapsed(parameters.Duration);
             }
             finally
             {
@@ -213,6 +180,69 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
             return MouseUiSimulationResponseFactory.CreateLongPressResult(parameters, inputPos, targetName, hitTarget);
+        }
+
+        private static SimulateMouseUiResponse? CreateInvalidLongPressDurationResponse(float duration)
+        {
+            if (duration <= 0f || float.IsNaN(duration) || float.IsInfinity(duration))
+            {
+                return new SimulateMouseUiResponse
+                {
+                    Success = false,
+                    Message = $"Duration must be positive, got: {duration}",
+                    Action = MouseAction.LongPress.ToString()
+                };
+            }
+
+            if (duration > SimulateInputConstants.MaxDurationSeconds)
+            {
+                return new SimulateMouseUiResponse
+                {
+                    Success = false,
+                    Message =
+                        $"Duration must be {SimulateInputConstants.MaxDurationSeconds} seconds or less, got: {duration}. The unit is seconds, not milliseconds.",
+                    Action = MouseAction.LongPress.ToString()
+                };
+            }
+
+            return null;
+        }
+
+        private static async Task<SimulateMouseUiResponse?> HoldLongPressOrAbortAsync(
+            float duration,
+            Vector2 inputPos,
+            string? targetName,
+            MouseUiMainThreadCleanupScheduler cleanupScheduler,
+            CancellationToken ct)
+        {
+            // Hold for Duration seconds, updating elapsed time each frame for overlay display
+            float startTime = Time.realtimeSinceStartup;
+            float elapsed = 0f;
+            while (elapsed < duration)
+            {
+                SimulateMouseUiOverlayState.UpdateLongPressElapsed(elapsed);
+                MouseUiFrameWaitOutcome frameOutcome = await MouseUiEditorFrameWaiter.WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
+                if (frameOutcome == MouseUiFrameWaitOutcome.TimedOut)
+                {
+                    cleanupScheduler.QueueOverlayClear();
+                    return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.LongPress, inputPos, null, targetName);
+                }
+
+                if (frameOutcome == MouseUiFrameWaitOutcome.Paused)
+                {
+                    // Returning here still runs the finally below, which releases pointerUp early.
+                    cleanupScheduler.QueueOverlayClear();
+                    return MouseUiSimulationResponseFactory.CreateInterruptedResult(
+                        MouseAction.LongPress, inputPos, targetName,
+                        "Long-press pointerDown was already dispatched. Unity paused during Pause Point inspection while holding; pointerUp was released early and the press duration was cut short.");
+                }
+
+                await MainThreadSwitcher.SwitchToMainThread(ct);
+                elapsed = Time.realtimeSinceStartup - startTime;
+            }
+
+            SimulateMouseUiOverlayState.UpdateLongPressElapsed(duration);
+            return null;
         }
 
         private static void ExecutePointerClickEvents(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileWriter.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileWriter.cs
@@ -276,10 +276,16 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
 
             byte[] bom = new byte[4];
+            int readCount = ReadBomPrefix(GetFileSystemPath(filePath), bom);
+            return EncodingFromBomPrefix(bom, readCount);
+        }
+
+        // FileStream.Read may return fewer bytes than requested; keep reading until EOF or 4 bytes.
+        private static int ReadBomPrefix(string fileSystemPath, byte[] bom)
+        {
             int readCount = 0;
-            using (FileStream stream = File.OpenRead(GetFileSystemPath(filePath)))
+            using (FileStream stream = File.OpenRead(fileSystemPath))
             {
-                // FileStream.Read may return fewer bytes than requested; read until EOF or 4 bytes.
                 while (readCount < bom.Length)
                 {
                     int read = stream.Read(bom, readCount, bom.Length - readCount);
@@ -292,33 +298,53 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
             }
 
-            // UTF-32 BOMs must be checked before UTF-16 because they share the same leading bytes.
-            if (readCount >= 4 && bom[0] == 0xFF && bom[1] == 0xFE && bom[2] == 0x00 && bom[3] == 0x00)
+            return readCount;
+        }
+
+        // UTF-32 BOMs must be checked before UTF-16 because they share the same leading bytes.
+        private static Encoding EncodingFromBomPrefix(byte[] bom, int readCount)
+        {
+            if (MatchesFourByteBom(bom, readCount, 0xFF, 0xFE, 0x00, 0x00))
             {
                 return new UTF32Encoding(bigEndian: false, byteOrderMark: true);
             }
 
-            if (readCount >= 4 && bom[0] == 0x00 && bom[1] == 0x00 && bom[2] == 0xFE && bom[3] == 0xFF)
+            if (MatchesFourByteBom(bom, readCount, 0x00, 0x00, 0xFE, 0xFF))
             {
                 return new UTF32Encoding(bigEndian: true, byteOrderMark: true);
             }
 
-            if (readCount >= 3 && bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF)
+            if (MatchesThreeByteBom(bom, readCount, 0xEF, 0xBB, 0xBF))
             {
                 return new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
             }
 
-            if (readCount >= 2 && bom[0] == 0xFF && bom[1] == 0xFE)
+            if (MatchesTwoByteBom(bom, readCount, 0xFF, 0xFE))
             {
                 return new UnicodeEncoding(bigEndian: false, byteOrderMark: true);
             }
 
-            if (readCount >= 2 && bom[0] == 0xFE && bom[1] == 0xFF)
+            if (MatchesTwoByteBom(bom, readCount, 0xFE, 0xFF))
             {
                 return new UnicodeEncoding(bigEndian: true, byteOrderMark: true);
             }
 
             return new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        }
+
+        private static bool MatchesTwoByteBom(byte[] bom, int readCount, byte first, byte second)
+        {
+            return readCount >= 2 && bom[0] == first && bom[1] == second;
+        }
+
+        private static bool MatchesThreeByteBom(byte[] bom, int readCount, byte first, byte second, byte third)
+        {
+            return readCount >= 3 && bom[0] == first && bom[1] == second && bom[2] == third;
+        }
+
+        private static bool MatchesFourByteBom(byte[] bom, int readCount, byte first, byte second, byte third, byte fourth)
+        {
+            return readCount >= 4 && bom[0] == first && bom[1] == second && bom[2] == third && bom[3] == fourth;
         }
 
         internal static void WriteAllTextWithEncoding(string filePath, string content, Encoding encoding)

--- a/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
+++ b/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
@@ -62,58 +62,44 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         // Why a helper: the ctor's Q/assert/throw fan-out is one query step, and leaving it
         // inline kept the constructor over CA1502.
+        // Why three phases: the original queried every node, emitted every missing-node
+        // Debug.Assert, and only then threw for the first missing one. Assert-then-throw
+        // per element skipped later asserts.
         private static RequiredSkillsPanelElements QueryRequiredElements(VisualElement root)
         {
-            return new RequiredSkillsPanelElements(
-                RequireNamedElement(
-                    root.Q<VisualElement>("skill-target-status-list"),
-                    "skill-target-status-list",
-                    "_skillTargetStatusList"),
-                RequireNamedElement(
-                    root.Q<VisualElement>("skill-target-status-divider"),
-                    "skill-target-status-divider",
-                    "_skillTargetStatusDivider"),
-                RequireNamedElement(
-                    root.Q<Label>("skill-target-status-summary"),
-                    "skill-target-status-summary",
-                    "_skillTargetStatusSummary"),
-                RequireNamedElement(
-                    root.Q<Label>("skills-no-targets-message"),
-                    "skills-no-targets-message",
-                    "_skillsNoTargetsMessage"),
-                RequireNamedElement(
-                    root.Q<Button>("install-all-skills-button"),
-                    "install-all-skills-button",
-                    "_installAllSkillsButton"),
-                RequireNamedElement(
-                    root.Q<Foldout>("install-specific-target-foldout"),
-                    "install-specific-target-foldout",
-                    "_installSpecificTargetFoldout"),
-                RequireNamedElement(
-                    root.Q<VisualElement>("group-skills-row"),
-                    "group-skills-row",
-                    "_groupSkillsRow"),
-                RequireNamedElement(
-                    root.Q<Toggle>("group-skills-toggle"),
-                    "group-skills-toggle",
-                    "_groupSkillsToggle"),
-                RequireNamedElement(
-                    root.Q<EnumField>("skills-target-field"),
-                    "skills-target-field",
-                    "_skillsTargetField"),
-                RequireNamedElement(
-                    root.Q<Button>("install-selected-skills-button"),
-                    "install-selected-skills-button",
-                    "_installSelectedSkillsButton"));
-        }
+            VisualElement skillTargetStatusList = root.Q<VisualElement>("skill-target-status-list");
+            VisualElement skillTargetStatusDivider = root.Q<VisualElement>("skill-target-status-divider");
+            Label skillTargetStatusSummary = root.Q<Label>("skill-target-status-summary");
+            Label skillsNoTargetsMessage = root.Q<Label>("skills-no-targets-message");
+            Button installAllSkillsButton = root.Q<Button>("install-all-skills-button");
+            Foldout installSpecificTargetFoldout = root.Q<Foldout>("install-specific-target-foldout");
+            VisualElement groupSkillsRow = root.Q<VisualElement>("group-skills-row");
+            Toggle groupSkillsToggle = root.Q<Toggle>("group-skills-toggle");
+            EnumField skillsTargetField = root.Q<EnumField>("skills-target-field");
+            Button installSelectedSkillsButton = root.Q<Button>("install-selected-skills-button");
 
-        // Why two names: Debug.Assert used the UXML name; ArgumentNullException used the field
-        // nameof. Combining them into one string changed the exception ParamName.
-        private static T RequireNamedElement<T>(T value, string assertName, string exceptionParamName)
-            where T : VisualElement
-        {
-            Debug.Assert(value != null, assertName + " must not be null");
-            return value ?? throw new System.ArgumentNullException(exceptionParamName);
+            Debug.Assert(skillTargetStatusList != null, "skill-target-status-list must not be null");
+            Debug.Assert(skillTargetStatusDivider != null, "skill-target-status-divider must not be null");
+            Debug.Assert(skillTargetStatusSummary != null, "skill-target-status-summary must not be null");
+            Debug.Assert(skillsNoTargetsMessage != null, "skills-no-targets-message must not be null");
+            Debug.Assert(installAllSkillsButton != null, "install-all-skills-button must not be null");
+            Debug.Assert(installSpecificTargetFoldout != null, "install-specific-target-foldout must not be null");
+            Debug.Assert(groupSkillsRow != null, "group-skills-row must not be null");
+            Debug.Assert(groupSkillsToggle != null, "group-skills-toggle must not be null");
+            Debug.Assert(skillsTargetField != null, "skills-target-field must not be null");
+            Debug.Assert(installSelectedSkillsButton != null, "install-selected-skills-button must not be null");
+
+            return new RequiredSkillsPanelElements(
+                skillTargetStatusList ?? throw new System.ArgumentNullException(nameof(_skillTargetStatusList)),
+                skillTargetStatusDivider ?? throw new System.ArgumentNullException(nameof(_skillTargetStatusDivider)),
+                skillTargetStatusSummary ?? throw new System.ArgumentNullException(nameof(_skillTargetStatusSummary)),
+                skillsNoTargetsMessage ?? throw new System.ArgumentNullException(nameof(_skillsNoTargetsMessage)),
+                installAllSkillsButton ?? throw new System.ArgumentNullException(nameof(_installAllSkillsButton)),
+                installSpecificTargetFoldout ?? throw new System.ArgumentNullException(nameof(_installSpecificTargetFoldout)),
+                groupSkillsRow ?? throw new System.ArgumentNullException(nameof(_groupSkillsRow)),
+                groupSkillsToggle ?? throw new System.ArgumentNullException(nameof(_groupSkillsToggle)),
+                skillsTargetField ?? throw new System.ArgumentNullException(nameof(_skillsTargetField)),
+                installSelectedSkillsButton ?? throw new System.ArgumentNullException(nameof(_installSelectedSkillsButton)));
         }
 
         private void WireEventHandlers()

--- a/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
+++ b/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
@@ -42,45 +42,49 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _refreshSkillsStateButton = refreshSkillsStateButton
                 ?? throw new System.ArgumentNullException(nameof(refreshSkillsStateButton));
 
-            _skillTargetStatusList = root.Q<VisualElement>("skill-target-status-list");
-            _skillTargetStatusDivider = root.Q<VisualElement>("skill-target-status-divider");
-            _skillTargetStatusSummary = root.Q<Label>("skill-target-status-summary");
-            _skillsNoTargetsMessage = root.Q<Label>("skills-no-targets-message");
-            _installAllSkillsButton = root.Q<Button>("install-all-skills-button");
-            _installSpecificTargetFoldout = root.Q<Foldout>("install-specific-target-foldout");
-            _groupSkillsRow = root.Q<VisualElement>("group-skills-row");
-            _groupSkillsToggle = root.Q<Toggle>("group-skills-toggle");
-            _skillsTargetField = root.Q<EnumField>("skills-target-field");
-            _installSelectedSkillsButton = root.Q<Button>("install-selected-skills-button");
-
-            Debug.Assert(_skillTargetStatusList != null, "skill-target-status-list must not be null");
-            Debug.Assert(_skillTargetStatusDivider != null, "skill-target-status-divider must not be null");
-            Debug.Assert(_skillTargetStatusSummary != null, "skill-target-status-summary must not be null");
-            Debug.Assert(_skillsNoTargetsMessage != null, "skills-no-targets-message must not be null");
-            Debug.Assert(_installAllSkillsButton != null, "install-all-skills-button must not be null");
-            Debug.Assert(_installSpecificTargetFoldout != null, "install-specific-target-foldout must not be null");
-            Debug.Assert(_groupSkillsRow != null, "group-skills-row must not be null");
-            Debug.Assert(_groupSkillsToggle != null, "group-skills-toggle must not be null");
-            Debug.Assert(_skillsTargetField != null, "skills-target-field must not be null");
-            Debug.Assert(_installSelectedSkillsButton != null, "install-selected-skills-button must not be null");
-
-            _ = _skillTargetStatusList ?? throw new System.ArgumentNullException(nameof(_skillTargetStatusList));
-            _ = _skillTargetStatusDivider ?? throw new System.ArgumentNullException(nameof(_skillTargetStatusDivider));
-            _ = _skillTargetStatusSummary ?? throw new System.ArgumentNullException(nameof(_skillTargetStatusSummary));
-            _ = _skillsNoTargetsMessage ?? throw new System.ArgumentNullException(nameof(_skillsNoTargetsMessage));
-            _ = _installAllSkillsButton ?? throw new System.ArgumentNullException(nameof(_installAllSkillsButton));
-            _ = _installSpecificTargetFoldout
-                ?? throw new System.ArgumentNullException(nameof(_installSpecificTargetFoldout));
-            _ = _groupSkillsRow ?? throw new System.ArgumentNullException(nameof(_groupSkillsRow));
-            _ = _groupSkillsToggle ?? throw new System.ArgumentNullException(nameof(_groupSkillsToggle));
-            _ = _skillsTargetField ?? throw new System.ArgumentNullException(nameof(_skillsTargetField));
-            _ = _installSelectedSkillsButton
-                ?? throw new System.ArgumentNullException(nameof(_installSelectedSkillsButton));
+            RequiredSkillsPanelElements elements = QueryRequiredElements(root);
+            _skillTargetStatusList = elements.StatusList;
+            _skillTargetStatusDivider = elements.StatusDivider;
+            _skillTargetStatusSummary = elements.StatusSummary;
+            _skillsNoTargetsMessage = elements.NoTargetsMessage;
+            _installAllSkillsButton = elements.InstallAllButton;
+            _installSpecificTargetFoldout = elements.InstallSpecificTargetFoldout;
+            _groupSkillsRow = elements.GroupSkillsRow;
+            _groupSkillsToggle = elements.GroupSkillsToggle;
+            _skillsTargetField = elements.SkillsTargetField;
+            _installSelectedSkillsButton = elements.InstallSelectedButton;
 
             _installSpecificTargetFoldout.SetValueWithoutNotify(false);
             ViewDataBinder.SetVisible(_groupSkillsRow, false);
             ViewDataBinder.SetVisible(_skillsNoTargetsMessage, false);
+            WireEventHandlers();
+        }
 
+        // Why a helper: the ctor's Q/assert/throw fan-out is one query step, and leaving it
+        // inline kept the constructor over CA1502.
+        private static RequiredSkillsPanelElements QueryRequiredElements(VisualElement root)
+        {
+            return new RequiredSkillsPanelElements(
+                RequireNamedElement(root.Q<VisualElement>("skill-target-status-list"), "skill-target-status-list"),
+                RequireNamedElement(root.Q<VisualElement>("skill-target-status-divider"), "skill-target-status-divider"),
+                RequireNamedElement(root.Q<Label>("skill-target-status-summary"), "skill-target-status-summary"),
+                RequireNamedElement(root.Q<Label>("skills-no-targets-message"), "skills-no-targets-message"),
+                RequireNamedElement(root.Q<Button>("install-all-skills-button"), "install-all-skills-button"),
+                RequireNamedElement(root.Q<Foldout>("install-specific-target-foldout"), "install-specific-target-foldout"),
+                RequireNamedElement(root.Q<VisualElement>("group-skills-row"), "group-skills-row"),
+                RequireNamedElement(root.Q<Toggle>("group-skills-toggle"), "group-skills-toggle"),
+                RequireNamedElement(root.Q<EnumField>("skills-target-field"), "skills-target-field"),
+                RequireNamedElement(root.Q<Button>("install-selected-skills-button"), "install-selected-skills-button"));
+        }
+
+        private static T RequireNamedElement<T>(T value, string name) where T : VisualElement
+        {
+            Debug.Assert(value != null, name + " must not be null");
+            return value ?? throw new System.ArgumentNullException(name);
+        }
+
+        private void WireEventHandlers()
+        {
             _installAllSkillsButton.clicked += () => OnInstallAllClicked?.Invoke();
             _installSelectedSkillsButton.clicked += () => OnInstallSelectedClicked?.Invoke();
             _refreshSkillsStateButton.clicked += () => OnRefreshClicked?.Invoke();
@@ -90,6 +94,44 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 OnGroupSkillsChanged?.Invoke(evt.newValue);
             });
             _groupSkillsRow.RegisterCallback<ClickEvent>(HandleGroupSkillsRowClicked);
+        }
+
+        private readonly struct RequiredSkillsPanelElements
+        {
+            internal readonly VisualElement StatusList;
+            internal readonly VisualElement StatusDivider;
+            internal readonly Label StatusSummary;
+            internal readonly Label NoTargetsMessage;
+            internal readonly Button InstallAllButton;
+            internal readonly Foldout InstallSpecificTargetFoldout;
+            internal readonly VisualElement GroupSkillsRow;
+            internal readonly Toggle GroupSkillsToggle;
+            internal readonly EnumField SkillsTargetField;
+            internal readonly Button InstallSelectedButton;
+
+            internal RequiredSkillsPanelElements(
+                VisualElement statusList,
+                VisualElement statusDivider,
+                Label statusSummary,
+                Label noTargetsMessage,
+                Button installAllButton,
+                Foldout installSpecificTargetFoldout,
+                VisualElement groupSkillsRow,
+                Toggle groupSkillsToggle,
+                EnumField skillsTargetField,
+                Button installSelectedButton)
+            {
+                StatusList = statusList;
+                StatusDivider = statusDivider;
+                StatusSummary = statusSummary;
+                NoTargetsMessage = noTargetsMessage;
+                InstallAllButton = installAllButton;
+                InstallSpecificTargetFoldout = installSpecificTargetFoldout;
+                GroupSkillsRow = groupSkillsRow;
+                GroupSkillsToggle = groupSkillsToggle;
+                SkillsTargetField = skillsTargetField;
+                InstallSelectedButton = installSelectedButton;
+            }
         }
 
         internal void ShowChecking()

--- a/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
+++ b/Packages/src/Editor/Presentation/Shared/SkillsSetupPanelView.cs
@@ -65,22 +65,55 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private static RequiredSkillsPanelElements QueryRequiredElements(VisualElement root)
         {
             return new RequiredSkillsPanelElements(
-                RequireNamedElement(root.Q<VisualElement>("skill-target-status-list"), "skill-target-status-list"),
-                RequireNamedElement(root.Q<VisualElement>("skill-target-status-divider"), "skill-target-status-divider"),
-                RequireNamedElement(root.Q<Label>("skill-target-status-summary"), "skill-target-status-summary"),
-                RequireNamedElement(root.Q<Label>("skills-no-targets-message"), "skills-no-targets-message"),
-                RequireNamedElement(root.Q<Button>("install-all-skills-button"), "install-all-skills-button"),
-                RequireNamedElement(root.Q<Foldout>("install-specific-target-foldout"), "install-specific-target-foldout"),
-                RequireNamedElement(root.Q<VisualElement>("group-skills-row"), "group-skills-row"),
-                RequireNamedElement(root.Q<Toggle>("group-skills-toggle"), "group-skills-toggle"),
-                RequireNamedElement(root.Q<EnumField>("skills-target-field"), "skills-target-field"),
-                RequireNamedElement(root.Q<Button>("install-selected-skills-button"), "install-selected-skills-button"));
+                RequireNamedElement(
+                    root.Q<VisualElement>("skill-target-status-list"),
+                    "skill-target-status-list",
+                    "_skillTargetStatusList"),
+                RequireNamedElement(
+                    root.Q<VisualElement>("skill-target-status-divider"),
+                    "skill-target-status-divider",
+                    "_skillTargetStatusDivider"),
+                RequireNamedElement(
+                    root.Q<Label>("skill-target-status-summary"),
+                    "skill-target-status-summary",
+                    "_skillTargetStatusSummary"),
+                RequireNamedElement(
+                    root.Q<Label>("skills-no-targets-message"),
+                    "skills-no-targets-message",
+                    "_skillsNoTargetsMessage"),
+                RequireNamedElement(
+                    root.Q<Button>("install-all-skills-button"),
+                    "install-all-skills-button",
+                    "_installAllSkillsButton"),
+                RequireNamedElement(
+                    root.Q<Foldout>("install-specific-target-foldout"),
+                    "install-specific-target-foldout",
+                    "_installSpecificTargetFoldout"),
+                RequireNamedElement(
+                    root.Q<VisualElement>("group-skills-row"),
+                    "group-skills-row",
+                    "_groupSkillsRow"),
+                RequireNamedElement(
+                    root.Q<Toggle>("group-skills-toggle"),
+                    "group-skills-toggle",
+                    "_groupSkillsToggle"),
+                RequireNamedElement(
+                    root.Q<EnumField>("skills-target-field"),
+                    "skills-target-field",
+                    "_skillsTargetField"),
+                RequireNamedElement(
+                    root.Q<Button>("install-selected-skills-button"),
+                    "install-selected-skills-button",
+                    "_installSelectedSkillsButton"));
         }
 
-        private static T RequireNamedElement<T>(T value, string name) where T : VisualElement
+        // Why two names: Debug.Assert used the UXML name; ArgumentNullException used the field
+        // nameof. Combining them into one string changed the exception ParamName.
+        private static T RequireNamedElement<T>(T value, string assertName, string exceptionParamName)
+            where T : VisualElement
         {
-            Debug.Assert(value != null, name + " must not be null");
-            return value ?? throw new System.ArgumentNullException(name);
+            Debug.Assert(value != null, assertName + " must not be null");
+            return value ?? throw new System.ArgumentNullException(exceptionParamName);
         }
 
         private void WireEventHandlers()


### PR DESCRIPTION
## Summary
- Split ten first-party Editor methods that already exceeded the CA1502 limit of 15, so the later fail-on-exceeded flip can land without blocking ordinary Editor tool work.
- No user-visible command, response, or error-string change.

## User Impact
- Before: these Editor methods sat above the repository complexity limit and would fail CI once complexity findings become errors.
- After: the same tools keep their current return paths, timeout messages, and restore order, now below the limit.

## Changes
- Extract meaning-sized helpers in input-system apply, dynamic-code literal hoisting, pause-point preview serialization, screenshot rendering capture, keyboard/mouse-ui executors, third-party migration BOM detection, and the skills setup panel constructor.
- Leave HotReload orchestrator/tools and TransformWorker for the next PRs.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Error 0
- `scripts/check-code-complexity.sh` → all ten named CA1502 findings gone; remaining 12 findings are HotReload-only (PR-4/PR-5)
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value "DynamicCodeLiteralHoister|SourcePausePointVariableFormatter|ScreenshotUseCase|ThirdPartyToolMigrationFileWriter|SkillsSetupPanelView"` → 131 passed, 0 failed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

