### PR TITLE
fix: guide hot-reload failures on uncompiled or unimported assemblies to compile

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -260,6 +260,8 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Condition | Notes |
 |-----------|-------|
 | File does not belong to any compiled assembly | Per-file entry with `Method` = `(file)`; only `Assets/` and `Packages/` sources resolve |
+| Resolved assembly name is missing from CompilationPipeline | Per-file entry with `Method` = `(file)`; Unity may have mapped a not-yet-imported `.asmdef` onto a predefined assembly. Run `uloop compile` first |
+| Script is not in the last compiled assembly's source list | Per-file entry with `Method` = `(file)`; a newly added script is not hot-reloadable until `uloop compile` |
 | Loaded assembly differs from the one on disk (pending compile) | Run `uloop compile` first, then retry |
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | Usually a stale assembly; run `uloop compile`. In-file renames and signature changes are classified as added members before reaching this point |

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -260,6 +260,8 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Condition | Notes |
 |-----------|-------|
 | File does not belong to any compiled assembly | Per-file entry with `Method` = `(file)`; only `Assets/` and `Packages/` sources resolve |
+| Resolved assembly name is missing from CompilationPipeline | Per-file entry with `Method` = `(file)`; Unity may have mapped a not-yet-imported `.asmdef` onto a predefined assembly. Run `uloop compile` first |
+| Script is not in the last compiled assembly's source list | Per-file entry with `Method` = `(file)`; a newly added script is not hot-reloadable until `uloop compile` |
 | Loaded assembly differs from the one on disk (pending compile) | Run `uloop compile` first, then retry |
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | Usually a stale assembly; run `uloop compile`. In-file renames and signature changes are classified as added members before reaching this point |

--- a/Assets/Tests/Editor/HotReload/HotReloadAssemblyResolutionDiagnosticsTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAssemblyResolutionDiagnosticsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using NUnit.Framework;
@@ -90,6 +91,57 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             UnityCompilationAssembly compilationAssembly = FindCompilationAssembly(HotReloadTestAssemblyName);
             Assert.That(compilationAssembly, Is.Not.Null);
+
+            string reason = HotReloadAssemblyResolutionDiagnostics.TryGetAssemblyResolutionFailureReason(
+                HotReloadTestAssemblyName,
+                compilationAssembly,
+                ExistingHotReloadScriptPath,
+                false);
+
+            Assert.That(reason, Is.Null);
+        }
+
+        /// <summary>
+        /// What: an on-disk .asmdef in the script's ancestor directory is detected without
+        /// creating or importing any new assets.
+        /// </summary>
+        [Test]
+        public void AncestorDirectoryContainsAsmdef_WhenAncestorHasAsmdef_ReturnsTrue()
+        {
+            Assert.That(
+                HotReloadAssemblyResolutionDiagnostics.AncestorDirectoryContainsAsmdef(
+                    "Assets/Tests/Editor/HotReload/NotExist.cs"),
+                Is.True);
+        }
+
+        /// <summary>
+        /// What: a loose Assets path whose ancestor directories have no .asmdef on disk
+        /// is not reported as an unimported-asmdef case.
+        /// </summary>
+        [Test]
+        public void AncestorDirectoryContainsAsmdef_WhenNoAncestorHasAsmdef_ReturnsFalse()
+        {
+            Assert.That(
+                HotReloadAssemblyResolutionDiagnostics.AncestorDirectoryContainsAsmdef(
+                    "Assets/RegressionHarness/HotReload/NotExist.cs"),
+                Is.False);
+        }
+
+        /// <summary>
+        /// What: sourceFiles that use Windows backslash separators still match the
+        /// project-relative path after separator normalization.
+        /// </summary>
+        [Test]
+        public void TryGetAssemblyResolutionFailureReason_WhenSourceFilesUseBackslashSeparators_ReturnsNull()
+        {
+            UnityCompilationAssembly compilationAssembly = new UnityCompilationAssembly(
+                HotReloadTestAssemblyName,
+                "Library/ScriptAssemblies/UnityCLILoop.Tests.Editor.HotReload.dll",
+                new[] { @"Assets\Tests\Editor\HotReload\HotReloadToolTests.cs" },
+                Array.Empty<string>(),
+                Array.Empty<UnityCompilationAssembly>(),
+                Array.Empty<string>(),
+                AssemblyFlags.None);
 
             string reason = HotReloadAssemblyResolutionDiagnostics.TryGetAssemblyResolutionFailureReason(
                 HotReloadTestAssemblyName,

--- a/Assets/Tests/Editor/HotReload/HotReloadAssemblyResolutionDiagnosticsTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAssemblyResolutionDiagnosticsTests.cs
@@ -1,0 +1,155 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Covers assembly-resolution Failed reasons for uncompiled or unimported hot-reload targets.
+    /// </summary>
+    public sealed class HotReloadAssemblyResolutionDiagnosticsTests
+    {
+        private const string MissingHotReloadScriptPath =
+            "Assets/Tests/Editor/HotReload/UncompiledNewScript.cs";
+        private const string ExistingHotReloadScriptPath =
+            "Assets/Tests/Editor/HotReload/HotReloadToolTests.cs";
+        private const string HotReloadTestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+
+        /// <summary>
+        /// What: a resolved assembly that is absent from CompilationPipeline gets the
+        /// compile-first reason that names the fallback predefined-assembly behavior.
+        /// </summary>
+        [Test]
+        public void TryGetAssemblyResolutionFailureReason_WhenCompilationAssemblyIsNull_ReturnsNotFoundReason()
+        {
+            string reason = HotReloadAssemblyResolutionDiagnostics.TryGetAssemblyResolutionFailureReason(
+                "Assembly-CSharp",
+                null,
+                MissingHotReloadScriptPath,
+                false);
+
+            Assert.That(
+                reason,
+                Is.EqualTo(
+                    "Resolved assembly 'Assembly-CSharp' was not found in the compilation pipeline. Unity resolves files under a not-yet-imported .asmdef to a predefined assembly, so a brand-new .asmdef or a brand-new script cannot be hot-reloaded. Run 'uloop compile' first."));
+        }
+
+        /// <summary>
+        /// What: a missing compilation assembly under an on-disk .asmdef that Unity has not
+        /// imported yet gets the more specific unimported-asmdef reason.
+        /// </summary>
+        [Test]
+        public void TryGetAssemblyResolutionFailureReason_WhenUnimportedAsmdefOnDisk_ReturnsSpecificReason()
+        {
+            string reason = HotReloadAssemblyResolutionDiagnostics.TryGetAssemblyResolutionFailureReason(
+                "Assembly-CSharp",
+                null,
+                MissingHotReloadScriptPath,
+                true);
+
+            Assert.That(
+                reason,
+                Is.EqualTo(
+                    "Resolved assembly 'Assembly-CSharp' was not found in the compilation pipeline. 'Assets/Tests/Editor/HotReload/UncompiledNewScript.cs' sits under a .asmdef that Unity has not imported yet, so hot reload cannot target it. Run 'uloop compile' first."));
+        }
+
+        /// <summary>
+        /// What: a path that Unity resolves to a compiled assembly but that is not in that
+        /// assembly's last compiled source list gets the newly-added-script reason.
+        /// </summary>
+        [Test]
+        public void TryGetAssemblyResolutionFailureReason_WhenSourceFilesDoNotContainPath_ReturnsNewScriptReason()
+        {
+            UnityCompilationAssembly compilationAssembly = FindCompilationAssembly(HotReloadTestAssemblyName);
+            Assert.That(compilationAssembly, Is.Not.Null);
+
+            string reason = HotReloadAssemblyResolutionDiagnostics.TryGetAssemblyResolutionFailureReason(
+                HotReloadTestAssemblyName,
+                compilationAssembly,
+                MissingHotReloadScriptPath,
+                false);
+
+            Assert.That(
+                reason,
+                Is.EqualTo(
+                    "'Assets/Tests/Editor/HotReload/UncompiledNewScript.cs' is not part of the last compiled assembly 'UnityCLILoop.Tests.Editor.HotReload' (a newly added script). New files require a real compile; run 'uloop compile' first."));
+        }
+
+        /// <summary>
+        /// What: a script that already belongs to the compiled assembly is not treated as a
+        /// resolution failure, so later hot-reload stages can still run.
+        /// </summary>
+        [Test]
+        public void TryGetAssemblyResolutionFailureReason_WhenSourceFilesContainPath_ReturnsNull()
+        {
+            UnityCompilationAssembly compilationAssembly = FindCompilationAssembly(HotReloadTestAssemblyName);
+            Assert.That(compilationAssembly, Is.Not.Null);
+
+            string reason = HotReloadAssemblyResolutionDiagnostics.TryGetAssemblyResolutionFailureReason(
+                HotReloadTestAssemblyName,
+                compilationAssembly,
+                ExistingHotReloadScriptPath,
+                false);
+
+            Assert.That(reason, Is.Null);
+        }
+
+        /// <summary>
+        /// What: ResolvePatchTarget fails with the newly-added-script reason when
+        /// CompilationPipeline maps a missing path onto an existing asmdef whose compiled
+        /// source list does not contain that path.
+        /// </summary>
+        [Test]
+        public void ResolvePatchTarget_WhenScriptIsNotInCompiledAssemblySourceFiles_ReturnsFailedReason()
+        {
+            List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
+            List<string> warnings = new List<string>();
+
+            (HotReloadOrchestrator.HotReloadFileProcessResult earlyResult,
+                string projectRelativePath,
+                string assemblyName,
+                UnityCompilationAssembly compilationAssembly,
+                string targetDllPath,
+                string projectRoot) = HotReloadPatchTargetSupport.ResolvePatchTarget(
+                MissingHotReloadScriptPath,
+                MissingHotReloadScriptPath,
+                outcomes,
+                warnings,
+                "assembly-resolution-wiring");
+
+            Assert.That(earlyResult, Is.Not.Null);
+            Assert.That(earlyResult.Outcomes.Count, Is.EqualTo(1));
+            Assert.That(earlyResult.Outcomes[0].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Failed));
+            Assert.That(
+                earlyResult.Outcomes[0].Reason,
+                Is.EqualTo(
+                    "'Assets/Tests/Editor/HotReload/UncompiledNewScript.cs' is not part of the last compiled assembly 'UnityCLILoop.Tests.Editor.HotReload' (a newly added script). New files require a real compile; run 'uloop compile' first."));
+            Assert.That(projectRelativePath, Is.Null);
+            Assert.That(assemblyName, Is.Null);
+            Assert.That(compilationAssembly, Is.Null);
+            Assert.That(targetDllPath, Is.Null);
+            Assert.That(projectRoot, Is.Null);
+        }
+
+        private static UnityCompilationAssembly FindCompilationAssembly(string assemblyName)
+        {
+            UnityCompilationAssembly[] assemblies = CompilationPipeline.GetAssemblies();
+            for (int index = 0; index < assemblies.Length; index++)
+            {
+                UnityCompilationAssembly assembly = assemblies[index];
+                if (assembly.name == assemblyName)
+                {
+                    return assembly;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadAssemblyResolutionDiagnosticsTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadAssemblyResolutionDiagnosticsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 85d1efcd715844d6dbb5c573e5424f41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAssemblyResolutionDiagnostics.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAssemblyResolutionDiagnostics.cs
@@ -1,0 +1,111 @@
+using System;
+using System.IO;
+
+using UnityEngine;
+
+using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Builds Failed reasons when hot-reload cannot target the resolved compilation assembly.
+    /// </summary>
+    internal static class HotReloadAssemblyResolutionDiagnostics
+    {
+        internal static string TryGetAssemblyResolutionFailureReason(
+            string assemblyName,
+            UnityCompilationAssembly compilationAssembly,
+            string projectRelativePath,
+            bool hasUnimportedAsmdefOnDisk)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+
+            if (compilationAssembly == null)
+            {
+                if (hasUnimportedAsmdefOnDisk)
+                {
+                    return string.Format(
+                        HotReloadConstants.UnimportedAsmdefCompilationAssemblyNotFoundReasonFormat,
+                        assemblyName,
+                        projectRelativePath);
+                }
+
+                return string.Format(
+                    HotReloadConstants.CompilationAssemblyNotFoundReasonFormat,
+                    assemblyName);
+            }
+
+            if (!ContainsProjectRelativeSourceFile(compilationAssembly.sourceFiles, projectRelativePath))
+            {
+                return string.Format(
+                    HotReloadConstants.SourceFileNotInCompiledAssemblyReasonFormat,
+                    projectRelativePath,
+                    compilationAssembly.name);
+            }
+
+            return null;
+        }
+
+        // Why disk scan instead of CompilationPipeline: GetAssemblyDefinitionFilePathFromScriptPath
+        // returns null for a not-yet-imported .asmdef, so only the on-disk ancestor file can
+        // distinguish that case from a true predefined-assembly script.
+        internal static bool AncestorDirectoryContainsAsmdef(string scriptPath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(scriptPath), "scriptPath must not be empty.");
+
+            string directory = Path.GetDirectoryName(Path.GetFullPath(scriptPath));
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            StringComparison comparison = Application.platform == RuntimePlatform.WindowsEditor
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                if (Directory.Exists(directory)
+                    && Directory.GetFiles(directory, "*.asmdef", SearchOption.TopDirectoryOnly).Length > 0)
+                {
+                    return true;
+                }
+
+                if (string.Equals(Path.GetFullPath(directory), projectRoot, comparison))
+                {
+                    return false;
+                }
+
+                directory = Path.GetDirectoryName(directory);
+            }
+
+            return false;
+        }
+
+        private static bool ContainsProjectRelativeSourceFile(string[] sourceFiles, string projectRelativePath)
+        {
+            if (sourceFiles == null || sourceFiles.Length == 0)
+            {
+                return false;
+            }
+
+            string normalizedTarget = projectRelativePath.Replace('\\', '/');
+            StringComparison comparison = Application.platform == RuntimePlatform.WindowsEditor
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            for (int index = 0; index < sourceFiles.Length; index++)
+            {
+                string sourceFile = sourceFiles[index];
+                if (string.IsNullOrEmpty(sourceFile))
+                {
+                    continue;
+                }
+
+                if (string.Equals(sourceFile.Replace('\\', '/'), normalizedTarget, comparison))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAssemblyResolutionDiagnostics.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAssemblyResolutionDiagnostics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 762c14b1e22fe40ba9a5228895c78d39
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -247,5 +247,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string VibeLogShimCompileStageRetry = "retry";
         public const string VibeLogIsolationTriggerShimCompileFailure = "shim_compile_failure";
         public const string VibeLogIsolationTriggerSignatureChangeGate = "signature_change_gate";
+
+        // Format: resolved assembly name. Unity maps not-yet-imported .asmdef scripts onto a
+        // predefined assembly, so the name from GetAssemblyNameFromScriptPath often does not
+        // exist in CompilationPipeline.GetAssemblies().
+        public const string CompilationAssemblyNotFoundReasonFormat =
+            "Resolved assembly '{0}' was not found in the compilation pipeline. Unity resolves files under a not-yet-imported .asmdef to a predefined assembly, so a brand-new .asmdef or a brand-new script cannot be hot-reloaded. Run 'uloop compile' first.";
+
+        // Format: resolved assembly name, project-relative script path. Used when the script
+        // has no imported .asmdef but an ancestor directory already has one on disk.
+        public const string UnimportedAsmdefCompilationAssemblyNotFoundReasonFormat =
+            "Resolved assembly '{0}' was not found in the compilation pipeline. '{1}' sits under a .asmdef that Unity has not imported yet, so hot reload cannot target it. Run 'uloop compile' first.";
+
+        // Format: project-relative script path, compiled assembly name.
+        public const string SourceFileNotInCompiledAssemblyReasonFormat =
+            "'{0}' is not part of the last compiled assembly '{1}' (a newly added script). New files require a real compile; run 'uloop compile' first.";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
@@ -51,12 +51,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             string assemblyName = Path.GetFileNameWithoutExtension(rawAssemblyName);
             UnityCompilationAssembly compilationAssembly = FindCompilationAssembly(assemblyName);
-            if (compilationAssembly == null)
+            string importedAsmdefPath = CompilationPipeline.GetAssemblyDefinitionFilePathFromScriptPath(projectRelativePath);
+            bool hasUnimportedAsmdefOnDisk = string.IsNullOrEmpty(importedAsmdefPath)
+                && HotReloadAssemblyResolutionDiagnostics.AncestorDirectoryContainsAsmdef(assemblyResolvePath);
+            string resolutionFailureReason = HotReloadAssemblyResolutionDiagnostics.TryGetAssemblyResolutionFailureReason(
+                assemblyName,
+                compilationAssembly,
+                projectRelativePath,
+                hasUnimportedAsmdefOnDisk);
+            if (resolutionFailureReason != null)
             {
                 outcomes.Add(
                     HotReloadMethodOutcome.Failed(
                         "(file)",
-                        "CompilationPipeline assembly not found: " + assemblyName,
+                        resolutionFailureReason,
                         assemblyResolvePath));
                 return (new HotReloadOrchestrator.HotReloadFileProcessResult(outcomes, warnings, 0), null, null, null, null, null);
             }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
@@ -51,8 +51,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             string assemblyName = Path.GetFileNameWithoutExtension(rawAssemblyName);
             UnityCompilationAssembly compilationAssembly = FindCompilationAssembly(assemblyName);
-            string importedAsmdefPath = CompilationPipeline.GetAssemblyDefinitionFilePathFromScriptPath(projectRelativePath);
-            bool hasUnimportedAsmdefOnDisk = string.IsNullOrEmpty(importedAsmdefPath)
+            // Why gate on compilationAssembly == null: the unimported-asmdef flag is only
+            // consumed on that branch, and walking ancestor directories on every successful
+            // resolve (including loose Assembly-CSharp scripts) is wasted disk I/O.
+            bool hasUnimportedAsmdefOnDisk = compilationAssembly == null
+                && string.IsNullOrEmpty(
+                    CompilationPipeline.GetAssemblyDefinitionFilePathFromScriptPath(projectRelativePath))
                 && HotReloadAssemblyResolutionDiagnostics.AncestorDirectoryContainsAsmdef(assemblyResolvePath);
             string resolutionFailureReason = HotReloadAssemblyResolutionDiagnostics.TryGetAssemblyResolutionFailureReason(
                 assemblyName,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -260,6 +260,8 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Condition | Notes |
 |-----------|-------|
 | File does not belong to any compiled assembly | Per-file entry with `Method` = `(file)`; only `Assets/` and `Packages/` sources resolve |
+| Resolved assembly name is missing from CompilationPipeline | Per-file entry with `Method` = `(file)`; Unity may have mapped a not-yet-imported `.asmdef` onto a predefined assembly. Run `uloop compile` first |
+| Script is not in the last compiled assembly's source list | Per-file entry with `Method` = `(file)`; a newly added script is not hot-reloadable until `uloop compile` |
 | Loaded assembly differs from the one on disk (pending compile) | Run `uloop compile` first, then retry |
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | Usually a stale assembly; run `uloop compile`. In-file renames and signature changes are classified as added members before reaching this point |


### PR DESCRIPTION
## Summary
- Hot reload no longer reports a misleading missing-assembly name when the real problem is a brand-new `.asmdef` or a newly added script.
- Those failures now tell you to run `uloop compile` first.

## User Impact
- Before: hot-reloading a script under a not-yet-imported `.asmdef` could fail with `CompilationPipeline assembly not found: Assembly-CSharp`, even though that assembly was never requested. A newly added script in an already compiled assembly could also slip through name resolution and fail later without saying that new files need a real compile.
- After: if Unity resolved an assembly that is not in the compilation pipeline, the Failed reason names that fallback and asks for `uloop compile`. If the resolved assembly exists but the file is not in its last compiled source list, the Failed reason says the script is newly added and needs `uloop compile`.

## Changes
- Resolve assembly targeting through a single helper that handles both "assembly missing from CompilationPipeline" and "script not in that assembly's source list".
- Walk ancestor directories for an on-disk `.asmdef` only when compilation-assembly lookup already failed.
- Document the two Failed cases in the hot-reload skill Failed table.

## Limitations
- The compilation-assembly-not-found branch is covered by helper tests (including on-disk `.asmdef` ancestor detection) rather than a live `ResolvePatchTarget` path that creates an unimported `.asmdef` under `Assets/`, because that import can domain-reload and freeze EditMode tests.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → ErrorCount: 0, Success: true
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value HotReloadAssemblyResolutionDiagnosticsTests` → TestCount 8, PassedCount 8, FailedCount 0
- Measured `CompilationPipeline.GetAssemblyNameFromScriptPath` on a missing path under an existing `.asmdef`: it returns the existing assembly name and that path is absent from `sourceFiles`, which is the live wiring case asserted by `ResolvePatchTarget_WhenScriptIsNotInCompiledAssemblySourceFiles_ReturnsFailedReason`
