### PR TITLE
feat: capture caller frames on pause-point hits

### DIFF
--- a/Assets/Tests/Editor/PausePointExpiredRecommendedNextActionTests.cs
+++ b/Assets/Tests/Editor/PausePointExpiredRecommendedNextActionTests.cs
@@ -91,6 +91,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 "Pause point expired.",
                 recommendedNextAction,
                 Array.Empty<UloopCapturedVariable>(),
+                Array.Empty<UloopPausePointCallerFrame>(),
                 false,
                 Array.Empty<string>(),
                 0,

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -1151,6 +1151,87 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(_pauseController.PauseCount, Is.EqualTo(1));
         }
 
+        /// <summary>
+        /// What: caller frames passed to HitWithCapturedFrame appear on the latest snapshot.
+        /// </summary>
+        [Test]
+        public void HitWithCapturedFrame_WhenCallerFramesAreProvided_StoresThemOnLatestSnapshot()
+        {
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePointCapturedVariableFrame frame = CreateEmptyCapturedFrame();
+            UloopPausePointCallerFrame[] callerFrames =
+            {
+                new("Game.Input.HandleJump", "Assets/Scripts/Input.cs", 10),
+                new("Game.Player.Update", "Assets/Scripts/Player.cs", 20),
+            };
+
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.HitWithCapturedFrame(
+                "jump", frame, Array.Empty<UloopCapturedVariable>(), false, callerFrames);
+
+            Assert.That(snapshot.CallerFrames, Is.EqualTo(callerFrames));
+        }
+
+        /// <summary>
+        /// What: each history frame stores the caller frames from that hit, not only the latest.
+        /// </summary>
+        [Test]
+        public void HitWithCapturedFrame_WhenMultipleHitsAreRecorded_StoresCallerFramesOnEachHistoryFrame()
+        {
+            UloopPausePointRegistry.Enable("jump", 30, UloopPausePointCaptureMode.Trace);
+            UloopPausePointCapturedVariableFrame frame = CreateEmptyCapturedFrame();
+            UloopPausePointCallerFrame[] firstCallerFrames =
+            {
+                new("Game.Input.HandleJump", "Assets/Scripts/Input.cs", 10),
+            };
+            UloopPausePointCallerFrame[] secondCallerFrames =
+            {
+                new("Game.AI.Tick", "Assets/Scripts/AI.cs", 44),
+                new("Game.World.Update", "Assets/Scripts/World.cs", 8),
+            };
+
+            UloopPausePointRegistry.HitWithCapturedFrame(
+                "jump", frame, Array.Empty<UloopCapturedVariable>(), false, firstCallerFrames);
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.HitWithCapturedFrame(
+                "jump", frame, Array.Empty<UloopCapturedVariable>(), false, secondCallerFrames);
+
+            Assert.That(snapshot.CallerFrames, Is.EqualTo(secondCallerFrames));
+            Assert.That(snapshot.CapturedVariableHistory, Has.Count.EqualTo(2));
+            Assert.That(snapshot.CapturedVariableHistory[0].CallerFrames, Is.EqualTo(firstCallerFrames));
+            Assert.That(snapshot.CapturedVariableHistory[1].CallerFrames, Is.EqualTo(secondCallerFrames));
+        }
+
+        /// <summary>
+        /// What: Hit(string) records an empty caller-frame list because that path has no stack capture.
+        /// </summary>
+        [Test]
+        public void Hit_WhenCalledWithoutCallerFrames_ReportsEmptyCallerFrames()
+        {
+            UloopPausePointRegistry.Enable("jump", 30);
+
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Hit("jump");
+
+            Assert.That(snapshot.CallerFrames, Is.Empty);
+        }
+
+        /// <summary>
+        /// What: HitWithCapturedVariables records an empty caller-frame list because that path
+        /// has no stack capture.
+        /// </summary>
+        [Test]
+        public void HitWithCapturedVariables_WhenCalledWithoutCallerFrames_ReportsEmptyCallerFrames()
+        {
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopCapturedVariable[] capturedVariables =
+            {
+                new("speed", UloopCapturedVariableScope.Local, "System.Int32", "5", string.Empty, string.Empty, 0, false)
+            };
+
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.HitWithCapturedVariables(
+                "jump", capturedVariables, false);
+
+            Assert.That(snapshot.CallerFrames, Is.Empty);
+        }
+
         [Test]
         public void TryGetCapturedValue_WhenLatestHitStoredRawFrame_ReturnsLiveReferences()
         {
@@ -1171,7 +1252,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new("scores", UloopCapturedVariableScope.Local, "System.Collections.Generic.List`1[System.Int32]", "[10,20,30]", string.Empty, string.Empty, 0, false)
             };
 
-            UloopPausePointRegistry.HitWithCapturedFrame("jump", frame, capturedVariables, false);
+            UloopPausePointRegistry.HitWithCapturedFrame(
+                "jump", frame, capturedVariables, false, Array.Empty<UloopPausePointCallerFrame>());
 
             (bool foundScores, object scoresValue) = UloopPausePoint.TryGetCapturedValue("scores");
             (bool foundNull, object nullValue) = UloopPausePoint.TryGetCapturedValue("empty");
@@ -1198,7 +1280,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 System.Array.Empty<string>(),
                 0);
             UloopPausePointRegistry.HitWithCapturedFrame(
-                "jump", frame, Array.Empty<UloopCapturedVariable>(), false);
+                "jump", frame, Array.Empty<UloopCapturedVariable>(), false, Array.Empty<UloopPausePointCallerFrame>());
 
             UloopPausePointRegistry.Clear("jump");
 
@@ -1225,8 +1307,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 System.Array.Empty<string>(),
                 0);
 
-            UloopPausePointRegistry.HitWithCapturedFrame("jump", jumpFrame, Array.Empty<UloopCapturedVariable>(), false);
-            UloopPausePointRegistry.HitWithCapturedFrame("land", landFrame, Array.Empty<UloopCapturedVariable>(), false);
+            UloopPausePointRegistry.HitWithCapturedFrame("jump", jumpFrame, Array.Empty<UloopCapturedVariable>(), false, Array.Empty<UloopPausePointCallerFrame>());
+            UloopPausePointRegistry.HitWithCapturedFrame("land", landFrame, Array.Empty<UloopCapturedVariable>(), false, Array.Empty<UloopPausePointCallerFrame>());
 
             (bool found, object value) = UloopPausePoint.TryGetCapturedValue("speed");
             Assert.That(found, Is.True);
@@ -1245,7 +1327,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 false,
                 System.Array.Empty<string>(),
                 0);
-            UloopPausePointRegistry.HitWithCapturedFrame("land", landFrame, Array.Empty<UloopCapturedVariable>(), false);
+            UloopPausePointRegistry.HitWithCapturedFrame("land", landFrame, Array.Empty<UloopCapturedVariable>(), false, Array.Empty<UloopPausePointCallerFrame>());
 
             UloopPausePointRegistry.Clear("jump");
 
@@ -1266,7 +1348,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 false,
                 System.Array.Empty<string>(),
                 0);
-            UloopPausePointRegistry.HitWithCapturedFrame("jump", frame, Array.Empty<UloopCapturedVariable>(), false);
+            UloopPausePointRegistry.HitWithCapturedFrame("jump", frame, Array.Empty<UloopCapturedVariable>(), false, Array.Empty<UloopPausePointCallerFrame>());
 
             UloopPausePointRegistry.Enable("jump", 30);
 
@@ -1287,7 +1369,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 false,
                 System.Array.Empty<string>(),
                 0);
-            UloopPausePointRegistry.HitWithCapturedFrame("jump", frame, Array.Empty<UloopCapturedVariable>(), false);
+            UloopPausePointRegistry.HitWithCapturedFrame("jump", frame, Array.Empty<UloopCapturedVariable>(), false, Array.Empty<UloopPausePointCallerFrame>());
 
             UloopPausePointRegistry.Enable("jump", 30);
             UloopPausePointRegistry.Clear("jump");
@@ -1578,6 +1660,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private const int FixtureLine = 12;
         private const string PhysicsFixtureFilePath = "Assets/Tests/Editor/PausePointToolsPhysicsFixture.cs";
         private const int PhysicsFixtureLine = 11;
+
+        private static UloopPausePointCapturedVariableFrame CreateEmptyCapturedFrame()
+        {
+            return new UloopPausePointCapturedVariableFrame(
+                Array.Empty<UloopPausePointCapturedVariableEntry>(),
+                false,
+                Array.Empty<string>(),
+                0);
+        }
 
         private static SourcePausePointResolution WithStaleMvid(SourcePausePointResolution resolution)
         {

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCapture.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCapture.cs
@@ -28,10 +28,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int maxPreviewElements = UloopPausePointRegistry.GetMaxPreviewElements(id);
             (UloopPausePointCapturedVariableFrame frame, List<UloopCapturedVariable> variables, bool truncated) =
                 CaptureFrame(instance, parameterNamesAndValues, localNamesAndValues, maxPreviewElements);
+            // The stack must be walked on the hitting thread; a deferred main-thread hit would see
+            // the scheduler's stack instead of the caller chain that reached the marker.
+            List<UloopPausePointCallerFrame> callerFrames =
+                SourcePausePointCallerFrameCapture.CaptureCallerFrames();
 
             if (MainThreadSwitcher.IsMainThread)
             {
-                UloopPausePointSnapshot snapshot = UloopPausePointRegistry.HitWithCapturedFrame(id, frame, variables, truncated);
+                UloopPausePointSnapshot snapshot = UloopPausePointRegistry.HitWithCapturedFrame(
+                    id, frame, variables, truncated, callerFrames);
                 LogHit(snapshot, truncated);
                 return;
             }
@@ -42,7 +47,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // marker that already got disarmed by a faster hit safely no-ops there.
             MainThreadSwitcher.AddContinuation(() =>
             {
-                UloopPausePointSnapshot snapshot = UloopPausePointRegistry.HitWithCapturedFrame(id, frame, variables, truncated);
+                UloopPausePointSnapshot snapshot = UloopPausePointRegistry.HitWithCapturedFrame(
+                    id, frame, variables, truncated, callerFrames);
                 LogHit(snapshot, truncated);
             });
         }

--- a/Packages/src/Runtime/PausePoints/UloopPausePointCapturedHistoryFrame.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointCapturedHistoryFrame.cs
@@ -13,13 +13,15 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             int frameCount,
             string hitAtUtc,
             IReadOnlyList<UloopCapturedVariable> capturedVariables,
-            bool truncated)
+            bool truncated,
+            IReadOnlyList<UloopPausePointCallerFrame> callerFrames)
         {
             HitSequence = hitSequence;
             FrameCount = frameCount;
             HitAtUtc = hitAtUtc;
             CapturedVariables = capturedVariables;
             Truncated = truncated;
+            CallerFrames = callerFrames;
         }
 
         public int HitSequence { get; }
@@ -27,6 +29,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public string HitAtUtc { get; }
         public IReadOnlyList<UloopCapturedVariable> CapturedVariables { get; }
         public bool Truncated { get; }
+        public IReadOnlyList<UloopPausePointCallerFrame> CallerFrames { get; }
     }
 }
 #endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
@@ -31,6 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             IsEnabled = true;
             Message = "Pause point enabled.";
             CapturedVariables = Array.Empty<UloopCapturedVariable>();
+            CallerFrames = Array.Empty<UloopPausePointCallerFrame>();
             TruncatedVariableNames = Array.Empty<string>();
             _capturedVariableHistory = new Queue<UloopPausePointCapturedHistoryFrame>(maxHistory);
         }
@@ -54,6 +55,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public bool IsPausedAtHit { get; private set; }
         public string Message { get; private set; }
         public IReadOnlyList<UloopCapturedVariable> CapturedVariables { get; private set; }
+        public IReadOnlyList<UloopPausePointCallerFrame> CallerFrames { get; private set; }
         public bool CapturedVariablesTruncated { get; private set; }
         public IReadOnlyList<string> TruncatedVariableNames { get; private set; }
         public int TruncatedVariableCount { get; private set; }
@@ -180,12 +182,14 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             IReadOnlyList<UloopCapturedVariable> capturedVariables,
             bool capturedVariablesTruncated,
             IReadOnlyList<string> truncatedVariableNames,
-            int truncatedVariableCount)
+            int truncatedVariableCount,
+            IReadOnlyList<UloopPausePointCallerFrame> callerFrames)
         {
             Debug.Assert(hitSequence > 0, "hitSequence must be greater than zero");
             Debug.Assert(capturedVariables != null, "capturedVariables must not be null");
             Debug.Assert(truncatedVariableNames != null, "truncatedVariableNames must not be null");
             Debug.Assert(truncatedVariableCount >= 0, "truncatedVariableCount must not be negative");
+            Debug.Assert(callerFrames != null, "callerFrames must not be null");
 
             if (HitCount == 0)
             {
@@ -204,6 +208,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 ? "Pause point hit; recorded to history without pausing (trace mode)."
                 : "Pause point hit; Unity pause was requested.";
             CapturedVariables = capturedVariables;
+            CallerFrames = callerFrames;
             CapturedVariablesTruncated = capturedVariablesTruncated;
             TruncatedVariableNames = truncatedVariableNames;
             TruncatedVariableCount = truncatedVariableCount;
@@ -220,7 +225,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                     frameCount,
                     FormatUtc(nowUtc),
                     capturedVariables,
-                    capturedVariablesTruncated));
+                    capturedVariablesTruncated,
+                    callerFrames));
         }
 
         public UloopPausePointSnapshot ToSnapshot(DateTime nowUtc, IUloopPausePointPauseController pauseController)
@@ -268,6 +274,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 Message,
                 recommendedNextAction,
                 CapturedVariables,
+                CallerFrames,
                 CapturedVariablesTruncated,
                 TruncatedVariableNames,
                 TruncatedVariableCount,

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -277,7 +277,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
         public static UloopPausePointSnapshot Hit(string id)
         {
-            return HitCore(id, null, Array.Empty<UloopCapturedVariable>(), false);
+            return HitCore(
+                id, null, Array.Empty<UloopCapturedVariable>(), false, Array.Empty<UloopPausePointCallerFrame>());
         }
 
         public static UloopPausePointSnapshot HitWithCapturedVariables(
@@ -285,19 +286,22 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         {
             Debug.Assert(capturedVariables != null, "capturedVariables must not be null");
 
-            return HitCore(id, null, capturedVariables, capturedVariablesTruncated);
+            return HitCore(
+                id, null, capturedVariables, capturedVariablesTruncated, Array.Empty<UloopPausePointCallerFrame>());
         }
 
         public static UloopPausePointSnapshot HitWithCapturedFrame(
             string id,
             UloopPausePointCapturedVariableFrame capturedFrame,
             IReadOnlyList<UloopCapturedVariable> capturedVariables,
-            bool capturedVariablesTruncated)
+            bool capturedVariablesTruncated,
+            IReadOnlyList<UloopPausePointCallerFrame> callerFrames)
         {
             Debug.Assert(capturedFrame != null, "capturedFrame must not be null");
             Debug.Assert(capturedVariables != null, "capturedVariables must not be null");
+            Debug.Assert(callerFrames != null, "callerFrames must not be null");
 
-            return HitCore(id, capturedFrame, capturedVariables, capturedVariablesTruncated);
+            return HitCore(id, capturedFrame, capturedVariables, capturedVariablesTruncated, callerFrames);
         }
 
         // Returns after a single dictionary lookup when the id is not armed. Harmony-injected
@@ -344,13 +348,16 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             string id,
             UloopPausePointCapturedVariableFrame capturedFrame,
             IReadOnlyList<UloopCapturedVariable> capturedVariables,
-            bool capturedVariablesTruncated)
+            bool capturedVariablesTruncated,
+            IReadOnlyList<UloopPausePointCallerFrame> callerFrames)
         {
             if (string.IsNullOrWhiteSpace(id))
             {
                 Debug.Assert(false, "id must not be null or empty");
                 return UloopPausePointSnapshot.NotEnabled(id ?? string.Empty, _pauseController);
             }
+
+            Debug.Assert(callerFrames != null, "callerFrames must not be null");
 
             DateTime now = NowUtc();
             if (!Entries.ContainsKey(id))
@@ -398,7 +405,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             entry.RecordHitWithCapturedVariables(
                 now, _pauseController.IsPlaying, _pauseController.IsPaused, hitSequence,
                 frameCount, capturedVariables, capturedVariablesTruncated,
-                truncatedVariableNames, truncatedVariableCount);
+                truncatedVariableNames, truncatedVariableCount, callerFrames);
             UloopPausePointSnapshot snapshot = entry.ToSnapshot(now, _pauseController);
             _latestHitSnapshot = snapshot;
             _hitSnapshots.RemoveAll(hitSnapshot => hitSnapshot.Id == id);

--- a/Packages/src/Runtime/PausePoints/UloopPausePointSnapshot.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointSnapshot.cs
@@ -36,6 +36,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             string message,
             string recommendedNextAction,
             IReadOnlyList<UloopCapturedVariable> capturedVariables,
+            IReadOnlyList<UloopPausePointCallerFrame> callerFrames,
             bool capturedVariablesTruncated,
             IReadOnlyList<string> truncatedVariableNames,
             int truncatedVariableCount,
@@ -74,6 +75,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             Message = message ?? string.Empty;
             RecommendedNextAction = recommendedNextAction ?? string.Empty;
             CapturedVariables = capturedVariables ?? Array.Empty<UloopCapturedVariable>();
+            CallerFrames = callerFrames ?? Array.Empty<UloopPausePointCallerFrame>();
             CapturedVariablesTruncated = capturedVariablesTruncated;
             TruncatedVariableNames = truncatedVariableNames ?? Array.Empty<string>();
             TruncatedVariableCount = truncatedVariableCount;
@@ -111,6 +113,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public string Message { get; }
         public string RecommendedNextAction { get; }
         public IReadOnlyList<UloopCapturedVariable> CapturedVariables { get; }
+        public IReadOnlyList<UloopPausePointCallerFrame> CallerFrames { get; }
         public bool CapturedVariablesTruncated { get; }
         public IReadOnlyList<string> TruncatedVariableNames { get; }
         public int TruncatedVariableCount { get; }
@@ -154,6 +157,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 "Pause point is not enabled.",
                 string.Empty,
                 Array.Empty<UloopCapturedVariable>(),
+                Array.Empty<UloopPausePointCallerFrame>(),
                 false,
                 Array.Empty<string>(),
                 0,


### PR DESCRIPTION
## Summary
- Pause-point hits now capture up to two caller stack frames on the hitting thread and store them on the latest snapshot and every history frame.
- CLI/status responses are unchanged in this PR; a follow-up will expose `CallerFrames` on the wire.

## User Impact
- Hit captures still return the same JSON payload as before.
- The next PR will start including `CallerFrames` on those payloads, using the frames stored here.

## Changes
- Walk the stack in `Capture` before any main-thread deferral so off-thread hits keep the caller chain that reached the marker.
- Thread caller frames through the registry, entry, snapshot, and history frame (no overloads; signatures change in place).
- Frame-less `Hit(string)` and `HitWithCapturedVariables` store an empty list.
- Add runtime tests for latest snapshot, per-history-frame storage, and the empty frame-less paths. The status-response contract fixture is untouched.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → `ErrorCount: 0`, `Success: true`
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "PausePoint"` → `TestCount: 401`, `PassedCount: 401`, `FailedCount: 0` (includes `PausePointStatusResponseContractTests`)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

