### PR TITLE
feat: log assembly-progress stalls while Unity keeps reporting compiling

### DIFF
--- a/Assets/Tests/Editor/CompileLifecycleRecoveryCoordinatorTests.cs
+++ b/Assets/Tests/Editor/CompileLifecycleRecoveryCoordinatorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using UnityEditor.Compilation;
 
@@ -157,10 +158,56 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(abortedWithMessage, Is.Null);
         }
 
+        /// <summary>
+        /// Verifies the stall handler emits compile_assembly_progress_stalled with the required context keys.
+        /// </summary>
+        [Test]
+        public void HandleAssemblyProgressStalled_WhenInvoked_LogsCompileAssemblyProgressStalledContext()
+        {
+            CompilerMessage[] compileMessages =
+            {
+                new()
+                {
+                    type = CompilerMessageType.Error,
+                    message = "CS0000: sample compile error",
+                    file = "Assets/Scripts/Sample.cs",
+                    line = 7
+                }
+            };
+            CompileLifecycleRecoveryCoordinator coordinator = CreateCoordinator(
+                getCompileMessages: () => compileMessages,
+                getAssemblyFinishedCount: () => 2);
+
+            VibeLogger.ClearMemoryLogs();
+            coordinator.HandleAssemblyProgressStalled(300000);
+
+            JArray entries = JArray.Parse(VibeLogger.GetLogsForAi());
+            JObject stallLog = null;
+            foreach (JToken token in entries)
+            {
+                JObject entry = (JObject)token;
+                if ((string)entry["operation"] == "compile_assembly_progress_stalled")
+                {
+                    stallLog = entry;
+                    break;
+                }
+            }
+
+            Assert.That(stallLog, Is.Not.Null);
+            JObject context = (JObject)stallLog["context"];
+            Assert.That(context, Is.Not.Null);
+            Assert.That((int)context["stalled_ms"], Is.EqualTo(300000));
+            Assert.That((int)context["assembly_finished_count"], Is.EqualTo(2));
+            Assert.That((int)context["message_count"], Is.EqualTo(1));
+            Assert.That(context["editor_compiling"].Type, Is.EqualTo(JTokenType.Boolean));
+            Assert.That(context["editor_updating"].Type, Is.EqualTo(JTokenType.Boolean));
+        }
+
         private static CompileLifecycleRecoveryCoordinator CreateCoordinator(
             Func<AssemblyDefinitionConsoleErrorResult> findAssemblyDefinitionErrors = null,
             Func<ValidationResult> validateNoDuplicateAsmdefNames = null,
             Func<CompilerMessage[]> getCompileMessages = null,
+            Func<int> getAssemblyFinishedCount = null,
             Func<bool> getIsForceCompile = null,
             Action<CompileResult> abortWithResult = null,
             Action<string> abort = null)
@@ -174,7 +221,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 validateNoDuplicateAsmdefNames: validateNoDuplicateAsmdefNames ?? ValidationResult.Success,
                 getIsForceCompile: getIsForceCompile ?? (() => false),
                 getCompileMessages: getCompileMessages ?? (() => new CompilerMessage[0]),
-                getAssemblyFinishedCount: () => 0,
+                getAssemblyFinishedCount: getAssemblyFinishedCount ?? (() => 0),
                 getMonotonicSeconds: () => 0d,
                 buildStateContext: context => context,
                 abortWithResult: abortWithResult ?? (_ => { }),

--- a/Assets/Tests/Editor/CompileLifecycleRecoveryCoordinatorTests.cs
+++ b/Assets/Tests/Editor/CompileLifecycleRecoveryCoordinatorTests.cs
@@ -139,6 +139,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(abortedWithResult.Errors[0].message, Is.EqualTo("CS0000: sample compile error"));
         }
 
+        /// <summary>
+        /// Verifies an assembly-progress stall warning never aborts the compile request.
+        /// </summary>
+        [Test]
+        public void HandleAssemblyProgressStalled_WhenInvoked_DoesNotAbort()
+        {
+            CompileResult abortedWithResult = null;
+            string abortedWithMessage = null;
+            CompileLifecycleRecoveryCoordinator coordinator = CreateCoordinator(
+                abortWithResult: result => abortedWithResult = result,
+                abort: message => abortedWithMessage = message);
+
+            coordinator.HandleAssemblyProgressStalled(300000);
+
+            Assert.That(abortedWithResult, Is.Null);
+            Assert.That(abortedWithMessage, Is.Null);
+        }
+
         private static CompileLifecycleRecoveryCoordinator CreateCoordinator(
             Func<AssemblyDefinitionConsoleErrorResult> findAssemblyDefinitionErrors = null,
             Func<ValidationResult> validateNoDuplicateAsmdefNames = null,
@@ -156,6 +174,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 validateNoDuplicateAsmdefNames: validateNoDuplicateAsmdefNames ?? ValidationResult.Success,
                 getIsForceCompile: getIsForceCompile ?? (() => false),
                 getCompileMessages: getCompileMessages ?? (() => new CompilerMessage[0]),
+                getAssemblyFinishedCount: () => 0,
+                getMonotonicSeconds: () => 0d,
                 buildStateContext: context => context,
                 abortWithResult: abortWithResult ?? (_ => { }),
                 abort: abort ?? (_ => { }));

--- a/Assets/Tests/Editor/CompileLifecycleWatchdogTests.cs
+++ b/Assets/Tests/Editor/CompileLifecycleWatchdogTests.cs
@@ -31,7 +31,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 _ => { },
                 _ => startTimeoutCount++,
                 stoppedMs => missedCallbackStoppedMs = stoppedMs,
-                _ => cancellationCount++);
+                _ => cancellationCount++,
+                () => 0,
+                () => 0d,
+                _ => { });
 
             await watchdog.WatchAsync(CancellationToken.None);
 
@@ -60,6 +63,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 _ => { },
                 _ => startTimeoutCount++,
                 _ => missedCallbackCount++,
+                _ => { },
+                () => 0,
+                () => 0d,
                 _ => { });
 
             await watchdog.WatchAsync(CancellationToken.None);
@@ -88,6 +94,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 _ => { },
                 _ => startTimeoutCount++,
                 _ => missedCallbackCount++,
+                _ => { },
+                () => 0,
+                () => 0d,
                 _ => { });
 
             await watchdog.WatchAsync(CancellationToken.None);
@@ -111,6 +120,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 _ => { },
                 waitedMs => startTimeoutMs = waitedMs,
                 _ => missedCallbackCount++,
+                _ => { },
+                () => 0,
+                () => 0d,
                 _ => { });
 
             await watchdog.WatchAsync(CancellationToken.None);
@@ -132,6 +144,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 _ => { },
                 _ => { },
                 _ => { },
+                _ => { },
+                () => 0,
+                () => 0d,
                 _ => { });
 
             InvalidOperationException actualException = Assert.ThrowsAsync<InvalidOperationException>(
@@ -221,6 +236,177 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result.IsIndeterminate, Is.True);
             Assert.That(result.ErrorCount, Is.EqualTo(1));
             Assert.That(result.Errors[0].message, Is.EqualTo("CS0000: sample compile error"));
+        }
+
+        /// <summary>
+        /// Verifies a stalled assembly-finished counter while isCompiling stays true raises the warning once.
+        /// </summary>
+        [Test]
+        public async Task WatchAsync_WhenAssemblyProgressStallsWhileCompiling_WarnsOnce()
+        {
+            ConstantCompilationState compilationState = new ConstantCompilationState(true);
+            int waitCount = 0;
+            double clockSeconds = 0;
+            int stallCallCount = 0;
+            int stalledMs = -1;
+            CompileLifecycleWatchdog watchdog = new CompileLifecycleWatchdog(
+                compilationState.IsCompiling,
+                () => waitCount >= 4,
+                () =>
+                {
+                    waitCount++;
+                    if (waitCount == 1)
+                    {
+                        clockSeconds = 300;
+                    }
+
+                    return Task.CompletedTask;
+                },
+                _ => { },
+                _ => { },
+                _ => { },
+                _ => { },
+                () => 1,
+                () => clockSeconds,
+                ms =>
+                {
+                    stallCallCount++;
+                    stalledMs = ms;
+                });
+
+            await watchdog.WatchAsync(CancellationToken.None);
+
+            Assert.That(stallCallCount, Is.EqualTo(1));
+            Assert.That(stalledMs, Is.EqualTo(300000));
+        }
+
+        /// <summary>
+        /// Verifies a zero assembly-finished count never raises the stall warning, even after the threshold.
+        /// </summary>
+        [Test]
+        public async Task WatchAsync_WhenNoAssemblyHasFinished_DoesNotWarnOnElapsedTime()
+        {
+            ConstantCompilationState compilationState = new ConstantCompilationState(true);
+            int waitCount = 0;
+            double clockSeconds = 0;
+            int stallCallCount = 0;
+            CompileLifecycleWatchdog watchdog = new CompileLifecycleWatchdog(
+                compilationState.IsCompiling,
+                () => waitCount >= 3,
+                () =>
+                {
+                    waitCount++;
+                    clockSeconds = 300;
+                    return Task.CompletedTask;
+                },
+                _ => { },
+                _ => { },
+                _ => { },
+                _ => { },
+                () => 0,
+                () => clockSeconds,
+                _ => stallCallCount++);
+
+            await watchdog.WatchAsync(CancellationToken.None);
+
+            Assert.That(stallCallCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies a later assembly-finished increment restarts the stall clock instead of warning from the old anchor.
+        /// </summary>
+        [Test]
+        public async Task WatchAsync_WhenAssemblyFinishedCountIncreases_ResetsStallMeasurement()
+        {
+            ConstantCompilationState compilationState = new ConstantCompilationState(true);
+            int waitCount = 0;
+            int assemblyFinishedCount = 1;
+            double clockSeconds = 0;
+            int stallCallCount = 0;
+            int stalledMs = -1;
+            CompileLifecycleWatchdog watchdog = new CompileLifecycleWatchdog(
+                compilationState.IsCompiling,
+                () => waitCount >= 6,
+                () =>
+                {
+                    waitCount++;
+                    if (waitCount == 1)
+                    {
+                        clockSeconds = 200;
+                    }
+                    else if (waitCount == 2)
+                    {
+                        assemblyFinishedCount = 2;
+                    }
+                    else if (waitCount == 3)
+                    {
+                        clockSeconds = 400;
+                    }
+                    else if (waitCount == 4)
+                    {
+                        clockSeconds = 500;
+                    }
+
+                    return Task.CompletedTask;
+                },
+                _ => { },
+                _ => { },
+                _ => { },
+                _ => { },
+                () => assemblyFinishedCount,
+                () => clockSeconds,
+                ms =>
+                {
+                    stallCallCount++;
+                    stalledMs = ms;
+                });
+
+            await watchdog.WatchAsync(CancellationToken.None);
+
+            Assert.That(stallCallCount, Is.EqualTo(1));
+            Assert.That(stalledMs, Is.EqualTo(300000));
+        }
+
+        /// <summary>
+        /// Verifies the stall warning does not end the watch, so a later compilationFinished can still complete it.
+        /// </summary>
+        [Test]
+        public async Task WatchAsync_WhenAssemblyProgressStallWarned_ContinuesUntilRequestCompletes()
+        {
+            ConstantCompilationState compilationState = new ConstantCompilationState(true);
+            int waitCount = 0;
+            double clockSeconds = 0;
+            int stallCallCount = 0;
+            int missedCallbackCount = 0;
+            int startTimeoutCount = 0;
+            int cancellationCount = 0;
+            CompileLifecycleWatchdog watchdog = new CompileLifecycleWatchdog(
+                compilationState.IsCompiling,
+                () => waitCount >= 4,
+                () =>
+                {
+                    waitCount++;
+                    if (waitCount == 1)
+                    {
+                        clockSeconds = 300;
+                    }
+
+                    return Task.CompletedTask;
+                },
+                _ => { },
+                _ => startTimeoutCount++,
+                _ => missedCallbackCount++,
+                _ => cancellationCount++,
+                () => 1,
+                () => clockSeconds,
+                _ => stallCallCount++);
+
+            await watchdog.WatchAsync(CancellationToken.None);
+
+            Assert.That(stallCallCount, Is.EqualTo(1));
+            Assert.That(missedCallbackCount, Is.EqualTo(0));
+            Assert.That(startTimeoutCount, Is.EqualTo(0));
+            Assert.That(cancellationCount, Is.EqualTo(0));
         }
 
         private sealed class SequenceCompilationState

--- a/Assets/Tests/Editor/CompileLifecycleWatchdogTests.cs
+++ b/Assets/Tests/Editor/CompileLifecycleWatchdogTests.cs
@@ -239,7 +239,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
-        /// Verifies a stalled assembly-finished counter while isCompiling stays true raises the warning once.
+        /// Verifies a stalled assembly-finished counter while isCompiling stays true raises one warning for that episode.
         /// </summary>
         [Test]
         public async Task WatchAsync_WhenAssemblyProgressStallsWhileCompiling_WarnsOnce()
@@ -407,6 +407,45 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(missedCallbackCount, Is.EqualTo(0));
             Assert.That(startTimeoutCount, Is.EqualTo(0));
             Assert.That(cancellationCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies a threshold crossing does not warn when that poll sees isCompiling=false.
+        /// </summary>
+        [Test]
+        public async Task WatchAsync_WhenElapsedExceedsThresholdButEditorIsNotCompiling_DoesNotWarn()
+        {
+            SequenceCompilationState compilationState = new SequenceCompilationState(
+                new bool[] { true, false, false });
+            int waitCount = 0;
+            double clockSeconds = 0;
+            int stallCallCount = 0;
+            int missedCallbackCount = 0;
+            CompileLifecycleWatchdog watchdog = new CompileLifecycleWatchdog(
+                compilationState.IsCompiling,
+                () => waitCount >= 2,
+                () =>
+                {
+                    waitCount++;
+                    if (waitCount == 1)
+                    {
+                        clockSeconds = 300;
+                    }
+
+                    return Task.CompletedTask;
+                },
+                _ => { },
+                _ => { },
+                _ => missedCallbackCount++,
+                _ => { },
+                () => 1,
+                () => clockSeconds,
+                _ => stallCallCount++);
+
+            await watchdog.WatchAsync(CancellationToken.None);
+
+            Assert.That(stallCallCount, Is.EqualTo(0));
+            Assert.That(missedCallbackCount, Is.EqualTo(0));
         }
 
         private sealed class SequenceCompilationState

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -26,6 +26,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private bool _reloadExternalSceneChanges = true;
         private CompileResultRecordingContext _resultRecordingContext = CompileResultRecordingContext.Disabled();
         private DateTime _compileStartedAtUtc = DateTime.MinValue;
+        private int _assemblyFinishedCount;
         private readonly CompileLifecycleRecoveryCoordinator _recoveryCoordinator;
 
         public CompileController(
@@ -47,6 +48,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 () => new AssemblyDefinitionDuplicationValidationService().ValidateNoDuplicateAsmdefNames(),
                 () => _isForceCompile,
                 () => _compileMessages.ToArray(),
+                () => _assemblyFinishedCount,
+                () => UnityEngine.Time.realtimeSinceStartupAsDouble,
                 BuildCompileControllerStateContext,
                 AbortCompileWithResult,
                 AbortCompile);
@@ -145,6 +148,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _pendingPausePointWarning = pausePointWarning;
             _isCompiling = true;
             _compileMessages.Clear();
+            _assemblyFinishedCount = 0;
             _compileStartedAtUtc = DateTime.UtcNow;
             TaskCompletionSource<CompileResult> compileTask = new();
             _currentCompileTask = compileTask;
@@ -437,12 +441,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <param name="messages">The compiler messages.</param>
         private void HandleAssemblyFinished(string asmPath, CompilerMessage[] messages)
         {
+            _assemblyFinishedCount++;
             string assemblyName = System.IO.Path.GetFileName(asmPath);
 
             foreach (CompilerMessage message in messages)
             {
                 _compileMessages.Add(message);
             }
+
+            VibeLogger.LogInfo(
+                "compile_assembly_finished_callback_received",
+                "Unity assemblyCompilationFinished callback was received.",
+                new
+                {
+                    assembly_name = assemblyName,
+                    message_count = messages.Length,
+                    elapsed_ms = CompileElapsedMilliseconds()
+                });
 
             OnAssemblyCompiled?.Invoke(assemblyName, messages);
         }

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -49,7 +49,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 () => _isForceCompile,
                 () => _compileMessages.ToArray(),
                 () => _assemblyFinishedCount,
-                () => UnityEngine.Time.realtimeSinceStartupAsDouble,
+                // Why not Time.realtimeSinceStartupAsDouble: it freezes while the Editor is paused,
+                // and pause-point compiles run in that state.
+                () => EditorApplication.timeSinceStartup,
                 BuildCompileControllerStateContext,
                 AbortCompileWithResult,
                 AbortCompile);

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleRecoveryCoordinator.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleRecoveryCoordinator.cs
@@ -24,6 +24,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly Func<ValidationResult> _validateNoDuplicateAsmdefNames;
         private readonly Func<bool> _getIsForceCompile;
         private readonly Func<CompilerMessage[]> _getCompileMessages;
+        private readonly Func<int> _getAssemblyFinishedCount;
+        private readonly Func<double> _getMonotonicSeconds;
         private readonly Func<Dictionary<string, object>, Dictionary<string, object>> _buildStateContext;
         private readonly Action<CompileResult> _abortWithResult;
         private readonly Action<string> _abort;
@@ -36,6 +38,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Func<ValidationResult> validateNoDuplicateAsmdefNames,
             Func<bool> getIsForceCompile,
             Func<CompilerMessage[]> getCompileMessages,
+            Func<int> getAssemblyFinishedCount,
+            Func<double> getMonotonicSeconds,
             Func<Dictionary<string, object>, Dictionary<string, object>> buildStateContext,
             Action<CompileResult> abortWithResult,
             Action<string> abort)
@@ -47,6 +51,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(validateNoDuplicateAsmdefNames != null, "validateNoDuplicateAsmdefNames must not be null");
             Debug.Assert(getIsForceCompile != null, "getIsForceCompile must not be null");
             Debug.Assert(getCompileMessages != null, "getCompileMessages must not be null");
+            Debug.Assert(getAssemblyFinishedCount != null, "getAssemblyFinishedCount must not be null");
+            Debug.Assert(getMonotonicSeconds != null, "getMonotonicSeconds must not be null");
             Debug.Assert(buildStateContext != null, "buildStateContext must not be null");
             Debug.Assert(abortWithResult != null, "abortWithResult must not be null");
             Debug.Assert(abort != null, "abort must not be null");
@@ -60,6 +66,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 throw new ArgumentNullException(nameof(validateNoDuplicateAsmdefNames));
             _getIsForceCompile = getIsForceCompile ?? throw new ArgumentNullException(nameof(getIsForceCompile));
             _getCompileMessages = getCompileMessages ?? throw new ArgumentNullException(nameof(getCompileMessages));
+            _getAssemblyFinishedCount = getAssemblyFinishedCount ??
+                throw new ArgumentNullException(nameof(getAssemblyFinishedCount));
+            _getMonotonicSeconds = getMonotonicSeconds ?? throw new ArgumentNullException(nameof(getMonotonicSeconds));
             _buildStateContext = buildStateContext ?? throw new ArgumentNullException(nameof(buildStateContext));
             _abortWithResult = abortWithResult ?? throw new ArgumentNullException(nameof(abortWithResult));
             _abort = abort ?? throw new ArgumentNullException(nameof(abort));
@@ -89,8 +98,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 _ => { },
                 HandleCompileStartTimeout,
                 HandleCompileStoppedWithoutFinishEvent,
-                _abort);
+                _abort,
+                _getAssemblyFinishedCount,
+                _getMonotonicSeconds,
+                HandleAssemblyProgressStalled);
             return watchdog.WatchAsync(ct);
+        }
+
+        /// <summary>
+        /// Records a warning when assembly callbacks stall while Unity still reports compiling.
+        /// Why not abort: assembly progress can pause for a valid long compile, and aborting
+        /// would create false-positive compile failures.
+        /// </summary>
+        internal void HandleAssemblyProgressStalled(int stalledMs)
+        {
+            CompilerMessage[] compileMessages = _getCompileMessages();
+            VibeLogger.LogWarning(
+                "compile_assembly_progress_stalled",
+                "Assembly compilation progress stalled while Unity still reports compiling.",
+                new
+                {
+                    stalled_ms = stalledMs,
+                    assembly_finished_count = _getAssemblyFinishedCount(),
+                    message_count = compileMessages.Length,
+                    editor_compiling = EditorApplication.isCompiling,
+                    editor_updating = EditorApplication.isUpdating
+                });
         }
 
         private static Task WaitForCompileWatchdogPollAsync()

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleWatchdog.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleWatchdog.cs
@@ -19,6 +19,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly Action<int> _onStartTimeout;
         private readonly Action<int> _onMissedCompletionCallback;
         private readonly Action<string> _onCancelled;
+        private readonly Func<int> _getAssemblyFinishedCount;
+        private readonly Func<double> _getMonotonicSeconds;
+        private readonly Action<int> _onAssemblyProgressStalled;
+        private int _assemblyProgressStallBaselineCount;
+        private double _assemblyProgressStallAnchorSeconds;
+        private bool _assemblyProgressStallMeasurementStarted;
+        private bool _assemblyProgressStallWarned;
 
         internal CompileLifecycleWatchdog(
             Func<bool> isEditorCompiling,
@@ -27,7 +34,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Action<int> onCompileStartedObserved,
             Action<int> onStartTimeout,
             Action<int> onMissedCompletionCallback,
-            Action<string> onCancelled)
+            Action<string> onCancelled,
+            Func<int> getAssemblyFinishedCount,
+            Func<double> getMonotonicSeconds,
+            Action<int> onAssemblyProgressStalled)
         {
             Debug.Assert(isEditorCompiling != null, "isEditorCompiling must not be null");
             Debug.Assert(isRequestCompleted != null, "isRequestCompleted must not be null");
@@ -36,6 +46,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(onStartTimeout != null, "onStartTimeout must not be null");
             Debug.Assert(onMissedCompletionCallback != null, "onMissedCompletionCallback must not be null");
             Debug.Assert(onCancelled != null, "onCancelled must not be null");
+            Debug.Assert(getAssemblyFinishedCount != null, "getAssemblyFinishedCount must not be null");
+            Debug.Assert(getMonotonicSeconds != null, "getMonotonicSeconds must not be null");
+            Debug.Assert(onAssemblyProgressStalled != null, "onAssemblyProgressStalled must not be null");
 
             _isEditorCompiling = isEditorCompiling ?? throw new ArgumentNullException(nameof(isEditorCompiling));
             _isRequestCompleted = isRequestCompleted ?? throw new ArgumentNullException(nameof(isRequestCompleted));
@@ -44,6 +57,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _onStartTimeout = onStartTimeout ?? throw new ArgumentNullException(nameof(onStartTimeout));
             _onMissedCompletionCallback = onMissedCompletionCallback ?? throw new ArgumentNullException(nameof(onMissedCompletionCallback));
             _onCancelled = onCancelled ?? throw new ArgumentNullException(nameof(onCancelled));
+            _getAssemblyFinishedCount = getAssemblyFinishedCount ??
+                throw new ArgumentNullException(nameof(getAssemblyFinishedCount));
+            _getMonotonicSeconds = getMonotonicSeconds ?? throw new ArgumentNullException(nameof(getMonotonicSeconds));
+            _onAssemblyProgressStalled = onAssemblyProgressStalled ??
+                throw new ArgumentNullException(nameof(onAssemblyProgressStalled));
         }
 
         /// <summary>
@@ -101,6 +119,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     }
                 }
 
+                NotifyAssemblyProgressStallIfNeeded(observedStart, isEditorCompiling);
+
                 // The delay is not cancelled directly because the watchdog must convert cancellation into cleanup.
                 await _waitForPollAsync().ConfigureAwait(false);
                 // Why CancellationToken.None: a cancelled ct would throw OCE here and skip the
@@ -111,6 +131,48 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     waitedForStartMs += UnityCliLoopConstants.COMPILE_START_POLL_INTERVAL_MS;
                 }
             }
+        }
+
+        /// <summary>
+        /// Warns once when assembly callbacks stop arriving while Unity still reports compiling.
+        /// Watch continues so a later compilationFinished can still complete the request.
+        /// </summary>
+        private void NotifyAssemblyProgressStallIfNeeded(bool observedStart, bool isEditorCompiling)
+        {
+            if (!observedStart)
+            {
+                return;
+            }
+
+            int assemblyFinishedCount = _getAssemblyFinishedCount();
+            if (assemblyFinishedCount < 1)
+            {
+                return;
+            }
+
+            if (!_assemblyProgressStallMeasurementStarted ||
+                assemblyFinishedCount != _assemblyProgressStallBaselineCount)
+            {
+                _assemblyProgressStallMeasurementStarted = true;
+                _assemblyProgressStallBaselineCount = assemblyFinishedCount;
+                _assemblyProgressStallAnchorSeconds = _getMonotonicSeconds();
+                _assemblyProgressStallWarned = false;
+                return;
+            }
+
+            if (!isEditorCompiling || _assemblyProgressStallWarned)
+            {
+                return;
+            }
+
+            int stalledMs = (int)((_getMonotonicSeconds() - _assemblyProgressStallAnchorSeconds) * 1000.0);
+            if (stalledMs < UnityCliLoopConstants.COMPILE_ASSEMBLY_PROGRESS_STALL_WARNING_MS)
+            {
+                return;
+            }
+
+            _assemblyProgressStallWarned = true;
+            _onAssemblyProgressStalled(stalledMs);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleWatchdog.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleWatchdog.cs
@@ -134,7 +134,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
-        /// Warns once when assembly callbacks stop arriving while Unity still reports compiling.
+        /// Warns once per stall episode when assembly callbacks stop arriving while Unity still
+        /// reports compiling. A later assemblyCompilationFinished callback re-arms the warning.
         /// Watch continues so a later compilationFinished can still complete the request.
         /// </summary>
         private void NotifyAssemblyProgressStallIfNeeded(bool observedStart, bool isEditorCompiling)

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -132,6 +132,11 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public const int COMPILE_START_TIMEOUT_MS = 5000;
         public const int COMPILE_START_POLL_INTERVAL_MS = 100;
         public const int COMPILE_FINISH_MISSED_CALLBACK_GRACE_MS = 2000;
+        /// <summary>
+        /// Wall-clock milliseconds without a new assemblyCompilationFinished callback while Unity
+        /// still reports isCompiling, after at least one assembly has finished. Warning only.
+        /// </summary>
+        public const int COMPILE_ASSEMBLY_PROGRESS_STALL_WARNING_MS = 300000;
         public const int EDITOR_FRAME_WAIT_TIMEOUT_MS = 5000;
         
         public const int MAX_SETTINGS_SIZE_BYTES = 1024 * 16;


### PR DESCRIPTION
## Summary
- Unity now records a warning when assembly compilation stops making progress while the Editor still reports that it is compiling.
- Compile results and recovery behavior are unchanged; this is diagnostic logging only.

## User Impact
- Before: a compile that stayed in `isCompiling=true` after assembly callbacks stopped left no C# evidence of that stall.
- After: vibe logs include `compile_assembly_finished_callback_received` for each finished assembly and a `compile_assembly_progress_stalled` warning once per stall episode (re-armed by a new assemblyCompilationFinished callback) after five minutes without further assembly progress. The compile request is not aborted.

## Changes
- Count `assemblyCompilationFinished` callbacks separately from compiler messages.
- Watch wall-clock time after the first finished assembly and warn once per stall episode if that count stays still while compiling.
- Stall timing uses `EditorApplication.timeSinceStartup` so pause-point pauses do not freeze the clock.
- A later finish callback can still complete the request normally.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`: ErrorCount 0, Success true
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "CompileLifecycleWatchdogTests|CompileLifecycleRecoveryCoordinatorTests"`: TestCount 21, PassedCount 21
