### PR TITLE
fix: name the --files option in the hot-reload missing-files validation message

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -28,10 +28,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(tool.ToolName, Is.EqualTo("hot-reload"));
         }
 
+        /// <summary>
+        /// What: calling hot-reload with neither --files, --revert-all, nor --status names
+        /// --files and shows a project-relative .cs example.
+        /// </summary>
         [Test]
         public async Task ExecuteAsync_WithoutFilesOrRevertAll_ReturnsValidationFailure()
         {
-            // Verifies --files is required when --revert-all is not set.
             HotReloadTool tool = new HotReloadTool();
             JObject parameters = new JObject();
 
@@ -41,7 +44,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(response, Is.Not.Null);
             Assert.That(response.Success, Is.False);
-            Assert.That(response.Message, Does.Contain("Files is required"));
+            Assert.That(
+                response.Message,
+                Is.EqualTo(
+                    "Files is required unless --revert-all or --status is set. Pass project-relative .cs paths with --files, e.g. 'uloop hot-reload --files Assets/Scripts/Player.cs'."));
         }
 
         /// <summary>
@@ -108,10 +114,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     + "Added-member calls are not instrumented, so InvocationCount is always 0 for this row."));
         }
 
+        /// <summary>
+        /// What: an empty Files list names --files and shows a project-relative .cs example.
+        /// </summary>
+        [Test]
+        public void ValidateApplyParameters_MissingFiles_ReturnsErrorNamingFilesOption()
+        {
+            HotReloadSchema schema = new HotReloadSchema
+            {
+                Files = Array.Empty<string>()
+            };
+
+            string error = HotReloadTool.ValidateApplyParameters(schema);
+
+            Assert.That(
+                error,
+                Is.EqualTo(
+                    "Files is required unless --revert-all or --status is set. Pass project-relative .cs paths with --files, e.g. 'uloop hot-reload --files Assets/Scripts/Player.cs'."));
+        }
+
+        /// <summary>
+        /// What: blank path entries are rejected before the orchestrator runs.
+        /// </summary>
         [Test]
         public void ValidateApplyParameters_WhitespaceOnlyPath_ReturnsError()
         {
-            // Verifies blank path entries are rejected before the orchestrator runs.
             HotReloadSchema schema = new HotReloadSchema
             {
                 Files = new[] { "   " }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -198,7 +198,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             if (parameters.Files == null || parameters.Files.Length == 0)
             {
-                return "Files is required unless --revert-all or --status is set.";
+                // Why: agents that omit --files otherwise cannot tell which option name to pass
+                // without a second --help round trip, and HotReloadResponse has no NextActions.
+                return "Files is required unless --revert-all or --status is set. Pass project-relative .cs paths with --files, e.g. 'uloop hot-reload --files Assets/Scripts/Player.cs'.";
             }
 
             for (int index = 0; index < parameters.Files.Length; index++)


### PR DESCRIPTION
## Summary
- `uloop hot-reload` with no files now names `--files` and shows a project-relative `.cs` example in the validation error.

## User Impact
- Before: an empty `uloop hot-reload` said only that Files was required, so agents needed a `--help` round trip to learn the option name.
- After: the same error tells them to pass project-relative `.cs` paths with `--files`, including an example command.

## Changes
- Extend the missing-files validation message with the `--files` option and example.
- Assert the full message as a fixed literal in EditMode tests.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>` → Success, ErrorCount 0
- `dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value HotReloadToolTests` → Passed (35/35)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

