### PR TITLE
fix: name the missing test-assembly cause in the no-tests-found explanation

### DIFF
--- a/Assets/Tests/Editor/RunTestsTestFrameworkResultTests.cs
+++ b/Assets/Tests/Editor/RunTestsTestFrameworkResultTests.cs
@@ -154,7 +154,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result.status, Is.EqualTo(RunTestsExecutionStatus.NoTestsFound));
             Assert.That(result.hasFailures, Is.False);
             Assert.That(result.noTestsFound, Is.True);
-            Assert.That(result.noTestsFoundExplanation, Does.Contain("not a test failure"));
+            Assert.That(result.noTestsFoundExplanation, Is.EqualTo("No tests were discovered for this run. This is not a test failure; check TestMode, FilterType, and FilterValue. If newly added test scripts are never discovered, the most common cause is a missing test assembly: add an .asmdef with Test Assemblies enabled to the test folder (EditMode test assemblies target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests."));
             Assert.That(result.message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
             Assert.That(result.testCount, Is.EqualTo(0));
             Assert.That(result.failedCount, Is.EqualTo(0));

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -223,6 +223,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.HasFailures, Is.False);
             Assert.That(response.NoTestsFound, Is.True);
             Assert.That(response.NoTestsFoundExplanation, Does.Contain("not a test failure"));
+            Assert.That(response.NoTestsFoundExplanation, Does.Contain("missing test assembly"));
             Assert.That(response.Message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
             Assert.That(response.TestCount, Is.EqualTo(0));
             Assert.That(response.FailedCount, Is.EqualTo(0));

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
@@ -14,7 +14,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         internal const string NoTestsFoundMessage = "No tests found matching the specified filter criteria";
         internal const string NoTestsFoundExplanationText =
-            "No tests were discovered for this run. This is not a test failure; check TestMode, FilterType, FilterValue, or test assembly configuration.";
+            "No tests were discovered for this run. This is not a test failure; check TestMode, FilterType, and FilterValue. If newly added test scripts are never discovered, the most common cause is a missing test assembly: add an .asmdef with Test Assemblies enabled to the test folder (EditMode test assemblies target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests.";
 
         public static readonly string TestFrameworkUnavailableMessage =
             $"run-tests requires the Unity Test Framework package ({UnityCliLoopConstants.PACKAGE_NAME_TEST_FRAMEWORK}). Install it via Package Manager to use test execution.";


### PR DESCRIPTION
## Summary
- When `uloop run-tests` discovers zero tests, the explanation now names the most common cause: a missing test assembly.
- It also states the recovery steps: add an `.asmdef` with Test Assemblies enabled, target Editor for EditMode, reference assemblies under test, then compile and rerun.

## User Impact
- Before: a NoTestsFound result only said to check TestMode, filters, or "test assembly configuration". Agents often spent an extra round guessing that a new test folder needed a test asmdef.
- After: the explanation states that missing test assembly as the usual cause and how to fix it. The existing "not a test failure" wording is unchanged.

## Changes
- Update the NoTestsFound explanation literal to name the missing test-assembly cause and recovery steps.
- Keep the NoTestsFound message unchanged.
- Pin the new wording with a `Does.Contain("missing test assembly")` assertion on the existing NoTestsFound use-case test.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → ErrorCount 0, Success true
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value "RunTestsUseCaseTests"` → Status Passed, TestCount 21, FailedCount 0


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

