### PR TITLE
fix: describe CLI-only options in await-pause-point and pause-point-status help

### DIFF
--- a/cli/common/tooldocs/pause_point_cli_options.go
+++ b/cli/common/tooldocs/pause_point_cli_options.go
@@ -15,6 +15,9 @@ const (
 	PausePointExpectFlagName                = "expect"
 	PausePointTriggerFlagName               = "trigger"
 	PausePointResumePlayFlagName            = "resume-play"
+	PausePointIDFlagName                    = "id"
+	PausePointTimeoutSecondsFlagName        = "timeout-seconds"
+	PausePointMatchingLogsMaxCountFlagName  = "matching-logs-max-count"
 )
 
 // Accepted --captured-variables values. Declared here because they appear in the option listings;
@@ -74,12 +77,103 @@ func PausePointEnableCLIOnlyOptions() []PausePointCLIOnlyOption {
 			Description: "Requires --await. Same as await-pause-point's --trigger",
 		},
 		{
-			FlagName: PausePointResumePlayFlagName,
-			Type:     "boolean",
-			Description: "Requires --await. After confirming the marker is armed, resume PlayMode if " +
-				"paused (before --trigger), so a paused-arm workflow can fire input in one call",
+			FlagName:    PausePointResumePlayFlagName,
+			Type:        "boolean",
+			Description: "Requires --await. " + pausePointResumePlayDescription,
 		},
 	}
+}
+
+const (
+	pausePointIDDescription                    = "Pause-point marker id matching UloopPausePoint.Pause or the id returned by enable-pause-point"
+	pausePointTimeoutSecondsDescription        = "Seconds to wait for a hit before timing out"
+	pausePointMatchingLogsMaxCountDescription  = "Maximum Console logs matching the marker id to include on a hit"
+	pausePointCapturedVariablesDescription     = "How much of each captured variable to include in the response"
+	pausePointCapturedVariableNamesDescription = "Restrict CapturedVariables to these comma-separated names"
+	pausePointExpectDescription                = "Compare a captured variable against an expected value (repeatable; name=value)"
+	pausePointTriggerDescription               = "Runs a single uloop subcommand in-process right after arming/registration"
+	pausePointResumePlayDescription            = "After confirming the marker is armed, resume PlayMode if paused " +
+		"(before --trigger), so a paused-arm workflow can fire input in one call"
+)
+
+func pausePointCapturedVariablesOption() PausePointCLIOnlyOption {
+	return PausePointCLIOnlyOption{
+		FlagName:    PausePointCapturedVariablesFlagName,
+		Type:        "string",
+		Description: pausePointCapturedVariablesDescription,
+		Values: []string{
+			PausePointCapturedVariablesModeFull,
+			PausePointCapturedVariablesModeNames,
+		},
+	}
+}
+
+func pausePointSharedQueryCLIOnlyOptions() []PausePointCLIOnlyOption {
+	return []PausePointCLIOnlyOption{
+		{
+			FlagName:    PausePointIDFlagName,
+			Type:        "string",
+			Description: pausePointIDDescription,
+		},
+		pausePointCapturedVariablesOption(),
+		{
+			FlagName:    PausePointCapturedVariableNamesFlagName,
+			Type:        "string",
+			Description: pausePointCapturedVariableNamesDescription,
+		},
+		{
+			FlagName:    PausePointExpectFlagName,
+			Type:        "string",
+			Description: pausePointExpectDescription,
+		},
+	}
+}
+
+// PausePointAwaitCLIOnlyOptions returns await-pause-point's flags. A fresh slice is built per
+// call so a caller that sorts or appends cannot mutate the shared table.
+func PausePointAwaitCLIOnlyOptions() []PausePointCLIOnlyOption {
+	return append(pausePointSharedQueryCLIOnlyOptions(),
+		PausePointCLIOnlyOption{
+			FlagName:    PausePointTimeoutSecondsFlagName,
+			Type:        "integer",
+			Description: pausePointTimeoutSecondsDescription,
+		},
+		PausePointCLIOnlyOption{
+			FlagName:    PausePointMatchingLogsMaxCountFlagName,
+			Type:        "integer",
+			Description: pausePointMatchingLogsMaxCountDescription,
+		},
+		PausePointCLIOnlyOption{
+			FlagName:    PausePointTriggerFlagName,
+			Type:        "string",
+			Description: pausePointTriggerDescription,
+		},
+		PausePointCLIOnlyOption{
+			FlagName:    PausePointResumePlayFlagName,
+			Type:        "boolean",
+			Description: pausePointResumePlayDescription,
+		},
+	)
+}
+
+// PausePointStatusCLIOnlyOptions returns pause-point-status's flags. A fresh slice is built per
+// call so a caller that sorts or appends cannot mutate the shared table.
+func PausePointStatusCLIOnlyOptions() []PausePointCLIOnlyOption {
+	return pausePointSharedQueryCLIOnlyOptions()
+}
+
+// PausePointCLIOnlyHelpEntries converts a CLI-only option table into --help rows.
+func PausePointCLIOnlyHelpEntries(options []PausePointCLIOnlyOption) []OptionHelpEntry {
+	entries := make([]OptionHelpEntry, 0, len(options))
+	for _, option := range options {
+		optionName := "--" + option.FlagName
+		entries = append(entries, OptionHelpEntry{
+			Name:        optionName,
+			Usage:       pausePointCLIOnlyOptionUsage(optionName, option),
+			Description: pausePointCLIOnlyOptionDescription(option),
+		})
+	}
+	return entries
 }
 
 func appendPausePointEnableCLIOnlyOptionHelpEntries(
@@ -90,16 +184,11 @@ func appendPausePointEnableCLIOnlyOptionHelpEntries(
 		return entries
 	}
 
-	for _, option := range PausePointEnableCLIOnlyOptions() {
-		optionName := "--" + option.FlagName
-		if hasOptionHelpEntry(entries, optionName) {
+	for _, entry := range PausePointCLIOnlyHelpEntries(PausePointEnableCLIOnlyOptions()) {
+		if hasOptionHelpEntry(entries, entry.Name) {
 			continue
 		}
-		entries = append(entries, OptionHelpEntry{
-			Name:        optionName,
-			Usage:       pausePointCLIOnlyOptionUsage(optionName, option),
-			Description: pausePointCLIOnlyOptionDescription(option),
-		})
+		entries = append(entries, entry)
 	}
 	return entries
 }

--- a/cli/common/tooldocs/pause_point_cli_options_test.go
+++ b/cli/common/tooldocs/pause_point_cli_options_test.go
@@ -77,6 +77,9 @@ func TestPausePointAwaitAndStatusCLIOnlyHelpEntries(t *testing.T) {
 		t.Fatalf("status help entries = %d, want %d", len(statusEntries), len(PausePointStatusCLIOnlyOptions()))
 	}
 	for _, entry := range statusEntries {
+		if entry.Usage == "" {
+			t.Errorf("status help entry %s has empty usage", entry.Name)
+		}
 		if entry.Description == "" {
 			t.Errorf("status help entry %s has empty description", entry.Name)
 		}

--- a/cli/common/tooldocs/pause_point_cli_options_test.go
+++ b/cli/common/tooldocs/pause_point_cli_options_test.go
@@ -56,6 +56,33 @@ func TestPausePointEnableCLIOnlyOptionHelpUsage(t *testing.T) {
 	}
 }
 
+// Verifies await and status CLI-only tables produce --help rows with usage and description, so
+// native-command help can render the same shape as schema-driven tool help.
+func TestPausePointAwaitAndStatusCLIOnlyHelpEntries(t *testing.T) {
+	awaitEntries := PausePointCLIOnlyHelpEntries(PausePointAwaitCLIOnlyOptions())
+	if len(awaitEntries) != len(PausePointAwaitCLIOnlyOptions()) {
+		t.Fatalf("await help entries = %d, want %d", len(awaitEntries), len(PausePointAwaitCLIOnlyOptions()))
+	}
+	for _, entry := range awaitEntries {
+		if entry.Usage == "" {
+			t.Errorf("await help entry %s has empty usage", entry.Name)
+		}
+		if entry.Description == "" {
+			t.Errorf("await help entry %s has empty description", entry.Name)
+		}
+	}
+
+	statusEntries := PausePointCLIOnlyHelpEntries(PausePointStatusCLIOnlyOptions())
+	if len(statusEntries) != len(PausePointStatusCLIOnlyOptions()) {
+		t.Fatalf("status help entries = %d, want %d", len(statusEntries), len(PausePointStatusCLIOnlyOptions()))
+	}
+	for _, entry := range statusEntries {
+		if entry.Description == "" {
+			t.Errorf("status help entry %s has empty description", entry.Name)
+		}
+	}
+}
+
 // Verifies the CLI-only option table is not applied to unrelated tools, which would advertise
 // pause-point orchestration flags on commands that reject them.
 func TestVisibleOptionHelpEntriesOmitPausePointCLIOnlyOptionsForOtherTools(t *testing.T) {

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "f588a3abc7f8b366afcd631ef91d94572a86dc7b"
+  "sharedInputsHash": "589ac8a75d1dd2118c4699feb2605346004acf9f"
 }

--- a/cli/project-runner/internal/projectrunner/native_command_help.go
+++ b/cli/project-runner/internal/projectrunner/native_command_help.go
@@ -11,33 +11,25 @@ import (
 // Runner-specific pause-point flags: --id and --timeout-seconds mirror the Unity-side schema, and
 // --matching-logs-max-count only exists on the wait commands. The CLI-only flags shared with
 // enable-pause-point's --help listing live in tooldocs instead (pause_point_cli_options.go).
+// The string values are the tooldocs constants so parsers and option tables cannot drift.
 const (
-	PausePointIDFlagName           = "id"
-	PausePointTimeoutFlagName      = "timeout-seconds"
-	PausePointLogsMaxCountFlagName = "matching-logs-max-count"
+	PausePointIDFlagName           = tooldocs.PausePointIDFlagName
+	PausePointTimeoutFlagName      = tooldocs.PausePointTimeoutSecondsFlagName
+	PausePointLogsMaxCountFlagName = tooldocs.PausePointMatchingLogsMaxCountFlagName
 )
 
-// runnerNativeCommandOptions lists the flags accepted by each runner-owned
-// native command. It lives with the runner binary (rather than the
-// dispatcher) so that adding a flag to a runner-owned command never requires
-// a dispatcher code change or release.
-var runnerNativeCommandOptions = map[string][]string{
-	clicore.PausePointAwaitCommandName: {
-		"--" + PausePointIDFlagName,
-		"--" + PausePointTimeoutFlagName,
-		"--" + PausePointLogsMaxCountFlagName,
-		"--" + tooldocs.PausePointCapturedVariablesFlagName,
-		"--" + tooldocs.PausePointCapturedVariableNamesFlagName,
-		"--" + tooldocs.PausePointExpectFlagName,
-		"--" + tooldocs.PausePointTriggerFlagName,
-		"--" + tooldocs.PausePointResumePlayFlagName,
-	},
-	clicore.PausePointStatusUserCommandName: {
-		"--" + PausePointIDFlagName,
-		"--" + tooldocs.PausePointCapturedVariablesFlagName,
-		"--" + tooldocs.PausePointCapturedVariableNamesFlagName,
-		"--" + tooldocs.PausePointExpectFlagName,
-	},
+// runnerNativeCLIOnlyOptions returns the tooldocs table for a runner-owned native command.
+// Help rendering and unknown-option owner lookup both read this, so a flag added to a table
+// is advertised and recognized without a second handwritten name list.
+func runnerNativeCLIOnlyOptions(command string) []tooldocs.PausePointCLIOnlyOption {
+	switch command {
+	case clicore.PausePointAwaitCommandName:
+		return tooldocs.PausePointAwaitCLIOnlyOptions()
+	case clicore.PausePointStatusUserCommandName:
+		return tooldocs.PausePointStatusCLIOnlyOptions()
+	default:
+		return nil
+	}
 }
 
 // tryPrintNativeCommandHelp prints command-specific help for a runner-owned
@@ -55,17 +47,20 @@ func tryPrintNativeCommandHelp(command string, stdout io.Writer) bool {
 
 func printNativeCommandHelp(command string, stdout io.Writer) {
 	entry, _ := clicore.NativeCommand(command)
-	options := sortedNativeCommandOptions(runnerNativeCommandOptions[command])
+	helpEntries := sortedNativeCommandHelpEntries(
+		tooldocs.PausePointCLIOnlyHelpEntries(runnerNativeCLIOnlyOptions(command)))
 
 	clicore.WriteLine(stdout, "Usage:")
-	if len(options) > 0 {
+	if len(helpEntries) > 0 {
 		clicore.WriteFormat(stdout, "  uloop %s [options]\n", command)
 		clicore.WriteLine(stdout, "")
 		clicore.WriteLine(stdout, entry.Description)
 		clicore.WriteLine(stdout, "")
 		clicore.WriteLine(stdout, "Options:")
-		for _, option := range options {
-			clicore.WriteFormat(stdout, "  %s\n", option)
+		for _, helpEntry := range helpEntries {
+			// Wide enough for the longest usage string (--captured-variable-names <value>), so no
+			// single row pushes its description out of the column. Matches dispatcher tool help.
+			clicore.WriteFormat(stdout, "  %-34s %s\n", helpEntry.Usage, helpEntry.Description)
 		}
 	} else {
 		clicore.WriteFormat(stdout, "  uloop %s\n", command)
@@ -85,8 +80,10 @@ func printNativeCommandHelp(command string, stdout io.Writer) {
 	}
 }
 
-func sortedNativeCommandOptions(options []string) []string {
-	result := append([]string{}, options...)
-	sort.Strings(result)
+func sortedNativeCommandHelpEntries(entries []tooldocs.OptionHelpEntry) []tooldocs.OptionHelpEntry {
+	result := append([]tooldocs.OptionHelpEntry{}, entries...)
+	sort.Slice(result, func(left int, right int) bool {
+		return result[left].Name < result[right].Name
+	})
 	return result
 }

--- a/cli/project-runner/internal/projectrunner/native_command_help_test.go
+++ b/cli/project-runner/internal/projectrunner/native_command_help_test.go
@@ -30,23 +30,21 @@ func TestRunProjectLocalAwaitPausePointHelpListsExpectedFlags(t *testing.T) {
 	}
 }
 
-// Verifies await-pause-point --help prints option descriptions, not names alone. The sentence is a
-// test-local literal so a renderer that drops the description column still fails even if the
-// tooldocs table is complete.
-func TestRunProjectLocalAwaitPausePointHelpDescribesTrigger(t *testing.T) {
-	t.Chdir(t.TempDir())
-
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	code := RunProjectLocal(context.Background(), []string{"await-pause-point", "--help"}, &stdout, &stderr)
-
-	if code != 0 {
-		t.Fatalf("await-pause-point --help failed: code=%d stderr=%s", code, stderr.String())
-	}
-	const expectedTriggerDescription = "Runs a single uloop subcommand in-process right after arming/registration"
-	if !strings.Contains(stdout.String(), expectedTriggerDescription) {
-		t.Fatalf("await-pause-point --help must describe --trigger: %s", stdout.String())
-	}
+// Verifies await-pause-point --help prints the full Options section: every usage column, every
+// description, %-34s alignment, and sort order. The expected text is a test-local literal so a
+// wrong non-empty description still fails.
+func TestRunProjectLocalAwaitPausePointHelpOptionsSection(t *testing.T) {
+	const expectedOptions = `Options:
+  --captured-variable-names <value>  Restrict CapturedVariables to these comma-separated names
+  --captured-variables <value>       How much of each captured variable to include in the response; values: full|names
+  --expect <value>                   Compare a captured variable against an expected value (repeatable; name=value)
+  --id <value>                       Pause-point marker id matching UloopPausePoint.Pause or the id returned by enable-pause-point
+  --matching-logs-max-count <value>  Maximum Console logs matching the marker id to include on a hit
+  --resume-play                      After confirming the marker is armed, resume PlayMode if paused (before --trigger), so a paused-arm workflow can fire input in one call
+  --timeout-seconds <value>          Seconds to wait for a hit before timing out
+  --trigger <value>                  Runs a single uloop subcommand in-process right after arming/registration
+`
+	assertNativeCommandHelpOptionsSection(t, "await-pause-point", expectedOptions)
 }
 
 // Verifies pause-point-status --help lists the flags it accepts.
@@ -68,6 +66,55 @@ func TestRunProjectLocalPausePointStatusHelpListsExpectedFlags(t *testing.T) {
 	if strings.Contains(stdout.String(), "--timeout-seconds") {
 		t.Fatalf("pause-point-status --help must not list await-pause-point-only flags: %s", stdout.String())
 	}
+}
+
+// Verifies pause-point-status --help prints the full Options section. Same test-local-literal
+// rule as TestRunProjectLocalAwaitPausePointHelpOptionsSection.
+func TestRunProjectLocalPausePointStatusHelpOptionsSection(t *testing.T) {
+	const expectedOptions = `Options:
+  --captured-variable-names <value>  Restrict CapturedVariables to these comma-separated names
+  --captured-variables <value>       How much of each captured variable to include in the response; values: full|names
+  --expect <value>                   Compare a captured variable against an expected value (repeatable; name=value)
+  --id <value>                       Pause-point marker id matching UloopPausePoint.Pause or the id returned by enable-pause-point
+`
+	assertNativeCommandHelpOptionsSection(t, "pause-point-status", expectedOptions)
+}
+
+func assertNativeCommandHelpOptionsSection(t *testing.T, command string, expectedOptions string) {
+	t.Helper()
+	t.Chdir(t.TempDir())
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunProjectLocal(context.Background(), []string{command, "--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("%s --help failed: code=%d stderr=%s", command, code, stderr.String())
+	}
+
+	actual, ok := nativeCommandHelpOptionsSection(stdout.String())
+	if !ok {
+		t.Fatalf("%s --help has no Options section: %s", command, stdout.String())
+	}
+	if actual != expectedOptions {
+		t.Fatalf("%s --help Options section mismatch:\n got:\n%s\nwant:\n%s", command, actual, expectedOptions)
+	}
+}
+
+func nativeCommandHelpOptionsSection(output string) (string, bool) {
+	// Why not compare stdout as-is: Windows test hosts can surface CRLF even though the
+	// writer emits \n, and a golden that only matches LF would fail there for an unrelated reason.
+	normalized := strings.ReplaceAll(output, "\r\n", "\n")
+	const header = "Options:\n"
+	start := strings.Index(normalized, header)
+	if start < 0 {
+		return "", false
+	}
+	rest := normalized[start:]
+	end := strings.Index(rest, "\nGlobal options:")
+	if end < 0 {
+		return "", false
+	}
+	return rest[:end], true
 }
 
 // Verifies runner-owned pause-point commands close their help with the instruction to load the

--- a/cli/project-runner/internal/projectrunner/native_command_help_test.go
+++ b/cli/project-runner/internal/projectrunner/native_command_help_test.go
@@ -30,6 +30,25 @@ func TestRunProjectLocalAwaitPausePointHelpListsExpectedFlags(t *testing.T) {
 	}
 }
 
+// Verifies await-pause-point --help prints option descriptions, not names alone. The sentence is a
+// test-local literal so a renderer that drops the description column still fails even if the
+// tooldocs table is complete.
+func TestRunProjectLocalAwaitPausePointHelpDescribesTrigger(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunProjectLocal(context.Background(), []string{"await-pause-point", "--help"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("await-pause-point --help failed: code=%d stderr=%s", code, stderr.String())
+	}
+	const expectedTriggerDescription = "Runs a single uloop subcommand in-process right after arming/registration"
+	if !strings.Contains(stdout.String(), expectedTriggerDescription) {
+		t.Fatalf("await-pause-point --help must describe --trigger: %s", stdout.String())
+	}
+}
+
 // Verifies pause-point-status --help lists the flags it accepts.
 func TestRunProjectLocalPausePointStatusHelpListsExpectedFlags(t *testing.T) {
 	t.Chdir(t.TempDir())

--- a/cli/project-runner/internal/projectrunner/pause_point_cli_options_contract_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_cli_options_contract_test.go
@@ -1,6 +1,7 @@
 package projectrunner
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/hatayama/unity-cli-loop/common/tooldocs"
@@ -163,6 +164,64 @@ func TestPausePointAwaitHelpOptionsAreAcceptedByTheWaitParser(t *testing.T) {
 		waitArgs := append([]string{"--" + PausePointIDFlagName, "marker"}, args...)
 		if _, err := parseWaitForPausePointOptions(waitArgs); err != nil {
 			t.Errorf("await-pause-point parser rejected advertised option %s: %v", optionName, err)
+		}
+	}
+}
+
+// pausePointAwaitAdvertisedFlagNames is the await-pause-point advertised flag set. These are
+// test-local literals, not tooldocs constants, so deleting a table row fails even when the
+// switch-based parser still accepts the flag.
+var pausePointAwaitAdvertisedFlagNames = []string{
+	"id",
+	"timeout-seconds",
+	"matching-logs-max-count",
+	"captured-variables",
+	"captured-variable-names",
+	"expect",
+	"trigger",
+	"resume-play",
+}
+
+// pausePointStatusAdvertisedFlagNames is the pause-point-status advertised flag set. Same
+// test-local-literal rule as pausePointAwaitAdvertisedFlagNames.
+var pausePointStatusAdvertisedFlagNames = []string{
+	"id",
+	"captured-variables",
+	"captured-variable-names",
+	"expect",
+}
+
+// Verifies the await-pause-point option table's flag names equal the advertised set. Table-to-parser
+// acceptance cannot see a deleted row: the parsers are switch-based, so a missing help row still
+// leaves the flag accepted.
+func TestPausePointAwaitCLIOnlyOptionsMatchFixedFlagSet(t *testing.T) {
+	assertPausePointCLIOnlyFlagNames(t, tooldocs.PausePointAwaitCLIOnlyOptions(), pausePointAwaitAdvertisedFlagNames)
+}
+
+// Verifies the same reverse-direction contract for pause-point-status.
+func TestPausePointStatusCLIOnlyOptionsMatchFixedFlagSet(t *testing.T) {
+	assertPausePointCLIOnlyFlagNames(t, tooldocs.PausePointStatusCLIOnlyOptions(), pausePointStatusAdvertisedFlagNames)
+}
+
+func assertPausePointCLIOnlyFlagNames(
+	t *testing.T,
+	options []tooldocs.PausePointCLIOnlyOption,
+	expected []string,
+) {
+	t.Helper()
+	actual := make([]string, 0, len(options))
+	for _, option := range options {
+		actual = append(actual, option.FlagName)
+	}
+	sort.Strings(actual)
+	want := append([]string{}, expected...)
+	sort.Strings(want)
+	if len(actual) != len(want) {
+		t.Fatalf("flag names = %v, want %v", actual, want)
+	}
+	for index, name := range want {
+		if actual[index] != name {
+			t.Fatalf("flag names = %v, want %v", actual, want)
 		}
 	}
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_cli_options_contract_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_cli_options_contract_test.go
@@ -3,7 +3,6 @@ package projectrunner
 import (
 	"testing"
 
-	"github.com/hatayama/unity-cli-loop/common/clicore"
 	"github.com/hatayama/unity-cli-loop/common/tooldocs"
 )
 
@@ -121,7 +120,7 @@ func TestPausePointSharedHelpOptionsAreAcceptedByTheWaitParser(t *testing.T) {
 }
 
 // runnerNativeCommandSampleArgs supplies one accepted argv form per flag advertised by a
-// runner-owned native command's --help. A flag added to runnerNativeCommandOptions without an entry
+// runner-owned native command's --help. A flag added to a tooldocs table without an entry
 // here fails the contract test below rather than silently going unchecked.
 var runnerNativeCommandSampleArgs = map[string][]string{
 	"--" + PausePointIDFlagName:                             {"--id", "marker"},
@@ -138,30 +137,48 @@ var runnerNativeCommandSampleArgs = map[string][]string{
 // own parser. The status parser is a separate switch from the await one, so a flag added to the help
 // table alone would be advertised and then rejected as unknown on use.
 func TestPausePointStatusHelpOptionsAreAcceptedByTheStatusParser(t *testing.T) {
-	for _, option := range runnerNativeCommandOptions[clicore.PausePointStatusUserCommandName] {
-		args, ok := runnerNativeCommandSampleArgs[option]
+	for _, option := range tooldocs.PausePointStatusCLIOnlyOptions() {
+		optionName := "--" + option.FlagName
+		args, ok := runnerNativeCommandSampleArgs[optionName]
 		if !ok {
-			t.Fatalf("no sample argv for %s: add one to runnerNativeCommandSampleArgs", option)
+			t.Fatalf("no sample argv for %s: add one to runnerNativeCommandSampleArgs", optionName)
 		}
 
 		statusArgs := append([]string{"--" + PausePointIDFlagName, "marker"}, args...)
 		if _, err := parsePausePointStatusOptions(statusArgs); err != nil {
-			t.Errorf("pause-point-status parser rejected advertised option %s: %v", option, err)
+			t.Errorf("pause-point-status parser rejected advertised option %s: %v", optionName, err)
 		}
 	}
 }
 
 // Verifies the same for await-pause-point, whose help table is the larger of the two.
 func TestPausePointAwaitHelpOptionsAreAcceptedByTheWaitParser(t *testing.T) {
-	for _, option := range runnerNativeCommandOptions[clicore.PausePointAwaitCommandName] {
-		args, ok := runnerNativeCommandSampleArgs[option]
+	for _, option := range tooldocs.PausePointAwaitCLIOnlyOptions() {
+		optionName := "--" + option.FlagName
+		args, ok := runnerNativeCommandSampleArgs[optionName]
 		if !ok {
-			t.Fatalf("no sample argv for %s: add one to runnerNativeCommandSampleArgs", option)
+			t.Fatalf("no sample argv for %s: add one to runnerNativeCommandSampleArgs", optionName)
 		}
 
 		waitArgs := append([]string{"--" + PausePointIDFlagName, "marker"}, args...)
 		if _, err := parseWaitForPausePointOptions(waitArgs); err != nil {
-			t.Errorf("await-pause-point parser rejected advertised option %s: %v", option, err)
+			t.Errorf("await-pause-point parser rejected advertised option %s: %v", optionName, err)
+		}
+	}
+}
+
+// Verifies every await-pause-point and pause-point-status help table row has a description. A
+// names-only listing is how --help used to render these commands, so an empty Description would
+// recreate that gap even after the renderer learned to print a second column.
+func TestPausePointAwaitAndStatusCLIOnlyOptionsHaveDescriptions(t *testing.T) {
+	for _, option := range tooldocs.PausePointAwaitCLIOnlyOptions() {
+		if option.Description == "" {
+			t.Errorf("await-pause-point --%s has an empty description", option.FlagName)
+		}
+	}
+	for _, option := range tooldocs.PausePointStatusCLIOnlyOptions() {
+		if option.Description == "" {
+			t.Errorf("pause-point-status --%s has an empty description", option.FlagName)
 		}
 	}
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_unknown_option.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_unknown_option.go
@@ -94,9 +94,10 @@ func pausePointCommandFlagNames(command string) []string {
 		return pausePointEnableFlagNames()
 	}
 
-	names := make([]string, 0, len(runnerNativeCommandOptions[command]))
-	for _, option := range runnerNativeCommandOptions[command] {
-		names = append(names, strings.TrimPrefix(option, "--"))
+	options := runnerNativeCLIOnlyOptions(command)
+	names := make([]string, 0, len(options))
+	for _, option := range options {
+		names = append(names, option.FlagName)
 	}
 	return names
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "fbe86d610cddff04a7e7ae09837319a7e4a0ccff"
+  "sharedInputsHash": "e37524fbe43b34906d149b4efd3e66c08f8de39a"
 }


### PR DESCRIPTION
## Summary
- `uloop await-pause-point --help` and `uloop pause-point-status --help` now describe each option, not just the flag names.
- `enable-pause-point --help` can say "same as await-pause-point's --trigger" and actually have a target: await's `--trigger` is a standalone description of in-process subcommand execution.

## User Impact
- Before: those two commands printed option names only, so agents and humans could not tell what `--trigger`, `--expect`, or `--captured-variables` meant without opening the skill.
- After: each option has a description in the same `%-34s %s` layout as other `uloop` tools. Shared flags use the same wording on await and status.

## Changes
- Added await and status CLI-only option tables next to enable's table, and render `--help` from those tables.
- Unknown-option owner lookup reads the same tables, so help and accepted flags cannot drift.
- Stamped shared release inputs because `cli/common/tooldocs` changed (`scripts/stamp-release-inputs.sh`).

## Verification
- `scripts/check-go-cli.sh` passed (format, vet, lint, tests, binary rebuild).
- Rebuilt help output:

```
$ dist/darwin-arm64/uloop await-pause-point --help
Usage:
  uloop await-pause-point [options]

Wait until a named UloopPausePoint.Pause marker pauses Unity

Options:
  --captured-variable-names <value>  Restrict CapturedVariables to these comma-separated names
  --captured-variables <value>       How much of each captured variable to include in the response; values: full|names
  --expect <value>                   Compare a captured variable against an expected value (repeatable; name=value)
  --id <value>                       Pause-point marker id matching UloopPausePoint.Pause or the id returned by enable-pause-point
  --matching-logs-max-count <value>  Maximum Console logs matching the marker id to include on a hit
  --resume-play                      After confirming the marker is armed, resume PlayMode if paused (before --trigger), so a paused-arm workflow can fire input in one call
  --timeout-seconds <value>          Seconds to wait for a hit before timing out
  --trigger <value>                  Runs a single uloop subcommand in-process right after arming/registration

Global options:
  --project-path <path>   Run against a Unity project outside the current directory

Load the uloop-pause-point skill for workflow rules and response fields that --help does not cover.
```

```
$ dist/darwin-arm64/uloop pause-point-status --help
Usage:
  uloop pause-point-status [options]

Show the state of a named UloopPausePoint.Pause marker

Options:
  --captured-variable-names <value>  Restrict CapturedVariables to these comma-separated names
  --captured-variables <value>       How much of each captured variable to include in the response; values: full|names
  --expect <value>                   Compare a captured variable against an expected value (repeatable; name=value)
  --id <value>                       Pause-point marker id matching UloopPausePoint.Pause or the id returned by enable-pause-point

Global options:
  --project-path <path>   Run against a Unity project outside the current directory

Load the uloop-pause-point skill for workflow rules and response fields that --help does not cover.
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

