### PR TITLE
refactor: compile the transform worker from every source file in its folder

### DIFF
--- a/Assets/Tests/Editor/HotReload/TransformWorkerBootstrapSourceEnumerationTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerBootstrapSourceEnumerationTests.cs
@@ -1,0 +1,133 @@
+using System.IO;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for transform-worker source enumeration, response-file membership,
+    /// and cache-key sensitivity. These cases cannot be covered by the live TransformWorker~
+    /// folder while it still contains a single .cs file.
+    /// </summary>
+    public class TransformWorkerBootstrapSourceEnumerationTests
+    {
+        /// <summary>
+        /// What: EnumerateWorkerSourceFiles returns every *.cs file sorted by file name with
+        /// StringComparer.Ordinal, independent of creation order.
+        /// </summary>
+        [Test]
+        public void EnumerateWorkerSourceFiles_SortsByFileNameOrdinal()
+        {
+            string directoryPath = CreateWorkDirectory();
+            WriteSource(directoryPath, "zeta.cs", "class Zeta {}");
+            WriteSource(directoryPath, "alpha.cs", "class Alpha {}");
+            WriteSource(directoryPath, "mu.cs", "class Mu {}");
+
+            string[] sourcePaths = TransformWorkerBootstrap.EnumerateWorkerSourceFiles(directoryPath);
+
+            Assert.That(sourcePaths.Length, Is.EqualTo(3));
+            Assert.That(Path.GetFileName(sourcePaths[0]), Is.EqualTo("alpha.cs"));
+            Assert.That(Path.GetFileName(sourcePaths[1]), Is.EqualTo("mu.cs"));
+            Assert.That(Path.GetFileName(sourcePaths[2]), Is.EqualTo("zeta.cs"));
+        }
+
+        /// <summary>
+        /// What: the csc response file lists every enumerated source path, in ordinal file-name
+        /// order, so a second .cs file cannot be silently dropped.
+        /// </summary>
+        [Test]
+        public void WriteWorkerResponseFile_AppendsEverySourceInOrdinalOrder()
+        {
+            string directoryPath = CreateWorkDirectory();
+            WriteSource(directoryPath, "zeta.cs", "class Zeta {}");
+            WriteSource(directoryPath, "alpha.cs", "class Alpha {}");
+            string[] sourcePaths = TransformWorkerBootstrap.EnumerateWorkerSourceFiles(directoryPath);
+
+            string sharedDirectoryPath = Path.Combine(directoryPath, "shared");
+            Directory.CreateDirectory(sharedDirectoryPath);
+            string responseFilePath = Path.Combine(directoryPath, "worker.rsp");
+            TransformWorkerBootstrap.WriteWorkerResponseFile(
+                responseFilePath,
+                sourcePaths,
+                Path.Combine(directoryPath, "worker.dll"),
+                CreateDummyCompilerPaths(sharedDirectoryPath));
+
+            string[] lines = File.ReadAllLines(responseFilePath);
+            int firstSourceIndex = lines.Length - sourcePaths.Length;
+            Assert.That(firstSourceIndex, Is.GreaterThanOrEqualTo(0));
+            Assert.That(lines[firstSourceIndex], Is.EqualTo("\"" + sourcePaths[0] + "\""));
+            Assert.That(lines[firstSourceIndex + 1], Is.EqualTo("\"" + sourcePaths[1] + "\""));
+            Assert.That(Path.GetFileName(sourcePaths[0]), Is.EqualTo("alpha.cs"));
+            Assert.That(Path.GetFileName(sourcePaths[1]), Is.EqualTo("zeta.cs"));
+        }
+
+        /// <summary>
+        /// What: ComputeCacheKey changes when any source file is renamed or when any source
+        /// file's bytes change, so a second file cannot be omitted from the cache identity.
+        /// </summary>
+        [Test]
+        public void ComputeCacheKey_ChangesWhenAnySourceNameOrContentChanges()
+        {
+            string directoryPath = CreateWorkDirectory();
+            WriteSource(directoryPath, "alpha.cs", "class Alpha {}");
+            WriteSource(directoryPath, "zeta.cs", "class Zeta {}");
+            ExternalCompilerPaths paths = CreateDummyCompilerPaths(directoryPath);
+
+            string originalKey = TransformWorkerBootstrap.ComputeCacheKey(
+                TransformWorkerBootstrap.EnumerateWorkerSourceFiles(directoryPath),
+                paths);
+
+            File.Move(
+                Path.Combine(directoryPath, "zeta.cs"),
+                Path.Combine(directoryPath, "mu.cs"));
+            string renamedKey = TransformWorkerBootstrap.ComputeCacheKey(
+                TransformWorkerBootstrap.EnumerateWorkerSourceFiles(directoryPath),
+                paths);
+            Assert.That(renamedKey, Is.Not.EqualTo(originalKey));
+
+            File.WriteAllText(Path.Combine(directoryPath, "alpha.cs"), "class AlphaChanged {}");
+            string contentChangedKey = TransformWorkerBootstrap.ComputeCacheKey(
+                TransformWorkerBootstrap.EnumerateWorkerSourceFiles(directoryPath),
+                paths);
+            Assert.That(contentChangedKey, Is.Not.EqualTo(renamedKey));
+            Assert.That(contentChangedKey, Is.Not.EqualTo(originalKey));
+        }
+
+        private static string CreateWorkDirectory()
+        {
+            string projectRootPath = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string workRootPath = Path.Combine(
+                projectRootPath,
+                "Library",
+                "UloopHotReloadTests",
+                "TransformWorkerBootstrap",
+                Path.GetRandomFileName());
+            Directory.CreateDirectory(workRootPath);
+            return workRootPath;
+        }
+
+        private static void WriteSource(string directoryPath, string fileName, string contents)
+        {
+            File.WriteAllText(Path.Combine(directoryPath, fileName), contents);
+        }
+
+        private static ExternalCompilerPaths CreateDummyCompilerPaths(string sharedDirectoryPath)
+        {
+            return new ExternalCompilerPaths(
+                "editor-contents",
+                "scripting-root",
+                "dotnet",
+                "csc.dll",
+                "csc.runtimeconfig.json",
+                "csc.deps.json",
+                "Microsoft.CodeAnalysis.dll",
+                "Microsoft.CodeAnalysis.CSharp.dll",
+                sharedDirectoryPath,
+                ExternalCompilerLayoutKind.Unknown);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerBootstrapSourceEnumerationTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerBootstrapSourceEnumerationTests.cs
@@ -16,8 +16,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     public class TransformWorkerBootstrapSourceEnumerationTests
     {
         /// <summary>
-        /// What: EnumerateWorkerSourceFiles returns every *.cs file sorted by file name with
-        /// StringComparer.Ordinal, independent of creation order.
+        /// What: EnumerateWorkerSourceFiles sorts by file name with StringComparer.Ordinal.
+        /// Mixed-case names (Beta.cs before alpha.cs) discriminate culture-sensitive and
+        /// case-insensitive sorts. GetFiles order cannot be forced from a test, so this does
+        /// not by itself prove a no-sort implementation fails on every filesystem.
         /// </summary>
         [Test]
         public void EnumerateWorkerSourceFiles_SortsByFileNameOrdinal()
@@ -26,13 +28,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             WriteSource(directoryPath, "zeta.cs", "class Zeta {}");
             WriteSource(directoryPath, "alpha.cs", "class Alpha {}");
             WriteSource(directoryPath, "mu.cs", "class Mu {}");
+            WriteSource(directoryPath, "Beta.cs", "class Beta {}");
 
             string[] sourcePaths = TransformWorkerBootstrap.EnumerateWorkerSourceFiles(directoryPath);
 
-            Assert.That(sourcePaths.Length, Is.EqualTo(3));
-            Assert.That(Path.GetFileName(sourcePaths[0]), Is.EqualTo("alpha.cs"));
-            Assert.That(Path.GetFileName(sourcePaths[1]), Is.EqualTo("mu.cs"));
-            Assert.That(Path.GetFileName(sourcePaths[2]), Is.EqualTo("zeta.cs"));
+            Assert.That(sourcePaths.Length, Is.EqualTo(4));
+            Assert.That(Path.GetFileName(sourcePaths[0]), Is.EqualTo("Beta.cs"));
+            Assert.That(Path.GetFileName(sourcePaths[1]), Is.EqualTo("alpha.cs"));
+            Assert.That(Path.GetFileName(sourcePaths[2]), Is.EqualTo("mu.cs"));
+            Assert.That(Path.GetFileName(sourcePaths[3]), Is.EqualTo("zeta.cs"));
         }
 
         /// <summary>
@@ -67,7 +71,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: ComputeCacheKey changes when any source file is renamed or when any source
-        /// file's bytes change, so a second file cannot be omitted from the cache identity.
+        /// file's bytes change, including a file that is not first in ordinal order, so hashing
+        /// only the first file's content cannot pass.
         /// </summary>
         [Test]
         public void ComputeCacheKey_ChangesWhenAnySourceNameOrContentChanges()
@@ -90,11 +95,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(renamedKey, Is.Not.EqualTo(originalKey));
 
             File.WriteAllText(Path.Combine(directoryPath, "alpha.cs"), "class AlphaChanged {}");
-            string contentChangedKey = TransformWorkerBootstrap.ComputeCacheKey(
+            string firstContentChangedKey = TransformWorkerBootstrap.ComputeCacheKey(
                 TransformWorkerBootstrap.EnumerateWorkerSourceFiles(directoryPath),
                 paths);
-            Assert.That(contentChangedKey, Is.Not.EqualTo(renamedKey));
-            Assert.That(contentChangedKey, Is.Not.EqualTo(originalKey));
+            Assert.That(firstContentChangedKey, Is.Not.EqualTo(renamedKey));
+            Assert.That(firstContentChangedKey, Is.Not.EqualTo(originalKey));
+
+            File.WriteAllText(Path.Combine(directoryPath, "mu.cs"), "class MuChanged {}");
+            string secondContentChangedKey = TransformWorkerBootstrap.ComputeCacheKey(
+                TransformWorkerBootstrap.EnumerateWorkerSourceFiles(directoryPath),
+                paths);
+            Assert.That(secondContentChangedKey, Is.Not.EqualTo(firstContentChangedKey));
+            Assert.That(secondContentChangedKey, Is.Not.EqualTo(renamedKey));
+            Assert.That(secondContentChangedKey, Is.Not.EqualTo(originalKey));
         }
 
         private static string CreateWorkDirectory()

--- a/Assets/Tests/Editor/HotReload/TransformWorkerBootstrapSourceEnumerationTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerBootstrapSourceEnumerationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76ad355b1704c4befbdbee6058a0646c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -20,7 +20,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // assembly happens to recompile.
         public const string PublicizedRefsRelativeDirectory = "Library/UloopHotReload/PublicizedRefs/fmt2";
 
-        // Worker binaries are keyed by SHA256 of the TransformWorker~/TransformWorker.cs source.
+        // Worker binaries are keyed by SHA256 of every TransformWorker~/*.cs file name and content.
         public const string WorkerCacheRelativeDirectory = "Library/UloopHotReload/Worker";
 
         // EditMode e2e tests place edited source copies here so AssetDatabase is never provoked.
@@ -31,9 +31,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // affect the on-disk layout. Adoption is decided at use time by PDB document checksum.
         public const string SourceSnapshotRelativeDirectory = "Library/UloopHotReload/SourceSnapshot";
 
-        // Package-relative path of the out-of-process transform worker source (tilde dir = Unity-ignored).
+        // Package-relative directory of the out-of-process transform worker sources (tilde dir = Unity-ignored).
         public const string WorkerSourcePackageRelativePath =
-            "Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs";
+            "Editor/FirstPartyTools/HotReload/TransformWorker~";
 
         public const string WorkerDllFileName = "worker.dll";
         public const string WorkerRuntimeConfigFileName = "worker.runtimeconfig.json";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerBootstrap.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerBootstrap.cs
@@ -38,16 +38,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     "External compiler paths could not be resolved for this Unity installation.");
             }
 
-            string workerSourcePath = ResolveWorkerSourcePath();
-            if (!File.Exists(workerSourcePath))
+            string workerSourceDirectory = ResolveWorkerSourceDirectory();
+            string[] workerSourcePaths = EnumerateWorkerSourceFiles(workerSourceDirectory);
+            if (workerSourcePaths.Length == 0)
             {
                 return TransformWorkerBootstrapResult.Failure(
-                    "Transform worker source not found: " + workerSourcePath);
+                    "Transform worker source not found: " + workerSourceDirectory);
             }
 
             // Include toolchain paths so a Unity Editor upgrade cannot reuse a stale sidecar that
             // points at a removed Roslyn directory under Library/.
-            string cacheKey = ComputeCacheKey(workerSourcePath, paths);
+            string cacheKey = ComputeCacheKey(workerSourcePaths, paths);
             string cacheDirectory = Path.Combine(ResolveWorkerCacheRoot(), cacheKey);
             string workerDllPath = Path.Combine(cacheDirectory, HotReloadConstants.WorkerDllFileName);
             string runtimeConfigPath = Path.Combine(cacheDirectory, HotReloadConstants.WorkerRuntimeConfigFileName);
@@ -63,7 +64,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Directory.CreateDirectory(cacheDirectory);
             TransformWorkerBootstrapResult compileResult = await CompileWorkerAsync(
                 paths,
-                workerSourcePath,
+                workerSourcePaths,
                 workerDllPath,
                 cacheDirectory,
                 ct).ConfigureAwait(false);
@@ -91,22 +92,44 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return TransformWorkerBootstrapResult.SuccessResult(cacheDirectory);
         }
 
-        internal static string ResolveWorkerSourcePath()
+        internal static string ResolveWorkerSourceDirectory()
         {
             PackageInfo packageInfo = PackageInfo.FindForAssembly(typeof(TransformWorkerBootstrap).Assembly);
             Debug.Assert(packageInfo != null, "PackageInfo must resolve for the HotReload assembly.");
             return Path.Combine(packageInfo.resolvedPath, HotReloadConstants.WorkerSourcePackageRelativePath);
         }
 
+        // why: Directory.GetFiles order is unspecified, so ordinal file-name sort keeps the
+        // response file and cache key identical on Windows and macOS.
+        internal static string[] EnumerateWorkerSourceFiles(string workerSourceDirectory)
+        {
+            if (!Directory.Exists(workerSourceDirectory))
+            {
+                return Array.Empty<string>();
+            }
+
+            string[] sourcePaths = Directory.GetFiles(workerSourceDirectory, "*.cs");
+            Array.Sort(sourcePaths, CompareWorkerSourceFileNamesOrdinal);
+            return sourcePaths;
+        }
+
+        private static int CompareWorkerSourceFileNamesOrdinal(string left, string right)
+        {
+            return string.Compare(
+                Path.GetFileName(left),
+                Path.GetFileName(right),
+                StringComparison.Ordinal);
+        }
+
         private static async Task<TransformWorkerBootstrapResult> CompileWorkerAsync(
             ExternalCompilerPaths paths,
-            string workerSourcePath,
+            IReadOnlyList<string> workerSourcePaths,
             string workerDllPath,
             string cacheDirectory,
             CancellationToken ct)
         {
             string responseFilePath = Path.Combine(cacheDirectory, HotReloadConstants.WorkerResponseFileName);
-            WriteWorkerResponseFile(responseFilePath, workerSourcePath, workerDllPath, paths);
+            WriteWorkerResponseFile(responseFilePath, workerSourcePaths, workerDllPath, paths);
 
             (int exitCode, string standardOutput, string standardError) = await HotReloadProcessRunner.RunAsync(
                 paths.DotnetHostPath,
@@ -125,9 +148,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return TransformWorkerBootstrapResult.SuccessResult(cacheDirectory);
         }
 
-        private static void WriteWorkerResponseFile(
+        internal static void WriteWorkerResponseFile(
             string responseFilePath,
-            string workerSourcePath,
+            IReadOnlyList<string> workerSourcePaths,
             string workerDllPath,
             ExternalCompilerPaths paths)
         {
@@ -155,15 +178,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             lines.Add("-r:\"" + paths.CodeAnalysisDllPath + "\"");
             lines.Add("-r:\"" + paths.CodeAnalysisCSharpDllPath + "\"");
-            lines.Add("\"" + workerSourcePath + "\"");
+            for (int index = 0; index < workerSourcePaths.Count; index++)
+            {
+                lines.Add("\"" + workerSourcePaths[index] + "\"");
+            }
+
             File.WriteAllLines(responseFilePath, lines);
         }
 
-        private static string ComputeCacheKey(string workerSourcePath, ExternalCompilerPaths paths)
+        internal static string ComputeCacheKey(
+            IReadOnlyList<string> workerSourcePaths,
+            ExternalCompilerPaths paths)
         {
             using SHA256 sha256 = SHA256.Create();
-            using FileStream sourceStream = File.OpenRead(workerSourcePath);
-            byte[] sourceHash = sha256.ComputeHash(sourceStream);
+            byte[] sourceHash = HashWorkerSourceFiles(workerSourcePaths);
 
             string toolchainIdentity = string.Join(
                 "|",
@@ -187,6 +215,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return builder.ToString();
+        }
+
+        // why: the cache must miss when either a source file name or its bytes change, not only
+        // when a single canonical file's content changes.
+        internal static byte[] HashWorkerSourceFiles(IReadOnlyList<string> workerSourcePaths)
+        {
+            using SHA256 sha256 = SHA256.Create();
+            using MemoryStream buffer = new MemoryStream();
+            for (int index = 0; index < workerSourcePaths.Count; index++)
+            {
+                string sourcePath = workerSourcePaths[index];
+                byte[] nameBytes = Encoding.UTF8.GetBytes(Path.GetFileName(sourcePath));
+                buffer.Write(nameBytes, 0, nameBytes.Length);
+                buffer.WriteByte(0);
+                byte[] contentBytes = File.ReadAllBytes(sourcePath);
+                buffer.Write(contentBytes, 0, contentBytes.Length);
+                buffer.WriteByte(0);
+            }
+
+            return sha256.ComputeHash(buffer.ToArray());
         }
 
         private static string ResolveWorkerCacheRoot()


### PR DESCRIPTION
## Summary
- The out-of-process transform worker now compiles from every `TransformWorker~/*.cs` file, not a single hard-coded source path.
- Follow-up splits in that folder can land without silently dropping extra files from the csc response file or the worker cache key.

## User Impact
- Before this change, the worker bootstrap hashed and compiled only `TransformWorker.cs`. Adding another source in that folder would still build the old single-file worker.
- After this change, every `*.cs` file in the folder is listed in ordinal file-name order and participates in the cache identity. Hot-reload behavior with the current single file is unchanged.

## Changes
- `WorkerSourcePackageRelativePath` now names the `TransformWorker~` directory.
- `TransformWorkerBootstrap` enumerates `*.cs` with `StringComparer.Ordinal` via `Path.GetFileName`, writes all of them into the response file, and hashes file name plus content in that order.
- EditMode tests in a temp directory with multiple sources cover (a) response-file membership and ordinal order, and (b) cache-key changes when any file is renamed or its bytes change.

## Verification
- `uloop compile` ErrorCount 0
- EditMode assembly `UnityCLILoop.Tests.Editor.HotReload`: 451 passed, 0 failed
- `scripts/regression-harness-hot-reload.sh` PASS
- `scripts/regression-harness-hot-reload-added-member.sh` PASS
- `scripts/regression-harness-hot-reload-signature-change.sh` PASS


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

