### PR TITLE
fix: name the unpatched resolved method in the pause-point compiled-line-map warning

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftTests.cs
@@ -24,12 +24,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string FixtureProjectRelativePath =
             "Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftFixture.cs";
 
-        private const string HotReloadCompiledLineMapWarning =
+        private const string HotReloadCompiledLineMapWarningPrefix =
             "'Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftFixture.cs' has active "
-            + "hot-reload patches. For methods this reload did not patch, --line resolves against "
-            + "the last compiled source, not the edited file. Methods currently patched by hot "
-            + "reload resolve against the edited file instead. Verify ResolvedMethod and "
-            + "ResolvedLineText, or run 'uloop compile' and re-enable.";
+            + "hot-reload patches. The resolved method '";
+
+        private const string HotReloadCompiledLineMapWarningSuffix =
+            "' is not patched by this reload, so --line resolved against the last compiled "
+            + "source, not the edited file. Verify ResolvedLineText matches the statement you "
+            + "meant, or run 'uloop compile' and re-enable.";
 
         private const string CompiledSnapshotSentinel = "SENTINEL_COMPILED_LINE_TEXT";
 
@@ -95,7 +97,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(enable.RetargetedToHotReloadPatch, Is.False);
             Assert.That(enable.ResolvedMethod, Does.Contain(nameof(HotReloadPausePointLineDriftFixture.AfterTarget)));
             Assert.That(enable.ResolvedMethod, Does.Not.Contain(nameof(HotReloadPausePointLineDriftFixture.UnpatchedTarget)));
-            Assert.That(enable.Warning, Does.Contain(HotReloadCompiledLineMapWarning));
+            string expectedCompiledLineMapWarning =
+                HotReloadCompiledLineMapWarningPrefix
+                + enable.ResolvedMethod
+                + HotReloadCompiledLineMapWarningSuffix;
+            Assert.That(enable.Warning, Does.Contain(expectedCompiledLineMapWarning));
             Assert.That(enable.ResolvedLineText, Is.EqualTo(CompiledSnapshotSentinel));
         }
 

--- a/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
+++ b/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
@@ -18,6 +18,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     {
         private const string ForwardSlashFile = "Assets/Scripts/Example.cs";
 
+        private const string ExampleResolvedMethod = "ExampleType.ExampleMethod";
+
+        private const string ExpectedCompiledLineMapWarning =
+            "'Assets/Scripts/Example.cs' has active hot-reload patches. The resolved method "
+            + "'ExampleType.ExampleMethod' is not patched by this reload, so --line resolved "
+            + "against the last compiled source, not the edited file. Verify ResolvedLineText "
+            + "matches the statement you meant, or run 'uloop compile' and re-enable.";
+
+        private const string ExpectedCompiledLineMapResolveFailureWarning =
+            "'Assets/Scripts/Example.cs' has active hot-reload patches. --line resolves against "
+            + "the last compiled source, not the edited file, so a line number taken from the "
+            + "edited file can miss or fail to resolve. Methods currently patched by hot reload "
+            + "resolve against the edited file instead. Recompute the line against the last "
+            + "compiled source, or run 'uloop compile' and re-enable.";
+
+        private const string ExpectedEnableResolveFailureWarning =
+            "'Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs' has active "
+            + "hot-reload patches. --line resolves against the last compiled source, not the "
+            + "edited file, so a line number taken from the edited file can miss or fail to "
+            + "resolve. Methods currently patched by hot reload resolve against the edited file "
+            + "instead. Recompute the line against the last compiled source, or run 'uloop compile' "
+            + "and re-enable.";
+
         private const string ResolveFailureFile =
             "Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs";
 
@@ -48,19 +71,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
-        /// What: an active-patch file produces the success-path compiled-line-map warning.
+        /// What: an active-patch file produces the success-path compiled-line-map warning
+        /// that names the unpatched resolved method.
         /// </summary>
         [Test]
         public void BuildCompiledLineMapWarningOrEmpty_WhenPatchesAreActive_ReturnsFormattedWarning()
         {
-            string warning = PausePointEnableWarnings.BuildCompiledLineMapWarningOrEmpty(true, ForwardSlashFile);
+            string warning = PausePointEnableWarnings.BuildCompiledLineMapWarningOrEmpty(
+                true,
+                ForwardSlashFile,
+                ExampleResolvedMethod);
 
-            Assert.That(
-                warning,
-                Is.EqualTo(
-                    string.Format(
-                        SourcePausePointConstants.HotReloadCompiledLineMapWarningFormat,
-                        ForwardSlashFile)));
+            Assert.That(warning, Is.EqualTo(ExpectedCompiledLineMapWarning));
         }
 
         /// <summary>
@@ -69,14 +91,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void BuildCompiledLineMapWarningOrEmpty_WhenFileUsesBackslashes_NormalizesToForwardSlashes()
         {
-            string warning = PausePointEnableWarnings.BuildCompiledLineMapWarningOrEmpty(true, "Assets\\Scripts\\Example.cs");
+            string warning = PausePointEnableWarnings.BuildCompiledLineMapWarningOrEmpty(
+                true,
+                "Assets\\Scripts\\Example.cs",
+                ExampleResolvedMethod);
 
-            Assert.That(
-                warning,
-                Is.EqualTo(
-                    string.Format(
-                        SourcePausePointConstants.HotReloadCompiledLineMapWarningFormat,
-                        ForwardSlashFile)));
+            Assert.That(warning, Is.EqualTo(ExpectedCompiledLineMapWarning));
         }
 
         /// <summary>
@@ -85,7 +105,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void BuildCompiledLineMapWarningOrEmpty_WhenPatchesAreInactive_ReturnsEmpty()
         {
-            string warning = PausePointEnableWarnings.BuildCompiledLineMapWarningOrEmpty(false, ForwardSlashFile);
+            string warning = PausePointEnableWarnings.BuildCompiledLineMapWarningOrEmpty(
+                false,
+                ForwardSlashFile,
+                ExampleResolvedMethod);
 
             Assert.That(warning, Is.EqualTo(string.Empty));
         }
@@ -101,12 +124,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 true,
                 ForwardSlashFile);
 
-            Assert.That(
-                warning,
-                Is.EqualTo(
-                    string.Format(
-                        SourcePausePointConstants.HotReloadCompiledLineMapResolveFailureWarningFormat,
-                        ForwardSlashFile)));
+            Assert.That(warning, Is.EqualTo(ExpectedCompiledLineMapResolveFailureWarning));
         }
 
         /// <summary>
@@ -120,12 +138,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 true,
                 "Assets\\Scripts\\Example.cs");
 
-            Assert.That(
-                warning,
-                Is.EqualTo(
-                    string.Format(
-                        SourcePausePointConstants.HotReloadCompiledLineMapResolveFailureWarningFormat,
-                        ForwardSlashFile)));
+            Assert.That(warning, Is.EqualTo(ExpectedCompiledLineMapResolveFailureWarning));
         }
 
         /// <summary>
@@ -572,7 +585,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     PausePointEnableWarnings.MergeWarnings(
                         PausePointEnableWarnings.MergeWarnings(
                             PausePointEnableWarnings.CreateEnableWarning(),
-                            PausePointEnableWarnings.BuildCompiledLineMapWarningOrEmpty(true, ResolveFailureFile)),
+                            PausePointEnableWarnings.BuildCompiledLineMapWarningOrEmpty(
+                                true,
+                                ResolveFailureFile,
+                                response.ResolvedMethod)),
                         expectedDrift),
                     SourcePausePointConstants.SmallMethodInliningRiskWarning);
                 Assert.That(response.Warning, Is.EqualTo(expectedWarning));
@@ -651,7 +667,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     PausePointEnableWarnings.MergeWarnings(
                         PausePointEnableWarnings.MergeWarnings(
                             PausePointEnableWarnings.CreateEnableWarning(),
-                            PausePointEnableWarnings.BuildCompiledLineMapWarningOrEmpty(true, ResolveFailureFile)),
+                            PausePointEnableWarnings.BuildCompiledLineMapWarningOrEmpty(
+                                true,
+                                ResolveFailureFile,
+                                response.ResolvedMethod)),
                         expectedSnap),
                     SourcePausePointConstants.SmallMethodInliningRiskWarning);
                 Assert.That(response.Warning, Is.EqualTo(expectedWarning));
@@ -1390,12 +1409,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
                 Assert.That(withPatches.Success, Is.False);
                 Assert.That(withPatches.ErrorCode, Is.EqualTo(SourcePausePointConstants.ErrorCodeResolveFailed));
-                Assert.That(
-                    withPatches.Warning,
-                    Is.EqualTo(
-                        string.Format(
-                            SourcePausePointConstants.HotReloadCompiledLineMapResolveFailureWarningFormat,
-                            ResolveFailureFile)));
+                Assert.That(withPatches.Warning, Is.EqualTo(ExpectedEnableResolveFailureWarning));
                 Assert.That(
                     withPatches.RecommendedNextAction,
                     Is.EqualTo(SourcePausePointConstants.HotReloadCompiledLineMapResolveFailureNextAction));

--- a/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
+++ b/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
@@ -560,6 +560,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     response.Success,
                     Is.True,
                     response.ErrorCode + " / " + response.Message + " / " + response.RecommendedNextAction);
+                Assert.That(
+                    response.ResolvedMethod,
+                    Is.EqualTo(
+                        "System.Int32 io.github.hatayama.UnityCliLoop.Tests.Editor.PausePointCompiledLineMapWarningTests::CompiledLineDriftProbe()"));
                 SourcePausePointResolveResult spanResult = SourcePausePointResolver.Resolve(
                     ResolveFailureFile,
                     response.ResolvedLine);
@@ -647,6 +651,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     response.Success,
                     Is.True,
                     response.ErrorCode + " / " + response.Message + " / " + response.RecommendedNextAction);
+                Assert.That(
+                    response.ResolvedMethod,
+                    Is.EqualTo(
+                        "System.Int32 io.github.hatayama.UnityCliLoop.Tests.Editor.PausePointCompiledLineMapWarningTests::CompiledLineDriftProbe()"));
                 Assert.That(response.ResolvedLine, Is.EqualTo(compiledResolvedLine));
                 SourcePausePointResolveResult spanResult = SourcePausePointResolver.Resolve(
                     ResolveFailureFile,

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEnableWarnings.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEnableWarnings.cs
@@ -458,16 +458,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return genericCompiledLineMapWarning;
         }
 
-        internal static string BuildCompiledLineMapWarningOrEmpty(bool hasActiveHotReloadPatches, string file)
+        internal static string BuildCompiledLineMapWarningOrEmpty(
+            bool hasActiveHotReloadPatches,
+            string file,
+            string resolvedMethod)
         {
             if (!hasActiveHotReloadPatches)
             {
                 return string.Empty;
             }
 
+            Debug.Assert(!string.IsNullOrEmpty(resolvedMethod), "resolvedMethod must not be empty.");
             return string.Format(
                 SourcePausePointConstants.HotReloadCompiledLineMapWarningFormat,
-                SourcePausePointPathNormalizer.ToForwardSlashes(file));
+                SourcePausePointPathNormalizer.ToForwardSlashes(file),
+                resolvedMethod);
         }
 
         internal static string BuildCompiledLineMapResolveFailureWarningOrEmpty(

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
@@ -407,7 +407,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 patchedMethodPdbUnavailableWarning,
                 PausePointEnableWarnings.BuildCompiledLineMapWarningOrEmpty(
                     compareCompiledLineDrift,
-                    parameters.File));
+                    parameters.File,
+                    resolvedMethod));
             enableWarning = PausePointEnableWarnings.MergeWarnings(enableWarning, compiledLineMapWarning);
             if (compareCompiledLineDrift)
             {

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -232,7 +232,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // without a ResolvedMethod comparison (FB9).
         // Format: file, resolved method display name.
         public const string HotReloadCompiledLineMapWarningFormat =
-            "'{0}' has active hot-reload patches. The resolved method '{1}' is not patched by this reload, so --line resolved against the last compiled source, not the edited file. Verify ResolvedLineText matches the statement you meant, or run 'uloop compile' and re-enable.";
+            "'{0}' has active hot-reload patches. The resolved method '{1}' is not patched by this reload, "
+            + "so --line resolved against the last compiled source, not the edited file. Verify "
+            + "ResolvedLineText matches the statement you meant, or run 'uloop compile' and re-enable.";
 
         // Why a separate failure string: resolve failure leaves ResolvedMethod and
         // ResolvedLineText empty, so pointing at those fields is a dead end.

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -228,12 +228,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             + "no longer resolves in the compiled assembly. Re-enable the marker after 'uloop compile'.";
 
         // Why: unpatched methods keep the compiled line map while the editor shows the edited
-        // file. Agents otherwise arm a different method with no signal (FB9).
+        // file. Naming the resolved method tells agents the marker is on an unpatched method
+        // without a ResolvedMethod comparison (FB9).
+        // Format: file, resolved method display name.
         public const string HotReloadCompiledLineMapWarningFormat =
-            "'{0}' has active hot-reload patches. For methods this reload did not patch, --line "
-            + "resolves against the last compiled source, not the edited file. Methods currently "
-            + "patched by hot reload resolve against the edited file instead. Verify "
-            + "ResolvedMethod and ResolvedLineText, or run 'uloop compile' and re-enable.";
+            "'{0}' has active hot-reload patches. The resolved method '{1}' is not patched by this reload, so --line resolved against the last compiled source, not the edited file. Verify ResolvedLineText matches the statement you meant, or run 'uloop compile' and re-enable.";
 
         // Why a separate failure string: resolve failure leaves ResolvedMethod and
         // ResolvedLineText empty, so pointing at those fields is a dead end.


### PR DESCRIPTION
## Summary
- When a file has active hot-reload patches, `enable-pause-point` now names the resolved method in the compiled-line-map warning so it is clear that method was not patched by this reload.
- `--line` still resolves against the last compiled source for that unpatched method; the warning tells you to check `ResolvedLineText` or run `uloop compile`.

## User Impact
- Before: the warning said some methods were unpatched and asked you to compare `ResolvedMethod` yourself.
- After: the warning names the resolved method and states it is not patched by this reload.

## Changes
- Success-path compiled-line-map warning now interpolates the resolved method display name.
- Resolve-failure warning and next-action text are unchanged (`ResolvedMethod` is empty on that path).
- Tests lock the new success wording and the unchanged failure wording as fixed literals.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>` → `Success: true`, `ErrorCount: 0`
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value "PausePointCompiledLineMapWarningTests|HotReloadPausePointLineDriftTests"` → `TestCount 61`, `PassedCount 61`, `FailedCount 0`
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value PausePoint` → `TestCount 482`, `PassedCount 482`, `FailedCount 0`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

