### PR TITLE
feat: include failed test details in run-tests failure responses

### DIFF
--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -49,6 +49,7 @@ Returns JSON with:
 - `SkippedCount` (number): Skipped tests
 - `XmlPath` (string): Path to NUnit XML result file. Empty string when no XML was saved (typically on `Success: true`); populated only when tests failed and the XML file exists on disk.
 - `ClearedPausePointIds` (string[], optional): IDs of pause points that were cleared before test execution. Omitted from JSON when no pause points were active.
+- `FailedTests` (array, optional): Up to 10 failed leaf tests with `FullName`, `Message`, and when the stack trace contains a path:line location, `File` and `Line`. Omitted when no tests failed. When `FailedCount` is greater than 10, `Message` ends with `first 10 of N failures listed; see XmlPath for full results.`
 
 ### XML Result File
 

--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -49,6 +49,7 @@ Returns JSON with:
 - `SkippedCount` (number): Skipped tests
 - `XmlPath` (string): Path to NUnit XML result file. Empty string when no XML was saved (typically on `Success: true`); populated only when tests failed and the XML file exists on disk.
 - `ClearedPausePointIds` (string[], optional): IDs of pause points that were cleared before test execution. Omitted from JSON when no pause points were active.
+- `FailedTests` (array, optional): Up to 10 failed leaf tests with `FullName`, `Message`, and when the stack trace contains a path:line location, `File` and `Line`. Omitted when no tests failed. When `FailedCount` is greater than 10, `Message` ends with `first 10 of N failures listed; see XmlPath for full results.`
 
 ### XML Result File
 

--- a/Assets/Tests/Editor/FailedTestStackLocationParserTests.cs
+++ b/Assets/Tests/Editor/FailedTestStackLocationParserTests.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests best-effort File/Line parsing from failed-test stack traces.
+    /// </summary>
+    public sealed class FailedTestStackLocationParserTests
+    {
+        /// <summary>
+        /// What: "(at path:line)" yields that file and line.
+        /// </summary>
+        [Test]
+        public void TryParse_WhenParenthesizedAtPathLine_ReturnsFileAndLine()
+        {
+            (string file, int? line) = FailedTestStackLocationParser.TryParse(
+                "  (at Assets/Tests/FailingTest.cs:42)");
+
+            Assert.That(file, Is.EqualTo("Assets/Tests/FailingTest.cs"));
+            Assert.That(line, Is.EqualTo(42));
+        }
+
+        /// <summary>
+        /// What: Unity Test Runner "in path:line" traces still yield File and Line.
+        /// </summary>
+        [Test]
+        public void TryParse_WhenUnityInPathLine_ReturnsFileAndLine()
+        {
+            (string file, int? line) = FailedTestStackLocationParser.TryParse(
+                "at Example.Tests.FailingTest () [0x00000] in Assets/Tests/FailingTest.cs:42");
+
+            Assert.That(file, Is.EqualTo("Assets/Tests/FailingTest.cs"));
+            Assert.That(line, Is.EqualTo(42));
+        }
+
+        /// <summary>
+        /// What: an empty stack trace yields no location.
+        /// </summary>
+        [Test]
+        public void TryParse_WhenStackTraceEmpty_ReturnsNullLocation()
+        {
+            (string file, int? line) = FailedTestStackLocationParser.TryParse(string.Empty);
+
+            Assert.That(file, Is.Null);
+            Assert.That(line, Is.Null);
+        }
+
+        /// <summary>
+        /// What: a stack without a path:line location yields no File or Line.
+        /// </summary>
+        [Test]
+        public void TryParse_WhenStackHasNoPathLine_ReturnsNullLocation()
+        {
+            (string file, int? line) = FailedTestStackLocationParser.TryParse(
+                "AssertionException: Expected 2 But was: 1");
+
+            Assert.That(file, Is.Null);
+            Assert.That(line, Is.Null);
+        }
+    }
+}

--- a/Assets/Tests/Editor/FailedTestStackLocationParserTests.cs
+++ b/Assets/Tests/Editor/FailedTestStackLocationParserTests.cs
@@ -59,5 +59,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(file, Is.Null);
             Assert.That(line, Is.Null);
         }
+
+        /// <summary>
+        /// What: a 20-digit line number yields no location instead of overflowing int.Parse
+        /// or reporting a truncated 9-digit line from an unanchored match.
+        /// </summary>
+        [Test]
+        public void TryParse_WhenLineNumberHasTwentyDigits_ReturnsNullLocation()
+        {
+            (string parenthesizedFile, int? parenthesizedLine) = FailedTestStackLocationParser.TryParse(
+                "  (at Assets/Tests/FailingTest.cs:12345678901234567890)");
+            Assert.That(parenthesizedFile, Is.Null);
+            Assert.That(parenthesizedLine, Is.Null);
+
+            (string inFile, int? inLine) = FailedTestStackLocationParser.TryParse(
+                "at Example.Tests.FailingTest () [0x00000] in Assets/Tests/FailingTest.cs:12345678901234567890");
+            Assert.That(inFile, Is.Null);
+            Assert.That(inLine, Is.Null);
+        }
     }
 }

--- a/Assets/Tests/Editor/FailedTestStackLocationParserTests.cs.meta
+++ b/Assets/Tests/Editor/FailedTestStackLocationParserTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 931752c46eb634faea53ee70da55ee18
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/RunTestsResponseContractTests.cs
+++ b/Assets/Tests/Editor/RunTestsResponseContractTests.cs
@@ -1,0 +1,85 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies run-tests JSON omits null FailedTests and null File/Line keys.
+    /// </summary>
+    public sealed class RunTestsResponseContractTests
+    {
+        /// <summary>
+        /// What: zero failures omit the FailedTests key, and a populated detail with
+        /// null File/Line omits those keys from the serialized object.
+        /// </summary>
+        [Test]
+        public void RunTestsResponse_WhenSerialized_OmitsNullFailedTestsAndNullFileLineKeys()
+        {
+            RunTestsResponse zeroFailures = new RunTestsResponse(
+                success: true,
+                message: "Test execution completed with status: Passed",
+                completedAt: "2026-01-01T00:00:00.0000000Z",
+                testCount: 1,
+                passedCount: 1,
+                failedCount: 0,
+                skippedCount: 0,
+                xmlPath: string.Empty,
+                status: RunTestsExecutionStatus.Passed,
+                hasFailures: false,
+                noTestsFound: false,
+                noTestsFoundExplanation: string.Empty);
+
+            JObject zeroFailuresJson = JObject.Parse(
+                JsonConvert.SerializeObject(
+                    zeroFailures,
+                    Formatting.None,
+                    UnityCliLoopJsonResponseSerializerSettings.Settings));
+
+            Assert.That(zeroFailuresJson.Property("FailedTests"), Is.Null);
+
+            RunTestsResponse populated = new RunTestsResponse(
+                success: false,
+                message: "Test execution completed with status: Failed",
+                completedAt: "2026-01-01T00:00:00.0000000Z",
+                testCount: 1,
+                passedCount: 0,
+                failedCount: 1,
+                skippedCount: 0,
+                xmlPath: "TestResults/example.xml",
+                status: RunTestsExecutionStatus.Failed,
+                hasFailures: true,
+                noTestsFound: false,
+                noTestsFoundExplanation: string.Empty)
+            {
+                FailedTests = new[]
+                {
+                    new SerializableTestResult.FailedTestDetail
+                    {
+                        FullName = "Example.Tests.FailingTest",
+                        Message = "Expected 2 But was: 1",
+                        File = null,
+                        Line = null
+                    }
+                }
+            };
+
+            JObject populatedJson = JObject.Parse(
+                JsonConvert.SerializeObject(
+                    populated,
+                    Formatting.None,
+                    UnityCliLoopJsonResponseSerializerSettings.Settings));
+            JArray failedTests = (JArray)populatedJson["FailedTests"];
+            Assert.That(failedTests, Is.Not.Null);
+            Assert.That(failedTests.Count, Is.EqualTo(1));
+            JObject first = (JObject)failedTests[0];
+            Assert.That(first["FullName"]?.Value<string>(), Is.EqualTo("Example.Tests.FailingTest"));
+            Assert.That(first["Message"]?.Value<string>(), Is.EqualTo("Expected 2 But was: 1"));
+            Assert.That(first.Property("File"), Is.Null);
+            Assert.That(first.Property("Line"), Is.Null);
+        }
+    }
+}

--- a/Assets/Tests/Editor/RunTestsResponseContractTests.cs.meta
+++ b/Assets/Tests/Editor/RunTestsResponseContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1fb52085808e043378c937f7e18390ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/RunTestsTestFrameworkResultTests.cs
+++ b/Assets/Tests/Editor/RunTestsTestFrameworkResultTests.cs
@@ -135,6 +135,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result.failedCount, Is.EqualTo(0));
             Assert.That(result.skippedCount, Is.EqualTo(0));
             Assert.That(result.xmlPath, Is.Null);
+            Assert.That(result.failedTests, Is.Null);
         }
 
         [Test]
@@ -157,6 +158,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result.message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
             Assert.That(result.testCount, Is.EqualTo(0));
             Assert.That(result.failedCount, Is.EqualTo(0));
+            Assert.That(result.failedTests, Is.Null);
         }
 
         [Test]
@@ -181,6 +183,99 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result.noTestsFoundExplanation, Is.Empty);
             Assert.That(result.testCount, Is.EqualTo(1));
             Assert.That(result.failedCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// What: a failed leaf copies FullName, Message, and File/Line parsed from (at path:line).
+        /// </summary>
+        [Test]
+        public void FromTestResult_WhenAChildTestFails_CollectsFailedTestDetailWithStackLocation()
+        {
+            ITestResultAdaptor resultAdaptor = CreateTestSuite(
+                "RootSuite",
+                TestResultStatus.Failed,
+                0.1,
+                new List<ITestResultAdaptor>
+                {
+                    CreateTestCase(
+                        "FailingTest",
+                        TestResultStatus.Failed,
+                        0.1,
+                        "Expected 2 But was: 1",
+                        "at Example.Tests.FailingTest () [0x00000] in /ignored/path.cs:1\n  (at Assets/Tests/FailingTest.cs:42)")
+                });
+
+            SerializableTestResult result = SerializableTestResultConverter.FromTestResult(resultAdaptor);
+
+            Assert.That(result.failedTests, Is.Not.Null);
+            Assert.That(result.failedTests.Length, Is.EqualTo(1));
+            Assert.That(result.failedTests[0].FullName, Is.EqualTo("Example.Tests.FailingTest"));
+            Assert.That(result.failedTests[0].Message, Is.EqualTo("Expected 2 But was: 1"));
+            Assert.That(result.failedTests[0].File, Is.EqualTo("Assets/Tests/FailingTest.cs"));
+            Assert.That(result.failedTests[0].Line, Is.EqualTo(42));
+        }
+
+        /// <summary>
+        /// What: only the first 10 failed leaves are listed when eleven tests fail.
+        /// </summary>
+        [Test]
+        public void FromTestResult_WhenElevenTestsFail_ListsFirstTenFailedDetails()
+        {
+            List<ITestResultAdaptor> children = new List<ITestResultAdaptor>();
+            for (int index = 0; index < 11; index++)
+            {
+                string suffix = index.ToString(CultureInfo.InvariantCulture);
+                children.Add(
+                    CreateTestCase(
+                        "FailingTest" + suffix,
+                        TestResultStatus.Failed,
+                        0.1,
+                        "boom " + suffix,
+                        "(at Assets/Tests/FailingTest.cs:" + (10 + index).ToString(CultureInfo.InvariantCulture) + ")"));
+            }
+
+            ITestResultAdaptor resultAdaptor = CreateTestSuite(
+                "RootSuite",
+                TestResultStatus.Failed,
+                0.1,
+                children);
+
+            SerializableTestResult result = SerializableTestResultConverter.FromTestResult(resultAdaptor);
+
+            Assert.That(result.failedCount, Is.EqualTo(11));
+            Assert.That(result.failedTests, Is.Not.Null);
+            Assert.That(result.failedTests.Length, Is.EqualTo(10));
+            Assert.That(result.failedTests[0].FullName, Is.EqualTo("Example.Tests.FailingTest0"));
+            Assert.That(result.failedTests[9].FullName, Is.EqualTo("Example.Tests.FailingTest9"));
+        }
+
+        /// <summary>
+        /// What: a passing leaf is omitted from FailedTests even when a sibling failed.
+        /// </summary>
+        [Test]
+        public void FromTestResult_WhenMixedPassAndFail_OmitsPassingLeafFromFailedTests()
+        {
+            ITestResultAdaptor resultAdaptor = CreateTestSuite(
+                "RootSuite",
+                TestResultStatus.Failed,
+                0.1,
+                new List<ITestResultAdaptor>
+                {
+                    CreateTestCase("PassingTest", TestResultStatus.Passed, 0.1),
+                    CreateTestCase(
+                        "FailingTest",
+                        TestResultStatus.Failed,
+                        0.1,
+                        "failed")
+                });
+
+            SerializableTestResult result = SerializableTestResultConverter.FromTestResult(resultAdaptor);
+
+            Assert.That(result.failedCount, Is.EqualTo(1));
+            Assert.That(result.failedTests.Length, Is.EqualTo(1));
+            Assert.That(result.failedTests[0].FullName, Is.EqualTo("Example.Tests.FailingTest"));
+            Assert.That(result.failedTests[0].File, Is.Null);
+            Assert.That(result.failedTests[0].Line, Is.Null);
         }
 
         [Test]
@@ -234,10 +329,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             return new FakeTestResultAdaptor(test, status, durationSeconds, children);
         }
 
-        private static ITestResultAdaptor CreateTestCase(string name, TestResultStatus status, double durationSeconds)
+        private static ITestResultAdaptor CreateTestCase(
+            string name,
+            TestResultStatus status,
+            double durationSeconds,
+            string message = "",
+            string stackTrace = "")
         {
             FakeTestAdaptor test = new FakeTestAdaptor(name, false);
-            return new FakeTestResultAdaptor(test, status, durationSeconds, new List<ITestResultAdaptor>());
+            return new FakeTestResultAdaptor(
+                test,
+                status,
+                durationSeconds,
+                new List<ITestResultAdaptor>(),
+                message,
+                stackTrace);
         }
 
         private sealed class FakeTestResultAdaptor : ITestResultAdaptor
@@ -246,17 +352,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             private readonly TestResultStatus _status;
             private readonly double _durationSeconds;
             private readonly IReadOnlyList<ITestResultAdaptor> _children;
+            private readonly string _message;
+            private readonly string _stackTrace;
 
             public FakeTestResultAdaptor(
                 ITestAdaptor test,
                 TestResultStatus status,
                 double durationSeconds,
-                IReadOnlyList<ITestResultAdaptor> children)
+                IReadOnlyList<ITestResultAdaptor> children,
+                string message = "",
+                string stackTrace = "")
             {
                 _test = test;
                 _status = status;
                 _durationSeconds = durationSeconds;
                 _children = children;
+                _message = message ?? string.Empty;
+                _stackTrace = stackTrace ?? string.Empty;
             }
 
             public ITestAdaptor Test => _test;
@@ -267,8 +379,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             public double Duration => _durationSeconds;
             public DateTime StartTime => new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             public DateTime EndTime => StartTime.AddSeconds(_durationSeconds);
-            public string Message => string.Empty;
-            public string StackTrace => string.Empty;
+            public string Message => _message;
+            public string StackTrace => _stackTrace;
             public int AssertCount => 0;
             public int FailCount => CountByStatus(TestResultStatus.Failed);
             public int PassCount => CountByStatus(TestResultStatus.Passed);

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -431,6 +431,134 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.ClearedPausePointIds, Is.Null);
         }
 
+        /// <summary>
+        /// What: FailedTests from the execution result is copied onto the response.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenTestsFail_CopiesFailedTestDetailsOntoResponse()
+        {
+            SerializableTestResult.FailedTestDetail detail = new SerializableTestResult.FailedTestDetail
+            {
+                FullName = "Example.Tests.FailingTest",
+                Message = "Expected 2 But was: 1",
+                File = "Assets/Tests/FailingTest.cs",
+                Line = 42
+            };
+            StubTestExecutionService executionService = new StubTestExecutionService
+            {
+                NextResult = new SerializableTestResult
+                {
+                    success = false,
+                    status = RunTestsExecutionStatus.Failed,
+                    hasFailures = true,
+                    noTestsFound = false,
+                    noTestsFoundExplanation = string.Empty,
+                    message = "Test execution completed with status: Failed",
+                    completedAt = "2026-01-01T00:00:00.0000000Z",
+                    testCount = 1,
+                    passedCount = 0,
+                    failedCount = 1,
+                    skippedCount = 0,
+                    xmlPath = "TestResults/example.xml",
+                    failedTests = new[] { detail }
+                }
+            };
+            StubTestExecutionStateValidationService validationService =
+                new StubTestExecutionStateValidationService(ValidationResult.Success());
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                waitForTestRunnerCleanupAsync: NoCleanupWait);
+            RunTestsSchema parameters = new RunTestsSchema();
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.FailedTests, Is.Not.Null);
+            Assert.That(response.FailedTests.Length, Is.EqualTo(1));
+            Assert.That(response.FailedTests[0].FullName, Is.EqualTo("Example.Tests.FailingTest"));
+            Assert.That(response.FailedTests[0].Message, Is.EqualTo("Expected 2 But was: 1"));
+            Assert.That(response.FailedTests[0].File, Is.EqualTo("Assets/Tests/FailingTest.cs"));
+            Assert.That(response.FailedTests[0].Line, Is.EqualTo(42));
+            Assert.That(
+                response.Message,
+                Is.EqualTo("Test execution completed with status: Failed"));
+        }
+
+        /// <summary>
+        /// What: FailedCount above 10 appends the fixed-literal truncation note to Message.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenElevenTestsFail_AppendsTruncationNoteToMessage()
+        {
+            SerializableTestResult.FailedTestDetail[] details = new SerializableTestResult.FailedTestDetail[10];
+            for (int index = 0; index < 10; index++)
+            {
+                details[index] = new SerializableTestResult.FailedTestDetail
+                {
+                    FullName = "Example.Tests.FailingTest" + index,
+                    Message = "boom"
+                };
+            }
+
+            StubTestExecutionService executionService = new StubTestExecutionService
+            {
+                NextResult = new SerializableTestResult
+                {
+                    success = false,
+                    status = RunTestsExecutionStatus.Failed,
+                    hasFailures = true,
+                    noTestsFound = false,
+                    noTestsFoundExplanation = string.Empty,
+                    message = "Test execution completed with status: Failed",
+                    completedAt = "2026-01-01T00:00:00.0000000Z",
+                    testCount = 11,
+                    passedCount = 0,
+                    failedCount = 11,
+                    skippedCount = 0,
+                    xmlPath = "TestResults/example.xml",
+                    failedTests = details
+                }
+            };
+            StubTestExecutionStateValidationService validationService =
+                new StubTestExecutionStateValidationService(ValidationResult.Success());
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                waitForTestRunnerCleanupAsync: NoCleanupWait);
+            RunTestsSchema parameters = new RunTestsSchema();
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.FailedTests.Length, Is.EqualTo(10));
+            Assert.That(
+                response.Message,
+                Is.EqualTo(
+                    "Test execution completed with status: Failed first 10 of 11 failures listed; see XmlPath for full results."));
+        }
+
+        /// <summary>
+        /// What: a passing run leaves FailedTests null so JSON omits the field.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenNoTestsFail_LeavesFailedTestsNull()
+        {
+            StubTestExecutionService executionService = new StubTestExecutionService();
+            StubTestExecutionStateValidationService validationService =
+                new StubTestExecutionStateValidationService(ValidationResult.Success());
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                waitForTestRunnerCleanupAsync: NoCleanupWait);
+            RunTestsSchema parameters = new RunTestsSchema();
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.FailedTests, Is.Null);
+        }
+
         [Test]
         public async Task ExecuteAsync_WithUnsupportedFilterType_ShouldNotClearPausePoints()
         {

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -539,6 +539,58 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: FailedCount equal to 10 leaves Message as the untruncated Failed status.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenExactlyTenTestsFail_LeavesMessageWithoutTruncationNote()
+        {
+            SerializableTestResult.FailedTestDetail[] details = new SerializableTestResult.FailedTestDetail[10];
+            for (int index = 0; index < 10; index++)
+            {
+                details[index] = new SerializableTestResult.FailedTestDetail
+                {
+                    FullName = "Example.Tests.FailingTest" + index,
+                    Message = "boom"
+                };
+            }
+
+            StubTestExecutionService executionService = new StubTestExecutionService
+            {
+                NextResult = new SerializableTestResult
+                {
+                    success = false,
+                    status = RunTestsExecutionStatus.Failed,
+                    hasFailures = true,
+                    noTestsFound = false,
+                    noTestsFoundExplanation = string.Empty,
+                    message = "Test execution completed with status: Failed",
+                    completedAt = "2026-01-01T00:00:00.0000000Z",
+                    testCount = 10,
+                    passedCount = 0,
+                    failedCount = 10,
+                    skippedCount = 0,
+                    xmlPath = "TestResults/example.xml",
+                    failedTests = details
+                }
+            };
+            StubTestExecutionStateValidationService validationService =
+                new StubTestExecutionStateValidationService(ValidationResult.Success());
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                waitForTestRunnerCleanupAsync: NoCleanupWait);
+            RunTestsSchema parameters = new RunTestsSchema();
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.FailedTests.Length, Is.EqualTo(10));
+            Assert.That(
+                response.Message,
+                Is.EqualTo("Test execution completed with status: Failed"));
+        }
+
+        /// <summary>
         /// What: a passing run leaves FailedTests null so JSON omits the field.
         /// </summary>
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/RunTests/FailedTestStackLocationParser.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/FailedTestStackLocationParser.cs
@@ -10,15 +10,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class FailedTestStackLocationParser
     {
+        // Why 9 not Int32.MaxValue's 10 digits: 9 ASCII digits never overflow int.Parse.
+        private const int MaxSafeAsciiLineDigitCount = 9;
+
         // Spec form used in some traces: "(at Assets/Foo.cs:12)".
+        // Why [0-9] not \d: \d matches Unicode Nd digits that int.Parse rejects with FormatException.
         private static readonly Regex ParenthesizedAtPathLineRegex = new Regex(
-            @"\(at (?<file>.+?):(?<line>\d+)\)",
+            @"\(at (?<file>.+?):(?<line>[0-9]+)\)",
             RegexOptions.CultureInvariant);
 
         // Why a second pattern: Unity Test Runner stack traces write
         // "at Type.Method () [0x00000] in Assets/Foo.cs:12" without parentheses around the path.
         private static readonly Regex InPathLineRegex = new Regex(
-            @"\bin (?<file>.+?):(?<line>\d+)",
+            @"\bin (?<file>.+?):(?<line>[0-9]+)",
             RegexOptions.CultureInvariant);
 
         internal static (string File, int? Line) TryParse(string stackTrace)
@@ -45,7 +49,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return (null, null);
             }
 
-            int line = int.Parse(match.Groups["line"].Value, CultureInfo.InvariantCulture);
+            string lineText = match.Groups["line"].Value;
+            // Why not {1,9} in the regex: InPathLineRegex has no trailing anchor, so the
+            // engine would backtrack and match the first 9 digits of a longer number.
+            if (lineText.Length > MaxSafeAsciiLineDigitCount)
+            {
+                return (null, null);
+            }
+
+            int line = int.Parse(lineText, CultureInfo.InvariantCulture);
             Debug.Assert(line >= 0, "parsed stack line must be non-negative.");
             return (match.Groups["file"].Value, line);
         }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/FailedTestStackLocationParser.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/FailedTestStackLocationParser.cs
@@ -1,0 +1,53 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Best-effort File/Line extraction from a failed-test stack trace.
+    /// </summary>
+    internal static class FailedTestStackLocationParser
+    {
+        // Spec form used in some traces: "(at Assets/Foo.cs:12)".
+        private static readonly Regex ParenthesizedAtPathLineRegex = new Regex(
+            @"\(at (?<file>.+?):(?<line>\d+)\)",
+            RegexOptions.CultureInvariant);
+
+        // Why a second pattern: Unity Test Runner stack traces write
+        // "at Type.Method () [0x00000] in Assets/Foo.cs:12" without parentheses around the path.
+        private static readonly Regex InPathLineRegex = new Regex(
+            @"\bin (?<file>.+?):(?<line>\d+)",
+            RegexOptions.CultureInvariant);
+
+        internal static (string File, int? Line) TryParse(string stackTrace)
+        {
+            if (string.IsNullOrEmpty(stackTrace))
+            {
+                return (null, null);
+            }
+
+            (string file, int? line) parenthesized = TryMatch(ParenthesizedAtPathLineRegex, stackTrace);
+            if (parenthesized.file != null)
+            {
+                return parenthesized;
+            }
+
+            return TryMatch(InPathLineRegex, stackTrace);
+        }
+
+        private static (string File, int? Line) TryMatch(Regex regex, string stackTrace)
+        {
+            Match match = regex.Match(stackTrace);
+            if (!match.Success)
+            {
+                return (null, null);
+            }
+
+            int line = int.Parse(match.Groups["line"].Value, CultureInfo.InvariantCulture);
+            Debug.Assert(line >= 0, "parsed stack line must be non-negative.");
+            return (match.Groups["file"].Value, line);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/RunTests/FailedTestStackLocationParser.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/FailedTestStackLocationParser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c79e24ae24f9e4bd8b3c17716e1badc7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs
@@ -1,0 +1,15 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Shared run-tests response limits and user-facing message formats.
+    /// </summary>
+    internal static class RunTestsConstants
+    {
+        public const int FailedTestDetailsLimit = 10;
+
+        // Format: listed count, total failed count. Emitted when FailedCount exceeds the
+        // listed cap so the truncation is never silent.
+        public const string FailedTestDetailsTruncatedMessageFormat =
+            "first {0} of {1} failures listed; see XmlPath for full results.";
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06ae2e9b419d346c28e35614e6ba8292
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
@@ -81,6 +81,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string[] ClearedPausePointIds { get; set; }
 
         /// <summary>
+        /// Failed leaf tests, omitted from JSON when none failed.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public SerializableTestResult.FailedTestDetail[] FailedTests { get; set; }
+
+        /// <summary>
         /// Create a new RunTestsResponse. Every field is required so classification decisions
         /// stay at the call site (the Unity Test Runner adapter and use-case), not in this DTO.
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using System.Threading;
 using UnityEngine;
@@ -164,6 +165,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (clearedPausePointIds != null && clearedPausePointIds.Length > 0)
             {
                 response.ClearedPausePointIds = clearedPausePointIds;
+            }
+
+            if (result.failedTests != null && result.failedTests.Length > 0)
+            {
+                response.FailedTests = result.failedTests;
+            }
+
+            if (result.failedCount > RunTestsConstants.FailedTestDetailsLimit)
+            {
+                response.Message = response.Message
+                    + " "
+                    + string.Format(
+                        CultureInfo.InvariantCulture,
+                        RunTestsConstants.FailedTestDetailsTruncatedMessageFormat,
+                        RunTestsConstants.FailedTestDetailsLimit,
+                        result.failedCount);
             }
 
             // Why switch here: cleanup waits with ConfigureAwait(false), so this resume is

--- a/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
@@ -49,6 +49,7 @@ Returns JSON with:
 - `SkippedCount` (number): Skipped tests
 - `XmlPath` (string): Path to NUnit XML result file. Empty string when no XML was saved (typically on `Success: true`); populated only when tests failed and the XML file exists on disk.
 - `ClearedPausePointIds` (string[], optional): IDs of pause points that were cleared before test execution. Omitted from JSON when no pause points were active.
+- `FailedTests` (array, optional): Up to 10 failed leaf tests with `FullName`, `Message`, and when the stack trace contains a path:line location, `File` and `Line`. Omitted when no tests failed. When `FailedCount` is greater than 10, `Message` ends with `first 10 of N failures listed; see XmlPath for full results.`
 
 ### XML Result File
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/SerializableTestResultConverter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/SerializableTestResultConverter.cs
@@ -1,5 +1,6 @@
 #if ULOOP_HAS_TEST_FRAMEWORK
 using System;
+using System.Collections.Generic;
 using UnityEditor.TestTools.TestRunner.Api;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -57,7 +58,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 passedCount = passedTests,
                 failedCount = failedTests,
                 skippedCount = skippedTests,
-                xmlPath = null
+                xmlPath = null,
+                failedTests = CollectFailedTestDetails(result)
             };
         }
 
@@ -139,6 +141,65 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 CountTestsByStatus(child, ref count, targetStatus);
             }
+        }
+
+        private static SerializableTestResult.FailedTestDetail[] CollectFailedTestDetails(ITestResultAdaptor result)
+        {
+            List<SerializableTestResult.FailedTestDetail> details =
+                new List<SerializableTestResult.FailedTestDetail>();
+            AppendFailedTestDetails(result, details);
+            if (details.Count == 0)
+            {
+                return null;
+            }
+
+            return details.ToArray();
+        }
+
+        private static void AppendFailedTestDetails(
+            ITestResultAdaptor result,
+            List<SerializableTestResult.FailedTestDetail> details)
+        {
+            if (details.Count >= RunTestsConstants.FailedTestDetailsLimit)
+            {
+                return;
+            }
+
+            if (!result.Test.IsSuite)
+            {
+                if (result.TestStatus == TestStatus.Failed)
+                {
+                    details.Add(CreateFailedTestDetail(result));
+                }
+
+                return;
+            }
+
+            if (result.Children == null)
+            {
+                return;
+            }
+
+            foreach (ITestResultAdaptor child in result.Children)
+            {
+                AppendFailedTestDetails(child, details);
+                if (details.Count >= RunTestsConstants.FailedTestDetailsLimit)
+                {
+                    return;
+                }
+            }
+        }
+
+        private static SerializableTestResult.FailedTestDetail CreateFailedTestDetail(ITestResultAdaptor result)
+        {
+            (string file, int? line) = FailedTestStackLocationParser.TryParse(result.StackTrace);
+            return new SerializableTestResult.FailedTestDetail
+            {
+                FullName = result.Test.FullName,
+                Message = result.Message ?? string.Empty,
+                File = file,
+                Line = line
+            };
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestRunner/SerializableTestResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestRunner/SerializableTestResult.cs
@@ -1,4 +1,5 @@
 using System;
+using Newtonsoft.Json;
 using UnityEngine;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -21,6 +22,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         [SerializeField] public int failedCount;
         [SerializeField] public int skippedCount;
         [SerializeField] public string xmlPath;
+
+        /// <summary>
+        /// Failed leaf tests, capped for the JSON response. Null when none failed.
+        /// </summary>
+        public FailedTestDetail[] failedTests;
+
+        /// <summary>
+        /// One failed test leaf included in a run-tests response.
+        /// </summary>
+        [Serializable]
+        public class FailedTestDetail
+        {
+            public string FullName { get; set; }
+
+            public string Message { get; set; }
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public string File { get; set; }
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public int? Line { get; set; }
+        }
 
         public static SerializableTestResult CreateTestFrameworkUnavailable()
         {


### PR DESCRIPTION
## Summary
- `uloop run-tests` failure responses now include up to 10 failed tests (`FullName`, `Message`, and File/Line when the stack trace has a path:line location), so agents no longer need a second XML parse just to see what failed.

## User Impact
- Before: a failed run reported only counts plus `XmlPath`, so diagnosing which test failed required reading the NUnit XML.
- After: the JSON lists the first 10 failures in `FailedTests`. When more than 10 tests fail, `Message` states that only the first 10 are listed and the rest are in `XmlPath`.

## Changes
- Collect failed leaf tests while converting Unity Test Runner results, capped at 10.
- Parse File/Line from `(at path:line)` and from Unity's `in path:line` stack form.
- Copy `FailedTests` onto the response; omit the field when nothing failed.

## Verification
- `uloop compile`: ErrorCount 0
- EditMode filter for parser / converter / use-case tests: TestCount 13, Passed 13
- Live check: a temporary always-failing test produced `FailedTests` with FullName, Message, File, and Line; the probe was deleted and is not in this PR


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

