### PR TITLE
fix: warn that an asmdef cannot reference Assembly-CSharp in the no-tests-found explanation

### DIFF
--- a/Assets/Tests/Editor/RunTestsTestFrameworkResultTests.cs
+++ b/Assets/Tests/Editor/RunTestsTestFrameworkResultTests.cs
@@ -154,7 +154,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result.status, Is.EqualTo(RunTestsExecutionStatus.NoTestsFound));
             Assert.That(result.hasFailures, Is.False);
             Assert.That(result.noTestsFound, Is.True);
-            Assert.That(result.noTestsFoundExplanation, Is.EqualTo("No tests were discovered for this run. This is not a test failure; check TestMode, FilterType, and FilterValue. If newly added test scripts are never discovered, the most common cause is a missing test assembly: add an .asmdef with Test Assemblies enabled to the test folder (EditMode test assemblies target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests."));
+            Assert.That(result.noTestsFoundExplanation, Is.EqualTo("No tests were discovered for this run. This is not a test failure; check TestMode, FilterType, and FilterValue. If newly added test scripts are never discovered, the most common cause is a missing test assembly: add an .asmdef with Test Assemblies enabled to the test folder (EditMode test assemblies target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests. An .asmdef cannot reference the predefined Assembly-CSharp: if the code under test lives there, move it into its own .asmdef and add any package assemblies it uses to that .asmdef's references."));
             Assert.That(result.message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
             Assert.That(result.testCount, Is.EqualTo(0));
             Assert.That(result.failedCount, Is.EqualTo(0));

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
@@ -14,7 +14,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         internal const string NoTestsFoundMessage = "No tests found matching the specified filter criteria";
         internal const string NoTestsFoundExplanationText =
-            "No tests were discovered for this run. This is not a test failure; check TestMode, FilterType, and FilterValue. If newly added test scripts are never discovered, the most common cause is a missing test assembly: add an .asmdef with Test Assemblies enabled to the test folder (EditMode test assemblies target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests.";
+            "No tests were discovered for this run. This is not a test failure; check TestMode, FilterType, and FilterValue. If newly added test scripts are never discovered, the most common cause is a missing test assembly: add an .asmdef with Test Assemblies enabled to the test folder (EditMode test assemblies target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests. An .asmdef cannot reference the predefined Assembly-CSharp: if the code under test lives there, move it into its own .asmdef and add any package assemblies it uses to that .asmdef's references.";
 
         public static readonly string TestFrameworkUnavailableMessage =
             $"run-tests requires the Unity Test Framework package ({UnityCliLoopConstants.PACKAGE_NAME_TEST_FRAMEWORK}). Install it via Package Manager to use test execution.";


### PR DESCRIPTION
## Summary
- When `uloop run-tests` discovers zero tests, the explanation now also says that an `.asmdef` cannot reference the predefined `Assembly-CSharp` assembly.
- Agents who already added a test assembly get the next recovery step in the same message instead of another round trip.

## User Impact
- Previously the no-tests-found explanation stopped at "add a test assembly and reference the assemblies under test." Testers still stalled when the code under test lived in predefined `Assembly-CSharp`, which an `.asmdef` cannot reference.
- After this change, the same explanation tells them to move that code into its own `.asmdef` and add package assemblies to that `.asmdef`'s references.

## Changes
- Append one sentence to the existing no-tests-found explanation text.
- Update the full fixed-literal assertion that pins that explanation; leave the partial `Does.Contain` assertions unchanged.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → `ErrorCount: 0`, `Success: true`
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value 'RunTestsUseCaseTests|RunTestsTestFrameworkResultTests'` → `Status: Passed`, `TestCount: 31`, `PassedCount: 31`, `FailedCount: 0`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

