### PR TITLE
feat: warn about const drift in sibling files of hot-reloaded assemblies

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -130,7 +130,9 @@ initializer, an attribute — leaves runtime behavior unchanged even though the
 response reports `Success` — shims resolve those symbols
 against the already-compiled assembly, and C# bakes `const` values into IL at compile
 time. Changed `const` values (including enum member values) are detected and reported
-as a `Warnings` entry naming the constant and both values. When a verified source
+as a `Warnings` entry naming the constant and both values. The scan includes
+changed sibling files in the same assembly, not only the file passed to
+`--files`. When a verified source
 baseline is available (next paragraph), other outside-body drift — existing-field
 initializers, attributes, and other declaration edits — is reported as a `Warnings`
 entry as well (handled added members and reported removed members are excluded

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -130,7 +130,9 @@ initializer, an attribute — leaves runtime behavior unchanged even though the
 response reports `Success` — shims resolve those symbols
 against the already-compiled assembly, and C# bakes `const` values into IL at compile
 time. Changed `const` values (including enum member values) are detected and reported
-as a `Warnings` entry naming the constant and both values. When a verified source
+as a `Warnings` entry naming the constant and both values. The scan includes
+changed sibling files in the same assembly, not only the file passed to
+`--files`. When a verified source
 baseline is available (next paragraph), other outside-body drift — existing-field
 initializers, attributes, and other declaration edits — is reported as a `Warnings`
 entry as well (handled added members and reported removed members are excluded

--- a/Assets/Tests/Editor/HotReload/HotReloadChangedSiblingSourceDetectorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadChangedSiblingSourceDetectorTests.cs
@@ -108,8 +108,48 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: more than 50 changed siblings truncates the path list and emits the cap warning
-        /// with the total count.
+        /// What: a snapshot-identical sibling is omitted while a byte-changed sibling is returned.
+        /// </summary>
+        [Test]
+        public void DetectFromSnapshotDirectory_WhenOneSiblingMatchesSnapshot_OmitsTheIdenticalSibling()
+        {
+            string projectRoot = CreateTempProjectRoot();
+            try
+            {
+                string editedRelative = "Assets/Edited.cs";
+                string changedRelative = "Assets/ChangedSibling.cs";
+                string identicalRelative = "Assets/IdenticalSibling.cs";
+                WriteProjectFile(projectRoot, editedRelative, "edited-disk");
+                WriteProjectFile(projectRoot, changedRelative, "changed-disk");
+                WriteProjectFile(projectRoot, identicalRelative, "identical-bytes");
+                WriteSnapshot(projectRoot, "Asm-mvid", editedRelative, "edited-snapshot");
+                WriteSnapshot(projectRoot, "Asm-mvid", changedRelative, "changed-snapshot");
+                WriteSnapshot(projectRoot, "Asm-mvid", identicalRelative, "identical-bytes");
+
+                HotReloadChangedSiblingScanResult result =
+                    HotReloadChangedSiblingSourceDetector.DetectFromSnapshotDirectory(
+                        projectRoot,
+                        "Asm-mvid",
+                        new[] { editedRelative, changedRelative, identicalRelative },
+                        editedRelative);
+
+                Assert.That(result.ChangedSiblingAbsolutePaths, Has.Length.EqualTo(1));
+                Assert.That(
+                    result.ChangedSiblingAbsolutePaths[0],
+                    Is.EqualTo(AbsoluteProjectPath(projectRoot, changedRelative)));
+                Assert.That(
+                    result.ChangedSiblingAbsolutePaths,
+                    Does.Not.Contain(AbsoluteProjectPath(projectRoot, identicalRelative)));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// What: 51 changed siblings truncates the path list to 50 and emits the cap warning
+        /// with the fixed 50/51 wording.
         /// </summary>
         [Test]
         public void DetectFromSnapshotDirectory_WhenMoreThanLimitChanged_TruncatesAndWarns()
@@ -117,15 +157,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string projectRoot = CreateTempProjectRoot();
             try
             {
-                const int extraChanged = 3;
-                int totalChanged = HotReloadConstants.SiblingConstDriftScanFileLimit + extraChanged;
+                const int changedSiblingCount = 51;
                 string editedRelative = "Assets/Edited.cs";
                 WriteProjectFile(projectRoot, editedRelative, "edited-disk");
                 WriteSnapshot(projectRoot, "Asm-mvid", editedRelative, "edited-snapshot");
 
-                string[] sourceFiles = new string[totalChanged + 1];
+                string[] sourceFiles = new string[changedSiblingCount + 1];
                 sourceFiles[0] = editedRelative;
-                for (int index = 0; index < totalChanged; index++)
+                for (int index = 0; index < changedSiblingCount; index++)
                 {
                     string relative = "Assets/Sibling" + index.ToString(CultureInfo.InvariantCulture) + ".cs";
                     sourceFiles[index + 1] = relative;
@@ -140,15 +179,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         sourceFiles,
                         editedRelative);
 
-                Assert.That(
-                    result.ChangedSiblingAbsolutePaths,
-                    Has.Length.EqualTo(HotReloadConstants.SiblingConstDriftScanFileLimit));
+                Assert.That(result.ChangedSiblingAbsolutePaths, Has.Length.EqualTo(50));
                 Assert.That(
                     result.ScanLimitWarning,
-                    Is.EqualTo(
-                        string.Format(
-                            HotReloadConstants.SiblingConstDriftScanLimitedWarningFormat,
-                            totalChanged)));
+                    Is.EqualTo("sibling const-drift scan limited to first 50 changed files (51 total)"));
             }
             finally
             {

--- a/Assets/Tests/Editor/HotReload/HotReloadChangedSiblingSourceDetectorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadChangedSiblingSourceDetectorTests.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for snapshot-vs-disk sibling change detection used by const-drift scanning.
+    /// </summary>
+    public class HotReloadChangedSiblingSourceDetectorTests
+    {
+        /// <summary>
+        /// What: a sibling whose on-disk bytes differ from its snapshot is returned, and the
+        /// edited file itself is excluded even when it also differs.
+        /// </summary>
+        [Test]
+        public void DetectFromSnapshotDirectory_WhenSiblingBytesDiffer_ReturnsSiblingAndExcludesEditedFile()
+        {
+            string projectRoot = CreateTempProjectRoot();
+            try
+            {
+                string editedRelative = "Assets/Edited.cs";
+                string siblingRelative = "Assets/Sibling.cs";
+                WriteProjectFile(projectRoot, editedRelative, "edited-disk");
+                WriteProjectFile(projectRoot, siblingRelative, "sibling-disk");
+                WriteSnapshot(projectRoot, "Asm-mvid", editedRelative, "edited-snapshot");
+                WriteSnapshot(projectRoot, "Asm-mvid", siblingRelative, "sibling-snapshot");
+
+                HotReloadChangedSiblingScanResult result =
+                    HotReloadChangedSiblingSourceDetector.DetectFromSnapshotDirectory(
+                        projectRoot,
+                        "Asm-mvid",
+                        new[] { editedRelative, siblingRelative },
+                        editedRelative);
+
+                Assert.That(result.ChangedSiblingAbsolutePaths, Has.Length.EqualTo(1));
+                Assert.That(
+                    result.ChangedSiblingAbsolutePaths[0],
+                    Is.EqualTo(AbsoluteProjectPath(projectRoot, siblingRelative)));
+                Assert.That(result.ScanLimitWarning, Is.EqualTo(string.Empty));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// What: a missing snapshot directory returns no siblings and no cap warning.
+        /// </summary>
+        [Test]
+        public void DetectFromSnapshotDirectory_WhenSnapshotDirectoryMissing_ReturnsEmpty()
+        {
+            string projectRoot = CreateTempProjectRoot();
+            try
+            {
+                string editedRelative = "Assets/Edited.cs";
+                string siblingRelative = "Assets/Sibling.cs";
+                WriteProjectFile(projectRoot, editedRelative, "edited-disk");
+                WriteProjectFile(projectRoot, siblingRelative, "sibling-disk");
+
+                HotReloadChangedSiblingScanResult result =
+                    HotReloadChangedSiblingSourceDetector.DetectFromSnapshotDirectory(
+                        projectRoot,
+                        "Asm-mvid",
+                        new[] { editedRelative, siblingRelative },
+                        editedRelative);
+
+                Assert.That(result.ChangedSiblingAbsolutePaths, Is.Empty);
+                Assert.That(result.ScanLimitWarning, Is.EqualTo(string.Empty));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// What: a missing DLL skips the snapshot walk instead of throwing.
+        /// </summary>
+        [Test]
+        public void Detect_WhenDllMissing_ReturnsEmpty()
+        {
+            string projectRoot = CreateTempProjectRoot();
+            try
+            {
+                HotReloadChangedSiblingScanResult result = HotReloadChangedSiblingSourceDetector.Detect(
+                    projectRoot,
+                    "Asm",
+                    Path.Combine(projectRoot, "missing.dll"),
+                    new[] { "Assets/Edited.cs", "Assets/Sibling.cs" },
+                    "Assets/Edited.cs");
+
+                Assert.That(result.ChangedSiblingAbsolutePaths, Is.Empty);
+                Assert.That(result.ScanLimitWarning, Is.EqualTo(string.Empty));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// What: more than 50 changed siblings truncates the path list and emits the cap warning
+        /// with the total count.
+        /// </summary>
+        [Test]
+        public void DetectFromSnapshotDirectory_WhenMoreThanLimitChanged_TruncatesAndWarns()
+        {
+            string projectRoot = CreateTempProjectRoot();
+            try
+            {
+                const int extraChanged = 3;
+                int totalChanged = HotReloadConstants.SiblingConstDriftScanFileLimit + extraChanged;
+                string editedRelative = "Assets/Edited.cs";
+                WriteProjectFile(projectRoot, editedRelative, "edited-disk");
+                WriteSnapshot(projectRoot, "Asm-mvid", editedRelative, "edited-snapshot");
+
+                string[] sourceFiles = new string[totalChanged + 1];
+                sourceFiles[0] = editedRelative;
+                for (int index = 0; index < totalChanged; index++)
+                {
+                    string relative = "Assets/Sibling" + index.ToString(CultureInfo.InvariantCulture) + ".cs";
+                    sourceFiles[index + 1] = relative;
+                    WriteProjectFile(projectRoot, relative, "disk-" + index.ToString(CultureInfo.InvariantCulture));
+                    WriteSnapshot(projectRoot, "Asm-mvid", relative, "snap-" + index.ToString(CultureInfo.InvariantCulture));
+                }
+
+                HotReloadChangedSiblingScanResult result =
+                    HotReloadChangedSiblingSourceDetector.DetectFromSnapshotDirectory(
+                        projectRoot,
+                        "Asm-mvid",
+                        sourceFiles,
+                        editedRelative);
+
+                Assert.That(
+                    result.ChangedSiblingAbsolutePaths,
+                    Has.Length.EqualTo(HotReloadConstants.SiblingConstDriftScanFileLimit));
+                Assert.That(
+                    result.ScanLimitWarning,
+                    Is.EqualTo(
+                        string.Format(
+                            HotReloadConstants.SiblingConstDriftScanLimitedWarningFormat,
+                            totalChanged)));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// What: DeduplicatePreserveOrder keeps the first copy of a repeated warning string.
+        /// </summary>
+        [Test]
+        public void DeduplicatePreserveOrder_WhenWarningsRepeat_KeepsFirstOccurrence()
+        {
+            System.Collections.Generic.List<string> unique =
+                HotReloadOutcomeAggregation.DeduplicatePreserveOrder(
+                    new[] { "a", "b", "a", "c", "b" });
+
+            Assert.That(unique, Is.EqualTo(new[] { "a", "b", "c" }));
+        }
+
+        private static string CreateTempProjectRoot()
+        {
+            string projectRoot = Path.Combine(
+                Path.GetTempPath(),
+                "uloop-sibling-scan-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectRoot);
+            return projectRoot;
+        }
+
+        private static void WriteProjectFile(string projectRoot, string projectRelativePath, string contents)
+        {
+            string absolutePath = AbsoluteProjectPath(projectRoot, projectRelativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(absolutePath));
+            File.WriteAllText(absolutePath, contents, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        }
+
+        private static void WriteSnapshot(
+            string projectRoot,
+            string assemblySnapshotDirectoryName,
+            string projectRelativePath,
+            string contents)
+        {
+            string snapshotDirectory = Path.Combine(
+                projectRoot,
+                HotReloadConstants.SourceSnapshotRelativeDirectory,
+                assemblySnapshotDirectoryName);
+            Directory.CreateDirectory(snapshotDirectory);
+            string snapshotPath = Path.Combine(
+                snapshotDirectory,
+                HotReloadSourceSnapshotter.HashProjectRelativePath(projectRelativePath.Replace('\\', '/')) + ".cs");
+            File.WriteAllBytes(
+                snapshotPath,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetBytes(contents));
+        }
+
+        private static string AbsoluteProjectPath(string projectRoot, string projectRelativePath)
+        {
+            return Path.GetFullPath(
+                Path.Combine(projectRoot, projectRelativePath.Replace('/', Path.DirectorySeparatorChar)));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadChangedSiblingSourceDetectorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadChangedSiblingSourceDetectorTests.cs
@@ -191,16 +191,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: DeduplicatePreserveOrder keeps the first copy of a repeated warning string.
+        /// What: sibling-derived warnings are ordinal-deduped among themselves and skipped
+        /// when the own-file list already contains the exact string, without collapsing
+        /// duplicates that were already in the own-file list.
         /// </summary>
         [Test]
-        public void DeduplicatePreserveOrder_WhenWarningsRepeat_KeepsFirstOccurrence()
+        public void AppendSiblingDerivedWarnings_DedupesAmongSiblingsAndSkipsOwnFileMatches()
         {
-            System.Collections.Generic.List<string> unique =
-                HotReloadOutcomeAggregation.DeduplicatePreserveOrder(
-                    new[] { "a", "b", "a", "c", "b" });
+            System.Collections.Generic.List<string> ownFileWarnings =
+                new System.Collections.Generic.List<string> { "own-a", "own-a", "shared" };
 
-            Assert.That(unique, Is.EqualTo(new[] { "a", "b", "c" }));
+            HotReloadOutcomeAggregation.AppendSiblingDerivedWarnings(
+                ownFileWarnings,
+                new[] { "shared", "sibling-b", "sibling-b", "own-a" });
+
+            Assert.That(
+                ownFileWarnings,
+                Is.EqualTo(new[] { "own-a", "own-a", "shared", "sibling-b" }));
         }
 
         private static string CreateTempProjectRoot()

--- a/Assets/Tests/Editor/HotReload/HotReloadChangedSiblingSourceDetectorTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadChangedSiblingSourceDetectorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db1b53e47a2c84e9eb589d3adc0fc014
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1513,6 +1513,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: ProcessFileAsync surfaces the sibling scan-cap warning when 51 assembly
+        /// siblings differ from their snapshots by a trailing comment (no const drift).
+        /// </summary>
+        [Test]
+        public async Task Run_WhenFiftyOneSiblingsChanged_WarnsScanLimit()
+        {
+            using (TouchSmallestSiblingsWithTrailingComment(ResolveSiblingConstUserPath(), 51))
+            {
+                HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                    new[] { ResolveSiblingConstUserPath() },
+                    null,
+                    CancellationToken.None);
+
+                AssertNoFileLevelFailure(result);
+                Assert.That(
+                    result.Warnings,
+                    Has.Some.EqualTo(
+                        "sibling const-drift scan limited to first 50 changed files (51 total)"),
+                    "Expected the orchestrator to copy the sibling scan-cap warning.\n"
+                    + string.Join("\n", result.Warnings));
+            }
+        }
+
+        /// <summary>
         /// What: an unchanged const produces no drift warning.
         /// </summary>
         [Test]
@@ -6037,7 +6061,78 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 original.Replace(
                     compiledDeclaration,
                     "public const int SiblingTuning = " + newValue + ";"));
-            return new FileRestoreScope(path, original);
+            return new FileRestoreScope(new[] { path }, new[] { original });
+        }
+
+        private static IDisposable TouchSmallestSiblingsWithTrailingComment(
+            string editedAbsolutePath,
+            int siblingCount)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            UnityEditor.Compilation.Assembly compilationAssembly = null;
+            foreach (UnityEditor.Compilation.Assembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name == "UnityCLILoop.Tests.Editor.HotReload")
+                {
+                    compilationAssembly = assembly;
+                    break;
+                }
+            }
+
+            Assert.That(compilationAssembly, Is.Not.Null, "HotReload test assembly missing from CompilationPipeline.");
+            Assert.That(compilationAssembly.sourceFiles, Is.Not.Null);
+
+            List<string> siblingPaths = new List<string>();
+            foreach (string relative in compilationAssembly.sourceFiles)
+            {
+                string absolute = Path.GetFullPath(
+                    Path.Combine(projectRoot, relative.Replace('/', Path.DirectorySeparatorChar)));
+                if (string.Equals(absolute, editedAbsolutePath, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (!File.Exists(absolute))
+                {
+                    continue;
+                }
+
+                siblingPaths.Add(absolute);
+            }
+
+            Assert.That(
+                siblingPaths.Count,
+                Is.GreaterThanOrEqualTo(siblingCount),
+                "Need at least " + siblingCount + " sibling sources in the HotReload test assembly.");
+
+            // Why shortest first: the worker parses every changed sibling, and this assembly
+            // contains multi-thousand-line test files that would dominate runtime without
+            // changing what the cap warning asserts.
+            siblingPaths.Sort(CompareByFileLengthThenPath);
+            string[] paths = new string[siblingCount];
+            string[] originals = new string[siblingCount];
+            EditorApplication.LockReloadAssemblies();
+            for (int index = 0; index < siblingCount; index++)
+            {
+                paths[index] = siblingPaths[index];
+                originals[index] = File.ReadAllText(paths[index]);
+                File.WriteAllText(paths[index], originals[index] + "\n// sibling-scan-cap-probe");
+            }
+
+            return new FileRestoreScope(paths, originals);
+        }
+
+        private static int CompareByFileLengthThenPath(string left, string right)
+        {
+            long leftLength = new FileInfo(left).Length;
+            long rightLength = new FileInfo(right).Length;
+            int lengthCompare = leftLength.CompareTo(rightLength);
+            if (lengthCompare != 0)
+            {
+                return lengthCompare;
+            }
+
+            return string.CompareOrdinal(left, right);
         }
 
         private static IDisposable HideAssemblySnapshotDirectory()
@@ -6069,14 +6164,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private sealed class FileRestoreScope : IDisposable
         {
-            private readonly string _path;
-            private readonly string _original;
+            private readonly string[] _paths;
+            private readonly string[] _originals;
             private bool _disposed;
 
-            public FileRestoreScope(string path, string original)
+            public FileRestoreScope(string[] paths, string[] originals)
             {
-                _path = path;
-                _original = original;
+                Debug.Assert(paths != null, "paths must not be null.");
+                Debug.Assert(originals != null, "originals must not be null.");
+                Debug.Assert(paths.Length == originals.Length, "paths and originals must be the same length.");
+                _paths = paths;
+                _originals = originals;
             }
 
             public void Dispose()
@@ -6087,7 +6185,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 }
 
                 _disposed = true;
-                File.WriteAllText(_path, _original);
+                for (int index = 0; index < _paths.Length; index++)
+                {
+                    File.WriteAllText(_paths[index], _originals[index]);
+                }
+
                 EditorApplication.UnlockReloadAssemblies();
             }
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1457,7 +1457,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: passing both the holder and the referencing file emits the sibling const-drift
-        /// warning once after string-equal dedupe.
+        /// warning once because the own-file copy wins and the sibling-derived copy is skipped.
         /// </summary>
         [Test]
         public async Task Run_HolderAndReferencingFiles_DedupesSiblingConstDriftWarning()
@@ -1482,7 +1482,39 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Assert.That(
                     matchCount,
                     Is.EqualTo(1),
-                    "Expected the sibling const-drift warning once after dedupe.\n"
+                    "Expected the sibling const-drift warning once after provenance merge.\n"
+                    + string.Join("\n", result.Warnings));
+            }
+        }
+
+        /// <summary>
+        /// What: passing the holder first, then the referencing file, still emits the sibling
+        /// const-drift warning once (reversed input order of the holder+user case).
+        /// </summary>
+        [Test]
+        public async Task Run_DefinitionsThenUser_DedupesSiblingConstDriftWarning()
+        {
+            using (MutateSiblingTuningValue(7))
+            {
+                HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                    new[] { ResolveSiblingConstDefinitionsPath(), ResolveSiblingConstUserPath() },
+                    null,
+                    CancellationToken.None);
+
+                AssertNoFileLevelFailure(result);
+                int matchCount = 0;
+                foreach (string warning in result.Warnings)
+                {
+                    if (warning == ExpectedSiblingTuningDriftWarning)
+                    {
+                        matchCount++;
+                    }
+                }
+
+                Assert.That(
+                    matchCount,
+                    Is.EqualTo(1),
+                    "Expected the sibling const-drift warning once with definitions-first order.\n"
                     + string.Join("\n", result.Warnings));
             }
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -12,6 +12,7 @@ using Newtonsoft.Json.Linq;
 
 using HarmonyLib;
 
+using UnityEditor;
 using UnityEditor.Compilation;
 using UnityEngine;
 
@@ -1429,6 +1430,86 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.True,
                 "Expected a const drift warning for TuningConst.\n"
                 + string.Join("\n", result.Warnings));
+        }
+
+        /// <summary>
+        /// What: hot-reloading only the referencing file still reports a sibling const-drift
+        /// warning when the holder file's on-disk bytes differ from the snapshot.
+        /// </summary>
+        [Test]
+        public async Task Run_ReferencingFileOnly_WarnsSiblingConstDrift()
+        {
+            using (MutateSiblingTuningValue(7))
+            {
+                HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                    new[] { ResolveSiblingConstUserPath() },
+                    null,
+                    CancellationToken.None);
+
+                AssertNoFileLevelFailure(result);
+                Assert.That(
+                    result.Warnings,
+                    Has.Some.EqualTo(ExpectedSiblingTuningDriftWarning),
+                    "Expected sibling const drift when only the referencing file is passed.\n"
+                    + string.Join("\n", result.Warnings));
+            }
+        }
+
+        /// <summary>
+        /// What: passing both the holder and the referencing file emits the sibling const-drift
+        /// warning once after string-equal dedupe.
+        /// </summary>
+        [Test]
+        public async Task Run_HolderAndReferencingFiles_DedupesSiblingConstDriftWarning()
+        {
+            using (MutateSiblingTuningValue(7))
+            {
+                HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                    new[] { ResolveSiblingConstUserPath(), ResolveSiblingConstDefinitionsPath() },
+                    null,
+                    CancellationToken.None);
+
+                AssertNoFileLevelFailure(result);
+                int matchCount = 0;
+                foreach (string warning in result.Warnings)
+                {
+                    if (warning == ExpectedSiblingTuningDriftWarning)
+                    {
+                        matchCount++;
+                    }
+                }
+
+                Assert.That(
+                    matchCount,
+                    Is.EqualTo(1),
+                    "Expected the sibling const-drift warning once after dedupe.\n"
+                    + string.Join("\n", result.Warnings));
+            }
+        }
+
+        /// <summary>
+        /// What: hiding the assembly snapshot directory skips sibling const-drift warnings.
+        /// </summary>
+        [Test]
+        public async Task Run_WhenAssemblySnapshotMissing_DoesNotWarnSiblingConstDrift()
+        {
+            using (MutateSiblingTuningValue(7))
+            using (HideAssemblySnapshotDirectory())
+            {
+                HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                    new[] { ResolveSiblingConstUserPath() },
+                    null,
+                    CancellationToken.None);
+
+                AssertNoFileLevelFailure(result);
+                foreach (string warning in result.Warnings)
+                {
+                    Assert.That(
+                        warning.Contains("SiblingTuning"),
+                        Is.False,
+                        "Sibling const drift must stay silent without a snapshot.\n" + warning);
+                }
+            }
         }
 
         /// <summary>
@@ -5912,6 +5993,137 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string path = Path.Combine(directory, fileName);
             File.WriteAllText(path, contents);
             return path;
+        }
+
+        private static string ResolveSiblingConstDefinitionsPath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadSiblingConstDefinitions.cs");
+            Assert.That(File.Exists(path), Is.True, "Sibling const holder fixture missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string ResolveSiblingConstUserPath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadSiblingConstUser.cs");
+            Assert.That(File.Exists(path), Is.True, "Sibling const user fixture missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private const string ExpectedSiblingTuningDriftWarning =
+            "const io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadSiblingConstDefinitions.SiblingTuning is 7 in the edited source but 6 in the compiled assembly; edits outside method bodies never take effect through hot reload. Run 'uloop compile' to apply this change.";
+
+        private static IDisposable MutateSiblingTuningValue(int newValue)
+        {
+            string path = ResolveSiblingConstDefinitionsPath();
+            string original = File.ReadAllText(path);
+            string compiledDeclaration = "public const int SiblingTuning = 6;";
+            Assert.That(
+                original.Contains(compiledDeclaration),
+                Is.True,
+                "Precondition: compiled sibling const declaration must still be on disk.");
+            EditorApplication.LockReloadAssemblies();
+            File.WriteAllText(
+                path,
+                original.Replace(
+                    compiledDeclaration,
+                    "public const int SiblingTuning = " + newValue + ";"));
+            return new FileRestoreScope(path, original);
+        }
+
+        private static IDisposable HideAssemblySnapshotDirectory()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string targetDllPath = Path.Combine(
+                projectRoot,
+                HotReloadConstants.ScriptAssembliesRelativeDirectory,
+                "UnityCLILoop.Tests.Editor.HotReload"
+                + HotReloadConstants.CompiledAssemblyExtension);
+            string mvid = HotReloadSourceSnapshotter.ReadAssemblyMvid(targetDllPath);
+            string snapshotDirectory = Path.Combine(
+                projectRoot,
+                HotReloadConstants.SourceSnapshotRelativeDirectory,
+                "UnityCLILoop.Tests.Editor.HotReload-" + mvid);
+            Assert.That(
+                Directory.Exists(snapshotDirectory),
+                Is.True,
+                "Precondition: assembly snapshot directory must exist to hide: " + snapshotDirectory);
+            string hiddenDirectory = snapshotDirectory + ".hidden-for-test";
+            if (Directory.Exists(hiddenDirectory))
+            {
+                Directory.Delete(hiddenDirectory, recursive: true);
+            }
+
+            Directory.Move(snapshotDirectory, hiddenDirectory);
+            return new DirectoryRestoreScope(snapshotDirectory, hiddenDirectory);
+        }
+
+        private sealed class FileRestoreScope : IDisposable
+        {
+            private readonly string _path;
+            private readonly string _original;
+            private bool _disposed;
+
+            public FileRestoreScope(string path, string original)
+            {
+                _path = path;
+                _original = original;
+            }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                File.WriteAllText(_path, _original);
+                EditorApplication.UnlockReloadAssemblies();
+            }
+        }
+
+        private sealed class DirectoryRestoreScope : IDisposable
+        {
+            private readonly string _originalDirectory;
+            private readonly string _hiddenDirectory;
+            private bool _disposed;
+
+            public DirectoryRestoreScope(string originalDirectory, string hiddenDirectory)
+            {
+                _originalDirectory = originalDirectory;
+                _hiddenDirectory = hiddenDirectory;
+            }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                if (!Directory.Exists(_hiddenDirectory))
+                {
+                    return;
+                }
+
+                if (Directory.Exists(_originalDirectory))
+                {
+                    Directory.Delete(_originalDirectory, recursive: true);
+                }
+
+                Directory.Move(_hiddenDirectory, _originalDirectory);
+            }
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadSiblingConstDefinitions.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSiblingConstDefinitions.cs
@@ -1,0 +1,11 @@
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled const holder used to assert sibling const-drift warnings when only a
+    /// referencing file is passed to hot reload.
+    /// </summary>
+    public static class HotReloadSiblingConstDefinitions
+    {
+        public const int SiblingTuning = 6;
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSiblingConstDefinitions.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSiblingConstDefinitions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5e13f3cfc4dc64a9e9c17127e8fed851
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadSiblingConstUser.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSiblingConstUser.cs
@@ -1,0 +1,14 @@
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled referencing type used as the --files target while the sibling const holder
+    /// is the file that actually drifted.
+    /// </summary>
+    public static class HotReloadSiblingConstUser
+    {
+        public static int ReadSiblingTuning()
+        {
+            return HotReloadSiblingConstDefinitions.SiblingTuning;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSiblingConstUser.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSiblingConstUser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7379540a7f30d402abded2e4d39c7d01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -772,6 +772,45 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a changed sibling const is reported when the worker runs against the referencing
+        /// file and ChangedSiblingSourcePaths points at the drifted holder.
+        /// </summary>
+        [Test]
+        public async Task Run_WithChangedSiblingConstHolder_EmitsSiblingConstDriftWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveE2EFixturePath());
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string siblingPath = Path.Combine(directory, "SiblingConstHolderDrift.cs");
+            File.WriteAllText(
+                siblingPath,
+                "namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload\n"
+                + "{\n"
+                + "    public static class HotReloadSiblingConstDefinitions\n"
+                + "    {\n"
+                + "        public const int SiblingTuning = 7;\n"
+                + "    }\n"
+                + "}\n");
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                ResolveE2EFixturePath(),
+                ResolveE2EFixtureProjectRelativePath(),
+                snapshotSource: onDisk,
+                additionalAssemblySourcePaths: null,
+                changedSiblingSourcePaths: new[] { siblingPath });
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.declarationDriftWarnings, Is.Not.Null);
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.Some.EqualTo(
+                    "const io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadSiblingConstDefinitions.SiblingTuning is 7 in the edited source but 6 in the compiled assembly; edits outside method bodies never take effect through hot reload. Run 'uloop compile' to apply this change."),
+                "Sibling const drift must use the same warning text as an edited-file const drift.\n"
+                + string.Join("\n", result.Output.declarationDriftWarnings));
+        }
+
+        /// <summary>
         /// What: editing only an enum member value emits the dedicated const-drift warning and
         /// does not also emit the generic outside-method-body warning.
         /// </summary>
@@ -2119,7 +2158,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string sourcePath,
             string projectRelativePath,
             string snapshotSource = null,
-            string[] additionalAssemblySourcePaths = null)
+            string[] additionalAssemblySourcePaths = null,
+            string[] changedSiblingSourcePaths = null)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string targetDllPath = Path.Combine(
@@ -2169,7 +2209,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 targetTypesAssemblyPath = targetDllPath,
                 snapshotSource = snapshotSource,
                 projectRelativePath = projectRelativePath,
-                assemblySourcePaths = assemblySourcePaths
+                assemblySourcePaths = assemblySourcePaths,
+                changedSiblingSourcePaths = changedSiblingSourcePaths
             };
 
             return await TransformWorkerClient.RunAsync(input, CancellationToken.None);

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -801,13 +801,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 changedSiblingSourcePaths: new[] { siblingPath });
 
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            Assert.That(result.Output.declarationDriftWarnings, Is.Not.Null);
+            Assert.That(result.Output.siblingConstDriftWarnings, Is.Not.Null);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.siblingConstDriftWarnings,
                 Has.Some.EqualTo(
                     "const io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadSiblingConstDefinitions.SiblingTuning is 7 in the edited source but 6 in the compiled assembly; edits outside method bodies never take effect through hot reload. Run 'uloop compile' to apply this change."),
                 "Sibling const drift must use the same warning text as an edited-file const drift.\n"
-                + string.Join("\n", result.Output.declarationDriftWarnings));
+                + string.Join("\n", result.Output.siblingConstDriftWarnings));
+            Assert.That(
+                result.Output.declarationDriftWarnings,
+                Has.None.EqualTo(
+                    "const io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadSiblingConstDefinitions.SiblingTuning is 7 in the edited source but 6 in the compiled assembly; edits outside method bodies never take effect through hot reload. Run 'uloop compile' to apply this change."),
+                "Sibling const-drift warnings must stay on siblingConstDriftWarnings, not declarationDriftWarnings.");
         }
 
         /// <summary>
@@ -2416,6 +2421,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(omitted.entries[0].calledAddedMethodKeys, Is.Not.Null);
             Assert.That(omitted.entries[0].calledAddedMethodKeys, Is.Empty);
             Assert.That(omitted.declarationDriftWarnings, Is.Not.Null);
+            Assert.That(omitted.siblingConstDriftWarnings, Is.Not.Null);
             Assert.That(omitted.unchangedMethods, Is.Not.Null);
             Assert.That(omitted.parseErrors, Is.Not.Null);
             Assert.That(omitted.skipped, Is.Not.Null);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSiblingScanResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSiblingScanResult.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Absolute paths of snapshot-mismatched sibling sources, plus a cap warning when truncated.
+    /// </summary>
+    internal sealed class HotReloadChangedSiblingScanResult
+    {
+        internal static readonly HotReloadChangedSiblingScanResult Empty =
+            new HotReloadChangedSiblingScanResult(Array.Empty<string>(), string.Empty);
+
+        internal string[] ChangedSiblingAbsolutePaths { get; }
+
+        internal string ScanLimitWarning { get; }
+
+        internal HotReloadChangedSiblingScanResult(string[] changedSiblingAbsolutePaths, string scanLimitWarning)
+        {
+            ChangedSiblingAbsolutePaths = changedSiblingAbsolutePaths ?? Array.Empty<string>();
+            ScanLimitWarning = scanLimitWarning ?? string.Empty;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSiblingScanResult.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSiblingScanResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b99e1ba21242b451e9d0304a49990773
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSiblingSourceDetector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSiblingSourceDetector.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 
 using UnityEngine;
@@ -149,7 +150,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string[] limited = new string[HotReloadConstants.SiblingConstDriftScanFileLimit];
             changedSiblingAbsolutePaths.CopyTo(0, limited, 0, HotReloadConstants.SiblingConstDriftScanFileLimit);
             string warning = string.Format(
+                CultureInfo.InvariantCulture,
                 HotReloadConstants.SiblingConstDriftScanLimitedWarningFormat,
+                HotReloadConstants.SiblingConstDriftScanFileLimit,
                 totalChanged);
             return new HotReloadChangedSiblingScanResult(limited, warning);
         }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSiblingSourceDetector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSiblingSourceDetector.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Finds compilation-assembly siblings whose on-disk bytes differ from the last compile snapshot.
+    /// </summary>
+    internal static class HotReloadChangedSiblingSourceDetector
+    {
+        /// <summary>
+        /// Returns changed sibling absolute paths for <paramref name="sourceFiles"/>, excluding
+        /// <paramref name="editedProjectRelativePath"/>. Missing snapshots or DLLs yield an empty
+        /// result with no extra warning — the existing missing-baseline path already covers that.
+        /// </summary>
+        internal static HotReloadChangedSiblingScanResult Detect(
+            string projectRoot,
+            string assemblyName,
+            string targetDllPath,
+            string[] sourceFiles,
+            string editedProjectRelativePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty.");
+            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
+            Debug.Assert(
+                !string.IsNullOrEmpty(editedProjectRelativePath),
+                "editedProjectRelativePath must not be null or empty.");
+
+            if (string.IsNullOrEmpty(targetDllPath) || !File.Exists(targetDllPath))
+            {
+                return HotReloadChangedSiblingScanResult.Empty;
+            }
+
+            string pdbPath = Path.ChangeExtension(targetDllPath, ".pdb");
+            if (!File.Exists(pdbPath))
+            {
+                return HotReloadChangedSiblingScanResult.Empty;
+            }
+
+            string mvid = HotReloadSourceSnapshotter.ReadAssemblyMvid(targetDllPath);
+            return DetectFromSnapshotDirectory(
+                projectRoot,
+                assemblyName + "-" + mvid,
+                sourceFiles,
+                editedProjectRelativePath);
+        }
+
+        // Why a directory-name entry: EditMode tests plant a snapshot tree without a real DLL.
+        internal static HotReloadChangedSiblingScanResult DetectFromSnapshotDirectory(
+            string projectRoot,
+            string assemblySnapshotDirectoryName,
+            string[] sourceFiles,
+            string editedProjectRelativePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty.");
+            Debug.Assert(
+                !string.IsNullOrEmpty(assemblySnapshotDirectoryName),
+                "assemblySnapshotDirectoryName must not be null or empty.");
+            Debug.Assert(
+                !string.IsNullOrEmpty(editedProjectRelativePath),
+                "editedProjectRelativePath must not be null or empty.");
+
+            if (sourceFiles == null || sourceFiles.Length == 0)
+            {
+                return HotReloadChangedSiblingScanResult.Empty;
+            }
+
+            string snapshotDirectory = Path.Combine(
+                projectRoot,
+                HotReloadConstants.SourceSnapshotRelativeDirectory,
+                assemblySnapshotDirectoryName);
+            if (!Directory.Exists(snapshotDirectory))
+            {
+                return HotReloadChangedSiblingScanResult.Empty;
+            }
+
+            List<string> changedSiblingAbsolutePaths = new List<string>();
+            for (int index = 0; index < sourceFiles.Length; index++)
+            {
+                string changedPath = TryResolveChangedSiblingAbsolutePath(
+                    projectRoot,
+                    snapshotDirectory,
+                    sourceFiles[index],
+                    editedProjectRelativePath);
+                if (changedPath != null)
+                {
+                    changedSiblingAbsolutePaths.Add(changedPath);
+                }
+            }
+
+            return LimitChangedSiblings(changedSiblingAbsolutePaths);
+        }
+
+        private static string TryResolveChangedSiblingAbsolutePath(
+            string projectRoot,
+            string snapshotDirectory,
+            string projectRelativeSourcePath,
+            string editedProjectRelativePath)
+        {
+            if (string.IsNullOrEmpty(projectRelativeSourcePath))
+            {
+                return null;
+            }
+
+            string normalizedRelativePath = projectRelativeSourcePath.Replace('\\', '/');
+            if (IsSameProjectRelativePath(normalizedRelativePath, editedProjectRelativePath))
+            {
+                return null;
+            }
+
+            string absoluteSourcePath = Path.GetFullPath(
+                Path.Combine(projectRoot, normalizedRelativePath.Replace('/', Path.DirectorySeparatorChar)));
+            if (!File.Exists(absoluteSourcePath))
+            {
+                return null;
+            }
+
+            string snapshotPath = Path.Combine(
+                snapshotDirectory,
+                HotReloadSourceSnapshotter.HashProjectRelativePath(normalizedRelativePath) + ".cs");
+            if (!File.Exists(snapshotPath))
+            {
+                return null;
+            }
+
+            byte[] diskBytes = File.ReadAllBytes(absoluteSourcePath);
+            byte[] snapshotBytes = File.ReadAllBytes(snapshotPath);
+            if (BytesEqual(diskBytes, snapshotBytes))
+            {
+                return null;
+            }
+
+            return absoluteSourcePath;
+        }
+
+        private static HotReloadChangedSiblingScanResult LimitChangedSiblings(List<string> changedSiblingAbsolutePaths)
+        {
+            int totalChanged = changedSiblingAbsolutePaths.Count;
+            if (totalChanged <= HotReloadConstants.SiblingConstDriftScanFileLimit)
+            {
+                return new HotReloadChangedSiblingScanResult(
+                    changedSiblingAbsolutePaths.ToArray(),
+                    string.Empty);
+            }
+
+            string[] limited = new string[HotReloadConstants.SiblingConstDriftScanFileLimit];
+            changedSiblingAbsolutePaths.CopyTo(0, limited, 0, HotReloadConstants.SiblingConstDriftScanFileLimit);
+            string warning = string.Format(
+                HotReloadConstants.SiblingConstDriftScanLimitedWarningFormat,
+                totalChanged);
+            return new HotReloadChangedSiblingScanResult(limited, warning);
+        }
+
+        private static bool IsSameProjectRelativePath(string left, string right)
+        {
+            string normalizedLeft = left.Replace('\\', '/');
+            string normalizedRight = right.Replace('\\', '/');
+            StringComparison comparison = Path.DirectorySeparatorChar == '\\'
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+            return string.Equals(normalizedLeft, normalizedRight, comparison);
+        }
+
+        private static bool BytesEqual(byte[] left, byte[] right)
+        {
+            if (left.Length != right.Length)
+            {
+                return false;
+            }
+
+            for (int index = 0; index < left.Length; index++)
+            {
+                if (left[index] != right[index])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSiblingSourceDetector.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSiblingSourceDetector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4bb5d37a52ee24b799203a5f21cceab9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -271,9 +271,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public const int SiblingConstDriftScanFileLimit = 50;
 
-        // Format: total changed sibling count. Emitted when the scan truncates to
-        // SiblingConstDriftScanFileLimit so the cap is never silent.
+        // Format: scan file limit, total changed sibling count. Emitted when the scan
+        // truncates so the cap is never silent.
         public const string SiblingConstDriftScanLimitedWarningFormat =
-            "sibling const-drift scan limited to first 50 changed files ({0} total)";
+            "sibling const-drift scan limited to first {0} changed files ({1} total)";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -268,5 +268,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public const string FailedWithNoApplyRecommendedNextAction =
             "Fix the failed methods and rerun, or run 'uloop compile'.";
+
+        public const int SiblingConstDriftScanFileLimit = 50;
+
+        // Format: total changed sibling count. Emitted when the scan truncates to
+        // SiblingConstDriftScanFileLimit so the cap is never silent.
+        public const string SiblingConstDriftScanLimitedWarningFormat =
+            "sibling const-drift scan limited to first 50 changed files ({0} total)";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -41,6 +41,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> retargetedPausePointIds = new List<string>();
             List<string> inlineRiskMethodLabels = new List<string>();
             List<string> addedFields = new List<string>();
+            List<string> siblingDerivedWarnings = new List<string>();
             int patchedTotal = 0;
             int unchangedTotal = 0;
             // Why after the file loop (not inside ProcessFileAsync): duplicate paths in one
@@ -67,6 +68,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     filePath,
                     workerSourcePath,
                     correlationId,
+                    siblingDerivedWarnings,
                     ct).ConfigureAwait(false);
 
                 outcomes.AddRange(fileResult.Outcomes);
@@ -122,10 +124,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 addedCount,
                 failedCount == 0,
                 correlationId);
-            List<string> uniqueWarnings = HotReloadOutcomeAggregation.DeduplicatePreserveOrder(warnings);
+            HotReloadOutcomeAggregation.AppendSiblingDerivedWarnings(warnings, siblingDerivedWarnings);
             return new HotReloadOrchestratorResult(
                 outcomes,
-                uniqueWarnings,
+                warnings,
                 patchedTotal,
                 HotReloadPatcher.ActiveChangeCount,
                 suppressedPausePointIds,
@@ -138,8 +140,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string assemblyResolvePath,
             string workerSourcePath,
             string correlationId,
+            List<string> siblingDerivedWarnings,
             CancellationToken ct)
         {
+            Debug.Assert(siblingDerivedWarnings != null, "siblingDerivedWarnings must not be null.");
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
             List<string> warnings = new List<string>();
             List<string> suppressedPausePointIds = new List<string>();
@@ -190,7 +194,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 projectRelativePath);
             if (!string.IsNullOrEmpty(siblingScan.ScanLimitWarning))
             {
-                warnings.Add(siblingScan.ScanLimitWarning);
+                siblingDerivedWarnings.Add(siblingScan.ScanLimitWarning);
             }
 
             TransformWorkerInputDto workerInput = new TransformWorkerInputDto
@@ -224,7 +228,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 assemblyName,
                 assemblyResolvePath,
                 outcomes,
-                warnings);
+                warnings,
+                siblingDerivedWarnings);
 
             TransformWorkerUnchangedMethodDto[] unchangedMethods =
                 workerOutput.unchangedMethods ?? Array.Empty<TransformWorkerUnchangedMethodDto>();
@@ -247,6 +252,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 projectRelativePath,
                 correlationId,
                 ct).ConfigureAwait(false);
+            AppendRetrySiblingConstDriftWarnings(siblingDerivedWarnings, gateResult.Isolation);
             // Why after the gate: a gated replacement is not applied, so listing it under
             // "Removed members stay present... edited bodies no longer call them" is false.
             string removedMembersWarning = HotReloadRemovedMembersWarning.FormatRemovedMembersWarning(
@@ -299,6 +305,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 suppressedPausePointIds,
                 retargetedPausePointIds,
                 unchangedMethodCount,
+                siblingDerivedWarnings,
                 ct).ConfigureAwait(false);
             if (earlyEntries != null)
             {
@@ -369,8 +376,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string assemblyName,
             string assemblyResolvePath,
             List<HotReloadMethodOutcome> outcomes,
-            List<string> warnings)
+            List<string> warnings,
+            List<string> siblingDerivedWarnings)
         {
+            Debug.Assert(siblingDerivedWarnings != null, "siblingDerivedWarnings must not be null.");
             if (snapshotSource == null
                 && CountPatchCandidateRows(workerOutput) >= 1)
             {
@@ -418,6 +427,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     warnings.Add(driftWarning);
                 }
+            }
+
+            if (workerOutput.siblingConstDriftWarnings != null)
+            {
+                foreach (string siblingWarning in workerOutput.siblingConstDriftWarnings)
+                {
+                    siblingDerivedWarnings.Add(siblingWarning);
+                }
+            }
+        }
+
+        private static void AppendRetrySiblingConstDriftWarnings(
+            List<string> siblingDerivedWarnings,
+            HotReloadShimIsolation.HotReloadShimIsolationResult isolation)
+        {
+            if (isolation == null || isolation.SiblingConstDriftWarnings == null)
+            {
+                return;
+            }
+
+            foreach (string siblingWarning in isolation.SiblingConstDriftWarnings)
+            {
+                siblingDerivedWarnings.Add(siblingWarning);
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -122,9 +122,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 addedCount,
                 failedCount == 0,
                 correlationId);
+            List<string> uniqueWarnings = HotReloadOutcomeAggregation.DeduplicatePreserveOrder(warnings);
             return new HotReloadOrchestratorResult(
                 outcomes,
-                warnings,
+                uniqueWarnings,
                 patchedTotal,
                 HotReloadPatcher.ActiveChangeCount,
                 suppressedPausePointIds,
@@ -181,6 +182,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 projectRelativePath,
                 targetDllPath);
 
+            HotReloadChangedSiblingScanResult siblingScan = HotReloadChangedSiblingSourceDetector.Detect(
+                projectRoot,
+                assemblyName,
+                targetDllPath,
+                compilationAssembly.sourceFiles,
+                projectRelativePath);
+            if (!string.IsNullOrEmpty(siblingScan.ScanLimitWarning))
+            {
+                warnings.Add(siblingScan.ScanLimitWarning);
+            }
+
             TransformWorkerInputDto workerInput = new TransformWorkerInputDto
             {
                 sourcePath = Path.GetFullPath(workerSourcePath),
@@ -189,7 +201,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 targetTypesAssemblyPath = Path.GetFullPath(targetDllPath),
                 snapshotSource = snapshotSource,
                 projectRelativePath = projectRelativePath,
-                assemblySourcePaths = HotReloadPatchTargetSupport.BuildAssemblySourcePaths(projectRoot, compilationAssembly.sourceFiles)
+                assemblySourcePaths = HotReloadPatchTargetSupport.BuildAssemblySourcePaths(projectRoot, compilationAssembly.sourceFiles),
+                changedSiblingSourcePaths = siblingScan.ChangedSiblingAbsolutePaths
             };
 
             TransformWorkerClientResult workerResult =

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOutcomeAggregation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOutcomeAggregation.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 
+using UnityEngine;
+
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
@@ -29,6 +31,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     target.Add(addition);
                 }
             }
+        }
+
+        // Why HashSet (not AppendDistinct): sibling const-drift warnings repeat once per
+        // --files entry of the same assembly. AppendDistinct is the pause-point id / method
+        // label merger and must stay dedicated to those lists.
+        internal static List<string> DeduplicatePreserveOrder(IReadOnlyList<string> warnings)
+        {
+            Debug.Assert(warnings != null, "warnings must not be null.");
+
+            HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
+            List<string> unique = new List<string>();
+            for (int index = 0; index < warnings.Count; index++)
+            {
+                string warning = warnings[index];
+                if (seen.Add(warning))
+                {
+                    unique.Add(warning);
+                }
+            }
+
+            return unique;
         }
 
         internal static (int patchedCount, int failedCount, int skippedCount, int alreadyActiveCount, int addedCount)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOutcomeAggregation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOutcomeAggregation.cs
@@ -33,25 +33,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        // Why HashSet (not AppendDistinct): sibling const-drift warnings repeat once per
-        // --files entry of the same assembly. AppendDistinct is the pause-point id / method
-        // label merger and must stay dedicated to those lists.
-        internal static List<string> DeduplicatePreserveOrder(IReadOnlyList<string> warnings)
+        // Why a dedicated sibling list (not a global HashSet over all warnings): duplicate
+        // file inputs must still emit the same own-file warning twice. Sibling-derived
+        // strings are appended after own-file warnings, ordinal-deduped among themselves,
+        // and skipped when the own-file list already contains the exact text so holder +
+        // referencing stays one warning in either file order.
+        internal static void AppendSiblingDerivedWarnings(
+            List<string> ownFileWarnings,
+            IReadOnlyList<string> siblingDerivedWarnings)
         {
-            Debug.Assert(warnings != null, "warnings must not be null.");
+            Debug.Assert(ownFileWarnings != null, "ownFileWarnings must not be null.");
+            Debug.Assert(siblingDerivedWarnings != null, "siblingDerivedWarnings must not be null.");
 
-            HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
-            List<string> unique = new List<string>();
-            for (int index = 0; index < warnings.Count; index++)
+            HashSet<string> seen = new HashSet<string>(ownFileWarnings, StringComparer.Ordinal);
+            for (int index = 0; index < siblingDerivedWarnings.Count; index++)
             {
-                string warning = warnings[index];
+                string warning = siblingDerivedWarnings[index];
+                if (string.IsNullOrEmpty(warning))
+                {
+                    continue;
+                }
+
                 if (seen.Add(warning))
                 {
-                    unique.Add(warning);
+                    ownFileWarnings.Add(warning);
                 }
             }
-
-            return unique;
         }
 
         internal static (int patchedCount, int failedCount, int skippedCount, int alreadyActiveCount, int addedCount)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
@@ -42,6 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> suppressedPausePointIds,
             List<string> retargetedPausePointIds,
             int unchangedMethodCount,
+            List<string> siblingDerivedWarnings,
             CancellationToken ct)
         {
             if (gateResult.UsedWorkerRetry)
@@ -111,6 +112,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 defines,
                 assemblyResolvePath,
                 correlationId,
+                siblingDerivedWarnings,
                 ct).ConfigureAwait(false);
             if (firstCompile.AddedFieldNames != null)
             {
@@ -166,8 +168,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string[] defines,
             string assemblyResolvePath,
             string correlationId,
+            List<string> siblingDerivedWarnings,
             CancellationToken ct)
         {
+            Debug.Assert(siblingDerivedWarnings != null, "siblingDerivedWarnings must not be null.");
             // BuildShimReferencePaths reads Application.dataPath / platform; stay on main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
             bool includeHarmonyReference = HotReloadShimReferenceBuilder.NeedsHarmonyReference(workerOutput);
@@ -253,6 +257,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         assemblyResolvePath));
             }
 
+            siblingDerivedWarnings.AddRange(isolation.SiblingConstDriftWarnings);
             List<HotReloadMethodOutcome> isolationOutcomes = new List<HotReloadMethodOutcome>();
             isolationOutcomes.AddRange(isolation.FailedMethodOutcomes);
             isolationOutcomes.AddRange(isolation.SkippedCallerOutcomes);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
@@ -107,7 +107,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // again and diverge the retry entries set from the first-pass isolation baseline.
                 snapshotSource = workerInput.snapshotSource,
                 projectRelativePath = workerInput.projectRelativePath,
-                assemblySourcePaths = workerInput.assemblySourcePaths
+                assemblySourcePaths = workerInput.assemblySourcePaths,
+                changedSiblingSourcePaths = workerInput.changedSiblingSourcePaths
             };
 
             TransformWorkerClientResult retryWorkerResult =

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
@@ -108,6 +108,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 snapshotSource = workerInput.snapshotSource,
                 projectRelativePath = workerInput.projectRelativePath,
                 assemblySourcePaths = workerInput.assemblySourcePaths,
+                // Why copy: retry must still scan the same snapshot-mismatched siblings so
+                // siblingConstDriftWarnings stay populated on the retry worker output.
                 changedSiblingSourcePaths = workerInput.changedSiblingSourcePaths
             };
 
@@ -156,7 +158,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         skippedCallerOutcomes,
                         Array.Empty<TransformWorkerEntryDto>(),
                         null,
-                        retryOutput.addedFieldNames));
+                        retryOutput.addedFieldNames,
+                        retryOutput.siblingConstDriftWarnings));
             }
 
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -198,7 +201,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     skippedCallerOutcomes,
                     retryOutput.entries,
                     retryCompileResult,
-                    retryOutput.addedFieldNames));
+                    retryOutput.addedFieldNames,
+                    retryOutput.siblingConstDriftWarnings));
         }
 
         /// <summary>
@@ -524,13 +528,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public TransformWorkerEntryDto[] RetryEntries { get; }
             public HotReloadShimCompileResult RetryCompileResult { get; }
             public string[] AddedFieldNames { get; }
+            public string[] SiblingConstDriftWarnings { get; }
 
             public HotReloadShimIsolationResult(
                 List<HotReloadMethodOutcome> failedMethodOutcomes,
                 List<HotReloadMethodOutcome> skippedCallerOutcomes,
                 TransformWorkerEntryDto[] retryEntries,
                 HotReloadShimCompileResult retryCompileResult,
-                string[] addedFieldNames = null)
+                string[] addedFieldNames = null,
+                string[] siblingConstDriftWarnings = null)
             {
                 Debug.Assert(skippedCallerOutcomes != null, "skippedCallerOutcomes must not be null.");
                 FailedMethodOutcomes = failedMethodOutcomes;
@@ -538,6 +544,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 RetryEntries = retryEntries;
                 RetryCompileResult = retryCompileResult;
                 AddedFieldNames = addedFieldNames ?? Array.Empty<string>();
+                SiblingConstDriftWarnings = siblingConstDriftWarnings ?? Array.Empty<string>();
             }
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -130,7 +130,9 @@ initializer, an attribute — leaves runtime behavior unchanged even though the
 response reports `Success` — shims resolve those symbols
 against the already-compiled assembly, and C# bakes `const` values into IL at compile
 time. Changed `const` values (including enum member values) are detected and reported
-as a `Warnings` entry naming the constant and both values. When a verified source
+as a `Warnings` entry naming the constant and both values. The scan includes
+changed sibling files in the same assembly, not only the file passed to
+`--files`. When a verified source
 baseline is available (next paragraph), other outside-body drift — existing-field
 initializers, attributes, and other declaration edits — is reported as a `Warnings`
 entry as well (handled added members and reported removed members are excluded

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
@@ -109,6 +109,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             output.skipped ??= Array.Empty<TransformWorkerSkippedDto>();
             output.parseErrors ??= Array.Empty<string>();
             output.declarationDriftWarnings ??= Array.Empty<string>();
+            output.siblingConstDriftWarnings ??= Array.Empty<string>();
             output.unchangedMethods ??= Array.Empty<TransformWorkerUnchangedMethodDto>();
             output.removedMembers ??= Array.Empty<TransformWorkerRemovedMemberDto>();
             output.removedMethodSignatures ??= Array.Empty<TransformWorkerRemovedMethodSignatureDto>();

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -34,6 +34,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Absolute paths of every source file in the edited file's compilation assembly.
         // The worker scans these for global using directives. Null/omitted is treated as empty.
         public string[] assemblySourcePaths;
+
+        // Absolute paths of snapshot-mismatched sibling sources in the same compilation assembly.
+        // The worker scans these for const drift the edited file's syntax tree cannot see.
+        // Null/omitted is treated as empty.
+        public string[] changedSiblingSourcePaths;
     }
 
     /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -53,6 +53,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string[] parseErrors;
         public string[] declarationDriftWarnings;
 
+        // Const-drift warnings collected from snapshot-mismatched sibling sources.
+        // Kept separate from declarationDriftWarnings so the orchestrator can dedupe
+        // sibling-derived text without collapsing own-file duplicate-input warnings.
+        public string[] siblingConstDriftWarnings;
+
         // Identities of methods left untouched because they match the verified snapshot.
         // Null/empty means none (or no baseline). UnchangedTotal is derived from Length.
         public TransformWorkerUnchangedMethodDto[] unchangedMethods;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/SiblingConstDriftCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/SiblingConstDriftCollector.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+internal static class SiblingConstDriftCollector
+{
+    /// <summary>
+    /// Parses each changed sibling source and reuses ConstDriftCollector against the compiled
+    /// target-types assembly. The edited file is already scanned on its in-memory tree; siblings
+    /// are the files TransformWorker's single-file compilation cannot see.
+    /// </summary>
+    internal static List<string> CollectConstDriftWarnings(
+        string[] changedSiblingSourcePaths,
+        CSharpParseOptions parseOptions,
+        IReadOnlyList<MetadataReference> references,
+        IAssemblySymbol targetTypesAssemblySymbol)
+    {
+        List<string> warnings = new List<string>();
+        if (changedSiblingSourcePaths == null
+            || changedSiblingSourcePaths.Length == 0
+            || targetTypesAssemblySymbol == null)
+        {
+            return warnings;
+        }
+
+        for (int index = 0; index < changedSiblingSourcePaths.Length; index++)
+        {
+            string siblingPath = changedSiblingSourcePaths[index];
+            if (string.IsNullOrEmpty(siblingPath) || !File.Exists(siblingPath))
+            {
+                continue;
+            }
+
+            string text = File.ReadAllText(
+                siblingPath,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(
+                SourceText.From(text, Encoding.UTF8),
+                parseOptions,
+                path: siblingPath);
+            CompilationUnitSyntax root = syntaxTree.GetCompilationUnitRoot();
+            CSharpCompilation siblingCompilation = CSharpCompilation.Create(
+                assemblyName: "UloopHotReloadSiblingConstDriftCompilation",
+                syntaxTrees: new[] { syntaxTree },
+                references: references,
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            SemanticModel semanticModel = siblingCompilation.GetSemanticModel(
+                syntaxTree,
+                ignoreAccessibility: true);
+            warnings.AddRange(
+                ConstDriftCollector.CollectConstDriftWarnings(
+                    root,
+                    semanticModel,
+                    targetTypesAssemblySymbol));
+        }
+
+        return warnings;
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -158,12 +158,11 @@ public static class TransformWorkerProgram
             root,
             semanticModel,
             targetTypesAssemblySymbol);
-        declarationDriftWarnings.AddRange(
-            SiblingConstDriftCollector.CollectConstDriftWarnings(
-                input.ChangedSiblingSourcePaths,
-                parseOptions,
-                references,
-                targetTypesAssemblySymbol));
+        List<string> siblingConstDriftWarnings = SiblingConstDriftCollector.CollectConstDriftWarnings(
+            input.ChangedSiblingSourcePaths,
+            parseOptions,
+            references,
+            targetTypesAssemblySymbol);
         // Why here: a compiled property/event can disappear or change kind with no
         // touched body, so the generic outside-body warning would bury the name.
         CompiledMemberKindChangeWarnings.SyntaxKeys kindChangeSyntaxKeys =
@@ -265,6 +264,7 @@ public static class TransformWorkerProgram
             entries,
             skipped,
             declarationDriftWarnings,
+            siblingConstDriftWarnings,
             parseErrors,
             unchangedMethods,
             baseline,
@@ -392,6 +392,7 @@ public static class TransformWorkerProgram
         List<WorkerEntry> entries,
         List<WorkerSkipped> skipped,
         List<string> declarationDriftWarnings,
+        List<string> siblingConstDriftWarnings,
         List<string> parseErrors,
         List<WorkerUnchangedMethod> unchangedMethods,
         BaselineSnapshotState baseline,
@@ -417,6 +418,7 @@ public static class TransformWorkerProgram
             Entries = entries.ToArray(),
             Skipped = skipped.ToArray(),
             DeclarationDriftWarnings = declarationDriftWarnings.ToArray(),
+            SiblingConstDriftWarnings = siblingConstDriftWarnings.ToArray(),
             ParseErrors = parseErrors.ToArray(),
             UnchangedMethods = unchangedMethods.ToArray(),
             BaselineDisabledByDuplicateKeys = baseline.BaselineDisabledByDuplicateKeys,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -105,6 +105,7 @@ public static class TransformWorkerProgram
         input.ExcludedMethodKeys ??= Array.Empty<string>();
         input.ExcludedAddedMethodKeys ??= Array.Empty<string>();
         input.AssemblySourcePaths ??= Array.Empty<string>();
+        input.ChangedSiblingSourcePaths ??= Array.Empty<string>();
         return input;
     }
 
@@ -157,6 +158,12 @@ public static class TransformWorkerProgram
             root,
             semanticModel,
             targetTypesAssemblySymbol);
+        declarationDriftWarnings.AddRange(
+            SiblingConstDriftCollector.CollectConstDriftWarnings(
+                input.ChangedSiblingSourcePaths,
+                parseOptions,
+                references,
+                targetTypesAssemblySymbol));
         // Why here: a compiled property/event can disappear or change kind with no
         // touched body, so the generic outside-body warning would bury the name.
         CompiledMemberKindChangeWarnings.SyntaxKeys kindChangeSyntaxKeys =

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerInput.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerInput.cs
@@ -42,7 +42,11 @@ internal sealed class WorkerInput
     // Project-relative forward-slash path embedded in #line document names.
     public string ProjectRelativePath { get; set; }
 
-    // Absolute paths of every source file in the edited file's compilation assembly.
-    // Null/omitted is treated as empty (no sibling global usings collected).
-    public string[] AssemblySourcePaths { get; set; }
-}
+        // Absolute paths of every source file in the edited file's compilation assembly.
+        // Null/omitted is treated as empty (no sibling global usings collected).
+        public string[] AssemblySourcePaths { get; set; }
+
+        // Absolute paths of snapshot-mismatched sibling sources in the same compilation assembly.
+        // Null/omitted is treated as empty (no sibling const-drift scan).
+        public string[] ChangedSiblingSourcePaths { get; set; }
+    }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerInput.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerInput.cs
@@ -42,11 +42,11 @@ internal sealed class WorkerInput
     // Project-relative forward-slash path embedded in #line document names.
     public string ProjectRelativePath { get; set; }
 
-        // Absolute paths of every source file in the edited file's compilation assembly.
-        // Null/omitted is treated as empty (no sibling global usings collected).
-        public string[] AssemblySourcePaths { get; set; }
+    // Absolute paths of every source file in the edited file's compilation assembly.
+    // Null/omitted is treated as empty (no sibling global usings collected).
+    public string[] AssemblySourcePaths { get; set; }
 
-        // Absolute paths of snapshot-mismatched sibling sources in the same compilation assembly.
-        // Null/omitted is treated as empty (no sibling const-drift scan).
-        public string[] ChangedSiblingSourcePaths { get; set; }
-    }
+    // Absolute paths of snapshot-mismatched sibling sources in the same compilation assembly.
+    // Null/omitted is treated as empty (no sibling const-drift scan).
+    public string[] ChangedSiblingSourcePaths { get; set; }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerOutput.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerOutput.cs
@@ -25,6 +25,9 @@ internal sealed class WorkerOutput
 
     public string[] DeclarationDriftWarnings { get; set; }
 
+    // Keep in sync with TransformWorkerOutputDto.siblingConstDriftWarnings.
+    public string[] SiblingConstDriftWarnings { get; set; }
+
     public string[] ParseErrors { get; set; }
 
     public WorkerUnchangedMethod[] UnchangedMethods { get; set; }


### PR DESCRIPTION
## Summary
- Hot reload now warns when a `const` (or enum member) changed in another file of the same assembly, even if you only passed the file that reads it.
- The warning still names both values and points at `uloop compile`.

## User Impact
- Before: changing `const X` in one file and hot-reloading only a referencing file returned "nothing to patch" with no const-drift warning, because the worker parsed just that one file.
- After: snapshot-mismatched sibling sources in the same assembly are scanned. A drifted const is reported in `Warnings` with the same text as when the holder file itself is passed.

## Changes
- Compare each compilation-assembly sibling against the last compile snapshot (byte-exact). Missing snapshots skip the sibling scan without a new warning.
- Cap the scan at 50 changed files and emit `sibling const-drift scan limited to first 50 changed files (N total)` when truncated.
- Reuse the existing const-drift collector on those siblings; aggregate warnings with string-equal dedupe so a multi-file run does not repeat the same line.

## Limitations
- The AlreadyActive short-circuit (unchanged applied source, worker not run) does not emit sibling const-drift warnings. That path is unchanged.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → ErrorCount 0
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value "HotReloadChangedSiblingSourceDetectorTests|Run_WithChangedSiblingConstHolder|Run_ReferencingFileOnly_WarnsSiblingConstDrift|Run_HolderAndReferencingFiles_DedupesSiblingConstDriftWarning|Run_WhenAssemblySnapshotMissing_DoesNotWarnSiblingConstDrift|Run_EditedConstValue_WarnsConstDrift"` → TestCount 10, PassedCount 10
- Live: compiled `SiblingTuning = 6`, edited the holder to `7`, hot-reloaded only `Assets/Tests/Editor/HotReload/HotReloadSiblingConstUser.cs`:

```json
{
  "Methods": [],
  "Warnings": [
    "const io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadSiblingConstDefinitions.SiblingTuning is 7 in the edited source but 6 in the compiled assembly; edits outside method bodies never take effect through hot reload. Run 'uloop compile' to apply this change."
  ],
  "PatchedTotal": 0,
  "UnchangedTotal": 1,
  "Message": "All 1 methods are unchanged since the last compile; nothing to patch. 1 warning(s). See Warnings.",
  "Success": true
}
```

Holder file restored to `6` after the check; compile ErrorCount 0.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

