### PR TITLE
ci: report source files exceeding the 500-line limit

### DIFF
--- a/.github/workflows/code-complexity.yml
+++ b/.github/workflows/code-complexity.yml
@@ -7,9 +7,12 @@ on:
       - 'cli/.go-version'
       - 'cli/.golangci-complexity.yml'
       - 'Packages/src/**/*.cs'
+      - 'tools/**/*.cs'
       - 'tools/UnityCliLoop.CodeComplexity/**'
       - 'tests/UnityCliLoop.CodeComplexity.Tests/**'
       - 'scripts/check-code-complexity.sh'
+      - 'scripts/check-file-length.sh'
+      - 'docs/file-length.md'
       - '.github/workflows/code-complexity.yml'
   workflow_dispatch:
 
@@ -71,3 +74,24 @@ jobs:
         with:
           name: code-complexity-results
           path: artifacts/*.json
+
+  file-length:
+    name: File Length Report
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: cli/.go-version
+          cache: false
+
+      - name: Report file length
+        env:
+          CODE_FILE_LENGTH_FAIL_ON_EXCEEDED: 'false'
+        run: scripts/check-file-length.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,15 @@ for C#. The `Code Complexity` workflow fails the pull request when findings exce
 threshold. When you touch a reported function, reduce its complexity before adding behavior.
 Commands and the five places the threshold is declared: `docs/code-complexity.md`.
 
+## File Length
+
+The repository-wide maximum production file length is 500 SLOC, counted by the
+file-length checker after dropping comments and blank lines. The `File Length
+Report` job currently reports over-limit files without failing the pull request.
+When you touch a reported file, split it before adding behavior. Commands, the
+exclusion list, and the two places the threshold is declared:
+`docs/file-length.md`.
+
 ## Native Go CLI Validation
 
 When running `uloop` commands for this project during CLI development, do not use the `uloop`

--- a/cli/release-automation/cmd/check-file-length/main.go
+++ b/cli/release-automation/cmd/check-file-length/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"strings"
+
+	"github.com/hatayama/unity-cli-loop/tools/release-automation/internal/automation"
+)
+
+func main() {
+	root := flag.String("root", ".", "repository root to scan")
+	maxLength := flag.Int("max-length", automation.DefaultMaxFileLength, "maximum allowed SLOC per file")
+	// Parsed as a string so the POSIX wrapper can pass `--fail-on-exceeded false`.
+	// Go's bool flags treat a bare `--fail-on-exceeded` as true and would ignore the
+	// following `false` token, which would flip report-only runs into fail mode.
+	failOnExceeded := flag.String("fail-on-exceeded", "false", "exit 1 when any file exceeds the limit (true/false)")
+	flag.Parse()
+
+	os.Exit(automation.RunFileLengthCheck(os.Stdout, os.Stderr, automation.FileLengthCheckOptions{
+		Root:           *root,
+		MaxLength:      *maxLength,
+		FailOnExceeded: failOnExceededEnabled(*failOnExceeded),
+	}))
+}
+
+func failOnExceededEnabled(value string) bool {
+	return strings.EqualFold(strings.TrimSpace(value), "true")
+}

--- a/cli/release-automation/cmd/check-file-length/main_test.go
+++ b/cli/release-automation/cmd/check-file-length/main_test.go
@@ -1,0 +1,22 @@
+package main
+
+import "testing"
+
+func TestFailOnExceededEnabledTreatsFalseTokenAsReportOnly(t *testing.T) {
+	// Verifies the POSIX wrapper's `--fail-on-exceeded false` does not enable fail mode.
+	if failOnExceededEnabled("false") {
+		t.Fatal("expected false to keep report-only mode")
+	}
+	if failOnExceededEnabled("FALSE") {
+		t.Fatal("expected FALSE to keep report-only mode")
+	}
+	if failOnExceededEnabled("") {
+		t.Fatal("expected empty value to keep report-only mode")
+	}
+	if !failOnExceededEnabled("true") {
+		t.Fatal("expected true to enable fail mode")
+	}
+	if !failOnExceededEnabled("TRUE") {
+		t.Fatal("expected TRUE to enable fail mode")
+	}
+}

--- a/cli/release-automation/internal/automation/file_length.go
+++ b/cli/release-automation/internal/automation/file_length.go
@@ -1,0 +1,182 @@
+package automation
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// DefaultMaxFileLength is the repository-wide SLOC limit. Keep this equal to
+// MAX_FILE_LENGTH in scripts/check-file-length.sh; those are the only two
+// declaration sites for the threshold.
+const DefaultMaxFileLength = 500
+
+// productionSourceRoots are the only trees the file-length checker walks.
+// Tests, Assets, and other trees stay out of scope by omission, not by a
+// second exclusion list that could drift from this table.
+var productionSourceRoots = []struct {
+	relativeDir string
+	extension   string
+}{
+	{relativeDir: "Packages/src", extension: ".cs"},
+	{relativeDir: "cli", extension: ".go"},
+	{relativeDir: "tools", extension: ".cs"},
+}
+
+// FileLengthFinding is one production source file whose SLOC exceeds the limit.
+type FileLengthFinding struct {
+	Path string
+	SLOC int
+}
+
+// FileLengthCheckOptions configures RunFileLengthCheck.
+type FileLengthCheckOptions struct {
+	Root           string
+	MaxLength      int
+	FailOnExceeded bool
+}
+
+// ScanFileLengths walks production sources under root and returns every file
+// whose SLOC is greater than maxLength. Paths use forward slashes so reports
+// stay stable on Windows.
+func ScanFileLengths(root string, maxLength int) ([]FileLengthFinding, error) {
+	findings := []FileLengthFinding{}
+	for _, sourceRoot := range productionSourceRoots {
+		rootFindings, err := scanProductionRoot(root, sourceRoot.relativeDir, sourceRoot.extension, maxLength)
+		if err != nil {
+			return nil, err
+		}
+		findings = append(findings, rootFindings...)
+	}
+	sort.Slice(findings, func(left int, right int) bool {
+		return findings[left].Path < findings[right].Path
+	})
+	return findings, nil
+}
+
+// RunFileLengthCheck prints findings and returns the process exit code.
+func RunFileLengthCheck(stdout io.Writer, stderr io.Writer, options FileLengthCheckOptions) int {
+	maxLength := options.MaxLength
+	if maxLength <= 0 {
+		maxLength = DefaultMaxFileLength
+	}
+	findings, err := ScanFileLengths(options.Root, maxLength)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "check-file-length:", err)
+		return 1
+	}
+	_, _ = fmt.Fprintf(stdout, "=== File length (SLOC, max %d) ===\n", maxLength)
+	if len(findings) == 0 {
+		_, _ = fmt.Fprintln(stdout, "No files exceeded the file-length limit.")
+		return 0
+	}
+	for _, finding := range findings {
+		_, _ = fmt.Fprintf(stdout, "%s: %d SLOC (limit %d)\n", finding.Path, finding.SLOC, maxLength)
+	}
+	_, _ = fmt.Fprintf(stdout, "%d files exceeded the %d-line limit.\n", len(findings), maxLength)
+	if options.FailOnExceeded {
+		return 1
+	}
+	_, _ = fmt.Fprintln(stdout, "File-length findings were reported in warning mode; set CODE_FILE_LENGTH_FAIL_ON_EXCEEDED=true to fail on findings.")
+	return 0
+}
+
+func scanProductionRoot(repoRoot string, relativeDir string, extension string, maxLength int) ([]FileLengthFinding, error) {
+	absoluteRoot := filepath.Join(repoRoot, filepath.FromSlash(relativeDir))
+	fileInfo, err := os.Stat(absoluteRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if !fileInfo.IsDir() {
+		return nil, fmt.Errorf("production source root %s is not a directory", relativeDir)
+	}
+
+	findings := []FileLengthFinding{}
+	walkErr := filepath.WalkDir(absoluteRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relativePath, err := filepath.Rel(repoRoot, path)
+		if err != nil {
+			return err
+		}
+		slashPath := filepath.ToSlash(relativePath)
+		if entry.IsDir() {
+			if shouldSkipFileLengthDirectory(slashPath, entry.Name()) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(strings.ToLower(entry.Name()), extension) {
+			return nil
+		}
+		if isExcludedFromFileLength(slashPath) {
+			return nil
+		}
+		finding, exceeded, err := inspectFileLength(path, slashPath, maxLength)
+		if err != nil {
+			return err
+		}
+		if exceeded {
+			findings = append(findings, finding)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return findings, nil
+}
+
+func inspectFileLength(absolutePath string, slashPath string, maxLength int) (FileLengthFinding, bool, error) {
+	source, err := os.ReadFile(absolutePath)
+	if err != nil {
+		return FileLengthFinding{}, false, err
+	}
+	language, ok := languageForPath(slashPath)
+	if !ok {
+		return FileLengthFinding{}, false, nil
+	}
+	sloc := CountSLOC(source, language)
+	if sloc <= maxLength {
+		return FileLengthFinding{}, false, nil
+	}
+	return FileLengthFinding{Path: slashPath, SLOC: sloc}, true, nil
+}
+
+func languageForPath(slashPath string) (SourceLanguage, bool) {
+	extension := strings.ToLower(filepath.Ext(slashPath))
+	if extension == ".cs" {
+		return LanguageCSharp, true
+	}
+	if extension == ".go" {
+		return LanguageGo, true
+	}
+	return 0, false
+}
+
+func shouldSkipFileLengthDirectory(slashPath string, directoryName string) bool {
+	if directoryName == "Tests" || directoryName == "testdata" {
+		return true
+	}
+	return isExcludedFromFileLength(slashPath + "/")
+}
+
+// isExcludedFromFileLength is the single exclusion list for the checker.
+// Keep this in step with docs/file-length.md.
+func isExcludedFromFileLength(slashPath string) bool {
+	if strings.Contains(slashPath, "/Tests/") || strings.HasPrefix(slashPath, "Tests/") {
+		return true
+	}
+	if strings.Contains(slashPath, "/testdata/") || strings.HasPrefix(slashPath, "testdata/") {
+		return true
+	}
+	return strings.HasSuffix(slashPath, "_test.go")
+}

--- a/cli/release-automation/internal/automation/file_length_sloc.go
+++ b/cli/release-automation/internal/automation/file_length_sloc.go
@@ -158,6 +158,15 @@ func (s *slocScanner) tryGoString() bool {
 		s.scanGoRawString()
 		return true
 	}
+	// why: a rune such as '\"' would otherwise leave the apostrophe as code and
+	// then treat the inner double-quote as an interpreted-string opener, so later
+	// comment-only lines can be swallowed as string content.
+	if current == '\'' {
+		s.markCode()
+		s.nextRune()
+		s.scanEscapedQuotedString('\'')
+		return true
+	}
 	return false
 }
 

--- a/cli/release-automation/internal/automation/file_length_sloc.go
+++ b/cli/release-automation/internal/automation/file_length_sloc.go
@@ -1,0 +1,408 @@
+package automation
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// SourceLanguage selects which comment and string rules CountSLOC applies.
+type SourceLanguage int
+
+const (
+	// LanguageCSharp counts C# comments and string literals, including verbatim,
+	// character, and interpolated forms.
+	LanguageCSharp SourceLanguage = iota
+	// LanguageGo counts Go comments, interpreted strings, and raw strings.
+	LanguageGo
+)
+
+const utf8BOM = '\uFEFF'
+
+// CountSLOC returns the number of source lines that are neither blank nor
+// comment-only. Comment markers inside string literals are treated as code,
+// which is why this counts with a lexer instead of line prefixes.
+func CountSLOC(source []byte, language SourceLanguage) int {
+	scanner := newSLOCScanner(source, language)
+	return scanner.count()
+}
+
+type slocScanner struct {
+	source      []byte
+	offset      int
+	language    SourceLanguage
+	lineHasCode bool
+	sloc        int
+}
+
+func newSLOCScanner(source []byte, language SourceLanguage) *slocScanner {
+	scanner := &slocScanner{
+		source:   source,
+		language: language,
+	}
+	scanner.skipBOM()
+	return scanner
+}
+
+func (s *slocScanner) count() int {
+	s.scanCode(false)
+	s.finishLine()
+	return s.sloc
+}
+
+func (s *slocScanner) skipBOM() {
+	if s.peekRune() == utf8BOM {
+		s.nextRune()
+	}
+}
+
+func (s *slocScanner) scanCode(stopOnUnmatchedBrace bool) {
+	braceDepth := 0
+	for !s.atEnd() {
+		current := s.peekRune()
+		if isNewline(current) {
+			s.consumeNewline()
+			continue
+		}
+		if isHorizontalWhitespace(current) {
+			s.nextRune()
+			continue
+		}
+		if s.tryComment() {
+			continue
+		}
+		if stopOnUnmatchedBrace && s.handleInterpolationBrace(current, &braceDepth) {
+			return
+		}
+		if s.tryString() {
+			continue
+		}
+		s.markCode()
+		s.nextRune()
+	}
+}
+
+func (s *slocScanner) handleInterpolationBrace(current rune, braceDepth *int) bool {
+	if current != '{' && current != '}' {
+		return false
+	}
+	s.markCode()
+	s.nextRune()
+	if current == '{' {
+		*braceDepth++
+		return false
+	}
+	if *braceDepth == 0 {
+		return true
+	}
+	*braceDepth--
+	return false
+}
+
+func (s *slocScanner) tryComment() bool {
+	if s.peekRune() != '/' {
+		return false
+	}
+	next := s.peekRuneAt(1)
+	if next == '/' {
+		s.skipLineComment()
+		return true
+	}
+	if next == '*' {
+		s.skipBlockComment()
+		return true
+	}
+	return false
+}
+
+func (s *slocScanner) skipLineComment() {
+	for !s.atEnd() && !isNewline(s.peekRune()) {
+		s.nextRune()
+	}
+}
+
+func (s *slocScanner) skipBlockComment() {
+	s.nextRune()
+	s.nextRune()
+	for !s.atEnd() {
+		if isNewline(s.peekRune()) {
+			s.consumeNewline()
+			continue
+		}
+		if s.peekRune() == '*' && s.peekRuneAt(1) == '/' {
+			s.nextRune()
+			s.nextRune()
+			return
+		}
+		s.nextRune()
+	}
+}
+
+func (s *slocScanner) tryString() bool {
+	if s.language == LanguageGo {
+		return s.tryGoString()
+	}
+	return s.tryCSharpString()
+}
+
+func (s *slocScanner) tryGoString() bool {
+	current := s.peekRune()
+	if current == '"' {
+		s.markCode()
+		s.nextRune()
+		s.scanEscapedQuotedString('"')
+		return true
+	}
+	if current == '`' {
+		s.markCode()
+		s.nextRune()
+		s.scanGoRawString()
+		return true
+	}
+	return false
+}
+
+func (s *slocScanner) tryCSharpString() bool {
+	if s.hasPrefix("$@\"") || s.hasPrefix("@$\"") {
+		s.markCode()
+		s.skipRunes(3)
+		s.scanCSharpInterpolatedString(true)
+		return true
+	}
+	if s.hasPrefix("$\"") {
+		s.markCode()
+		s.skipRunes(2)
+		s.scanCSharpInterpolatedString(false)
+		return true
+	}
+	if s.hasPrefix("@\"") {
+		s.markCode()
+		s.skipRunes(2)
+		s.scanCSharpVerbatimString()
+		return true
+	}
+	current := s.peekRune()
+	if current == '"' || current == '\'' {
+		s.markCode()
+		s.nextRune()
+		s.scanEscapedQuotedString(current)
+		return true
+	}
+	return false
+}
+
+func (s *slocScanner) scanEscapedQuotedString(quote rune) {
+	for !s.atEnd() {
+		current := s.peekRune()
+		if isNewline(current) {
+			s.consumeNewline()
+			continue
+		}
+		if current == '\\' {
+			s.consumeEscapedRune()
+			continue
+		}
+		if current == quote {
+			s.markCode()
+			s.nextRune()
+			return
+		}
+		s.consumeStringRune(current)
+	}
+}
+
+func (s *slocScanner) scanCSharpVerbatimString() {
+	for !s.atEnd() {
+		current := s.peekRune()
+		if isNewline(current) {
+			s.consumeNewline()
+			continue
+		}
+		if current == '"' {
+			s.markCode()
+			s.nextRune()
+			if s.peekRune() == '"' {
+				s.nextRune()
+				continue
+			}
+			return
+		}
+		s.consumeStringRune(current)
+	}
+}
+
+func (s *slocScanner) scanGoRawString() {
+	for !s.atEnd() {
+		current := s.peekRune()
+		if isNewline(current) {
+			s.consumeNewline()
+			continue
+		}
+		if current == '`' {
+			s.markCode()
+			s.nextRune()
+			return
+		}
+		s.consumeStringRune(current)
+	}
+}
+
+func (s *slocScanner) scanCSharpInterpolatedString(verbatim bool) {
+	for !s.atEnd() {
+		current := s.peekRune()
+		if isNewline(current) {
+			s.consumeNewline()
+			continue
+		}
+		if current == '{' {
+			s.consumeInterpolationHole()
+			continue
+		}
+		if current == '}' && s.peekRuneAt(1) == '}' {
+			s.markCode()
+			s.nextRune()
+			s.nextRune()
+			continue
+		}
+		if !verbatim && current == '\\' {
+			s.consumeEscapedRune()
+			continue
+		}
+		if s.consumeInterpolatedQuote(current, verbatim) {
+			return
+		}
+		s.consumeStringRune(current)
+	}
+}
+
+func (s *slocScanner) consumeInterpolatedQuote(current rune, verbatim bool) bool {
+	if current != '"' {
+		return false
+	}
+	if verbatim && s.peekRuneAt(1) == '"' {
+		s.markCode()
+		s.nextRune()
+		s.nextRune()
+		return false
+	}
+	s.markCode()
+	s.nextRune()
+	return true
+}
+
+func (s *slocScanner) consumeInterpolationHole() {
+	if s.peekRuneAt(1) == '{' {
+		s.markCode()
+		s.nextRune()
+		s.nextRune()
+		return
+	}
+	s.markCode()
+	s.nextRune()
+	s.scanCode(true)
+}
+
+func (s *slocScanner) consumeEscapedRune() {
+	s.markCode()
+	s.nextRune()
+	if s.atEnd() || isNewline(s.peekRune()) {
+		return
+	}
+	s.nextRune()
+}
+
+func (s *slocScanner) consumeStringRune(current rune) {
+	if !isHorizontalWhitespace(current) {
+		s.markCode()
+	}
+	s.nextRune()
+}
+
+func (s *slocScanner) consumeNewline() {
+	if s.peekRune() == '\r' {
+		s.nextRune()
+		if s.peekRune() == '\n' {
+			s.nextRune()
+		}
+	} else {
+		s.nextRune()
+	}
+	s.finishLine()
+}
+
+func (s *slocScanner) finishLine() {
+	if !s.lineHasCode {
+		return
+	}
+	s.sloc++
+	s.lineHasCode = false
+}
+
+func (s *slocScanner) markCode() {
+	s.lineHasCode = true
+}
+
+func (s *slocScanner) atEnd() bool {
+	return s.offset >= len(s.source)
+}
+
+func (s *slocScanner) peekRune() rune {
+	return s.peekRuneAt(0)
+}
+
+func (s *slocScanner) peekRuneAt(runeOffset int) rune {
+	offset := s.offset
+	remaining := runeOffset
+	for remaining >= 0 {
+		if offset >= len(s.source) {
+			return 0
+		}
+		value, width := utf8.DecodeRune(s.source[offset:])
+		if remaining == 0 {
+			return value
+		}
+		offset += width
+		remaining--
+	}
+	return 0
+}
+
+func (s *slocScanner) nextRune() rune {
+	if s.atEnd() {
+		return 0
+	}
+	value, width := utf8.DecodeRune(s.source[s.offset:])
+	s.offset += width
+	return value
+}
+
+func (s *slocScanner) skipRunes(count int) {
+	for index := 0; index < count; index++ {
+		s.nextRune()
+	}
+}
+
+func (s *slocScanner) hasPrefix(prefix string) bool {
+	offset := s.offset
+	for _, expected := range prefix {
+		if offset >= len(s.source) {
+			return false
+		}
+		value, width := utf8.DecodeRune(s.source[offset:])
+		if value != expected {
+			return false
+		}
+		offset += width
+	}
+	return true
+}
+
+func isNewline(value rune) bool {
+	return value == '\n' || value == '\r'
+}
+
+func isHorizontalWhitespace(value rune) bool {
+	if isNewline(value) {
+		return false
+	}
+	return unicode.IsSpace(value)
+}

--- a/cli/release-automation/internal/automation/file_length_test.go
+++ b/cli/release-automation/internal/automation/file_length_test.go
@@ -58,12 +58,25 @@ func TestCountSLOCTreatsCRLFAndLFAsTheSameCount(t *testing.T) {
 }
 
 func TestCountSLOCIgnoresUTF8BOM(t *testing.T) {
-	// Verifies a UTF-8 BOM does not add a source line or hide the first statement.
-	withoutBOM := "int x = 1;\n"
-	withBOM := append([]byte{0xEF, 0xBB, 0xBF}, []byte(withoutBOM)...)
-	if CountSLOC(withBOM, LanguageCSharp) != CountSLOC([]byte(withoutBOM), LanguageCSharp) {
-		t.Fatal("expected BOM and BOM-less sources to count the same SLOC")
+	// Verifies a UTF-8 BOM on a comment-only line is not itself SLOC.
+	// why not pair BOM with a code line: unicode.IsSpace(U+FEFF) is false, so a
+	// missing skipBOM would still pass if that line is counted for other code.
+	withBOM := append([]byte{0xEF, 0xBB, 0xBF}, []byte("// comment only\n")...)
+	if CountSLOC(withBOM, LanguageCSharp) != 0 {
+		t.Fatal("expected BOM followed by a comment-only line to count 0 SLOC")
 	}
+}
+
+func TestCountSLOCDoesNotTreatGoRuneLiteralQuoteAsStringOpener(t *testing.T) {
+	// Verifies a Go rune containing a double-quote does not swallow a later comment line.
+	source := "q := '\\\"'\n// comment only\nx := 1\n"
+	assertSLOC(t, source, LanguageGo, 2)
+}
+
+func TestCountSLOCCountsGoRuneLiteralWithEscapedApostrophe(t *testing.T) {
+	// Verifies an escaped apostrophe inside a Go rune literal still closes correctly.
+	source := "q := '\\''\n"
+	assertSLOC(t, source, LanguageGo, 1)
 }
 
 func TestCountSLOCExcludesBlankAndCommentOnlyLines(t *testing.T) {

--- a/cli/release-automation/internal/automation/file_length_test.go
+++ b/cli/release-automation/internal/automation/file_length_test.go
@@ -1,0 +1,217 @@
+package automation
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCountSLOCIgnoresCommentMarkersInsideCSharpStrings(t *testing.T) {
+	// Verifies // and /* inside C# quoted strings count as code, not comments.
+	source := "string url = \"http://example.com/*path*/\";\n"
+	assertSLOC(t, source, LanguageCSharp, 1)
+}
+
+func TestCountSLOCIgnoresCommentMarkersInsideGoStrings(t *testing.T) {
+	// Verifies // and /* inside Go interpreted strings count as code, not comments.
+	source := "url := \"http://example.com/*path*/\"\n"
+	assertSLOC(t, source, LanguageGo, 1)
+}
+
+func TestCountSLOCCountsVerbatimStringCommentLookalikes(t *testing.T) {
+	// Verifies a verbatim string line that looks like a comment still counts as SLOC.
+	source := "string s = @\"\n// not a comment\n/* also not */\n\";"
+	assertSLOC(t, source, LanguageCSharp, 4)
+}
+
+func TestCountSLOCCountsGoRawStringCommentLookalikes(t *testing.T) {
+	// Verifies a Go raw-string line that looks like a comment still counts as SLOC.
+	source := "s := `\n// not a comment\n/* also not */\n`"
+	assertSLOC(t, source, LanguageGo, 4)
+}
+
+func TestCountSLOCCountsTrailingLineCommentWithCode(t *testing.T) {
+	// Verifies `code(); // note` is one SLOC because the statement remains.
+	source := "code(); // note\n"
+	assertSLOC(t, source, LanguageCSharp, 1)
+	assertSLOC(t, source, LanguageGo, 1)
+}
+
+func TestCountSLOCCountsBlockCommentMixedWithCodeOnSameLine(t *testing.T) {
+	// Verifies a line that mixes a block comment with statements still counts once.
+	source := "int x = 1; /* comment */ int y = 2;\n"
+	assertSLOC(t, source, LanguageCSharp, 1)
+	assertSLOC(t, source, LanguageGo, 1)
+}
+
+func TestCountSLOCTreatsCRLFAndLFAsTheSameCount(t *testing.T) {
+	// Verifies Windows CRLF and Unix LF produce the same SLOC for the same statements.
+	lfSource := "int x = 1;\n\nint y = 2;\n"
+	crlfSource := "int x = 1;\r\n\r\nint y = 2;\r\n"
+	lfCount := CountSLOC([]byte(lfSource), LanguageCSharp)
+	crlfCount := CountSLOC([]byte(crlfSource), LanguageCSharp)
+	if lfCount != 2 || crlfCount != lfCount {
+		t.Fatalf("expected CRLF and LF to both count 2 SLOC, got LF=%d CRLF=%d", lfCount, crlfCount)
+	}
+}
+
+func TestCountSLOCIgnoresUTF8BOM(t *testing.T) {
+	// Verifies a UTF-8 BOM does not add a source line or hide the first statement.
+	withoutBOM := "int x = 1;\n"
+	withBOM := append([]byte{0xEF, 0xBB, 0xBF}, []byte(withoutBOM)...)
+	if CountSLOC(withBOM, LanguageCSharp) != CountSLOC([]byte(withoutBOM), LanguageCSharp) {
+		t.Fatal("expected BOM and BOM-less sources to count the same SLOC")
+	}
+}
+
+func TestCountSLOCExcludesBlankAndCommentOnlyLines(t *testing.T) {
+	// Verifies blank lines, // comments, /// docs, and block-comment-only lines are not SLOC.
+	source := "// line comment\n" +
+		"/// xml doc\n" +
+		"\n" +
+		"/*\n" +
+		" block\n" +
+		" */\n" +
+		"int x = 1;\n"
+	assertSLOC(t, source, LanguageCSharp, 1)
+}
+
+func TestCountSLOCCountsCSharpInterpolatedStringHolesAsCode(t *testing.T) {
+	// Verifies interpolation holes are scanned as code so nested strings stay intact.
+	source := "string s = $\"http://example.com/{id}\";\n"
+	assertSLOC(t, source, LanguageCSharp, 1)
+}
+
+func TestCountSLOCCountsCSharpVerbatimInterpolationCommentLookalikes(t *testing.T) {
+	// Verifies $@ verbatim interpolation still treats // inside the string as code.
+	source := "string s = $@\"\n// not a comment {id}\n\";"
+	assertSLOC(t, source, LanguageCSharp, 3)
+}
+
+func TestCountSLOCCountsCSharpCharacterLiteralWithEscapedQuote(t *testing.T) {
+	// Verifies an escaped quote in a char literal does not end the literal early.
+	source := "char quote = '\\''; // note\n"
+	assertSLOC(t, source, LanguageCSharp, 1)
+}
+
+func TestScanFileLengthsReportsOnlyProductionSourcesOverTheLimit(t *testing.T) {
+	// Verifies the centralized exclusion list drops tests, testdata, and Assets.
+	root := t.TempDir()
+	writeRepoFile(t, root, "Packages/src/OverLimit.cs", csharpLines(3))
+	writeRepoFile(t, root, "Packages/src/Tests/OverLimitTest.cs", csharpLines(3))
+	writeRepoFile(t, root, "cli/over_limit.go", goLines(3))
+	writeRepoFile(t, root, "cli/over_limit_test.go", goLines(3))
+	writeRepoFile(t, root, "cli/internal/testdata/sample.go", goLines(3))
+	writeRepoFile(t, root, "tools/OverLimit.cs", csharpLines(3))
+	writeRepoFile(t, root, "Assets/OverLimit.cs", csharpLines(3))
+	writeRepoFile(t, root, "Packages/src/UnderLimit.cs", csharpLines(1))
+
+	findings, err := ScanFileLengths(root, 2)
+	if err != nil {
+		t.Fatalf("ScanFileLengths returned %v", err)
+	}
+	got := findingPaths(findings)
+	want := []string{
+		"Packages/src/OverLimit.cs",
+		"cli/over_limit.go",
+		"tools/OverLimit.cs",
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("unexpected findings: got %v want %v", got, want)
+	}
+}
+
+func TestRunFileLengthCheckWarnsWithoutFailingWhenFindingsExist(t *testing.T) {
+	// Verifies warning mode prints findings and still exits 0.
+	root := t.TempDir()
+	writeRepoFile(t, root, "Packages/src/OverLimit.cs", csharpLines(3))
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	exitCode := RunFileLengthCheck(stdout, stderr, FileLengthCheckOptions{
+		Root:           root,
+		MaxLength:      2,
+		FailOnExceeded: false,
+	})
+	if exitCode != 0 {
+		t.Fatalf("expected warning mode to exit 0, got %d", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "Packages/src/OverLimit.cs: 3 SLOC (limit 2)") {
+		t.Fatalf("expected finding in stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "CODE_FILE_LENGTH_FAIL_ON_EXCEEDED=true") {
+		t.Fatalf("expected warning-mode hint, got %q", stdout.String())
+	}
+}
+
+func TestRunFileLengthCheckFailsWhenFailOnExceeded(t *testing.T) {
+	// Verifies fail mode exits 1 when any file exceeds the limit.
+	root := t.TempDir()
+	writeRepoFile(t, root, "cli/over_limit.go", goLines(3))
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	exitCode := RunFileLengthCheck(stdout, stderr, FileLengthCheckOptions{
+		Root:           root,
+		MaxLength:      2,
+		FailOnExceeded: true,
+	})
+	if exitCode != 1 {
+		t.Fatalf("expected fail mode to exit 1, got %d", exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr on findings, got %q", stderr.String())
+	}
+}
+
+func TestDefaultMaxFileLengthIsFiveHundred(t *testing.T) {
+	// Verifies the Go default stays at the documented 500-line threshold.
+	if DefaultMaxFileLength != 500 {
+		t.Fatalf("DefaultMaxFileLength = %d, want 500", DefaultMaxFileLength)
+	}
+}
+
+func assertSLOC(t *testing.T, source string, language SourceLanguage, want int) {
+	t.Helper()
+	got := CountSLOC([]byte(source), language)
+	if got != want {
+		t.Fatalf("CountSLOC() = %d, want %d for %q", got, want, source)
+	}
+}
+
+func writeRepoFile(t *testing.T, root string, relativePath string, contents string) {
+	t.Helper()
+	absolutePath := filepath.Join(root, filepath.FromSlash(relativePath))
+	if err := os.MkdirAll(filepath.Dir(absolutePath), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(absolutePath), err)
+	}
+	if err := os.WriteFile(absolutePath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", relativePath, err)
+	}
+}
+
+func csharpLines(count int) string {
+	builder := strings.Builder{}
+	for index := 0; index < count; index++ {
+		builder.WriteString("int value = 1;\n")
+	}
+	return builder.String()
+}
+
+func goLines(count int) string {
+	builder := strings.Builder{}
+	for index := 0; index < count; index++ {
+		builder.WriteString("x := 1\n")
+	}
+	return builder.String()
+}
+
+func findingPaths(findings []FileLengthFinding) []string {
+	paths := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		paths = append(paths, finding.Path)
+	}
+	return paths
+}

--- a/docs/file-length.md
+++ b/docs/file-length.md
@@ -1,0 +1,69 @@
+# File Length Checks
+
+This repository limits production source files to 500 source lines of code (SLOC).
+SLOC is the number of lines that are neither blank nor comment-only. Line comments
+(`//`, including C# `///`) and block comments (`/* */`) are excluded. Comment
+markers inside string literals are code, not comments.
+
+## Scope
+
+The checker walks only these trees:
+
+- `Packages/src/**/*.cs`, including Unity-ignored `~` folders
+- `cli/**/*.go`
+- `tools/**/*.cs`
+
+It excludes tests and fixtures with one list, owned by the Go tool:
+
+- any path containing `/Tests/`
+- any path containing `/testdata/`
+- `*_test.go`
+- `Assets/` and every other tree, by not walking them
+
+`partial class` is not a permitted way to satisfy the limit. Split files with
+real Extract Class / Move Method so each type keeps one source file.
+
+## Local Usage
+
+Run the check:
+
+```sh
+scripts/check-file-length.sh
+```
+
+Use a different limit:
+
+```sh
+CODE_FILE_LENGTH_MAX_LENGTH=600 scripts/check-file-length.sh
+```
+
+Fail on findings:
+
+```sh
+CODE_FILE_LENGTH_FAIL_ON_EXCEEDED=true scripts/check-file-length.sh
+```
+
+Run the Go tool directly:
+
+```sh
+(cd cli/release-automation && go run ./cmd/check-file-length --root ../.. --max-length 500)
+```
+
+## Operating Policy
+
+The repository-wide maximum file length is 500 SLOC. It is declared in two
+places that must stay in step:
+
+1. `MAX_FILE_LENGTH` in `scripts/check-file-length.sh`
+2. `DefaultMaxFileLength` in `cli/release-automation/internal/automation/file_length.go`
+
+The `File Length Report` job on the `Code Complexity` workflow reports files
+over the limit and does not fail the pull request yet. Locally the check stays
+in warning mode unless `CODE_FILE_LENGTH_FAIL_ON_EXCEEDED=true` is set.
+
+When touching a reported file, split it below the limit before adding behavior.
+A new over-limit file in a change under review is a required fix, not noise to
+defer.
+
+CRLF and LF encodings of the same source must produce the same SLOC. A UTF-8
+BOM is ignored and does not count as a source line.

--- a/scripts/check-file-length.sh
+++ b/scripts/check-file-length.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
+MAX_FILE_LENGTH=${CODE_FILE_LENGTH_MAX_LENGTH:-500}
+FAIL_ON_EXCEEDED=$(printf '%s' "${CODE_FILE_LENGTH_FAIL_ON_EXCEEDED:-false}" | tr '[:upper:]' '[:lower:]')
+
+(
+  cd "$ROOT_DIR/cli/release-automation"
+  go run ./cmd/check-file-length --root "$ROOT_DIR" --max-length "$MAX_FILE_LENGTH" --fail-on-exceeded "$FAIL_ON_EXCEEDED"
+)


### PR DESCRIPTION
## Summary
- Pull requests that touch production C#, Go CLI, or tools sources now get a **File Length Report** job that lists files over 500 SLOC.
- The job is advisory: it does not fail the pull request yet, so existing over-limit files can be split in follow-up changes.

## User Impact
- Before this change, file length was not measured in CI, so oversized production files could grow unnoticed.
- After this change, the report shows every over-limit production file on the pull request. Splitting those files is still follow-up work; this PR only makes the debt visible.

## Changes
- Lexer-based SLOC checker (`cli/release-automation/cmd/check-file-length`) that treats `//` / `/*` inside strings as code, not comments.
- POSIX wrapper `scripts/check-file-length.sh` with `MAX_FILE_LENGTH=500` and `CODE_FILE_LENGTH_FAIL_ON_EXCEEDED` defaulting to false.
- Separate `File Length Report` job on the existing Code Complexity workflow (report-only). Reuses the current checkout/setup-go SHA pins.
- `docs/file-length.md` and an AGENTS.md File Length section. The 500 SLOC threshold is declared only in the wrapper script and `DefaultMaxFileLength`.

## First-run over-limit inventory

This list is the authoritative split target for follow-up PRs. Captured from the first local `scripts/check-file-length.sh` run on this branch:

```
Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs: 2899 SLOC (limit 500)
Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs: 584 SLOC (limit 500)
Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs: 7807 SLOC (limit 500)
Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs: 884 SLOC (limit 500)
Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs: 886 SLOC (limit 500)
Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs: 604 SLOC (limit 500)
Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs: 654 SLOC (limit 500)
7 files exceeded the 500-line limit.
```

Go production sources currently have no findings.

## Test plan
- [x] `go test ./cmd/check-file-length ./internal/automation -count=1` in `cli/release-automation` (string-literal comments, verbatim/raw strings, trailing `code(); // note`, mixed block comments, CRLF vs LF, BOM, exclusion list, warning vs fail mode)
- [x] `go test ./internal/architecture -run 'TestWorkflowActions|TestPullRequestWorkflow|TestProductionGoFilesStayFocused' -count=1`
- [x] `scripts/check-go-cli.sh`
- [x] `scripts/check-file-length.sh` exits 0 in warning mode and prints the seven files above


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

