### PR TITLE
feat: warn when a window screenshot is captured during Play Mode

### DIFF
--- a/.agents/skills/uloop-screenshot/SKILL.md
+++ b/.agents/skills/uloop-screenshot/SKILL.md
@@ -51,6 +51,7 @@ The window name is the text displayed in the window's title bar (tab). Common na
 Returns JSON with:
 
 - `ScreenshotCount`: Number of windows captured
+- `Warning`: Appears only for window captures taken while Play Mode is running with at least one image.
 - `Screenshots`: Array of screenshot info, each containing:
   - `ImagePath`: Absolute path to the saved PNG file. Empty when `--elements-only` is used because no image file is written. Always open the file named here — the output directory accumulates every past capture, so guessing the newest file with directory listing (`ls -t` or similar) can silently pick a stale screenshot from an earlier run.
   - `FileSizeBytes`: Size of the saved file in bytes

--- a/.claude/skills/uloop-screenshot/SKILL.md
+++ b/.claude/skills/uloop-screenshot/SKILL.md
@@ -51,6 +51,7 @@ The window name is the text displayed in the window's title bar (tab). Common na
 Returns JSON with:
 
 - `ScreenshotCount`: Number of windows captured
+- `Warning`: Appears only for window captures taken while Play Mode is running with at least one image.
 - `Screenshots`: Array of screenshot info, each containing:
   - `ImagePath`: Absolute path to the saved PNG file. Empty when `--elements-only` is used because no image file is written. Always open the file named here — the output directory accumulates every past capture, so guessing the newest file with directory listing (`ls -t` or similar) can silently pick a stale screenshot from an earlier run.
   - `FileSizeBytes`: Size of the saved file in bytes

--- a/Assets/Tests/Editor/ScreenshotPlayModeWindowWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/ScreenshotPlayModeWindowWarningBuilderTests.cs
@@ -6,17 +6,17 @@ using io.github.hatayama.UnityCliLoop.ToolContracts;
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
     /// <summary>
-    /// Verifies the Play Mode window-capture Warning is emitted only for window + playing.
+    /// Verifies the Play Mode window-capture Warning is emitted only for window + playing + at least one image.
     /// </summary>
     public sealed class ScreenshotPlayModeWindowWarningBuilderTests
     {
         /// <summary>
-        /// What: a window capture during Play Mode warns that Editor chrome is included.
+        /// What: a window capture during Play Mode with at least one image warns that Editor chrome is included.
         /// </summary>
         [Test]
         public void Build_WhenWindowCaptureDuringPlayMode_ReturnsChromeWarning()
         {
-            string warning = ScreenshotPlayModeWindowWarningBuilder.Build(CaptureMode.window, true);
+            string warning = ScreenshotPlayModeWindowWarningBuilder.Build(CaptureMode.window, true, 1);
 
             Assert.That(
                 warning,
@@ -30,7 +30,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void Build_WhenWindowCaptureInEditMode_ReturnsEmpty()
         {
-            string warning = ScreenshotPlayModeWindowWarningBuilder.Build(CaptureMode.window, false);
+            string warning = ScreenshotPlayModeWindowWarningBuilder.Build(CaptureMode.window, false, 1);
 
             Assert.That(warning, Is.EqualTo(string.Empty));
         }
@@ -41,7 +41,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void Build_WhenRenderingCaptureDuringPlayMode_ReturnsEmpty()
         {
-            string warning = ScreenshotPlayModeWindowWarningBuilder.Build(CaptureMode.rendering, true);
+            string warning = ScreenshotPlayModeWindowWarningBuilder.Build(CaptureMode.rendering, true, 1);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: a Play Mode window capture with zero images does not warn about chrome that was never saved.
+        /// </summary>
+        [Test]
+        public void Build_WhenWindowCaptureDuringPlayModeWithZeroImages_ReturnsEmpty()
+        {
+            string warning = ScreenshotPlayModeWindowWarningBuilder.Build(CaptureMode.window, true, 0);
 
             Assert.That(warning, Is.EqualTo(string.Empty));
         }

--- a/Assets/Tests/Editor/ScreenshotPlayModeWindowWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/ScreenshotPlayModeWindowWarningBuilderTests.cs
@@ -1,0 +1,49 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies the Play Mode window-capture Warning is emitted only for window + playing.
+    /// </summary>
+    public sealed class ScreenshotPlayModeWindowWarningBuilderTests
+    {
+        /// <summary>
+        /// What: a window capture during Play Mode warns that Editor chrome is included.
+        /// </summary>
+        [Test]
+        public void Build_WhenWindowCaptureDuringPlayMode_ReturnsChromeWarning()
+        {
+            string warning = ScreenshotPlayModeWindowWarningBuilder.Build(CaptureMode.window, true);
+
+            Assert.That(
+                warning,
+                Is.EqualTo(
+                    "This window capture includes Unity Editor chrome. If you wanted the Game View image (typical during Play Mode), re-run with --capture-mode rendering."));
+        }
+
+        /// <summary>
+        /// What: a window capture in Edit Mode does not warn.
+        /// </summary>
+        [Test]
+        public void Build_WhenWindowCaptureInEditMode_ReturnsEmpty()
+        {
+            string warning = ScreenshotPlayModeWindowWarningBuilder.Build(CaptureMode.window, false);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: a rendering capture during Play Mode does not warn.
+        /// </summary>
+        [Test]
+        public void Build_WhenRenderingCaptureDuringPlayMode_ReturnsEmpty()
+        {
+            string warning = ScreenshotPlayModeWindowWarningBuilder.Build(CaptureMode.rendering, true);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+    }
+}

--- a/Assets/Tests/Editor/ScreenshotPlayModeWindowWarningBuilderTests.cs.meta
+++ b/Assets/Tests/Editor/ScreenshotPlayModeWindowWarningBuilderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db51b27acd5b84794a6b9050f8884be2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/ScreenshotResponseWarningContractTests.cs
+++ b/Assets/Tests/Editor/ScreenshotResponseWarningContractTests.cs
@@ -1,0 +1,61 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Pins ScreenshotResponse.Warning wire presence so deleting ShouldSerializeWarning cannot go unnoticed.
+    /// </summary>
+    public sealed class ScreenshotResponseWarningContractTests
+    {
+        /// <summary>
+        /// What: an empty Warning is omitted from production JSON so `"Warning":""` cannot reappear unnoticed.
+        /// </summary>
+        [Test]
+        public void ScreenshotResponse_WhenWarningIsEmpty_OmitsWarningPropertyFromJson()
+        {
+            ScreenshotResponse response = new ScreenshotResponse();
+
+            string json = JsonConvert.SerializeObject(
+                response,
+                Formatting.None,
+                JsonRpcResponseSerializer.Settings);
+            JObject parsed = JObject.Parse(json);
+
+            Assert.That(json, Does.Not.Contain("\"Warning\""));
+            Assert.That(parsed.Property("Warning"), Is.Null);
+        }
+
+        /// <summary>
+        /// What: a set Warning serializes under Warning with the exact chrome-warning sentence.
+        /// </summary>
+        [Test]
+        public void ScreenshotResponse_WhenWarningIsSet_SerializesExactChromeWarningSentence()
+        {
+            ScreenshotResponse response = new ScreenshotResponse
+            {
+                Warning =
+                    "This window capture includes Unity Editor chrome. If you wanted the Game View image (typical during Play Mode), re-run with --capture-mode rendering."
+            };
+
+            string json = JsonConvert.SerializeObject(
+                response,
+                Formatting.None,
+                JsonRpcResponseSerializer.Settings);
+            JObject parsed = JObject.Parse(json);
+
+            Assert.That(
+                json,
+                Does.Contain(
+                    "\"Warning\":\"This window capture includes Unity Editor chrome. If you wanted the Game View image (typical during Play Mode), re-run with --capture-mode rendering.\""));
+            Assert.That(
+                parsed.Value<string>("Warning"),
+                Is.EqualTo(
+                    "This window capture includes Unity Editor chrome. If you wanted the Game View image (typical during Play Mode), re-run with --capture-mode rendering."));
+        }
+    }
+}

--- a/Assets/Tests/Editor/ScreenshotResponseWarningContractTests.cs.meta
+++ b/Assets/Tests/Editor/ScreenshotResponseWarningContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7bacf2a126b984fac8d8584fbb1bba9a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotPlayModeWindowWarningBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotPlayModeWindowWarningBuilder.cs
@@ -1,0 +1,22 @@
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Builds the Warning for a window screenshot taken while Play Mode is running.
+    /// </summary>
+    internal static class ScreenshotPlayModeWindowWarningBuilder
+    {
+        // Why only window+playing: rendering already is the Game View image, and Edit Mode
+        // window captures are the expected chrome-inclusive Editor screenshot.
+        public static string Build(CaptureMode captureMode, bool isPlaying)
+        {
+            if (captureMode != CaptureMode.window || !isPlaying)
+            {
+                return string.Empty;
+            }
+
+            return "This window capture includes Unity Editor chrome. If you wanted the Game View image (typical during Play Mode), re-run with --capture-mode rendering.";
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotPlayModeWindowWarningBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotPlayModeWindowWarningBuilder.cs
@@ -7,11 +7,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class ScreenshotPlayModeWindowWarningBuilder
     {
-        // Why only window+playing: rendering already is the Game View image, and Edit Mode
-        // window captures are the expected chrome-inclusive Editor screenshot.
-        public static string Build(CaptureMode captureMode, bool isPlaying)
+        // Why window+playing+at-least-one-image: rendering already is the Game View image,
+        // Edit Mode window captures are the expected chrome-inclusive Editor screenshot,
+        // and a chrome warning would describe images that do not exist when capturedCount is 0.
+        public static string Build(CaptureMode captureMode, bool isPlaying, int capturedCount)
         {
-            if (captureMode != CaptureMode.window || !isPlaying)
+            if (captureMode != CaptureMode.window || !isPlaying || capturedCount == 0)
             {
                 return string.Empty;
             }

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotPlayModeWindowWarningBuilder.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotPlayModeWindowWarningBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4fb9acf84482042ab893a6a258b2287b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -540,7 +540,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 correlationId: correlationId
             );
 
-            return new ScreenshotResponse { Screenshots = screenshots };
+            return new ScreenshotResponse
+            {
+                Screenshots = screenshots,
+                Warning = ScreenshotPlayModeWindowWarningBuilder.Build(
+                    request.CaptureMode, EditorApplication.isPlaying)
+            };
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -432,6 +432,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string safeWindowName = ScreenshotCaptureResults.SanitizeFileName(captureWindowName);
             string timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss_fff");
             List<ScreenshotInfo> screenshots = new();
+            // Why before the loop: a Play Mode exit mid-capture must not skew the chrome Warning.
+            bool isPlaying = EditorApplication.isPlaying;
 
             // Why SwitchTo before hide: SetActive/Canvas/RT clear are main-thread only. Keep this
             // await outside try — nothing is hidden yet if cancellation throws here.
@@ -451,10 +453,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         ct).ConfigureAwait(false);
                     if (!hideFramesReady)
                     {
-                        return ScreenshotCaptureResults.CreateTimedOutResult(
+                        ScreenshotResponse hideTimedOut = ScreenshotCaptureResults.CreateTimedOutResult(
                             "input visualization overlay hide",
                             correlationId,
                             screenshots);
+                        hideTimedOut.Warning = ScreenshotPlayModeWindowWarningBuilder.Build(
+                            request.CaptureMode, isPlaying, hideTimedOut.Screenshots.Count);
+                        return hideTimedOut;
                     }
 
                     await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
@@ -470,7 +475,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         ct).ConfigureAwait(false);
                     if (timedOut)
                     {
-                        return ScreenshotCaptureResults.CreateTimedOutResult("EditorWindow capture", correlationId, screenshots);
+                        ScreenshotResponse captureTimedOut = ScreenshotCaptureResults.CreateTimedOutResult(
+                            "EditorWindow capture",
+                            correlationId,
+                            screenshots);
+                        captureTimedOut.Warning = ScreenshotPlayModeWindowWarningBuilder.Build(
+                            request.CaptureMode, isPlaying, captureTimedOut.Screenshots.Count);
+                        return captureTimedOut;
                     }
 
                     await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
@@ -544,7 +555,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 Screenshots = screenshots,
                 Warning = ScreenshotPlayModeWindowWarningBuilder.Build(
-                    request.CaptureMode, EditorApplication.isPlaying)
+                    request.CaptureMode, isPlaying, screenshots.Count)
             };
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/SKILL.md
@@ -51,6 +51,7 @@ The window name is the text displayed in the window's title bar (tab). Common na
 Returns JSON with:
 
 - `ScreenshotCount`: Number of windows captured
+- `Warning`: Appears only for window captures taken while Play Mode is running with at least one image.
 - `Screenshots`: Array of screenshot info, each containing:
   - `ImagePath`: Absolute path to the saved PNG file. Empty when `--elements-only` is used because no image file is written. Always open the file named here — the output directory accumulates every past capture, so guessing the newest file with directory listing (`ls -t` or similar) can silently pick a stale screenshot from an earlier run.
   - `FileSizeBytes`: Size of the saved file in bytes

--- a/Packages/src/Editor/ToolContracts/ScreenshotResponse.cs
+++ b/Packages/src/Editor/ToolContracts/ScreenshotResponse.cs
@@ -37,8 +37,15 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public List<ScreenshotInfo> Screenshots { get; set; } = new List<ScreenshotInfo>();
         public bool TimedOut { get; set; }
         public string Message { get; set; } = "";
+        public string Warning { get; set; } = "";
         public string[] NextActions { get; set; } = new string[0];
 
         public int ScreenshotCount => Screenshots.Count;
+
+        // Why omit empty: Edit Mode and rendering captures must not grow a Warning field.
+        public bool ShouldSerializeWarning()
+        {
+            return !string.IsNullOrEmpty(Warning);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `uloop screenshot` with the default window capture now warns during Play Mode that the image includes Unity Editor chrome, and points at `--capture-mode rendering`.

## User Impact
- Before: Play Mode window captures included Editor chrome, and the only hint was `ScreenshotToInputFormula: "unavailable: ..."`, which cost an extra round trip.
- After: the same capture returns a `Warning` telling agents to re-run with `--capture-mode rendering` if they wanted the Game View image.

## Changes
- Add a Play Mode window-capture Warning on successful window screenshots.
- Omit the field when capture-mode is rendering or Unity is in Edit Mode.
- Assert the three cases as fixed literals.

Closes #2306

## Verification
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>` → Success, ErrorCount 0
- `dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value ScreenshotPlayModeWindowWarningBuilderTests` → Passed (3/3)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

