### PR TITLE
feat: name changed declarations in the outside-body drift warning

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
@@ -12,6 +12,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     public class HotReloadAddedMemberHost
     {
         public int PublicSeed = 3;
+        public int PairAlpha = 1, PairBeta = 2;
 
         public HotReloadAddedMemberHost Inner;
 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -809,7 +809,119 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             Assert.That(foundDrift, Is.True, "Existing field initializer edits must still warn.");
+            AssertHasDeclarationDriftWarning(
+                result,
+                "Edits outside method bodies in AddedFieldWithInitializerDrift.cs (field initializer: PublicSeed) are not applied by hot reload; run uloop compile to pick them up.");
             Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
+        }
+
+        /// <summary>
+        /// What: editing an existing field initializer names that field in the outside-body
+        /// warning rather than emitting the file-only wording.
+        /// </summary>
+        [Test]
+        public async Task Drift_ExistingInitializerEdit_NamesDeclaration()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int PublicSeed = 3;",
+                "        public int PublicSeed = 99;",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("NamedInitializerDrift.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Is.EqualTo(
+                    new[]
+                    {
+                        "Edits outside method bodies in NamedInitializerDrift.cs (field initializer: PublicSeed) are not applied by hot reload; run uloop compile to pick them up."
+                    }));
+        }
+
+        /// <summary>
+        /// What: changing attributes on a multi-declarator field names every sibling rather
+        /// than attributing the edit to a single variable.
+        /// </summary>
+        [Test]
+        public async Task Drift_MultiDeclaratorAttributeEdit_NamesEverySibling()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            Assert.That(onDisk, Does.Contain("        public int PairAlpha = 1, PairBeta = 2;"));
+            string edited = onDisk.Replace(
+                "        public int PairAlpha = 1, PairBeta = 2;",
+                "        [Obsolete]\n        public int PairAlpha = 1, PairBeta = 2;",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("MultiDeclaratorAttributeDrift.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Is.EqualTo(
+                    new[]
+                    {
+                        "Edits outside method bodies in MultiDeclaratorAttributeDrift.cs (field attributes: PairAlpha, PairBeta) are not applied by hot reload; run uloop compile to pick them up."
+                    }));
+        }
+
+        /// <summary>
+        /// What: changing one initializer on a multi-declarator field names only that
+        /// variable, not its sibling.
+        /// </summary>
+        [Test]
+        public async Task Drift_MultiDeclaratorInitializerEdit_NamesOnlyChangedVariable()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int PairAlpha = 1, PairBeta = 2;",
+                "        public int PairAlpha = 99, PairBeta = 2;",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("MultiDeclaratorInitializerDrift.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Is.EqualTo(
+                    new[]
+                    {
+                        "Edits outside method bodies in MultiDeclaratorInitializerDrift.cs (field initializer: PairAlpha) are not applied by hot reload; run uloop compile to pick them up."
+                    }));
+        }
+
+        /// <summary>
+        /// What: a duplicate field syntax key fails open to the file-only outside-body warning
+        /// instead of suppressing it or emitting a named declaration warning.
+        /// </summary>
+        [Test]
+        public async Task Drift_DuplicateFieldSyntaxKey_FailsOpenToFileOnlyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string snapshotSource = onDisk.Replace(
+                "        public int PublicSeed = 3;",
+                "        public int PublicSeed = 3;\n        public int DupCollide;\n        public int DupCollide;",
+                StringComparison.Ordinal);
+            string edited = onDisk.Replace(
+                "        public int PublicSeed = 3;",
+                "        public int PublicSeed = 99;",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("DupFieldKeyFailOpen.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: snapshotSource);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Is.EqualTo(
+                    new[]
+                    {
+                        "Edits outside method bodies in DupFieldKeyFailOpen.cs (fields, initializers, or attributes) are not applied by hot reload; run uloop compile to pick them up."
+                    }));
         }
 
         /// <summary>
@@ -1002,6 +1114,120 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CompiledEventWarningFormat,
                 "ScoreChanged",
                 "WarnEventRewrittenAsField.cs");
+        }
+
+        /// <summary>
+        /// What: rewriting compiled property Hp to a field emits the kind-change warning and
+        /// does not also emit the generic outside-body warning.
+        /// </summary>
+        [Test]
+        public async Task Drift_PropertyKindChangeOnly_DoesNotEmitOutsideBodyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int Hp { get; set; }",
+                "        public int Hp;",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("PropertyKindChangeOnlyNoOutsideBody.cs", edited),
+                FieldKindChangeProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Is.EqualTo(
+                    new[]
+                    {
+                        "Compiled property 'io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadFieldKindChangeFixture.Hp' was removed or redeclared as a different member kind in the edited source; the compiled member stays until 'uloop compile'."
+                    }));
+        }
+
+        /// <summary>
+        /// What: rewriting compiled event ScoreChanged to a field emits the kind-change warning
+        /// and does not also emit the generic outside-body warning.
+        /// </summary>
+        [Test]
+        public async Task Drift_EventKindChangeOnly_DoesNotEmitOutsideBodyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public event Action ScoreChanged;",
+                "        public int ScoreChanged;",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("EventKindChangeOnlyNoOutsideBody.cs", edited),
+                FieldKindChangeProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Is.EqualTo(
+                    new[]
+                    {
+                        "Compiled event 'io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadFieldKindChangeFixture.ScoreChanged' was removed or redeclared as a different member kind in the edited source; the compiled member stays until 'uloop compile'."
+                    }));
+        }
+
+        /// <summary>
+        /// What: a property-to-field kind change in the same file as an initializer edit keeps
+        /// the named outside-body warning for that initializer.
+        /// </summary>
+        [Test]
+        public async Task Drift_PropertyKindChangeWithInitializerEdit_StillEmitsNamedOutsideBodyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int Hp { get; set; }",
+                "        public int Hp;",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                "        public int PublicSeed = 3;",
+                "        public int PublicSeed = 99;",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("PropertyKindChangeWithInitializer.cs", edited),
+                FieldKindChangeProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Is.EqualTo(
+                    new[]
+                    {
+                        "Compiled property 'io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadFieldKindChangeFixture.Hp' was removed or redeclared as a different member kind in the edited source; the compiled member stays until 'uloop compile'.",
+                        "Edits outside method bodies in PropertyKindChangeWithInitializer.cs (field initializer: PublicSeed) are not applied by hot reload; run uloop compile to pick them up."
+                    }));
+        }
+
+        /// <summary>
+        /// What: an event-to-field kind change in the same file as an initializer edit keeps
+        /// the named outside-body warning for that initializer.
+        /// </summary>
+        [Test]
+        public async Task Drift_EventKindChangeWithInitializerEdit_StillEmitsNamedOutsideBodyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public event Action ScoreChanged;",
+                "        public int ScoreChanged;",
+                StringComparison.Ordinal);
+            edited = edited.Replace(
+                "        public int PublicSeed = 3;",
+                "        public int PublicSeed = 99;",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("EventKindChangeWithInitializer.cs", edited),
+                FieldKindChangeProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Is.EqualTo(
+                    new[]
+                    {
+                        "Compiled event 'io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadFieldKindChangeFixture.ScoreChanged' was removed or redeclared as a different member kind in the edited source; the compiled member stays until 'uloop compile'.",
+                        "Edits outside method bodies in EventKindChangeWithInitializer.cs (field initializer: PublicSeed) are not applied by hot reload; run uloop compile to pick them up."
+                    }));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -895,6 +895,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: splitting a multi-declarator across declarations fails open to the file-only
+        /// warning instead of stripping both names and going silent.
+        /// </summary>
+        [Test]
+        public async Task Drift_MultiDeclaratorRegroup_FailsOpenToFileOnlyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int PairAlpha = 1, PairBeta = 2;",
+                "        public int PairAlpha = 1;\n        [Obsolete] public int PairBeta = 2;",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("MultiDeclaratorRegroupDrift.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Is.EqualTo(
+                    new[]
+                    {
+                        "Edits outside method bodies in MultiDeclaratorRegroupDrift.cs (fields, initializers, or attributes) are not applied by hot reload; run uloop compile to pick them up."
+                    }));
+        }
+
+        /// <summary>
         /// What: a duplicate field syntax key fails open to the file-only outside-body warning
         /// instead of suppressing it or emitting a named declaration warning.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -842,6 +842,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: swapping two compiled field declarations without changing initializers still
+        /// emits the file-only outside-body warning, because initializer order is observable.
+        /// </summary>
+        [Test]
+        public async Task Drift_FieldDeclarationOrderSwap_EmitsFileOnlyWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            const string originalOrder =
+                "        public int PublicSeed = 3;\n        public int PairAlpha = 1, PairBeta = 2;";
+            const string swappedOrder =
+                "        public int PairAlpha = 1, PairBeta = 2;\n        public int PublicSeed = 3;";
+            Assert.That(onDisk, Does.Contain(originalOrder));
+            string edited = onDisk.Replace(originalOrder, swappedOrder, StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("FieldOrderSwapDrift.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Is.EqualTo(
+                    new[]
+                    {
+                        "Edits outside method bodies in FieldOrderSwapDrift.cs (fields, initializers, or attributes) are not applied by hot reload; run uloop compile to pick them up."
+                    }));
+        }
+
+        /// <summary>
         /// What: changing attributes on a multi-declarator field names every sibling rather
         /// than attributing the edit to a single variable.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -840,7 +840,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 result.Output.declarationDriftWarnings,
                 Has.Some.Contain("Edits outside method bodies"),
                 "Non-const field initializer edits must still emit the outside-body warning.");
-            AssertContainsOutsideMethodBodyDriftWarning(result, "NonConstFieldInitializerDrift.cs");
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Does.Contain(
+                    "Edits outside method bodies in NonConstFieldInitializerDrift.cs (field initializer: _secret) are not applied by hot reload; run uloop compile to pick them up."));
         }
 
         /// <summary>
@@ -1808,7 +1811,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "        public HotReloadUnsupportedKindCtorFixture()\n        {",
                 "        public HotReloadUnsupportedKindCtorFixture() : this(0)\n        {");
 
-            AssertContainsOutsideMethodBodyDriftWarning(result, fileName);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Does.Contain(
+                    "Edits outside method bodies in UnsupportedKindCtorInitializerDrift.cs (constructor: .ctor) are not applied by hot reload; run uloop compile to pick them up."));
         }
 
         /// <summary>
@@ -1824,7 +1830,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "        public static HotReloadUnsupportedKindOperatorFixture operator +(",
                 "        [Obsolete]\n        public static HotReloadUnsupportedKindOperatorFixture operator +(");
 
-            AssertContainsOutsideMethodBodyDriftWarning(result, fileName);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Does.Contain(
+                    "Edits outside method bodies in UnsupportedKindOperatorAttributeDrift.cs (operator: +) are not applied by hot reload; run uloop compile to pick them up."));
         }
 
         /// <summary>
@@ -1840,7 +1849,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "        public static implicit operator int(HotReloadUnsupportedKindConversionFixture value)",
                 "        [Obsolete]\n        public static implicit operator int(HotReloadUnsupportedKindConversionFixture value)");
 
-            AssertContainsOutsideMethodBodyDriftWarning(result, fileName);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Does.Contain(
+                    "Edits outside method bodies in UnsupportedKindConversionAttributeDrift.cs (conversion: implicit->int) are not applied by hot reload; run uloop compile to pick them up."));
         }
 
         /// <summary>
@@ -1856,7 +1868,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "        public event Action Edited",
                 "        [Obsolete]\n        public event Action Edited");
 
-            AssertContainsOutsideMethodBodyDriftWarning(result, fileName);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Does.Contain(
+                    "Edits outside method bodies in UnsupportedKindEventAttributeDrift.cs (event: Edited) are not applied by hot reload; run uloop compile to pick them up."));
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/CompiledMemberKindChangeWarnings.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/CompiledMemberKindChangeWarnings.cs
@@ -23,19 +23,26 @@ internal static class CompiledMemberKindChangeWarnings
     internal const string CompiledEventKindChangeWarningFormat =
         "Compiled event '{0}' was removed or redeclared as a different member kind in the edited source; the compiled member stays until 'uloop compile'.";
 
+    internal sealed class SyntaxKeys
+    {
+        internal readonly List<string> PropertySyntaxKeys = new List<string>();
+        internal readonly List<string> EventSyntaxKeys = new List<string>();
+    }
+
     /// <summary>
     /// What: names compiled properties and events that the edited source deleted or
     /// redeclared as another member kind, even when no method body changed.
     /// </summary>
-    internal static void AppendCompiledPropertyOrEventKindChangeWarnings(
+    internal static SyntaxKeys AppendCompiledPropertyOrEventKindChangeWarnings(
         CompilationUnitSyntax root,
         SemanticModel semanticModel,
         IAssemblySymbol targetTypesAssemblySymbol,
         List<string> warnings)
     {
+        SyntaxKeys syntaxKeys = new SyntaxKeys();
         if (targetTypesAssemblySymbol == null)
         {
-            return;
+            return syntaxKeys;
         }
 
         HashSet<string> seenTypeMetadataNames = new HashSet<string>(StringComparer.Ordinal);
@@ -71,14 +78,23 @@ internal static class CompiledMemberKindChangeWarnings
                 continue;
             }
 
-            AppendMissingCompiledPropertyOrEventWarnings(compiledType, sourceType, warnings);
+            AppendMissingCompiledPropertyOrEventWarnings(
+                compiledType,
+                sourceType,
+                typeMetadataName,
+                warnings,
+                syntaxKeys);
         }
+
+        return syntaxKeys;
     }
 
     internal static void AppendMissingCompiledPropertyOrEventWarnings(
         INamedTypeSymbol compiledType,
         INamedTypeSymbol sourceType,
-        List<string> warnings)
+        string typeMetadataName,
+        List<string> warnings,
+        SyntaxKeys syntaxKeys)
     {
         foreach (ISymbol compiledMember in compiledType.GetMembers())
         {
@@ -89,6 +105,19 @@ internal static class CompiledMemberKindChangeWarnings
             }
 
             warnings.Add(warning);
+            // Why metadata name rather than ToDisplayString: nested types use '+' in syntax
+            // keys and '.' in display strings, so parsing the warning text cannot rebuild the key.
+            string syntaxKey = typeMetadataName
+                + TransformWorkerProgramMarker.AddedFieldKeySeparator
+                + compiledMember.Name;
+            if (compiledMember is IPropertySymbol)
+            {
+                syntaxKeys.PropertySyntaxKeys.Add(syntaxKey);
+            }
+            else
+            {
+                syntaxKeys.EventSyntaxKeys.Add(syntaxKey);
+            }
         }
     }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OutsideMethodBodyDeclarationDiff.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OutsideMethodBodyDeclarationDiff.cs
@@ -20,6 +20,7 @@ internal static class OutsideMethodBodyDeclarationDiff
     internal sealed class Result
     {
         internal bool DuplicateKeys;
+        internal bool OrderDrift;
         internal readonly List<string> ChangedLabels = new List<string>();
         internal readonly HashSet<string> PairedSyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
     }
@@ -111,6 +112,7 @@ internal static class OutsideMethodBodyDeclarationDiff
             handledCurrentKeys,
             result,
             FormatEventLabel);
+        MarkOrderDriftIfPairedKeysReordered(snapshotMaps, currentMaps, result);
         return result;
     }
 
@@ -460,5 +462,116 @@ internal static class OutsideMethodBodyDeclarationDiff
     private static string FormatEventLabel(EventDeclarationSyntax eventDeclaration)
     {
         return "event: " + eventDeclaration.Identifier.Text;
+    }
+
+    private static void MarkOrderDriftIfPairedKeysReordered(
+        MemberMaps snapshotMaps,
+        MemberMaps currentMaps,
+        Result result)
+    {
+        if (result.PairedSyntaxKeys.Count < 2)
+        {
+            return;
+        }
+
+        List<string> snapshotOrder = OrderKeysBySpanStart(result.PairedSyntaxKeys, snapshotMaps);
+        List<string> currentOrder = OrderKeysBySpanStart(result.PairedSyntaxKeys, currentMaps);
+        result.OrderDrift = !StringListsEqual(snapshotOrder, currentOrder);
+    }
+
+    private static List<string> OrderKeysBySpanStart(HashSet<string> keys, MemberMaps maps)
+    {
+        List<string> ordered = new List<string>(keys);
+        ordered.Sort(new SyntaxKeySpanComparer(maps));
+        return ordered;
+    }
+
+    private static bool StringListsEqual(List<string> left, List<string> right)
+    {
+        if (left.Count != right.Count)
+        {
+            return false;
+        }
+
+        for (int index = 0; index < left.Count; index++)
+        {
+            if (!string.Equals(left[index], right[index], StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static int GetMappedNodeSpanStart(MemberMaps maps, string key)
+    {
+        SyntaxNode node = FindMappedNodeOrNull(maps, key);
+        if (node == null)
+        {
+            return int.MaxValue;
+        }
+
+        return node.SpanStart;
+    }
+
+    private static SyntaxNode FindMappedNodeOrNull(MemberMaps maps, string key)
+    {
+        if (maps.Fields.ContainsKey(key))
+        {
+            return maps.Fields[key];
+        }
+
+        if (maps.EventFields.ContainsKey(key))
+        {
+            return maps.EventFields[key];
+        }
+
+        if (maps.Methods.ContainsKey(key))
+        {
+            return maps.Methods[key];
+        }
+
+        if (maps.Properties.ContainsKey(key))
+        {
+            return maps.Properties[key];
+        }
+
+        if (maps.Indexers.ContainsKey(key))
+        {
+            return maps.Indexers[key];
+        }
+
+        if (maps.Constructors.ContainsKey(key))
+        {
+            return maps.Constructors[key];
+        }
+
+        if (maps.Operators.ContainsKey(key))
+        {
+            return maps.Operators[key];
+        }
+
+        if (maps.Events.ContainsKey(key))
+        {
+            return maps.Events[key];
+        }
+
+        return null;
+    }
+
+    private sealed class SyntaxKeySpanComparer : IComparer<string>
+    {
+        private readonly MemberMaps _maps;
+
+        internal SyntaxKeySpanComparer(MemberMaps maps)
+        {
+            _maps = maps;
+        }
+
+        public int Compare(string left, string right)
+        {
+            return GetMappedNodeSpanStart(_maps, left).CompareTo(GetMappedNodeSpanStart(_maps, right));
+        }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OutsideMethodBodyDeclarationDiff.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OutsideMethodBodyDeclarationDiff.cs
@@ -1,0 +1,436 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+internal static class OutsideMethodBodyDeclarationDiff
+{
+    internal sealed class Result
+    {
+        internal bool DuplicateKeys;
+        internal readonly List<string> ChangedLabels = new List<string>();
+        internal readonly HashSet<string> PairedSyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
+    }
+
+    private sealed class MemberMaps
+    {
+        internal Dictionary<string, MethodDeclarationSyntax> Methods;
+        internal Dictionary<string, VariableDeclaratorSyntax> Fields;
+        internal Dictionary<string, PropertyDeclarationSyntax> Properties;
+        internal Dictionary<string, IndexerDeclarationSyntax> Indexers;
+        internal Dictionary<string, ConstructorDeclarationSyntax> Constructors;
+        internal Dictionary<string, MemberDeclarationSyntax> Operators;
+        internal Dictionary<string, EventDeclarationSyntax> Events;
+        internal Dictionary<string, VariableDeclaratorSyntax> EventFields;
+    }
+
+    /// <summary>
+    /// Pairs declarations by syntax key and records changed labels plus intersection keys
+    /// so the residual tree compare can peel members that already have a named warning.
+    /// </summary>
+    internal static Result Diff(
+        CompilationUnitSyntax snapshotRoot,
+        CompilationUnitSyntax currentRoot,
+        HashSet<string> handledSnapshotKeys,
+        HashSet<string> handledCurrentKeys)
+    {
+        MemberMaps snapshotMaps = TryBuildMemberMaps(snapshotRoot);
+        MemberMaps currentMaps = TryBuildMemberMaps(currentRoot);
+        Result result = new Result();
+        if (snapshotMaps == null || currentMaps == null)
+        {
+            result.DuplicateKeys = true;
+            return result;
+        }
+
+        AppendBaseFieldChangeLabels(
+            snapshotMaps.Fields,
+            currentMaps.Fields,
+            handledSnapshotKeys,
+            handledCurrentKeys,
+            result,
+            "field");
+        AppendBaseFieldChangeLabels(
+            snapshotMaps.EventFields,
+            currentMaps.EventFields,
+            handledSnapshotKeys,
+            handledCurrentKeys,
+            result,
+            "event");
+        AppendPairedSyntaxNodeLabels(
+            snapshotMaps.Methods,
+            currentMaps.Methods,
+            handledSnapshotKeys,
+            handledCurrentKeys,
+            result,
+            FormatMethodLabel);
+        AppendPairedSyntaxNodeLabels(
+            snapshotMaps.Properties,
+            currentMaps.Properties,
+            handledSnapshotKeys,
+            handledCurrentKeys,
+            result,
+            FormatPropertyLabel);
+        AppendPairedSyntaxNodeLabels(
+            snapshotMaps.Indexers,
+            currentMaps.Indexers,
+            handledSnapshotKeys,
+            handledCurrentKeys,
+            result,
+            FormatIndexerLabel);
+        AppendPairedSyntaxNodeLabels(
+            snapshotMaps.Constructors,
+            currentMaps.Constructors,
+            handledSnapshotKeys,
+            handledCurrentKeys,
+            result,
+            FormatConstructorLabel);
+        AppendPairedSyntaxNodeLabels(
+            snapshotMaps.Operators,
+            currentMaps.Operators,
+            handledSnapshotKeys,
+            handledCurrentKeys,
+            result,
+            FormatOperatorLabel);
+        AppendPairedSyntaxNodeLabels(
+            snapshotMaps.Events,
+            currentMaps.Events,
+            handledSnapshotKeys,
+            handledCurrentKeys,
+            result,
+            FormatEventLabel);
+        return result;
+    }
+
+    private static MemberMaps TryBuildMemberMaps(CompilationUnitSyntax root)
+    {
+        MemberMaps maps = new MemberMaps();
+        maps.Methods = WorkerSyntaxIndex.BuildSyntaxMethodMapOrNull(root);
+        maps.Fields = WorkerSyntaxIndex.BuildSyntaxFieldMapOrNull(root);
+        maps.Properties = WorkerSyntaxIndex.BuildSyntaxPropertyMapOrNull(root);
+        maps.Indexers = WorkerSyntaxIndex.BuildSyntaxIndexerMapOrNull(root);
+        maps.Constructors = WorkerSyntaxIndex.BuildSyntaxConstructorMapOrNull(root);
+        maps.Operators = WorkerSyntaxIndex.BuildSyntaxOperatorMapOrNull(root);
+        maps.Events = WorkerSyntaxIndex.BuildSyntaxEventMapOrNull(root);
+        maps.EventFields = WorkerSyntaxIndex.BuildSyntaxEventFieldMapOrNull(root);
+        if (maps.Methods == null
+            || maps.Fields == null
+            || maps.Properties == null
+            || maps.Indexers == null
+            || maps.Constructors == null
+            || maps.Operators == null
+            || maps.Events == null
+            || maps.EventFields == null)
+        {
+            return null;
+        }
+
+        return maps;
+    }
+
+    private static void AppendPairedSyntaxNodeLabels<TNode>(
+        Dictionary<string, TNode> snapshotMap,
+        Dictionary<string, TNode> currentMap,
+        HashSet<string> handledSnapshotKeys,
+        HashSet<string> handledCurrentKeys,
+        Result result,
+        Func<TNode, string> formatLabel)
+        where TNode : SyntaxNode
+    {
+        foreach (KeyValuePair<string, TNode> pair in snapshotMap)
+        {
+            if (!currentMap.ContainsKey(pair.Key))
+            {
+                continue;
+            }
+
+            // Why not pair handled keys: return-type replacements strip the current
+            // declaration always and the snapshot only when the rest of the signature
+            // matches. Peeling both via intersection would hide attribute drift.
+            if (handledSnapshotKeys.Contains(pair.Key) || handledCurrentKeys.Contains(pair.Key))
+            {
+                continue;
+            }
+
+            TNode currentNode = currentMap[pair.Key];
+            result.PairedSyntaxKeys.Add(pair.Key);
+
+            if (SyntaxFactory.AreEquivalent(pair.Value, currentNode, topLevel: false))
+            {
+                continue;
+            }
+
+            result.ChangedLabels.Add(formatLabel(pair.Value));
+        }
+    }
+
+    private static void AppendBaseFieldChangeLabels(
+        Dictionary<string, VariableDeclaratorSyntax> snapshotMap,
+        Dictionary<string, VariableDeclaratorSyntax> currentMap,
+        HashSet<string> handledSnapshotKeys,
+        HashSet<string> handledCurrentKeys,
+        Result result,
+        string kindNoun)
+    {
+        HashSet<BaseFieldDeclarationSyntax> processedParents =
+            new HashSet<BaseFieldDeclarationSyntax>();
+        foreach (KeyValuePair<string, VariableDeclaratorSyntax> pair in snapshotMap)
+        {
+            if (!currentMap.ContainsKey(pair.Key))
+            {
+                continue;
+            }
+
+            if (handledSnapshotKeys.Contains(pair.Key) || handledCurrentKeys.Contains(pair.Key))
+            {
+                continue;
+            }
+
+            result.PairedSyntaxKeys.Add(pair.Key);
+            BaseFieldDeclarationSyntax snapshotParent =
+                pair.Value.Parent?.Parent as BaseFieldDeclarationSyntax;
+            if (snapshotParent == null || !processedParents.Add(snapshotParent))
+            {
+                continue;
+            }
+
+            AppendLabelsForBaseFieldDeclaration(
+                snapshotParent,
+                snapshotMap,
+                currentMap,
+                handledSnapshotKeys,
+                handledCurrentKeys,
+                result,
+                kindNoun);
+        }
+    }
+
+    private static void AppendLabelsForBaseFieldDeclaration(
+        BaseFieldDeclarationSyntax snapshotParent,
+        Dictionary<string, VariableDeclaratorSyntax> snapshotMap,
+        Dictionary<string, VariableDeclaratorSyntax> currentMap,
+        HashSet<string> handledSnapshotKeys,
+        HashSet<string> handledCurrentKeys,
+        Result result,
+        string kindNoun)
+    {
+        List<string> comparableKeys = CollectComparableSiblingKeys(
+            snapshotParent,
+            snapshotMap,
+            currentMap,
+            handledSnapshotKeys,
+            handledCurrentKeys);
+        if (comparableKeys.Count == 0)
+        {
+            return;
+        }
+
+        VariableDeclaratorSyntax currentFirst = currentMap[comparableKeys[0]];
+        BaseFieldDeclarationSyntax currentParent =
+            currentFirst.Parent?.Parent as BaseFieldDeclarationSyntax;
+        if (currentParent == null)
+        {
+            return;
+        }
+
+        bool attributesDiffer = AttributeListsDiffer(
+            snapshotParent.AttributeLists,
+            currentParent.AttributeLists);
+        bool modifiersDiffer = TokenListsDiffer(snapshotParent.Modifiers, currentParent.Modifiers);
+        bool typeDiffers = !SyntaxFactory.AreEquivalent(
+            snapshotParent.Declaration.Type,
+            currentParent.Declaration.Type,
+            topLevel: false);
+        if (attributesDiffer || modifiersDiffer || typeDiffers)
+        {
+            result.ChangedLabels.Add(
+                FormatSharedHeaderLabel(
+                    kindNoun,
+                    comparableKeys,
+                    snapshotMap,
+                    attributesDiffer,
+                    modifiersDiffer,
+                    typeDiffers));
+        }
+
+        AppendInitializerLabels(
+            comparableKeys,
+            snapshotMap,
+            currentMap,
+            result,
+            kindNoun);
+    }
+
+    private static List<string> CollectComparableSiblingKeys(
+        BaseFieldDeclarationSyntax snapshotParent,
+        Dictionary<string, VariableDeclaratorSyntax> snapshotMap,
+        Dictionary<string, VariableDeclaratorSyntax> currentMap,
+        HashSet<string> handledSnapshotKeys,
+        HashSet<string> handledCurrentKeys)
+    {
+        List<string> comparableKeys = new List<string>();
+        foreach (KeyValuePair<string, VariableDeclaratorSyntax> pair in snapshotMap)
+        {
+            if (pair.Value.Parent?.Parent != snapshotParent)
+            {
+                continue;
+            }
+
+            if (!currentMap.ContainsKey(pair.Key))
+            {
+                continue;
+            }
+
+            if (handledSnapshotKeys.Contains(pair.Key) || handledCurrentKeys.Contains(pair.Key))
+            {
+                continue;
+            }
+
+            comparableKeys.Add(pair.Key);
+        }
+
+        return comparableKeys;
+    }
+
+    private static string FormatSharedHeaderLabel(
+        string kindNoun,
+        List<string> comparableKeys,
+        Dictionary<string, VariableDeclaratorSyntax> snapshotMap,
+        bool attributesDiffer,
+        bool modifiersDiffer,
+        bool typeDiffers)
+    {
+        List<string> names = new List<string>();
+        foreach (string key in comparableKeys)
+        {
+            names.Add(snapshotMap[key].Identifier.Text);
+        }
+
+        names.Sort(StringComparer.Ordinal);
+        string joinedNames = string.Join(", ", names);
+        if (attributesDiffer && !modifiersDiffer && !typeDiffers)
+        {
+            return kindNoun + " attributes: " + joinedNames;
+        }
+
+        return kindNoun + ": " + joinedNames;
+    }
+
+    private static void AppendInitializerLabels(
+        List<string> comparableKeys,
+        Dictionary<string, VariableDeclaratorSyntax> snapshotMap,
+        Dictionary<string, VariableDeclaratorSyntax> currentMap,
+        Result result,
+        string kindNoun)
+    {
+        foreach (string key in comparableKeys)
+        {
+            VariableDeclaratorSyntax snapshotVariable = snapshotMap[key];
+            VariableDeclaratorSyntax currentVariable = currentMap[key];
+            if (SyntaxFactory.AreEquivalent(snapshotVariable, currentVariable, topLevel: false))
+            {
+                continue;
+            }
+
+            result.ChangedLabels.Add(kindNoun + " initializer: " + snapshotVariable.Identifier.Text);
+        }
+    }
+
+    private static bool AttributeListsDiffer(
+        SyntaxList<AttributeListSyntax> left,
+        SyntaxList<AttributeListSyntax> right)
+    {
+        if (left.Count != right.Count)
+        {
+            return true;
+        }
+
+        for (int index = 0; index < left.Count; index++)
+        {
+            if (!SyntaxFactory.AreEquivalent(left[index], right[index], topLevel: false))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TokenListsDiffer(SyntaxTokenList left, SyntaxTokenList right)
+    {
+        if (left.Count != right.Count)
+        {
+            return true;
+        }
+
+        for (int index = 0; index < left.Count; index++)
+        {
+            if (!SyntaxFactory.AreEquivalent(left[index], right[index]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string FormatMethodLabel(MethodDeclarationSyntax method)
+    {
+        string name = method.Identifier.Text;
+        if (method.ExplicitInterfaceSpecifier != null)
+        {
+            name = method.ExplicitInterfaceSpecifier.Name.NormalizeWhitespace().ToString()
+                + "." + name;
+        }
+
+        return "method: " + name;
+    }
+
+    private static string FormatPropertyLabel(PropertyDeclarationSyntax property)
+    {
+        return "property: " + property.Identifier.Text;
+    }
+
+    private static string FormatIndexerLabel(IndexerDeclarationSyntax indexer)
+    {
+        return "indexer: this";
+    }
+
+    private static string FormatConstructorLabel(ConstructorDeclarationSyntax constructor)
+    {
+        string name = constructor.Modifiers.Any(SyntaxKind.StaticKeyword) ? ".cctor" : ".ctor";
+        return "constructor: " + name;
+    }
+
+    private static string FormatOperatorLabel(MemberDeclarationSyntax member)
+    {
+        if (member is OperatorDeclarationSyntax operatorDeclaration)
+        {
+            return "operator: " + operatorDeclaration.OperatorToken.ValueText;
+        }
+
+        ConversionOperatorDeclarationSyntax conversion =
+            (ConversionOperatorDeclarationSyntax)member;
+        string targetType = conversion.Type != null
+            ? conversion.Type.NormalizeWhitespace().ToString()
+            : string.Empty;
+        return "conversion: " + conversion.ImplicitOrExplicitKeyword.ValueText + "->" + targetType;
+    }
+
+    private static string FormatEventLabel(EventDeclarationSyntax eventDeclaration)
+    {
+        return "event: " + eventDeclaration.Identifier.Text;
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OutsideMethodBodyDeclarationDiff.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OutsideMethodBodyDeclarationDiff.cs
@@ -198,7 +198,6 @@ internal static class OutsideMethodBodyDeclarationDiff
                 continue;
             }
 
-            result.PairedSyntaxKeys.Add(pair.Key);
             BaseFieldDeclarationSyntax snapshotParent =
                 pair.Value.Parent?.Parent as BaseFieldDeclarationSyntax;
             if (snapshotParent == null || !processedParents.Add(snapshotParent))
@@ -243,6 +242,19 @@ internal static class OutsideMethodBodyDeclarationDiff
         if (currentParent == null)
         {
             return;
+        }
+
+        // Why fail-open: splitting a multi-declarator across declarations makes the shared
+        // header ambiguous. Pairing here would strip siblings whose own header was never
+        // compared and hide the residual warning.
+        if (!CurrentDeclaratorsShareParent(comparableKeys, currentMap, currentParent))
+        {
+            return;
+        }
+
+        foreach (string key in comparableKeys)
+        {
+            result.PairedSyntaxKeys.Add(key);
         }
 
         bool attributesDiffer = AttributeListsDiffer(
@@ -302,6 +314,22 @@ internal static class OutsideMethodBodyDeclarationDiff
         }
 
         return comparableKeys;
+    }
+
+    private static bool CurrentDeclaratorsShareParent(
+        List<string> comparableKeys,
+        Dictionary<string, VariableDeclaratorSyntax> currentMap,
+        BaseFieldDeclarationSyntax currentParent)
+    {
+        foreach (string key in comparableKeys)
+        {
+            if (currentMap[key].Parent?.Parent != currentParent)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static string FormatSharedHeaderLabel(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OutsideMethodBodyDriftChecker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OutsideMethodBodyDriftChecker.cs
@@ -20,30 +20,126 @@ internal static class OutsideMethodBodyDriftChecker
     internal const string OutsideMethodBodyDriftWarningFormat =
         "Edits outside method bodies in {0} (fields, initializers, or attributes) are not applied by hot reload; run uloop compile to pick them up.";
 
+    internal const string OutsideMethodBodyNamedDriftWarningFormat =
+        "Edits outside method bodies in {0} ({1}) are not applied by hot reload; run uloop compile to pick them up.";
+
     internal static void AppendOutsideMethodBodyDriftWarningIfNeeded(
         CompilationUnitSyntax snapshotRoot,
         CompilationUnitSyntax currentRoot,
         string fileName,
         List<string> declarationDriftWarnings,
         AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog,
+        IReadOnlyCollection<string> kindChangePropertySyntaxKeys,
+        IReadOnlyCollection<string> kindChangeEventSyntaxKeys)
+    {
+        HashSet<string> snapshotHandled = CollectHandledSnapshotKeys(addedMethodCatalog, addedFieldCatalog);
+        HashSet<string> currentHandled = CollectHandledCurrentKeys(addedMethodCatalog, addedFieldCatalog);
+
+        StripMethodBodiesRewriter bodyStripper = new StripMethodBodiesRewriter();
+        CompilationUnitSyntax snapshotBodiesStripped =
+            (CompilationUnitSyntax)bodyStripper.Visit(snapshotRoot);
+        CompilationUnitSyntax currentBodiesStripped =
+            (CompilationUnitSyntax)bodyStripper.Visit(currentRoot);
+        OutsideMethodBodyDeclarationDiff.Result diff = OutsideMethodBodyDeclarationDiff.Diff(
+            snapshotBodiesStripped,
+            currentBodiesStripped,
+            snapshotHandled,
+            currentHandled);
+        if (diff.DuplicateKeys)
+        {
+            // Why fail-open: a colliding syntax key makes pairing ambiguous. Suppressing the
+            // warning would hide real declaration drift (#2241).
+            AppendFileOnlyWarningIfTreesDiffer(
+                snapshotRoot,
+                currentRoot,
+                fileName,
+                declarationDriftWarnings,
+                snapshotHandled,
+                currentHandled,
+                addedMethodCatalog.AddedTypeSyntaxKeys,
+                addedMethodCatalog.AddedPropertySyntaxKeys);
+            return;
+        }
+
+        AppendNamedWarningIfNeeded(fileName, declarationDriftWarnings, diff.ChangedLabels);
+
+        HashSet<string> snapshotResidual = new HashSet<string>(snapshotHandled, StringComparer.Ordinal);
+        UnionInto(snapshotResidual, diff.PairedSyntaxKeys);
+        UnionInto(snapshotResidual, kindChangePropertySyntaxKeys);
+        UnionInto(snapshotResidual, kindChangeEventSyntaxKeys);
+        HashSet<string> currentResidual = new HashSet<string>(currentHandled, StringComparer.Ordinal);
+        UnionInto(currentResidual, diff.PairedSyntaxKeys);
+        AppendFileOnlyWarningIfTreesDiffer(
+            snapshotRoot,
+            currentRoot,
+            fileName,
+            declarationDriftWarnings,
+            snapshotResidual,
+            currentResidual,
+            addedMethodCatalog.AddedTypeSyntaxKeys,
+            addedMethodCatalog.AddedPropertySyntaxKeys);
+    }
+
+    private static HashSet<string> CollectHandledSnapshotKeys(
+        AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog)
     {
-        HashSet<string> snapshotKeys = new HashSet<string>(
+        HashSet<string> snapshotHandled = new HashSet<string>(
             addedMethodCatalog.RemovedSyntaxKeys,
             StringComparer.Ordinal);
-        foreach (string key in addedFieldCatalog.RemovedSyntaxKeys)
-        {
-            snapshotKeys.Add(key);
-        }
+        UnionInto(snapshotHandled, addedFieldCatalog.RemovedSyntaxKeys);
+        return snapshotHandled;
+    }
 
-        HashSet<string> currentKeys = new HashSet<string>(
+    private static HashSet<string> CollectHandledCurrentKeys(
+        AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        HashSet<string> currentHandled = new HashSet<string>(
             addedMethodCatalog.AddedSyntaxKeys,
             StringComparer.Ordinal);
-        foreach (string key in addedFieldCatalog.AddedSyntaxKeys)
+        UnionInto(currentHandled, addedFieldCatalog.AddedSyntaxKeys);
+        return currentHandled;
+    }
+
+    private static void AppendNamedWarningIfNeeded(
+        string fileName,
+        List<string> declarationDriftWarnings,
+        List<string> changedLabels)
+    {
+        if (changedLabels.Count == 0)
         {
-            currentKeys.Add(key);
+            return;
         }
 
+        changedLabels.Sort(StringComparer.Ordinal);
+        declarationDriftWarnings.Add(
+            string.Format(
+                CultureInfo.InvariantCulture,
+                OutsideMethodBodyNamedDriftWarningFormat,
+                fileName,
+                string.Join("; ", changedLabels)));
+    }
+
+    private static void UnionInto(HashSet<string> target, IEnumerable<string> source)
+    {
+        foreach (string key in source)
+        {
+            target.Add(key);
+        }
+    }
+
+    private static void AppendFileOnlyWarningIfTreesDiffer(
+        CompilationUnitSyntax snapshotRoot,
+        CompilationUnitSyntax currentRoot,
+        string fileName,
+        List<string> declarationDriftWarnings,
+        HashSet<string> snapshotKeys,
+        HashSet<string> currentKeys,
+        IReadOnlyCollection<string> addedTypeSyntaxKeys,
+        IReadOnlyCollection<string> addedPropertySyntaxKeys)
+    {
         StripHandledMemberDeclarationsRewriter stripSnapshot =
             new StripHandledMemberDeclarationsRewriter(
                 snapshotKeys,
@@ -52,8 +148,8 @@ internal static class OutsideMethodBodyDriftChecker
         StripHandledMemberDeclarationsRewriter stripCurrent =
             new StripHandledMemberDeclarationsRewriter(
                 currentKeys,
-                addedMethodCatalog.AddedTypeSyntaxKeys,
-                addedMethodCatalog.AddedPropertySyntaxKeys);
+                addedTypeSyntaxKeys,
+                addedPropertySyntaxKeys);
         StripMethodBodiesRewriter bodyStripper = new StripMethodBodiesRewriter();
         SyntaxNode strippedSnapshot = bodyStripper.Visit(stripSnapshot.Visit(snapshotRoot));
         SyntaxNode strippedCurrent = bodyStripper.Visit(stripCurrent.Visit(currentRoot));

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OutsideMethodBodyDriftChecker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OutsideMethodBodyDriftChecker.cs
@@ -65,11 +65,18 @@ internal static class OutsideMethodBodyDriftChecker
         AppendNamedWarningIfNeeded(fileName, declarationDriftWarnings, diff.ChangedLabels);
 
         HashSet<string> snapshotResidual = new HashSet<string>(snapshotHandled, StringComparer.Ordinal);
-        UnionInto(snapshotResidual, diff.PairedSyntaxKeys);
+        HashSet<string> currentResidual = new HashSet<string>(currentHandled, StringComparer.Ordinal);
+        // Why skip paired keys on order drift: pairing is position-blind, so equivalent
+        // members that only swapped declaration order would otherwise be stripped from
+        // both residual trees and go silent. Initializer order is observable.
+        if (!diff.OrderDrift)
+        {
+            UnionInto(snapshotResidual, diff.PairedSyntaxKeys);
+            UnionInto(currentResidual, diff.PairedSyntaxKeys);
+        }
+
         UnionInto(snapshotResidual, kindChangePropertySyntaxKeys);
         UnionInto(snapshotResidual, kindChangeEventSyntaxKeys);
-        HashSet<string> currentResidual = new HashSet<string>(currentHandled, StringComparer.Ordinal);
-        UnionInto(currentResidual, diff.PairedSyntaxKeys);
         AppendFileOnlyWarningIfTreesDiffer(
             snapshotRoot,
             currentRoot,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/StripHandledMemberDeclarationsRewriter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/StripHandledMemberDeclarationsRewriter.cs
@@ -110,12 +110,142 @@ internal sealed class StripHandledMemberDeclarationsRewriter : CSharpSyntaxRewri
         string syntaxKey = WorkerSyntaxIndex.BuildSyntaxPropertyKey(
             WorkerSyntaxIndex.BuildTypeMetadataNameFromSyntax(typeDeclaration),
             node);
-        if (_propertySyntaxKeysToStrip.Contains(syntaxKey))
+        if (_propertySyntaxKeysToStrip.Contains(syntaxKey) || _syntaxKeysToStrip.Contains(syntaxKey))
         {
             return null;
         }
 
         return base.VisitPropertyDeclaration(node);
+    }
+
+    public override SyntaxNode VisitIndexerDeclaration(IndexerDeclarationSyntax node)
+    {
+        TypeDeclarationSyntax typeDeclaration = node.Parent as TypeDeclarationSyntax;
+        if (typeDeclaration == null)
+        {
+            return base.VisitIndexerDeclaration(node);
+        }
+
+        string syntaxKey = WorkerSyntaxIndex.BuildSyntaxIndexerKey(
+            WorkerSyntaxIndex.BuildTypeMetadataNameFromSyntax(typeDeclaration),
+            node);
+        if (_syntaxKeysToStrip.Contains(syntaxKey))
+        {
+            return null;
+        }
+
+        return base.VisitIndexerDeclaration(node);
+    }
+
+    public override SyntaxNode VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
+    {
+        TypeDeclarationSyntax typeDeclaration = node.Parent as TypeDeclarationSyntax;
+        if (typeDeclaration == null)
+        {
+            return base.VisitConstructorDeclaration(node);
+        }
+
+        string syntaxKey = WorkerSyntaxIndex.BuildSyntaxConstructorKey(
+            WorkerSyntaxIndex.BuildTypeMetadataNameFromSyntax(typeDeclaration),
+            node);
+        if (_syntaxKeysToStrip.Contains(syntaxKey))
+        {
+            return null;
+        }
+
+        return base.VisitConstructorDeclaration(node);
+    }
+
+    public override SyntaxNode VisitOperatorDeclaration(OperatorDeclarationSyntax node)
+    {
+        TypeDeclarationSyntax typeDeclaration = node.Parent as TypeDeclarationSyntax;
+        if (typeDeclaration == null)
+        {
+            return base.VisitOperatorDeclaration(node);
+        }
+
+        string syntaxKey = WorkerSyntaxIndex.BuildSyntaxOperatorKey(
+            WorkerSyntaxIndex.BuildTypeMetadataNameFromSyntax(typeDeclaration),
+            node);
+        if (_syntaxKeysToStrip.Contains(syntaxKey))
+        {
+            return null;
+        }
+
+        return base.VisitOperatorDeclaration(node);
+    }
+
+    public override SyntaxNode VisitConversionOperatorDeclaration(ConversionOperatorDeclarationSyntax node)
+    {
+        TypeDeclarationSyntax typeDeclaration = node.Parent as TypeDeclarationSyntax;
+        if (typeDeclaration == null)
+        {
+            return base.VisitConversionOperatorDeclaration(node);
+        }
+
+        string syntaxKey = WorkerSyntaxIndex.BuildSyntaxConversionOperatorKey(
+            WorkerSyntaxIndex.BuildTypeMetadataNameFromSyntax(typeDeclaration),
+            node);
+        if (_syntaxKeysToStrip.Contains(syntaxKey))
+        {
+            return null;
+        }
+
+        return base.VisitConversionOperatorDeclaration(node);
+    }
+
+    public override SyntaxNode VisitEventDeclaration(EventDeclarationSyntax node)
+    {
+        TypeDeclarationSyntax typeDeclaration = node.Parent as TypeDeclarationSyntax;
+        if (typeDeclaration == null)
+        {
+            return base.VisitEventDeclaration(node);
+        }
+
+        string syntaxKey = WorkerSyntaxIndex.BuildSyntaxEventKey(
+            WorkerSyntaxIndex.BuildTypeMetadataNameFromSyntax(typeDeclaration),
+            node);
+        if (_syntaxKeysToStrip.Contains(syntaxKey))
+        {
+            return null;
+        }
+
+        return base.VisitEventDeclaration(node);
+    }
+
+    public override SyntaxNode VisitEventFieldDeclaration(EventFieldDeclarationSyntax node)
+    {
+        TypeDeclarationSyntax typeDeclaration = node.Parent as TypeDeclarationSyntax;
+        if (typeDeclaration == null)
+        {
+            return base.VisitEventFieldDeclaration(node);
+        }
+
+        string typeMetadataName = WorkerSyntaxIndex.BuildTypeMetadataNameFromSyntax(typeDeclaration);
+        List<VariableDeclaratorSyntax> remaining = new List<VariableDeclaratorSyntax>();
+        foreach (VariableDeclaratorSyntax variable in node.Declaration.Variables)
+        {
+            string syntaxKey = WorkerSyntaxIndex.BuildSyntaxFieldKey(
+                typeMetadataName,
+                variable.Identifier.Text);
+            if (!_syntaxKeysToStrip.Contains(syntaxKey))
+            {
+                remaining.Add(variable);
+            }
+        }
+
+        if (remaining.Count == 0)
+        {
+            return null;
+        }
+
+        if (remaining.Count == node.Declaration.Variables.Count)
+        {
+            return base.VisitEventFieldDeclaration(node);
+        }
+
+        return node.WithDeclaration(
+            node.Declaration.WithVariables(SyntaxFactory.SeparatedList(remaining)));
     }
 
     public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -159,11 +159,12 @@ public static class TransformWorkerProgram
             targetTypesAssemblySymbol);
         // Why here: a compiled property/event can disappear or change kind with no
         // touched body, so the generic outside-body warning would bury the name.
-        CompiledMemberKindChangeWarnings.AppendCompiledPropertyOrEventKindChangeWarnings(
-            root,
-            semanticModel,
-            targetTypesAssemblySymbol,
-            declarationDriftWarnings);
+        CompiledMemberKindChangeWarnings.SyntaxKeys kindChangeSyntaxKeys =
+            CompiledMemberKindChangeWarnings.AppendCompiledPropertyOrEventKindChangeWarnings(
+                root,
+                semanticModel,
+                targetTypesAssemblySymbol,
+                declarationDriftWarnings);
 
         BaselineSnapshotState baseline = BaselineSnapshotBuilder.BuildBaselineSnapshotState(input, parseOptions, plainRoot);
 
@@ -245,7 +246,9 @@ public static class TransformWorkerProgram
                 Path.GetFileName(input.SourcePath),
                 declarationDriftWarnings,
                 addedMethodCatalog,
-                addedFieldCatalog);
+                addedFieldCatalog,
+                kindChangeSyntaxKeys.PropertySyntaxKeys,
+                kindChangeSyntaxKeys.EventSyntaxKeys);
         }
 
         return BuildWorkerOutput(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSyntaxIndex.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSyntaxIndex.cs
@@ -423,4 +423,33 @@ internal static class WorkerSyntaxIndex
 
         return map;
     }
+
+    internal static Dictionary<string, VariableDeclaratorSyntax> BuildSyntaxEventFieldMapOrNull(
+        CompilationUnitSyntax root)
+    {
+        Dictionary<string, VariableDeclaratorSyntax> map =
+            new Dictionary<string, VariableDeclaratorSyntax>(StringComparer.Ordinal);
+        foreach (TypeDeclarationSyntax typeDeclaration in TransformWorkerProgram.EnumerateTypeDeclarations(root))
+        {
+            string typeMetadataName = BuildTypeMetadataNameFromSyntax(typeDeclaration);
+            foreach (EventFieldDeclarationSyntax eventFieldDeclaration in typeDeclaration.Members
+                .OfType<EventFieldDeclarationSyntax>())
+            {
+                foreach (VariableDeclaratorSyntax variable in eventFieldDeclaration.Declaration.Variables)
+                {
+                    // Why field key format: kind-change identity is type metadata + "::" + name,
+                    // the same shape BuildSyntaxFieldKey already uses.
+                    string key = BuildSyntaxFieldKey(typeMetadataName, variable.Identifier.Text);
+                    if (map.ContainsKey(key))
+                    {
+                        return null;
+                    }
+
+                    map[key] = variable;
+                }
+            }
+        }
+
+        return map;
+    }
 }


### PR DESCRIPTION
## Summary
- Hot reload now names the changed field, property, event, or other declaration in the outside-body drift warning instead of only naming the file.
- A property or event that is removed or rewritten as another member kind no longer also emits that generic file-only warning for the same edit.

## User Impact
- Before: `Edits outside method bodies in Foo.cs (fields, initializers, or attributes)...` did not say which member changed. A compiled property or event rewritten as a field produced both a dedicated kind-change warning and the generic file-only sentence for one edit.
- After: initializer and attribute edits name the declaration (for example `field initializer: PublicSeed`). A pure kind-crossing edit keeps the dedicated warning only. Other outside-body edits in the same file still produce the generic warning.

## Changes
- Pair snapshot and current declarations by syntax key, collect changed names, and keep the original file-only wording for leftover type-header or unmatched-member diffs.
- Duplicate syntax keys fail open to the file-only warning instead of suppressing it.
- Pass structured property/event identities (metadata name + member name, not display-string parsing) into the snapshot strip so kind-change coverage does not double-report.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` — Success, 0 errors
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value TransformWorker` — 150 passed
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value "HotReloadOrchestratorTests|HotReloadToolTests"` — 154 passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

