### PR TITLE
chore: Clear leftover play-mode exit hooks between simulate-keyboard tests

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/DeferredPlayerLatchSynchronizer.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/DeferredPlayerLatchSynchronizer.cs
@@ -75,6 +75,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal static void ResetForTests()
         {
             ClearPendingAndUnsubscribe();
+            // Why: leftover playModeStateChanged survives tests when domain reload is
+            // skipped. Schedule re-hooks on next use via HookPlayModeExitIfNeeded.
+            if (playModeExitHooked)
+            {
+                EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+                playModeExitHooked = false;
+            }
         }
 
         private static void HookPlayModeExitIfNeeded()


### PR DESCRIPTION
## Summary
- Simulate-keyboard PlayMode tests now drop the leftover Play Mode exit hook in teardown, so later tests start with fully clean static state.

## User Impact
- No runtime change for `uloop simulate-keyboard`. Production still re-hooks on the next `Schedule` via the existing one-shot Play Mode exit registration.
- Before: tests cleared pending keys and the input-update callback, but left `EditorApplication.playModeStateChanged` subscribed.
- After: teardown also unsubscribes that handler and clears the hook flag.

## Changes
- `ResetForTests` unsubscribes `EditorApplication.playModeStateChanged` and resets `playModeExitHooked` when it was hooked.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`: Success, ErrorCount 0
- PlayMode `--filter-type regex --filter-value "DeferredPlayerLatchSync|SimulateKeyboardRelease|ReleasedKeyStateMapping"`: 18 passed / 0 failed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

