### PR TITLE
fix: name the exit command in the EditMode-during-play test failure message

### DIFF
--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -18,7 +18,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies validation failures remain command failures without pretending tests failed.
             StubTestExecutionService executionService = new();
             StubTestExecutionStateValidationService validationService = new(
-                ValidationResult.Failure("EditMode tests cannot run during play mode"));
+                ValidationResult.Failure("EditMode tests cannot run during play mode. Use control-play-mode --action Stop to exit play mode, then rerun the tests."));
             RunTestsUseCase useCase = new(
                 new TestFilterCreationService(),
                 executionService,
@@ -38,7 +38,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.HasFailures, Is.False);
             Assert.That(response.NoTestsFound, Is.False);
             Assert.That(response.NoTestsFoundExplanation, Is.Empty);
-            Assert.That(response.Message, Is.EqualTo("EditMode tests cannot run during play mode"));
+            Assert.That(response.Message, Is.EqualTo("EditMode tests cannot run during play mode. Use control-play-mode --action Stop to exit play mode, then rerun the tests."));
             Assert.That(response.CompletedAt, Is.Not.Empty);
             Assert.That(response.TestCount, Is.EqualTo(0));
             Assert.That(response.PassedCount, Is.EqualTo(0));
@@ -288,7 +288,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             int cleanupWaitCount = 0;
             StubTestExecutionService executionService = new();
             StubTestExecutionStateValidationService validationService = new(
-                ValidationResult.Failure("EditMode tests cannot run during play mode"));
+                ValidationResult.Failure("EditMode tests cannot run during play mode. Use control-play-mode --action Stop to exit play mode, then rerun the tests."));
             RunTestsUseCase useCase = new(
                 new TestFilterCreationService(),
                 executionService,
@@ -370,7 +370,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool clearCalled = false;
             StubTestExecutionService executionService = new();
             StubTestExecutionStateValidationService validationService = new(
-                ValidationResult.Failure("EditMode tests cannot run during play mode"));
+                ValidationResult.Failure("EditMode tests cannot run during play mode. Use control-play-mode --action Stop to exit play mode, then rerun the tests."));
             RunTestsUseCase useCase = new(
                 new TestFilterCreationService(),
                 executionService,

--- a/Assets/Tests/Editor/TestExecutionStateValidationServiceTests.cs
+++ b/Assets/Tests/Editor/TestExecutionStateValidationServiceTests.cs
@@ -18,7 +18,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ValidationResult result = service.Validate(UnityCliLoopTestMode.EditMode, saveBeforeRun: false);
 
             Assert.That(result.IsValid, Is.False);
-            Assert.That(result.ErrorMessage, Is.EqualTo("EditMode tests cannot run during play mode"));
+            Assert.That(result.ErrorMessage, Is.EqualTo("EditMode tests cannot run during play mode. Use control-play-mode --action Stop to exit play mode, then rerun the tests."));
         }
 
         [Test]
@@ -96,7 +96,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ValidationResult result = service.Validate(UnityCliLoopTestMode.EditMode, saveBeforeRun: false);
 
             Assert.That(result.IsValid, Is.False);
-            Assert.That(result.ErrorMessage, Is.EqualTo("EditMode tests cannot run during play mode"));
+            Assert.That(result.ErrorMessage, Is.EqualTo("EditMode tests cannot run during play mode. Use control-play-mode --action Stop to exit play mode, then rerun the tests."));
         }
 
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionStateValidationService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionStateValidationService.cs
@@ -16,6 +16,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             "Use control-play-mode --action Play to resume, " +
             "or clear-pause-point --all if a pause point caused the pause.";
 
+        private const string EditModePlayModeBlockedMessage =
+            "EditMode tests cannot run during play mode. Use control-play-mode --action Stop to exit play mode, then rerun the tests.";
+
         private const string UnsavedEditorChangesFailureMessage =
             "Tests cannot run while the editor has unsaved scene or prefab changes. Save or discard these changes before running tests.";
         private const string UnsavedEditorChangesSaveFailureMessage =
@@ -68,7 +71,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (testMode == UnityCliLoopTestMode.EditMode && IsPlaying)
             {
-                return ValidationResult.Failure("EditMode tests cannot run during play mode");
+                return ValidationResult.Failure(EditModePlayModeBlockedMessage);
             }
 
             if (testMode == UnityCliLoopTestMode.PlayMode && IsPaused)


### PR DESCRIPTION
## Summary
- When EditMode tests are requested while Play Mode is running, the failure message now names `control-play-mode --action Stop` so the next action is explicit.

## User Impact
- Before: the message was only `EditMode tests cannot run during play mode`, with no command to leave Play Mode.
- After: the same failure tells you to stop Play Mode and rerun the tests, matching the existing paused-PlayMode guidance.

## Changes
- Promoted the EditMode-during-play failure text to a named constant and added the Stop command.
- Updated the six test literals that assert this message with `Is.EqualTo`.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Success, ErrorCount 0
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value "TestExecutionStateValidationServiceTests|RunTestsUseCaseTests"` → TestCount 32, PassedCount 32, FailedCount 0


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

