### PR TITLE
fix: append edited-line candidates to pause-point resolve failures under hot reload

### DIFF
--- a/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
+++ b/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
@@ -1085,6 +1085,139 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: an active hot-reload gate plus a compiled-source match appends Candidate after
+        /// Nearby methods on a resolve-failure Message.
+        /// </summary>
+        [Test]
+        public void BuildResolveFailureMessage_WhenHotReloadGateTrueAndLineMatches_AppendsNearbyThenCandidate()
+        {
+            const string errorMessage =
+                "No sequence point found on or after line 116 in 'Assets/Scripts/Enemy.cs'.";
+            SourcePausePointNearbyCompiledMethod[] nearby =
+            {
+                new SourcePausePointNearbyCompiledMethod("Enemy.Update", 100, 120)
+            };
+            string[] compiledLines =
+            {
+                "            return 2;"
+            };
+
+            string result = PausePointEnableWarnings.BuildResolveFailureMessage(
+                errorMessage,
+                nearby,
+                true,
+                116,
+                true,
+                "return 2;",
+                compiledLines);
+
+            Assert.That(
+                result,
+                Is.EqualTo(
+                    "No sequence point found on or after line 116 in 'Assets/Scripts/Enemy.cs'."
+                    + " Nearby methods in the last compiled source: 'Enemy.Update' spans lines 100-120."
+                    + " Candidate: the text at --line 116 in the edited file appears at line 1 in the last compiled source."));
+        }
+
+        /// <summary>
+        /// What: the same matching inputs without the hot-reload gate keep Nearby methods and omit
+        /// Candidate.
+        /// </summary>
+        [Test]
+        public void BuildResolveFailureMessage_WhenHotReloadGateFalseAndLineMatches_AppendsNearbyOnly()
+        {
+            const string errorMessage =
+                "No sequence point found on or after line 116 in 'Assets/Scripts/Enemy.cs'.";
+            SourcePausePointNearbyCompiledMethod[] nearby =
+            {
+                new SourcePausePointNearbyCompiledMethod("Enemy.Update", 100, 120)
+            };
+            string[] compiledLines =
+            {
+                "            return 2;"
+            };
+
+            string result = PausePointEnableWarnings.BuildResolveFailureMessage(
+                errorMessage,
+                nearby,
+                false,
+                116,
+                true,
+                "return 2;",
+                compiledLines);
+
+            Assert.That(
+                result,
+                Is.EqualTo(
+                    "No sequence point found on or after line 116 in 'Assets/Scripts/Enemy.cs'."
+                    + " Nearby methods in the last compiled source: 'Enemy.Update' spans lines 100-120."));
+        }
+
+        /// <summary>
+        /// What: a null compiled-source list under an active hot-reload gate keeps Nearby methods
+        /// and omits Candidate.
+        /// </summary>
+        [Test]
+        public void BuildResolveFailureMessage_WhenCompiledSourceLinesNull_AppendsNearbyOnly()
+        {
+            const string errorMessage =
+                "No sequence point found on or after line 116 in 'Assets/Scripts/Enemy.cs'.";
+            SourcePausePointNearbyCompiledMethod[] nearby =
+            {
+                new SourcePausePointNearbyCompiledMethod("Enemy.Update", 100, 120)
+            };
+
+            string result = PausePointEnableWarnings.BuildResolveFailureMessage(
+                errorMessage,
+                nearby,
+                true,
+                116,
+                true,
+                "return 2;",
+                null);
+
+            Assert.That(
+                result,
+                Is.EqualTo(
+                    "No sequence point found on or after line 116 in 'Assets/Scripts/Enemy.cs'."
+                    + " Nearby methods in the last compiled source: 'Enemy.Update' spans lines 100-120."));
+        }
+
+        /// <summary>
+        /// What: a failed edited-line read under an active hot-reload gate keeps Nearby methods and
+        /// omits Candidate even when compiled source would match.
+        /// </summary>
+        [Test]
+        public void BuildResolveFailureMessage_WhenRequestedLineReadFails_AppendsNearbyOnly()
+        {
+            const string errorMessage =
+                "No sequence point found on or after line 116 in 'Assets/Scripts/Enemy.cs'.";
+            SourcePausePointNearbyCompiledMethod[] nearby =
+            {
+                new SourcePausePointNearbyCompiledMethod("Enemy.Update", 100, 120)
+            };
+            string[] compiledLines =
+            {
+                "            return 2;"
+            };
+
+            string result = PausePointEnableWarnings.BuildResolveFailureMessage(
+                errorMessage,
+                nearby,
+                true,
+                116,
+                false,
+                "return 2;",
+                compiledLines);
+
+            Assert.That(
+                result,
+                Is.EqualTo(
+                    "No sequence point found on or after line 116 in 'Assets/Scripts/Enemy.cs'."
+                    + " Nearby methods in the last compiled source: 'Enemy.Update' spans lines 100-120."));
+        }
+
+        /// <summary>
         /// What: retarget warning interpolates resolved method, requested line, and edited span.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
+++ b/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
@@ -933,6 +933,158 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: one compiled-source match for the requested --line text is appended to a
+        /// resolve-failure Message.
+        /// </summary>
+        [Test]
+        public void AppendResolveFailureRequestedLineCandidateSuffixOrUnchanged_WhenOneLineMatches_AppendsCandidate()
+        {
+            const string message =
+                "No sequence point found on or after line 116 in 'Assets/Scripts/Enemy.cs'.";
+            string[] compiledLines = new string[110];
+            for (int index = 0; index < compiledLines.Length; index++)
+            {
+                compiledLines[index] = "            return 0;";
+            }
+
+            compiledLines[109] = "            return 2;";
+
+            string result = PausePointEnableWarnings.AppendResolveFailureRequestedLineCandidateSuffixOrUnchanged(
+                message,
+                116,
+                "  return 2;  ",
+                compiledLines);
+
+            Assert.That(
+                result,
+                Is.EqualTo(
+                    "No sequence point found on or after line 116 in 'Assets/Scripts/Enemy.cs'."
+                    + " Candidate: the text at --line 116 in the edited file appears at line 110 in the last compiled source."));
+        }
+
+        /// <summary>
+        /// What: two compiled-source matches for the requested --line text append both line numbers.
+        /// </summary>
+        [Test]
+        public void AppendResolveFailureRequestedLineCandidateSuffixOrUnchanged_WhenTwoLinesMatch_AppendsBothCandidates()
+        {
+            const string message =
+                "No sequence point found on or after line 116 in 'Assets/Scripts/Enemy.cs'.";
+            string[] compiledLines =
+            {
+                "class Sample",
+                "            return 2;",
+                "            return 1;",
+                "            return 2;"
+            };
+
+            string result = PausePointEnableWarnings.AppendResolveFailureRequestedLineCandidateSuffixOrUnchanged(
+                message,
+                116,
+                "return 2;",
+                compiledLines);
+
+            Assert.That(
+                result,
+                Is.EqualTo(
+                    "No sequence point found on or after line 116 in 'Assets/Scripts/Enemy.cs'."
+                    + " Candidate: the text at --line 116 in the edited file appears at lines 2, 4 in the last compiled source."));
+        }
+
+        /// <summary>
+        /// What: more than three compiled-source matches for a resolve-failure Message cap at the
+        /// first three.
+        /// </summary>
+        [Test]
+        public void AppendResolveFailureRequestedLineCandidateSuffixOrUnchanged_WhenMoreThanThreeLinesMatch_CapsAtFirstThree()
+        {
+            const string message =
+                "No sequence point found on or after line 116 in 'Assets/Scripts/Enemy.cs'.";
+            string[] compiledLines =
+            {
+                "            return 2;",
+                "            return 1;",
+                "            return 2;",
+                "            return 2;",
+                "            return 2;"
+            };
+
+            string result = PausePointEnableWarnings.AppendResolveFailureRequestedLineCandidateSuffixOrUnchanged(
+                message,
+                116,
+                "return 2;",
+                compiledLines);
+
+            Assert.That(
+                result,
+                Is.EqualTo(
+                    "No sequence point found on or after line 116 in 'Assets/Scripts/Enemy.cs'."
+                    + " Candidate: the text at --line 116 in the edited file appears at lines 1, 3, 4 (first 3 matches) in the last compiled source."));
+        }
+
+        /// <summary>
+        /// What: a resolve-failure Message stays unchanged when compiled source has no matching line.
+        /// </summary>
+        [Test]
+        public void AppendResolveFailureRequestedLineCandidateSuffixOrUnchanged_WhenNoLineMatches_ReturnsUnchanged()
+        {
+            const string message =
+                "No sequence point found on or after line 116 in 'Assets/Scripts/Enemy.cs'.";
+            string[] compiledLines =
+            {
+                "            return 0;"
+            };
+
+            string result = PausePointEnableWarnings.AppendResolveFailureRequestedLineCandidateSuffixOrUnchanged(
+                message,
+                116,
+                "return 2;",
+                compiledLines);
+
+            Assert.That(result, Is.EqualTo(message));
+        }
+
+        /// <summary>
+        /// What: a resolve-failure Message stays unchanged when the edited line text is blank.
+        /// </summary>
+        [Test]
+        public void AppendResolveFailureRequestedLineCandidateSuffixOrUnchanged_WhenEditedTextEmpty_ReturnsUnchanged()
+        {
+            const string message =
+                "No sequence point found on or after line 116 in 'Assets/Scripts/Enemy.cs'.";
+            string[] compiledLines =
+            {
+                "            return 2;"
+            };
+
+            string result = PausePointEnableWarnings.AppendResolveFailureRequestedLineCandidateSuffixOrUnchanged(
+                message,
+                116,
+                "   ",
+                compiledLines);
+
+            Assert.That(result, Is.EqualTo(message));
+        }
+
+        /// <summary>
+        /// What: a resolve-failure Message stays unchanged when compiled source lines are null.
+        /// </summary>
+        [Test]
+        public void AppendResolveFailureRequestedLineCandidateSuffixOrUnchanged_WhenCompiledSourceLinesNull_ReturnsUnchanged()
+        {
+            const string message =
+                "No sequence point found on or after line 116 in 'Assets/Scripts/Enemy.cs'.";
+
+            string result = PausePointEnableWarnings.AppendResolveFailureRequestedLineCandidateSuffixOrUnchanged(
+                message,
+                116,
+                "return 2;",
+                null);
+
+            Assert.That(result, Is.EqualTo(message));
+        }
+
+        /// <summary>
         /// What: retarget warning interpolates resolved method, requested line, and edited span.
         /// </summary>
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEnableWarnings.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEnableWarnings.cs
@@ -231,6 +231,48 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 truncated);
         }
 
+        /// <summary>
+        /// Appends compiled-line Candidate text to a resolve-failure Message when the edited
+        /// --line text appears in the last compiled source.
+        /// </summary>
+        internal static string AppendResolveFailureRequestedLineCandidateSuffixOrUnchanged(
+            string message,
+            int requestedLine,
+            string requestedLineEditedText,
+            IReadOnlyList<string> compiledSourceLines)
+        {
+            if (string.IsNullOrEmpty(message) || requestedLine <= 0)
+            {
+                return message ?? string.Empty;
+            }
+
+            if (string.IsNullOrEmpty(requestedLineEditedText) || compiledSourceLines == null)
+            {
+                return message;
+            }
+
+            string editedTrimmed = requestedLineEditedText.Trim();
+            if (editedTrimmed.Length == 0)
+            {
+                return message;
+            }
+
+            (List<int> matches, bool truncated) = CollectCandidateCompiledLineNumbers(
+                editedTrimmed,
+                compiledSourceLines);
+            if (matches.Count == 0)
+            {
+                return message;
+            }
+
+            // Why no drift-warning gate: resolve-failure Messages have no drift warning, and
+            // Candidate is the only compiled-line number the caller can retry with.
+            return message + FormatRequestedLineCandidateCompiledLinesSuffix(
+                requestedLine,
+                matches,
+                truncated);
+        }
+
         private static (List<int> matches, bool truncated) CollectCandidateCompiledLineNumbers(
             string editedTrimmed,
             IReadOnlyList<string> compiledSourceLines)

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEnableWarnings.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEnableWarnings.cs
@@ -273,6 +273,34 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 truncated);
         }
 
+        /// <summary>
+        /// Builds a resolve-failure Message: Nearby methods, then Candidate when hot-reload
+        /// patches are active and the edited --line text was read.
+        /// </summary>
+        internal static string BuildResolveFailureMessage(
+            string errorMessage,
+            IReadOnlyList<SourcePausePointNearbyCompiledMethod> nearbyCompiledMethods,
+            bool hasActiveHotReloadPatches,
+            int requestedLine,
+            bool requestedLineReadOk,
+            string requestedLineEditedText,
+            IReadOnlyList<string> compiledSourceLinesOrNull)
+        {
+            string message = AppendNearbyCompiledMethodsSuffix(errorMessage, nearbyCompiledMethods);
+            // Why skip Candidate when the edited line was not read: the Candidate sentence names
+            // the text at --line N in the edited file, which is false if that read failed.
+            if (!hasActiveHotReloadPatches || !requestedLineReadOk)
+            {
+                return message;
+            }
+
+            return AppendResolveFailureRequestedLineCandidateSuffixOrUnchanged(
+                message,
+                requestedLine,
+                requestedLineEditedText,
+                compiledSourceLinesOrNull);
+        }
+
         private static (List<int> matches, bool truncated) CollectCandidateCompiledLineNumbers(
             string editedTrimmed,
             IReadOnlyList<string> compiledSourceLines)

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
@@ -273,14 +273,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 string recommendedNextAction = hasActiveHotReloadPatches
                     ? SourcePausePointConstants.HotReloadCompiledLineMapResolveFailureNextAction
                     : SourcePausePointConstants.ResolveFailedRecommendedNextAction;
-                string compiledSnapshotSource = LoadCompiledSnapshotSourceOrEmpty(parameters.File);
-                IReadOnlyList<string> compiledSourceLinesOrNull = string.IsNullOrEmpty(compiledSnapshotSource)
-                    ? null
-                    : SourcePausePointSourceLineReader.SplitSourceLines(compiledSnapshotSource);
-                (bool requestedLineReadOk, string requestedLineEditedText) =
-                    PausePointCompiledLineComparisonWarnings.ReadEditedLineText(
-                        parameters.File,
-                        parameters.Line);
+                IReadOnlyList<string> compiledSourceLinesOrNull = null;
+                bool requestedLineReadOk = false;
+                string requestedLineEditedText = string.Empty;
+                // Why skip snapshot/edited-line IO without patches: Candidate is omitted on that
+                // path, so those reads would change the historical no-patch failure for no gain.
+                if (hasActiveHotReloadPatches)
+                {
+                    string compiledSnapshotSource = LoadCompiledSnapshotSourceOrEmpty(parameters.File);
+                    compiledSourceLinesOrNull = string.IsNullOrEmpty(compiledSnapshotSource)
+                        ? null
+                        : SourcePausePointSourceLineReader.SplitSourceLines(compiledSnapshotSource);
+                    (requestedLineReadOk, requestedLineEditedText) =
+                        PausePointCompiledLineComparisonWarnings.ReadEditedLineText(
+                            parameters.File,
+                            parameters.Line);
+                }
+
                 string message = PausePointEnableWarnings.BuildResolveFailureMessage(
                     resolveResult.ErrorMessage,
                     resolveResult.NearbyCompiledMethods,

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
@@ -273,10 +273,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 string recommendedNextAction = hasActiveHotReloadPatches
                     ? SourcePausePointConstants.HotReloadCompiledLineMapResolveFailureNextAction
                     : SourcePausePointConstants.ResolveFailedRecommendedNextAction;
+                string message = PausePointEnableWarnings.AppendNearbyCompiledMethodsSuffix(
+                    resolveResult.ErrorMessage,
+                    resolveResult.NearbyCompiledMethods);
+                if (hasActiveHotReloadPatches)
+                {
+                    message = AppendResolveFailureRequestedLineCandidateOrUnchanged(
+                        message,
+                        parameters);
+                }
+
                 PausePointResponse response = CreateValidationFailure(
-                    PausePointEnableWarnings.AppendNearbyCompiledMethodsSuffix(
-                        resolveResult.ErrorMessage,
-                        resolveResult.NearbyCompiledMethods),
+                    message,
                     SourcePausePointConstants.ErrorCodeResolveFailed,
                     recommendedNextAction);
                 response.Warning = PausePointEnableWarnings.ChooseCompiledLineMapWarning(
@@ -490,6 +498,36 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string snapshotSource =
                 HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile?.Invoke(normalizedFile);
             return snapshotSource ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Appends a compiled-line Candidate to a resolve-failure Message when the edited
+        /// --line text exists in the compiled snapshot.
+        /// </summary>
+        private static string AppendResolveFailureRequestedLineCandidateOrUnchanged(
+            string message,
+            EnablePausePointSchema parameters)
+        {
+            string compiledSnapshotSource = LoadCompiledSnapshotSourceOrEmpty(parameters.File);
+            if (string.IsNullOrEmpty(compiledSnapshotSource))
+            {
+                return message;
+            }
+
+            (bool editedReadOk, string requestedLineEditedText) =
+                PausePointCompiledLineComparisonWarnings.ReadEditedLineText(
+                    parameters.File,
+                    parameters.Line);
+            if (!editedReadOk)
+            {
+                return message;
+            }
+
+            return PausePointEnableWarnings.AppendResolveFailureRequestedLineCandidateSuffixOrUnchanged(
+                message,
+                parameters.Line,
+                requestedLineEditedText,
+                SourcePausePointSourceLineReader.SplitSourceLines(compiledSnapshotSource));
         }
 
         // The derived id must use the originally requested file/line (not the resolved/rounded

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
@@ -273,15 +273,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 string recommendedNextAction = hasActiveHotReloadPatches
                     ? SourcePausePointConstants.HotReloadCompiledLineMapResolveFailureNextAction
                     : SourcePausePointConstants.ResolveFailedRecommendedNextAction;
-                string message = PausePointEnableWarnings.AppendNearbyCompiledMethodsSuffix(
+                string compiledSnapshotSource = LoadCompiledSnapshotSourceOrEmpty(parameters.File);
+                IReadOnlyList<string> compiledSourceLinesOrNull = string.IsNullOrEmpty(compiledSnapshotSource)
+                    ? null
+                    : SourcePausePointSourceLineReader.SplitSourceLines(compiledSnapshotSource);
+                (bool requestedLineReadOk, string requestedLineEditedText) =
+                    PausePointCompiledLineComparisonWarnings.ReadEditedLineText(
+                        parameters.File,
+                        parameters.Line);
+                string message = PausePointEnableWarnings.BuildResolveFailureMessage(
                     resolveResult.ErrorMessage,
-                    resolveResult.NearbyCompiledMethods);
-                if (hasActiveHotReloadPatches)
-                {
-                    message = AppendResolveFailureRequestedLineCandidateOrUnchanged(
-                        message,
-                        parameters);
-                }
+                    resolveResult.NearbyCompiledMethods,
+                    hasActiveHotReloadPatches,
+                    parameters.Line,
+                    requestedLineReadOk,
+                    requestedLineEditedText,
+                    compiledSourceLinesOrNull);
 
                 PausePointResponse response = CreateValidationFailure(
                     message,
@@ -498,36 +505,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string snapshotSource =
                 HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile?.Invoke(normalizedFile);
             return snapshotSource ?? string.Empty;
-        }
-
-        /// <summary>
-        /// Appends a compiled-line Candidate to a resolve-failure Message when the edited
-        /// --line text exists in the compiled snapshot.
-        /// </summary>
-        private static string AppendResolveFailureRequestedLineCandidateOrUnchanged(
-            string message,
-            EnablePausePointSchema parameters)
-        {
-            string compiledSnapshotSource = LoadCompiledSnapshotSourceOrEmpty(parameters.File);
-            if (string.IsNullOrEmpty(compiledSnapshotSource))
-            {
-                return message;
-            }
-
-            (bool editedReadOk, string requestedLineEditedText) =
-                PausePointCompiledLineComparisonWarnings.ReadEditedLineText(
-                    parameters.File,
-                    parameters.Line);
-            if (!editedReadOk)
-            {
-                return message;
-            }
-
-            return PausePointEnableWarnings.AppendResolveFailureRequestedLineCandidateSuffixOrUnchanged(
-                message,
-                parameters.Line,
-                requestedLineEditedText,
-                SourcePausePointSourceLineReader.SplitSourceLines(compiledSnapshotSource));
         }
 
         // The derived id must use the originally requested file/line (not the resolved/rounded


### PR DESCRIPTION
## Summary
- When `enable-pause-point` fails to resolve a line on a file that already has hot-reload patches, the failure Message now names the compiled-source line that matches the edited `--line` text.
- Callers can retry with that compiled line instead of guessing from Nearby methods alone.

## User Impact
- Before: `PAUSE_POINT_RESOLVE_FAILED` listed nearby compiled methods but not which compiled line contained the edited `--line` text. Agents using the edited-file line number had no number to pass back.
- After: if hot-reload patches are active and that edited line's text appears in the last compiled source, the Message appends the existing Candidate sentence (for example `Candidate: the text at --line 116 in the edited file appears at line 110 in the last compiled source.`). Without patches, or when the snapshot/text does not match, the Message is unchanged.

## Changes
- Add a resolve-failure Candidate helper that reuses the existing requested-line Candidate formats, without the drift-warning gate.
- Append that suffix on the hot-reload resolve-failure path after Nearby methods.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` — Success, 0 errors
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value PausePointCompiledLineMapWarningTests` — 50 passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

