### PR TITLE
feat: add a caller frame selector for pause-point hit captures

### DIFF
--- a/Assets/Tests/Editor/PausePointCallerFrameSelectorTests.cs
+++ b/Assets/Tests/Editor/PausePointCallerFrameSelectorTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 using NUnit.Framework;
 
@@ -252,6 +253,67 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(selected, Is.Empty);
         }
 
+        /// <summary>
+        /// What: Select demangles async state-machine callers, so deleting FormatMethodDisplay
+        /// from Select fails this case even if the helper still has its own tests.
+        /// </summary>
+        [Test]
+        public void Select_WhenCallerIsAsyncStateMachine_ReportsLogicalMethodName()
+        {
+            SourcePausePointRawStackFrame[] rawFrames =
+            {
+                CreateRawFrame(MarkerType, MarkerMethod, MarkerFile, MarkerLine),
+                CreateRawFrame("Game.Enemy+<Chase>d__7", "MoveNext", "Assets/Scripts/Enemy.cs", 55),
+            };
+
+            List<UloopPausePointCallerFrame> selected = SourcePausePointCallerFrameSelector.Select(rawFrames);
+
+            Assert.That(selected, Has.Count.EqualTo(1));
+            Assert.That(selected[0].Method, Is.EqualTo("Game.Enemy.Chase"));
+            Assert.That(selected[0].File, Is.EqualTo("Assets/Scripts/Enemy.cs"));
+            Assert.That(selected[0].Line, Is.EqualTo(55));
+        }
+
+        /// <summary>
+        /// What: Select normalizes Windows separators and a leading ./, so deleting
+        /// NormalizeFilePath from Select fails this case even if the helper still has
+        /// its own tests.
+        /// </summary>
+        [Test]
+        public void Select_WhenFileHasDotSlashAndBackslashes_NormalizesThroughSelect()
+        {
+            SourcePausePointRawStackFrame[] rawFrames =
+            {
+                CreateRawFrame(MarkerType, MarkerMethod, MarkerFile, MarkerLine),
+                CreateRawFrame(UserType, UserMethod, ".\\Assets\\Scripts\\Input.cs", 10),
+            };
+
+            List<UloopPausePointCallerFrame> selected = SourcePausePointCallerFrameSelector.Select(rawFrames);
+
+            Assert.That(selected, Has.Count.EqualTo(1));
+            Assert.That(selected[0].File, Is.EqualTo("Assets/Scripts/Input.cs"));
+            Assert.That(selected[0].Line, Is.EqualTo(10));
+        }
+
+        /// <summary>
+        /// What: a live StackTrace walk treats Level2 as the marker, skips capture
+        /// infrastructure, and returns Level1 then Level0 as the two nearest callers.
+        /// </summary>
+        [Test]
+        public void CaptureCallerFrames_OnRealStack_ReturnsTwoNearestCallersAboveMarker()
+        {
+            List<UloopPausePointCallerFrame> selected =
+                PausePointCallerFrameLiveTestSupport.StackHost.Level0();
+
+            Assert.That(selected, Has.Count.EqualTo(2));
+            Assert.That(
+                selected[0].Method,
+                Is.EqualTo("PausePointCallerFrameLiveTestSupport.StackHost.Level1"));
+            Assert.That(
+                selected[1].Method,
+                Is.EqualTo("PausePointCallerFrameLiveTestSupport.StackHost.Level0"));
+        }
+
         private static SourcePausePointRawStackFrame CreateRawFrame(
             string typeFullName,
             string methodName,
@@ -260,5 +322,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             return new SourcePausePointRawStackFrame(typeFullName, methodName, fileName, line);
         }
+    }
+}
+
+// Why a non-uloop namespace: the selector skips types that start with
+// io.github.hatayama.UnityCliLoop, so a helper in the test namespace would
+// be dropped as infrastructure and a stubbed CaptureCallerFrames would still
+// leave every other test green.
+namespace PausePointCallerFrameLiveTestSupport
+{
+    internal static class StackHost
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static List<UloopPausePointCallerFrame> Level0() { return Level1(); }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static List<UloopPausePointCallerFrame> Level1() { return Level2(); }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static List<UloopPausePointCallerFrame> Level2() { return SourcePausePointCallerFrameCapture.CaptureCallerFrames(); }
     }
 }

--- a/Assets/Tests/Editor/PausePointCallerFrameSelectorTests.cs
+++ b/Assets/Tests/Editor/PausePointCallerFrameSelectorTests.cs
@@ -1,0 +1,264 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Runtime;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies caller-frame selection rules for pause-point hit captures.
+    /// </summary>
+    [TestFixture]
+    public sealed class PausePointCallerFrameSelectorTests
+    {
+        private const string MarkerType = "Game.Player";
+        private const string MarkerMethod = "Jump";
+        private const string MarkerFile = "Assets/Scripts/Player.cs";
+        private const int MarkerLine = 42;
+
+        private const string UserType = "Game.Input";
+        private const string UserMethod = "HandleJump";
+        private const string UserFile = "Assets/Scripts/Input.cs";
+        private const int UserLine = 10;
+
+        /// <summary>
+        /// What: rawFrames[0] is the marker's own frame and is skipped by position, so it
+        /// never appears in the selected callers.
+        /// </summary>
+        [Test]
+        public void Select_WhenMarkerIsFirstFrame_ExcludesMarkerFromResult()
+        {
+            SourcePausePointRawStackFrame[] rawFrames =
+            {
+                CreateRawFrame(MarkerType, MarkerMethod, MarkerFile, MarkerLine),
+                CreateRawFrame(UserType, UserMethod, UserFile, UserLine),
+            };
+
+            List<UloopPausePointCallerFrame> selected = SourcePausePointCallerFrameSelector.Select(rawFrames);
+
+            Assert.That(selected, Has.Count.EqualTo(1));
+            Assert.That(selected[0].Method, Is.EqualTo(UserType + "." + UserMethod));
+            Assert.That(selected[0].File, Is.EqualTo(UserFile));
+            Assert.That(selected[0].Line, Is.EqualTo(UserLine));
+        }
+
+        /// <summary>
+        /// What: each infrastructure type prefix is skipped so deleting any one skip rule
+        /// makes that case fail.
+        /// </summary>
+        [TestCase("System.Runtime.CompilerServices.AsyncTaskMethodBuilder")]
+        [TestCase("Microsoft.CSharp.RuntimeBinder.Binder")]
+        [TestCase("Mono.Cecil.Cil.ILProcessor")]
+        [TestCase("HarmonyLib.Harmony")]
+        [TestCase("MonoMod.RuntimeDetour.Hook")]
+        [TestCase("io.github.hatayama.UnityCliLoop.FirstPartyTools.SourcePausePointCapture")]
+        public void Select_WhenFrameTypeStartsWithSkippedPrefix_OmitsThatFrame(string skippedTypeFullName)
+        {
+            SourcePausePointRawStackFrame[] rawFrames =
+            {
+                CreateRawFrame(MarkerType, MarkerMethod, MarkerFile, MarkerLine),
+                CreateRawFrame(skippedTypeFullName, "Run", "Packages/Infrastructure/Run.cs", 7),
+            };
+
+            List<UloopPausePointCallerFrame> selected = SourcePausePointCallerFrameSelector.Select(rawFrames);
+
+            Assert.That(selected, Is.Empty);
+        }
+
+        /// <summary>
+        /// What: UnityEditor frames stay because an editor entry point is itself diagnostic.
+        /// </summary>
+        [Test]
+        public void Select_WhenFrameIsUnityEditorEditorApplication_KeepsTheFrame()
+        {
+            SourcePausePointRawStackFrame[] rawFrames =
+            {
+                CreateRawFrame(MarkerType, MarkerMethod, MarkerFile, MarkerLine),
+                CreateRawFrame(
+                    "UnityEditor.EditorApplication",
+                    "update",
+                    "Packages/UnityEditor/EditorApplication.cs",
+                    120),
+            };
+
+            List<UloopPausePointCallerFrame> selected = SourcePausePointCallerFrameSelector.Select(rawFrames);
+
+            Assert.That(selected, Has.Count.EqualTo(1));
+            Assert.That(selected[0].Method, Is.EqualTo("UnityEditor.EditorApplication.update"));
+            Assert.That(selected[0].File, Is.EqualTo("Packages/UnityEditor/EditorApplication.cs"));
+            Assert.That(selected[0].Line, Is.EqualTo(120));
+        }
+
+        /// <summary>
+        /// What: a dynamic frame with no declaring type keeps its raw method name and reports
+        /// no file or line instead of being silently dropped.
+        /// </summary>
+        [Test]
+        public void Select_WhenTypeFullNameIsNull_KeepsRawMethodNameWithoutFileOrLine()
+        {
+            SourcePausePointRawStackFrame[] rawFrames =
+            {
+                CreateRawFrame(MarkerType, MarkerMethod, MarkerFile, MarkerLine),
+                CreateRawFrame(null, "DMD<Foo>", null, 99),
+            };
+
+            List<UloopPausePointCallerFrame> selected = SourcePausePointCallerFrameSelector.Select(rawFrames);
+
+            Assert.That(selected, Has.Count.EqualTo(1));
+            Assert.That(selected[0].Method, Is.EqualTo("DMD<Foo>"));
+            Assert.That(selected[0].File, Is.Null);
+            Assert.That(selected[0].Line, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: selection stops at two user frames even when more callers remain.
+        /// </summary>
+        [Test]
+        public void Select_WhenMoreThanTwoUserFramesExist_ReturnsAtMostTwo()
+        {
+            SourcePausePointRawStackFrame[] rawFrames =
+            {
+                CreateRawFrame(MarkerType, MarkerMethod, MarkerFile, MarkerLine),
+                CreateRawFrame("Game.A", "M1", "Assets/Scripts/A.cs", 1),
+                CreateRawFrame("Game.B", "M2", "Assets/Scripts/B.cs", 2),
+                CreateRawFrame("Game.C", "M3", "Assets/Scripts/C.cs", 3),
+            };
+
+            List<UloopPausePointCallerFrame> selected = SourcePausePointCallerFrameSelector.Select(rawFrames);
+
+            Assert.That(selected, Has.Count.EqualTo(2));
+            Assert.That(selected[0].Method, Is.EqualTo("Game.A.M1"));
+            Assert.That(selected[1].Method, Is.EqualTo("Game.B.M2"));
+        }
+
+        /// <summary>
+        /// What: compiler-generated async state-machine MoveNext frames demangle to the
+        /// logical Type.Method name.
+        /// </summary>
+        [Test]
+        public void FormatMethodDisplay_WhenAsyncStateMachineMoveNext_ReturnsLogicalMethodName()
+        {
+            string display = SourcePausePointCallerFrameSelector.FormatMethodDisplay(
+                "Ns.Type+<DoWork>d__3",
+                "MoveNext");
+
+            Assert.That(display, Is.EqualTo("Ns.Type.DoWork"));
+        }
+
+        /// <summary>
+        /// What: ordinary methods are reported as TypeFullName.MethodName.
+        /// </summary>
+        [Test]
+        public void FormatMethodDisplay_WhenOrdinaryMethod_ReturnsTypeDotMethod()
+        {
+            string display = SourcePausePointCallerFrameSelector.FormatMethodDisplay("Ns.Type", "Update");
+
+            Assert.That(display, Is.EqualTo("Ns.Type.Update"));
+        }
+
+        /// <summary>
+        /// What: a dynamic frame with no type or method name reports (unknown).
+        /// </summary>
+        [Test]
+        public void FormatMethodDisplay_WhenTypeAndMethodAreNull_ReturnsUnknown()
+        {
+            string display = SourcePausePointCallerFrameSelector.FormatMethodDisplay(null, null);
+
+            Assert.That(display, Is.EqualTo("(unknown)"));
+        }
+
+        /// <summary>
+        /// What: Windows backslashes become forward slashes so the payload is stable across
+        /// platforms.
+        /// </summary>
+        [Test]
+        public void NormalizeFilePath_WhenWindowsSeparators_ReturnsForwardSlashes()
+        {
+            string normalized = SourcePausePointCallerFrameSelector.NormalizeFilePath(
+                "Assets\\Scripts\\Foo.cs");
+
+            Assert.That(normalized, Is.EqualTo("Assets/Scripts/Foo.cs"));
+        }
+
+        /// <summary>
+        /// What: Mono's leading ./ on script-assembly sources is stripped.
+        /// </summary>
+        [Test]
+        public void NormalizeFilePath_WhenLeadingDotSlash_StripsPrefix()
+        {
+            string normalized = SourcePausePointCallerFrameSelector.NormalizeFilePath("./Packages/Foo.cs");
+
+            Assert.That(normalized, Is.EqualTo("Packages/Foo.cs"));
+        }
+
+        /// <summary>
+        /// What: a missing file name normalizes to null rather than empty.
+        /// </summary>
+        [Test]
+        public void NormalizeFilePath_WhenFileNameIsNull_ReturnsNull()
+        {
+            string normalized = SourcePausePointCallerFrameSelector.NormalizeFilePath(null);
+
+            Assert.That(normalized, Is.Null);
+        }
+
+        /// <summary>
+        /// What: a frame without a file reports Line 0 even when the raw line number is stale.
+        /// </summary>
+        [Test]
+        public void Select_WhenFileNameIsNull_ReportsLineZeroRegardlessOfRawLine()
+        {
+            SourcePausePointRawStackFrame[] rawFrames =
+            {
+                CreateRawFrame(MarkerType, MarkerMethod, MarkerFile, MarkerLine),
+                CreateRawFrame(UserType, UserMethod, null, 42),
+            };
+
+            List<UloopPausePointCallerFrame> selected = SourcePausePointCallerFrameSelector.Select(rawFrames);
+
+            Assert.That(selected, Has.Count.EqualTo(1));
+            Assert.That(selected[0].File, Is.Null);
+            Assert.That(selected[0].Line, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: an empty raw stack yields no callers.
+        /// </summary>
+        [Test]
+        public void Select_WhenRawFramesAreEmpty_ReturnsEmptyList()
+        {
+            SourcePausePointRawStackFrame[] rawFrames = { };
+
+            List<UloopPausePointCallerFrame> selected = SourcePausePointCallerFrameSelector.Select(rawFrames);
+
+            Assert.That(selected, Is.Empty);
+        }
+
+        /// <summary>
+        /// What: a stack that is only the marker frame yields no callers.
+        /// </summary>
+        [Test]
+        public void Select_WhenOnlyMarkerFrameIsPresent_ReturnsEmptyList()
+        {
+            SourcePausePointRawStackFrame[] rawFrames =
+            {
+                CreateRawFrame(MarkerType, MarkerMethod, MarkerFile, MarkerLine),
+            };
+
+            List<UloopPausePointCallerFrame> selected = SourcePausePointCallerFrameSelector.Select(rawFrames);
+
+            Assert.That(selected, Is.Empty);
+        }
+
+        private static SourcePausePointRawStackFrame CreateRawFrame(
+            string typeFullName,
+            string methodName,
+            string fileName,
+            int line)
+        {
+            return new SourcePausePointRawStackFrame(typeFullName, methodName, fileName, line);
+        }
+    }
+}

--- a/Assets/Tests/Editor/PausePointCallerFrameSelectorTests.cs.meta
+++ b/Assets/Tests/Editor/PausePointCallerFrameSelectorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8df84b96c4e24c47a5b810f072e8d26
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCallerFrameCapture.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCallerFrameCapture.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+
+using io.github.hatayama.UnityCliLoop.Runtime;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Captures the managed call stack at a pause point hit and reduces it to the caller
+    /// frames worth reporting. Must be called synchronously on the hitting thread.
+    /// </summary>
+    internal static class SourcePausePointCallerFrameCapture
+    {
+        // fNeedFileInfo:true is effectively free on Mono (measured at parity with false,
+        // ~0.12 ms per capture) and yields file:line for script assemblies compiled with
+        // Debug code optimization — the same prerequisite pause points already require.
+        public static List<UloopPausePointCallerFrame> CaptureCallerFrames()
+        {
+            StackTrace stackTrace = new StackTrace(fNeedFileInfo: true);
+            int frameCount = Math.Min(
+                stackTrace.FrameCount, SourcePausePointConstants.MaxCallerStackFramesToExamine);
+            List<SourcePausePointRawStackFrame> rawFrames =
+                new List<SourcePausePointRawStackFrame>(frameCount);
+            bool pastCaptureInfrastructure = false;
+            for (int i = 0; i < frameCount; i++)
+            {
+                StackFrame frame = stackTrace.GetFrame(i);
+                MethodBase method = frame?.GetMethod();
+                string typeFullName = method?.DeclaringType?.FullName;
+                if (!pastCaptureInfrastructure)
+                {
+                    // Skip our own capture frames by identity, not by a fixed count, so
+                    // inlining or a future refactor of the call chain cannot silently shift
+                    // which frame is treated as the marker's own.
+                    bool isCaptureInfrastructure =
+                        typeFullName == typeof(SourcePausePointCallerFrameCapture).FullName ||
+                        typeFullName == typeof(SourcePausePointCapture).FullName;
+                    if (isCaptureInfrastructure)
+                    {
+                        continue;
+                    }
+
+                    pastCaptureInfrastructure = true;
+                }
+
+                rawFrames.Add(new SourcePausePointRawStackFrame(
+                    typeFullName,
+                    method?.Name,
+                    frame.GetFileName(),
+                    frame.GetFileLineNumber()));
+            }
+
+            return SourcePausePointCallerFrameSelector.Select(rawFrames);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCallerFrameCapture.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCallerFrameCapture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd8d9f7c808004c2dadbe2f063ca2544
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCallerFrameSelector.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCallerFrameSelector.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Runtime;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Selects the caller frames worth reporting from a raw stack captured at a pause point hit.
+    /// Pure logic over pre-extracted frame data so the selection rules stay unit-testable.
+    /// </summary>
+    internal static class SourcePausePointCallerFrameSelector
+    {
+        // Frames whose declaring type starts with one of these carry no diagnostic value for
+        // "how execution reached the marker": runtime async machinery, patching infrastructure,
+        // and uloop's own plumbing. Unity engine/editor frames are deliberately kept because an
+        // entry point such as EditorApplication.update is itself diagnostic.
+        private static readonly string[] SkippedTypePrefixes =
+        {
+            "System.",
+            "Microsoft.",
+            "Mono.",
+            "HarmonyLib.",
+            "MonoMod.",
+            "io.github.hatayama.UnityCliLoop",
+        };
+
+        // rawFrames[0] must be the marker's own frame (the patched method). It is skipped
+        // positionally instead of by identity because a hot-reload-patched marker method can
+        // appear as a Harmony dynamic method whose display name is not predictable.
+        public static List<UloopPausePointCallerFrame> Select(
+            IReadOnlyList<SourcePausePointRawStackFrame> rawFrames)
+        {
+            Debug.Assert(rawFrames != null, "rawFrames must not be null");
+
+            List<UloopPausePointCallerFrame> selected =
+                new List<UloopPausePointCallerFrame>(SourcePausePointConstants.MaxCallerFrames);
+            for (int i = 1; i < rawFrames.Count; i++)
+            {
+                if (selected.Count == SourcePausePointConstants.MaxCallerFrames)
+                {
+                    break;
+                }
+
+                SourcePausePointRawStackFrame frame = rawFrames[i];
+                if (frame.TypeFullName != null && IsSkippedInfrastructureType(frame.TypeFullName))
+                {
+                    continue;
+                }
+
+                string file = NormalizeFilePath(frame.FileName);
+                selected.Add(new UloopPausePointCallerFrame(
+                    FormatMethodDisplay(frame.TypeFullName, frame.MethodName),
+                    file,
+                    file == null ? 0 : frame.Line));
+            }
+
+            return selected;
+        }
+
+        internal static bool IsSkippedInfrastructureType(string typeFullName)
+        {
+            Debug.Assert(typeFullName != null, "typeFullName must not be null");
+
+            foreach (string prefix in SkippedTypePrefixes)
+            {
+                if (typeFullName.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // Compiler-generated async state machines surface as "Ns.Type+<Method>d__N.MoveNext";
+        // report the logical "Ns.Type.Method" instead. Every other shape (including lambdas and
+        // genuine nested types) is reported verbatim as "TypeFullName.MethodName".
+        internal static string FormatMethodDisplay(string typeFullName, string methodName)
+        {
+            if (typeFullName == null)
+            {
+                return string.IsNullOrEmpty(methodName) ? "(unknown)" : methodName;
+            }
+
+            if (methodName == "MoveNext")
+            {
+                int open = typeFullName.LastIndexOf("+<", StringComparison.Ordinal);
+                if (open >= 0)
+                {
+                    int close = typeFullName.IndexOf(">d__", open, StringComparison.Ordinal);
+                    if (close > open + 2)
+                    {
+                        string logicalMethod = typeFullName.Substring(open + 2, close - (open + 2));
+                        return typeFullName.Substring(0, open) + "." + logicalMethod;
+                    }
+                }
+            }
+
+            return typeFullName + "." + (string.IsNullOrEmpty(methodName) ? "(unknown)" : methodName);
+        }
+
+        // Mono reports script-assembly sources as "./Packages/..." on macOS and may use
+        // backslashes on Windows; normalize so the payload is stable across platforms.
+        internal static string NormalizeFilePath(string fileName)
+        {
+            if (string.IsNullOrEmpty(fileName))
+            {
+                return null;
+            }
+
+            string normalized = fileName.Replace('\\', '/');
+            if (normalized.StartsWith("./", StringComparison.Ordinal))
+            {
+                normalized = normalized.Substring(2);
+            }
+
+            return normalized;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCallerFrameSelector.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCallerFrameSelector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 62bfe98ca24c44245b38105400dc4c91
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -42,6 +42,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const int MaxCollectionPreviewValueLength = 1024;
         public const int MaxCollectionPreviewDepth = 2;
 
+        // Nearest caller plus one more; the CLI has no option to raise this.
+        public const int MaxCallerFrames = 2;
+        // Walk this many raw stack frames so skipped infrastructure still leaves room for two callers.
+        public const int MaxCallerStackFramesToExamine = 24;
+
         public const string HarmonyId = "io.github.hatayama.uloop.source-pause-point";
         public const string BurstCompileAttributeFullName = "Unity.Burst.BurstCompileAttribute";
 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointRawStackFrame.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointRawStackFrame.cs
@@ -1,0 +1,27 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Frame data pre-extracted from System.Diagnostics.StackFrame so the caller frame
+    /// selection logic can run on plain values in unit tests.
+    /// </summary>
+    internal readonly struct SourcePausePointRawStackFrame
+    {
+        public SourcePausePointRawStackFrame(string typeFullName, string methodName, string fileName, int line)
+        {
+            TypeFullName = typeFullName;
+            MethodName = methodName;
+            FileName = fileName;
+            Line = line;
+        }
+
+        // Null for dynamic methods (no declaring type), e.g. Harmony-generated bodies.
+        public string TypeFullName { get; }
+
+        public string MethodName { get; }
+
+        // Null when debug symbols are unavailable for the frame.
+        public string FileName { get; }
+
+        public int Line { get; }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointRawStackFrame.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointRawStackFrame.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a797400b41f2418cb5b23a65d2859a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Runtime/PausePoints/UloopPausePointCallerFrame.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointCallerFrame.cs
@@ -1,0 +1,31 @@
+#if UNITY_EDITOR
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.Runtime
+{
+    /// <summary>
+    /// One managed caller stack frame captured at a pause point hit, nearest caller first.
+    /// </summary>
+    internal sealed class UloopPausePointCallerFrame
+    {
+        public UloopPausePointCallerFrame(string method, string file, int line)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(method), "method must not be null or empty");
+            // A frame without debug symbols must not report a stale line number.
+            Debug.Assert(file != null || line == 0, "line must be 0 when file is null");
+
+            Method = method;
+            File = file;
+            Line = line;
+        }
+
+        public string Method { get; }
+
+        // Null when debug symbols are unavailable for the frame (for example a caller whose
+        // body is currently hot-reload patched and executes as a Harmony dynamic method).
+        public string File { get; }
+
+        public int Line { get; }
+    }
+}
+#endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointCallerFrame.cs.meta
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointCallerFrame.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 121bb6e89c706497dbfbdb5fb6a6e32c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Adds the caller-frame selection core that later pause-point hit captures will use to report how execution reached a marker (nearest caller first, up to two frames).
- This PR does not yet attach frames to hit responses; it lands the DTO, selector, stack adapter, and unit tests so the wiring PRs stay small.

## User Impact
- Pause-point hits still return the same payload as before.
- The next PRs will start including `CallerFrames` on hits; this change is the selection rules those responses will follow (skip the marker itself and runtime/patching/uloop plumbing, keep Unity editor/engine frames, demangle async callers, normalize file paths).

## Changes
- Add a caller-frame DTO and a unit-testable selector over pre-extracted stack frames.
- Add a hitting-thread stack adapter that reduces a live `StackTrace` to those frames.
- Cap reported callers at 2 and the examined stack depth at 24.
- Cover marker skip, all six skip prefixes, UnityEditor keep, dynamic frames, the two-frame cap, async demangling, Windows/`./` path normalization, missing-file line zeroing, and empty stacks.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → `ErrorCount: 0`, `Success: true`
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "PausePointCallerFrameSelector"` → `TestCount: 19`, `PassedCount: 19`, `FailedCount: 0`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

