### PR TITLE
test: split pause-point truncated-note tests under the complexity gate

### DIFF
--- a/cli/project-runner/internal/projectrunner/pause_point_captured_variable_names_filter_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_captured_variable_names_filter_test.go
@@ -261,7 +261,11 @@ func TestFilterPausePointCapturedVariablesByNameSetsTruncatedNote(t *testing.T) 
 			t.Fatalf("unfiltered responses must not get the CLI note: %q", result.CapturedVariablesTruncatedNote)
 		}
 	})
+}
 
+// TestFilterPausePointCapturedVariablesByNameOmitsTruncatedNote verifies additional
+// negative cases where the CLI must not attach CapturedVariablesTruncatedNote.
+func TestFilterPausePointCapturedVariablesByNameOmitsTruncatedNote(t *testing.T) {
 	t.Run("note is omitted when TruncatedVariableCount is already non-zero", func(t *testing.T) {
 		response := truncatedNameFilterResponse()
 		response.TruncatedVariableCount = 1


### PR DESCRIPTION
## Summary
- Split the pause-point truncated-note test into two top-level tests so cyclop stays at or under 15.
- Assertions and case contents are unchanged; this is a mechanical split only.

## User Impact
- Before: Complexity Report failed on v3-beta because `TestFilterPausePointCapturedVariablesByNameSetsTruncatedNote` was cyclomatic complexity 16.
- After: the same six cases run as two tests (`SetsTruncatedNote` / `OmitsTruncatedNote`), unblocking the complexity gate.

## Changes
- Keep the positive case and the two basic negatives in `TestFilterPausePointCapturedVariablesByNameSetsTruncatedNote`.
- Move the three additional negatives into `TestFilterPausePointCapturedVariablesByNameOmitsTruncatedNote`.

## Verification
- `CODE_COMPLEXITY_FAIL_ON_EXCEEDED=true scripts/check-code-complexity.sh` → 0 issues
- `scripts/check-go-cli.sh` passed
- `go test ./internal/projectrunner -run 'TestFilterPausePointCapturedVariablesByNameSetsTruncatedNote|TestFilterPausePointCapturedVariablesByNameOmitsTruncatedNote' -v` → 6 subtests PASS


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

