### PR TITLE
feat: include the running tool's elapsed time in single-flight busy rejections

### DIFF
--- a/Assets/Tests/Editor/JsonRpcResponseFactoryWireShapeCharacterizationTests.cs
+++ b/Assets/Tests/Editor/JsonRpcResponseFactoryWireShapeCharacterizationTests.cs
@@ -100,6 +100,28 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(dataToken["type"]!.Value<string>(), Is.EqualTo(JsonRpcErrorTypes.ServerBusy));
             Assert.That(dataToken["secondsSinceLastMainThreadTick"], Is.Not.Null);
             Assert.That(dataToken["secondsSinceLastMainThreadTick"]!.Value<double>(), Is.GreaterThanOrEqualTo(0));
+            Assert.That(dataToken["runningToolElapsedSeconds"], Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies a single-flight busy payload copies the session elapsed seconds onto the wire.
+        /// </summary>
+        [Test]
+        public void CreateErrorResponse_ForBusyException_IncludesRunningToolElapsedSeconds()
+        {
+            UnityCliLoopToolBusyException busyException = new(
+                "running-tool",
+                "requested-tool",
+                isPlaying: true,
+                isPaused: true,
+                runningToolElapsedSeconds: 12);
+
+            string response = JsonRpcResponseFactory.CreateErrorResponse(1, busyException);
+
+            JObject json = JObject.Parse(response);
+            JToken dataToken = json["error"]!["data"]!;
+            Assert.That(dataToken["type"]!.Value<string>(), Is.EqualTo(JsonRpcErrorTypes.ServerBusy));
+            Assert.That(dataToken["runningToolElapsedSeconds"]!.Value<int>(), Is.EqualTo(12));
         }
 
         [Test]

--- a/Assets/Tests/Editor/ServerBusyErrorContractTests.cs
+++ b/Assets/Tests/Editor/ServerBusyErrorContractTests.cs
@@ -30,7 +30,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 message: "Unity is busy running 'compile'. Retry 'get-logs' after the running tool completes.",
                 secondsSinceLastMainThreadTick: 1.5,
                 isCompiling: true,
-                isUpdating: false);
+                isUpdating: false,
+                runningToolElapsedSeconds: 12);
             string json = JsonConvert.SerializeObject(
                 errorData,
                 Formatting.None,

--- a/Assets/Tests/Editor/ToolExecutionSessionTests.cs
+++ b/Assets/Tests/Editor/ToolExecutionSessionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -172,6 +173,115 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(busyAfterOneExit.IsEntered, Is.False);
             Assert.That(busyAfterOneExit.RunningToolName, Is.EqualTo(UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE));
             Assert.That(enteredAfterBothExit.IsEntered, Is.True);
+
+            session.Exit();
+        }
+
+        /// <summary>
+        /// Verifies a shared-slot second enter does not overwrite the first start timestamp.
+        /// </summary>
+        [Test]
+        public void TryEnter_WhenSharedSlotSecondEnter_ShouldKeepFirstStartTimestamp()
+        {
+            long timestamp = 0;
+            ToolExecutionSession session = new ToolExecutionSession(() => timestamp);
+
+            session.TryEnter(UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE);
+            timestamp += 3 * Stopwatch.Frequency;
+            session.TryEnter(UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE);
+            timestamp += 4 * Stopwatch.Frequency;
+            ToolExecutionSessionEnterResult busyResult = session.TryEnter("other-tool");
+
+            Assert.That(busyResult.IsEntered, Is.False);
+            Assert.That(busyResult.RunningToolName, Is.EqualTo(UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE));
+            Assert.That(busyResult.RunningToolElapsedSeconds, Is.EqualTo(7));
+
+            session.Exit();
+            session.Exit();
+        }
+
+        /// <summary>
+        /// Verifies one shared-slot exit keeps the original start timestamp for the remaining execution.
+        /// </summary>
+        [Test]
+        public void Exit_WhenOneSharedExecutionRemains_ShouldKeepOriginalStartTimestamp()
+        {
+            long timestamp = 0;
+            ToolExecutionSession session = new ToolExecutionSession(() => timestamp);
+
+            session.TryEnter(UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE);
+            session.TryEnter(UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE);
+            timestamp += 5 * Stopwatch.Frequency;
+            session.Exit();
+            ToolExecutionSessionEnterResult busyResult = session.TryEnter("other-tool");
+
+            Assert.That(busyResult.IsEntered, Is.False);
+            Assert.That(busyResult.RunningToolElapsedSeconds, Is.EqualTo(5));
+
+            session.Exit();
+        }
+
+        /// <summary>
+        /// Verifies the start timestamp is cleared when the last execution exits.
+        /// </summary>
+        [Test]
+        public void Exit_WhenLastExecutionExits_ShouldClearStartTimestamp()
+        {
+            long timestamp = 0;
+            ToolExecutionSession session = new ToolExecutionSession(() => timestamp);
+
+            session.TryEnter("first-tool");
+            timestamp += 10 * Stopwatch.Frequency;
+            session.Exit();
+            session.TryEnter("second-tool");
+            timestamp += 2 * Stopwatch.Frequency;
+            ToolExecutionSessionEnterResult busyResult = session.TryEnter("other-tool");
+
+            Assert.That(busyResult.IsEntered, Is.False);
+            Assert.That(busyResult.RunningToolName, Is.EqualTo("second-tool"));
+            Assert.That(busyResult.RunningToolElapsedSeconds, Is.EqualTo(2));
+
+            session.Exit();
+        }
+
+        /// <summary>
+        /// Verifies a busy decision returns the running tool name and elapsed seconds from one snapshot.
+        /// </summary>
+        [Test]
+        public void TryEnter_WhenBusy_ShouldReturnNameAndElapsedFromSameSnapshot()
+        {
+            long timestamp = 0;
+            ToolExecutionSession session = new ToolExecutionSession(() => timestamp);
+
+            session.TryEnter("running-tool");
+            timestamp += 4 * Stopwatch.Frequency + (Stopwatch.Frequency - 1);
+            ToolExecutionSessionEnterResult busyResult = session.TryEnter("requested-tool");
+
+            Assert.That(busyResult.IsEntered, Is.False);
+            Assert.That(busyResult.RunningToolName, Is.EqualTo("running-tool"));
+            Assert.That(busyResult.RunningToolElapsedSeconds, Is.EqualTo(4));
+
+            session.Exit();
+        }
+
+        /// <summary>
+        /// Verifies Begin busy results carry the same elapsed snapshot as TryEnter.
+        /// </summary>
+        [Test]
+        public void Begin_WhenDifferentToolIsRunning_ShouldReturnBusyWithElapsedSeconds()
+        {
+            long timestamp = 0;
+            ToolExecutionSession session = new ToolExecutionSession(() => timestamp);
+            SessionTestTool requestedTool = new SessionTestTool("requested-tool");
+            UnityCliLoopToolRegistry registry = CreateRegistry(new InMemoryToolSettingsPort(), new IUnityCliLoopTool[] { requestedTool });
+            session.TryEnter("running-tool");
+            timestamp += 6 * Stopwatch.Frequency;
+
+            ToolExecutionSessionBeginResult result = session.Begin(registry, requestedTool.ToolName);
+
+            Assert.That(result.IsEntered, Is.False);
+            Assert.That(result.RunningToolName, Is.EqualTo("running-tool"));
+            Assert.That(result.RunningToolElapsedSeconds, Is.EqualTo(6));
 
             session.Exit();
         }

--- a/Assets/Tests/Editor/UnityCliLoopToolExecutionServiceTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopToolExecutionServiceTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.Application;
@@ -95,6 +97,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 System.Threading.SynchronizationContext.SetSynchronizationContext(previousContext);
                 RestoreEditorMainThreadDispatcher();
             }
+        }
+
+        /// <summary>
+        /// Verifies ExecuteToolAsync copies the session elapsed-seconds snapshot onto the busy exception.
+        /// </summary>
+        [Test]
+        public void ExecuteToolAsync_WhenAnotherToolIsRunning_ShouldThrowBusyWithElapsedSeconds()
+        {
+            long timestamp = 0;
+            ToolExecutionSession session = new ToolExecutionSession(() => timestamp);
+            session.TryEnter("running-tool");
+            timestamp += 5 * Stopwatch.Frequency;
+
+            UnityCliLoopToolRegistry registry = ToolRegistryTestFactory.Create();
+            BusyRouteRequestedTool requestedTool = new BusyRouteRequestedTool();
+            registry.RegisterTool(requestedTool);
+            UnityCliLoopToolExecutionService executionService =
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort(), session);
+
+            UnityCliLoopToolBusyException exception = Assert.ThrowsAsync<UnityCliLoopToolBusyException>(
+                () => executionService.ExecuteToolAsync(
+                    registry,
+                    requestedTool.ToolName,
+                    null,
+                    CancellationToken.None));
+
+            Assert.That(exception.RunningToolName, Is.EqualTo("running-tool"));
+            Assert.That(exception.RequestedToolName, Is.EqualTo(requestedTool.ToolName));
+            Assert.That(exception.RunningToolElapsedSeconds, Is.EqualTo(5));
+
+            session.Exit();
         }
 
         [Test]
@@ -196,6 +229,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             public void Complete()
             {
                 _completionSource.TrySetResult(new PendingTypedResponse());
+            }
+        }
+
+        private sealed class BusyRouteRequestedTool : IUnityCliLoopTool
+        {
+            public string ToolName => "requested-tool";
+
+            public ToolParameterSchema ParameterSchema => new();
+
+            public Task<UnityCliLoopToolResponse> ExecuteAsync(JToken paramsToken, CancellationToken ct)
+            {
+                return Task.FromResult<UnityCliLoopToolResponse>(new PendingTypedResponse());
             }
         }
 

--- a/Packages/src/Editor/Application/UnityCliLoopToolBusyException.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopToolBusyException.cs
@@ -13,7 +13,8 @@ namespace io.github.hatayama.UnityCliLoop.Application
             bool? isPlaying = null,
             bool? isPaused = null,
             bool? isCompiling = null,
-            bool? isUpdating = null)
+            bool? isUpdating = null,
+            int? runningToolElapsedSeconds = null)
             : base(CreateMessage(runningToolName, requestedToolName))
         {
             RunningToolName = runningToolName;
@@ -22,6 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.Application
             IsPaused = isPaused;
             IsCompiling = isCompiling;
             IsUpdating = isUpdating;
+            RunningToolElapsedSeconds = runningToolElapsedSeconds;
         }
 
         public string RunningToolName { get; }
@@ -35,6 +37,8 @@ namespace io.github.hatayama.UnityCliLoop.Application
         public bool? IsCompiling { get; }
 
         public bool? IsUpdating { get; }
+
+        public int? RunningToolElapsedSeconds { get; }
 
         private static string CreateMessage(string runningToolName, string requestedToolName)
         {

--- a/Packages/src/Editor/Application/UnityCliLoopToolExecutionService.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopToolExecutionService.cs
@@ -38,7 +38,11 @@ namespace io.github.hatayama.UnityCliLoop.Application
             ToolExecutionSessionBeginResult beginResult = _executionSession.Begin(registry, toolName);
             if (!beginResult.IsEntered)
             {
-                throw CreateBusyException(beginResult.RunningToolName, toolName, _editorRuntimeStatePort);
+                throw CreateBusyException(
+                    beginResult.RunningToolName,
+                    toolName,
+                    _editorRuntimeStatePort,
+                    beginResult.RunningToolElapsedSeconds);
             }
 
             try
@@ -64,7 +68,8 @@ namespace io.github.hatayama.UnityCliLoop.Application
         internal static UnityCliLoopToolBusyException CreateBusyException(
             string runningToolName,
             string requestedToolName,
-            IEditorRuntimeStatePort editorRuntimeStatePort)
+            IEditorRuntimeStatePort editorRuntimeStatePort,
+            int? runningToolElapsedSeconds = null)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(runningToolName), "runningToolName must not be null or whitespace");
             Debug.Assert(!string.IsNullOrWhiteSpace(requestedToolName), "requestedToolName must not be null or whitespace");
@@ -78,7 +83,8 @@ namespace io.github.hatayama.UnityCliLoop.Application
                     editorRuntimeStatePort.IsPlaying,
                     editorRuntimeStatePort.IsPaused,
                     editorRuntimeStatePort.IsCompiling,
-                    editorRuntimeStatePort.IsUpdating);
+                    editorRuntimeStatePort.IsUpdating,
+                    runningToolElapsedSeconds);
             }
 
             (bool HasValue, bool IsPlaying, bool IsPaused) playState =
@@ -89,10 +95,14 @@ namespace io.github.hatayama.UnityCliLoop.Application
                     runningToolName,
                     requestedToolName,
                     playState.IsPlaying,
-                    playState.IsPaused);
+                    playState.IsPaused,
+                    runningToolElapsedSeconds: runningToolElapsedSeconds);
             }
 
-            return new UnityCliLoopToolBusyException(runningToolName, requestedToolName);
+            return new UnityCliLoopToolBusyException(
+                runningToolName,
+                requestedToolName,
+                runningToolElapsedSeconds: runningToolElapsedSeconds);
         }
     }
 }

--- a/Packages/src/Editor/Application/UnityCliLoopToolExecutionService.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopToolExecutionService.cs
@@ -15,13 +15,16 @@ namespace io.github.hatayama.UnityCliLoop.Application
     internal sealed class UnityCliLoopToolExecutionService
     {
         private readonly IEditorRuntimeStatePort _editorRuntimeStatePort;
-        private readonly ToolExecutionSession _executionSession = new();
+        private readonly ToolExecutionSession _executionSession;
 
-        internal UnityCliLoopToolExecutionService(IEditorRuntimeStatePort editorRuntimeStatePort)
+        internal UnityCliLoopToolExecutionService(
+            IEditorRuntimeStatePort editorRuntimeStatePort,
+            ToolExecutionSession executionSession = null)
         {
             Debug.Assert(editorRuntimeStatePort != null, "editorRuntimeStatePort must not be null");
 
             _editorRuntimeStatePort = editorRuntimeStatePort ?? throw new ArgumentNullException(nameof(editorRuntimeStatePort));
+            _executionSession = executionSession ?? new ToolExecutionSession();
         }
 
         internal async Task<UnityCliLoopToolResponse> ExecuteToolAsync(

--- a/Packages/src/Editor/Domain/ToolExecutionSession.cs
+++ b/Packages/src/Editor/Domain/ToolExecutionSession.cs
@@ -13,8 +13,15 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         private const string UnknownToolName = "unknown";
 
         private readonly object _executionStateLock = new();
+        private readonly Func<long> _timestampProvider;
         private string _runningToolName;
         private int _runningExecutionCount;
+        private long _runningStartedTimestamp;
+
+        internal ToolExecutionSession(Func<long> timestampProvider = null)
+        {
+            _timestampProvider = timestampProvider ?? Stopwatch.GetTimestamp;
+        }
 
         internal ToolExecutionSessionBeginResult Begin(UnityCliLoopToolRegistry registry, string toolName)
         {
@@ -40,7 +47,9 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             ToolExecutionSessionEnterResult enterResult = TryEnter(toolName);
             if (!enterResult.IsEntered)
             {
-                return ToolExecutionSessionBeginResult.Busy(enterResult.RunningToolName);
+                return ToolExecutionSessionBeginResult.Busy(
+                    enterResult.RunningToolName,
+                    enterResult.RunningToolElapsedSeconds);
             }
 
             return ToolExecutionSessionBeginResult.Entered(tool);
@@ -56,16 +65,21 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 {
                     _runningToolName = requestedToolName;
                     _runningExecutionCount = 1;
+                    _runningStartedTimestamp = _timestampProvider();
                     return ToolExecutionSessionEnterResult.Entered();
                 }
 
                 if (CanShareExecutionSlot(_runningToolName, requestedToolName))
                 {
+                    // Why not refresh the start timestamp: shared-slot re-entry is the same
+                    // flight, so elapsed must keep measuring from the first Begin.
                     _runningExecutionCount++;
                     return ToolExecutionSessionEnterResult.Entered();
                 }
 
-                return ToolExecutionSessionEnterResult.Busy(GetRunningToolNameInsideLock());
+                return ToolExecutionSessionEnterResult.Busy(
+                    GetRunningToolNameInsideLock(),
+                    GetRunningToolElapsedSecondsInsideLock());
             }
         }
 
@@ -81,6 +95,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 }
 
                 _runningToolName = null;
+                _runningStartedTimestamp = 0;
             }
         }
 
@@ -96,6 +111,13 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 ? UnknownToolName
                 : _runningToolName;
         }
+
+        private int GetRunningToolElapsedSecondsInsideLock()
+        {
+            long elapsedTicks = _timestampProvider() - _runningStartedTimestamp;
+            Debug.Assert(elapsedTicks >= 0, "monotonic session clock must not go backwards");
+            return (int)(elapsedTicks / Stopwatch.Frequency);
+        }
     }
 
     /// <summary>
@@ -106,8 +128,13 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public readonly bool IsEntered;
         public readonly IUnityCliLoopTool Tool;
         public readonly string RunningToolName;
+        public readonly int? RunningToolElapsedSeconds;
 
-        private ToolExecutionSessionBeginResult(bool isEntered, IUnityCliLoopTool tool, string runningToolName)
+        private ToolExecutionSessionBeginResult(
+            bool isEntered,
+            IUnityCliLoopTool tool,
+            string runningToolName,
+            int? runningToolElapsedSeconds)
         {
             Debug.Assert(isEntered == (tool != null), "entered sessions must carry a tool");
             Debug.Assert(isEntered || !string.IsNullOrWhiteSpace(runningToolName), "runningToolName must not be null or whitespace for busy decisions");
@@ -115,18 +142,19 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             IsEntered = isEntered;
             Tool = tool;
             RunningToolName = runningToolName;
+            RunningToolElapsedSeconds = runningToolElapsedSeconds;
         }
 
         public static ToolExecutionSessionBeginResult Entered(IUnityCliLoopTool tool)
         {
             Debug.Assert(tool != null, "tool must not be null");
 
-            return new ToolExecutionSessionBeginResult(true, tool, string.Empty);
+            return new ToolExecutionSessionBeginResult(true, tool, string.Empty, null);
         }
 
-        public static ToolExecutionSessionBeginResult Busy(string runningToolName)
+        public static ToolExecutionSessionBeginResult Busy(string runningToolName, int? runningToolElapsedSeconds = null)
         {
-            return new ToolExecutionSessionBeginResult(false, null, runningToolName);
+            return new ToolExecutionSessionBeginResult(false, null, runningToolName, runningToolElapsedSeconds);
         }
     }
 
@@ -137,23 +165,25 @@ namespace io.github.hatayama.UnityCliLoop.Domain
     {
         public readonly bool IsEntered;
         public readonly string RunningToolName;
+        public readonly int? RunningToolElapsedSeconds;
 
-        private ToolExecutionSessionEnterResult(bool isEntered, string runningToolName)
+        private ToolExecutionSessionEnterResult(bool isEntered, string runningToolName, int? runningToolElapsedSeconds)
         {
             Debug.Assert(isEntered || !string.IsNullOrWhiteSpace(runningToolName), "runningToolName must not be null or whitespace for busy decisions");
 
             IsEntered = isEntered;
             RunningToolName = runningToolName;
+            RunningToolElapsedSeconds = runningToolElapsedSeconds;
         }
 
         public static ToolExecutionSessionEnterResult Entered()
         {
-            return new ToolExecutionSessionEnterResult(true, string.Empty);
+            return new ToolExecutionSessionEnterResult(true, string.Empty, null);
         }
 
-        public static ToolExecutionSessionEnterResult Busy(string runningToolName)
+        public static ToolExecutionSessionEnterResult Busy(string runningToolName, int? runningToolElapsedSeconds = null)
         {
-            return new ToolExecutionSessionEnterResult(false, runningToolName);
+            return new ToolExecutionSessionEnterResult(false, runningToolName, runningToolElapsedSeconds);
         }
     }
 }

--- a/Packages/src/Editor/Infrastructure/Api/JsonRpcResponseFactory.cs
+++ b/Packages/src/Editor/Infrastructure/Api/JsonRpcResponseFactory.cs
@@ -80,7 +80,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     exceptionResponse.Explanation ?? ex.Message,
                     EditorMainThreadLivenessTracker.SecondsSinceLastMainThreadTick(),
                     busyEx.IsCompiling,
-                    busyEx.IsUpdating);
+                    busyEx.IsUpdating,
+                    busyEx.RunningToolElapsedSeconds);
             }
             else
             {

--- a/Packages/src/Editor/Infrastructure/Api/ServerBusyErrorData.cs
+++ b/Packages/src/Editor/Infrastructure/Api/ServerBusyErrorData.cs
@@ -30,6 +30,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public double? secondsSinceLastMainThreadTick { get; }
 
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public int? runningToolElapsedSeconds { get; }
+
         public ServerBusyErrorData(
             string runningToolName,
             string requestedToolName,
@@ -38,7 +41,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string message,
             double? secondsSinceLastMainThreadTick = null,
             bool? isCompiling = null,
-            bool? isUpdating = null)
+            bool? isUpdating = null,
+            int? runningToolElapsedSeconds = null)
             : base(message)
         {
             this.runningToolName = runningToolName;
@@ -48,6 +52,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             this.isCompiling = isCompiling;
             this.isUpdating = isUpdating;
             this.secondsSinceLastMainThreadTick = secondsSinceLastMainThreadTick;
+            this.runningToolElapsedSeconds = runningToolElapsedSeconds;
         }
     }
 }

--- a/cli/common/errors/busy_status.go
+++ b/cli/common/errors/busy_status.go
@@ -12,6 +12,14 @@ func unityServerBusyMessage(fallback string, data serverBusyErrorData, requested
 	}
 	// This surfaces only after the CLI's bounded busy retry gives up, so it is the one
 	// guaranteed teaching moment for the single-flight contract.
+	if data.RunningToolElapsedSeconds != nil {
+		return fmt.Sprintf(
+			"'%s' was not executed because Unity is busy running '%s' (running for %ds). uloop is single-flight by design; never run uloop commands in parallel. The CLI already retried for up to 10 seconds, so wait for '%s' to complete and run the command again.",
+			requestedToolName,
+			runningToolName,
+			*data.RunningToolElapsedSeconds,
+			runningToolName)
+	}
 	return fmt.Sprintf(
 		"'%s' was not executed because Unity is busy running '%s'. uloop is single-flight by design; never run uloop commands in parallel. The CLI already retried for up to 10 seconds, so wait for '%s' to complete and run the command again.",
 		requestedToolName,

--- a/cli/common/errors/error_envelope_test.go
+++ b/cli/common/errors/error_envelope_test.go
@@ -302,6 +302,22 @@ func TestClassifyServerBusyRPCError(t *testing.T) {
 	}
 }
 
+func TestClassifyServerBusyRPCError_WhenElapsedSecondsPresent_IncludesElapsedMessage(t *testing.T) {
+	// Verifies a present runningToolElapsedSeconds field uses the elapsed busy wording verbatim.
+	err := &unityipc.RPCError{
+		Code:    -32603,
+		Message: "Unity is busy running 'compile'. Retry 'get-logs' after the running tool completes.",
+		Data: json.RawMessage(
+			`{"type":"server_busy","runningToolName":"compile","requestedToolName":"get-logs","runningToolElapsedSeconds":12}`),
+	}
+
+	cliErr := ClassifyError(err, ErrorContext{ProjectRoot: "/tmp/MyProject", Command: "get-logs"})
+	expectedMessage := "'get-logs' was not executed because Unity is busy running 'compile' (running for 12s). uloop is single-flight by design; never run uloop commands in parallel. The CLI already retried for up to 10 seconds, so wait for 'compile' to complete and run the command again."
+	if cliErr.Message != expectedMessage {
+		t.Fatalf("message mismatch: %s", cliErr.Message)
+	}
+}
+
 func TestClassifyServerBusyRPCError_WhenCompiling_IncludesEditorActivityAndGuidance(t *testing.T) {
 	// Verifies compiling busy payloads add editor activity details and compile-specific guidance.
 	err := &unityipc.RPCError{

--- a/cli/common/errors/rpc_error_data.go
+++ b/cli/common/errors/rpc_error_data.go
@@ -13,6 +13,7 @@ type serverBusyErrorData struct {
 	IsCompiling                    *bool    `json:"isCompiling"`
 	IsUpdating                     *bool    `json:"isUpdating"`
 	SecondsSinceLastMainThreadTick *float64 `json:"secondsSinceLastMainThreadTick"`
+	RunningToolElapsedSeconds      *int     `json:"runningToolElapsedSeconds"`
 }
 
 // Mirrors Packages/src/Editor/Infrastructure/Api/CliUpdateRequiredErrorData.cs public properties.

--- a/cli/common/errors/server_busy_error_contract_test.go
+++ b/cli/common/errors/server_busy_error_contract_test.go
@@ -18,6 +18,12 @@ func TestDecodeServerBusyErrorData_WhenContractFixture_ReadsEveryField(t *testin
 	contract := readServerBusyErrorContract(t)
 
 	decoded := decodeServerBusyErrorData(contract.ErrorData)
+	assertServerBusyContractIdentity(t, decoded)
+	assertServerBusyContractEditorState(t, decoded)
+}
+
+func assertServerBusyContractIdentity(t *testing.T, decoded serverBusyErrorData) {
+	t.Helper()
 	if decoded.Type != "server_busy" {
 		t.Fatalf("type mismatch: %#v", decoded)
 	}
@@ -30,6 +36,13 @@ func TestDecodeServerBusyErrorData_WhenContractFixture_ReadsEveryField(t *testin
 	if decoded.RequestedToolName != "get-logs" {
 		t.Fatalf("requestedToolName mismatch: %#v", decoded)
 	}
+	if decoded.RunningToolElapsedSeconds == nil || *decoded.RunningToolElapsedSeconds != 12 {
+		t.Fatalf("runningToolElapsedSeconds mismatch: %#v", decoded)
+	}
+}
+
+func assertServerBusyContractEditorState(t *testing.T, decoded serverBusyErrorData) {
+	t.Helper()
 	if decoded.IsPlaying == nil || !*decoded.IsPlaying {
 		t.Fatalf("isPlaying mismatch: %#v", decoded)
 	}
@@ -44,9 +57,6 @@ func TestDecodeServerBusyErrorData_WhenContractFixture_ReadsEveryField(t *testin
 	}
 	if decoded.SecondsSinceLastMainThreadTick == nil || *decoded.SecondsSinceLastMainThreadTick != 1.5 {
 		t.Fatalf("secondsSinceLastMainThreadTick mismatch: %#v", decoded)
-	}
-	if decoded.RunningToolElapsedSeconds == nil || *decoded.RunningToolElapsedSeconds != 12 {
-		t.Fatalf("runningToolElapsedSeconds mismatch: %#v", decoded)
 	}
 }
 

--- a/cli/common/errors/server_busy_error_contract_test.go
+++ b/cli/common/errors/server_busy_error_contract_test.go
@@ -45,6 +45,9 @@ func TestDecodeServerBusyErrorData_WhenContractFixture_ReadsEveryField(t *testin
 	if decoded.SecondsSinceLastMainThreadTick == nil || *decoded.SecondsSinceLastMainThreadTick != 1.5 {
 		t.Fatalf("secondsSinceLastMainThreadTick mismatch: %#v", decoded)
 	}
+	if decoded.RunningToolElapsedSeconds == nil || *decoded.RunningToolElapsedSeconds != 12 {
+		t.Fatalf("runningToolElapsedSeconds mismatch: %#v", decoded)
+	}
 }
 
 func readServerBusyErrorContract(t *testing.T) serverBusyErrorContractFile {

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "37b3868ecf195cac6405ed46a758ffa87cdc84db"
+  "sharedInputsHash": "e1e52ec72e80d17b0f0e00e649cf571e1b2bb058"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "b3ae61bb3dd3d8285919d640eb1f431bede2c2b6"
+  "sharedInputsHash": "a78209f9349893f453d2f9f88dddf4f93651df0b"
 }

--- a/tests/contracts/server_busy_error_contract.json
+++ b/tests/contracts/server_busy_error_contract.json
@@ -9,6 +9,7 @@
     "isPaused": false,
     "isCompiling": true,
     "isUpdating": false,
-    "secondsSinceLastMainThreadTick": 1.5
+    "secondsSinceLastMainThreadTick": 1.5,
+    "runningToolElapsedSeconds": 12
   }
 }


### PR DESCRIPTION
## Summary
- Single-flight busy rejections now say how long the running tool has already been in flight.
- Older packages and editor-state busy replies keep the previous wording when elapsed seconds are absent.

## User Impact
- Before: a rejected command only said Unity was busy running another tool, with no sense of how long that wait had already lasted.
- After: the busy message includes `(running for {E}s)` when the Editor reports elapsed seconds, so a multi-minute compile lockout is visible instead of looking like an immediate deadlock. Commands that hit a busy Editor without that field keep the existing message.

## Changes
- The execution session records a monotonic start time with the running tool name, keeps it across shared-slot re-entry, and clears it when the last execution exits.
- Elapsed seconds are floored and copied additively onto the `server_busy` payload (`runningToolElapsedSeconds`). The IPC protocol version is unchanged.
- The CLI uses the elapsed wording only when that field is present.

## Verification
- `scripts/check-go-cli.sh`: pass (`common/errors` 0.832s, `project-runner` 16.686s)
- `scripts/stamp-release-inputs.sh`: run because `cli/common` non-test sources changed
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`: ErrorCount 0, Success true
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value "ToolExecutionSessionTests|ServerBusyErrorContractTests|JsonRpcResponseFactoryWireShapeCharacterizationTests"`: 23 passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

