### PR TITLE
feat: echo enable-time resolved marker fields on expired pause-point responses

### DIFF
--- a/cli/project-runner/internal/projectrunner/pause_point_enable.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable.go
@@ -359,14 +359,32 @@ func runEnablePausePointAndAwait(
 	)
 }
 
-// enablePausePointPropagatedFields carries enable-time fields into the --await hit response,
-// matching how Warning alone used to be forwarded from runEnablePausePointAndAwait.
+// enablePausePointPropagatedFields carries enable-time fields into the --await hit and Expired
+// responses, matching how Warning alone used to be forwarded from runEnablePausePointAndAwait.
 type enablePausePointPropagatedFields struct {
 	Warning          string
 	ResolvedLine     int
 	ResolvedLineText string
 	ResolvedMethod   string
 	SnapshotTiming   string
+}
+
+// mergeEnablePausePointResolvedFields copies enable-time resolution onto a wait status for both
+// hit and Expired. Why Line/Text as a pair: Unity SetResolvedLine always writes or clears both
+// together, so field-by-field fallback can mix a status line number with enable-time text.
+// Prefer the status pair when ResolvedLine is non-zero; otherwise keep enable-time.
+// Why Method/SnapshotTiming always from enable: the Unity status DTO still does not carry them.
+func mergeEnablePausePointResolvedFields(
+	response pausePointStatusResponse,
+	enableFields enablePausePointPropagatedFields,
+) pausePointStatusResponse {
+	if response.ResolvedLine == 0 {
+		response.ResolvedLine = enableFields.ResolvedLine
+		response.ResolvedLineText = enableFields.ResolvedLineText
+	}
+	response.ResolvedMethod = enableFields.ResolvedMethod
+	response.SnapshotTiming = enableFields.SnapshotTiming
+	return response
 }
 
 // runPausePointWaitAfterEnable mirrors runWaitForPausePoint's response shaping (the shared
@@ -399,17 +417,7 @@ func runPausePointWaitAfterEnable(
 
 		response.TriggerResult = triggerResult
 		response.ResumePlayResult = resumeResult
-		// Why treat ResolvedLine/Text as a pair: Unity SetResolvedLine always writes or clears
-		// both together. Falling back field-by-field can synthesize a line number from status
-		// with enable-time text (or the reverse) when ReadLineText returns empty.
-		// Prefer the status pair when ResolvedLine is non-zero; otherwise keep enable-time.
-		if response.ResolvedLine == 0 {
-			response.ResolvedLine = enableFields.ResolvedLine
-			response.ResolvedLineText = enableFields.ResolvedLineText
-		}
-		// ResolvedMethod / SnapshotTiming are still enable-only on the status DTO today.
-		response.ResolvedMethod = enableFields.ResolvedMethod
-		response.SnapshotTiming = enableFields.SnapshotTiming
+		response = mergeEnablePausePointResolvedFields(response, enableFields)
 		response = filterPausePointCapturedVariableHistory(response)
 		response = applyPausePointHitStatusNote(response)
 		response = filterPausePointCapturedVariablesByName(response, options.capturedVariableNames)
@@ -449,6 +457,9 @@ func runPausePointWaitAfterEnable(
 	if state == pausePointWaitStateTimeout && !hasNewHitBaseline {
 		response, markerClearedByThisCommand = refreshPausePointStatusAfterWaitTimeoutAutoClear(
 			ctx, connection, options.id, response)
+	}
+	if state == pausePointWaitStateExpired {
+		response = mergeEnablePausePointResolvedFields(response, enableFields)
 	}
 
 	waitErr := pausePointWaitError(

--- a/cli/project-runner/internal/projectrunner/pause_point_enable.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable.go
@@ -359,34 +359,6 @@ func runEnablePausePointAndAwait(
 	)
 }
 
-// enablePausePointPropagatedFields carries enable-time fields into the --await hit and Expired
-// responses, matching how Warning alone used to be forwarded from runEnablePausePointAndAwait.
-type enablePausePointPropagatedFields struct {
-	Warning          string
-	ResolvedLine     int
-	ResolvedLineText string
-	ResolvedMethod   string
-	SnapshotTiming   string
-}
-
-// mergeEnablePausePointResolvedFields copies enable-time resolution onto a wait status for both
-// hit and Expired. Why Line/Text as a pair: Unity SetResolvedLine always writes or clears both
-// together, so field-by-field fallback can mix a status line number with enable-time text.
-// Prefer the status pair when ResolvedLine is non-zero; otherwise keep enable-time.
-// Why Method/SnapshotTiming always from enable: the Unity status DTO still does not carry them.
-func mergeEnablePausePointResolvedFields(
-	response pausePointStatusResponse,
-	enableFields enablePausePointPropagatedFields,
-) pausePointStatusResponse {
-	if response.ResolvedLine == 0 {
-		response.ResolvedLine = enableFields.ResolvedLine
-		response.ResolvedLineText = enableFields.ResolvedLineText
-	}
-	response.ResolvedMethod = enableFields.ResolvedMethod
-	response.SnapshotTiming = enableFields.SnapshotTiming
-	return response
-}
-
 // runPausePointWaitAfterEnable mirrors runWaitForPausePoint's response shaping (the shared
 // helpers it calls are reused as-is) but also folds enable-time fields (Warning and the
 // file:line resolution details) into the merged response, since --await must not drop evidence

--- a/cli/project-runner/internal/projectrunner/pause_point_enable_resolved_fields.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable_resolved_fields.go
@@ -1,0 +1,29 @@
+package projectrunner
+
+// enablePausePointPropagatedFields carries enable-time fields into the --await hit and Expired
+// responses, matching how Warning alone used to be forwarded from runEnablePausePointAndAwait.
+type enablePausePointPropagatedFields struct {
+	Warning          string
+	ResolvedLine     int
+	ResolvedLineText string
+	ResolvedMethod   string
+	SnapshotTiming   string
+}
+
+// mergeEnablePausePointResolvedFields copies enable-time resolution onto a wait status for both
+// hit and Expired. Why Line/Text as a pair: Unity SetResolvedLine always writes or clears both
+// together, so field-by-field fallback can mix a status line number with enable-time text.
+// Prefer the status pair when ResolvedLine is non-zero; otherwise keep enable-time.
+// Why Method/SnapshotTiming always from enable: the Unity status DTO still does not carry them.
+func mergeEnablePausePointResolvedFields(
+	response pausePointStatusResponse,
+	enableFields enablePausePointPropagatedFields,
+) pausePointStatusResponse {
+	if response.ResolvedLine == 0 {
+		response.ResolvedLine = enableFields.ResolvedLine
+		response.ResolvedLineText = enableFields.ResolvedLineText
+	}
+	response.ResolvedMethod = enableFields.ResolvedMethod
+	response.SnapshotTiming = enableFields.SnapshotTiming
+	return response
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_enable_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable_test.go
@@ -699,6 +699,77 @@ func TestRunEnablePausePointCommandAwaitOmitsResolvedFieldsForMethodArm(t *testi
 	}
 }
 
+// Verifies enable --await Expired copies enable-time ResolvedLine / ResolvedLineText /
+// ResolvedMethod / SnapshotTiming into the error Details and explains how to read them.
+func TestRunPausePointWaitAfterEnablePropagatesResolvedFieldsOnExpired(t *testing.T) {
+	originalQuery := queryPausePointStatus
+	originalPoll := pausePointStatusPoll
+	pausePointStatusPoll = time.Millisecond
+	t.Cleanup(func() {
+		queryPausePointStatus = originalQuery
+		pausePointStatusPoll = originalPoll
+	})
+
+	queryPausePointStatus = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+	) (pausePointStatusResponse, error) {
+		return pausePointStatusResponse{
+			Id:          id,
+			Status:      pausePointStatusExpired,
+			Expired:     true,
+			EditorState: pausePointEditorState{IsPlaying: true, CapturedAt: "Current"},
+		}, nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runPausePointWaitAfterEnable(
+		context.Background(),
+		unityipc.Connection{ProjectRoot: "/tmp/MyProject"},
+		waitForPausePointOptions{
+			id:                   "Assets/Foo.cs:42",
+			timeoutSeconds:       1,
+			timeout:              time.Second,
+			matchingLogsMaxCount: 5,
+			markerJustEnabled:    true,
+		},
+		enablePausePointPropagatedFields{
+			ResolvedLine:     42,
+			ResolvedLineText: "    DoJump();",
+			ResolvedMethod:   "Player.Update",
+			SnapshotTiming:   "OnEnter",
+		},
+		&stdout,
+		&stderr,
+	)
+	if code != 1 {
+		t.Fatalf("expected expired failure, got %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	envelope := parsePausePointErrorEnvelope(t, stderr.Bytes())
+	if envelope.Error.ErrorCode != "PAUSE_POINT_EXPIRED" {
+		t.Fatalf("error code mismatch: %s", envelope.Error.ErrorCode)
+	}
+	if envelope.Error.Details["ResolvedLine"] != float64(42) {
+		t.Fatalf("ResolvedLine mismatch: %#v", envelope.Error.Details["ResolvedLine"])
+	}
+	if envelope.Error.Details["ResolvedLineText"] != "    DoJump();" {
+		t.Fatalf("ResolvedLineText mismatch: %#v", envelope.Error.Details["ResolvedLineText"])
+	}
+	if envelope.Error.Details["ResolvedMethod"] != "Player.Update" {
+		t.Fatalf("ResolvedMethod mismatch: %#v", envelope.Error.Details["ResolvedMethod"])
+	}
+	if envelope.Error.Details["SnapshotTiming"] != "OnEnter" {
+		t.Fatalf("SnapshotTiming mismatch: %#v", envelope.Error.Details["SnapshotTiming"])
+	}
+	wantMessage := "Pause point expired before it was hit. The marker stayed armed on ResolvedLine/ResolvedLineText below; the line was never executed within the window."
+	if envelope.Error.Message != wantMessage {
+		t.Fatalf("Message mismatch:\nwant: %q\ngot:  %q", wantMessage, envelope.Error.Message)
+	}
+}
+
 // Verifies a log fetch failure after --await never turns a successful hit into an error, and
 // omits MatchingLogs entirely (like the plain await-pause-point path) rather than emitting an
 // empty array, so "empty array" keeps meaning "fetch succeeded with no matches" for both commands.

--- a/cli/project-runner/internal/projectrunner/pause_point_enable_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable_test.go
@@ -764,7 +764,7 @@ func TestRunPausePointWaitAfterEnablePropagatesResolvedFieldsOnExpired(t *testin
 	if envelope.Error.Details["SnapshotTiming"] != "OnEnter" {
 		t.Fatalf("SnapshotTiming mismatch: %#v", envelope.Error.Details["SnapshotTiming"])
 	}
-	wantMessage := "Pause point expired before it was hit. The marker stayed armed on ResolvedLine/ResolvedLineText below; the line was never executed within the window."
+	wantMessage := "Pause point expired before it was hit. The marker stayed armed at the resolved line shown in Details; that line was never executed within the window."
 	if envelope.Error.Message != wantMessage {
 		t.Fatalf("Message mismatch:\nwant: %q\ngot:  %q", wantMessage, envelope.Error.Message)
 	}

--- a/cli/project-runner/internal/projectrunner/pause_point_errors.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors.go
@@ -40,6 +40,7 @@ func pausePointWaitError(
 		if hint != "" {
 			expiredError.Details["Hint"] = hint
 		}
+		applyPausePointExpiredResolvedFieldDetails(expiredError.Details, response)
 		if note := pausePointExpiredResolvedFieldsNote(response); note != "" {
 			expiredError.Message = expiredError.Message + " " + note
 		}
@@ -126,10 +127,11 @@ const (
 
 	pausePointHintTimeoutAutoCleared = "This command disarmed the marker on timeout; re-enable the pause point (enable-pause-point) before waiting again. "
 
-	// Explains how to read enable-time resolution echoed on Expired --await. Why not claim the
-	// method ran or did not: that granularity belongs to issue #2307; expiry only proves the
-	// armed line was not executed within the window.
-	pausePointExpiredResolvedFieldsGuidance = "The marker stayed armed on ResolvedLine/ResolvedLineText below; the line was never executed within the window."
+	// Explains how to read resolved-line Details on Expired when HitCount is still 0.
+	// Why not mention ResolvedLineText: C# omits empty text, so Details may carry only ResolvedLine.
+	// Why not emit this when HitCount > 0: a trace/continuous hit can land just before expiry and
+	// the next poll then reports Expired; claiming the line never ran would contradict HitCount.
+	pausePointExpiredResolvedFieldsGuidance = "The marker stayed armed at the resolved line shown in Details; that line was never executed within the window."
 
 	// Shared by both pausePointTimeoutHint and pausePointExpiredHint: reasons a wait saw no hit —
 	// a physics/message callback missing a pre-existing GameObject, a pre-bound delegate
@@ -266,18 +268,6 @@ func pausePointStateErrorDetails(
 		"RecommendedNextAction":           response.RecommendedNextAction,
 		"SuppressedByHotReload":           response.SuppressedByHotReload,
 	}
-	if response.ResolvedLine != 0 {
-		details["ResolvedLine"] = response.ResolvedLine
-	}
-	if response.ResolvedLineText != "" {
-		details["ResolvedLineText"] = response.ResolvedLineText
-	}
-	if response.ResolvedMethod != "" {
-		details["ResolvedMethod"] = response.ResolvedMethod
-	}
-	if response.SnapshotTiming != "" {
-		details["SnapshotTiming"] = response.SnapshotTiming
-	}
 	if response.ClearedReason != "" {
 		details["ClearedReason"] = response.ClearedReason
 	}
@@ -320,8 +310,23 @@ func pausePointRemainingMilliseconds(options waitForPausePointOptions, response 
 }
 
 func pausePointExpiredResolvedFieldsNote(response pausePointStatusResponse) string {
-	if response.ResolvedLine == 0 && response.ResolvedLineText == "" {
+	if response.HitCount != 0 || response.ResolvedLine == 0 {
 		return ""
 	}
 	return pausePointExpiredResolvedFieldsGuidance
+}
+
+func applyPausePointExpiredResolvedFieldDetails(details map[string]any, response pausePointStatusResponse) {
+	if response.ResolvedLine != 0 {
+		details["ResolvedLine"] = response.ResolvedLine
+	}
+	if response.ResolvedLineText != "" {
+		details["ResolvedLineText"] = response.ResolvedLineText
+	}
+	if response.ResolvedMethod != "" {
+		details["ResolvedMethod"] = response.ResolvedMethod
+	}
+	if response.SnapshotTiming != "" {
+		details["SnapshotTiming"] = response.SnapshotTiming
+	}
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_errors.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors.go
@@ -40,6 +40,9 @@ func pausePointWaitError(
 		if hint != "" {
 			expiredError.Details["Hint"] = hint
 		}
+		if note := pausePointExpiredResolvedFieldsNote(response); note != "" {
+			expiredError.Message = expiredError.Message + " " + note
+		}
 		return expiredError
 	case pausePointWaitStateTriggerFailed:
 		triggerFailedError := pausePointStateError(
@@ -122,6 +125,11 @@ const (
 	pausePointHintAlreadyHitWaitingForNew = "The marker had already hit and Unity may still be paused by that hit; pass --resume-play or resume Play Mode so a new hit can occur."
 
 	pausePointHintTimeoutAutoCleared = "This command disarmed the marker on timeout; re-enable the pause point (enable-pause-point) before waiting again. "
+
+	// Explains how to read enable-time resolution echoed on Expired --await. Why not claim the
+	// method ran or did not: that granularity belongs to issue #2307; expiry only proves the
+	// armed line was not executed within the window.
+	pausePointExpiredResolvedFieldsGuidance = "The marker stayed armed on ResolvedLine/ResolvedLineText below; the line was never executed within the window."
 
 	// Shared by both pausePointTimeoutHint and pausePointExpiredHint: reasons a wait saw no hit —
 	// a physics/message callback missing a pre-existing GameObject, a pre-bound delegate
@@ -258,6 +266,18 @@ func pausePointStateErrorDetails(
 		"RecommendedNextAction":           response.RecommendedNextAction,
 		"SuppressedByHotReload":           response.SuppressedByHotReload,
 	}
+	if response.ResolvedLine != 0 {
+		details["ResolvedLine"] = response.ResolvedLine
+	}
+	if response.ResolvedLineText != "" {
+		details["ResolvedLineText"] = response.ResolvedLineText
+	}
+	if response.ResolvedMethod != "" {
+		details["ResolvedMethod"] = response.ResolvedMethod
+	}
+	if response.SnapshotTiming != "" {
+		details["SnapshotTiming"] = response.SnapshotTiming
+	}
 	if response.ClearedReason != "" {
 		details["ClearedReason"] = response.ClearedReason
 	}
@@ -297,4 +317,11 @@ func pausePointRemainingMilliseconds(options waitForPausePointOptions, response 
 		return 0
 	}
 	return remainingMilliseconds
+}
+
+func pausePointExpiredResolvedFieldsNote(response pausePointStatusResponse) string {
+	if response.ResolvedLine == 0 && response.ResolvedLineText == "" {
+		return ""
+	}
+	return pausePointExpiredResolvedFieldsGuidance
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_types.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_types.go
@@ -59,11 +59,13 @@ type pausePointStatusResponse struct {
 	// on the wait payload, not as hit-time Warning.
 	Warning string `json:"Warning,omitempty"`
 
-	// ResolvedLine / ResolvedLineText are merged as a pair on the --await hit path: when status
-	// carries a non-zero ResolvedLine (retarget-updated), both fields come from status; otherwise
-	// both fall back to the enable-pause-point response. ResolvedMethod / SnapshotTiming are still
-	// enable-only today. Method-name arms leave them empty on the Unity side, so omitempty keeps
-	// the historical await schema unchanged for those cases.
+	// ResolvedLine / ResolvedLineText are merged as a pair on the --await hit path and the
+	// --await Expired path: when status carries a non-zero ResolvedLine (retarget-updated),
+	// both fields come from status; otherwise both fall back to the enable-pause-point response.
+	// ResolvedMethod / SnapshotTiming are still enable-only on the Unity status DTO today, so
+	// --await copies them from the enable response on both hit and Expired. Method-name arms
+	// leave them empty on the Unity side, so omitempty keeps the historical await schema
+	// unchanged for those cases.
 	ResolvedLine     int    `json:"ResolvedLine,omitempty"`
 	ResolvedLineText string `json:"ResolvedLineText,omitempty"`
 	ResolvedMethod   string `json:"ResolvedMethod,omitempty"`

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -1469,6 +1469,102 @@ func TestPausePointExpiredErrorReportsNoRemainingTime(t *testing.T) {
 	}
 }
 
+// Verifies Expired with HitCount > 0 still copies Resolved* into Details but does not claim
+// the armed line never ran.
+func TestPausePointExpiredErrorOmitsResolvedNoteWhenHitCountPositive(t *testing.T) {
+	response := pausePointStatusResponse{
+		Id:               "jump",
+		Status:           pausePointStatusExpired,
+		Expired:          true,
+		HitCount:         1,
+		ResolvedLine:     42,
+		ResolvedLineText: "    DoJump();",
+		ResolvedMethod:   "Player.Update",
+		SnapshotTiming:   "OnEnter",
+		EditorState:      pausePointEditorState{IsPlaying: true, CapturedAt: "Current"},
+	}
+
+	cliErr := pausePointWaitError("/tmp/MyProject", waitForPausePointOptions{
+		id:             "jump",
+		timeoutSeconds: 1,
+	}, response, pausePointWaitStateExpired, false, false)
+
+	if cliErr.Message != "Pause point expired before it was hit." {
+		t.Fatalf("Message mismatch: %q", cliErr.Message)
+	}
+	if cliErr.Details["ResolvedLine"] != 42 {
+		t.Fatalf("ResolvedLine mismatch: %#v", cliErr.Details["ResolvedLine"])
+	}
+	if cliErr.Details["ResolvedLineText"] != "    DoJump();" {
+		t.Fatalf("ResolvedLineText mismatch: %#v", cliErr.Details["ResolvedLineText"])
+	}
+	if cliErr.Details["ResolvedMethod"] != "Player.Update" {
+		t.Fatalf("ResolvedMethod mismatch: %#v", cliErr.Details["ResolvedMethod"])
+	}
+	if cliErr.Details["SnapshotTiming"] != "OnEnter" {
+		t.Fatalf("SnapshotTiming mismatch: %#v", cliErr.Details["SnapshotTiming"])
+	}
+}
+
+// Verifies Expired with a non-zero ResolvedLine and empty ResolvedLineText still adds the
+// reading note and omits the empty text key from Details.
+func TestPausePointExpiredErrorNotesResolvedLineWhenTextEmpty(t *testing.T) {
+	response := pausePointStatusResponse{
+		Id:               "jump",
+		Status:           pausePointStatusExpired,
+		Expired:          true,
+		ResolvedLine:     55,
+		ResolvedLineText: "",
+		EditorState:      pausePointEditorState{IsPlaying: true, CapturedAt: "Current"},
+	}
+
+	cliErr := pausePointWaitError("/tmp/MyProject", waitForPausePointOptions{
+		id:             "jump",
+		timeoutSeconds: 1,
+	}, response, pausePointWaitStateExpired, false, false)
+
+	if cliErr.Details["ResolvedLine"] != 55 {
+		t.Fatalf("ResolvedLine mismatch: %#v", cliErr.Details["ResolvedLine"])
+	}
+	if _, present := cliErr.Details["ResolvedLineText"]; present {
+		t.Fatalf("ResolvedLineText must be absent, got %#v", cliErr.Details["ResolvedLineText"])
+	}
+	wantMessage := "Pause point expired before it was hit. The marker stayed armed at the resolved line shown in Details; that line was never executed within the window."
+	if cliErr.Message != wantMessage {
+		t.Fatalf("Message mismatch:\nwant: %q\ngot:  %q", wantMessage, cliErr.Message)
+	}
+}
+
+// Verifies a Timeout envelope stays byte-identical for Resolved* even when the status stub
+// already carries ResolvedLine.
+func TestPausePointTimeoutErrorOmitsResolvedFieldDetails(t *testing.T) {
+	response := pausePointStatusResponse{
+		Id:               "jump",
+		Status:           pausePointStatusEnabled,
+		IsEnabled:        true,
+		ResolvedLine:     42,
+		ResolvedLineText: "    DoJump();",
+		ResolvedMethod:   "Player.Update",
+		SnapshotTiming:   "OnEnter",
+		EditorState:      pausePointEditorState{IsPlaying: true, CapturedAt: "Current"},
+		HitCount:         0,
+	}
+
+	cliErr := pausePointWaitError("/tmp/MyProject", waitForPausePointOptions{
+		id:             "jump",
+		timeoutSeconds: 1,
+	}, response, pausePointWaitStateTimeout, false, false)
+
+	if cliErr.Message != "Pause point was not hit within 1s." {
+		t.Fatalf("Message mismatch: %q", cliErr.Message)
+	}
+	for _, field := range []string{"ResolvedLine", "ResolvedLineText", "ResolvedMethod", "SnapshotTiming"} {
+		if _, present := cliErr.Details[field]; present {
+			t.Fatalf("%s must be absent from Timeout Details, got %#v", field, cliErr.Details[field])
+		}
+	}
+}
+
 // Verifies disabled native pause-point commands are rejected before Unity dispatch.
 func TestRunProjectLocalWaitForPausePointRespectsToolSettings(t *testing.T) {
 	projectRoot := createLaunchTestProject(t)


### PR DESCRIPTION
## Summary
- `enable-pause-point --await` that ends with `Status: Expired` now repeats the enable-time resolved marker fields, so callers can tell which statement stayed armed without a second Unity round trip.

## User Impact
- Before: an Expired `--await` error had no `ResolvedLine` / `ResolvedLineText` / `ResolvedMethod` / `SnapshotTiming`, so a wrong armed line and a correct line that never ran looked the same.
- After: those four fields are copied from the enable response into `Details` (same merge as the hit path), and `Message` points at `ResolvedLine` / `ResolvedLineText`. Standalone `pause-point-status` is unchanged: Unity's status payload still does not carry `ResolvedMethod` / `SnapshotTiming`.

## Changes
- Reuse the hit-path enable-time merge on the Expired `--await` path (`ResolvedLine`/`ResolvedLineText` as a pair; `ResolvedMethod`/`SnapshotTiming` always from enable).
- Echo non-empty resolved fields on the Expired error `Details`, and append a one-line reading note to `Message` when a resolved line is present.
- Update the shared response type comment to document the Expired merge.
- Move the merge helper into `pause_point_enable_resolved_fields.go` so `pause_point_enable.go` stays under the 500-line cap.

## Verification
- `scripts/check-go-cli.sh` passed (format, vet, lint, tests, dist rebuild).
- `TestRunPausePointWaitAfterEnablePropagatesResolvedFieldsOnExpired` ran and passed with fixed-literal expectations for the four fields and the Message sentence.
- Existing hit-path resolved-field tests still passed (`AwaitPropagatesFileLineResolvedFields`, `AwaitPrefersStatusResolvedFieldsOverEnable`, `AwaitKeepsStatusResolvedPairWhenTextEmpty`, `AwaitOmitsResolvedFieldsForMethodArm`).
- Live Unity Expired `--await` was not re-run (unit-tested via `runPausePointWaitAfterEnable` with a stubbed Expired status).
