### PR TITLE
feat: warn when hot-reload leaves unpatched-method line numbers shifted from compiled source

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilderTests.cs
@@ -31,7 +31,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 warning,
                 Is.EqualTo(
-                    "Assets/Scripts/Player.cs: line numbers have shifted vs the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods resolve against the edited file."));
+                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
+        }
+
+        /// <summary>
+        /// What: a file whose edited source lost a line vs compiled still warns (count can shrink).
+        /// </summary>
+        [Test]
+        public void Build_WhenEditedLineCountIsFewerThanCompiled_ReturnsShiftWarning()
+        {
+            string warning = HotReloadUnpatchedMethodLineShiftWarningBuilder.Build(
+                "Assets/Scripts/Player.cs",
+                "line1\nline2",
+                "line1\nline2\nline3");
+
+            Assert.That(
+                warning,
+                Is.EqualTo(
+                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 2 lines vs compiled 3). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
         }
 
         /// <summary>
@@ -46,6 +63,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "alpha-edited\nbeta-edited");
 
             Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: CRLF vs LF with the same logical lines is not a count change after newline normalization.
+        /// </summary>
+        [Test]
+        public void Build_WhenCrlfAndLfHaveSameLogicalLineCount_ReturnsEmpty()
+        {
+            string warning = HotReloadUnpatchedMethodLineShiftWarningBuilder.Build(
+                "Assets/Scripts/Player.cs",
+                "line1\r\nline2",
+                "line1\nline2");
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: a trailing newline alone increases the split count and therefore warns.
+        /// </summary>
+        [Test]
+        public void Build_WhenOnlyTrailingNewlineAddsALine_ReturnsShiftWarning()
+        {
+            string warning = HotReloadUnpatchedMethodLineShiftWarningBuilder.Build(
+                "Assets/Scripts/Player.cs",
+                "line1\nline2\n",
+                "line1\nline2");
+
+            Assert.That(
+                warning,
+                Is.EqualTo(
+                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
         }
 
         /// <summary>
@@ -85,7 +133,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 warnings[0],
                 Is.EqualTo(
-                    "Assets/Scripts/Player.cs: line numbers have shifted vs the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods resolve against the edited file."));
+                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
+        }
+
+        /// <summary>
+        /// What: relative and absolute spellings of the same apply file emit one warning labeled
+        /// with the project-relative path.
+        /// </summary>
+        [Test]
+        public void Append_WhenSameFileIsRelativeAndAbsolute_AddsOneWarningLabeledWithRelativePath()
+        {
+            string relativePath = "Assets/Scripts/Player.cs";
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string absolutePath = Path.Combine(
+                projectRoot,
+                relativePath.Replace('/', Path.DirectorySeparatorChar));
+
+            List<string> warnings = new List<string>();
+            List<HotReloadMethodOutcome> methods = new List<HotReloadMethodOutcome>
+            {
+                HotReloadMethodOutcome.Patched("Player.Jump", relativePath),
+                HotReloadMethodOutcome.Patched("Player.Move", absolutePath)
+            };
+
+            HotReloadUnpatchedMethodLineShiftWarningBuilder.Append(
+                warnings,
+                methods,
+                file => "line1\nline2\nline3",
+                file => "line1\nline2");
+
+            Assert.That(warnings.Count, Is.EqualTo(1));
+            Assert.That(
+                warnings[0],
+                Is.EqualTo(
+                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
         }
 
         /// <summary>
@@ -115,11 +196,45 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 warnings[0],
                 Is.EqualTo(
-                    "Assets/Scripts/Player.cs: line numbers have shifted vs the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods resolve against the edited file."));
+                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
         }
 
         /// <summary>
-        /// What: a line-shift warning counted with one other hot-reload warning keeps the
+        /// What: two files that both change line count each get their own warning.
+        /// </summary>
+        [Test]
+        public void Append_WhenTwoFilesBothShifted_AddsTwoWarnings()
+        {
+            List<string> warnings = new List<string>();
+            List<HotReloadMethodOutcome> methods = new List<HotReloadMethodOutcome>
+            {
+                HotReloadMethodOutcome.Patched("Player.Jump", "Assets/Scripts/Player.cs"),
+                HotReloadMethodOutcome.Patched("Enemy.Idle", "Assets/Scripts/Enemy.cs")
+            };
+
+            HotReloadUnpatchedMethodLineShiftWarningBuilder.Append(
+                warnings,
+                methods,
+                file => file.IndexOf("Player", StringComparison.Ordinal) >= 0
+                    ? "line1\nline2\nline3"
+                    : "a\nb\nc\nd",
+                file => file.IndexOf("Player", StringComparison.Ordinal) >= 0
+                    ? "line1\nline2"
+                    : "a\nb");
+
+            Assert.That(warnings.Count, Is.EqualTo(2));
+            Assert.That(
+                warnings[0],
+                Is.EqualTo(
+                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
+            Assert.That(
+                warnings[1],
+                Is.EqualTo(
+                    "Assets/Scripts/Enemy.cs: line count differs from the last compiled source (edited 4 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
+        }
+
+        /// <summary>
+        /// What: a line-count warning counted with one other hot-reload warning keeps the
         /// single-compile resolution suffix, because compile restores compiled-source line numbers.
         /// </summary>
         [Test]
@@ -153,7 +268,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Assert.That(
                     response.Warnings[1],
                     Is.EqualTo(
-                        "Library/UloopHotReload/TestSources/line-shift-warning-probe.cs: line numbers have shifted vs the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods resolve against the edited file."));
+                        "Library/UloopHotReload/TestSources/line-shift-warning-probe.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
                 Assert.That(
                     response.Message,
                     Is.EqualTo(

--- a/Assets/Tests/Editor/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilderTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Verifies hot-reload apply warns when a patched file's line count differs from last compiled source.
+    /// </summary>
+    public sealed class HotReloadUnpatchedMethodLineShiftWarningBuilderTests
+    {
+        /// <summary>
+        /// What: a file whose edited source gained lines vs the last compiled snapshot warns that
+        /// unpatched methods still resolve --line against compiled source.
+        /// </summary>
+        [Test]
+        public void Build_WhenEditedLineCountDiffersFromCompiled_ReturnsShiftWarning()
+        {
+            string warning = HotReloadUnpatchedMethodLineShiftWarningBuilder.Build(
+                "Assets/Scripts/Player.cs",
+                "line1\nline2\nline3",
+                "line1\nline2");
+
+            Assert.That(
+                warning,
+                Is.EqualTo(
+                    "Assets/Scripts/Player.cs: line numbers have shifted vs the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods resolve against the edited file."));
+        }
+
+        /// <summary>
+        /// What: a same-line-count edit (body-only change) does not emit the line-shift warning.
+        /// </summary>
+        [Test]
+        public void Build_WhenEditedAndCompiledLineCountsMatch_ReturnsEmpty()
+        {
+            string warning = HotReloadUnpatchedMethodLineShiftWarningBuilder.Build(
+                "Assets/Scripts/Player.cs",
+                "alpha\nbeta",
+                "alpha-edited\nbeta-edited");
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: a missing compiled snapshot cannot claim a line-count shift, so no warning is emitted.
+        /// </summary>
+        [Test]
+        public void Build_WhenCompiledSourceIsMissing_ReturnsEmpty()
+        {
+            string warning = HotReloadUnpatchedMethodLineShiftWarningBuilder.Build(
+                "Assets/Scripts/Player.cs",
+                "line1\nline2\nline3",
+                null);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: two methods in the same shifted file produce a single warning for that file.
+        /// </summary>
+        [Test]
+        public void Append_WhenTwoMethodsShareAShiftedFile_AddsOneWarning()
+        {
+            List<string> warnings = new List<string>();
+            List<HotReloadMethodOutcome> methods = new List<HotReloadMethodOutcome>
+            {
+                HotReloadMethodOutcome.Patched("Player.Jump", "Assets/Scripts/Player.cs"),
+                HotReloadMethodOutcome.Skipped("Player.Move", "unchanged body", "Assets/Scripts/Player.cs")
+            };
+
+            HotReloadUnpatchedMethodLineShiftWarningBuilder.Append(
+                warnings,
+                methods,
+                file => "line1\nline2\nline3",
+                file => "line1\nline2");
+
+            Assert.That(warnings.Count, Is.EqualTo(1));
+            Assert.That(
+                warnings[0],
+                Is.EqualTo(
+                    "Assets/Scripts/Player.cs: line numbers have shifted vs the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods resolve against the edited file."));
+        }
+
+        /// <summary>
+        /// What: a two-file apply warns only for the file whose line count changed.
+        /// </summary>
+        [Test]
+        public void Append_WhenOneFileShiftedAndOneUnchanged_AddsOnlyShiftedFileWarning()
+        {
+            List<string> warnings = new List<string>();
+            List<HotReloadMethodOutcome> methods = new List<HotReloadMethodOutcome>
+            {
+                HotReloadMethodOutcome.Patched("Player.Jump", "Assets/Scripts/Player.cs"),
+                HotReloadMethodOutcome.Patched("Enemy.Idle", "Assets/Scripts/Enemy.cs")
+            };
+
+            HotReloadUnpatchedMethodLineShiftWarningBuilder.Append(
+                warnings,
+                methods,
+                file => file.IndexOf("Player", StringComparison.Ordinal) >= 0
+                    ? "line1\nline2\nline3"
+                    : "same\ncount",
+                file => file.IndexOf("Player", StringComparison.Ordinal) >= 0
+                    ? "line1\nline2"
+                    : "same\ncount");
+
+            Assert.That(warnings.Count, Is.EqualTo(1));
+            Assert.That(
+                warnings[0],
+                Is.EqualTo(
+                    "Assets/Scripts/Player.cs: line numbers have shifted vs the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods resolve against the edited file."));
+        }
+
+        /// <summary>
+        /// What: a line-shift warning counted with one other hot-reload warning keeps the
+        /// single-compile resolution suffix, because compile restores compiled-source line numbers.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_WhenLineShiftAndOneOtherHotReloadWarning_AppendsSingleCompileResolution()
+        {
+            string relativePath = "Library/UloopHotReload/TestSources/line-shift-warning-probe.cs";
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string absolutePath = Path.Combine(
+                projectRoot,
+                relativePath.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(absolutePath));
+            File.WriteAllText(absolutePath, "line1\nline2\nline3");
+
+            Func<string, string> previousLoader =
+                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile;
+            HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = _ => "line1\nline2";
+            try
+            {
+                HotReloadResponse response = HotReloadTool.BuildApplyResponse(
+                    new HotReloadOrchestratorResult(
+                        new List<HotReloadMethodOutcome>
+                        {
+                            HotReloadMethodOutcome.Patched("Probe.M", relativePath)
+                        },
+                        new List<string> { "const-drift" },
+                        patchedTotal: 1,
+                        activePatchTotal: 1));
+
+                Assert.That(response.Warnings.Count, Is.EqualTo(2));
+                Assert.That(response.Warnings[0], Is.EqualTo("const-drift"));
+                Assert.That(
+                    response.Warnings[1],
+                    Is.EqualTo(
+                        "Library/UloopHotReload/TestSources/line-shift-warning-probe.cs: line numbers have shifted vs the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods resolve against the edited file."));
+                Assert.That(
+                    response.Message,
+                    Is.EqualTo(
+                        "Hot reload applied. PatchedTotal=1, ActivePatchTotal=1. "
+                        + "2 warning(s). See Warnings. "
+                        + "A single 'uloop compile' clears all of them at once."));
+            }
+            finally
+            {
+                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = previousLoader;
+                if (File.Exists(absolutePath))
+                {
+                    File.Delete(absolutePath);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilderTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4fee02e141f534f3aa1d6d2aa07436fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -243,6 +243,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             List<string> warnings = new List<string>(result.Warnings);
+            // Why before the pause-point extras: this warning is cleared by compile, so it must
+            // count toward the single-compile resolution suffix instead of suppressing it.
+            HotReloadUnpatchedMethodLineShiftWarningBuilder.Append(
+                warnings,
+                result.Methods,
+                HotReloadUnpatchedMethodLineShiftWarningBuilder.ReadEditedSourceFromDisk,
+                HotReloadUnpatchedMethodLineShiftWarningBuilder.ReadCompiledSnapshot);
             int orchestratorWarningCount = warnings.Count;
             AppendRetargetLineDriftWarnings(warnings);
             AppendExpiredNotRetargetedWarnings(warnings);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilder.cs
@@ -14,9 +14,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class HotReloadUnpatchedMethodLineShiftWarningBuilder
     {
-        // Why file+line-count only: pause-point --line for methods not patched in this run still
-        // resolves against the compiled snapshot; one sentence per file is enough.
-        // Why empty when counts match: in-body edits do not shift later methods' compiled lines.
+        // Why "line count differs" not "line numbers have shifted": a trailing newline changes
+        // the split count without moving statements. Why "patched methods with debug symbols":
+        // PatchedMethodPdbUnavailable still falls through to the compiled line map.
         public static string Build(string file, string editedSource, string compiledSource)
         {
             if (string.IsNullOrEmpty(file) || editedSource == null || string.IsNullOrEmpty(compiledSource))
@@ -34,14 +34,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string normalizedFile = HotReloadSourcePathNormalizer.ToForwardSlashes(file);
             return string.Format(
                 CultureInfo.InvariantCulture,
-                "{0}: line numbers have shifted vs the last compiled source (edited {1} lines vs compiled {2}). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods resolve against the edited file.",
+                "{0}: line count differs from the last compiled source (edited {1} lines vs compiled {2}). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file.",
                 normalizedFile,
                 editedLineCount,
                 compiledLineCount);
         }
 
-        // Why unique file: the apply lists one Methods row per member; one shift sentence per file
-        // is enough for agents to recompute --line against compiled source.
+        // Why unique canonical file: outcome FilePath is the raw apply input, so absolute+relative
+        // (or Windows casing) spellings of one file would otherwise emit duplicate warnings.
         public static void Append(
             List<string> warnings,
             IReadOnlyList<HotReloadMethodOutcome> methods,
@@ -53,7 +53,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(readEditedSource != null, "readEditedSource must not be null.");
             Debug.Assert(readCompiledSource != null, "readCompiledSource must not be null.");
 
-            HashSet<string> seenFiles = new HashSet<string>(StringComparer.Ordinal);
+            StringComparer fileComparer = Application.platform == RuntimePlatform.WindowsEditor
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal;
+            HashSet<string> seenFiles = new HashSet<string>(fileComparer);
             for (int index = 0; index < methods.Count; index++)
             {
                 string filePath = methods[index].FilePath;
@@ -62,16 +65,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                string normalizedFile = HotReloadSourcePathNormalizer.ToForwardSlashes(filePath);
-                if (!seenFiles.Add(normalizedFile))
+                string canonicalFile = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(filePath);
+                if (!seenFiles.Add(canonicalFile))
                 {
                     continue;
                 }
 
                 string warning = Build(
-                    normalizedFile,
-                    readEditedSource(filePath),
-                    readCompiledSource(filePath));
+                    canonicalFile,
+                    readEditedSource(canonicalFile),
+                    readCompiledSource(canonicalFile));
                 if (warning.Length == 0)
                 {
                     continue;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilder.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Builds the apply Warning when a hot-reloaded file's line count differs from last compiled source.
+    /// </summary>
+    internal static class HotReloadUnpatchedMethodLineShiftWarningBuilder
+    {
+        // Why file+line-count only: pause-point --line for methods not patched in this run still
+        // resolves against the compiled snapshot; one sentence per file is enough.
+        // Why empty when counts match: in-body edits do not shift later methods' compiled lines.
+        public static string Build(string file, string editedSource, string compiledSource)
+        {
+            if (string.IsNullOrEmpty(file) || editedSource == null || string.IsNullOrEmpty(compiledSource))
+            {
+                return string.Empty;
+            }
+
+            int editedLineCount = CountLines(editedSource);
+            int compiledLineCount = CountLines(compiledSource);
+            if (editedLineCount == compiledLineCount)
+            {
+                return string.Empty;
+            }
+
+            string normalizedFile = HotReloadSourcePathNormalizer.ToForwardSlashes(file);
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "{0}: line numbers have shifted vs the last compiled source (edited {1} lines vs compiled {2}). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods resolve against the edited file.",
+                normalizedFile,
+                editedLineCount,
+                compiledLineCount);
+        }
+
+        // Why unique file: the apply lists one Methods row per member; one shift sentence per file
+        // is enough for agents to recompute --line against compiled source.
+        public static void Append(
+            List<string> warnings,
+            IReadOnlyList<HotReloadMethodOutcome> methods,
+            Func<string, string> readEditedSource,
+            Func<string, string> readCompiledSource)
+        {
+            Debug.Assert(warnings != null, "warnings must not be null.");
+            Debug.Assert(methods != null, "methods must not be null.");
+            Debug.Assert(readEditedSource != null, "readEditedSource must not be null.");
+            Debug.Assert(readCompiledSource != null, "readCompiledSource must not be null.");
+
+            HashSet<string> seenFiles = new HashSet<string>(StringComparer.Ordinal);
+            for (int index = 0; index < methods.Count; index++)
+            {
+                string filePath = methods[index].FilePath;
+                if (string.IsNullOrEmpty(filePath))
+                {
+                    continue;
+                }
+
+                string normalizedFile = HotReloadSourcePathNormalizer.ToForwardSlashes(filePath);
+                if (!seenFiles.Add(normalizedFile))
+                {
+                    continue;
+                }
+
+                string warning = Build(
+                    normalizedFile,
+                    readEditedSource(filePath),
+                    readCompiledSource(filePath));
+                if (warning.Length == 0)
+                {
+                    continue;
+                }
+
+                warnings.Add(warning);
+            }
+        }
+
+        internal static string ReadEditedSourceFromDisk(string projectRelativePath)
+        {
+            if (string.IsNullOrEmpty(projectRelativePath))
+            {
+                return null;
+            }
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string absolutePath = Path.Combine(
+                projectRoot,
+                projectRelativePath.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(absolutePath))
+            {
+                return null;
+            }
+
+            return File.ReadAllText(absolutePath);
+        }
+
+        internal static string ReadCompiledSnapshot(string projectRelativePath)
+        {
+            if (string.IsNullOrEmpty(projectRelativePath))
+            {
+                return null;
+            }
+
+            Func<string, string> loader = HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile;
+            if (loader == null)
+            {
+                return null;
+            }
+
+            return loader(HotReloadSourcePathNormalizer.ToForwardSlashes(projectRelativePath));
+        }
+
+        // Why the same split as pause-point compiled-line reads: --line is 1-based against that split,
+        // so this warning's N vs M must use that counting, not a different newline convention.
+        private static int CountLines(string sourceText)
+        {
+            if (string.IsNullOrEmpty(sourceText))
+            {
+                return 0;
+            }
+
+            return sourceText.Replace("\r\n", "\n").Split('\n').Length;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilder.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8fa853709e7e147f38533d23a7c663c5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- After a hot-reload apply that adds or removes lines, the success response now warns that `enable-pause-point --line` for methods not patched in that run still uses last compiled source.

## User Impact
- Before, a line-shifting hot reload succeeded with no mention of compiled vs edited line numbers. The next `enable-pause-point --line` against an unpatched method in the same file failed, and only that error explained the rule.
- After, the apply `Warnings` array includes one sentence per shifted file, with edited vs compiled line counts, so the compiled-source `--line` rule is visible on the successful reload.

## Changes
- Compare each apply file's current source against the existing compiled snapshot (`GetVerifiedSnapshotSourceForFile`).
- Emit at most one warning per file, and only when the line counts differ (in-body edits stay quiet).
- Count the new warning with other compile-cleared hot-reload warnings so `A single 'uloop compile' clears all of them at once.` still appears when appropriate. Pause-point extras still suppress that suffix.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>`: Success, ErrorCount 0
- EditMode tests `HotReloadUnpatchedMethodLineShiftWarningBuilderTests|HotReloadToolTests`: TestCount 41, PassedCount 41


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

