### PR TITLE
feat: name the Script Updating Consent dialog in the compile stall warning

### DIFF
--- a/cli/project-runner/internal/projectrunner/compile_wait_interim.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_interim.go
@@ -87,7 +87,7 @@ func formatCompileWaitProgressLine(elapsed time.Duration, status compileStatusRe
 
 func formatCompileWaitSilentLine(silentFor time.Duration) string {
 	return fmt.Sprintf(
-		"compile: Unity has not answered status polls for %ds. The Editor may be blocked by a modal dialog — commonly Unity's 'Script Updating Consent' or 'API Update Required' dialog, which uloop cannot click — or stuck. Check the Unity window, or restart Unity with 'uloop launch -r'.",
+		"compile: Unity has not answered status polls for %ds. The Editor may be blocked by a modal dialog — commonly Unity's 'Script Updating Consent' or 'API Update Required' dialog, which uloop cannot click — or stuck. Ask the user to answer the dialog in the Unity window. Restarting with 'uloop launch -r' helps only when no dialog is shown: the dialog reappears on every compile until the obsolete-API code is fixed or a person answers it.",
 		int(silentFor/time.Second),
 	)
 }

--- a/cli/project-runner/internal/projectrunner/compile_wait_interim.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_interim.go
@@ -87,7 +87,7 @@ func formatCompileWaitProgressLine(elapsed time.Duration, status compileStatusRe
 
 func formatCompileWaitSilentLine(silentFor time.Duration) string {
 	return fmt.Sprintf(
-		"compile: Unity has not answered status polls for %ds. The Editor may be blocked by a modal dialog or stuck; if this persists, restart Unity with 'uloop launch -r'.",
+		"compile: Unity has not answered status polls for %ds. The Editor may be blocked by a modal dialog — commonly Unity's 'Script Updating Consent' or 'API Update Required' dialog, which uloop cannot click — or stuck. Check the Unity window, or restart Unity with 'uloop launch -r'.",
 		int(silentFor/time.Second),
 	)
 }

--- a/cli/project-runner/internal/projectrunner/compile_wait_interim_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_interim_test.go
@@ -56,7 +56,7 @@ func TestCompileWaitInterimSwitchesToSilentLineAfterThirtySecondsWithoutSuccess(
 	if !due {
 		t.Fatal("expected a silent line after 30s without a successful poll")
 	}
-	expected := "compile: Unity has not answered status polls for 30s. The Editor may be blocked by a modal dialog or stuck; if this persists, restart Unity with 'uloop launch -r'."
+	expected := "compile: Unity has not answered status polls for 30s. The Editor may be blocked by a modal dialog — commonly Unity's 'Script Updating Consent' or 'API Update Required' dialog, which uloop cannot click — or stuck. Check the Unity window, or restart Unity with 'uloop launch -r'."
 	if line != expected {
 		t.Fatalf("silent line mismatch:\n got: %q\nwant: %q", line, expected)
 	}
@@ -76,7 +76,7 @@ func TestCompileWaitInterimReportsSilentLineWhenNoSuccessfulPolls(t *testing.T) 
 	if !due {
 		t.Fatal("expected a silent line at 30s with zero successful polls")
 	}
-	expected := "compile: Unity has not answered status polls for 30s. The Editor may be blocked by a modal dialog or stuck; if this persists, restart Unity with 'uloop launch -r'."
+	expected := "compile: Unity has not answered status polls for 30s. The Editor may be blocked by a modal dialog — commonly Unity's 'Script Updating Consent' or 'API Update Required' dialog, which uloop cannot click — or stuck. Check the Unity window, or restart Unity with 'uloop launch -r'."
 	if line != expected {
 		t.Fatalf("silent line mismatch:\n got: %q\nwant: %q", line, expected)
 	}
@@ -140,7 +140,7 @@ func TestWaitForAttachedCompileCompletionReportsInterimSilentLine(t *testing.T) 
 	if outcome != attachWaitTimedOut {
 		t.Fatalf("expected attach timeout: %v", outcome)
 	}
-	expected := "compile: Unity has not answered status polls for 30s. The Editor may be blocked by a modal dialog or stuck; if this persists, restart Unity with 'uloop launch -r'."
+	expected := "compile: Unity has not answered status polls for 30s. The Editor may be blocked by a modal dialog — commonly Unity's 'Script Updating Consent' or 'API Update Required' dialog, which uloop cannot click — or stuck. Check the Unity window, or restart Unity with 'uloop launch -r'."
 	if len(lines) == 0 || lines[0] != expected {
 		t.Fatalf("attach wait silent line mismatch: %#v", lines)
 	}

--- a/cli/project-runner/internal/projectrunner/compile_wait_interim_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_interim_test.go
@@ -56,7 +56,7 @@ func TestCompileWaitInterimSwitchesToSilentLineAfterThirtySecondsWithoutSuccess(
 	if !due {
 		t.Fatal("expected a silent line after 30s without a successful poll")
 	}
-	expected := "compile: Unity has not answered status polls for 30s. The Editor may be blocked by a modal dialog — commonly Unity's 'Script Updating Consent' or 'API Update Required' dialog, which uloop cannot click — or stuck. Check the Unity window, or restart Unity with 'uloop launch -r'."
+	expected := "compile: Unity has not answered status polls for 30s. The Editor may be blocked by a modal dialog — commonly Unity's 'Script Updating Consent' or 'API Update Required' dialog, which uloop cannot click — or stuck. Ask the user to answer the dialog in the Unity window. Restarting with 'uloop launch -r' helps only when no dialog is shown: the dialog reappears on every compile until the obsolete-API code is fixed or a person answers it."
 	if line != expected {
 		t.Fatalf("silent line mismatch:\n got: %q\nwant: %q", line, expected)
 	}
@@ -76,7 +76,7 @@ func TestCompileWaitInterimReportsSilentLineWhenNoSuccessfulPolls(t *testing.T) 
 	if !due {
 		t.Fatal("expected a silent line at 30s with zero successful polls")
 	}
-	expected := "compile: Unity has not answered status polls for 30s. The Editor may be blocked by a modal dialog — commonly Unity's 'Script Updating Consent' or 'API Update Required' dialog, which uloop cannot click — or stuck. Check the Unity window, or restart Unity with 'uloop launch -r'."
+	expected := "compile: Unity has not answered status polls for 30s. The Editor may be blocked by a modal dialog — commonly Unity's 'Script Updating Consent' or 'API Update Required' dialog, which uloop cannot click — or stuck. Ask the user to answer the dialog in the Unity window. Restarting with 'uloop launch -r' helps only when no dialog is shown: the dialog reappears on every compile until the obsolete-API code is fixed or a person answers it."
 	if line != expected {
 		t.Fatalf("silent line mismatch:\n got: %q\nwant: %q", line, expected)
 	}
@@ -140,7 +140,7 @@ func TestWaitForAttachedCompileCompletionReportsInterimSilentLine(t *testing.T) 
 	if outcome != attachWaitTimedOut {
 		t.Fatalf("expected attach timeout: %v", outcome)
 	}
-	expected := "compile: Unity has not answered status polls for 30s. The Editor may be blocked by a modal dialog — commonly Unity's 'Script Updating Consent' or 'API Update Required' dialog, which uloop cannot click — or stuck. Check the Unity window, or restart Unity with 'uloop launch -r'."
+	expected := "compile: Unity has not answered status polls for 30s. The Editor may be blocked by a modal dialog — commonly Unity's 'Script Updating Consent' or 'API Update Required' dialog, which uloop cannot click — or stuck. Ask the user to answer the dialog in the Unity window. Restarting with 'uloop launch -r' helps only when no dialog is shown: the dialog reappears on every compile until the obsolete-API code is fixed or a person answers it."
 	if len(lines) == 0 || lines[0] != expected {
 		t.Fatalf("attach wait silent line mismatch: %#v", lines)
 	}


### PR DESCRIPTION
## Summary
- When a CLI compile stalls because Unity stops answering status polls, the interim warning now names the two modal dialogs that commonly block the Editor: **Script Updating Consent** and **API Update Required**.
- Restart guidance is limited to the no-dialog case: answering the dialog or fixing obsolete APIs is the path that stops it from coming back.

## User Impact
- Before: a silent compile wait only said the Editor might be blocked by "a modal dialog or stuck", then pointed at `uloop launch -r`.
- After: the same wait names those two Unity dialogs, asks the operator to answer the dialog, and says restart helps only when no dialog is shown — because the dialog reappears on every compile until the obsolete-API code is fixed or a person answers it.

## Changes
- Replace the compile-wait silent-line format string and the matching full-literal test expectations.

## Verification
- `scripts/check-go-cli.sh` passed (format / vet / lint / tests / rebuild).
- Rebuilt `uloop-project-runner` via `ULOOP_PROJECT_RUNNER_PATH` + `uloop compile` returned `Success: true`, `ErrorCount: 0`.

Refs #2320
