### PR TITLE
feat: add RecommendedNextAction to hot-reload responses with failed outcomes

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -369,3 +369,4 @@ Returns JSON with:
 - `ActivePatchTotal` (number): Active changes after this run — patched methods plus added members. `--revert-all` clears both and reports the combined count in `ClearedCount`
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)
 - `Message` (string): Short summary
+- `RecommendedNextAction` (string): Present when any method outcome is `Failed`. A partial apply (some methods patched or added) says to fix and rerun, run `uloop compile`, or `uloop hot-reload --revert-all`; a failure with nothing applied says to fix and rerun or compile. Omitted on success.

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -369,3 +369,4 @@ Returns JSON with:
 - `ActivePatchTotal` (number): Active changes after this run — patched methods plus added members. `--revert-all` clears both and reports the combined count in `ClearedCount`
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)
 - `Message` (string): Short summary
+- `RecommendedNextAction` (string): Present when any method outcome is `Failed`. A partial apply (some methods patched or added) says to fix and rerun, run `uloop compile`, or `uloop hot-reload --revert-all`; a failure with nothing applied says to fix and rerun or compile. Omitted on success.

--- a/Assets/Tests/Editor/HotReload/HotReloadRecommendedNextActionTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadRecommendedNextActionTests.cs
@@ -1,0 +1,77 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Covers RecommendedNextAction wording for failed hot-reload apply responses.
+    /// </summary>
+    public sealed class HotReloadRecommendedNextActionTests
+    {
+        /// <summary>
+        /// What: a Failed run that still patched methods recommends fix-and-rerun, compile, or
+        /// revert-all.
+        /// </summary>
+        [Test]
+        public void Resolve_WhenFailureWithPatchedMethods_ReturnsPartialApplyAction()
+        {
+            string action = HotReloadRecommendedNextAction.Resolve(
+                hasFailure: true,
+                patchedTotal: 1,
+                addedCount: 0);
+
+            Assert.That(
+                action,
+                Is.EqualTo(
+                    "Partially applied. Fix the failed methods and rerun, run 'uloop compile' to apply every edit, or run 'uloop hot-reload --revert-all' to discard the applied patches."));
+        }
+
+        /// <summary>
+        /// What: a Failed run that applied only added members is still treated as a partial apply.
+        /// </summary>
+        [Test]
+        public void Resolve_WhenFailureWithAddedMembers_ReturnsPartialApplyAction()
+        {
+            string action = HotReloadRecommendedNextAction.Resolve(
+                hasFailure: true,
+                patchedTotal: 0,
+                addedCount: 1);
+
+            Assert.That(
+                action,
+                Is.EqualTo(
+                    "Partially applied. Fix the failed methods and rerun, run 'uloop compile' to apply every edit, or run 'uloop hot-reload --revert-all' to discard the applied patches."));
+        }
+
+        /// <summary>
+        /// What: a Failed run that applied nothing recommends fix-and-rerun or compile.
+        /// </summary>
+        [Test]
+        public void Resolve_WhenFailureWithNothingApplied_ReturnsFixOrCompileAction()
+        {
+            string action = HotReloadRecommendedNextAction.Resolve(
+                hasFailure: true,
+                patchedTotal: 0,
+                addedCount: 0);
+
+            Assert.That(
+                action,
+                Is.EqualTo("Fix the failed methods and rerun, or run 'uloop compile'."));
+        }
+
+        /// <summary>
+        /// What: a successful apply does not recommend a next action.
+        /// </summary>
+        [Test]
+        public void Resolve_WhenNoFailure_ReturnsEmpty()
+        {
+            string action = HotReloadRecommendedNextAction.Resolve(
+                hasFailure: false,
+                patchedTotal: 1,
+                addedCount: 1);
+
+            Assert.That(action, Is.EqualTo(string.Empty));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadRecommendedNextActionTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadRecommendedNextActionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43de5abeb1ff64cb5b09aee4ce6c7ef9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -143,6 +143,78 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: BuildApplyResponse sets the partial-apply RecommendedNextAction when a Failed
+        /// outcome is mixed with patched methods.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_WhenFailureWithPatchedMethods_SetsPartialApplyRecommendedNextAction()
+        {
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>
+                {
+                    HotReloadMethodOutcome.Patched("Type.Ok", "Assets/A.cs"),
+                    HotReloadMethodOutcome.Failed("Type.Bad", "shim compile failed", "Assets/A.cs")
+                },
+                new List<string>(),
+                patchedTotal: 1,
+                activePatchTotal: 1);
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+            Assert.That(
+                response.RecommendedNextAction,
+                Is.EqualTo(
+                    "Partially applied. Fix the failed methods and rerun, run 'uloop compile' to apply every edit, or run 'uloop hot-reload --revert-all' to discard the applied patches."));
+            Assert.That(response.ShouldSerializeRecommendedNextAction(), Is.True);
+        }
+
+        /// <summary>
+        /// What: BuildApplyResponse sets the fix-or-compile RecommendedNextAction when every
+        /// outcome failed and nothing was applied.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_WhenFailureWithNothingApplied_SetsFixOrCompileRecommendedNextAction()
+        {
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>
+                {
+                    HotReloadMethodOutcome.Failed("Type.Method", "shim compile failed", "Assets/A.cs")
+                },
+                new List<string>(),
+                patchedTotal: 0,
+                activePatchTotal: 0);
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+            Assert.That(
+                response.RecommendedNextAction,
+                Is.EqualTo("Fix the failed methods and rerun, or run 'uloop compile'."));
+            Assert.That(response.ShouldSerializeRecommendedNextAction(), Is.True);
+        }
+
+        /// <summary>
+        /// What: BuildApplyResponse leaves RecommendedNextAction empty on a successful apply
+        /// so the field is omitted from JSON.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_WhenSuccess_LeavesRecommendedNextActionEmpty()
+        {
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>
+                {
+                    HotReloadMethodOutcome.Patched("Type.Method", "Assets/A.cs")
+                },
+                new List<string>(),
+                patchedTotal: 1,
+                activePatchTotal: 1);
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+            Assert.That(response.RecommendedNextAction, Is.EqualTo(string.Empty));
+            Assert.That(response.ShouldSerializeRecommendedNextAction(), Is.False);
+        }
+
+        /// <summary>
         /// What: BuildApplyResponse does not emit pause-point warnings when no markers
         /// were retargeted or suppressed, even if PatchedTotal &gt; 0.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -169,6 +169,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: BuildApplyResponse treats a Failed run that applied only added members as a
+        /// partial apply, so CountAddedOutcomes cannot be dropped without this test failing.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_WhenFailureWithOnlyAddedMembers_SetsPartialApplyRecommendedNextAction()
+        {
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                new List<HotReloadMethodOutcome>
+                {
+                    HotReloadMethodOutcome.Added("Type.NewMember", "Assets/A.cs"),
+                    HotReloadMethodOutcome.Failed("Type.Bad", "shim compile failed", "Assets/A.cs")
+                },
+                new List<string>(),
+                patchedTotal: 0,
+                activePatchTotal: 1);
+
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
+
+            Assert.That(
+                response.RecommendedNextAction,
+                Is.EqualTo(
+                    "Partially applied. Fix the failed methods and rerun, run 'uloop compile' to apply every edit, or run 'uloop hot-reload --revert-all' to discard the applied patches."));
+            Assert.That(response.ShouldSerializeRecommendedNextAction(), Is.True);
+        }
+
+        /// <summary>
         /// What: BuildApplyResponse sets the fix-or-compile RecommendedNextAction when every
         /// outcome failed and nothing was applied.
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -262,5 +262,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Format: project-relative script path, compiled assembly name.
         public const string SourceFileNotInCompiledAssemblyReasonFormat =
             "'{0}' is not part of the last compiled assembly '{1}' (a newly added script). New files require a real compile; run 'uloop compile' first.";
+
+        public const string PartialApplyRecommendedNextAction =
+            "Partially applied. Fix the failed methods and rerun, run 'uloop compile' to apply every edit, or run 'uloop hot-reload --revert-all' to discard the applied patches.";
+
+        public const string FailedWithNoApplyRecommendedNextAction =
+            "Fix the failed methods and rerun, or run 'uloop compile'.";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRecommendedNextAction.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRecommendedNextAction.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Chooses RecommendedNextAction for hot-reload apply responses that include Failed outcomes.
+    /// </summary>
+    internal static class HotReloadRecommendedNextAction
+    {
+        internal static string Resolve(bool hasFailure, int patchedTotal, int addedCount)
+        {
+            Debug.Assert(patchedTotal >= 0, "patchedTotal must not be negative.");
+            Debug.Assert(addedCount >= 0, "addedCount must not be negative.");
+
+            if (!hasFailure)
+            {
+                return string.Empty;
+            }
+
+            if (patchedTotal + addedCount > 0)
+            {
+                return HotReloadConstants.PartialApplyRecommendedNextAction;
+            }
+
+            return HotReloadConstants.FailedWithNoApplyRecommendedNextAction;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRecommendedNextAction.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRecommendedNextAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad6b49fc3e2154e9e91487447214f273
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -77,6 +77,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string[] AddedFields { get; set; } = Array.Empty<string>();
 
         public string Message { get; set; } = string.Empty;
+
+        public string RecommendedNextAction { get; set; } = string.Empty;
+
+        // Why omit empty: success and validation-only payloads must not grow a next-action
+        // field that PausePoint-style responses leave blank on the wire.
+        public bool ShouldSerializeRecommendedNextAction()
+        {
+            return !string.IsNullOrEmpty(RecommendedNextAction);
+        }
     }
 
     /// <summary>
@@ -272,7 +281,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     hasFailure,
                     warnings.Count,
                     appendCompileResolution: orchestratorWarningCount >= 2
-                        && orchestratorWarningCount == warnings.Count)
+                        && orchestratorWarningCount == warnings.Count),
+                RecommendedNextAction = HotReloadRecommendedNextAction.Resolve(
+                    hasFailure,
+                    result.PatchedTotal,
+                    CountAddedOutcomes(result))
             };
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -369,3 +369,4 @@ Returns JSON with:
 - `ActivePatchTotal` (number): Active changes after this run — patched methods plus added members. `--revert-all` clears both and reports the combined count in `ClearedCount`
 - `ClearedCount` (number): Patches removed by `--revert-all` (0 on apply)
 - `Message` (string): Short summary
+- `RecommendedNextAction` (string): Present when any method outcome is `Failed`. A partial apply (some methods patched or added) says to fix and rerun, run `uloop compile`, or `uloop hot-reload --revert-all`; a failure with nothing applied says to fix and rerun or compile. Omitted on success.

--- a/cli/project-runner/internal/projectrunner/pause_point_captured_variable_names_filter_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_captured_variable_names_filter_test.go
@@ -226,92 +226,109 @@ func truncatedNameFilterResponse() pausePointStatusResponse {
 	}
 }
 
+const truncatedByNameFilterNote = "the truncation flag refers to a variable excluded by --captured-variable-names; every variable listed here is complete."
+
 // TestFilterPausePointCapturedVariablesByNameSetsTruncatedNote verifies the CLI
 // explains CapturedVariablesTruncated when --captured-variable-names dropped every
 // truncated variable, and that it does not rewrite the truncation flag.
 func TestFilterPausePointCapturedVariablesByNameSetsTruncatedNote(t *testing.T) {
-	const wantTruncatedNote = "the truncation flag refers to a variable excluded by --captured-variable-names; every variable listed here is complete."
+	t.Run("note is set when the truncated variable is excluded", truncatedNoteWhenExcluded)
+	t.Run("note is omitted when a truncated variable remains", truncatedNoteOmittedWhenTruncatedRemains)
+	t.Run("note is omitted when no name filter is applied", truncatedNoteOmittedWhenNoNameFilter)
+	t.Run("note is omitted when TruncatedVariableCount is already non-zero", truncatedNoteOmittedWhenCountCap)
+	t.Run("note is omitted when CapturedVariablesTruncated is false", truncatedNoteOmittedWhenNotTruncated)
+	t.Run("note is omitted when only a history variable remains truncated", truncatedNoteOmittedWhenHistoryTruncated)
+}
 
-	t.Run("note is set when the truncated variable is excluded", func(t *testing.T) {
-		result := filterPausePointCapturedVariablesByName(truncatedNameFilterResponse(), []string{"health"})
-		if !result.CapturedVariablesTruncated {
-			t.Fatal("CapturedVariablesTruncated must stay true; the note explains it")
-		}
-		if result.CapturedVariablesTruncatedNote != wantTruncatedNote {
-			t.Fatalf("expected truncated-by-name-filter note: %q", result.CapturedVariablesTruncatedNote)
-		}
-		if len(result.CapturedVariables) != 1 || result.CapturedVariables[0].Name != "health" {
-			t.Fatalf("expected only health to survive: %#v", result.CapturedVariables)
-		}
-	})
+func truncatedNoteWhenExcluded(t *testing.T) {
+	result := filterPausePointCapturedVariablesByName(truncatedNameFilterResponse(), []string{"health"})
+	if !result.CapturedVariablesTruncated {
+		t.Fatal("CapturedVariablesTruncated must stay true; the note explains it")
+	}
+	if result.CapturedVariablesTruncatedNote != truncatedByNameFilterNote {
+		t.Fatalf("expected truncated-by-name-filter note: %q", result.CapturedVariablesTruncatedNote)
+	}
+	if len(result.CapturedVariables) != 1 {
+		t.Fatalf("expected only health to survive: %#v", result.CapturedVariables)
+	}
+	if result.CapturedVariables[0].Name != "health" {
+		t.Fatalf("expected only health to survive: %#v", result.CapturedVariables)
+	}
+}
 
-	t.Run("note is omitted when a truncated variable remains", func(t *testing.T) {
-		result := filterPausePointCapturedVariablesByName(truncatedNameFilterResponse(), []string{"board"})
-		if result.CapturedVariablesTruncatedNote != "" {
-			t.Fatalf("listed truncated values must not get the complete-list note: %q", result.CapturedVariablesTruncatedNote)
-		}
-		if !result.CapturedVariablesTruncated {
-			t.Fatal("CapturedVariablesTruncated must stay true")
-		}
-	})
+func truncatedNoteOmittedWhenTruncatedRemains(t *testing.T) {
+	result := filterPausePointCapturedVariablesByName(truncatedNameFilterResponse(), []string{"board"})
+	if result.CapturedVariablesTruncatedNote != "" {
+		t.Fatalf("listed truncated values must not get the complete-list note: %q", result.CapturedVariablesTruncatedNote)
+	}
+	if !result.CapturedVariablesTruncated {
+		t.Fatal("CapturedVariablesTruncated must stay true")
+	}
+}
 
-	t.Run("note is omitted when no name filter is applied", func(t *testing.T) {
-		result := filterPausePointCapturedVariablesByName(truncatedNameFilterResponse(), nil)
-		if result.CapturedVariablesTruncatedNote != "" {
-			t.Fatalf("unfiltered responses must not get the CLI note: %q", result.CapturedVariablesTruncatedNote)
-		}
-	})
+func truncatedNoteOmittedWhenNoNameFilter(t *testing.T) {
+	result := filterPausePointCapturedVariablesByName(truncatedNameFilterResponse(), nil)
+	if result.CapturedVariablesTruncatedNote != "" {
+		t.Fatalf("unfiltered responses must not get the CLI note: %q", result.CapturedVariablesTruncatedNote)
+	}
+}
 
-	t.Run("note is omitted when TruncatedVariableCount is already non-zero", func(t *testing.T) {
-		response := truncatedNameFilterResponse()
-		response.TruncatedVariableCount = 1
-		response.TruncatedVariableNames = []string{"extraField"}
-		result := filterPausePointCapturedVariablesByName(response, []string{"health"})
-		if result.CapturedVariablesTruncatedNote != "" {
-			t.Fatalf("count-cap truncation must not be described as a name-filter drop: %q", result.CapturedVariablesTruncatedNote)
-		}
-	})
+func truncatedNoteOmittedWhenCountCap(t *testing.T) {
+	response := truncatedNameFilterResponse()
+	response.TruncatedVariableCount = 1
+	response.TruncatedVariableNames = []string{"extraField"}
+	result := filterPausePointCapturedVariablesByName(response, []string{"health"})
+	if result.CapturedVariablesTruncatedNote != "" {
+		t.Fatalf("count-cap truncation must not be described as a name-filter drop: %q", result.CapturedVariablesTruncatedNote)
+	}
+}
 
-	t.Run("note is omitted when CapturedVariablesTruncated is false", func(t *testing.T) {
-		response := truncatedNameFilterResponse()
-		response.CapturedVariablesTruncated = false
-		result := filterPausePointCapturedVariablesByName(response, []string{"health"})
-		if result.CapturedVariablesTruncatedNote != "" {
-			t.Fatalf("a non-truncated snapshot must not get the CLI note: %q", result.CapturedVariablesTruncatedNote)
-		}
-	})
+func truncatedNoteOmittedWhenNotTruncated(t *testing.T) {
+	response := truncatedNameFilterResponse()
+	response.CapturedVariablesTruncated = false
+	result := filterPausePointCapturedVariablesByName(response, []string{"health"})
+	if result.CapturedVariablesTruncatedNote != "" {
+		t.Fatalf("a non-truncated snapshot must not get the CLI note: %q", result.CapturedVariablesTruncatedNote)
+	}
+}
 
-	t.Run("note is omitted when only a history variable remains truncated", func(t *testing.T) {
-		response := pausePointStatusResponse{
-			CapturedVariablesTruncated: true,
-			TruncatedVariableCount:     0,
-			CapturedVariables: []pausePointCapturedVariable{
-				{Name: "health", Scope: "Local", TypeName: "Int32", Value: pausePointVariableValue("100")},
-				{Name: "velocity", Scope: "Local", TypeName: "Vector3", Value: pausePointVariableValue("(1,0,0)")},
-			},
-			CapturedVariableHistory: []pausePointCapturedHistoryFrame{
-				{
-					HitSequence: 1,
-					CapturedVariables: []pausePointCapturedVariable{
-						{Name: "health", Scope: "Local", TypeName: "Int32", Value: pausePointVariableValue("100")},
-						{Name: "board", Scope: "Local", TypeName: "Boolean[,]", Value: pausePointVariableValue("[...]"), Truncated: true},
-					},
+func truncatedNoteOmittedWhenHistoryTruncated(t *testing.T) {
+	response := pausePointStatusResponse{
+		CapturedVariablesTruncated: true,
+		TruncatedVariableCount:     0,
+		CapturedVariables: []pausePointCapturedVariable{
+			{Name: "health", Scope: "Local", TypeName: "Int32", Value: pausePointVariableValue("100")},
+			{Name: "velocity", Scope: "Local", TypeName: "Vector3", Value: pausePointVariableValue("(1,0,0)")},
+		},
+		CapturedVariableHistory: []pausePointCapturedHistoryFrame{
+			{
+				HitSequence: 1,
+				CapturedVariables: []pausePointCapturedVariable{
+					{Name: "health", Scope: "Local", TypeName: "Int32", Value: pausePointVariableValue("100")},
+					{Name: "board", Scope: "Local", TypeName: "Boolean[,]", Value: pausePointVariableValue("[...]"), Truncated: true},
 				},
 			},
-		}
-		result := filterPausePointCapturedVariablesByName(response, []string{"health", "board"})
-		if result.CapturedVariablesTruncatedNote != "" {
-			t.Fatalf("a truncated history survivor must not get the complete-list note: %q", result.CapturedVariablesTruncatedNote)
-		}
-		if len(result.CapturedVariables) != 1 || result.CapturedVariables[0].Truncated {
-			t.Fatalf("expected only complete current variables: %#v", result.CapturedVariables)
-		}
-		if len(result.CapturedVariableHistory) != 1 ||
-			len(result.CapturedVariableHistory[0].CapturedVariables) != 2 ||
-			!result.CapturedVariableHistory[0].CapturedVariables[1].Truncated {
-			t.Fatalf("expected truncated board to remain in history: %#v", result.CapturedVariableHistory)
-		}
-	})
+		},
+	}
+	result := filterPausePointCapturedVariablesByName(response, []string{"health", "board"})
+	if result.CapturedVariablesTruncatedNote != "" {
+		t.Fatalf("a truncated history survivor must not get the complete-list note: %q", result.CapturedVariablesTruncatedNote)
+	}
+	if len(result.CapturedVariables) != 1 {
+		t.Fatalf("expected only complete current variables: %#v", result.CapturedVariables)
+	}
+	if result.CapturedVariables[0].Truncated {
+		t.Fatalf("expected only complete current variables: %#v", result.CapturedVariables)
+	}
+	if len(result.CapturedVariableHistory) != 1 {
+		t.Fatalf("expected truncated board to remain in history: %#v", result.CapturedVariableHistory)
+	}
+	if len(result.CapturedVariableHistory[0].CapturedVariables) != 2 {
+		t.Fatalf("expected truncated board to remain in history: %#v", result.CapturedVariableHistory)
+	}
+	if !result.CapturedVariableHistory[0].CapturedVariables[1].Truncated {
+		t.Fatalf("expected truncated board to remain in history: %#v", result.CapturedVariableHistory)
+	}
 }
 
 // TestPausePointStatusResponseIncludesCapturedVariablesTruncatedNote verifies the


### PR DESCRIPTION
## Summary
- Failed hot-reload responses now include `RecommendedNextAction` so you can tell whether to rerun after a fix, compile, or discard already-applied patches.
- Successful applies omit the field.

## User Impact
- Before: a mixed Failed apply could still patch some methods (`Success: false` with `PatchedTotal >= 1`) and left no next-step guidance.
- After: partial applies say to fix and rerun, run `uloop compile`, or `uloop hot-reload --revert-all`. Failures that applied nothing say to fix and rerun or compile.

## Changes
- `HotReloadResponse.RecommendedNextAction` is filled from a single helper during `BuildApplyResponse` and omitted from JSON when empty.
- `BuildApplyResponse` wiring covers patched partial applies, added-only partial applies, failures with nothing applied, and success.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → ErrorCount: 0, Success: true
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value RecommendedNextAction` → TestCount 11, PassedCount 11, FailedCount 0
- Mutation: `CountAddedOutcomes` forced to `return 0` made only `BuildApplyResponse_WhenFailureWithOnlyAddedMembers_SetsPartialApplyRecommendedNextAction` fail (10 passed / 1 failed); the production loop was restored afterward
