### PR TITLE
feat: expose pause-point caller frames in hit responses and the CLI payload

### DIFF
--- a/Assets/Tests/Editor/PausePointCallerFrameSelectorTests.cs
+++ b/Assets/Tests/Editor/PausePointCallerFrameSelectorTests.cs
@@ -219,6 +219,43 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: an absolute path under Library/PackageCache/ is stripped to a project-relative path.
+        /// </summary>
+        [Test]
+        public void NormalizeFilePath_WhenAbsolutePackageCachePath_ReturnsProjectRelative()
+        {
+            string normalized = SourcePausePointCallerFrameSelector.NormalizeFilePath(
+                "/Users/<USER_NAME>/project/Library/PackageCache/com.example.pkg@1.2.3/Runtime/Foo.cs");
+
+            Assert.That(normalized, Is.EqualTo("Library/PackageCache/com.example.pkg@1.2.3/Runtime/Foo.cs"));
+        }
+
+        /// <summary>
+        /// What: a rooted path with no recognizable project segment normalizes to null instead of
+        /// leaking a machine path into the payload.
+        /// </summary>
+        [Test]
+        public void NormalizeFilePath_WhenRootedPathHasNoProjectSegment_ReturnsNull()
+        {
+            string normalized = SourcePausePointCallerFrameSelector.NormalizeFilePath(
+                "/Users/<USER_NAME>/External/Src/Foo.cs");
+
+            Assert.That(normalized, Is.Null);
+        }
+
+        /// <summary>
+        /// What: a Windows drive path with no recognizable project segment normalizes to null.
+        /// </summary>
+        [Test]
+        public void NormalizeFilePath_WhenDrivePathHasNoProjectSegment_ReturnsNull()
+        {
+            string normalized = SourcePausePointCallerFrameSelector.NormalizeFilePath(
+                "C:/External/Src/Foo.cs");
+
+            Assert.That(normalized, Is.Null);
+        }
+
+        /// <summary>
         /// What: a missing file name normalizes to null rather than empty.
         /// </summary>
         [Test]
@@ -341,6 +378,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(selected, Has.Count.EqualTo(1));
             Assert.That(selected[0].File, Is.EqualTo("Assets/Scripts/Input.cs"));
             Assert.That(selected[0].Line, Is.EqualTo(10));
+        }
+
+        /// <summary>
+        /// What: Select degrades a rooted no-project-segment path to a method-only frame with
+        /// File null and Line 0, so the payload never carries an absolute machine path.
+        /// </summary>
+        [Test]
+        public void Select_WhenFileIsRootedWithoutProjectSegment_DegradesToMethodOnlyFrame()
+        {
+            SourcePausePointRawStackFrame[] rawFrames =
+            {
+                CreateRawFrame(MarkerType, MarkerMethod, MarkerFile, MarkerLine),
+                CreateRawFrame(UserType, UserMethod, "/Users/<USER_NAME>/External/Src/Foo.cs", 10),
+            };
+
+            List<UloopPausePointCallerFrame> selected = SourcePausePointCallerFrameSelector.Select(rawFrames);
+
+            Assert.That(selected, Has.Count.EqualTo(1));
+            Assert.That(selected[0].File, Is.Null);
+            Assert.That(selected[0].Line, Is.EqualTo(0));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/PausePointCallerFrameSelectorTests.cs
+++ b/Assets/Tests/Editor/PausePointCallerFrameSelectorTests.cs
@@ -195,6 +195,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: an absolute macOS path under Assets/ is stripped to a project-relative path.
+        /// </summary>
+        [Test]
+        public void NormalizeFilePath_WhenAbsoluteAssetsPath_ReturnsProjectRelative()
+        {
+            string normalized = SourcePausePointCallerFrameSelector.NormalizeFilePath(
+                "/Users/<USER_NAME>/project/Assets/Scripts/Input.cs");
+
+            Assert.That(normalized, Is.EqualTo("Assets/Scripts/Input.cs"));
+        }
+
+        /// <summary>
+        /// What: an absolute path under Packages/ is stripped to a project-relative path.
+        /// </summary>
+        [Test]
+        public void NormalizeFilePath_WhenAbsolutePackagesPath_ReturnsProjectRelative()
+        {
+            string normalized = SourcePausePointCallerFrameSelector.NormalizeFilePath(
+                "C:/Users/<USER_NAME>/project/Packages/src/Foo.cs");
+
+            Assert.That(normalized, Is.EqualTo("Packages/src/Foo.cs"));
+        }
+
+        /// <summary>
         /// What: a missing file name normalizes to null rather than empty.
         /// </summary>
         [Test]
@@ -286,6 +310,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 CreateRawFrame(MarkerType, MarkerMethod, MarkerFile, MarkerLine),
                 CreateRawFrame(UserType, UserMethod, ".\\Assets\\Scripts\\Input.cs", 10),
+            };
+
+            List<UloopPausePointCallerFrame> selected = SourcePausePointCallerFrameSelector.Select(rawFrames);
+
+            Assert.That(selected, Has.Count.EqualTo(1));
+            Assert.That(selected[0].File, Is.EqualTo("Assets/Scripts/Input.cs"));
+            Assert.That(selected[0].Line, Is.EqualTo(10));
+        }
+
+        /// <summary>
+        /// What: Select strips an absolute Assets/ path to project-relative form, so deleting
+        /// that step from Select fails this case even if the helper still has its own tests.
+        /// </summary>
+        [Test]
+        public void Select_WhenFileIsAbsoluteAssetsPath_NormalizesThroughSelect()
+        {
+            SourcePausePointRawStackFrame[] rawFrames =
+            {
+                CreateRawFrame(MarkerType, MarkerMethod, MarkerFile, MarkerLine),
+                CreateRawFrame(
+                    UserType,
+                    UserMethod,
+                    "/Users/<USER_NAME>/project/Assets/Scripts/Input.cs",
+                    10),
             };
 
             List<UloopPausePointCallerFrame> selected = SourcePausePointCallerFrameSelector.Select(rawFrames);

--- a/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
+++ b/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
@@ -45,7 +45,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                         FrameCount = 42,
                         HitAtUtc = "2026-06-03T00:00:01.0000000Z",
                         CapturedVariables = new List<PausePointStatusCapturedVariable>(),
-                        Truncated = false
+                        Truncated = false,
+                        CallerFrames = new List<PausePointStatusCallerFrame>
+                        {
+                            new()
+                            {
+                                Method = "Game.AI.Tick",
+                                File = "Assets/Scripts/AI.cs",
+                                Line = 44
+                            }
+                        }
                     }
                 },
                 HistoryDroppedCount = 0,
@@ -78,6 +87,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                         UnityObjectPath = "MainScene:/Root/Enemy",
                         UnityObjectInstanceId = -1234,
                         Truncated = false
+                    }
+                },
+                CallerFrames = new List<PausePointStatusCallerFrame>
+                {
+                    new()
+                    {
+                        Method = "Game.AI.Tick",
+                        File = "Assets/Scripts/AI.cs",
+                        Line = 44
                     }
                 },
                 CapturedVariablesTruncated = true,

--- a/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
+++ b/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
@@ -55,6 +55,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                                 Line = 44
                             }
                         }
+                    },
+                    new()
+                    {
+                        HitSequence = 2,
+                        FrameCount = 43,
+                        HitAtUtc = "2026-06-03T00:00:02.0000000Z",
+                        CapturedVariables = new List<PausePointStatusCapturedVariable>(),
+                        Truncated = false,
+                        CallerFrames = new List<PausePointStatusCallerFrame>()
                     }
                 },
                 HistoryDroppedCount = 0,

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -1232,6 +1232,70 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(snapshot.CallerFrames, Is.Empty);
         }
 
+        /// <summary>
+        /// What: PausePointStatusResponse maps caller frames onto both the latest capture and
+        /// each history frame.
+        /// </summary>
+        [Test]
+        public void StatusFromSnapshot_WhenCallerFramesArePresent_MapsTopLevelAndHistory()
+        {
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePointCallerFrame[] callerFrames =
+            {
+                new("Game.Input.HandleJump", "Assets/Scripts/Input.cs", 10),
+            };
+            UloopPausePointRegistry.HitWithCapturedFrame(
+                "jump",
+                CreateEmptyCapturedFrame(),
+                Array.Empty<UloopCapturedVariable>(),
+                false,
+                callerFrames);
+
+            PausePointStatusResponse response =
+                PausePointStatusResponse.FromSnapshot(UloopPausePointRegistry.GetStatus("jump"));
+
+            Assert.That(response.CallerFrames, Has.Count.EqualTo(1));
+            Assert.That(response.CallerFrames[0].Method, Is.EqualTo("Game.Input.HandleJump"));
+            Assert.That(response.CallerFrames[0].File, Is.EqualTo("Assets/Scripts/Input.cs"));
+            Assert.That(response.CallerFrames[0].Line, Is.EqualTo(10));
+            Assert.That(response.CapturedVariableHistory, Has.Count.EqualTo(1));
+            Assert.That(response.CapturedVariableHistory[0].CallerFrames, Has.Count.EqualTo(1));
+            Assert.That(
+                response.CapturedVariableHistory[0].CallerFrames[0].Method,
+                Is.EqualTo("Game.Input.HandleJump"));
+        }
+
+        /// <summary>
+        /// What: PausePointResponse maps caller frames onto history frames only (no top-level
+        /// CallerFrames on the enable/clear payload).
+        /// </summary>
+        [Test]
+        public void FromSnapshot_WhenCallerFramesArePresent_MapsHistoryFramesOnly()
+        {
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePointCallerFrame[] callerFrames =
+            {
+                new("Game.Input.HandleJump", "Assets/Scripts/Input.cs", 10),
+            };
+            UloopPausePointRegistry.HitWithCapturedFrame(
+                "jump",
+                CreateEmptyCapturedFrame(),
+                Array.Empty<UloopCapturedVariable>(),
+                false,
+                callerFrames);
+
+            PausePointResponse response =
+                PausePointResponse.FromSnapshot(UloopPausePointRegistry.GetStatus("jump"));
+
+            Assert.That(response.CapturedVariableHistory, Has.Count.EqualTo(1));
+            Assert.That(response.CapturedVariableHistory[0].CallerFrames, Has.Count.EqualTo(1));
+            Assert.That(
+                response.CapturedVariableHistory[0].CallerFrames[0].Method,
+                Is.EqualTo("Game.Input.HandleJump"));
+            Assert.That(response.CapturedVariableHistory[0].CallerFrames[0].File, Is.EqualTo("Assets/Scripts/Input.cs"));
+            Assert.That(response.CapturedVariableHistory[0].CallerFrames[0].Line, Is.EqualTo(10));
+        }
+
         [Test]
         public void TryGetCapturedValue_WhenLatestHitStoredRawFrame_ReturnsLiveReferences()
         {

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -179,6 +179,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public IReadOnlyList<PausePointCapturedVariable> CapturedVariables { get; set; } =
             Array.Empty<PausePointCapturedVariable>();
         public bool Truncated { get; set; }
+        public IReadOnlyList<PausePointCallerFrame> CallerFrames { get; set; } =
+            Array.Empty<PausePointCallerFrame>();
 
         internal static PausePointCapturedHistoryFrame FromSnapshot(
             UloopPausePointCapturedHistoryFrame snapshot)
@@ -196,7 +198,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 CapturedVariables = snapshot.CapturedVariables
                     .Select(PausePointCapturedVariable.FromSnapshot)
                     .ToList(),
-                Truncated = snapshot.Truncated
+                Truncated = snapshot.Truncated,
+                CallerFrames = snapshot.CallerFrames
+                    .Select(PausePointCallerFrame.FromSnapshot)
+                    .ToList()
             };
         }
     }
@@ -232,6 +237,36 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 UnityObjectPath = snapshot.UnityObjectPath,
                 UnityObjectInstanceId = snapshot.UnityObjectInstanceId,
                 Truncated = snapshot.Truncated
+            };
+        }
+    }
+
+    /// <summary>
+    /// One managed caller stack frame included in a pause point capture history frame.
+    /// </summary>
+    public class PausePointCallerFrame
+    {
+        public string Method { get; set; } = string.Empty;
+
+        // Null when debug symbols are unavailable; omit to match Go omitempty.
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string File { get; set; }
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int Line { get; set; }
+
+        internal static PausePointCallerFrame FromSnapshot(UloopPausePointCallerFrame snapshot)
+        {
+            if (snapshot == null)
+            {
+                throw new ArgumentNullException(nameof(snapshot));
+            }
+
+            return new PausePointCallerFrame
+            {
+                Method = snapshot.Method,
+                File = snapshot.File,
+                Line = snapshot.Line
             };
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCallerFrameSelector.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCallerFrameSelector.cs
@@ -104,7 +104,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         // Mono reports script-assembly sources as "./Packages/..." on macOS, as an absolute
         // project path on some Editors, and may use backslashes on Windows; normalize so the
-        // payload is a stable project-relative forward-slash path.
+        // payload is a stable project-relative forward-slash path. A rooted path with no
+        // recognizable project segment degrades to null so the payload never carries a
+        // machine path.
         internal static string NormalizeFilePath(string fileName)
         {
             if (string.IsNullOrEmpty(fileName))
@@ -121,23 +123,58 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return StripToUnityProjectRelative(normalized);
         }
 
+        // Known Unity project-relative roots. Earliest match wins so a duplicate segment
+        // deeper in the path cannot hijack the strip point.
+        private static readonly string[] ProjectRelativeRootSegments =
+        {
+            "/Assets/",
+            "/Packages/",
+            "/Library/PackageCache/"
+        };
+
         private static string StripToUnityProjectRelative(string normalized)
         {
-            const string assetsSegment = "/Assets/";
-            const string packagesSegment = "/Packages/";
-            int assetsIndex = normalized.IndexOf(assetsSegment, StringComparison.Ordinal);
-            int packagesIndex = normalized.IndexOf(packagesSegment, StringComparison.Ordinal);
-            if (assetsIndex >= 0 && (packagesIndex < 0 || assetsIndex < packagesIndex))
+            if (normalized.Length == 0)
             {
-                return normalized.Substring(assetsIndex + 1);
+                return null;
             }
 
-            if (packagesIndex >= 0)
+            int earliest = -1;
+            foreach (string segment in ProjectRelativeRootSegments)
             {
-                return normalized.Substring(packagesIndex + 1);
+                int index = normalized.IndexOf(segment, StringComparison.Ordinal);
+                if (index >= 0 && (earliest < 0 || index < earliest))
+                {
+                    earliest = index;
+                }
+            }
+
+            if (earliest >= 0)
+            {
+                return normalized.Substring(earliest + 1);
+            }
+
+            if (IsRootedPath(normalized))
+            {
+                // A rooted path with no recognizable project segment would leak a machine
+                // path into the payload; degrade to a method-only frame instead. Select
+                // already coerces Line to 0 when File is null.
+                return null;
             }
 
             return normalized;
+        }
+
+        // Detects absolute paths on both platforms: POSIX (and UNC after backslash
+        // normalization) via the leading slash, Windows drive paths via "X:/".
+        private static bool IsRootedPath(string normalized)
+        {
+            if (normalized[0] == '/')
+            {
+                return true;
+            }
+
+            return normalized.Length >= 3 && normalized[1] == ':' && normalized[2] == '/';
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCallerFrameSelector.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCallerFrameSelector.cs
@@ -102,8 +102,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return typeFullName + "." + (string.IsNullOrEmpty(methodName) ? "(unknown)" : methodName);
         }
 
-        // Mono reports script-assembly sources as "./Packages/..." on macOS and may use
-        // backslashes on Windows; normalize so the payload is stable across platforms.
+        // Mono reports script-assembly sources as "./Packages/..." on macOS, as an absolute
+        // project path on some Editors, and may use backslashes on Windows; normalize so the
+        // payload is a stable project-relative forward-slash path.
         internal static string NormalizeFilePath(string fileName)
         {
             if (string.IsNullOrEmpty(fileName))
@@ -115,6 +116,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (normalized.StartsWith("./", StringComparison.Ordinal))
             {
                 normalized = normalized.Substring(2);
+            }
+
+            return StripToUnityProjectRelative(normalized);
+        }
+
+        private static string StripToUnityProjectRelative(string normalized)
+        {
+            const string assetsSegment = "/Assets/";
+            const string packagesSegment = "/Packages/";
+            int assetsIndex = normalized.IndexOf(assetsSegment, StringComparison.Ordinal);
+            int packagesIndex = normalized.IndexOf(packagesSegment, StringComparison.Ordinal);
+            if (assetsIndex >= 0 && (packagesIndex < 0 || assetsIndex < packagesIndex))
+            {
+                return normalized.Substring(assetsIndex + 1);
+            }
+
+            if (packagesIndex >= 0)
+            {
+                return normalized.Substring(packagesIndex + 1);
             }
 
             return normalized;

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -150,6 +150,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public string RecommendedNextAction { get; set; } = string.Empty;
         public IReadOnlyList<PausePointStatusCapturedVariable> CapturedVariables { get; set; } =
             Array.Empty<PausePointStatusCapturedVariable>();
+        public IReadOnlyList<PausePointStatusCallerFrame> CallerFrames { get; set; } =
+            Array.Empty<PausePointStatusCallerFrame>();
         public bool CapturedVariablesTruncated { get; set; }
         public IReadOnlyList<string> TruncatedVariableNames { get; set; } = Array.Empty<string>();
         public int TruncatedVariableCount { get; set; }
@@ -211,6 +213,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 CapturedVariables = snapshot.CapturedVariables
                     .Select(PausePointStatusCapturedVariable.FromCapturedVariable)
                     .ToList(),
+                CallerFrames = snapshot.CallerFrames
+                    .Select(PausePointStatusCallerFrame.FromCallerFrame)
+                    .ToList(),
                 CapturedVariablesTruncated = snapshot.CapturedVariablesTruncated,
                 TruncatedVariableNames = snapshot.TruncatedVariableNames,
                 TruncatedVariableCount = snapshot.TruncatedVariableCount,
@@ -257,6 +262,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public IReadOnlyList<PausePointStatusCapturedVariable> CapturedVariables { get; set; } =
             Array.Empty<PausePointStatusCapturedVariable>();
         public bool Truncated { get; set; }
+        public IReadOnlyList<PausePointStatusCallerFrame> CallerFrames { get; set; } =
+            Array.Empty<PausePointStatusCallerFrame>();
 
         internal static PausePointStatusCapturedHistoryFrame FromSnapshot(
             UloopPausePointCapturedHistoryFrame snapshot)
@@ -274,7 +281,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 CapturedVariables = snapshot.CapturedVariables
                     .Select(PausePointStatusCapturedVariable.FromCapturedVariable)
                     .ToList(),
-                Truncated = snapshot.Truncated
+                Truncated = snapshot.Truncated,
+                CallerFrames = snapshot.CallerFrames
+                    .Select(PausePointStatusCallerFrame.FromCallerFrame)
+                    .ToList()
             };
         }
     }
@@ -336,6 +346,36 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 UnityObjectPath = capturedVariable.UnityObjectPath,
                 UnityObjectInstanceId = capturedVariable.UnityObjectInstanceId,
                 Truncated = capturedVariable.Truncated
+            };
+        }
+    }
+
+    /// <summary>
+    /// One managed caller stack frame included in the CLI-only pause point status response.
+    /// </summary>
+    public class PausePointStatusCallerFrame
+    {
+        public string Method { get; set; } = string.Empty;
+
+        // Null when debug symbols are unavailable; omit to match Go omitempty.
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string File { get; set; }
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int Line { get; set; }
+
+        internal static PausePointStatusCallerFrame FromCallerFrame(UloopPausePointCallerFrame callerFrame)
+        {
+            if (callerFrame == null)
+            {
+                throw new ArgumentNullException(nameof(callerFrame));
+            }
+
+            return new PausePointStatusCallerFrame
+            {
+                Method = callerFrame.Method,
+                File = callerFrame.File,
+                Line = callerFrame.Line
             };
         }
     }

--- a/cli/project-runner/internal/projectrunner/pause_point_status_response_contract_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_status_response_contract_test.go
@@ -32,6 +32,47 @@ func TestPausePointStatusResponseMatchesSharedContract(t *testing.T) {
 	}
 }
 
+// Verifies empty caller-frame lists stay visible as [] in the re-marshaled CLI payload
+// (matching the always-present C# serialization) instead of being dropped.
+func TestPausePointStatusResponseKeepsEmptyCallerFramesVisible(t *testing.T) {
+	response := pausePointStatusResponse{
+		CallerFrames: []pausePointCallerFrame{},
+		CapturedVariableHistory: []pausePointCapturedHistoryFrame{
+			{CallerFrames: []pausePointCallerFrame{}},
+		},
+	}
+
+	data, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("failed to marshal pause point status response: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("failed to unmarshal round-tripped payload: %v", err)
+	}
+
+	topLevel, ok := payload["CallerFrames"].([]any)
+	if !ok || len(topLevel) != 0 {
+		t.Fatalf("expected top-level CallerFrames to be an empty array, got %#v", payload["CallerFrames"])
+	}
+
+	history, ok := payload["CapturedVariableHistory"].([]any)
+	if !ok || len(history) != 1 {
+		t.Fatalf("expected one history frame, got %#v", payload["CapturedVariableHistory"])
+	}
+
+	historyFrame, ok := history[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected history frame object, got %#v", history[0])
+	}
+
+	historyFrames, ok := historyFrame["CallerFrames"].([]any)
+	if !ok || len(historyFrames) != 0 {
+		t.Fatalf("expected history CallerFrames to be an empty array, got %#v", historyFrame["CallerFrames"])
+	}
+}
+
 func readPausePointStatusResponseContract(t *testing.T) []byte {
 	t.Helper()
 

--- a/cli/project-runner/internal/projectrunner/pause_point_types.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_types.go
@@ -27,7 +27,7 @@ type pausePointStatusResponse struct {
 	Message                         string                           `json:"Message"`
 	RecommendedNextAction           string                           `json:"RecommendedNextAction"`
 	CapturedVariables               []pausePointCapturedVariable     `json:"CapturedVariables"`
-	CallerFrames                    []pausePointCallerFrame          `json:"CallerFrames,omitempty"`
+	CallerFrames                    []pausePointCallerFrame          `json:"CallerFrames"`
 	CapturedVariablesTruncated      bool                             `json:"CapturedVariablesTruncated"`
 	TruncatedVariableNames          []string                         `json:"TruncatedVariableNames"`
 	TruncatedVariableCount          int                              `json:"TruncatedVariableCount"`
@@ -119,7 +119,7 @@ type pausePointCapturedHistoryFrame struct {
 	HitAtUtc          string                       `json:"HitAtUtc"`
 	CapturedVariables []pausePointCapturedVariable `json:"CapturedVariables"`
 	Truncated         bool                         `json:"Truncated"`
-	CallerFrames      []pausePointCallerFrame      `json:"CallerFrames,omitempty"`
+	CallerFrames      []pausePointCallerFrame      `json:"CallerFrames"`
 }
 
 // pausePointCallerFrame mirrors the Unity-side caller-frame DTO: Method is always

--- a/cli/project-runner/internal/projectrunner/pause_point_types.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_types.go
@@ -27,6 +27,7 @@ type pausePointStatusResponse struct {
 	Message                         string                           `json:"Message"`
 	RecommendedNextAction           string                           `json:"RecommendedNextAction"`
 	CapturedVariables               []pausePointCapturedVariable     `json:"CapturedVariables"`
+	CallerFrames                    []pausePointCallerFrame          `json:"CallerFrames,omitempty"`
 	CapturedVariablesTruncated      bool                             `json:"CapturedVariablesTruncated"`
 	TruncatedVariableNames          []string                         `json:"TruncatedVariableNames"`
 	TruncatedVariableCount          int                              `json:"TruncatedVariableCount"`
@@ -118,6 +119,15 @@ type pausePointCapturedHistoryFrame struct {
 	HitAtUtc          string                       `json:"HitAtUtc"`
 	CapturedVariables []pausePointCapturedVariable `json:"CapturedVariables"`
 	Truncated         bool                         `json:"Truncated"`
+	CallerFrames      []pausePointCallerFrame      `json:"CallerFrames,omitempty"`
+}
+
+// pausePointCallerFrame mirrors the Unity-side caller-frame DTO: Method is always
+// present; File and Line are omitted when debug symbols are unavailable.
+type pausePointCallerFrame struct {
+	Method string `json:"Method"`
+	File   string `json:"File,omitempty"`
+	Line   int    `json:"Line,omitempty"`
 }
 
 // pausePointCapturedVariable mirrors the flat Unity-side

--- a/tests/contracts/pause_point_status_response_contract.json
+++ b/tests/contracts/pause_point_status_response_contract.json
@@ -15,7 +15,14 @@
       "FrameCount": 42,
       "HitAtUtc": "2026-06-03T00:00:01.0000000Z",
       "CapturedVariables": [],
-      "Truncated": false
+      "Truncated": false,
+      "CallerFrames": [
+        {
+          "Method": "Game.AI.Tick",
+          "File": "Assets/Scripts/AI.cs",
+          "Line": 44
+        }
+      ]
     }
   ],
   "HistoryDroppedCount": 0,
@@ -45,6 +52,13 @@
       "UnityObjectPath": "MainScene:/Root/Enemy",
       "UnityObjectInstanceId": -1234,
       "Truncated": false
+    }
+  ],
+  "CallerFrames": [
+    {
+      "Method": "Game.AI.Tick",
+      "File": "Assets/Scripts/AI.cs",
+      "Line": 44
     }
   ],
   "CapturedVariablesTruncated": true,

--- a/tests/contracts/pause_point_status_response_contract.json
+++ b/tests/contracts/pause_point_status_response_contract.json
@@ -23,6 +23,14 @@
           "Line": 44
         }
       ]
+    },
+    {
+      "HitSequence": 2,
+      "FrameCount": 43,
+      "HitAtUtc": "2026-06-03T00:00:02.0000000Z",
+      "CapturedVariables": [],
+      "Truncated": false,
+      "CallerFrames": []
     }
   ],
   "HistoryDroppedCount": 0,


### PR DESCRIPTION
## Summary
- Pause-point hit payloads now include `CallerFrames` (up to two managed callers, nearest first) so agents can see how execution reached the marker without reading a stack dump.
- `pause-point-status` / `await-pause-point` expose frames on the latest hit and on every history frame; `enable-pause-point` / `clear-pause-point` expose them on history frames only, matching the existing captured-variable response split.

## User Impact
- Before this change, a hit told you locals and `this` at the marker line, but not which user method called into it.
- After this change, `CallerFrames` is always present (empty array when no managed callers were captured). Each frame has `Method`; within a frame, `File`/`Line` are omitted when debug symbols are unavailable. `File` is project-relative with forward slashes (`Assets/...`, `Packages/...`, or `Library/PackageCache/...`). A rooted path with no recognizable project segment degrades to a method-only frame instead of leaking a machine path.

## Changes
- Map `CallerFrames` through `PausePointStatusResponse` (top-level + history) and `PausePointResponse` (history-only via a new `PausePointCallerFrame` mirror DTO).
- Update the shared `pause_point_status_response_contract.json` fixture plus the C# and Go contract tests in the same PR (the fixture couples them). The fixture now also pins an empty history `CallerFrames` array.
- Add Go `pausePointCallerFrame` on the status and history structs without `omitempty` on the slices, matching always-present C# `[]` serialization. The await hit payload embeds the status response, so no extra copy.
- Strip absolute Mono script paths to `Assets/...` / `Packages/...` / `Library/PackageCache/...`, and drop `File` for any other rooted path.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>`: `ErrorCount: 0`, `Success: true`
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "PausePoint"`: `410/410 Passed`
- `scripts/check-go-cli.sh`: pass (including `project-runner/internal/projectrunner`)
- Existing regression (PATH `uloop`, `KeyStateAfterPauseInterruption` scene):
  - `scripts/regression-harness-pause-point-trigger.sh`: PASS
  - `scripts/regression-harness-resume-play-paused-arm.sh`: PASS
- Live feature checks (`dist/darwin-arm64/uloop` only):
  1. Marker on a user callee (`Mark` called from `Update`): top-level `CallerFrames` = `[{Method: CallerFrameProbe.Probe.Update, File: Assets/CallerFrameProbe.cs, Line: 15}]` (max 1 in this chain; no `+<...>d__`)
  2. `--mode trace`: `HitCount` 1160, top-level `CallerFrames` present, all 19 history frames each carried the same `CallerFrames`
  3. Engine-direct `SpaceHoldPoller.Update`: `"CallerFrames": []` (explicit empty array), `Success: true`, no error/warning
