### PR TITLE
ci: fail the Code Complexity workflow on findings

### DIFF
--- a/.github/workflows/code-complexity.yml
+++ b/.github/workflows/code-complexity.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Report complexity
         env:
-          CODE_COMPLEXITY_FAIL_ON_EXCEEDED: 'false'
+          CODE_COMPLEXITY_FAIL_ON_EXCEEDED: 'true'
         run: scripts/check-code-complexity.sh
 
       - name: Write complexity artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,10 +133,9 @@ as described in `docs/dead-code-scanner.md` (commands, and what `KeptByUnityOrRe
 ## Code Complexity
 
 The repository-wide maximum cyclomatic complexity is 15, enforced by `cyclop` for Go and CA1502
-for C#. The `Code Complexity` workflow reports findings but never fails the build, so a finding
-only does its job if someone acts on it: when you touch a reported function, reduce its
-complexity before adding behavior. Commands and the two places the threshold is declared:
-`docs/code-complexity.md`.
+for C#. The `Code Complexity` workflow fails the pull request when findings exceed that
+threshold. When you touch a reported function, reduce its complexity before adding behavior.
+Commands and the three places the threshold is declared: `docs/code-complexity.md`.
 
 ## Native Go CLI Validation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ as described in `docs/dead-code-scanner.md` (commands, and what `KeptByUnityOrRe
 The repository-wide maximum cyclomatic complexity is 15, enforced by `cyclop` for Go and CA1502
 for C#. The `Code Complexity` workflow fails the pull request when findings exceed that
 threshold. When you touch a reported function, reduce its complexity before adding behavior.
-Commands and the three places the threshold is declared: `docs/code-complexity.md`.
+Commands and the five places the threshold is declared: `docs/code-complexity.md`.
 
 ## Native Go CLI Validation
 

--- a/docs/code-complexity.md
+++ b/docs/code-complexity.md
@@ -5,7 +5,9 @@ This repository measures cyclomatic complexity for both implementation stacks:
 - Go native CLI code uses `golangci-lint` with the `cyclop` linter.
 - Unity package C# code uses Microsoft's CA1502 analyzer through the local `UnityCliLoop.CodeComplexity` host.
 
-The first rollout is advisory. The check reports findings but does not fail CI unless `CODE_COMPLEXITY_FAIL_ON_EXCEEDED=true` is set.
+The `Code Complexity` workflow fails the pull request when cyclop or CA1502 findings exceed the
+threshold of 15. Locally the check still reports in warning mode unless
+`CODE_COMPLEXITY_FAIL_ON_EXCEEDED=true` is set.
 
 ## Local Usage
 
@@ -39,10 +41,9 @@ The repository-wide maximum cyclomatic complexity is 15. It is declared in three
 stay in step: `MAX_COMPLEXITY` in `scripts/check-code-complexity.sh`, `cyclop.max-complexity`
 in `cli/.golangci-complexity.yml`, and `--max-complexity` in the artifact step of
 `.github/workflows/code-complexity.yml`. The `Code Complexity` workflow runs on every pull request that
-touches `cli/**/*.go` or `Packages/src/**/*.cs`, reports findings, and uploads per-module JSON
-artifacts — it never fails the build.
+touches `cli/**/*.go` or `Packages/src/**/*.cs`, fails the job when findings exceed the threshold,
+and uploads per-module JSON artifacts.
 
-When touching a reported function, prefer reducing complexity before adding behavior. Use tests first, then refactor with small steps such as guard clauses, Extract Method, or data-driven dispatch.
+When touching a reported function, reduce its complexity before adding behavior. Use tests first, then refactor with small steps such as guard clauses, Extract Method, or data-driven dispatch.
 
-Because the check is advisory, the threshold only does its job if someone reads the report. Treat
-a new finding in code you are already editing as review feedback, not as noise to defer.
+A new finding in code you are already editing is a required fix, not noise to defer.

--- a/docs/code-complexity.md
+++ b/docs/code-complexity.md
@@ -37,10 +37,18 @@ dotnet run --project tools/UnityCliLoop.CodeComplexity -- --root . --max-complex
 
 ## Operating Policy
 
-The repository-wide maximum cyclomatic complexity is 15. It is declared in three places that must
-stay in step: `MAX_COMPLEXITY` in `scripts/check-code-complexity.sh`, `cyclop.max-complexity`
-in `cli/.golangci-complexity.yml`, and `--max-complexity` in the artifact step of
-`.github/workflows/code-complexity.yml`. The `Code Complexity` workflow runs on every pull request that
+The repository-wide maximum cyclomatic complexity is 15. It is declared in five places that must
+stay in step:
+
+1. `MAX_COMPLEXITY` in `scripts/check-code-complexity.sh`
+2. `cyclop.max-complexity` in `cli/.golangci-complexity.yml`
+3. `--max-complexity` in the artifact step of `.github/workflows/code-complexity.yml`
+4. `CA1502: 15` in `tools/UnityCliLoop.CodeComplexity/CodeMetricsConfig.txt` — this file-backed
+   config is the one the C# host actually consumes whenever the requested threshold is 15
+5. `maxComplexity: 15` in `CodeComplexityOptions.Default` — covers argument-less runs of the
+   C# host only
+
+The `Code Complexity` workflow runs on every pull request that
 touches `cli/**/*.go` or `Packages/src/**/*.cs`, fails the job when findings exceed the threshold,
 and uploads per-module JSON artifacts.
 


### PR DESCRIPTION
## Summary
- The Code Complexity workflow now fails the pull request when cyclop or CA1502 findings exceed 15, instead of only reporting them.
- Contributor docs match that enforcing policy.

## User Impact
- Before: over-threshold complexity could land on a feature branch and only surface later, because CI never failed the job.
- After: a pull request that introduces cyclop or CA1502 findings above 15 fails Complexity Report.

## Changes
- Set `CODE_COMPLEXITY_FAIL_ON_EXCEEDED: 'true'` on the Report complexity step. No `uses:` refs were added or retargeted.
- Update `docs/code-complexity.md` and `AGENTS.md` from advisory wording to enforcing wording. Local `scripts/check-code-complexity.sh` still defaults to warning mode unless the env var is set.

## Verification
- On merged v3-beta (`7fd6e5bfe`): `CODE_COMPLEXITY_FAIL_ON_EXCEEDED=true scripts/check-code-complexity.sh` → exit 0 (Go cyclop 0 issues × 4 modules; C# "No CA1502 complexity issues found above threshold 15")
- Read `docs/github-actions-security.md` before editing the workflow (checkout still `persist-credentials: false`; setup-go still `cache: false`; no new actions)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

