### PR TITLE
feat: suggest option values and near-miss option names on argument parsing errors

### DIFF
--- a/cli/project-runner/internal/projectrunner/tool_param_suggestions.go
+++ b/cli/project-runner/internal/projectrunner/tool_param_suggestions.go
@@ -1,0 +1,209 @@
+package projectrunner
+
+import (
+	"sort"
+	"strings"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+	"github.com/hatayama/unity-cli-loop/common/tooldocs"
+)
+
+// Why not 1 or 2: kebab prefixes like "no" (negated booleans) and single letters would
+// pair unrelated flags. Three characters is the shortest token that still encodes a concept.
+const minSharedKebabTokenLength = 3
+
+type visibleToolOption struct {
+	name     string
+	property clicore.ToolProperty
+}
+
+func unexpectedArgumentError(tool clicore.ToolDefinition, arg string) *clierrors.ArgumentError {
+	return &clierrors.ArgumentError{
+		Message:     "Unexpected argument: " + arg,
+		Received:    arg,
+		Command:     tool.Name,
+		NextActions: prependSuggestions(enumValueOptionSuggestions(tool, arg), "Pass tool inputs as `--option value` pairs."),
+	}
+}
+
+func unknownToolOptionError(tool clicore.ToolDefinition, flagName string) *clierrors.ArgumentError {
+	return &clierrors.ArgumentError{
+		Message: "Unknown option for " + tool.Name + ": --" + flagName,
+		Option:  "--" + flagName,
+		Command: tool.Name,
+		NextActions: prependSuggestions(
+			unknownOptionSuggestions(tool, flagName),
+			"Run `uloop "+tool.Name+" --help` to inspect supported options.",
+		),
+	}
+}
+
+func unknownOptionSuggestions(tool clicore.ToolDefinition, flagName string) []string {
+	// Why enum first: `--status` is the enum value itself, not a misspelled option name.
+	// A name-similarity suggestion would hide the option+value form the caller actually needs.
+	enumSuggestions := enumValueOptionSuggestions(tool, flagName)
+	if len(enumSuggestions) > 0 {
+		return enumSuggestions
+	}
+
+	if suggestion, ok := closestOptionNameSuggestion(tool, flagName); ok {
+		return []string{suggestion}
+	}
+
+	return sharedTokenOptionSuggestions(tool, flagName)
+}
+
+func enumValueOptionSuggestions(tool clicore.ToolDefinition, received string) []string {
+	suggestions := make([]string, 0)
+	for _, option := range visibleToolOptions(tool) {
+		matchedValue := matchingEnumValue(option.property.Enum, received)
+		if matchedValue == "" {
+			continue
+		}
+		suggestions = append(suggestions, didYouMeanOptionValue(tool.Name, option.name, matchedValue))
+	}
+	return suggestions
+}
+
+func matchingEnumValue(enumValues []string, received string) string {
+	for _, enumValue := range enumValues {
+		if strings.EqualFold(enumValue, received) {
+			return enumValue
+		}
+	}
+	return ""
+}
+
+func closestOptionNameSuggestion(tool clicore.ToolDefinition, flagName string) (string, bool) {
+	unknown := strings.ToLower(flagName)
+	threshold := max(2, len(unknown)/3)
+	bestName := ""
+	bestDistance := threshold + 1
+
+	for _, option := range visibleToolOptions(tool) {
+		distance := levenshteinDistance(unknown, strings.ToLower(option.name))
+		if distance > threshold || distance >= bestDistance {
+			continue
+		}
+		bestDistance = distance
+		bestName = option.name
+	}
+
+	if bestName == "" {
+		return "", false
+	}
+	return didYouMeanOption(tool.Name, bestName), true
+}
+
+func sharedTokenOptionSuggestions(tool clicore.ToolDefinition, flagName string) []string {
+	unknownToken := firstKebabToken(flagName)
+	if len(unknownToken) < minSharedKebabTokenLength {
+		return nil
+	}
+
+	unknown := strings.ToLower(flagName)
+	matches := make([]visibleToolOption, 0)
+	bestDistance := -1
+	for _, option := range visibleToolOptions(tool) {
+		if firstKebabToken(option.name) != unknownToken {
+			continue
+		}
+		distance := levenshteinDistance(unknown, strings.ToLower(option.name))
+		if bestDistance < 0 || distance < bestDistance {
+			bestDistance = distance
+			matches = []visibleToolOption{option}
+			continue
+		}
+		if distance == bestDistance {
+			matches = append(matches, option)
+		}
+	}
+
+	suggestions := make([]string, 0, len(matches))
+	for _, option := range matches {
+		suggestions = append(suggestions, didYouMeanOption(tool.Name, option.name))
+	}
+	return suggestions
+}
+
+func visibleToolOptions(tool clicore.ToolDefinition) []visibleToolOption {
+	schema := tool.EffectiveInputSchema()
+	propertyNames := make([]string, 0, len(schema.Properties))
+	for propertyName := range schema.Properties {
+		propertyNames = append(propertyNames, propertyName)
+	}
+	sort.Strings(propertyNames)
+
+	options := make([]visibleToolOption, 0, len(propertyNames))
+	for _, propertyName := range propertyNames {
+		property := schema.Properties[propertyName]
+		if property.Hidden {
+			continue
+		}
+		options = append(options, visibleToolOption{
+			name:     tooldocs.OptionNameForProperty(tool.Name, propertyName, property),
+			property: property,
+		})
+	}
+	return options
+}
+
+func firstKebabToken(name string) string {
+	token, _, _ := strings.Cut(strings.ToLower(name), "-")
+	return token
+}
+
+func prependSuggestions(suggestions []string, fallback string) []string {
+	if len(suggestions) == 0 {
+		return []string{fallback}
+	}
+	nextActions := make([]string, 0, len(suggestions)+1)
+	nextActions = append(nextActions, suggestions...)
+	return append(nextActions, fallback)
+}
+
+func didYouMeanOption(toolName string, optionName string) string {
+	return "Did you mean: uloop " + toolName + " --" + optionName
+}
+
+func didYouMeanOptionValue(toolName string, optionName string, value string) string {
+	return didYouMeanOption(toolName, optionName) + " " + value
+}
+
+// levenshteinDistance is local so suggestion matching does not touch cli/common
+// (and therefore does not trip shared-release-input stamping).
+func levenshteinDistance(left string, right string) int {
+	if left == right {
+		return 0
+	}
+	if len(left) == 0 {
+		return len(right)
+	}
+	if len(right) == 0 {
+		return len(left)
+	}
+
+	previous := make([]int, len(right)+1)
+	current := make([]int, len(right)+1)
+	for column := 0; column <= len(right); column++ {
+		previous[column] = column
+	}
+
+	for row := 1; row <= len(left); row++ {
+		current[0] = row
+		for column := 1; column <= len(right); column++ {
+			deletionCost := previous[column] + 1
+			insertionCost := current[column-1] + 1
+			substitutionCost := previous[column-1]
+			if left[row-1] != right[column-1] {
+				substitutionCost++
+			}
+			current[column] = min(deletionCost, insertionCost, substitutionCost)
+		}
+		previous, current = current, previous
+	}
+
+	return previous[len(right)]
+}

--- a/cli/project-runner/internal/projectrunner/tool_params.go
+++ b/cli/project-runner/internal/projectrunner/tool_params.go
@@ -19,12 +19,7 @@ func buildToolParams(args []string, tool clicore.ToolDefinition) (map[string]any
 	for index := 0; index < len(args); index++ {
 		arg := args[index]
 		if !strings.HasPrefix(arg, "--") {
-			return nil, "", &clierrors.ArgumentError{
-				Message:     "Unexpected argument: " + arg,
-				Received:    arg,
-				Command:     tool.Name,
-				NextActions: []string{"Pass tool inputs as `--option value` pairs."},
-			}
+			return nil, "", unexpectedArgumentError(tool, arg)
 		}
 
 		flag, err := parseToolFlag(arg)
@@ -46,12 +41,7 @@ func buildToolParams(args []string, tool clicore.ToolDefinition) (map[string]any
 
 		propertyName, property, negated, ok := tooldocs.FindProperty(tool, flag.name)
 		if !ok {
-			return nil, "", &clierrors.ArgumentError{
-				Message:     "Unknown option for " + tool.Name + ": --" + flag.name,
-				Option:      "--" + flag.name,
-				Command:     tool.Name,
-				NextActions: []string{"Run `uloop " + tool.Name + " --help` to inspect supported options."},
-			}
+			return nil, "", unknownToolOptionError(tool, flag.name)
 		}
 
 		option := "--" + flag.name

--- a/cli/project-runner/internal/projectrunner/tool_params_test.go
+++ b/cli/project-runner/internal/projectrunner/tool_params_test.go
@@ -214,3 +214,95 @@ func TestBuildToolParamsUnknownOptionIgnoresShortSharedKebabToken(t *testing.T) 
 		"Run `uloop sample-tool --help` to inspect supported options.",
 	})
 }
+
+// Verifies an enum-value match beats a close option-name typo so --status suggests --action Status, not --stat.
+func TestBuildToolParamsUnknownOptionPrefersEnumMatchOverCloseOptionName(t *testing.T) {
+	tool := clicore.ToolDefinition{
+		Name: "sample-tool",
+		InputSchema: clicore.InputSchema{
+			Properties: map[string]clicore.ToolProperty{
+				"Action": {Type: "string", Enum: []string{"Status"}},
+				"Stat":   {Type: "string"},
+			},
+		},
+	}
+
+	_, _, err := buildToolParams([]string{"--status"}, tool)
+	requireNextActions(t, err, []string{
+		"Did you mean: uloop sample-tool --action Status",
+		"Run `uloop sample-tool --help` to inspect supported options.",
+	})
+}
+
+// Verifies a close typo beats a shared kebab token so --time-out suggests --timeout, not --time-scale.
+func TestBuildToolParamsUnknownOptionPrefersCloseTypoOverSharedKebabToken(t *testing.T) {
+	tool := clicore.ToolDefinition{
+		Name: "sample-tool",
+		InputSchema: clicore.InputSchema{
+			Properties: map[string]clicore.ToolProperty{
+				"Timeout":   {Type: "integer"},
+				"TimeScale": {Type: "number"},
+			},
+		},
+	}
+
+	_, _, err := buildToolParams([]string{"--time-out"}, tool)
+	requireNextActions(t, err, []string{
+		"Did you mean: uloop sample-tool --timeout",
+		"Run `uloop sample-tool --help` to inspect supported options.",
+	})
+}
+
+// Verifies an unknown flag at edit distance 2 still suggests the nearest option (threshold inclusive).
+func TestBuildToolParamsUnknownOptionSuggestsAtEditDistanceTwo(t *testing.T) {
+	tool := clicore.ToolDefinition{
+		Name: "sample-tool",
+		InputSchema: clicore.InputSchema{
+			Properties: map[string]clicore.ToolProperty{
+				"Action": {Type: "string"},
+			},
+		},
+	}
+
+	_, _, err := buildToolParams([]string{"--acxxon"}, tool)
+	requireNextActions(t, err, []string{
+		"Did you mean: uloop sample-tool --action",
+		"Run `uloop sample-tool --help` to inspect supported options.",
+	})
+}
+
+// Verifies an unknown flag at edit distance 3 does not suggest an option past the threshold.
+func TestBuildToolParamsUnknownOptionDoesNotSuggestAtEditDistanceThree(t *testing.T) {
+	tool := clicore.ToolDefinition{
+		Name: "sample-tool",
+		InputSchema: clicore.InputSchema{
+			Properties: map[string]clicore.ToolProperty{
+				"Action": {Type: "string"},
+			},
+		},
+	}
+
+	_, _, err := buildToolParams([]string{"--acxxxn"}, tool)
+	requireNextActions(t, err, []string{
+		"Run `uloop sample-tool --help` to inspect supported options.",
+	})
+}
+
+// Verifies equal edit-distance option names suggest the sorted-first property name only.
+func TestBuildToolParamsUnknownOptionTieBreaksToSortedFirstOptionName(t *testing.T) {
+	tool := clicore.ToolDefinition{
+		Name: "sample-tool",
+		InputSchema: clicore.InputSchema{
+			Properties: map[string]clicore.ToolProperty{
+				"OutputPile": {Type: "string"},
+				"OutputFile": {Type: "string"},
+			},
+		},
+	}
+
+	_, _, err := buildToolParams([]string{"--output-bile"}, tool)
+	requireNextActions(t, err, []string{
+		"Did you mean: uloop sample-tool --output-file",
+		"Run `uloop sample-tool --help` to inspect supported options.",
+	})
+}

--- a/cli/project-runner/internal/projectrunner/tool_params_test.go
+++ b/cli/project-runner/internal/projectrunner/tool_params_test.go
@@ -103,3 +103,114 @@ func TestConvertValuePassesThroughStringWithoutEnum(t *testing.T) {
 		t.Fatalf("expected converted value %q, got %q", "anything", converted)
 	}
 }
+
+func toolParamsSuggestionTool() clicore.ToolDefinition {
+	return clicore.ToolDefinition{
+		Name: "sample-tool",
+		InputSchema: clicore.InputSchema{
+			Properties: map[string]clicore.ToolProperty{
+				"Action": {
+					Type: "string",
+					Enum: []string{"Play", "Stop", "Pause", "Status"},
+				},
+				"OutputDirectory": {
+					Type: "string",
+				},
+			},
+		},
+	}
+}
+
+func requireArgumentError(t *testing.T, err error) *clierrors.ArgumentError {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	var argumentError *clierrors.ArgumentError
+	if !errors.As(err, &argumentError) {
+		t.Fatalf("expected an *ArgumentError, got %T: %v", err, err)
+	}
+	return argumentError
+}
+
+func requireNextActions(t *testing.T, err error, want []string) {
+	t.Helper()
+	argumentError := requireArgumentError(t, err)
+	if len(argumentError.NextActions) != len(want) {
+		t.Fatalf("NextActions length mismatch:\nwant: %#v\ngot:  %#v", want, argumentError.NextActions)
+	}
+	for index := range want {
+		if argumentError.NextActions[index] != want[index] {
+			t.Fatalf("NextActions mismatch at %d:\nwant: %#v\ngot:  %#v", index, want, argumentError.NextActions)
+		}
+	}
+}
+
+// Verifies a positional token that matches an option enum value suggests the --option Value form.
+func TestBuildToolParamsUnexpectedArgumentSuggestsMatchingEnumOption(t *testing.T) {
+	_, _, err := buildToolParams([]string{"status"}, toolParamsSuggestionTool())
+	requireNextActions(t, err, []string{
+		"Did you mean: uloop sample-tool --action Status",
+		"Pass tool inputs as `--option value` pairs.",
+	})
+}
+
+// Verifies a positional token that matches no enum keeps only the original NextAction.
+func TestBuildToolParamsUnexpectedArgumentWithoutEnumMatchKeepsOriginalNextAction(t *testing.T) {
+	_, _, err := buildToolParams([]string{"not-an-enum"}, toolParamsSuggestionTool())
+	requireNextActions(t, err, []string{
+		"Pass tool inputs as `--option value` pairs.",
+	})
+}
+
+// Verifies an unknown flag whose name matches an option enum value suggests that option and value.
+func TestBuildToolParamsUnknownOptionSuggestsMatchingEnumValue(t *testing.T) {
+	_, _, err := buildToolParams([]string{"--status"}, toolParamsSuggestionTool())
+	requireNextActions(t, err, []string{
+		"Did you mean: uloop sample-tool --action Status",
+		"Run `uloop sample-tool --help` to inspect supported options.",
+	})
+}
+
+// Verifies a close typo of a known option name suggests that option via edit distance.
+func TestBuildToolParamsUnknownOptionSuggestsCloseTypo(t *testing.T) {
+	_, _, err := buildToolParams([]string{"--output-directry"}, toolParamsSuggestionTool())
+	requireNextActions(t, err, []string{
+		"Did you mean: uloop sample-tool --output-directory",
+		"Run `uloop sample-tool --help` to inspect supported options.",
+	})
+}
+
+// Verifies an unknown flag that shares a kebab first token with a known option suggests that option.
+func TestBuildToolParamsUnknownOptionSuggestsSharedKebabToken(t *testing.T) {
+	_, _, err := buildToolParams([]string{"--output-path"}, toolParamsSuggestionTool())
+	requireNextActions(t, err, []string{
+		"Did you mean: uloop sample-tool --output-directory",
+		"Run `uloop sample-tool --help` to inspect supported options.",
+	})
+}
+
+// Verifies an unrelated unknown flag keeps only the --help NextAction.
+func TestBuildToolParamsUnknownOptionWithoutSuggestionKeepsHelpNextAction(t *testing.T) {
+	_, _, err := buildToolParams([]string{"--zzzzzzzz"}, toolParamsSuggestionTool())
+	requireNextActions(t, err, []string{
+		"Run `uloop sample-tool --help` to inspect supported options.",
+	})
+}
+
+// Verifies a 2-character shared kebab prefix such as "no" does not pair unrelated flags.
+func TestBuildToolParamsUnknownOptionIgnoresShortSharedKebabToken(t *testing.T) {
+	tool := clicore.ToolDefinition{
+		Name: "sample-tool",
+		InputSchema: clicore.InputSchema{
+			Properties: map[string]clicore.ToolProperty{
+				"Cache": {Type: "boolean", Default: true},
+			},
+		},
+	}
+
+	_, _, err := buildToolParams([]string{"--no-foo"}, tool)
+	requireNextActions(t, err, []string{
+		"Run `uloop sample-tool --help` to inspect supported options.",
+	})
+}


### PR DESCRIPTION
## Summary
- Argument parse errors now suggest the intended `--option` (and enum value when that is what was typed), so a typo or a positional value no longer needs a `--help` round trip to recover.

## User Impact
- Before: `uloop control-play-mode Status` reported `Unexpected argument: Status`, `uloop control-play-mode --status` reported an unknown option, and `uloop screenshot --output-path` reported an unknown option, each with only a generic next action.
- After: those errors prepend a `Did you mean` next action (`--action Status`, `--action Status`, and `--output-directory` respectively). Unrelated unknown flags still point at `--help` only.

## Changes
- Unexpected positionals that match a tool schema enum value (case-insensitive) prepend `Did you mean: uloop <tool> --<option> <Value>`.
- Unknown flags try, in order: enum-value match, then a close typo (edit distance `<= max(2, len/3)`), then a shared kebab first token of at least 3 characters. Suggestions are derived from the tool schema, not per-tool special cases.

## Verification
- `scripts/check-go-cli.sh` passed (format, vet, lint, tests, dist rebuild).
- New `TestBuildToolParams*` cases ran and passed (enum positional, enum flag, typo `output-directry`, shared token `output-path`, no-suggestion, short `no-` token ignored).
- Dist binary smoke:
  - `uloop control-play-mode Status` → `Did you mean: uloop control-play-mode --action Status`
  - `uloop control-play-mode --status` → `Did you mean: uloop control-play-mode --action Status`
  - `uloop screenshot --output-path` → `Did you mean: uloop screenshot --output-directory`
  - `uloop screenshot --zzzzzzzz` → help next action only


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

