### PR TITLE
ci: fail the file-length check on findings

### DIFF
--- a/.github/workflows/code-complexity.yml
+++ b/.github/workflows/code-complexity.yml
@@ -93,5 +93,5 @@ jobs:
 
       - name: Report file length
         env:
-          CODE_FILE_LENGTH_FAIL_ON_EXCEEDED: 'false'
+          CODE_FILE_LENGTH_FAIL_ON_EXCEEDED: 'true'
         run: scripts/check-file-length.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ Commands and the five places the threshold is declared: `docs/code-complexity.md
 
 The repository-wide maximum production file length is 500 SLOC, counted by the
 file-length checker after dropping comments and blank lines. The `File Length
-Report` job currently reports over-limit files without failing the pull request.
+Report` job fails the pull request when findings exceed that limit.
 When you touch a reported file, split it before adding behavior. Commands, the
 exclusion list, and the two places the threshold is declared:
 `docs/file-length.md`.

--- a/docs/file-length.md
+++ b/docs/file-length.md
@@ -57,9 +57,9 @@ places that must stay in step:
 1. `MAX_FILE_LENGTH` in `scripts/check-file-length.sh`
 2. `DefaultMaxFileLength` in `cli/release-automation/internal/automation/file_length.go`
 
-The `File Length Report` job on the `Code Complexity` workflow reports files
-over the limit and does not fail the pull request yet. Locally the check stays
-in warning mode unless `CODE_FILE_LENGTH_FAIL_ON_EXCEEDED=true` is set.
+The `File Length Report` job on the `Code Complexity` workflow fails the pull
+request when findings exceed the 500 SLOC limit. Locally the check stays in
+warning mode unless `CODE_FILE_LENGTH_FAIL_ON_EXCEEDED=true` is set.
 
 When touching a reported file, split it below the limit before adding behavior.
 A new over-limit file in a change under review is a required fix, not noise to


### PR DESCRIPTION
## Summary
- Flip the `File Length Report` job to fail pull requests when any production file exceeds 500 SLOC.
- Update warning-mode wording in `docs/file-length.md` and `AGENTS.md` to match: CI fails; local runs still warn unless `CODE_FILE_LENGTH_FAIL_ON_EXCEEDED=true`.

## User Impact
- New over-limit production files on a pull request now fail CI instead of only appearing in a report. Local `scripts/check-file-length.sh` is unchanged (warning by default).

## Changes
- `.github/workflows/code-complexity.yml`: `CODE_FILE_LENGTH_FAIL_ON_EXCEEDED` `'false'` → `'true'`.
- Docs only. No checker logic, threshold, or exclusion-list changes.

## Test plan
- [x] On merged `v3-beta` (`7e6f7ffbb`): `CODE_FILE_LENGTH_FAIL_ON_EXCEEDED=true scripts/check-file-length.sh` exit 0
- [ ] This PR's File Length Report job is green with the fail flag


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

