### PR TITLE
feat: suggest candidate compiled lines when an enable line drifts from the edited file

### DIFF
--- a/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
+++ b/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
@@ -376,9 +376,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 warning,
                 Is.EqualTo(
-                    drift + string.Format(
-                        SourcePausePointConstants.HotReloadCompiledLineDriftCandidateSingleFormat,
-                        2)));
+                    drift + " Candidate: the edited line's text appears at line 2 in the last compiled source."));
         }
 
         /// <summary>
@@ -410,9 +408,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 warning,
                 Is.EqualTo(
-                    drift + string.Format(
-                        SourcePausePointConstants.HotReloadCompiledLineDriftCandidateMultipleFormat,
-                        "2, 4, 5")));
+                    drift + " Candidate: the edited line's text appears at lines 2, 4, 5 in the last compiled source."));
         }
 
         /// <summary>
@@ -444,9 +440,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 warning,
                 Is.EqualTo(
-                    drift + string.Format(
-                        SourcePausePointConstants.HotReloadCompiledLineDriftCandidateMultipleFormat,
-                        "1, 3, 4" + SourcePausePointConstants.HotReloadCompiledLineDriftCandidateTruncatedMatchesSuffix)));
+                    drift + " Candidate: the edited line's text appears at lines 1, 3, 4 (first 3 matches) in the last compiled source."));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
+++ b/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
@@ -223,6 +223,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             string[] snapshotLines = diskSource.Replace("\r\n", "\n").Split('\n');
             snapshotLines[requestedLine - 1] = "            return 0;";
+            snapshotLines[markerLine - 1] = "            return 424242;";
             string snapshotSource = string.Join("\n", snapshotLines);
 
             try
@@ -259,6 +260,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     response.ResolvedMethod,
                     spanResult.Resolution.CompiledMethodStartLine,
                     spanResult.Resolution.CompiledMethodEndLine);
+                expectedDrift = PausePointEnableWarnings.AppendCandidateCompiledLinesToDriftWarningOrUnchanged(
+                    expectedDrift,
+                    "return 424242;",
+                    snapshotLines);
                 string expectedWarning = PausePointEnableWarnings.MergeWarnings(
                     PausePointEnableWarnings.MergeWarnings(
                         PausePointEnableWarnings.MergeWarnings(
@@ -340,6 +345,151 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 "Example.Run",
                 8,
                 11);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: one trimmed compiled-source match appends a single-line candidate to the drift warning.
+        /// </summary>
+        [Test]
+        public void AppendCandidateCompiledLinesToDriftWarningOrUnchanged_WhenOneLineMatches_AppendsSingleCandidate()
+        {
+            string drift = string.Format(
+                SourcePausePointConstants.HotReloadCompiledLineMapLineDriftWarningFormat,
+                ForwardSlashFile,
+                17,
+                "return 1;",
+                "return 2;");
+            string[] compiledLines =
+            {
+                "class Sample",
+                "            return 2;",
+                "            return 1;"
+            };
+
+            string warning = PausePointEnableWarnings.AppendCandidateCompiledLinesToDriftWarningOrUnchanged(
+                drift,
+                "  return 2;  ",
+                compiledLines);
+
+            Assert.That(
+                warning,
+                Is.EqualTo(
+                    drift + string.Format(
+                        SourcePausePointConstants.HotReloadCompiledLineDriftCandidateSingleFormat,
+                        2)));
+        }
+
+        /// <summary>
+        /// What: two or three trimmed compiled-source matches append every matching line number.
+        /// </summary>
+        [Test]
+        public void AppendCandidateCompiledLinesToDriftWarningOrUnchanged_WhenThreeLinesMatch_AppendsAllCandidates()
+        {
+            string drift = string.Format(
+                SourcePausePointConstants.HotReloadCompiledLineMapLineDriftWarningFormat,
+                ForwardSlashFile,
+                17,
+                "return 1;",
+                "return 2;");
+            string[] compiledLines =
+            {
+                "class Sample",
+                "            return 2;",
+                "            return 1;",
+                "            return 2;",
+                "            return 2;"
+            };
+
+            string warning = PausePointEnableWarnings.AppendCandidateCompiledLinesToDriftWarningOrUnchanged(
+                drift,
+                "return 2;",
+                compiledLines);
+
+            Assert.That(
+                warning,
+                Is.EqualTo(
+                    drift + string.Format(
+                        SourcePausePointConstants.HotReloadCompiledLineDriftCandidateMultipleFormat,
+                        "2, 4, 5")));
+        }
+
+        /// <summary>
+        /// What: more than three trimmed compiled-source matches append the first three and a truncation note.
+        /// </summary>
+        [Test]
+        public void AppendCandidateCompiledLinesToDriftWarningOrUnchanged_WhenMoreThanThreeLinesMatch_CapsAtFirstThree()
+        {
+            string drift = string.Format(
+                SourcePausePointConstants.HotReloadCompiledLineMapLineDriftWarningFormat,
+                ForwardSlashFile,
+                17,
+                "return 1;",
+                "return 2;");
+            string[] compiledLines =
+            {
+                "            return 2;",
+                "            return 1;",
+                "            return 2;",
+                "            return 2;",
+                "            return 2;"
+            };
+
+            string warning = PausePointEnableWarnings.AppendCandidateCompiledLinesToDriftWarningOrUnchanged(
+                drift,
+                "return 2;",
+                compiledLines);
+
+            Assert.That(
+                warning,
+                Is.EqualTo(
+                    drift + string.Format(
+                        SourcePausePointConstants.HotReloadCompiledLineDriftCandidateMultipleFormat,
+                        "1, 3, 4" + SourcePausePointConstants.HotReloadCompiledLineDriftCandidateTruncatedMatchesSuffix)));
+        }
+
+        /// <summary>
+        /// What: no compiled-source match leaves the drift warning unchanged.
+        /// </summary>
+        [Test]
+        public void AppendCandidateCompiledLinesToDriftWarningOrUnchanged_WhenNoLineMatches_LeavesWarningUnchanged()
+        {
+            string drift = string.Format(
+                SourcePausePointConstants.HotReloadCompiledLineMapLineDriftWarningFormat,
+                ForwardSlashFile,
+                17,
+                "return 1;",
+                "return 2;");
+            string[] compiledLines =
+            {
+                "class Sample",
+                "            return 1;"
+            };
+
+            string warning = PausePointEnableWarnings.AppendCandidateCompiledLinesToDriftWarningOrUnchanged(
+                drift,
+                "return 2;",
+                compiledLines);
+
+            Assert.That(warning, Is.EqualTo(drift));
+        }
+
+        /// <summary>
+        /// What: an empty drift warning stays empty even when compiled source contains the edited text.
+        /// </summary>
+        [Test]
+        public void AppendCandidateCompiledLinesToDriftWarningOrUnchanged_WhenDriftIsEmpty_ReturnsEmpty()
+        {
+            string[] compiledLines =
+            {
+                "            return 2;"
+            };
+
+            string warning = PausePointEnableWarnings.AppendCandidateCompiledLinesToDriftWarningOrUnchanged(
+                string.Empty,
+                "return 2;",
+                compiledLines);
 
             Assert.That(warning, Is.EqualTo(string.Empty));
         }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEnableWarnings.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEnableWarnings.cs
@@ -193,7 +193,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string listed = string.Join(", ", matches);
             if (truncated)
             {
-                listed += SourcePausePointConstants.HotReloadCompiledLineDriftCandidateTruncatedMatchesSuffix;
+                listed += string.Format(
+                    SourcePausePointConstants.HotReloadCompiledLineDriftCandidateTruncatedMatchesSuffixFormat,
+                    SourcePausePointConstants.CompiledLineDriftCandidateMatchLimit);
             }
 
             return string.Format(

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEnableWarnings.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEnableWarnings.cs
@@ -115,6 +115,92 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 compiledMethodEndLine);
         }
 
+        // Why only after a non-empty drift warning: a candidate list without drift would look
+        // like a second resolution, and empty edited text never produces drift in the first place.
+        internal static string AppendCandidateCompiledLinesToDriftWarningOrUnchanged(
+            string driftWarning,
+            string editedLineText,
+            IReadOnlyList<string> compiledSourceLines)
+        {
+            if (string.IsNullOrEmpty(driftWarning))
+            {
+                return driftWarning ?? string.Empty;
+            }
+
+            if (string.IsNullOrEmpty(editedLineText) || compiledSourceLines == null)
+            {
+                return driftWarning;
+            }
+
+            string editedTrimmed = editedLineText.Trim();
+            if (editedTrimmed.Length == 0)
+            {
+                return driftWarning;
+            }
+
+            (List<int> matches, bool truncated) = CollectCandidateCompiledLineNumbers(
+                editedTrimmed,
+                compiledSourceLines);
+            if (matches.Count == 0)
+            {
+                return driftWarning;
+            }
+
+            return driftWarning + FormatCandidateCompiledLinesSuffix(matches, truncated);
+        }
+
+        private static (List<int> matches, bool truncated) CollectCandidateCompiledLineNumbers(
+            string editedTrimmed,
+            IReadOnlyList<string> compiledSourceLines)
+        {
+            int matchLimit = SourcePausePointConstants.CompiledLineDriftCandidateMatchLimit;
+            List<int> matches = new List<int>();
+            bool truncated = false;
+            for (int index = 0; index < compiledSourceLines.Count; index++)
+            {
+                string compiledLine = compiledSourceLines[index];
+                if (compiledLine == null)
+                {
+                    continue;
+                }
+
+                if (!string.Equals(compiledLine.Trim(), editedTrimmed, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (matches.Count == matchLimit)
+                {
+                    truncated = true;
+                    break;
+                }
+
+                matches.Add(index + 1);
+            }
+
+            return (matches, truncated);
+        }
+
+        private static string FormatCandidateCompiledLinesSuffix(List<int> matches, bool truncated)
+        {
+            if (matches.Count == 1 && !truncated)
+            {
+                return string.Format(
+                    SourcePausePointConstants.HotReloadCompiledLineDriftCandidateSingleFormat,
+                    matches[0]);
+            }
+
+            string listed = string.Join(", ", matches);
+            if (truncated)
+            {
+                listed += SourcePausePointConstants.HotReloadCompiledLineDriftCandidateTruncatedMatchesSuffix;
+            }
+
+            return string.Format(
+                SourcePausePointConstants.HotReloadCompiledLineDriftCandidateMultipleFormat,
+                listed);
+        }
+
         internal static string BuildRetargetedToHotReloadPatchWarningOrEmpty(
             bool retargetedToHotReloadPatch,
             string resolvedMethod,

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
@@ -350,12 +350,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 snapshot = UloopPausePointRegistry.GetStatus(id);
             }
 
-            string resolvedLineText = ResolveEnableLineText(
-                parameters.File,
-                resolvedLine,
-                resolvedEndLine,
-                retargetedToHotReloadPatch,
-                hasActiveHotReloadPatches);
+            bool compareCompiledLineDrift = hasActiveHotReloadPatches && !retargetedToHotReloadPatch;
+            string compiledSnapshotSource = compareCompiledLineDrift
+                ? LoadCompiledSnapshotSourceOrEmpty(parameters.File)
+                : string.Empty;
+            // Why snapshot over disk: the editor file may already include unpatched-line drift, so
+            // reading disk at the compiled ResolvedLine shows the wrong statement (FB9 empty/mismatch).
+            // The snapshot read stays single-line because the verified snapshot has no end-line data;
+            // the disk read spans resolvedLine..resolvedEndLine so a rounded-forward multi-line
+            // statement returns its full text.
+            string resolvedLineText = compareCompiledLineDrift
+                ? SourcePausePointSourceLineReader.ReadLineTextFromSource(compiledSnapshotSource, resolvedLine)
+                : PausePointLineTextReader.ReadResolvedLineText(parameters.File, resolvedLine, resolvedEndLine);
             UloopPausePointRegistry.SetResolvedLine(id, resolvedLine, resolvedLineText);
 
             PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
@@ -373,7 +379,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     parameters.Line,
                     editedMethodStartLine,
                     editedMethodEndLine));
-            bool compareCompiledLineDrift = hasActiveHotReloadPatches && !retargetedToHotReloadPatch;
             string compiledLineMapWarning = PausePointEnableWarnings.ChooseCompiledLineMapWarning(
                 patchedMethodPdbUnavailableWarning,
                 PausePointEnableWarnings.BuildCompiledLineMapWarningOrEmpty(
@@ -393,6 +398,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     resolvedMethod,
                     compiledMethodStartLine,
                     compiledMethodEndLine);
+                string[] compiledSourceLines = SourcePausePointSourceLineReader.SplitSourceLines(compiledSnapshotSource);
+                driftWarning = PausePointEnableWarnings.AppendCandidateCompiledLinesToDriftWarningOrUnchanged(
+                    driftWarning,
+                    editedLineText,
+                    compiledSourceLines);
                 enableWarning = PausePointEnableWarnings.MergeWarnings(enableWarning, driftWarning);
                 if (driftWarning.Length > 0)
                 {
@@ -466,27 +476,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 });
         }
 
-        // Why snapshot over disk: the editor file may already include unpatched-line drift, so
-        // reading disk at the compiled ResolvedLine shows the wrong statement (FB9 empty/mismatch).
-        // The snapshot read stays single-line because the verified snapshot has no end-line data;
-        // the disk read spans resolvedLine..resolvedEndLine so a rounded-forward multi-line
-        // statement returns its full text.
-        private static string ResolveEnableLineText(
-            string requestedFile,
-            int resolvedLine,
-            int resolvedEndLine,
-            bool retargetedToHotReloadPatch,
-            bool hasActiveHotReloadPatches)
+        private static string LoadCompiledSnapshotSourceOrEmpty(string requestedFile)
         {
-            if (hasActiveHotReloadPatches && !retargetedToHotReloadPatch)
-            {
-                string normalizedFile = SourcePausePointPathNormalizer.ToForwardSlashes(requestedFile);
-                string snapshotSource =
-                    HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile?.Invoke(normalizedFile);
-                return SourcePausePointSourceLineReader.ReadLineTextFromSource(snapshotSource, resolvedLine);
-            }
-
-            return PausePointLineTextReader.ReadResolvedLineText(requestedFile, resolvedLine, resolvedEndLine);
+            string normalizedFile = SourcePausePointPathNormalizer.ToForwardSlashes(requestedFile);
+            string snapshotSource =
+                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile?.Invoke(normalizedFile);
+            return snapshotSource ?? string.Empty;
         }
 
         // The derived id must use the originally requested file/line (not the resolved/rounded

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -268,8 +268,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string HotReloadCompiledLineDriftCandidateMultipleFormat =
             " Candidate: the edited line's text appears at lines {0} in the last compiled source.";
 
-        public const string HotReloadCompiledLineDriftCandidateTruncatedMatchesSuffix =
-            " (first 3 matches)";
+        // Why format from CompiledLineDriftCandidateMatchLimit: a hard-coded "3" would lie
+        // if the cap changed.
+        public const string HotReloadCompiledLineDriftCandidateTruncatedMatchesSuffixFormat =
+            " (first {0} matches)";
 
         public const string NearbyCompiledMethodsPrefix =
             " Nearby methods in the last compiled source: ";

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -256,6 +256,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string HotReloadCompiledMethodSpanInLastCompiledSourceFormat =
             " In the last compiled source, '{0}' spans lines {1}-{2}.";
 
+        // Why cap 3: a longer match list turns the enable warning into another line-number puzzle.
+        public const int CompiledLineDriftCandidateMatchLimit = 3;
+
+        // Format: 1-based compiled line number. Why "Candidate": this is a search hit, not a
+        // guarantee that re-enabling there is the intended statement.
+        public const string HotReloadCompiledLineDriftCandidateSingleFormat =
+            " Candidate: the edited line's text appears at line {0} in the last compiled source.";
+
+        // Format: comma-separated 1-based compiled line numbers, with an optional truncation note.
+        public const string HotReloadCompiledLineDriftCandidateMultipleFormat =
+            " Candidate: the edited line's text appears at lines {0} in the last compiled source.";
+
+        public const string HotReloadCompiledLineDriftCandidateTruncatedMatchesSuffix =
+            " (first 3 matches)";
+
         public const string NearbyCompiledMethodsPrefix =
             " Nearby methods in the last compiled source: ";
 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointSourceLineReader.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointSourceLineReader.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -34,6 +35,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return string.Join(" ", trimmedNonEmptyLines);
         }
 
+        public static string[] SplitSourceLines(string sourceText)
+        {
+            if (string.IsNullOrEmpty(sourceText))
+            {
+                return Array.Empty<string>();
+            }
+
+            return sourceText.Replace("\r\n", "\n").Split('\n');
+        }
+
         public static string ReadLineTextFromSource(string sourceText, int lineNumber)
         {
             if (string.IsNullOrEmpty(sourceText) || lineNumber <= 0)
@@ -41,7 +52,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return string.Empty;
             }
 
-            string[] lines = sourceText.Replace("\r\n", "\n").Split('\n');
+            string[] lines = SplitSourceLines(sourceText);
             if (lineNumber > lines.Length)
             {
                 return string.Empty;


### PR DESCRIPTION
## Summary
- When `--line` from an edited file lands on a different statement in the last compiled source (hot-reload line drift), the enable warning now lists up to 3 candidate compiled line numbers whose text matches the edited statement.

## User Impact
- Before: the drift warning showed compiled vs edited text at the resolved line, but not where that edited statement lives in the last compiled source, so you had to recompute `--line` by hand.
- After: a non-empty drift warning appends candidate compiled line numbers (1 match / several matches / first 3 plus a truncation note). No extra file reads: candidate search reuses the compiled snapshot already loaded for `ResolvedLineText`.

## Changes
- Search last-compiled-source lines for an Ordinal trimmed match of the edited line text, only when the existing drift warning is non-empty.
- Append a candidate sentence that names last-compiled-source line numbers; 0 matches add nothing.
- Enable path loads the verified compiled snapshot once and reuses it for resolved line text and candidate search.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → ErrorCount 0
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value "PausePointCompiledLineMapWarningTests"` → 29 passed, 0 failed
- `CODE_COMPLEXITY_FAIL_ON_EXCEEDED=true scripts/check-code-complexity.sh` → no CA1502 findings above 15


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

