### PR TITLE
feat: decline the Script Updating Consent dialog during CLI compiles

### DIFF
--- a/.agents/skills/uloop-compile/SKILL.md
+++ b/.agents/skills/uloop-compile/SKILL.md
@@ -52,4 +52,4 @@ Returns JSON:
 
 ## Troubleshooting
 
-If compile times out or Unity stops responding to uloop while the Editor looks idle, check whether Unity is showing **API Update Required** / **Script Updating Consent**. Ask the user to choose Go Ahead or No — never auto-dismiss that modal. Interactive Editors have no public uloop/Unity API to suppress it.
+When Unity's API Updater asks for consent to rewrite source files during a CLI compile (the 'Script Updating Consent' dialog), uloop declines automatically — source files are never rewritten without explicit user consent — and the response's Warning discloses the decline. The obsolete-API errors the updater would have fixed appear in Errors; fix them in code, or have the user accept the dialog in an interactive Unity session. Outside CLI compiles, and for the separate 'API Update Required' dialog, the modal can still appear and uloop cannot click it: if compile times out while the Editor looks idle, ask the user to answer the dialog — never auto-dismiss it.

--- a/.claude/skills/uloop-compile/SKILL.md
+++ b/.claude/skills/uloop-compile/SKILL.md
@@ -52,4 +52,4 @@ Returns JSON:
 
 ## Troubleshooting
 
-If compile times out or Unity stops responding to uloop while the Editor looks idle, check whether Unity is showing **API Update Required** / **Script Updating Consent**. Ask the user to choose Go Ahead or No — never auto-dismiss that modal. Interactive Editors have no public uloop/Unity API to suppress it.
+When Unity's API Updater asks for consent to rewrite source files during a CLI compile (the 'Script Updating Consent' dialog), uloop declines automatically — source files are never rewritten without explicit user consent — and the response's Warning discloses the decline. The obsolete-API errors the updater would have fixed appear in Errors; fix them in code, or have the user accept the dialog in an interactive Unity session. Outside CLI compiles, and for the separate 'API Update Required' dialog, the modal can still appear and uloop cannot click it: if compile times out while the Editor looks idle, ask the user to answer the dialog — never auto-dismiss it.

--- a/Assets/Tests/Editor/CompileApiUpdaterConsentDecisionTests.cs
+++ b/Assets/Tests/Editor/CompileApiUpdaterConsentDecisionTests.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests the pure intercept decision for Unity's Script Updating Consent dialog.
+    /// </summary>
+    [TestFixture]
+    public sealed class CompileApiUpdaterConsentDecisionTests
+    {
+        /// <summary>
+        /// What: an in-flight CLI compile is required before the dialog is intercepted.
+        /// </summary>
+        [Test]
+        public void Decide_WhenCliCompileIsNotInFlight_DoesNotIntercept()
+        {
+            (bool intercept, int declinedResult) decision = CompileApiUpdaterConsentDecision.Decide(
+                isCliCompileInFlight: false,
+                title: "Script Updating Consent");
+
+            Assert.That(decision.intercept, Is.False);
+            Assert.That(decision.declinedResult, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: a different dialog title is left to Unity even during a CLI compile.
+        /// </summary>
+        [Test]
+        public void Decide_WhenTitleDoesNotMatch_DoesNotIntercept()
+        {
+            (bool intercept, int declinedResult) decision = CompileApiUpdaterConsentDecision.Decide(
+                isCliCompileInFlight: true,
+                title: "API Update Required");
+
+            Assert.That(decision.intercept, Is.False);
+            Assert.That(decision.declinedResult, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: in-flight plus the Script Updating Consent title declines with result 1 (No).
+        /// </summary>
+        [Test]
+        public void Decide_WhenInFlightAndTitleMatches_InterceptsWithDeclinedResult()
+        {
+            (bool intercept, int declinedResult) decision = CompileApiUpdaterConsentDecision.Decide(
+                isCliCompileInFlight: true,
+                title: "Script Updating Consent");
+
+            Assert.That(decision.intercept, Is.True);
+            Assert.That(decision.declinedResult, Is.EqualTo(1));
+        }
+    }
+}

--- a/Assets/Tests/Editor/CompileApiUpdaterConsentDecisionTests.cs.meta
+++ b/Assets/Tests/Editor/CompileApiUpdaterConsentDecisionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0fa441c8d514449669486d0683439a18
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/CompileApiUpdaterConsentLifecycleTests.cs
+++ b/Assets/Tests/Editor/CompileApiUpdaterConsentLifecycleTests.cs
@@ -21,6 +21,52 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: CompleteCompileRequest copies a live decline onto the stored compile response.
+        /// </summary>
+        [Test]
+        public void CompleteCompileRequest_WhenConsentWasDeclined_PersistsDisclosure()
+        {
+            UnityCliLoopCompileResultSessionRepository compileResultSessionRepository =
+                UnityCliLoopEditorSessionStateTestFactory.CreateCompileResultSessionRepository();
+            UnityCliLoopPendingCompileSessionRepository pendingCompileSessionRepository =
+                UnityCliLoopEditorSessionStateTestFactory.CreatePendingCompileSessionRepository();
+            UnityCliLoopEditorSessionStateSnapshot originalSnapshot =
+                UnityCliLoopEditorSessionStateTestFactory.CaptureSnapshot();
+            UnityCliLoopEditorSessionStateTestFactory.ClearAll();
+
+            try
+            {
+                using CompileController controller = new(
+                    compileResultSessionRepository,
+                    pendingCompileSessionRepository);
+                controller.SetResultRecordingContext(
+                    CompileResultRecordingContext.Create(
+                        new CompileSchema
+                        {
+                            WaitForDomainReload = true,
+                            RequestId = "compile_consent_controller",
+                            ForceRecompile = false
+                        }));
+                CompileApiUpdaterConsentState.BeginCliCompile();
+                CompileApiUpdaterConsentState.MarkDeclined();
+
+                controller.CompleteCompileRequestForTesting(CreateSuccessfulResult());
+
+                UnityCliLoopStoredCompileResult storedResult =
+                    compileResultSessionRepository.GetCompileResult("compile_consent_controller");
+                Assert.That(storedResult.HasResult, Is.True);
+                Assert.That(
+                    storedResult.ResultJson,
+                    Does.Contain(
+                        "Unity's API Updater requested consent to rewrite source files ('Script Updating Consent' dialog). uloop declines this automatically: source files are not rewritten without explicit user consent. The obsolete-API compile errors it would have fixed are reported in Errors."));
+            }
+            finally
+            {
+                originalSnapshot.Restore();
+            }
+        }
+
+        /// <summary>
         /// What: the normal completion path leaves the in-flight flag false.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/CompileApiUpdaterConsentLifecycleTests.cs
+++ b/Assets/Tests/Editor/CompileApiUpdaterConsentLifecycleTests.cs
@@ -1,0 +1,145 @@
+using System;
+using NUnit.Framework;
+using UnityEditor.Compilation;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests that every CompileController exit path clears the CLI-compile in-flight flag.
+    /// </summary>
+    [TestFixture]
+    public sealed class CompileApiUpdaterConsentLifecycleTests
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            CompileApiUpdaterConsentState.EndCliCompile();
+        }
+
+        /// <summary>
+        /// What: the normal completion path leaves the in-flight flag false.
+        /// </summary>
+        [Test]
+        public void CompleteCompileRequest_WhenCompileFinishes_ClearsInFlight()
+        {
+            using CompileController controller = CreateController();
+            CompileApiUpdaterConsentState.BeginCliCompile();
+
+            controller.CompleteCompileRequestForTesting(CreateSuccessfulResult());
+
+            Assert.That(CompileApiUpdaterConsentState.IsCliCompileInFlight, Is.False);
+        }
+
+        /// <summary>
+        /// What: failing before RequestScriptCompilation transfers the task still clears the flag.
+        /// </summary>
+        [Test]
+        public void ClearUntransferredCompileState_WhenRequestDoesNotStart_ClearsInFlight()
+        {
+            using CompileController controller = CreateController();
+            CompileApiUpdaterConsentState.BeginCliCompile();
+
+            controller.ClearUntransferredCompileStateForTesting();
+
+            Assert.That(CompileApiUpdaterConsentState.IsCliCompileInFlight, Is.False);
+        }
+
+        /// <summary>
+        /// What: recovery and watchdog abort share CompleteCompileRequest and clear the flag.
+        /// </summary>
+        [Test]
+        public void CompleteCompileRequest_WhenWatchdogAborts_ClearsInFlight()
+        {
+            using CompileController controller = CreateController();
+            CompileApiUpdaterConsentState.BeginCliCompile();
+            CompileResult abortResult = new CompileResult(
+                success: false,
+                errorCount: 0,
+                warningCount: 0,
+                completedAt: DateTime.Now,
+                messages: Array.Empty<CompilerMessage>(),
+                errors: Array.Empty<CompilerMessage>(),
+                warnings: Array.Empty<CompilerMessage>(),
+                isIndeterminate: true,
+                message: "Compilation watchdog failed unexpectedly.");
+
+            controller.CompleteCompileRequestForTesting(abortResult);
+
+            Assert.That(CompileApiUpdaterConsentState.IsCliCompileInFlight, Is.False);
+        }
+
+        /// <summary>
+        /// What: cancellation completes through CompleteCompileRequest and clears the flag.
+        /// </summary>
+        [Test]
+        public void CompleteCompileRequest_WhenCancelled_ClearsInFlight()
+        {
+            using CompileController controller = CreateController();
+            CompileApiUpdaterConsentState.BeginCliCompile();
+            CompileResult cancelledResult = new CompileResult(
+                success: false,
+                errorCount: 0,
+                warningCount: 0,
+                completedAt: DateTime.Now,
+                messages: Array.Empty<CompilerMessage>(),
+                errors: Array.Empty<CompilerMessage>(),
+                warnings: Array.Empty<CompilerMessage>(),
+                isIndeterminate: true,
+                message: "Compilation was cancelled.");
+
+            controller.CompleteCompileRequestForTesting(cancelledResult);
+
+            Assert.That(CompileApiUpdaterConsentState.IsCliCompileInFlight, Is.False);
+        }
+
+        /// <summary>
+        /// What: Cleanup clears the in-flight flag without waiting for a compile callback.
+        /// </summary>
+        [Test]
+        public void Cleanup_WhenCliCompileIsInFlight_ClearsInFlight()
+        {
+            CompileController controller = CreateController();
+            CompileApiUpdaterConsentState.BeginCliCompile();
+
+            controller.Cleanup();
+
+            Assert.That(CompileApiUpdaterConsentState.IsCliCompileInFlight, Is.False);
+            controller.Dispose();
+        }
+
+        /// <summary>
+        /// What: Dispose clears the in-flight flag through Cleanup.
+        /// </summary>
+        [Test]
+        public void Dispose_WhenCliCompileIsInFlight_ClearsInFlight()
+        {
+            CompileController controller = CreateController();
+            CompileApiUpdaterConsentState.BeginCliCompile();
+
+            controller.Dispose();
+
+            Assert.That(CompileApiUpdaterConsentState.IsCliCompileInFlight, Is.False);
+        }
+
+        private static CompileController CreateController()
+        {
+            return new CompileController(
+                UnityCliLoopEditorSessionStateTestFactory.CreateCompileResultSessionRepository(),
+                UnityCliLoopEditorSessionStateTestFactory.CreatePendingCompileSessionRepository());
+        }
+
+        private static CompileResult CreateSuccessfulResult()
+        {
+            return new CompileResult(
+                success: true,
+                errorCount: 0,
+                warningCount: 0,
+                completedAt: DateTime.Now,
+                messages: Array.Empty<CompilerMessage>(),
+                errors: Array.Empty<CompilerMessage>(),
+                warnings: Array.Empty<CompilerMessage>());
+        }
+    }
+}

--- a/Assets/Tests/Editor/CompileApiUpdaterConsentLifecycleTests.cs
+++ b/Assets/Tests/Editor/CompileApiUpdaterConsentLifecycleTests.cs
@@ -2,7 +2,9 @@ using System;
 using NUnit.Framework;
 using UnityEditor.Compilation;
 
+using io.github.hatayama.UnityCliLoop.Domain;
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
@@ -44,6 +46,49 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             controller.ClearUntransferredCompileStateForTesting();
 
             Assert.That(CompileApiUpdaterConsentState.IsCliCompileInFlight, Is.False);
+        }
+
+        /// <summary>
+        /// What: failing before transfer also drops the request-scoped recording context
+        /// so a later completion cannot store a result under the abandoned request id.
+        /// </summary>
+        [Test]
+        public void ClearUntransferredCompileState_WhenRecordingWasEnabled_DoesNotStoreLaterResult()
+        {
+            UnityCliLoopCompileResultSessionRepository compileResultSessionRepository =
+                UnityCliLoopEditorSessionStateTestFactory.CreateCompileResultSessionRepository();
+            UnityCliLoopPendingCompileSessionRepository pendingCompileSessionRepository =
+                UnityCliLoopEditorSessionStateTestFactory.CreatePendingCompileSessionRepository();
+            UnityCliLoopEditorSessionStateSnapshot originalSnapshot =
+                UnityCliLoopEditorSessionStateTestFactory.CaptureSnapshot();
+            UnityCliLoopEditorSessionStateTestFactory.ClearAll();
+
+            try
+            {
+                using CompileController controller = new(
+                    compileResultSessionRepository,
+                    pendingCompileSessionRepository);
+                controller.SetResultRecordingContext(
+                    CompileResultRecordingContext.Create(
+                        new CompileSchema
+                        {
+                            WaitForDomainReload = true,
+                            RequestId = "abandoned_compile_request",
+                            ForceRecompile = false
+                        }));
+                CompileApiUpdaterConsentState.BeginCliCompile();
+
+                controller.ClearUntransferredCompileStateForTesting();
+                controller.CompleteCompileRequestForTesting(CreateSuccessfulResult());
+
+                UnityCliLoopStoredCompileResult storedResult =
+                    compileResultSessionRepository.GetCompileResult("abandoned_compile_request");
+                Assert.That(storedResult.HasResult, Is.False);
+            }
+            finally
+            {
+                originalSnapshot.Restore();
+            }
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/CompileApiUpdaterConsentLifecycleTests.cs.meta
+++ b/Assets/Tests/Editor/CompileApiUpdaterConsentLifecycleTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c43ca57d613294c4ebeaf63a8922fe82
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/CompileApiUpdaterConsentPropagationTests.cs
+++ b/Assets/Tests/Editor/CompileApiUpdaterConsentPropagationTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UnityEditor.Compilation;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests that a Script Updating Consent decline reaches both delayed and immediate compile responses.
+    /// </summary>
+    [TestFixture]
+    public sealed class CompileApiUpdaterConsentPropagationTests
+    {
+        private const string WarningText =
+            "Unity's API Updater requested consent to rewrite source files ('Script Updating Consent' dialog). uloop declines this automatically: source files are not rewritten without explicit user consent. The obsolete-API compile errors it would have fixed are reported in Errors.";
+
+        private const string NextActionText =
+            "Fix the obsolete API usages reported in Errors, or ask the user to accept the Script Updating Consent dialog in an interactive Unity session.";
+
+        /// <summary>
+        /// What: the delayed SessionState path stores the decline Warning and NextActions.
+        /// </summary>
+        [Test]
+        public void RecordCompileResult_WhenConsentWasDeclined_PersistsDisclosure()
+        {
+            UnityCliLoopCompileResultSessionRepository compileResultSessionRepository =
+                UnityCliLoopEditorSessionStateTestFactory.CreateCompileResultSessionRepository();
+            UnityCliLoopPendingCompileSessionRepository pendingCompileSessionRepository =
+                UnityCliLoopEditorSessionStateTestFactory.CreatePendingCompileSessionRepository();
+            UnityCliLoopCompileSessionLifecycleService compileSessionLifecycleService =
+                UnityCliLoopEditorSessionStateTestFactory.CreateCompileSessionLifecycleService();
+            UnityCliLoopEditorSessionStateSnapshot originalSnapshot =
+                UnityCliLoopEditorSessionStateTestFactory.CaptureSnapshot();
+            UnityCliLoopEditorSessionStateTestFactory.ClearAll();
+
+            try
+            {
+                compileSessionLifecycleService.MarkPendingCompileRequest(
+                    "compile_consent_delayed",
+                    forceRecompile: false,
+                    markedAtUtc: DateTime.UtcNow);
+                CompileResult result = CreateDeclinedResult();
+
+                CompileResponse response = CompileResultSessionRecorder.RecordCompileResult(
+                    compileResultSessionRepository,
+                    pendingCompileSessionRepository,
+                    "compile_consent_delayed",
+                    forceRecompile: false,
+                    result,
+                    "compile_consent_delayed");
+                UnityCliLoopStoredCompileResult storedResult =
+                    compileResultSessionRepository.GetCompileResult("compile_consent_delayed");
+
+                Assert.That(response.Warning, Is.EqualTo(WarningText));
+                Assert.That(response.NextActions, Is.EqualTo(new[] { NextActionText }));
+                Assert.That(storedResult.ResultJson, Does.Contain(WarningText));
+                Assert.That(storedResult.ResultJson, Does.Contain(NextActionText));
+            }
+            finally
+            {
+                originalSnapshot.Restore();
+            }
+        }
+
+        /// <summary>
+        /// What: the immediate UseCase path shapes the same decline Warning and NextActions.
+        /// </summary>
+        [Test]
+        public async Task CompileAsync_WhenConsentWasDeclined_ReturnsDisclosure()
+        {
+            UnityCliLoopCompileResultSessionRepository compileResultSessionRepository =
+                UnityCliLoopEditorSessionStateTestFactory.CreateCompileResultSessionRepository();
+            UnityCliLoopPendingCompileSessionRepository pendingCompileSessionRepository =
+                UnityCliLoopEditorSessionStateTestFactory.CreatePendingCompileSessionRepository();
+            UnityCliLoopCompileSessionLifecycleService compileSessionLifecycleService =
+                new(
+                    UnityCliLoopEditorSessionStateTestFactory.CreateSessionFlagsRepository(),
+                    compileResultSessionRepository,
+                    pendingCompileSessionRepository);
+            UnityCliLoopEditorSessionStateSnapshot originalSnapshot =
+                UnityCliLoopEditorSessionStateTestFactory.CaptureSnapshot();
+            UnityCliLoopEditorSessionStateTestFactory.ClearAll();
+
+            try
+            {
+                CompileResult executionResult = CreateDeclinedResult();
+                CompileUseCase useCase = new(
+                    compileSessionLifecycleService,
+                    compileResultSessionRepository,
+                    pendingCompileSessionRepository);
+                useCase.SetCompilationStateValidationForTesting(() => ValidationResult.Success());
+                useCase.SetCompilationExecutionForTesting((compileRequest, pausePointWarning, ct) =>
+                {
+                    ct.ThrowIfCancellationRequested();
+                    return Task.FromResult(executionResult);
+                });
+
+                CompileResponse response = await useCase.CompileAsync(
+                    new CompileSchema
+                    {
+                        WaitForDomainReload = false,
+                        RequestId = "compile_consent_immediate",
+                        ForceRecompile = false,
+                        ReloadExternalSceneChanges = true
+                    },
+                    CancellationToken.None);
+
+                Assert.That(response.Warning, Is.EqualTo(WarningText));
+                Assert.That(response.NextActions, Is.EqualTo(new[] { NextActionText }));
+            }
+            finally
+            {
+                originalSnapshot.Restore();
+            }
+        }
+
+        /// <summary>
+        /// What: CreateResponse appends the decline disclosure onto an existing pause-point Warning.
+        /// </summary>
+        [Test]
+        public void CreateResponse_WhenDeclinedWithExistingWarning_AppendsFixedWarning()
+        {
+            CompileResult result = CreateDeclinedResult();
+
+            CompileResponse response = CompileResponseFactory.CreateResponse(
+                result,
+                forceRecompile: false,
+                pausePointWarning: "Play Mode was active with 2 enabled pause point(s).");
+
+            Assert.That(
+                response.Warning,
+                Is.EqualTo(
+                    "Play Mode was active with 2 enabled pause point(s).\n" + WarningText));
+            Assert.That(response.NextActions, Is.EqualTo(new[] { NextActionText }));
+        }
+
+        /// <summary>
+        /// What: CreateResponse appends the decline NextAction after force-compile NextActions.
+        /// </summary>
+        [Test]
+        public void CreateResponse_WhenDeclinedForceCompile_AppendsFixedNextAction()
+        {
+            CompileResult result = new CompileResult(
+                success: null,
+                errorCount: 0,
+                warningCount: 0,
+                completedAt: DateTime.Now,
+                messages: Array.Empty<CompilerMessage>(),
+                errors: Array.Empty<CompilerMessage>(),
+                warnings: Array.Empty<CompilerMessage>(),
+                isIndeterminate: true,
+                apiUpdaterConsentDeclined: true);
+
+            CompileResponse response = CompileResponseFactory.CreateResponse(
+                result,
+                forceRecompile: true,
+                pausePointWarning: null);
+
+            Assert.That(response.Warning, Is.EqualTo(WarningText));
+            Assert.That(
+                response.NextActions,
+                Is.EqualTo(new[]
+                {
+                    "Wait for domain reload to complete, then run `uloop compile` without --force-recompile to obtain a definitive result.",
+                    NextActionText
+                }));
+        }
+
+        private static CompileResult CreateDeclinedResult()
+        {
+            return new CompileResult(
+                success: false,
+                errorCount: 1,
+                warningCount: 0,
+                completedAt: DateTime.Now,
+                messages: Array.Empty<CompilerMessage>(),
+                errors: Array.Empty<CompilerMessage>(),
+                warnings: Array.Empty<CompilerMessage>(),
+                apiUpdaterConsentDeclined: true);
+        }
+    }
+}

--- a/Assets/Tests/Editor/CompileApiUpdaterConsentPropagationTests.cs.meta
+++ b/Assets/Tests/Editor/CompileApiUpdaterConsentPropagationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a3a2a7dc6074a412c8bfc03d07e68f27
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/CompileApiUpdaterConsentResponseComposerTests.cs
+++ b/Assets/Tests/Editor/CompileApiUpdaterConsentResponseComposerTests.cs
@@ -1,0 +1,122 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests Warning and NextActions composition for a declined Script Updating Consent dialog.
+    /// </summary>
+    [TestFixture]
+    public sealed class CompileApiUpdaterConsentResponseComposerTests
+    {
+        private const string WarningText =
+            "Unity's API Updater requested consent to rewrite source files ('Script Updating Consent' dialog). uloop declines this automatically: source files are not rewritten without explicit user consent. The obsolete-API compile errors it would have fixed are reported in Errors.";
+
+        private const string NextActionText =
+            "Fix the obsolete API usages reported in Errors, or ask the user to accept the Script Updating Consent dialog in an interactive Unity session.";
+
+        /// <summary>
+        /// What: a declined compile with empty Warning and NextActions gets the fixed literals only.
+        /// </summary>
+        [Test]
+        public void Apply_WhenWarningAndNextActionsAreEmpty_AssignsFixedLiterals()
+        {
+            CompileResponse response = CreateEmptyResponse();
+
+            CompileApiUpdaterConsentResponseComposer.Apply(response, apiUpdaterConsentDeclined: true);
+
+            Assert.That(response.Warning, Is.EqualTo(WarningText));
+            Assert.That(response.NextActions, Is.EqualTo(new[] { NextActionText }));
+        }
+
+        /// <summary>
+        /// What: an existing Warning is kept and the API Updater warning is appended after a newline.
+        /// </summary>
+        [Test]
+        public void Apply_WhenWarningAlreadyExists_AppendsFixedWarning()
+        {
+            CompileResponse response = CreateEmptyResponse();
+            response.Warning = "Play Mode was active with 2 enabled pause point(s).";
+
+            CompileApiUpdaterConsentResponseComposer.Apply(response, apiUpdaterConsentDeclined: true);
+
+            Assert.That(
+                response.Warning,
+                Is.EqualTo("Play Mode was active with 2 enabled pause point(s).\n" + WarningText));
+            Assert.That(response.NextActions, Is.EqualTo(new[] { NextActionText }));
+        }
+
+        /// <summary>
+        /// What: existing NextActions are kept and the API Updater action is appended at the end.
+        /// </summary>
+        [Test]
+        public void Apply_WhenNextActionsAlreadyExist_AppendsFixedNextAction()
+        {
+            CompileResponse response = CreateEmptyResponse();
+            response.NextActions = new[] { "Wait for domain reload to complete, then run `uloop compile` without --force-recompile to obtain a definitive result." };
+
+            CompileApiUpdaterConsentResponseComposer.Apply(response, apiUpdaterConsentDeclined: true);
+
+            Assert.That(response.Warning, Is.EqualTo(WarningText));
+            Assert.That(
+                response.NextActions,
+                Is.EqualTo(new[]
+                {
+                    "Wait for domain reload to complete, then run `uloop compile` without --force-recompile to obtain a definitive result.",
+                    NextActionText
+                }));
+        }
+
+        /// <summary>
+        /// What: existing Warning and NextActions are both preserved and the API Updater lines are appended.
+        /// </summary>
+        [Test]
+        public void Apply_WhenWarningAndNextActionsAlreadyExist_AppendsBoth()
+        {
+            CompileResponse response = CreateEmptyResponse();
+            response.Warning = "Play Mode was active with 2 enabled pause point(s).";
+            response.NextActions = new[] { "Wait for domain reload to complete, then run `uloop compile` without --force-recompile to obtain a definitive result." };
+
+            CompileApiUpdaterConsentResponseComposer.Apply(response, apiUpdaterConsentDeclined: true);
+
+            Assert.That(
+                response.Warning,
+                Is.EqualTo("Play Mode was active with 2 enabled pause point(s).\n" + WarningText));
+            Assert.That(
+                response.NextActions,
+                Is.EqualTo(new[]
+                {
+                    "Wait for domain reload to complete, then run `uloop compile` without --force-recompile to obtain a definitive result.",
+                    NextActionText
+                }));
+        }
+
+        /// <summary>
+        /// What: a compile that did not decline leaves Warning and NextActions unchanged.
+        /// </summary>
+        [Test]
+        public void Apply_WhenNotDeclined_LeavesResponseUnchanged()
+        {
+            CompileResponse response = CreateEmptyResponse();
+            response.Warning = "existing";
+            response.NextActions = new[] { "keep" };
+
+            CompileApiUpdaterConsentResponseComposer.Apply(response, apiUpdaterConsentDeclined: false);
+
+            Assert.That(response.Warning, Is.EqualTo("existing"));
+            Assert.That(response.NextActions, Is.EqualTo(new[] { "keep" }));
+        }
+
+        private static CompileResponse CreateEmptyResponse()
+        {
+            return new CompileResponse(
+                success: true,
+                errorCount: 0,
+                warningCount: 0,
+                errors: null,
+                warnings: null,
+                message: null);
+        }
+    }
+}

--- a/Assets/Tests/Editor/CompileApiUpdaterConsentResponseComposerTests.cs.meta
+++ b/Assets/Tests/Editor/CompileApiUpdaterConsentResponseComposerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9dd8cf38b65534df5921881439ba0a6d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/CompileApiUpdaterConsentStateTests.cs
+++ b/Assets/Tests/Editor/CompileApiUpdaterConsentStateTests.cs
@@ -1,0 +1,79 @@
+using System;
+using NUnit.Framework;
+using UnityEditor.Compilation;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests the static CLI-compile in-flight gate and decline transfer onto CompileResult.
+    /// </summary>
+    [TestFixture]
+    public sealed class CompileApiUpdaterConsentStateTests
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            CompileApiUpdaterConsentState.EndCliCompile();
+        }
+
+        /// <summary>
+        /// What: Begin marks the compile in flight and End clears it.
+        /// </summary>
+        [Test]
+        public void BeginAndEnd_ToggleInFlightFlag()
+        {
+            CompileApiUpdaterConsentState.BeginCliCompile();
+            Assert.That(CompileApiUpdaterConsentState.IsCliCompileInFlight, Is.True);
+
+            CompileApiUpdaterConsentState.EndCliCompile();
+            Assert.That(CompileApiUpdaterConsentState.IsCliCompileInFlight, Is.False);
+        }
+
+        /// <summary>
+        /// What: multiple declines still copy onto the result as a single declined fact.
+        /// </summary>
+        [Test]
+        public void AttachDeclined_WhenMarkedMultipleTimes_CopiesOnceOntoResult()
+        {
+            CompileApiUpdaterConsentState.BeginCliCompile();
+            CompileApiUpdaterConsentState.MarkDeclined();
+            CompileApiUpdaterConsentState.MarkDeclined();
+            CompileResult result = CreateSuccessfulResult();
+
+            CompileResult attached = CompileApiUpdaterConsentState.AttachDeclined(result);
+
+            Assert.That(attached.ApiUpdaterConsentDeclined, Is.True);
+            Assert.That(result.ApiUpdaterConsentDeclined, Is.False);
+        }
+
+        /// <summary>
+        /// What: End clears a decline that was never copied onto a result.
+        /// </summary>
+        [Test]
+        public void EndCliCompile_ClearsUnconsumedDecline()
+        {
+            CompileApiUpdaterConsentState.BeginCliCompile();
+            CompileApiUpdaterConsentState.MarkDeclined();
+            CompileApiUpdaterConsentState.EndCliCompile();
+
+            CompileResult attached = CompileApiUpdaterConsentState.AttachDeclined(CreateSuccessfulResult());
+
+            Assert.That(CompileApiUpdaterConsentState.IsCliCompileInFlight, Is.False);
+            Assert.That(attached.ApiUpdaterConsentDeclined, Is.False);
+        }
+
+        private static CompileResult CreateSuccessfulResult()
+        {
+            return new CompileResult(
+                success: true,
+                errorCount: 0,
+                warningCount: 0,
+                completedAt: DateTime.Now,
+                messages: Array.Empty<CompilerMessage>(),
+                errors: Array.Empty<CompilerMessage>(),
+                warnings: Array.Empty<CompilerMessage>());
+        }
+    }
+}

--- a/Assets/Tests/Editor/CompileApiUpdaterConsentStateTests.cs.meta
+++ b/Assets/Tests/Editor/CompileApiUpdaterConsentStateTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 816ba7904ffa6444dbb19ff261da9dcd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HarmonyVendoringSmoke/CompileApiUpdaterConsentPatchWiringTests.cs
+++ b/Assets/Tests/Editor/HarmonyVendoringSmoke/CompileApiUpdaterConsentPatchWiringTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Reflection;
 
@@ -6,24 +7,31 @@ using HarmonyLib;
 using NUnit.Framework;
 
 using UnityEditor;
+using UnityEditor.Compilation;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
     /// <summary>
-    /// Tests that the Script Updating Consent Harmony prefix is installed on DisplayDialogComplex.
-    /// Does not invoke DisplayDialogComplex itself — that would freeze the Editor in a modal loop.
+    /// Tests that the Script Updating Consent Harmony prefix is installed on DisplayDialogComplex
+    /// and that Prefix records a decline. Does not invoke DisplayDialogComplex itself — that
+    /// would freeze the Editor in a modal loop.
     /// </summary>
     public sealed class CompileApiUpdaterConsentPatchWiringTests
     {
+        [TearDown]
+        public void TearDown()
+        {
+            CompileApiUpdaterConsentState.EndCliCompile();
+        }
+
         /// <summary>
         /// What: EditorUtility.DisplayDialogComplex has the compile consent prefix after startup.
         /// </summary>
         [Test]
         public void DisplayDialogComplex_AfterStartup_HasCompileConsentPrefix()
         {
-            CompileEditorStartup.Initialize();
             MethodInfo original = typeof(EditorUtility).GetMethod(
                 nameof(EditorUtility.DisplayDialogComplex),
                 BindingFlags.Public | BindingFlags.Static,
@@ -38,6 +46,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 .Where(patch => patch.owner == "io.github.hatayama.uloop.compile-api-updater-consent")
                 .ToArray();
             Assert.That(ownedPrefixes.Length, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// What: Prefix declines Script Updating Consent while a CLI compile is in flight and
+        /// records that decline onto the compile result.
+        /// </summary>
+        [Test]
+        public void Prefix_WhenCliCompileIsInFlight_DeclinesAndRecordsConsent()
+        {
+            MethodInfo prefix = typeof(CompileApiUpdaterConsentPatcher).GetMethod(
+                "Prefix",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(prefix, Is.Not.Null);
+
+            CompileApiUpdaterConsentState.BeginCliCompile();
+            object[] arguments = { "Script Updating Consent", 0 };
+            object invokeResult = prefix.Invoke(null, arguments);
+
+            Assert.That(invokeResult, Is.EqualTo(false));
+            Assert.That(arguments[1], Is.EqualTo(1));
+
+            CompileResult attached = CompileApiUpdaterConsentState.AttachDeclined(
+                new CompileResult(
+                    success: true,
+                    errorCount: 0,
+                    warningCount: 0,
+                    completedAt: DateTime.Now,
+                    messages: Array.Empty<CompilerMessage>(),
+                    errors: Array.Empty<CompilerMessage>(),
+                    warnings: Array.Empty<CompilerMessage>()));
+            Assert.That(attached.ApiUpdaterConsentDeclined, Is.True);
         }
     }
 }

--- a/Assets/Tests/Editor/HarmonyVendoringSmoke/CompileApiUpdaterConsentPatchWiringTests.cs
+++ b/Assets/Tests/Editor/HarmonyVendoringSmoke/CompileApiUpdaterConsentPatchWiringTests.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using System.Reflection;
+
+using HarmonyLib;
+
+using NUnit.Framework;
+
+using UnityEditor;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests that the Script Updating Consent Harmony prefix is installed on DisplayDialogComplex.
+    /// Does not invoke DisplayDialogComplex itself — that would freeze the Editor in a modal loop.
+    /// </summary>
+    public sealed class CompileApiUpdaterConsentPatchWiringTests
+    {
+        /// <summary>
+        /// What: EditorUtility.DisplayDialogComplex has the compile consent prefix after startup.
+        /// </summary>
+        [Test]
+        public void DisplayDialogComplex_AfterStartup_HasCompileConsentPrefix()
+        {
+            CompileEditorStartup.Initialize();
+            MethodInfo original = typeof(EditorUtility).GetMethod(
+                nameof(EditorUtility.DisplayDialogComplex),
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                types: new[] { typeof(string), typeof(string), typeof(string), typeof(string), typeof(string) },
+                modifiers: null);
+
+            Assert.That(original, Is.Not.Null);
+            Patches patchInfo = Harmony.GetPatchInfo(original);
+            Assert.That(patchInfo, Is.Not.Null);
+            Patch[] ownedPrefixes = patchInfo.Prefixes
+                .Where(patch => patch.owner == "io.github.hatayama.uloop.compile-api-updater-consent")
+                .ToArray();
+            Assert.That(ownedPrefixes.Length, Is.EqualTo(1));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HarmonyVendoringSmoke/CompileApiUpdaterConsentPatchWiringTests.cs.meta
+++ b/Assets/Tests/Editor/HarmonyVendoringSmoke/CompileApiUpdaterConsentPatchWiringTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 23b5b57e202514d898a809d46120c6b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HarmonyVendoringSmoke/UnityCLILoop.Tests.Editor.HarmonyVendoringSmoke.asmdef
+++ b/Assets/Tests/Editor/HarmonyVendoringSmoke/UnityCLILoop.Tests.Editor.HarmonyVendoringSmoke.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "io.github.hatayama.UnityCliLoop.Tests.Editor",
     "references": [
         "GUID:0acc523941302664db1f4e527237feb3",
-        "GUID:27619889b8ba8c24980f49ee34dbb44a"
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:a39242918a7ab45519b2c80f798dce33"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/FirstPartyTools/Compile/AssemblyInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/AssemblyInfo.cs
@@ -2,5 +2,6 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]
+[assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.HarmonyVendoringSmoke")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.PlayMode")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Demo.Editor")]

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentConstants.cs
@@ -1,0 +1,20 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Fixed literals for declining Unity's Script Updating Consent dialog during CLI compiles.
+    /// </summary>
+    internal static class CompileApiUpdaterConsentConstants
+    {
+        public const string HarmonyId = "io.github.hatayama.uloop.compile-api-updater-consent";
+
+        public const string DialogTitle = "Script Updating Consent";
+
+        public const int DeclinedDialogResult = 1;
+
+        public const string WarningText =
+            "Unity's API Updater requested consent to rewrite source files ('Script Updating Consent' dialog). uloop declines this automatically: source files are not rewritten without explicit user consent. The obsolete-API compile errors it would have fixed are reported in Errors.";
+
+        public const string NextActionText =
+            "Fix the obsolete API usages reported in Errors, or ask the user to accept the Script Updating Consent dialog in an interactive Unity session.";
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentConstants.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentConstants.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 89701f0c543184044ae28edcee748fe5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentDecision.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentDecision.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Pure intercept decision for the Script Updating Consent dialog during a CLI compile.
+    /// </summary>
+    internal static class CompileApiUpdaterConsentDecision
+    {
+        /// <summary>
+        /// Returns whether <paramref name="title"/> should be declined without showing the dialog.
+        /// </summary>
+        internal static (bool intercept, int declinedResult) Decide(bool isCliCompileInFlight, string title)
+        {
+            if (!isCliCompileInFlight)
+            {
+                return (false, 0);
+            }
+
+            if (!string.Equals(title, CompileApiUpdaterConsentConstants.DialogTitle, StringComparison.Ordinal))
+            {
+                return (false, 0);
+            }
+
+            return (true, CompileApiUpdaterConsentConstants.DeclinedDialogResult);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentDecision.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentDecision.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56104954928014d1ea3d292466888642
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentPatcher.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Reflection;
+
+using HarmonyLib;
+
+using UnityEditor;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Installs a Harmony prefix that declines Unity's Script Updating Consent dialog while a
+    /// CLI compile is in flight.
+    /// </summary>
+    internal static class CompileApiUpdaterConsentPatcher
+    {
+        private static readonly Harmony HarmonyInstance =
+            new Harmony(CompileApiUpdaterConsentConstants.HarmonyId);
+
+        private static bool _installAttempted;
+
+        /// <summary>
+        /// Patches <see cref="EditorUtility.DisplayDialogComplex"/> once. Fail-open on install
+        /// errors so a missing method or Harmony emit failure never blocks the Editor.
+        /// </summary>
+        internal static void Install()
+        {
+            if (_installAttempted)
+            {
+                return;
+            }
+
+            _installAttempted = true;
+
+            MethodInfo original = typeof(EditorUtility).GetMethod(
+                nameof(EditorUtility.DisplayDialogComplex),
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                types: new[] { typeof(string), typeof(string), typeof(string), typeof(string), typeof(string) },
+                modifiers: null);
+            if (original == null)
+            {
+                VibeLogger.LogWarning(
+                    "compile_api_updater_consent_patch_missing_method",
+                    "Could not resolve EditorUtility.DisplayDialogComplex; Script Updating Consent decline is disabled.",
+                    new { });
+                return;
+            }
+
+            MethodInfo prefix = typeof(CompileApiUpdaterConsentPatcher).GetMethod(
+                nameof(Prefix),
+                BindingFlags.NonPublic | BindingFlags.Static);
+            UnityEngine.Debug.Assert(prefix != null, "consent prefix must resolve");
+            if (prefix == null)
+            {
+                VibeLogger.LogWarning(
+                    "compile_api_updater_consent_patch_missing_prefix",
+                    "Could not resolve the Script Updating Consent prefix; decline is disabled.",
+                    new { });
+                return;
+            }
+
+            try
+            {
+                // User-approved exception to the no-try-catch policy: Harmony emit/JIT
+                // failures cannot be pre-validated, and an escaping exception during Editor
+                // startup would disable the whole composition-root bootstrap. Log and fail
+                // open so CLI compile still runs and the dialog appears as before.
+                HarmonyInstance.Patch(original, prefix: new HarmonyMethod(prefix));
+            }
+            catch (Exception exception)
+            {
+                VibeLogger.LogWarning(
+                    "compile_api_updater_consent_patch_failed",
+                    "Harmony failed to patch EditorUtility.DisplayDialogComplex; Script Updating Consent decline is disabled.",
+                    new
+                    {
+                        exception_type = exception.GetType().Name,
+                        exception_message = exception.Message
+                    });
+            }
+        }
+
+        // Why no try-catch: this prefix must stay exception-free so a failure cannot swallow
+        // unrelated Editor dialogs. Decide and MarkDeclined only read/write static bools.
+        // Why ref __result: Harmony's prefix contract for replacing the original return value.
+        private static bool Prefix(string title, ref int __result)
+        {
+            (bool intercept, int declinedResult) decision = CompileApiUpdaterConsentDecision.Decide(
+                CompileApiUpdaterConsentState.IsCliCompileInFlight,
+                title);
+            if (!decision.intercept)
+            {
+                return true;
+            }
+
+            __result = decision.declinedResult;
+            CompileApiUpdaterConsentState.MarkDeclined();
+            return false;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentPatcher.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentPatcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8881856dfc9ec44339a08683411ed0d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentResponseComposer.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentResponseComposer.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Applies the API Updater decline disclosure onto an already-shaped CompileResponse.
+    /// </summary>
+    internal static class CompileApiUpdaterConsentResponseComposer
+    {
+        /// <summary>
+        /// Appends the fixed Warning and NextActions literals without overwriting existing values.
+        /// </summary>
+        internal static void Apply(CompileResponse response, bool apiUpdaterConsentDeclined)
+        {
+            Debug.Assert(response != null, "response must not be null");
+            if (!apiUpdaterConsentDeclined)
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(response.Warning))
+            {
+                response.Warning = CompileApiUpdaterConsentConstants.WarningText;
+            }
+            else
+            {
+                response.Warning = response.Warning + "\n" + CompileApiUpdaterConsentConstants.WarningText;
+            }
+
+            if (response.NextActions == null || response.NextActions.Length == 0)
+            {
+                response.NextActions = new[] { CompileApiUpdaterConsentConstants.NextActionText };
+                return;
+            }
+
+            string[] nextActions = new string[response.NextActions.Length + 1];
+            for (int index = 0; index < response.NextActions.Length; index++)
+            {
+                nextActions[index] = response.NextActions[index];
+            }
+
+            nextActions[response.NextActions.Length] = CompileApiUpdaterConsentConstants.NextActionText;
+            response.NextActions = nextActions;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentResponseComposer.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentResponseComposer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c3bddcb3ad5c4b9f83538d5a9812ba4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentState.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentState.cs
@@ -1,0 +1,66 @@
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Holds the in-flight CLI compile flag that the Harmony prefix reads, and the decline
+    /// fact until it is copied onto the request's CompileResult.
+    /// </summary>
+    internal static class CompileApiUpdaterConsentState
+    {
+        // Why static: Harmony prefix on EditorUtility.DisplayDialogComplex has no CompileController
+        // instance, so the in-flight gate must be reachable from a static prefix.
+        private static bool _cliCompileInFlight;
+        private static bool _declinedDuringCurrentCompile;
+
+        internal static bool IsCliCompileInFlight => _cliCompileInFlight;
+
+        /// <summary>
+        /// Marks a CLI-started compile as in flight so the consent dialog can be declined.
+        /// </summary>
+        internal static void BeginCliCompile()
+        {
+            _cliCompileInFlight = true;
+            _declinedDuringCurrentCompile = false;
+        }
+
+        /// <summary>
+        /// Clears the in-flight gate and any unconsumed decline fact.
+        /// </summary>
+        internal static void EndCliCompile()
+        {
+            _cliCompileInFlight = false;
+            _declinedDuringCurrentCompile = false;
+        }
+
+        /// <summary>
+        /// Records that the consent dialog was declined at least once for the current compile.
+        /// Multiple declines still collapse to a single disclosure.
+        /// </summary>
+        internal static void MarkDeclined()
+        {
+            if (!_cliCompileInFlight)
+            {
+                return;
+            }
+
+            _declinedDuringCurrentCompile = true;
+        }
+
+        /// <summary>
+        /// Moves the decline fact onto <paramref name="result"/> so it is no longer stored only
+        /// in this static gate.
+        /// </summary>
+        internal static CompileResult AttachDeclined(CompileResult result)
+        {
+            Debug.Assert(result != null, "result must not be null");
+            if (!_declinedDuringCurrentCompile)
+            {
+                return result;
+            }
+
+            _declinedDuringCurrentCompile = false;
+            return result.WithApiUpdaterConsentDeclined();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentState.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileApiUpdaterConsentState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9eb525c4aff948959334cc1c4beaf62
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -160,7 +160,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             try
             {
-                // Execute asset refresh.
+                // Why before Refresh: AssetDatabase.Refresh() can start a script compile itself,
+                // and that compile can raise Script Updating Consent. Begin must be set first
+                // or the prefix lets the modal through on the typical "edit then uloop compile" path.
+                CompileApiUpdaterConsentState.BeginCliCompile();
                 AssetDatabase.Refresh();
 
                 AssemblyDefinitionConsoleErrorValidationService assemblyDefinitionValidationService = new();
@@ -190,7 +193,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 string startMessage = forceRecompile ? "Forced recompile started after asset refresh..." : "Compilation started after asset refresh...";
                 OnCompileStarted?.Invoke(startMessage);
 
-                CompileApiUpdaterConsentState.BeginCliCompile();
                 if (forceRecompile)
                 {
                     CompilationPipeline.RequestScriptCompilation(RequestScriptCompilationOptions.CleanBuildCache);

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -363,7 +363,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _currentCompileTask = null;
             _isCompiling = false;
             _isForceCompile = false;
+            _resultRecordingContext = CompileResultRecordingContext.Disabled();
             _compileStartedAtUtc = DateTime.MinValue;
+            _pendingPausePointWarning = null;
             CompileApiUpdaterConsentState.EndCliCompile();
             compileTask.TrySetCanceled();
         }

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -190,6 +190,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 string startMessage = forceRecompile ? "Forced recompile started after asset refresh..." : "Compilation started after asset refresh...";
                 OnCompileStarted?.Invoke(startMessage);
 
+                CompileApiUpdaterConsentState.BeginCliCompile();
                 if (forceRecompile)
                 {
                     CompilationPipeline.RequestScriptCompilation(RequestScriptCompilationOptions.CleanBuildCache);
@@ -209,16 +210,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     ReferenceEquals(_currentCompileTask, compileTask) &&
                     !compileTask.Task.IsCompleted)
                 {
-                    if (eventsRegistered)
-                    {
-                        UnregisterCompilationEvents();
-                    }
-
-                    _currentCompileTask = null;
-                    _isCompiling = false;
-                    _isForceCompile = false;
-                    _compileStartedAtUtc = DateTime.MinValue;
-                    compileTask.TrySetCanceled();
+                    ClearUntransferredCompileState(compileTask, eventsRegistered);
                 }
             }
         }
@@ -326,11 +318,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             UnityEngine.Debug.Assert(result != null, "result must not be null");
 
+            CompileResult resultToComplete = CompileApiUpdaterConsentState.AttachDeclined(result);
             TaskCompletionSource<CompileResult> task = _currentCompileTask;
             // Completion subscribers are outside this controller, so state cleanup cannot depend on them returning.
             try
             {
-                RecordCompileResultIfNeeded(result, _pendingPausePointWarning);
+                RecordCompileResultIfNeeded(resultToComplete, _pendingPausePointWarning);
 
                 if (unregisterEvents)
                 {
@@ -339,7 +332,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 _isCompiling = false;
                 _isForceCompile = false;
-                OnCompileCompleted?.Invoke(result);
+                OnCompileCompleted?.Invoke(resultToComplete);
             }
             finally
             {
@@ -351,10 +344,48 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     _resultRecordingContext = CompileResultRecordingContext.Disabled();
                     _compileStartedAtUtc = DateTime.MinValue;
                     _pendingPausePointWarning = null;
+                    CompileApiUpdaterConsentState.EndCliCompile();
                 }
 
-                task?.TrySetResult(result);
+                task?.TrySetResult(resultToComplete);
             }
+        }
+
+        private void ClearUntransferredCompileState(
+            TaskCompletionSource<CompileResult> compileTask,
+            bool eventsRegistered)
+        {
+            if (eventsRegistered)
+            {
+                UnregisterCompilationEvents();
+            }
+
+            _currentCompileTask = null;
+            _isCompiling = false;
+            _isForceCompile = false;
+            _compileStartedAtUtc = DateTime.MinValue;
+            CompileApiUpdaterConsentState.EndCliCompile();
+            compileTask.TrySetCanceled();
+        }
+
+        /// <summary>
+        /// Completes an in-flight compile for tests without invoking Unity's compilation pipeline.
+        /// </summary>
+        internal void CompleteCompileRequestForTesting(CompileResult result)
+        {
+            UnityEngine.Debug.Assert(result != null, "result must not be null");
+            _currentCompileTask = new TaskCompletionSource<CompileResult>();
+            CompleteCompileRequest(result, unregisterEvents: false);
+        }
+
+        /// <summary>
+        /// Runs the request-before-transfer cleanup path for tests.
+        /// </summary>
+        internal void ClearUntransferredCompileStateForTesting()
+        {
+            TaskCompletionSource<CompileResult> compileTask = new();
+            _currentCompileTask = compileTask;
+            ClearUntransferredCompileState(compileTask, eventsRegistered: false);
         }
 
         private void RecordCompileResultIfNeeded(CompileResult result, string pausePointWarning)
@@ -485,6 +516,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _resultRecordingContext = CompileResultRecordingContext.Disabled();
             _compileStartedAtUtc = DateTime.MinValue;
             _pendingPausePointWarning = null;
+            CompileApiUpdaterConsentState.EndCliCompile();
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileEditorStartup.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileEditorStartup.cs
@@ -1,0 +1,12 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    // Keeps compile startup wiring inside the compile assembly so the composition
+    // root only depends on the bundled-tool facade.
+    internal static class CompileEditorStartup
+    {
+        public static void Initialize()
+        {
+            CompileApiUpdaterConsentPatcher.Install();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileEditorStartup.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileEditorStartup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 606fb4791eeee4b3d9fff40315b799b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileResponseFactory.cs
@@ -32,6 +32,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(result != null, "result must not be null");
 
+            CompileResponse response = CreateResponseWithoutApiUpdaterConsent(
+                result,
+                forceRecompile,
+                pausePointWarning);
+            CompileApiUpdaterConsentResponseComposer.Apply(response, result.ApiUpdaterConsentDeclined);
+            return response;
+        }
+
+        private static CompileResponse CreateResponseWithoutApiUpdaterConsent(
+            CompileResult result,
+            bool forceRecompile,
+            string pausePointWarning)
+        {
             if (forceRecompile && !result.PreserveDetailsWhenForceRecompile)
             {
                 return CreateForceCompileResult(result, pausePointWarning);

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileResult.cs
@@ -59,6 +59,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal bool PreserveDetailsWhenForceRecompile { get; }
 
         /// <summary>
+        /// Whether this compile declined Unity's Script Updating Consent dialog at least once.
+        /// </summary>
+        internal bool ApiUpdaterConsentDeclined { get; }
+
+        /// <summary>
         /// Initializes the compilation result.
         /// </summary>
         /// <param name="success">The compilation success flag. Null indicates indeterminate status.</param>
@@ -79,7 +84,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             CompilerMessage[] warnings,
             bool isIndeterminate = false,
             string message = null,
-            bool preserveDetailsWhenForceRecompile = false
+            bool preserveDetailsWhenForceRecompile = false,
+            bool apiUpdaterConsentDeclined = false
         )
         {
             Success = success;
@@ -92,6 +98,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             IsIndeterminate = isIndeterminate;
             Message = message;
             PreserveDetailsWhenForceRecompile = preserveDetailsWhenForceRecompile;
+            ApiUpdaterConsentDeclined = apiUpdaterConsentDeclined;
+        }
+
+        /// <summary>
+        /// Returns a copy that records a Script Updating Consent decline for response shaping.
+        /// </summary>
+        internal CompileResult WithApiUpdaterConsentDeclined()
+        {
+            return new CompileResult(
+                Success,
+                ErrorCount,
+                WarningCount,
+                CompletedAt,
+                Messages,
+                Errors,
+                Warnings,
+                IsIndeterminate,
+                Message,
+                PreserveDetailsWhenForceRecompile,
+                apiUpdaterConsentDeclined: true);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
@@ -52,4 +52,4 @@ Returns JSON:
 
 ## Troubleshooting
 
-If compile times out or Unity stops responding to uloop while the Editor looks idle, check whether Unity is showing **API Update Required** / **Script Updating Consent**. Ask the user to choose Go Ahead or No — never auto-dismiss that modal. Interactive Editors have no public uloop/Unity API to suppress it.
+When Unity's API Updater asks for consent to rewrite source files during a CLI compile (the 'Script Updating Consent' dialog), uloop declines automatically — source files are never rewritten without explicit user consent — and the response's Warning discloses the decline. The obsolete-API errors the updater would have fixed appear in Errors; fix them in code, or have the user accept the dialog in an interactive Unity session. Outside CLI compiles, and for the separate 'API Update Required' dialog, the modal can still appear and uloop cannot click it: if compile times out while the Editor looks idle, ask the user to answer the dialog — never auto-dismiss it.

--- a/Packages/src/Editor/FirstPartyTools/Compile/UnityCLILoop.FirstPartyTools.Compile.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Compile/UnityCLILoop.FirstPartyTools.Compile.Editor.asmdef
@@ -14,8 +14,11 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "UnityCliLoop.0Harmony.dll",
+        "Newtonsoft.Json.dll"
+    ],
     "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],

--- a/Packages/src/Editor/FirstPartyTools/FirstPartyToolsEditorStartup.cs
+++ b/Packages/src/Editor/FirstPartyTools/FirstPartyToolsEditorStartup.cs
@@ -12,6 +12,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ExternalSceneChangeTracker.Initialize();
             ControlPlayModeEditorStartup.Initialize();
             PausePointEditorStartup.Initialize();
+            CompileEditorStartup.Initialize();
             HotReloadEditorStartup.Initialize();
             ExecuteDynamicCodeEditorStartup.Initialize();
             GetLogsEditorStartup.Initialize();


### PR DESCRIPTION
## Summary
- CLI compiles no longer hang on Unity's Script Updating Consent dialog.
- uloop declines the rewrite, reports the decline in the compile response, and leaves obsolete-API errors in `Errors` for the agent to fix.

## User Impact
- Before: an interactive Editor could show Script Updating Consent during compile, freeze the main thread, and leave `uloop compile` silent until timeout.
- After: a CLI-started compile declines that dialog automatically (source is never rewritten without explicit user consent). The response Warning explains the decline; NextActions tell the agent to fix the obsolete APIs or ask the user to accept the dialog in an interactive session.
- Compiles that did not start from the CLI, and the separate API Update Required dialog, are unchanged.

## Changes
- While a CLI compile is in flight, intercept `EditorUtility.DisplayDialogComplex` only when the title is `Script Updating Consent`, and return the No button.
- Copy the decline onto the compile result before clearing in-flight state, then apply the same Warning / NextActions composition on both the delayed SessionState path and the immediate UseCase path.
- Install the Harmony prefix from `CompileEditorStartup` (no `[InitializeOnLoad]`). Fail open if patch install fails.
- Replace the compile skill Troubleshooting paragraph to match the new behavior.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Success, ErrorCount 0 (one pre-existing unrelated CS0414 warning).
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value "CompileApiUpdaterConsent"` → 22 passed, 0 failed.
- Related compile tests (`CompileResponseFactoryTests`, `CompileResultSessionRecorderTests`, `CompileUseCaseTests`, Harmony vendoring smoke, production startup-hook onion test) also passed in the broader 37-test run.
- `uloop skills install --claude --agents` regenerated the compile skill copies.

Refs #2320


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

