### PR TITLE
fix: align clear-pause-point messages with ClearedCount for auto-disarmed and expired markers

### DIFF
--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -57,7 +57,7 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is 0 or 1 for `--id`, and the number of markers actually cleared for `--all`.
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of marker records removed: 0 or 1 for `--id`, and the number of records removed for `--all`. Auto-disarmed and expired markers still count as 1 because this call removes their records.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -57,7 +57,7 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1 because the clear removes their leftover code patch and marks their record cleared; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state).
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state).
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -28,7 +28,7 @@ The response returns the derived marker `Id` (`Assets/Scripts/Enemy.cs:42`), the
 
 3. Read `CapturedVariables` in the hit response first: the locals, parameters, and `this` instance fields at the paused line are already there (see Reading CapturedVariables).
 4. While Unity is still paused, capture any additional evidence with `uloop execute-dynamic-code`, `uloop get-hierarchy`, `uloop find-game-objects`, and one screenshot.
-5. A `single-shot` marker (the default) disarms itself after the hit, so no clear call is required before moving on. Clearing is still what removes the underlying code patch (a disarmed marker leaves the patch installed), so for `continuous`/`trace` markers, or when the method must run fully untouched again, clear it with `uloop clear-pause-point --id "Assets/Scripts/Enemy.cs:42"` (or `--all` to clear every active marker at once) or stop PlayMode. Clearing resumes Play Mode only when the current pause is owned by a pause-point hit — the clear response then carries a `Warning` saying it resumed Play Mode. A manual pause (`control-play-mode --action Pause` or the Editor pause button) is left untouched by clear.
+5. A `single-shot` marker (the default) disarms itself after the hit, so no clear call is required before moving on. Clearing is still what removes the underlying code patch (a disarmed marker leaves the patch installed), so for `continuous`/`trace` markers, or when the method must run fully untouched again, clear it with `uloop clear-pause-point --id "Assets/Scripts/Enemy.cs:42"` (or `--all` to clear every non-cleared pause point marker (armed, auto-disarmed, or expired) at once) or stop PlayMode. Clearing resumes Play Mode only when the current pause is owned by a pause-point hit — the clear response then carries a `Warning` saying it resumed Play Mode. A manual pause (`control-play-mode --action Pause` or the Editor pause button) is left untouched by clear.
 
 A hit pauses Unity at the next frame boundary — the patched method and the rest of that frame still run to completion. Only `CapturedVariables` is evidence of the values at the patched line; state read after the pause (for example via `execute-dynamic-code`) may already have advanced past it.
 
@@ -57,12 +57,12 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of marker records removed: 0 or 1 for `--id`, and the number of records removed for `--all`. Auto-disarmed and expired markers still count as 1 because this call removes their records.
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1 because the clear removes their leftover code patch and marks their record cleared; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state).
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--id` | string | - | Named pause point id to clear |
-| `--all` | flag | - | Clear every active pause point marker |
+| `--all` | flag | - | Clear every non-cleared pause point marker (armed, auto-disarmed, or expired) |
 
 ### enable-watch
 

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -57,7 +57,7 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is 0 or 1 for `--id`, and the number of markers actually cleared for `--all`.
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of marker records removed: 0 or 1 for `--id`, and the number of records removed for `--all`. Auto-disarmed and expired markers still count as 1 because this call removes their records.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -57,7 +57,7 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1 because the clear removes their leftover code patch and marks their record cleared; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state).
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state).
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -28,7 +28,7 @@ The response returns the derived marker `Id` (`Assets/Scripts/Enemy.cs:42`), the
 
 3. Read `CapturedVariables` in the hit response first: the locals, parameters, and `this` instance fields at the paused line are already there (see Reading CapturedVariables).
 4. While Unity is still paused, capture any additional evidence with `uloop execute-dynamic-code`, `uloop get-hierarchy`, `uloop find-game-objects`, and one screenshot.
-5. A `single-shot` marker (the default) disarms itself after the hit, so no clear call is required before moving on. Clearing is still what removes the underlying code patch (a disarmed marker leaves the patch installed), so for `continuous`/`trace` markers, or when the method must run fully untouched again, clear it with `uloop clear-pause-point --id "Assets/Scripts/Enemy.cs:42"` (or `--all` to clear every active marker at once) or stop PlayMode. Clearing resumes Play Mode only when the current pause is owned by a pause-point hit — the clear response then carries a `Warning` saying it resumed Play Mode. A manual pause (`control-play-mode --action Pause` or the Editor pause button) is left untouched by clear.
+5. A `single-shot` marker (the default) disarms itself after the hit, so no clear call is required before moving on. Clearing is still what removes the underlying code patch (a disarmed marker leaves the patch installed), so for `continuous`/`trace` markers, or when the method must run fully untouched again, clear it with `uloop clear-pause-point --id "Assets/Scripts/Enemy.cs:42"` (or `--all` to clear every non-cleared pause point marker (armed, auto-disarmed, or expired) at once) or stop PlayMode. Clearing resumes Play Mode only when the current pause is owned by a pause-point hit — the clear response then carries a `Warning` saying it resumed Play Mode. A manual pause (`control-play-mode --action Pause` or the Editor pause button) is left untouched by clear.
 
 A hit pauses Unity at the next frame boundary — the patched method and the rest of that frame still run to completion. Only `CapturedVariables` is evidence of the values at the patched line; state read after the pause (for example via `execute-dynamic-code`) may already have advanced past it.
 
@@ -57,12 +57,12 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of marker records removed: 0 or 1 for `--id`, and the number of records removed for `--all`. Auto-disarmed and expired markers still count as 1 because this call removes their records.
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1 because the clear removes their leftover code patch and marks their record cleared; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state).
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--id` | string | - | Named pause point id to clear |
-| `--all` | flag | - | Clear every active pause point marker |
+| `--all` | flag | - | Clear every non-cleared pause point marker (armed, auto-disarmed, or expired) |
 
 ### enable-watch
 

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -324,7 +324,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
-        /// What: clearing an auto-disarmed hit reports leftover-patch removal with ClearedCount 1.
+        /// What: clearing an auto-disarmed hit reports that the record was marked cleared with ClearedCount 1.
         /// </summary>
         [Test]
         public void Clear_WhenPausePointWasHit_ReportsAlreadyHitMessage()
@@ -338,7 +338,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 snapshot.Message,
                 Is.EqualTo(
-                    "Pause point was already auto-disarmed by its hit; this clear removed its leftover code patch and marked the record cleared. Capture history is preserved."));
+                    "Pause point was already auto-disarmed by its hit; this clear marked the record cleared. Capture history is preserved."));
             Assert.That(clearedCount, Is.EqualTo(1));
             Assert.That(_pauseController.IsPaused, Is.False);
         }
@@ -603,7 +603,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
-        /// What: clearing an expired never-hit marker reports leftover-patch removal with ClearedCount 1.
+        /// What: clearing an expired never-hit marker reports that the record was marked cleared with ClearedCount 1.
         /// </summary>
         [Test]
         public void Clear_WhenPausePointExpired_ReportsAlreadyExpiredMessage()
@@ -617,15 +617,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 snapshot.Message,
                 Is.EqualTo(
-                    "Pause point had already expired before being hit; this clear removed its leftover code patch and marked the record cleared."));
+                    "Pause point had already expired before being hit; this clear marked the record cleared."));
             Assert.That(clearedCount, Is.EqualTo(1));
         }
 
         /// <summary>
-        /// What: clearing an expired marker that already hit reports leftover-patch removal with ClearedCount 1.
+        /// What: clearing an expired marker that already hit reports that the record was marked cleared with ClearedCount 1.
         /// </summary>
         [Test]
-        public void Clear_WhenExpiredHitMarkerIsCleared_ReportsLeftoverPatchRemovedMessageAndClearedCountOne()
+        public void Clear_WhenExpiredHitMarkerIsCleared_ReportsRecordClearedMessageAndClearedCountOne()
         {
             UloopPausePointRegistry.Enable("jump", 1, UloopPausePointCaptureMode.Trace);
             UloopPausePoint.Pause("jump");
@@ -637,7 +637,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 snapshot.Message,
                 Is.EqualTo(
-                    "Pause point capture window had already expired; this clear removed its leftover code patch and marked the record cleared."));
+                    "Pause point capture window had already expired; this clear marked the record cleared."));
             Assert.That(clearedCount, Is.EqualTo(1));
         }
 

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -324,7 +324,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
-        /// What: clearing an auto-disarmed hit reports record removal with ClearedCount 1.
+        /// What: clearing an auto-disarmed hit reports leftover-patch removal with ClearedCount 1.
         /// </summary>
         [Test]
         public void Clear_WhenPausePointWasHit_ReportsAlreadyHitMessage()
@@ -338,7 +338,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 snapshot.Message,
                 Is.EqualTo(
-                    "Pause point was already auto-disarmed by its hit; this clear removed its record. Capture history was preserved until this clear."));
+                    "Pause point was already auto-disarmed by its hit; this clear removed its leftover code patch and marked the record cleared. Capture history is preserved."));
             Assert.That(clearedCount, Is.EqualTo(1));
             Assert.That(_pauseController.IsPaused, Is.False);
         }
@@ -603,7 +603,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
-        /// What: clearing an expired never-hit marker reports record removal with ClearedCount 1.
+        /// What: clearing an expired never-hit marker reports leftover-patch removal with ClearedCount 1.
         /// </summary>
         [Test]
         public void Clear_WhenPausePointExpired_ReportsAlreadyExpiredMessage()
@@ -617,15 +617,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 snapshot.Message,
                 Is.EqualTo(
-                    "Pause point had already expired before being hit; this clear removed its record."));
+                    "Pause point had already expired before being hit; this clear removed its leftover code patch and marked the record cleared."));
             Assert.That(clearedCount, Is.EqualTo(1));
         }
 
         /// <summary>
-        /// What: clearing an expired marker that already hit reports record removal with ClearedCount 1.
+        /// What: clearing an expired marker that already hit reports leftover-patch removal with ClearedCount 1.
         /// </summary>
         [Test]
-        public void Clear_WhenExpiredHitMarkerIsCleared_ReportsRecordRemovedMessageAndClearedCountOne()
+        public void Clear_WhenExpiredHitMarkerIsCleared_ReportsLeftoverPatchRemovedMessageAndClearedCountOne()
         {
             UloopPausePointRegistry.Enable("jump", 1, UloopPausePointCaptureMode.Trace);
             UloopPausePoint.Pause("jump");
@@ -637,7 +637,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 snapshot.Message,
                 Is.EqualTo(
-                    "Pause point capture window had already expired; this clear removed its record."));
+                    "Pause point capture window had already expired; this clear removed its leftover code patch and marked the record cleared."));
             Assert.That(clearedCount, Is.EqualTo(1));
         }
 

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -323,16 +323,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(_pauseController.PauseCount, Is.EqualTo(0));
         }
 
+        /// <summary>
+        /// What: clearing an auto-disarmed hit reports record removal with ClearedCount 1.
+        /// </summary>
         [Test]
         public void Clear_WhenPausePointWasHit_ReportsAlreadyHitMessage()
         {
-            // Verifies clearing an already-hit one-shot marker explains why nothing was armed anymore.
             UloopPausePointRegistry.Enable("jump", 30);
             UloopPausePoint.Pause("jump");
 
-            (UloopPausePointSnapshot snapshot, _, _) = UloopPausePointRegistry.Clear("jump");
+            (UloopPausePointSnapshot snapshot, bool _, int clearedCount) =
+                UloopPausePointRegistry.Clear("jump");
 
-            Assert.That(snapshot.Message, Is.EqualTo("Pause point was already hit (auto-disarmed); nothing to clear."));
+            Assert.That(
+                snapshot.Message,
+                Is.EqualTo(
+                    "Pause point was already auto-disarmed by its hit; this clear removed its record. Capture history was preserved until this clear."));
+            Assert.That(clearedCount, Is.EqualTo(1));
             Assert.That(_pauseController.IsPaused, Is.False);
         }
 
@@ -595,16 +602,43 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(_pauseController.IsPaused, Is.False);
         }
 
+        /// <summary>
+        /// What: clearing an expired never-hit marker reports record removal with ClearedCount 1.
+        /// </summary>
         [Test]
         public void Clear_WhenPausePointExpired_ReportsAlreadyExpiredMessage()
         {
-            // Verifies clearing an expired marker explains it was never hit instead of claiming a clear.
             UloopPausePointRegistry.Enable("jump", 1);
             _nowUtc = _nowUtc.AddSeconds(2);
 
-            (UloopPausePointSnapshot snapshot, _, _) = UloopPausePointRegistry.Clear("jump");
+            (UloopPausePointSnapshot snapshot, bool _, int clearedCount) =
+                UloopPausePointRegistry.Clear("jump");
 
-            Assert.That(snapshot.Message, Is.EqualTo("Pause point had already expired before being hit; nothing to clear."));
+            Assert.That(
+                snapshot.Message,
+                Is.EqualTo(
+                    "Pause point had already expired before being hit; this clear removed its record."));
+            Assert.That(clearedCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// What: clearing an expired marker that already hit reports record removal with ClearedCount 1.
+        /// </summary>
+        [Test]
+        public void Clear_WhenExpiredHitMarkerIsCleared_ReportsRecordRemovedMessageAndClearedCountOne()
+        {
+            UloopPausePointRegistry.Enable("jump", 1, UloopPausePointCaptureMode.Trace);
+            UloopPausePoint.Pause("jump");
+            _nowUtc = _nowUtc.AddSeconds(2);
+
+            (UloopPausePointSnapshot snapshot, bool _, int clearedCount) =
+                UloopPausePointRegistry.Clear("jump");
+
+            Assert.That(
+                snapshot.Message,
+                Is.EqualTo(
+                    "Pause point capture window had already expired; this clear removed its record."));
+            Assert.That(clearedCount, Is.EqualTo(1));
         }
 
         [Test]

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -57,7 +57,7 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is 0 or 1 for `--id`, and the number of markers actually cleared for `--all`.
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of marker records removed: 0 or 1 for `--id`, and the number of records removed for `--all`. Auto-disarmed and expired markers still count as 1 because this call removes their records.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -57,7 +57,7 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1 because the clear removes their leftover code patch and marks their record cleared; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state).
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state).
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -28,7 +28,7 @@ The response returns the derived marker `Id` (`Assets/Scripts/Enemy.cs:42`), the
 
 3. Read `CapturedVariables` in the hit response first: the locals, parameters, and `this` instance fields at the paused line are already there (see Reading CapturedVariables).
 4. While Unity is still paused, capture any additional evidence with `uloop execute-dynamic-code`, `uloop get-hierarchy`, `uloop find-game-objects`, and one screenshot.
-5. A `single-shot` marker (the default) disarms itself after the hit, so no clear call is required before moving on. Clearing is still what removes the underlying code patch (a disarmed marker leaves the patch installed), so for `continuous`/`trace` markers, or when the method must run fully untouched again, clear it with `uloop clear-pause-point --id "Assets/Scripts/Enemy.cs:42"` (or `--all` to clear every active marker at once) or stop PlayMode. Clearing resumes Play Mode only when the current pause is owned by a pause-point hit — the clear response then carries a `Warning` saying it resumed Play Mode. A manual pause (`control-play-mode --action Pause` or the Editor pause button) is left untouched by clear.
+5. A `single-shot` marker (the default) disarms itself after the hit, so no clear call is required before moving on. Clearing is still what removes the underlying code patch (a disarmed marker leaves the patch installed), so for `continuous`/`trace` markers, or when the method must run fully untouched again, clear it with `uloop clear-pause-point --id "Assets/Scripts/Enemy.cs:42"` (or `--all` to clear every non-cleared pause point marker (armed, auto-disarmed, or expired) at once) or stop PlayMode. Clearing resumes Play Mode only when the current pause is owned by a pause-point hit — the clear response then carries a `Warning` saying it resumed Play Mode. A manual pause (`control-play-mode --action Pause` or the Editor pause button) is left untouched by clear.
 
 A hit pauses Unity at the next frame boundary — the patched method and the rest of that frame still run to completion. Only `CapturedVariables` is evidence of the values at the patched line; state read after the pause (for example via `execute-dynamic-code`) may already have advanced past it.
 
@@ -57,12 +57,12 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of marker records removed: 0 or 1 for `--id`, and the number of records removed for `--all`. Auto-disarmed and expired markers still count as 1 because this call removes their records.
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1 because the clear removes their leftover code patch and marks their record cleared; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state).
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--id` | string | - | Named pause point id to clear |
-| `--all` | flag | - | Clear every active pause point marker |
+| `--all` | flag | - | Clear every non-cleared pause point marker (armed, auto-disarmed, or expired) |
 
 ### enable-watch
 

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -131,16 +131,18 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             // Resolve expiry first so a clear after the timeout reports "expired", not a normal clear.
             TryExpire(entry, now);
             int clearedCount = entry.Status == UloopPausePointStatus.Cleared ? 0 : 1;
+            // Why not "nothing to clear": ClearedCount 1 means this call removed the record,
+            // including auto-disarmed and already-expired markers.
             string message = !entry.IsEnabled && entry.Status == UloopPausePointStatus.Hit
-                ? "Pause point was already hit (auto-disarmed); nothing to clear."
+                ? "Pause point was already auto-disarmed by its hit; this clear removed its record. Capture history was preserved until this clear."
                 : entry.Status switch
             {
                 UloopPausePointStatus.Hit =>
                     $"Pause point cleared after {entry.HitCount} hit(s); capture history is preserved.",
                 UloopPausePointStatus.Expired when entry.HitCount > 0 =>
-                    "Pause point capture window had already expired; nothing to clear.",
+                    "Pause point capture window had already expired; this clear removed its record.",
                 UloopPausePointStatus.Expired =>
-                    "Pause point had already expired before being hit; nothing to clear.",
+                    "Pause point had already expired before being hit; this clear removed its record.",
                 UloopPausePointStatus.Cleared => "Pause point was already cleared.",
                 _ => "Pause point cleared."
             };

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -131,18 +131,19 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             // Resolve expiry first so a clear after the timeout reports "expired", not a normal clear.
             TryExpire(entry, now);
             int clearedCount = entry.Status == UloopPausePointStatus.Cleared ? 0 : 1;
-            // Why not "nothing to clear": ClearedCount 1 means this call removed the record,
-            // including auto-disarmed and already-expired markers.
+            // Why not "nothing to clear" or "removed its record": ClearedCount 1 means this
+            // call unpatched leftover Harmony code and marked the entry Cleared; the entry
+            // stays in Entries and remains readable via pause-point-status.
             string message = !entry.IsEnabled && entry.Status == UloopPausePointStatus.Hit
-                ? "Pause point was already auto-disarmed by its hit; this clear removed its record. Capture history was preserved until this clear."
+                ? "Pause point was already auto-disarmed by its hit; this clear removed its leftover code patch and marked the record cleared. Capture history is preserved."
                 : entry.Status switch
             {
                 UloopPausePointStatus.Hit =>
                     $"Pause point cleared after {entry.HitCount} hit(s); capture history is preserved.",
                 UloopPausePointStatus.Expired when entry.HitCount > 0 =>
-                    "Pause point capture window had already expired; this clear removed its record.",
+                    "Pause point capture window had already expired; this clear removed its leftover code patch and marked the record cleared.",
                 UloopPausePointStatus.Expired =>
-                    "Pause point had already expired before being hit; this clear removed its record.",
+                    "Pause point had already expired before being hit; this clear removed its leftover code patch and marked the record cleared.",
                 UloopPausePointStatus.Cleared => "Pause point was already cleared.",
                 _ => "Pause point cleared."
             };

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -131,19 +131,19 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             // Resolve expiry first so a clear after the timeout reports "expired", not a normal clear.
             TryExpire(entry, now);
             int clearedCount = entry.Status == UloopPausePointStatus.Cleared ? 0 : 1;
-            // Why not "nothing to clear" or "removed its record": ClearedCount 1 means this
-            // call unpatched leftover Harmony code and marked the entry Cleared; the entry
-            // stays in Entries and remains readable via pause-point-status.
+            // Why not claim leftover-patch removal: this Runtime registry cannot know whether a
+            // patch exists. Id-only enables never call SourcePausePointPatcher, so OnCleared's
+            // Unpatch hook no-ops when MethodById lacks the id.
             string message = !entry.IsEnabled && entry.Status == UloopPausePointStatus.Hit
-                ? "Pause point was already auto-disarmed by its hit; this clear removed its leftover code patch and marked the record cleared. Capture history is preserved."
+                ? "Pause point was already auto-disarmed by its hit; this clear marked the record cleared. Capture history is preserved."
                 : entry.Status switch
             {
                 UloopPausePointStatus.Hit =>
                     $"Pause point cleared after {entry.HitCount} hit(s); capture history is preserved.",
                 UloopPausePointStatus.Expired when entry.HitCount > 0 =>
-                    "Pause point capture window had already expired; this clear removed its leftover code patch and marked the record cleared.",
+                    "Pause point capture window had already expired; this clear marked the record cleared.",
                 UloopPausePointStatus.Expired =>
-                    "Pause point had already expired before being hit; this clear removed its leftover code patch and marked the record cleared.",
+                    "Pause point had already expired before being hit; this clear marked the record cleared.",
                 UloopPausePointStatus.Cleared => "Pause point was already cleared.",
                 _ => "Pause point cleared."
             };

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -408,7 +408,7 @@
     },
     {
       "name": "clear-pause-point",
-      "description": "Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1 because the clear removes their leftover code patch and marks their record cleared; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state).",
+      "description": "Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state).",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -408,7 +408,7 @@
     },
     {
       "name": "clear-pause-point",
-      "description": "Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of marker records removed: 0 or 1 for `--id`, and the number of records removed for `--all`. Auto-disarmed and expired markers still count as 1 because this call removes their records.",
+      "description": "Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1 because the clear removes their leftover code patch and marks their record cleared; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state).",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -418,7 +418,7 @@
           },
           "All": {
             "type": "boolean",
-            "description": "Clear every active pause point marker"
+            "description": "Clear every non-cleared pause point marker (armed, auto-disarmed, or expired)"
           }
         }
       }

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -408,7 +408,7 @@
     },
     {
       "name": "clear-pause-point",
-      "description": "Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is 0 or 1 for `--id`, and the number of markers actually cleared for `--all`.",
+      "description": "Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of marker records removed: 0 or 1 for `--id`, and the number of records removed for `--all`. Auto-disarmed and expired markers still count as 1 because this call removes their records.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "ecc70a15e709cfc9f4f19832736c564d8ff07073"
+  "sharedInputsHash": "a6dc92d6a132470a8e3b97488d33ee7590c97971"
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "a6dc92d6a132470a8e3b97488d33ee7590c97971"
+  "sharedInputsHash": "0e716971c0854f6f73596d38f09343e4c97345f2"
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "589ac8a75d1dd2118c4699feb2605346004acf9f"
+  "sharedInputsHash": "ecc70a15e709cfc9f4f19832736c564d8ff07073"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "d42fd6ad78432e33c9506aa69cd1e0ae2edd855c"
+  "sharedInputsHash": "c61b52ee050d0c742d32cfa2dddbce455e631aa1"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "0fca0a1c7d53d69f67417e428f1d147710b286ff"
+  "sharedInputsHash": "d42fd6ad78432e33c9506aa69cd1e0ae2edd855c"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "e37524fbe43b34906d149b4efd3e66c08f8de39a"
+  "sharedInputsHash": "0fca0a1c7d53d69f67417e428f1d147710b286ff"
 }


### PR DESCRIPTION
## Summary
- `clear-pause-point` now describes auto-disarmed and expired markers as marking the record cleared, matching `ClearedCount: 1`.
- `--all` now says it clears every non-cleared marker (armed, auto-disarmed, or expired).

## User Impact
- Before: clearing an already-hit or expired marker returned `ClearedCount: 1` with a Message that said "nothing to clear".
- After: the Message says this clear marked the record cleared. The record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state). Capture history remains preserved on the AlreadyHit path.

## Changes
- Replace the AlreadyHit and Expired clear messages so they no longer say "nothing to clear" and do not claim a leftover code patch was removed (id-only markers have no patch).
- Document `ClearedCount` as the number of markers transitioned to Cleared.
- Describe `--all` as clearing every non-cleared marker, including auto-disarmed and expired.
- Assert Message plus `ClearedCount` as fixed literals for AlreadyHit, expired-with-hit, and expired-without-hit.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>` → Success, ErrorCount 0
- The three Message+ClearedCount pair tests ran and passed (3/3)
