### PR TITLE
feat: install skills into any directory with the new --output-dir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ REPOSITORY=hatayama/unity-cli-loop
 RELEASE_TAG=dispatcher-v<RELEASE_VERSION>
 SOURCE_REF=refs/heads/v3-beta
 tmp_dir=$(mktemp -d)
-gh release download "$RELEASE_TAG" --repo "$REPOSITORY" --pattern 'install.sh' --pattern 'install.sh.sigstore.json' --output-dir "$tmp_dir" && \
+gh release download "$RELEASE_TAG" --repo "$REPOSITORY" --pattern 'install.sh' --pattern 'install.sh.sigstore.json' --dir "$tmp_dir" && \
 tag_sha=$(gh api "repos/$REPOSITORY/commits/$RELEASE_TAG" --jq .sha) && \
 gh attestation verify "$tmp_dir/install.sh" --bundle "$tmp_dir/install.sh.sigstore.json" --repo "$REPOSITORY" --signer-workflow "$REPOSITORY/.github/workflows/dispatcher-publish.yml" --source-ref "$SOURCE_REF" --source-digest "$tag_sha" && \
 manifest=$(jq -r '.dsseEnvelope.payload | @base64d | fromjson | .subject[] | "\(.digest.sha256)  \(.name)"' "$tmp_dir/install.sh.sigstore.json" | LC_ALL=C sort) && \
@@ -153,7 +153,7 @@ $repository = 'hatayama/unity-cli-loop'
 $releaseTag = 'dispatcher-v<RELEASE_VERSION>'
 $sourceRef = 'refs/heads/v3-beta'
 $temporaryDirectory = New-Item -ItemType Directory -Force -Path (Join-Path $env:TEMP ([guid]::NewGuid()))
-gh release download $releaseTag --repo $repository --pattern 'install.ps1' --pattern 'install.ps1.sigstore.json' --output-dir $temporaryDirectory.FullName
+gh release download $releaseTag --repo $repository --pattern 'install.ps1' --pattern 'install.ps1.sigstore.json' --dir $temporaryDirectory.FullName
 if ($LASTEXITCODE -ne 0) { throw 'Installer download failed.' }
 $tagSha = gh api "repos/$repository/commits/$releaseTag" --jq .sha
 if ($LASTEXITCODE -ne 0) { throw 'Release tag resolution failed.' }

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ REPOSITORY=hatayama/unity-cli-loop
 RELEASE_TAG=dispatcher-v<RELEASE_VERSION>
 SOURCE_REF=refs/heads/v3-beta
 tmp_dir=$(mktemp -d)
-gh release download "$RELEASE_TAG" --repo "$REPOSITORY" --pattern 'install.sh' --pattern 'install.sh.sigstore.json' --dir "$tmp_dir" && \
+gh release download "$RELEASE_TAG" --repo "$REPOSITORY" --pattern 'install.sh' --pattern 'install.sh.sigstore.json' --output-dir "$tmp_dir" && \
 tag_sha=$(gh api "repos/$REPOSITORY/commits/$RELEASE_TAG" --jq .sha) && \
 gh attestation verify "$tmp_dir/install.sh" --bundle "$tmp_dir/install.sh.sigstore.json" --repo "$REPOSITORY" --signer-workflow "$REPOSITORY/.github/workflows/dispatcher-publish.yml" --source-ref "$SOURCE_REF" --source-digest "$tag_sha" && \
 manifest=$(jq -r '.dsseEnvelope.payload | @base64d | fromjson | .subject[] | "\(.digest.sha256)  \(.name)"' "$tmp_dir/install.sh.sigstore.json" | LC_ALL=C sort) && \
@@ -153,7 +153,7 @@ $repository = 'hatayama/unity-cli-loop'
 $releaseTag = 'dispatcher-v<RELEASE_VERSION>'
 $sourceRef = 'refs/heads/v3-beta'
 $temporaryDirectory = New-Item -ItemType Directory -Force -Path (Join-Path $env:TEMP ([guid]::NewGuid()))
-gh release download $releaseTag --repo $repository --pattern 'install.ps1' --pattern 'install.ps1.sigstore.json' --dir $temporaryDirectory.FullName
+gh release download $releaseTag --repo $repository --pattern 'install.ps1' --pattern 'install.ps1.sigstore.json' --output-dir $temporaryDirectory.FullName
 if ($LASTEXITCODE -ne 0) { throw 'Installer download failed.' }
 $tagSha = gh api "repos/$repository/commits/$releaseTag" --jq .sha
 if ($LASTEXITCODE -ne 0) { throw 'Release tag resolution failed.' }
@@ -222,6 +222,10 @@ uloop skills install --codex
 
 # Or install globally
 uloop skills install --claude --global
+
+# Or sync into a custom directory (e.g. an external skill-package store),
+# flat as <path>/<skill-name>; unmanaged files there are left untouched
+uloop skills install --output-dir path/to/skills
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ uloop skills install --codex
 uloop skills install --claude --global
 
 # Or sync into a custom directory (e.g. an external skill-package store),
-# flat as <path>/<skill-name>; unmanaged files there are left untouched
+# flat as <path>/<skill-name>; unmanaged top-level files there are left
+# untouched (skill-owned directories such as references/ are replaced wholly)
 uloop skills install --output-dir path/to/skills
 ```
 </details>

--- a/README_ja.md
+++ b/README_ja.md
@@ -227,6 +227,11 @@ uloop skills install --codex
 
 # または、グローバルにインストール
 uloop skills install --claude --global
+
+# または、任意のディレクトリ（外部のスキルパッケージストアなど）へ
+# <path>/<skill-name> のフラット構成で同期。uloopが管理しないトップレベルの
+# ファイルはそのまま残る（references/ などスキル所有のディレクトリは丸ごと置換）
+uloop skills install --output-dir path/to/skills
 ```
 </details>
 

--- a/cli/dispatcher/internal/dispatcher/skills.go
+++ b/cli/dispatcher/internal/dispatcher/skills.go
@@ -85,9 +85,10 @@ type skillTarget struct {
 }
 
 type skillCommandOptions struct {
-	global  bool
-	flat    bool
-	targets []skillTarget
+	global    bool
+	flat      bool
+	outputDir string
+	targets   []skillTarget
 }
 
 type skillDefinition struct {
@@ -120,6 +121,15 @@ func tryHandleSkillsRequest(args []string, startPath string, globalProjectPath s
 		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{Command: clicore.SkillsCommandName})
 		return true, 1
 	}
+	if isV3MigrationSkillSubcommand(subcommand) && options.outputDir != "" {
+		clierrors.WriteClassifiedError(stderr, &clierrors.ArgumentError{
+			Message:     "The --output-dir option is not supported for " + subcommand + ".",
+			Option:      "--output-dir",
+			Command:     clicore.SkillsCommandName,
+			NextActions: []string{"Run the subcommand with target flags such as --claude instead."},
+		}, clierrors.ErrorContext{Command: clicore.SkillsCommandName})
+		return true, 1
+	}
 
 	projectRoot, err := resolveSkillsProjectRoot(startPath, globalProjectPath, options.global)
 	if err != nil {
@@ -138,49 +148,6 @@ func tryHandleSkillsRequest(args []string, startPath string, globalProjectPath s
 	}
 
 	return true, runSkillsSubcommand(subcommand, projectRoot, skills, options, stdout, stderr)
-}
-
-func parseSkillsOptions(args []string) (skillCommandOptions, error) {
-	options := skillCommandOptions{}
-	seenTargets := map[string]bool{}
-	for _, arg := range args {
-		switch arg {
-		case "-g", "--global":
-			options.global = true
-		case "--flat":
-			options.flat = true
-		default:
-			targetID, ok := skillTargetIDFromFlag(arg)
-			if !ok {
-				return skillCommandOptions{}, &clierrors.ArgumentError{
-					Message:     "Unknown skills option: " + arg,
-					Option:      arg,
-					Command:     clicore.SkillsCommandName,
-					NextActions: []string{"Run `uloop skills --help` to inspect supported skills options."},
-				}
-			}
-			if seenTargets[targetID] {
-				continue
-			}
-			options.targets = append(options.targets, targetConfigs[targetID])
-			seenTargets[targetID] = true
-		}
-	}
-	return options, nil
-}
-
-// skillTargetIDFromFlag reports the target id for a --<id> flag when it maps to
-// a known entry in targetConfigs. The lookup is driven by targetConfigs so the
-// set of accepted flags stays consistent with the help output.
-func skillTargetIDFromFlag(arg string) (string, bool) {
-	if !strings.HasPrefix(arg, "--") {
-		return "", false
-	}
-	id := strings.TrimPrefix(arg, "--")
-	if _, ok := targetConfigs[id]; !ok {
-		return "", false
-	}
-	return id, true
 }
 
 func isKnownSkillsSubcommand(subcommand string) bool {

--- a/cli/dispatcher/internal/dispatcher/skills.go
+++ b/cli/dispatcher/internal/dispatcher/skills.go
@@ -121,10 +121,10 @@ func tryHandleSkillsRequest(args []string, startPath string, globalProjectPath s
 		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{Command: clicore.SkillsCommandName})
 		return true, 1
 	}
-	if isV3MigrationSkillSubcommand(subcommand) && options.outputDir != "" {
+	if !skillsSubcommandSupportsOutputDir(subcommand) && options.outputDir != "" {
 		clierrors.WriteClassifiedError(stderr, &clierrors.ArgumentError{
-			Message:     "The --output-dir option is not supported for " + subcommand + ".",
-			Option:      "--output-dir",
+			Message:     "The " + skillsOutputDirFlagName + " option is not supported for " + subcommand + ".",
+			Option:      skillsOutputDirFlagName,
 			Command:     clicore.SkillsCommandName,
 			NextActions: []string{"Run the subcommand with target flags such as --claude instead."},
 		}, clierrors.ErrorContext{Command: clicore.SkillsCommandName})
@@ -157,6 +157,13 @@ func isKnownSkillsSubcommand(subcommand string) bool {
 	default:
 		return false
 	}
+}
+
+// skillsSubcommandSupportsOutputDir reports whether a known skills subcommand
+// accepts --output-dir. Help, guidance, and the routing rejection all consult
+// this one predicate so their notion of support cannot drift.
+func skillsSubcommandSupportsOutputDir(subcommand string) bool {
+	return !isV3MigrationSkillSubcommand(subcommand)
 }
 
 func isV3MigrationSkillSubcommand(subcommand string) bool {

--- a/cli/dispatcher/internal/dispatcher/skills.go
+++ b/cli/dispatcher/internal/dispatcher/skills.go
@@ -159,11 +159,18 @@ func isKnownSkillsSubcommand(subcommand string) bool {
 	}
 }
 
-// skillsSubcommandSupportsOutputDir reports whether a known skills subcommand
-// accepts --output-dir. Help, guidance, and the routing rejection all consult
-// this one predicate so their notion of support cannot drift.
+// skillsSubcommandSupportsOutputDir reports whether a skills subcommand runs
+// in --output-dir mode. Help, guidance, and the routing rejection all consult
+// this one predicate; it is a positive list matching the dir-mode dispatch, so
+// a future subcommand is not advertised as supporting the flag until dir mode
+// is actually wired for it.
 func skillsSubcommandSupportsOutputDir(subcommand string) bool {
-	return !isV3MigrationSkillSubcommand(subcommand)
+	switch subcommand {
+	case "list", "install", "uninstall":
+		return true
+	default:
+		return false
+	}
 }
 
 func isV3MigrationSkillSubcommand(subcommand string) bool {

--- a/cli/dispatcher/internal/dispatcher/skills_dir.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir.go
@@ -5,6 +5,12 @@ package dispatcher
 // destination may hold files uloop does not own (package manifests placed next
 // to SKILL.md), so every operation here touches only entries that exist in the
 // skill source directory.
+//
+// Deliberate omissions compared to target installs: disabled-tool filtering and
+// deprecated-skill cleanup do not run here. An external store is not scoped to
+// one Unity project, so one project's tool settings must not hide skills from
+// it, and deleting directories whose names uloop merely used in the past would
+// break the guarantee that only source-owned entries are ever removed.
 
 import (
 	"bytes"
@@ -120,9 +126,12 @@ func installSkillIntoDir(baseDir string, skill skillDefinition, result *skillIns
 
 // uninstallSkillFromDir deletes only entries that exist in the skill source, so
 // foreign files survive; the skill directory itself is removed only once empty.
+// Presence is keyed on the owned entries rather than SKILL.md alone, so a
+// partially removed install (references/ left behind without SKILL.md) is still
+// cleaned up instead of being reported as not installed.
 func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) {
 	skillDir := filepath.Join(baseDir, skill.name)
-	if _, err := os.Stat(filepath.Join(skillDir, skillscan.SkillFileName)); err != nil {
+	if _, err := os.Stat(skillDir); err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
@@ -132,12 +141,21 @@ func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) 
 	if err != nil {
 		return false, err
 	}
+	removedAny := false
 	for _, entryName := range entryNames {
-		if err := os.RemoveAll(filepath.Join(skillDir, entryName)); err != nil {
+		entryPath := filepath.Join(skillDir, entryName)
+		if _, err := os.Stat(entryPath); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
 			return false, err
 		}
+		if err := os.RemoveAll(entryPath); err != nil {
+			return false, err
+		}
+		removedAny = true
 	}
-	return true, removeEmptyDir(skillDir)
+	return removedAny, removeEmptyDir(skillDir)
 }
 
 // getDirSkillStatus reports install status for the --output-dir layout. It compares
@@ -158,22 +176,29 @@ func getDirSkillStatus(baseDir string, skill skillDefinition) (string, error) {
 	if !bytes.Equal(installedContent, expectedContent) {
 		return "outdated", nil
 	}
-	if dirSkillFilesOutdated(skillDir, skill) {
+	filesOutdated, err := dirSkillFilesOutdated(skillDir, skill)
+	if err != nil {
+		return "", err
+	}
+	if filesOutdated {
 		return "outdated", nil
 	}
 	return "installed", nil
 }
 
-func dirSkillFilesOutdated(skillDir string, skill skillDefinition) bool {
+func dirSkillFilesOutdated(skillDir string, skill skillDefinition) (bool, error) {
 	expectedFiles := collectComparableSkillFiles(skill.sourceDirectory)
 	installedFiles := collectComparableSkillFiles(skillDir)
 	for relativePath, expectedContent := range expectedFiles {
 		installedContent, ok := installedFiles[relativePath]
 		if !ok || !bytes.Equal(expectedContent, installedContent) {
-			return true
+			return true, nil
 		}
 	}
-	ownedDirs := sourceOwnedDirNames(skill.sourceDirectory)
+	ownedDirs, err := sourceOwnedDirNames(skill.sourceDirectory)
+	if err != nil {
+		return false, err
+	}
 	for relativePath := range installedFiles {
 		topLevel := topLevelPathSegment(relativePath)
 		// Top-level files absent from the source are foreign files and stay
@@ -185,10 +210,10 @@ func dirSkillFilesOutdated(skillDir string, skill skillDefinition) bool {
 			continue
 		}
 		if _, ok := expectedFiles[relativePath]; !ok {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // syncSkillDirectoryPreservingForeignFiles copies every source-owned entry into
@@ -217,10 +242,9 @@ func syncSkillEntry(sourceDir string, destinationDir string, entry os.DirEntry) 
 	sourcePath := filepath.Join(sourceDir, entry.Name())
 	destinationPath := filepath.Join(destinationDir, entry.Name())
 	if entry.IsDir() {
-		if err := os.RemoveAll(destinationPath); err != nil {
-			return err
-		}
-		return copySkillDirectory(sourcePath, destinationPath)
+		// Replace through a temp copy plus rename so a mid-copy failure (disk
+		// full, permission) cannot leave the installed directory half-deleted.
+		return syncSkillDirectory(sourcePath, destinationPath)
 	}
 	content, err := os.ReadFile(sourcePath)
 	if err != nil {
@@ -247,18 +271,18 @@ func sourceOwnedEntryNames(sourceDir string) ([]string, error) {
 	return names, nil
 }
 
-func sourceOwnedDirNames(sourceDir string) map[string]bool {
-	ownedDirs := map[string]bool{}
+func sourceOwnedDirNames(sourceDir string) (map[string]bool, error) {
 	entries, err := os.ReadDir(sourceDir)
 	if err != nil {
-		return ownedDirs
+		return nil, err
 	}
+	ownedDirs := map[string]bool{}
 	for _, entry := range entries {
 		if entry.IsDir() && !shouldSkipSkillFile(entry.Name()) {
 			ownedDirs[entry.Name()] = true
 		}
 	}
-	return ownedDirs
+	return ownedDirs, nil
 }
 
 func topLevelPathSegment(relativePath string) string {

--- a/cli/dispatcher/internal/dispatcher/skills_dir.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir.go
@@ -90,15 +90,19 @@ func runSkillsDirList(absDir string, skills []skillDefinition, stdout io.Writer,
 }
 
 func installSkillIntoDir(baseDir string, skill skillDefinition, result *skillInstallResult) error {
+	// Status first: its Lstat guard rejects a symlink or file occupying the
+	// skill's name before artifact cleanup runs, whose ReadDir would follow the
+	// symlink and delete matching entries outside the store (and surface a raw
+	// platform-divergent error for a plain file).
+	status, err := getDirSkillStatus(baseDir, skill)
+	if err != nil {
+		return err
+	}
 	ownedNames, err := sourceOwnedEntryNames(skill.sourceDirectory)
 	if err != nil {
 		return err
 	}
 	if _, err := removeStaleSyncArtifacts(filepath.Join(baseDir, skill.name), ownedNames); err != nil {
-		return err
-	}
-	status, err := getDirSkillStatus(baseDir, skill)
-	if err != nil {
 		return err
 	}
 	if status == "installed" {
@@ -316,7 +320,7 @@ func syncSkillEntry(sourceDir string, destinationDir string, entry os.DirEntry) 
 // writeSkillFileAtomically writes through a temp file plus rename so an
 // interrupted write cannot leave a truncated file at the destination.
 func writeSkillFileAtomically(destinationPath string, content []byte) error {
-	tempFile, err := os.CreateTemp(filepath.Dir(destinationPath), filepath.Base(destinationPath)+".tmp-")
+	tempFile, err := os.CreateTemp(filepath.Dir(destinationPath), filepath.Base(destinationPath)+skillSyncTempSuffix)
 	if err != nil {
 		return err
 	}
@@ -405,11 +409,31 @@ func removeStaleSyncArtifacts(skillDir string, ownedNames []string) (bool, error
 // produce for the temp and backup copies of source-owned entries.
 func isStaleSyncArtifactName(name string, ownedNames []string) bool {
 	for _, ownedName := range ownedNames {
-		if strings.HasPrefix(name, ownedName+".tmp-") || strings.HasPrefix(name, ownedName+".backup-") {
+		if hasSyncArtifactSuffix(name, ownedName+skillSyncTempSuffix) ||
+			hasSyncArtifactSuffix(name, ownedName+skillSyncBackupSuffix) {
 			return true
 		}
 	}
 	return false
+}
+
+// hasSyncArtifactSuffix requires the digits-only random suffix os.CreateTemp
+// and os.MkdirTemp append, so human-named files like references.backup-manual
+// stay classified as foreign instead of being deleted as uloop's own debris.
+func hasSyncArtifactSuffix(name string, prefix string) bool {
+	if !strings.HasPrefix(name, prefix) {
+		return false
+	}
+	suffix := name[len(prefix):]
+	if suffix == "" {
+		return false
+	}
+	for _, character := range suffix {
+		if character < '0' || character > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func topLevelPathSegment(relativePath string) string {

--- a/cli/dispatcher/internal/dispatcher/skills_dir.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir.go
@@ -215,6 +215,11 @@ func getDirSkillStatus(baseDir string, skill skillDefinition) (string, error) {
 	// on Unix but maps to IsNotExist on Windows — the platforms would otherwise
 	// diverge between an aborted run and a bogus install attempt.
 	if !info.IsDir() {
+		// A symlink gets its own message: "not a directory" would mislead when
+		// the link points at one — it is the refusal to follow that matters.
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "", fmt.Errorf("cannot manage skill %q: %s is a symlink, which uloop never follows", skill.name, skillDir)
+		}
 		return "", fmt.Errorf("cannot manage skill %q: %s exists but is not a directory", skill.name, skillDir)
 	}
 	matches, err := installedSkillFileMatches(skillDir, skill)

--- a/cli/dispatcher/internal/dispatcher/skills_dir.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir.go
@@ -243,6 +243,10 @@ func dirSkillStatusWithoutSkillFile(skillDir string, skill skillDefinition) (str
 	return "not_installed", nil
 }
 
+// dirSkillFilesOutdated reports whether the installed copies of source-owned
+// files differ from the source. Extra installed files count as stale only when
+// they sit inside a source-owned directory; top-level foreign files are the
+// mode's design point and never mark the skill outdated.
 func dirSkillFilesOutdated(skillDir string, skill skillDefinition) (bool, error) {
 	expectedFiles := collectComparableSkillFiles(skill.sourceDirectory)
 	installedFiles := collectComparableSkillFiles(skillDir)

--- a/cli/dispatcher/internal/dispatcher/skills_dir.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir.go
@@ -307,6 +307,9 @@ func syncSkillDirectoryPreservingForeignFiles(sourceDir string, destinationDir s
 func syncSkillEntry(sourceDir string, destinationDir string, entry os.DirEntry) error {
 	sourcePath := filepath.Join(sourceDir, entry.Name())
 	destinationPath := filepath.Join(destinationDir, entry.Name())
+	if err := removeEntryOfWrongType(destinationPath, entry.IsDir()); err != nil {
+		return err
+	}
 	if entry.IsDir() {
 		// Replace through a temp copy plus rename so a mid-copy failure (disk
 		// full, permission) cannot leave the installed directory half-deleted.
@@ -318,6 +321,32 @@ func syncSkillEntry(sourceDir string, destinationDir string, entry os.DirEntry) 
 	}
 	content = normalizeSkillFileContent(entry.Name(), content)
 	return writeSkillFileAtomically(destinationPath, content)
+}
+
+// removeEntryOfWrongType clears a destination entry whose type does not match
+// the source-owned entry about to be written. Ownership is name-scoped, so
+// whatever occupies an owned name is uloop's to replace — but the replace paths
+// cannot do it themselves: replaceSkillDirectory resolves the occupant with
+// os.Stat, which misclassifies a dangling symlink as absent and then fails the
+// rename with a raw ENOTDIR (and would follow a live symlink), and a plain
+// rename over a directory fails the same way for file entries.
+func removeEntryOfWrongType(destinationPath string, wantDir bool) error {
+	// Lstat, not Stat: the occupant itself is what must be examined and
+	// removed; a symlink must never be followed into data outside the store.
+	info, err := os.Lstat(destinationPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.IsDir() == wantDir {
+		return nil
+	}
+	if info.IsDir() {
+		return os.RemoveAll(destinationPath)
+	}
+	return os.Remove(destinationPath)
 }
 
 // writeSkillFileAtomically writes through a temp file plus rename so an
@@ -383,10 +412,11 @@ func sourceOwnedEntryNames(sourceDir string) ([]string, error) {
 }
 
 // removeStaleSyncArtifacts deletes leftover temp and backup entries that an
-// interrupted sync can leave behind (SKILL.md.tmp-*, references.backup-*, ...).
-// They are uloop's own artifacts, so removing them keeps the foreign-file
-// guarantee intact; left alone they would be treated as foreign forever and
-// keep the skill directory from ever being removed on uninstall.
+// interrupted sync can leave behind (SKILL.md.uloop-tmp-*, ...). They carry
+// the uloop namespace marker, so they are uloop's own artifacts by
+// construction and removing them keeps the foreign-file guarantee intact;
+// left alone they would be treated as foreign forever and keep the skill
+// directory from ever being removed on uninstall.
 func removeStaleSyncArtifacts(skillDir string, ownedNames []string) (bool, error) {
 	entries, err := os.ReadDir(skillDir)
 	if err != nil {
@@ -408,35 +438,18 @@ func removeStaleSyncArtifacts(skillDir string, ownedNames []string) (bool, error
 	return removedAny, nil
 }
 
-// isStaleSyncArtifactName matches the names os.CreateTemp and os.MkdirTemp
-// produce for the temp and backup copies of source-owned entries.
+// isStaleSyncArtifactName matches the namespaced names the sync helpers mint
+// for temp and backup copies of source-owned entries. The uloop marker in the
+// suffix constants is what makes name-based matching safe: a user file would
+// have to deliberately adopt uloop's namespace to be captured.
 func isStaleSyncArtifactName(name string, ownedNames []string) bool {
 	for _, ownedName := range ownedNames {
-		if hasSyncArtifactSuffix(name, ownedName+skillSyncTempSuffix) ||
-			hasSyncArtifactSuffix(name, ownedName+skillSyncBackupSuffix) {
+		if strings.HasPrefix(name, ownedName+skillSyncTempSuffix) ||
+			strings.HasPrefix(name, ownedName+skillSyncBackupSuffix) {
 			return true
 		}
 	}
 	return false
-}
-
-// hasSyncArtifactSuffix requires the digits-only random suffix os.CreateTemp
-// and os.MkdirTemp append, so human-named files like references.backup-manual
-// stay classified as foreign instead of being deleted as uloop's own debris.
-func hasSyncArtifactSuffix(name string, prefix string) bool {
-	if !strings.HasPrefix(name, prefix) {
-		return false
-	}
-	suffix := name[len(prefix):]
-	if suffix == "" {
-		return false
-	}
-	for _, character := range suffix {
-		if character < '0' || character > '9' {
-			return false
-		}
-	}
-	return true
 }
 
 func topLevelPathSegment(relativePath string) string {

--- a/cli/dispatcher/internal/dispatcher/skills_dir.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir.go
@@ -10,7 +10,10 @@ package dispatcher
 // deprecated-skill cleanup do not run here. An external store is not scoped to
 // one Unity project, so one project's tool settings must not hide skills from
 // it, and deleting directories whose names uloop merely used in the past would
-// break the guarantee that only source-owned entries are ever removed.
+// break the guarantee that only source-owned entries are ever removed. The same
+// trade-off applies within a skill: ownership derives from the current source
+// and no manifest is written into the store, so a top-level entry that a newer
+// skill version dropped or renamed is left behind rather than cleaned up.
 
 import (
 	"fmt"

--- a/cli/dispatcher/internal/dispatcher/skills_dir.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir.go
@@ -37,7 +37,7 @@ func runSkillsDirInstall(absDir string, skills []skillDefinition, stdout io.Writ
 	clicore.WriteLine(stdout, "Installing uloop skills (directory)...")
 	clicore.WriteLine(stdout, "")
 	result := skillInstallResult{}
-	blocked := 0
+	blockedReasons := []string{}
 	for _, skill := range skills {
 		conflictReason, err := installSkillIntoDir(absDir, skill, &result)
 		if err != nil {
@@ -48,22 +48,41 @@ func runSkillsDirInstall(absDir string, skills []skillDefinition, stdout io.Writ
 		// sync, and the summary below still prints, so an interrupted-looking
 		// half-synced store cannot result from one occupied name.
 		if conflictReason != "" {
-			blocked++
-			clicore.WriteLine(stderr, conflictReason)
+			blockedReasons = append(blockedReasons, conflictReason)
 		}
 	}
 	clicore.WriteLine(stdout, "Directory:")
 	clicore.WriteFormat(stdout, "  Installed: %d\n", result.installed)
 	clicore.WriteFormat(stdout, "  Updated: %d\n", result.updated)
 	clicore.WriteFormat(stdout, "  Skipped: %d\n", result.skipped)
-	if blocked > 0 {
-		clicore.WriteFormat(stdout, "  Blocked: %d\n", blocked)
+	if len(blockedReasons) > 0 {
+		clicore.WriteFormat(stdout, "  Blocked: %d\n", len(blockedReasons))
 	}
 	clicore.WriteFormat(stdout, "  Location: %s\n\n", absDir)
-	if blocked > 0 {
+	if len(blockedReasons) > 0 {
+		writeSkillStoreConflictError(stderr, blockedReasons)
 		return 1
 	}
 	return 0
+}
+
+// writeSkillStoreConflictError reports blocked skills through the classified
+// error envelope every other dispatcher exit-1 path uses, so callers parsing
+// stderr as JSON see the reasons instead of bare text.
+func writeSkillStoreConflictError(stderr io.Writer, blockedReasons []string) {
+	clierrors.WriteErrorEnvelope(stderr, clierrors.CLIError{
+		// Declared inline rather than in the shared error-code table: the code
+		// is dispatcher-local, and cli/common is a shared release input whose
+		// changes require a release-trigger update.
+		ErrorCode:   "SKILL_STORE_CONFLICT",
+		Phase:       clierrors.ErrorPhaseExecution,
+		Message:     strings.Join(blockedReasons, "; "),
+		Retryable:   false,
+		SafeToRetry: true,
+		Command:     clicore.SkillsCommandName,
+		NextActions: []string{"Remove or rename the conflicting entries in the store, then rerun the command."},
+		Details:     map[string]any{"BlockedCount": len(blockedReasons)},
+	})
 }
 
 func runSkillsDirUninstall(absDir string, skills []skillDefinition, stdout io.Writer, stderr io.Writer) int {
@@ -105,6 +124,11 @@ func runSkillsDirList(absDir string, skills []skillDefinition, stdout io.Writer,
 			return 1
 		}
 		clicore.WriteFormat(stdout, "  %s %s (%s)\n", statusIcon(state.status), skill.name, statusText(state.status))
+		// The reason is part of the listing: without it the only way to learn
+		// why a skill conflicts would be running install, a mutating command.
+		if state.conflictReason != "" {
+			clicore.WriteFormat(stdout, "      %s\n", state.conflictReason)
+		}
 	}
 	clicore.WriteLine(stdout, "")
 	clicore.WriteFormat(stdout, "Total: %d skills\n", len(skills))
@@ -146,30 +170,31 @@ func installSkillIntoDir(baseDir string, skill skillDefinition, result *skillIns
 
 // uninstallSkillFromDir deletes only entries that exist in the skill source, so
 // foreign files survive; the skill directory itself is removed only once
-// nothing but ignorable OS/tool debris (.DS_Store, *.meta) remains in it.
-// Removal requires install evidence (SKILL.md, or owned content matching the
-// source): a partially removed install (references/ left behind without
-// SKILL.md) is still cleaned up, while a hand-authored directory that merely
-// uses a skill's name — possibly in a store uloop never installed into — is
-// preserved and reported as not found. Entries are matched by their exact
-// on-disk names, so a case-insensitive filesystem cannot make uloop delete a
-// user's skill.md or References/ as if they were the source-owned entries.
+// nothing but ignorable OS/tool debris remains in it. Removal requires install
+// evidence (SKILL.md, or owned content matching the current source): a
+// partially removed install (references/ left behind without SKILL.md) is
+// cleaned up while its content still matches the current source, whereas a
+// hand-authored directory that merely uses a skill's name — possibly in a
+// store uloop never installed into — is preserved and reported as not found.
+// Names are matched by their exact on-disk spelling, the skill directory
+// itself included, so a case-insensitive filesystem cannot make uloop delete a
+// user's Uloop-Sample/, skill.md, or References/ as if they were uloop's.
 func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) {
-	skillDir := filepath.Join(baseDir, skill.name)
-	// Lstat, not Stat: a symlink occupying the skill's name must not be
-	// followed, or the removals below would destroy data outside the store.
-	info, err := os.Lstat(skillDir)
+	baseEntries, err := os.ReadDir(baseDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
 		return false, err
 	}
-	// A foreign top-level file or symlink occupying the skill's name is not an
+	// A missing exact name (a case variant is a different, foreign directory),
+	// a foreign file, or a symlink occupying the skill's name is not an
 	// install of ours, so it is preserved and the skill reported as not found.
-	if !info.IsDir() {
+	skillDirEntry := findExactDirEntry(baseEntries, skill.name)
+	if skillDirEntry == nil || !skillDirEntry.IsDir() {
 		return false, nil
 	}
+	skillDir := filepath.Join(baseDir, skill.name)
 	ownedEntries, err := sourceOwnedEntries(skill.sourceDirectory)
 	if err != nil {
 		return false, err
@@ -192,12 +217,26 @@ func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) 
 		if !artifactsRemoved {
 			return false, nil
 		}
-		return false, removeSkillDirWithIgnorableDebris(skillDir)
+		// Without evidence even "ignorable" leftovers may be user data, so the
+		// directory goes only when removing uloop's artifacts emptied it.
+		return false, removeSkillDirIfEmpty(skillDir)
 	}
+	removedAny, err := removeOwnedEntries(skillDir, ownedEntries, dirEntries)
+	if err != nil {
+		return false, err
+	}
+	if !removedAny && !artifactsRemoved {
+		return false, nil
+	}
+	return removedAny, removeSkillDirWithIgnorableDebris(skillDir, ownedEntries)
+}
+
+// removeOwnedEntries deletes the owned entries present in the skill directory
+// by exact-name lookup from the ReadDir listing (dangling symlinks included),
+// never a path probe the filesystem could case-fold.
+func removeOwnedEntries(skillDir string, ownedEntries []os.DirEntry, dirEntries []os.DirEntry) (bool, error) {
 	removedAny := false
 	for _, owned := range ownedEntries {
-		// Exact-name lookup from the ReadDir listing (dangling symlinks
-		// included), never a path probe the filesystem could case-fold.
 		if findExactDirEntry(dirEntries, owned.Name()) == nil {
 			continue
 		}
@@ -206,10 +245,7 @@ func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) 
 		}
 		removedAny = true
 	}
-	if !removedAny && !artifactsRemoved {
-		return false, nil
-	}
-	return removedAny, removeSkillDirWithIgnorableDebris(skillDir)
+	return removedAny, nil
 }
 
 // removeSkillDirWithIgnorableDebris removes an uninstalled skill's directory
@@ -218,7 +254,7 @@ func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) 
 // Unity warn — while removing them deletes nothing a skill install could have
 // provided. Any other remaining entry is genuinely foreign and keeps the
 // directory in place.
-func removeSkillDirWithIgnorableDebris(skillDir string) error {
+func removeSkillDirWithIgnorableDebris(skillDir string, ownedEntries []os.DirEntry) error {
 	entries, err := os.ReadDir(skillDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -227,7 +263,7 @@ func removeSkillDirWithIgnorableDebris(skillDir string) error {
 		return err
 	}
 	for _, entry := range entries {
-		if !isIgnorableStoreDebris(entry.Name()) {
+		if !isIgnorableStoreDebris(entry.Name(), ownedEntries) {
 			return nil
 		}
 	}
@@ -235,11 +271,37 @@ func removeSkillDirWithIgnorableDebris(skillDir string) error {
 }
 
 // isIgnorableStoreDebris authorizes deleting a leftover entry along with its
-// skill directory. Deliberately separate from shouldSkipSkillFile even though
-// the patterns coincide today: that one filters what a sync copies, and
+// skill directory: OS junk, plus the Unity .meta stubs minted for entries
+// uloop itself installed. A user's own .meta data file (dataset.meta) keeps
+// the directory alive. Deliberately separate from shouldSkipSkillFile even
+// though the patterns overlap: that one filters what a sync copies, and
 // widening a copy filter must never silently widen what uninstall may delete.
-func isIgnorableStoreDebris(name string) bool {
-	return name == ".DS_Store" || strings.HasSuffix(name, ".meta")
+func isIgnorableStoreDebris(name string, ownedEntries []os.DirEntry) bool {
+	if name == ".DS_Store" || name == "Thumbs.db" || name == "desktop.ini" {
+		return true
+	}
+	stem, found := strings.CutSuffix(name, ".meta")
+	if !found {
+		return false
+	}
+	return findExactDirEntry(ownedEntries, stem) != nil
+}
+
+// removeSkillDirIfEmpty drops the skill directory only when nothing remains at
+// all — the state removing uloop's own sync artifacts leaves behind when they
+// were the directory's sole content.
+func removeSkillDirIfEmpty(skillDir string) error {
+	entries, err := os.ReadDir(skillDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if len(entries) > 0 {
+		return nil
+	}
+	return os.Remove(skillDir)
 }
 
 // syncSkillDirectoryPreservingForeignFiles copies every source-owned entry into
@@ -293,8 +355,9 @@ func syncSkillEntry(sourceDir string, destinationDir string, entry os.DirEntry) 
 
 // removeEntryOfWrongType clears a destination entry whose type does not match
 // the source-owned entry about to be written. Syncs only reach here for skill
-// directories with install evidence, so the occupant is uloop's to replace —
-// but the replace paths cannot do it themselves: replaceSkillDirectory
+// directories that carry install evidence or hold nothing at owned names, so
+// the occupant is uloop's to replace — but the replace paths cannot do it
+// themselves: replaceSkillDirectory
 // resolves the occupant with os.Stat, which misclassifies a dangling symlink
 // as absent and then fails the rename with a raw ENOTDIR (and would follow a
 // live symlink), and a plain rename over a directory fails the same way for
@@ -396,14 +459,32 @@ func removeStaleSyncArtifacts(skillDir string) (bool, error) {
 }
 
 // isStaleSyncArtifactName matches the namespaced names the sync helpers mint
-// for temp and backup copies of source-owned entries. The uloop marker in the
-// suffix constants is the whole safety argument — a user file would have to
-// deliberately adopt uloop's namespace to be captured — so matching is not
-// restricted to currently owned entry names: debris minted for an entry a
+// for temp and backup copies of source-owned entries: the uloop marker
+// followed by the digits os.CreateTemp and os.MkdirTemp append. The marker
+// claims the namespace and the digit tail keeps a human-named file that
+// merely embeds it (my-archive.uloop-tmp-keepme) out of reach. Matching is
+// not restricted to currently owned entry names: debris minted for an entry a
 // newer skill version dropped or renamed must still be cleaned up.
 func isStaleSyncArtifactName(name string) bool {
-	return strings.Contains(name, skillSyncTempSuffix) ||
-		strings.Contains(name, skillSyncBackupSuffix)
+	return hasSyncArtifactSuffix(name, skillSyncTempSuffix) ||
+		hasSyncArtifactSuffix(name, skillSyncBackupSuffix)
+}
+
+func hasSyncArtifactSuffix(name string, marker string) bool {
+	markerIndex := strings.LastIndex(name, marker)
+	if markerIndex < 0 {
+		return false
+	}
+	tail := name[markerIndex+len(marker):]
+	if tail == "" {
+		return false
+	}
+	for _, char := range tail {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func skillsDirErrorContext() clierrors.ErrorContext {

--- a/cli/dispatcher/internal/dispatcher/skills_dir.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir.go
@@ -213,11 +213,11 @@ func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) 
 }
 
 // removeSkillDirWithIgnorableDebris removes an uninstalled skill's directory
-// when the only entries left are names uloop itself never installs (.DS_Store,
-// Unity *.meta, per shouldSkipSkillFile). Leaving them would ghost the
-// directory in the store forever — and orphaned .meta files make Unity warn —
-// while removing them deletes nothing a skill install could have provided. Any
-// other remaining entry is genuinely foreign and keeps the directory in place.
+// when the only entries left are ignorable OS/tool debris. Leaving them would
+// ghost the directory in the store forever — and orphaned .meta files make
+// Unity warn — while removing them deletes nothing a skill install could have
+// provided. Any other remaining entry is genuinely foreign and keeps the
+// directory in place.
 func removeSkillDirWithIgnorableDebris(skillDir string) error {
 	entries, err := os.ReadDir(skillDir)
 	if err != nil {
@@ -227,11 +227,19 @@ func removeSkillDirWithIgnorableDebris(skillDir string) error {
 		return err
 	}
 	for _, entry := range entries {
-		if !shouldSkipSkillFile(entry.Name()) {
+		if !isIgnorableStoreDebris(entry.Name()) {
 			return nil
 		}
 	}
 	return os.RemoveAll(skillDir)
+}
+
+// isIgnorableStoreDebris authorizes deleting a leftover entry along with its
+// skill directory. Deliberately separate from shouldSkipSkillFile even though
+// the patterns coincide today: that one filters what a sync copies, and
+// widening a copy filter must never silently widen what uninstall may delete.
+func isIgnorableStoreDebris(name string) bool {
+	return name == ".DS_Store" || strings.HasSuffix(name, ".meta")
 }
 
 // syncSkillDirectoryPreservingForeignFiles copies every source-owned entry into

--- a/cli/dispatcher/internal/dispatcher/skills_dir.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir.go
@@ -235,85 +235,6 @@ func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) 
 	return removedAny, removeSkillDirWithIgnorableDebris(skillDir, ownedEntries)
 }
 
-// removeOwnedEntries deletes the owned entries present in the skill directory
-// by exact-name lookup from the ReadDir listing (dangling symlinks included),
-// never a path probe the filesystem could case-fold.
-func removeOwnedEntries(skillDir string, ownedEntries []os.DirEntry, dirEntries []os.DirEntry) (bool, error) {
-	removedAny := false
-	for _, owned := range ownedEntries {
-		if findExactDirEntry(dirEntries, owned.Name()) == nil {
-			continue
-		}
-		if err := os.RemoveAll(filepath.Join(skillDir, owned.Name())); err != nil {
-			return false, err
-		}
-		removedAny = true
-	}
-	return removedAny, nil
-}
-
-// removeSkillDirWithIgnorableDebris removes an uninstalled skill's directory
-// when the only entries left are ignorable OS/tool debris. Leaving them would
-// ghost the directory in the store forever — and orphaned .meta files make
-// Unity warn — while removing them deletes nothing a skill install could have
-// provided. Any other remaining entry is genuinely foreign and keeps the
-// directory in place.
-func removeSkillDirWithIgnorableDebris(skillDir string, ownedEntries []os.DirEntry) error {
-	entries, err := os.ReadDir(skillDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	for _, entry := range entries {
-		if !isIgnorableStoreDebris(entry, ownedEntries) {
-			return nil
-		}
-	}
-	return os.RemoveAll(skillDir)
-}
-
-// isIgnorableStoreDebris authorizes deleting a leftover entry along with its
-// skill directory: OS junk, plus the Unity .meta stubs minted for entries
-// uloop itself installed. Only regular files qualify — a directory bearing a
-// debris name is user data whose contents uloop never wrote. A user's own
-// .meta data file (dataset.meta) keeps the directory alive. Deliberately
-// separate from shouldSkipSkillFile even though the patterns overlap: that
-// one filters what a sync copies, and widening a copy filter must never
-// silently widen what uninstall may delete.
-func isIgnorableStoreDebris(entry os.DirEntry, ownedEntries []os.DirEntry) bool {
-	if !entry.Type().IsRegular() {
-		return false
-	}
-	name := entry.Name()
-	if name == ".DS_Store" || name == "Thumbs.db" || name == "desktop.ini" {
-		return true
-	}
-	stem, found := strings.CutSuffix(name, ".meta")
-	if !found {
-		return false
-	}
-	return findExactDirEntry(ownedEntries, stem) != nil
-}
-
-// removeSkillDirIfEmpty drops the skill directory only when nothing remains at
-// all — the state removing uloop's own sync artifacts leaves behind when they
-// were the directory's sole content.
-func removeSkillDirIfEmpty(skillDir string) error {
-	entries, err := os.ReadDir(skillDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	if len(entries) > 0 {
-		return nil
-	}
-	return os.Remove(skillDir)
-}
-
 // syncSkillDirectoryPreservingForeignFiles copies every source-owned entry into
 // destinationDir while leaving unknown files untouched. Source-owned
 // directories are replaced wholly so stale files inside them do not linger.
@@ -361,34 +282,6 @@ func syncSkillEntry(sourceDir string, destinationDir string, entry os.DirEntry) 
 	}
 	content = normalizeSkillFileContent(entry.Name(), content)
 	return writeSkillFileAtomically(destinationPath, content)
-}
-
-// removeEntryOfWrongType clears a destination entry whose type does not match
-// the source-owned entry about to be written. Syncs only reach here for skill
-// directories that carry install evidence or hold nothing at owned names, so
-// the occupant is uloop's to replace — but the replace paths cannot do it
-// themselves: replaceSkillDirectory
-// resolves the occupant with os.Stat, which misclassifies a dangling symlink
-// as absent and then fails the rename with a raw ENOTDIR (and would follow a
-// live symlink), and a plain rename over a directory fails the same way for
-// file entries.
-func removeEntryOfWrongType(destinationPath string, wantDir bool) error {
-	// Lstat, not Stat: the occupant itself is what must be examined and
-	// removed; a symlink must never be followed into data outside the store.
-	info, err := os.Lstat(destinationPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	if info.IsDir() == wantDir {
-		return nil
-	}
-	if info.IsDir() {
-		return os.RemoveAll(destinationPath)
-	}
-	return os.Remove(destinationPath)
 }
 
 // writeSkillFileAtomically writes through a temp file plus rename so an
@@ -439,67 +332,6 @@ func sourceOwnedEntries(sourceDir string) ([]os.DirEntry, error) {
 		owned = append(owned, entry)
 	}
 	return owned, nil
-}
-
-// removeStaleSyncArtifacts deletes leftover temp and backup entries that an
-// interrupted sync can leave behind (SKILL.md.uloop-tmp-*, ...). They carry
-// the uloop namespace marker, so they are uloop's own artifacts by
-// construction and removing them keeps the foreign-file guarantee intact;
-// left alone they would be treated as foreign forever and keep the skill
-// directory from ever being removed on uninstall.
-func removeStaleSyncArtifacts(skillDir string, ownedEntries []os.DirEntry) (bool, error) {
-	entries, err := os.ReadDir(skillDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	removedAny := false
-	for _, entry := range entries {
-		if !isStaleSyncArtifactName(entry.Name()) {
-			continue
-		}
-		// Current source-owned names are live managed content, not leftovers,
-		// even when they resemble artifact names.
-		if findExactDirEntry(ownedEntries, entry.Name()) != nil {
-			continue
-		}
-		if err := os.RemoveAll(filepath.Join(skillDir, entry.Name())); err != nil {
-			return false, err
-		}
-		removedAny = true
-	}
-	return removedAny, nil
-}
-
-// isStaleSyncArtifactName matches the namespaced names the sync helpers mint
-// for temp and backup copies of source-owned entries: the uloop marker
-// followed by the digits os.CreateTemp and os.MkdirTemp append. The marker
-// claims the namespace and the digit tail keeps a human-named file that
-// merely embeds it (my-archive.uloop-tmp-keepme) out of reach. Matching is
-// not restricted to currently owned entry names: debris minted for an entry a
-// newer skill version dropped or renamed must still be cleaned up.
-func isStaleSyncArtifactName(name string) bool {
-	return hasSyncArtifactSuffix(name, skillSyncTempSuffix) ||
-		hasSyncArtifactSuffix(name, skillSyncBackupSuffix)
-}
-
-func hasSyncArtifactSuffix(name string, marker string) bool {
-	markerIndex := strings.LastIndex(name, marker)
-	if markerIndex < 0 {
-		return false
-	}
-	tail := name[markerIndex+len(marker):]
-	if tail == "" {
-		return false
-	}
-	for _, char := range tail {
-		if char < '0' || char > '9' {
-			return false
-		}
-	}
-	return true
 }
 
 func skillsDirErrorContext() clierrors.ErrorContext {

--- a/cli/dispatcher/internal/dispatcher/skills_dir.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir.go
@@ -13,7 +13,6 @@ package dispatcher
 // break the guarantee that only source-owned entries are ever removed.
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -91,6 +90,13 @@ func runSkillsDirList(absDir string, skills []skillDefinition, stdout io.Writer,
 }
 
 func installSkillIntoDir(baseDir string, skill skillDefinition, result *skillInstallResult) error {
+	ownedNames, err := sourceOwnedEntryNames(skill.sourceDirectory)
+	if err != nil {
+		return err
+	}
+	if _, err := removeStaleSyncArtifacts(filepath.Join(baseDir, skill.name), ownedNames); err != nil {
+		return err
+	}
 	status, err := getDirSkillStatus(baseDir, skill)
 	if err != nil {
 		return err
@@ -117,19 +123,25 @@ func installSkillIntoDir(baseDir string, skill skillDefinition, result *skillIns
 // cleaned up instead of being reported as not installed.
 func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) {
 	skillDir := filepath.Join(baseDir, skill.name)
-	info, err := os.Stat(skillDir)
+	// Lstat, not Stat: a symlink occupying the skill's name must not be
+	// followed, or the removals below would destroy data outside the store.
+	info, err := os.Lstat(skillDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
 		return false, err
 	}
-	// A foreign top-level file occupying the skill's name is not an install of
-	// ours, so it is preserved and the skill reported as not found.
+	// A foreign top-level file or symlink occupying the skill's name is not an
+	// install of ours, so it is preserved and the skill reported as not found.
 	if !info.IsDir() {
 		return false, nil
 	}
 	entryNames, err := sourceOwnedEntryNames(skill.sourceDirectory)
+	if err != nil {
+		return false, err
+	}
+	artifactsRemoved, err := removeStaleSyncArtifacts(skillDir, entryNames)
 	if err != nil {
 		return false, err
 	}
@@ -149,6 +161,11 @@ func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) 
 		}
 		removedAny = true
 	}
+	// Nothing of ours was found: leave the directory alone, even when empty —
+	// a user-created scaffold directory bearing a skill name is foreign.
+	if !removedAny && !artifactsRemoved {
+		return false, nil
+	}
 	return removedAny, removeEmptyDir(skillDir)
 }
 
@@ -158,7 +175,10 @@ func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) 
 // compared both ways because syncing replaces those directories wholly.
 func getDirSkillStatus(baseDir string, skill skillDefinition) (string, error) {
 	skillDir := filepath.Join(baseDir, skill.name)
-	info, err := os.Stat(skillDir)
+	// Lstat, not Stat: a symlink occupying the skill's name must not be
+	// followed, or install would write through it into a directory outside the
+	// store that uninstall would then delete from.
+	info, err := os.Lstat(skillDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "not_installed", nil
@@ -176,7 +196,11 @@ func getDirSkillStatus(baseDir string, skill skillDefinition) (string, error) {
 		if os.IsNotExist(err) {
 			return dirSkillStatusWithoutSkillFile(skillDir, skill)
 		}
-		return "", err
+		// Wrapped so an unreadable SKILL.md (permissions, or a directory with
+		// that name) surfaces with the affected skill instead of a bare OS
+		// error; dir mode surfaces such states rather than rewriting an
+		// external store whose files cannot even be read.
+		return "", fmt.Errorf("cannot read %s for skill %q: %w", skillscan.SkillFileName, skill.name, err)
 	}
 	if !matches {
 		return "outdated", nil
@@ -215,24 +239,25 @@ func dirSkillStatusWithoutSkillFile(skillDir string, skill skillDefinition) (str
 func dirSkillFilesOutdated(skillDir string, skill skillDefinition) (bool, error) {
 	expectedFiles := collectComparableSkillFiles(skill.sourceDirectory)
 	installedFiles := collectComparableSkillFiles(skillDir)
-	for relativePath, expectedContent := range expectedFiles {
-		installedContent, ok := installedFiles[relativePath]
-		if !ok || !bytes.Equal(expectedContent, installedContent) {
-			return true, nil
-		}
+	if !comparableFilesMatch(expectedFiles, installedFiles) {
+		return true, nil
 	}
-	ownedDirs, err := sourceOwnedDirNames(skill.sourceDirectory)
+	ownedEntries, err := sourceOwnedEntries(skill.sourceDirectory)
 	if err != nil {
 		return false, err
 	}
-	for relativePath := range installedFiles {
-		topLevel := topLevelPathSegment(relativePath)
-		// Top-level files absent from the source are foreign files and stay
-		// untouched, so they must not flag the skill as outdated.
-		if topLevel == relativePath {
-			continue
+	ownedDirs := map[string]bool{}
+	for _, entry := range ownedEntries {
+		if entry.IsDir() {
+			ownedDirs[entry.Name()] = true
 		}
-		if !ownedDirs[topLevel] {
+	}
+	for relativePath := range installedFiles {
+		// Only files inside source-owned directories count as stale: a
+		// top-level foreign file's own name never appears in ownedDirs, and a
+		// file shadowing an owned directory name is already reported outdated
+		// by the expected-files comparison above.
+		if !ownedDirs[topLevelPathSegment(relativePath)] {
 			continue
 		}
 		if _, ok := expectedFiles[relativePath]; !ok {
@@ -252,15 +277,12 @@ func syncSkillDirectoryPreservingForeignFiles(sourceDir string, destinationDir s
 	if err := os.MkdirAll(destinationDir, 0o755); err != nil {
 		return err
 	}
-	entries, err := os.ReadDir(sourceDir)
+	entries, err := sourceOwnedEntries(sourceDir)
 	if err != nil {
 		return err
 	}
 	var skillFileEntry os.DirEntry
 	for _, entry := range entries {
-		if shouldSkipSkillFile(entry.Name()) {
-			continue
-		}
 		if !entry.IsDir() && entry.Name() == skillscan.SkillFileName {
 			skillFileEntry = entry
 			continue
@@ -322,35 +344,72 @@ func writeSkillFileAtomically(destinationPath string, content []byte) error {
 	return nil
 }
 
-// sourceOwnedEntryNames lists the top-level entries of a skill source, which is
-// exactly the set of paths uloop owns inside an installed skill directory.
-func sourceOwnedEntryNames(sourceDir string) ([]string, error) {
+// sourceOwnedEntries lists the top-level entries of a skill source after the
+// skip rules — exactly the set of entries uloop owns inside an installed skill
+// directory. Every consumer of the ownership rule derives from this one
+// listing so status, sync, and uninstall cannot disagree on what is owned.
+func sourceOwnedEntries(sourceDir string) ([]os.DirEntry, error) {
 	entries, err := os.ReadDir(sourceDir)
+	if err != nil {
+		return nil, err
+	}
+	owned := []os.DirEntry{}
+	for _, entry := range entries {
+		if shouldSkipSkillFile(entry.Name()) {
+			continue
+		}
+		owned = append(owned, entry)
+	}
+	return owned, nil
+}
+
+func sourceOwnedEntryNames(sourceDir string) ([]string, error) {
+	entries, err := sourceOwnedEntries(sourceDir)
 	if err != nil {
 		return nil, err
 	}
 	names := []string{}
 	for _, entry := range entries {
-		if shouldSkipSkillFile(entry.Name()) {
-			continue
-		}
 		names = append(names, entry.Name())
 	}
 	return names, nil
 }
 
-func sourceOwnedDirNames(sourceDir string) (map[string]bool, error) {
-	entries, err := os.ReadDir(sourceDir)
+// removeStaleSyncArtifacts deletes leftover temp and backup entries that an
+// interrupted sync can leave behind (SKILL.md.tmp-*, references.backup-*, ...).
+// They are uloop's own artifacts, so removing them keeps the foreign-file
+// guarantee intact; left alone they would be treated as foreign forever and
+// keep the skill directory from ever being removed on uninstall.
+func removeStaleSyncArtifacts(skillDir string, ownedNames []string) (bool, error) {
+	entries, err := os.ReadDir(skillDir)
 	if err != nil {
-		return nil, err
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
 	}
-	ownedDirs := map[string]bool{}
+	removedAny := false
 	for _, entry := range entries {
-		if entry.IsDir() && !shouldSkipSkillFile(entry.Name()) {
-			ownedDirs[entry.Name()] = true
+		if !isStaleSyncArtifactName(entry.Name(), ownedNames) {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(skillDir, entry.Name())); err != nil {
+			return false, err
+		}
+		removedAny = true
+	}
+	return removedAny, nil
+}
+
+// isStaleSyncArtifactName matches the names os.CreateTemp and os.MkdirTemp
+// produce for the temp and backup copies of source-owned entries.
+func isStaleSyncArtifactName(name string, ownedNames []string) bool {
+	for _, ownedName := range ownedNames {
+		if strings.HasPrefix(name, ownedName+".tmp-") || strings.HasPrefix(name, ownedName+".backup-") {
+			return true
 		}
 	}
-	return ownedDirs, nil
+	return false
 }
 
 func topLevelPathSegment(relativePath string) string {

--- a/cli/dispatcher/internal/dispatcher/skills_dir.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir.go
@@ -263,7 +263,7 @@ func removeSkillDirWithIgnorableDebris(skillDir string, ownedEntries []os.DirEnt
 		return err
 	}
 	for _, entry := range entries {
-		if !isIgnorableStoreDebris(entry.Name(), ownedEntries) {
+		if !isIgnorableStoreDebris(entry, ownedEntries) {
 			return nil
 		}
 	}
@@ -272,11 +272,17 @@ func removeSkillDirWithIgnorableDebris(skillDir string, ownedEntries []os.DirEnt
 
 // isIgnorableStoreDebris authorizes deleting a leftover entry along with its
 // skill directory: OS junk, plus the Unity .meta stubs minted for entries
-// uloop itself installed. A user's own .meta data file (dataset.meta) keeps
-// the directory alive. Deliberately separate from shouldSkipSkillFile even
-// though the patterns overlap: that one filters what a sync copies, and
-// widening a copy filter must never silently widen what uninstall may delete.
-func isIgnorableStoreDebris(name string, ownedEntries []os.DirEntry) bool {
+// uloop itself installed. Only regular files qualify — a directory bearing a
+// debris name is user data whose contents uloop never wrote. A user's own
+// .meta data file (dataset.meta) keeps the directory alive. Deliberately
+// separate from shouldSkipSkillFile even though the patterns overlap: that
+// one filters what a sync copies, and widening a copy filter must never
+// silently widen what uninstall may delete.
+func isIgnorableStoreDebris(entry os.DirEntry, ownedEntries []os.DirEntry) bool {
+	if !entry.Type().IsRegular() {
+		return false
+	}
+	name := entry.Name()
 	if name == ".DS_Store" || name == "Thumbs.db" || name == "desktop.ini" {
 		return true
 	}

--- a/cli/dispatcher/internal/dispatcher/skills_dir.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir.go
@@ -101,11 +101,7 @@ func installSkillIntoDir(baseDir string, skill skillDefinition, result *skillIns
 	if err != nil {
 		return err
 	}
-	ownedNames, err := sourceOwnedEntryNames(skill.sourceDirectory)
-	if err != nil {
-		return err
-	}
-	if _, err := removeStaleSyncArtifacts(filepath.Join(baseDir, skill.name), ownedNames); err != nil {
+	if _, err := removeStaleSyncArtifacts(filepath.Join(baseDir, skill.name)); err != nil {
 		return err
 	}
 	if status == "installed" {
@@ -124,7 +120,8 @@ func installSkillIntoDir(baseDir string, skill skillDefinition, result *skillIns
 }
 
 // uninstallSkillFromDir deletes only entries that exist in the skill source, so
-// foreign files survive; the skill directory itself is removed only once empty.
+// foreign files survive; the skill directory itself is removed only once
+// nothing but ignorable OS/tool debris (.DS_Store, *.meta) remains in it.
 // Presence is keyed on the owned entries rather than SKILL.md alone, so a
 // partially removed install (references/ left behind without SKILL.md) is still
 // cleaned up instead of being reported as not installed.
@@ -148,7 +145,7 @@ func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) 
 	if err != nil {
 		return false, err
 	}
-	artifactsRemoved, err := removeStaleSyncArtifacts(skillDir, entryNames)
+	artifactsRemoved, err := removeStaleSyncArtifacts(skillDir)
 	if err != nil {
 		return false, err
 	}
@@ -173,7 +170,29 @@ func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) 
 	if !removedAny && !artifactsRemoved {
 		return false, nil
 	}
-	return removedAny, removeEmptyDir(skillDir)
+	return removedAny, removeSkillDirWithIgnorableDebris(skillDir)
+}
+
+// removeSkillDirWithIgnorableDebris removes an uninstalled skill's directory
+// when the only entries left are names uloop itself never installs (.DS_Store,
+// Unity *.meta, per shouldSkipSkillFile). Leaving them would ghost the
+// directory in the store forever — and orphaned .meta files make Unity warn —
+// while removing them deletes nothing a skill install could have provided. Any
+// other remaining entry is genuinely foreign and keeps the directory in place.
+func removeSkillDirWithIgnorableDebris(skillDir string) error {
+	entries, err := os.ReadDir(skillDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	for _, entry := range entries {
+		if !shouldSkipSkillFile(entry.Name()) {
+			return nil
+		}
+	}
+	return os.RemoveAll(skillDir)
 }
 
 // getDirSkillStatus reports install status for the --output-dir layout. It compares
@@ -421,7 +440,7 @@ func sourceOwnedEntryNames(sourceDir string) ([]string, error) {
 // construction and removing them keeps the foreign-file guarantee intact;
 // left alone they would be treated as foreign forever and keep the skill
 // directory from ever being removed on uninstall.
-func removeStaleSyncArtifacts(skillDir string, ownedNames []string) (bool, error) {
+func removeStaleSyncArtifacts(skillDir string) (bool, error) {
 	entries, err := os.ReadDir(skillDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -431,7 +450,7 @@ func removeStaleSyncArtifacts(skillDir string, ownedNames []string) (bool, error
 	}
 	removedAny := false
 	for _, entry := range entries {
-		if !isStaleSyncArtifactName(entry.Name(), ownedNames) {
+		if !isStaleSyncArtifactName(entry.Name()) {
 			continue
 		}
 		if err := os.RemoveAll(filepath.Join(skillDir, entry.Name())); err != nil {
@@ -444,16 +463,13 @@ func removeStaleSyncArtifacts(skillDir string, ownedNames []string) (bool, error
 
 // isStaleSyncArtifactName matches the namespaced names the sync helpers mint
 // for temp and backup copies of source-owned entries. The uloop marker in the
-// suffix constants is what makes name-based matching safe: a user file would
-// have to deliberately adopt uloop's namespace to be captured.
-func isStaleSyncArtifactName(name string, ownedNames []string) bool {
-	for _, ownedName := range ownedNames {
-		if strings.HasPrefix(name, ownedName+skillSyncTempSuffix) ||
-			strings.HasPrefix(name, ownedName+skillSyncBackupSuffix) {
-			return true
-		}
-	}
-	return false
+// suffix constants is the whole safety argument — a user file would have to
+// deliberately adopt uloop's namespace to be captured — so matching is not
+// restricted to currently owned entry names: debris minted for an entry a
+// newer skill version dropped or renamed must still be cleaned up.
+func isStaleSyncArtifactName(name string) bool {
+	return strings.Contains(name, skillSyncTempSuffix) ||
+		strings.Contains(name, skillSyncBackupSuffix)
 }
 
 func topLevelPathSegment(relativePath string) string {

--- a/cli/dispatcher/internal/dispatcher/skills_dir.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir.go
@@ -1,0 +1,274 @@
+package dispatcher
+
+// --output-dir mode syncs skills flat into a caller-chosen directory (for example an
+// external skill-package store such as APM). Unlike target installs, the
+// destination may hold files uloop does not own (package manifests placed next
+// to SKILL.md), so every operation here touches only entries that exist in the
+// skill source directory.
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+	"github.com/hatayama/unity-cli-loop/common/skillscan"
+)
+
+func runSkillsDirInstall(directory string, skills []skillDefinition, stdout io.Writer, stderr io.Writer) int {
+	absDir, err := filepath.Abs(directory)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, skillsDirErrorContext())
+		return 1
+	}
+	clicore.WriteLine(stdout, "")
+	clicore.WriteLine(stdout, "Installing uloop skills (directory)...")
+	clicore.WriteLine(stdout, "")
+	result := skillInstallResult{}
+	for _, skill := range skills {
+		if err := installSkillIntoDir(absDir, skill, &result); err != nil {
+			clierrors.WriteClassifiedError(stderr, err, skillsDirErrorContext())
+			return 1
+		}
+	}
+	clicore.WriteLine(stdout, "Directory:")
+	clicore.WriteFormat(stdout, "  Installed: %d\n", result.installed)
+	clicore.WriteFormat(stdout, "  Updated: %d\n", result.updated)
+	clicore.WriteFormat(stdout, "  Skipped: %d\n", result.skipped)
+	clicore.WriteFormat(stdout, "  Location: %s\n\n", absDir)
+	return 0
+}
+
+func runSkillsDirUninstall(directory string, skills []skillDefinition, stdout io.Writer, stderr io.Writer) int {
+	absDir, err := filepath.Abs(directory)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, skillsDirErrorContext())
+		return 1
+	}
+	clicore.WriteLine(stdout, "")
+	clicore.WriteLine(stdout, "Uninstalling uloop skills (directory)...")
+	clicore.WriteLine(stdout, "")
+	removed := 0
+	notFound := 0
+	for _, skill := range skills {
+		wasInstalled, err := uninstallSkillFromDir(absDir, skill)
+		if err != nil {
+			clierrors.WriteClassifiedError(stderr, err, skillsDirErrorContext())
+			return 1
+		}
+		if wasInstalled {
+			removed++
+			continue
+		}
+		notFound++
+	}
+	clicore.WriteLine(stdout, "Directory:")
+	clicore.WriteFormat(stdout, "  Removed: %d\n", removed)
+	clicore.WriteFormat(stdout, "  Not found: %d\n", notFound)
+	clicore.WriteFormat(stdout, "  Location: %s\n\n", absDir)
+	return 0
+}
+
+func runSkillsDirList(directory string, skills []skillDefinition, stdout io.Writer, stderr io.Writer) int {
+	absDir, err := filepath.Abs(directory)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, skillsDirErrorContext())
+		return 1
+	}
+	clicore.WriteLine(stdout, "")
+	clicore.WriteLine(stdout, "uloop Skills Status:")
+	clicore.WriteLine(stdout, "")
+	clicore.WriteLine(stdout, "Directory:")
+	clicore.WriteFormat(stdout, "Location: %s\n", absDir)
+	clicore.WriteLine(stdout, strings.Repeat("=", 50))
+	for _, skill := range skills {
+		status, err := getDirSkillStatus(absDir, skill)
+		if err != nil {
+			clierrors.WriteClassifiedError(stderr, err, skillsDirErrorContext())
+			return 1
+		}
+		clicore.WriteFormat(stdout, "  %s %s (%s)\n", statusIcon(status), skill.name, statusText(status))
+	}
+	clicore.WriteLine(stdout, "")
+	clicore.WriteFormat(stdout, "Total: %d skills\n", len(skills))
+	return 0
+}
+
+func installSkillIntoDir(baseDir string, skill skillDefinition, result *skillInstallResult) error {
+	status, err := getDirSkillStatus(baseDir, skill)
+	if err != nil {
+		return err
+	}
+	if status == "installed" {
+		result.skipped++
+		return nil
+	}
+	if err := syncSkillDirectoryPreservingForeignFiles(skill.sourceDirectory, filepath.Join(baseDir, skill.name)); err != nil {
+		return err
+	}
+	if status == "outdated" {
+		result.updated++
+		return nil
+	}
+	result.installed++
+	return nil
+}
+
+// uninstallSkillFromDir deletes only entries that exist in the skill source, so
+// foreign files survive; the skill directory itself is removed only once empty.
+func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) {
+	skillDir := filepath.Join(baseDir, skill.name)
+	if _, err := os.Stat(filepath.Join(skillDir, skillscan.SkillFileName)); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	entryNames, err := sourceOwnedEntryNames(skill.sourceDirectory)
+	if err != nil {
+		return false, err
+	}
+	for _, entryName := range entryNames {
+		if err := os.RemoveAll(filepath.Join(skillDir, entryName)); err != nil {
+			return false, err
+		}
+	}
+	return true, removeEmptyDir(skillDir)
+}
+
+// getDirSkillStatus reports install status for the --output-dir layout. It compares
+// only source-owned paths, so foreign files kept next to SKILL.md never mark
+// the skill outdated; files inside source-owned directories (references/) are
+// compared both ways because syncing replaces those directories wholly.
+func getDirSkillStatus(baseDir string, skill skillDefinition) (string, error) {
+	skillDir := filepath.Join(baseDir, skill.name)
+	installedContent, err := os.ReadFile(filepath.Join(skillDir, skillscan.SkillFileName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "not_installed", nil
+		}
+		return "", err
+	}
+	installedContent = normalizeSkillFileContent(skillscan.SkillFileName, installedContent)
+	expectedContent := normalizeSkillFileContent(skillscan.SkillFileName, skill.content)
+	if !bytes.Equal(installedContent, expectedContent) {
+		return "outdated", nil
+	}
+	if dirSkillFilesOutdated(skillDir, skill) {
+		return "outdated", nil
+	}
+	return "installed", nil
+}
+
+func dirSkillFilesOutdated(skillDir string, skill skillDefinition) bool {
+	expectedFiles := collectComparableSkillFiles(skill.sourceDirectory)
+	installedFiles := collectComparableSkillFiles(skillDir)
+	for relativePath, expectedContent := range expectedFiles {
+		installedContent, ok := installedFiles[relativePath]
+		if !ok || !bytes.Equal(expectedContent, installedContent) {
+			return true
+		}
+	}
+	ownedDirs := sourceOwnedDirNames(skill.sourceDirectory)
+	for relativePath := range installedFiles {
+		topLevel := topLevelPathSegment(relativePath)
+		// Top-level files absent from the source are foreign files and stay
+		// untouched, so they must not flag the skill as outdated.
+		if topLevel == relativePath {
+			continue
+		}
+		if !ownedDirs[topLevel] {
+			continue
+		}
+		if _, ok := expectedFiles[relativePath]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
+// syncSkillDirectoryPreservingForeignFiles copies every source-owned entry into
+// destinationDir while leaving unknown files untouched. Source-owned
+// directories are replaced wholly so stale files inside them do not linger.
+func syncSkillDirectoryPreservingForeignFiles(sourceDir string, destinationDir string) error {
+	if err := os.MkdirAll(destinationDir, 0o755); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(sourceDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if shouldSkipSkillFile(entry.Name()) {
+			continue
+		}
+		if err := syncSkillEntry(sourceDir, destinationDir, entry); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func syncSkillEntry(sourceDir string, destinationDir string, entry os.DirEntry) error {
+	sourcePath := filepath.Join(sourceDir, entry.Name())
+	destinationPath := filepath.Join(destinationDir, entry.Name())
+	if entry.IsDir() {
+		if err := os.RemoveAll(destinationPath); err != nil {
+			return err
+		}
+		return copySkillDirectory(sourcePath, destinationPath)
+	}
+	content, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return err
+	}
+	content = normalizeSkillFileContent(entry.Name(), content)
+	return os.WriteFile(destinationPath, content, 0o644)
+}
+
+// sourceOwnedEntryNames lists the top-level entries of a skill source, which is
+// exactly the set of paths uloop owns inside an installed skill directory.
+func sourceOwnedEntryNames(sourceDir string) ([]string, error) {
+	entries, err := os.ReadDir(sourceDir)
+	if err != nil {
+		return nil, err
+	}
+	names := []string{}
+	for _, entry := range entries {
+		if shouldSkipSkillFile(entry.Name()) {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	return names, nil
+}
+
+func sourceOwnedDirNames(sourceDir string) map[string]bool {
+	ownedDirs := map[string]bool{}
+	entries, err := os.ReadDir(sourceDir)
+	if err != nil {
+		return ownedDirs
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && !shouldSkipSkillFile(entry.Name()) {
+			ownedDirs[entry.Name()] = true
+		}
+	}
+	return ownedDirs
+}
+
+func topLevelPathSegment(relativePath string) string {
+	separatorIndex := strings.IndexRune(relativePath, filepath.Separator)
+	if separatorIndex < 0 {
+		return relativePath
+	}
+	return relativePath[:separatorIndex]
+}
+
+func skillsDirErrorContext() clierrors.ErrorContext {
+	return clierrors.ErrorContext{Command: clicore.SkillsCommandName}
+}

--- a/cli/dispatcher/internal/dispatcher/skills_dir.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir.go
@@ -14,6 +14,7 @@ package dispatcher
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -25,12 +26,7 @@ import (
 	"github.com/hatayama/unity-cli-loop/common/skillscan"
 )
 
-func runSkillsDirInstall(directory string, skills []skillDefinition, stdout io.Writer, stderr io.Writer) int {
-	absDir, err := filepath.Abs(directory)
-	if err != nil {
-		clierrors.WriteClassifiedError(stderr, err, skillsDirErrorContext())
-		return 1
-	}
+func runSkillsDirInstall(absDir string, skills []skillDefinition, stdout io.Writer, stderr io.Writer) int {
 	clicore.WriteLine(stdout, "")
 	clicore.WriteLine(stdout, "Installing uloop skills (directory)...")
 	clicore.WriteLine(stdout, "")
@@ -49,12 +45,7 @@ func runSkillsDirInstall(directory string, skills []skillDefinition, stdout io.W
 	return 0
 }
 
-func runSkillsDirUninstall(directory string, skills []skillDefinition, stdout io.Writer, stderr io.Writer) int {
-	absDir, err := filepath.Abs(directory)
-	if err != nil {
-		clierrors.WriteClassifiedError(stderr, err, skillsDirErrorContext())
-		return 1
-	}
+func runSkillsDirUninstall(absDir string, skills []skillDefinition, stdout io.Writer, stderr io.Writer) int {
 	clicore.WriteLine(stdout, "")
 	clicore.WriteLine(stdout, "Uninstalling uloop skills (directory)...")
 	clicore.WriteLine(stdout, "")
@@ -79,12 +70,7 @@ func runSkillsDirUninstall(directory string, skills []skillDefinition, stdout io
 	return 0
 }
 
-func runSkillsDirList(directory string, skills []skillDefinition, stdout io.Writer, stderr io.Writer) int {
-	absDir, err := filepath.Abs(directory)
-	if err != nil {
-		clierrors.WriteClassifiedError(stderr, err, skillsDirErrorContext())
-		return 1
-	}
+func runSkillsDirList(absDir string, skills []skillDefinition, stdout io.Writer, stderr io.Writer) int {
 	clicore.WriteLine(stdout, "")
 	clicore.WriteLine(stdout, "uloop Skills Status:")
 	clicore.WriteLine(stdout, "")
@@ -131,11 +117,17 @@ func installSkillIntoDir(baseDir string, skill skillDefinition, result *skillIns
 // cleaned up instead of being reported as not installed.
 func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) {
 	skillDir := filepath.Join(baseDir, skill.name)
-	if _, err := os.Stat(skillDir); err != nil {
+	info, err := os.Stat(skillDir)
+	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
 		return false, err
+	}
+	// A foreign top-level file occupying the skill's name is not an install of
+	// ours, so it is preserved and the skill reported as not found.
+	if !info.IsDir() {
+		return false, nil
 	}
 	entryNames, err := sourceOwnedEntryNames(skill.sourceDirectory)
 	if err != nil {
@@ -144,7 +136,9 @@ func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) 
 	removedAny := false
 	for _, entryName := range entryNames {
 		entryPath := filepath.Join(skillDir, entryName)
-		if _, err := os.Stat(entryPath); err != nil {
+		// Lstat, not Stat: a dangling symlink at an owned entry name must still
+		// be detected and removed instead of being skipped as missing.
+		if _, err := os.Lstat(entryPath); err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
@@ -164,16 +158,27 @@ func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) 
 // compared both ways because syncing replaces those directories wholly.
 func getDirSkillStatus(baseDir string, skill skillDefinition) (string, error) {
 	skillDir := filepath.Join(baseDir, skill.name)
-	installedContent, err := os.ReadFile(filepath.Join(skillDir, skillscan.SkillFileName))
+	info, err := os.Stat(skillDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "not_installed", nil
 		}
 		return "", err
 	}
-	installedContent = normalizeSkillFileContent(skillscan.SkillFileName, installedContent)
-	expectedContent := normalizeSkillFileContent(skillscan.SkillFileName, skill.content)
-	if !bytes.Equal(installedContent, expectedContent) {
+	// Checked explicitly because ReadFile below a file path fails with ENOTDIR
+	// on Unix but maps to IsNotExist on Windows — the platforms would otherwise
+	// diverge between an aborted run and a bogus install attempt.
+	if !info.IsDir() {
+		return "", fmt.Errorf("cannot manage skill %q: %s exists but is not a directory", skill.name, skillDir)
+	}
+	matches, err := installedSkillFileMatches(skillDir, skill)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return dirSkillStatusWithoutSkillFile(skillDir, skill)
+		}
+		return "", err
+	}
+	if !matches {
 		return "outdated", nil
 	}
 	filesOutdated, err := dirSkillFilesOutdated(skillDir, skill)
@@ -184,6 +189,27 @@ func getDirSkillStatus(baseDir string, skill skillDefinition) (string, error) {
 		return "outdated", nil
 	}
 	return "installed", nil
+}
+
+// dirSkillStatusWithoutSkillFile classifies a skill directory whose SKILL.md is
+// missing. Owned entries left behind mean a partial install worth repairing, so
+// the state reads as outdated; list, install, and uninstall then agree on it
+// instead of reporting not-installed, installed, and removed respectively.
+func dirSkillStatusWithoutSkillFile(skillDir string, skill skillDefinition) (string, error) {
+	entryNames, err := sourceOwnedEntryNames(skill.sourceDirectory)
+	if err != nil {
+		return "", err
+	}
+	for _, entryName := range entryNames {
+		if _, err := os.Lstat(filepath.Join(skillDir, entryName)); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", err
+		}
+		return "outdated", nil
+	}
+	return "not_installed", nil
 }
 
 func dirSkillFilesOutdated(skillDir string, skill skillDefinition) (bool, error) {
@@ -219,6 +245,9 @@ func dirSkillFilesOutdated(skillDir string, skill skillDefinition) (bool, error)
 // syncSkillDirectoryPreservingForeignFiles copies every source-owned entry into
 // destinationDir while leaving unknown files untouched. Source-owned
 // directories are replaced wholly so stale files inside them do not linger.
+// SKILL.md is written last: it is what the status check keys on, so a sync that
+// fails partway leaves the old SKILL.md in place and the skill keeps reporting
+// outdated instead of pairing new metadata with old files.
 func syncSkillDirectoryPreservingForeignFiles(sourceDir string, destinationDir string) error {
 	if err := os.MkdirAll(destinationDir, 0o755); err != nil {
 		return err
@@ -227,15 +256,23 @@ func syncSkillDirectoryPreservingForeignFiles(sourceDir string, destinationDir s
 	if err != nil {
 		return err
 	}
+	var skillFileEntry os.DirEntry
 	for _, entry := range entries {
 		if shouldSkipSkillFile(entry.Name()) {
+			continue
+		}
+		if !entry.IsDir() && entry.Name() == skillscan.SkillFileName {
+			skillFileEntry = entry
 			continue
 		}
 		if err := syncSkillEntry(sourceDir, destinationDir, entry); err != nil {
 			return err
 		}
 	}
-	return nil
+	if skillFileEntry == nil {
+		return nil
+	}
+	return syncSkillEntry(sourceDir, destinationDir, skillFileEntry)
 }
 
 func syncSkillEntry(sourceDir string, destinationDir string, entry os.DirEntry) error {
@@ -251,7 +288,38 @@ func syncSkillEntry(sourceDir string, destinationDir string, entry os.DirEntry) 
 		return err
 	}
 	content = normalizeSkillFileContent(entry.Name(), content)
-	return os.WriteFile(destinationPath, content, 0o644)
+	return writeSkillFileAtomically(destinationPath, content)
+}
+
+// writeSkillFileAtomically writes through a temp file plus rename so an
+// interrupted write cannot leave a truncated file at the destination.
+func writeSkillFileAtomically(destinationPath string, content []byte) error {
+	tempFile, err := os.CreateTemp(filepath.Dir(destinationPath), filepath.Base(destinationPath)+".tmp-")
+	if err != nil {
+		return err
+	}
+	tempPath := tempFile.Name()
+	renamed := false
+	defer func() {
+		_ = tempFile.Close()
+		if !renamed {
+			_ = os.Remove(tempPath)
+		}
+	}()
+	if _, err := tempFile.Write(content); err != nil {
+		return err
+	}
+	if err := tempFile.Chmod(0o644); err != nil {
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, destinationPath); err != nil {
+		return err
+	}
+	renamed = true
+	return nil
 }
 
 // sourceOwnedEntryNames lists the top-level entries of a skill source, which is

--- a/cli/dispatcher/internal/dispatcher/skills_dir.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir.go
@@ -4,7 +4,12 @@ package dispatcher
 // external skill-package store such as APM). Unlike target installs, the
 // destination may hold files uloop does not own (package manifests placed next
 // to SKILL.md), so every operation here touches only entries that exist in the
-// skill source directory.
+// skill source directory — and only inside skill directories that carry
+// evidence of a uloop install (see dirSkillHasInstallEvidence): a name match
+// alone never authorizes replacing or deleting anything. A skill whose name is
+// occupied by content uloop cannot manage is reported as a per-skill conflict
+// and the run continues, so one occupied name cannot leave the rest of the
+// store half-synced with no summary.
 //
 // Deliberate omissions compared to target installs: disabled-tool filtering and
 // deprecated-skill cleanup do not run here. An external store is not scoped to
@@ -16,7 +21,6 @@ package dispatcher
 // skill version dropped or renamed is left behind rather than cleaned up.
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -33,17 +37,32 @@ func runSkillsDirInstall(absDir string, skills []skillDefinition, stdout io.Writ
 	clicore.WriteLine(stdout, "Installing uloop skills (directory)...")
 	clicore.WriteLine(stdout, "")
 	result := skillInstallResult{}
+	blocked := 0
 	for _, skill := range skills {
-		if err := installSkillIntoDir(absDir, skill, &result); err != nil {
+		conflictReason, err := installSkillIntoDir(absDir, skill, &result)
+		if err != nil {
 			clierrors.WriteClassifiedError(stderr, err, skillsDirErrorContext())
 			return 1
+		}
+		// A conflict blocks only its own skill: the remaining skills still
+		// sync, and the summary below still prints, so an interrupted-looking
+		// half-synced store cannot result from one occupied name.
+		if conflictReason != "" {
+			blocked++
+			clicore.WriteLine(stderr, conflictReason)
 		}
 	}
 	clicore.WriteLine(stdout, "Directory:")
 	clicore.WriteFormat(stdout, "  Installed: %d\n", result.installed)
 	clicore.WriteFormat(stdout, "  Updated: %d\n", result.updated)
 	clicore.WriteFormat(stdout, "  Skipped: %d\n", result.skipped)
+	if blocked > 0 {
+		clicore.WriteFormat(stdout, "  Blocked: %d\n", blocked)
+	}
 	clicore.WriteFormat(stdout, "  Location: %s\n\n", absDir)
+	if blocked > 0 {
+		return 1
+	}
 	return 0
 }
 
@@ -80,51 +99,61 @@ func runSkillsDirList(absDir string, skills []skillDefinition, stdout io.Writer,
 	clicore.WriteFormat(stdout, "Location: %s\n", absDir)
 	clicore.WriteLine(stdout, strings.Repeat("=", 50))
 	for _, skill := range skills {
-		status, err := getDirSkillStatus(absDir, skill)
+		state, err := getDirSkillState(absDir, skill)
 		if err != nil {
 			clierrors.WriteClassifiedError(stderr, err, skillsDirErrorContext())
 			return 1
 		}
-		clicore.WriteFormat(stdout, "  %s %s (%s)\n", statusIcon(status), skill.name, statusText(status))
+		clicore.WriteFormat(stdout, "  %s %s (%s)\n", statusIcon(state.status), skill.name, statusText(state.status))
 	}
 	clicore.WriteLine(stdout, "")
 	clicore.WriteFormat(stdout, "Total: %d skills\n", len(skills))
 	return 0
 }
 
-func installSkillIntoDir(baseDir string, skill skillDefinition, result *skillInstallResult) error {
-	// Status first: its Lstat guard rejects a symlink or file occupying the
-	// skill's name before artifact cleanup runs, whose ReadDir would follow the
-	// symlink and delete matching entries outside the store (and surface a raw
-	// platform-divergent error for a plain file).
-	status, err := getDirSkillStatus(baseDir, skill)
+// installSkillIntoDir syncs one skill and returns the conflict reason when the
+// skill's name is occupied by content uloop cannot manage; the caller reports
+// it and continues with the remaining skills.
+func installSkillIntoDir(baseDir string, skill skillDefinition, result *skillInstallResult) (string, error) {
+	// State first: its Lstat guard classifies a symlink or file occupying the
+	// skill's name as a conflict before artifact cleanup runs, whose ReadDir
+	// would follow the symlink and delete matching entries outside the store
+	// (and surface a raw platform-divergent error for a plain file).
+	state, err := getDirSkillState(baseDir, skill)
 	if err != nil {
-		return err
+		return "", err
+	}
+	if state.status == "conflict" {
+		return state.conflictReason, nil
 	}
 	if _, err := removeStaleSyncArtifacts(filepath.Join(baseDir, skill.name)); err != nil {
-		return err
+		return "", err
 	}
-	if status == "installed" {
+	if state.status == "installed" {
 		result.skipped++
-		return nil
+		return "", nil
 	}
 	if err := syncSkillDirectoryPreservingForeignFiles(skill.sourceDirectory, filepath.Join(baseDir, skill.name)); err != nil {
-		return err
+		return "", err
 	}
-	if status == "outdated" {
+	if state.status == "outdated" {
 		result.updated++
-		return nil
+		return "", nil
 	}
 	result.installed++
-	return nil
+	return "", nil
 }
 
 // uninstallSkillFromDir deletes only entries that exist in the skill source, so
 // foreign files survive; the skill directory itself is removed only once
 // nothing but ignorable OS/tool debris (.DS_Store, *.meta) remains in it.
-// Presence is keyed on the owned entries rather than SKILL.md alone, so a
-// partially removed install (references/ left behind without SKILL.md) is still
-// cleaned up instead of being reported as not installed.
+// Removal requires install evidence (SKILL.md, or owned content matching the
+// source): a partially removed install (references/ left behind without
+// SKILL.md) is still cleaned up, while a hand-authored directory that merely
+// uses a skill's name — possibly in a store uloop never installed into — is
+// preserved and reported as not found. Entries are matched by their exact
+// on-disk names, so a case-insensitive filesystem cannot make uloop delete a
+// user's skill.md or References/ as if they were the source-owned entries.
 func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) {
 	skillDir := filepath.Join(baseDir, skill.name)
 	// Lstat, not Stat: a symlink occupying the skill's name must not be
@@ -141,32 +170,42 @@ func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) 
 	if !info.IsDir() {
 		return false, nil
 	}
-	entryNames, err := sourceOwnedEntryNames(skill.sourceDirectory)
+	ownedEntries, err := sourceOwnedEntries(skill.sourceDirectory)
 	if err != nil {
 		return false, err
 	}
+	// Artifacts carry the uloop namespace marker, so they are uloop's own
+	// debris by construction and are cleaned up regardless of install evidence.
 	artifactsRemoved, err := removeStaleSyncArtifacts(skillDir)
 	if err != nil {
 		return false, err
 	}
-	removedAny := false
-	for _, entryName := range entryNames {
-		entryPath := filepath.Join(skillDir, entryName)
-		// Lstat, not Stat: a dangling symlink at an owned entry name must still
-		// be detected and removed instead of being skipped as missing.
-		if _, err := os.Lstat(entryPath); err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return false, err
+	dirEntries, err := os.ReadDir(skillDir)
+	if err != nil {
+		return false, err
+	}
+	evidence, err := dirSkillHasInstallEvidence(skillDir, skill, ownedEntries, dirEntries)
+	if err != nil {
+		return false, err
+	}
+	if !evidence {
+		if !artifactsRemoved {
+			return false, nil
 		}
-		if err := os.RemoveAll(entryPath); err != nil {
+		return false, removeSkillDirWithIgnorableDebris(skillDir)
+	}
+	removedAny := false
+	for _, owned := range ownedEntries {
+		// Exact-name lookup from the ReadDir listing (dangling symlinks
+		// included), never a path probe the filesystem could case-fold.
+		if findExactDirEntry(dirEntries, owned.Name()) == nil {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(skillDir, owned.Name())); err != nil {
 			return false, err
 		}
 		removedAny = true
 	}
-	// Nothing of ours was found: leave the directory alone, even when empty —
-	// a user-created scaffold directory bearing a skill name is foreign.
 	if !removedAny && !artifactsRemoved {
 		return false, nil
 	}
@@ -193,113 +232,6 @@ func removeSkillDirWithIgnorableDebris(skillDir string) error {
 		}
 	}
 	return os.RemoveAll(skillDir)
-}
-
-// getDirSkillStatus reports install status for the --output-dir layout. It compares
-// only source-owned paths, so foreign files kept next to SKILL.md never mark
-// the skill outdated; files inside source-owned directories (references/) are
-// compared both ways because syncing replaces those directories wholly.
-func getDirSkillStatus(baseDir string, skill skillDefinition) (string, error) {
-	skillDir := filepath.Join(baseDir, skill.name)
-	// Lstat, not Stat: a symlink occupying the skill's name must not be
-	// followed, or install would write through it into a directory outside the
-	// store that uninstall would then delete from.
-	info, err := os.Lstat(skillDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "not_installed", nil
-		}
-		return "", err
-	}
-	// Checked explicitly because ReadFile below a file path fails with ENOTDIR
-	// on Unix but maps to IsNotExist on Windows — the platforms would otherwise
-	// diverge between an aborted run and a bogus install attempt.
-	if !info.IsDir() {
-		// A symlink gets its own message: "not a directory" would mislead when
-		// the link points at one — it is the refusal to follow that matters.
-		if info.Mode()&os.ModeSymlink != 0 {
-			return "", fmt.Errorf("cannot manage skill %q: %s is a symlink, which uloop never follows", skill.name, skillDir)
-		}
-		return "", fmt.Errorf("cannot manage skill %q: %s exists but is not a directory", skill.name, skillDir)
-	}
-	matches, err := installedSkillFileMatches(skillDir, skill)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return dirSkillStatusWithoutSkillFile(skillDir, skill)
-		}
-		// Wrapped so an unreadable SKILL.md (permissions, or a directory with
-		// that name) surfaces with the affected skill instead of a bare OS
-		// error; dir mode surfaces such states rather than rewriting an
-		// external store whose files cannot even be read.
-		return "", fmt.Errorf("cannot read %s for skill %q: %w", skillscan.SkillFileName, skill.name, err)
-	}
-	if !matches {
-		return "outdated", nil
-	}
-	filesOutdated, err := dirSkillFilesOutdated(skillDir, skill)
-	if err != nil {
-		return "", err
-	}
-	if filesOutdated {
-		return "outdated", nil
-	}
-	return "installed", nil
-}
-
-// dirSkillStatusWithoutSkillFile classifies a skill directory whose SKILL.md is
-// missing. Owned entries left behind mean a partial install worth repairing, so
-// the state reads as outdated; list, install, and uninstall then agree on it
-// instead of reporting not-installed, installed, and removed respectively.
-func dirSkillStatusWithoutSkillFile(skillDir string, skill skillDefinition) (string, error) {
-	entryNames, err := sourceOwnedEntryNames(skill.sourceDirectory)
-	if err != nil {
-		return "", err
-	}
-	for _, entryName := range entryNames {
-		if _, err := os.Lstat(filepath.Join(skillDir, entryName)); err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return "", err
-		}
-		return "outdated", nil
-	}
-	return "not_installed", nil
-}
-
-// dirSkillFilesOutdated reports whether the installed copies of source-owned
-// files differ from the source. Extra installed files count as stale only when
-// they sit inside a source-owned directory; top-level foreign files are the
-// mode's design point and never mark the skill outdated.
-func dirSkillFilesOutdated(skillDir string, skill skillDefinition) (bool, error) {
-	expectedFiles := collectComparableSkillFiles(skill.sourceDirectory)
-	installedFiles := collectComparableSkillFiles(skillDir)
-	if !comparableFilesMatch(expectedFiles, installedFiles) {
-		return true, nil
-	}
-	ownedEntries, err := sourceOwnedEntries(skill.sourceDirectory)
-	if err != nil {
-		return false, err
-	}
-	ownedDirs := map[string]bool{}
-	for _, entry := range ownedEntries {
-		if entry.IsDir() {
-			ownedDirs[entry.Name()] = true
-		}
-	}
-	for relativePath := range installedFiles {
-		// Only files inside source-owned directories count as stale: a
-		// top-level foreign file's own name never appears in ownedDirs, and a
-		// file shadowing an owned directory name is already reported outdated
-		// by the expected-files comparison above.
-		if !ownedDirs[topLevelPathSegment(relativePath)] {
-			continue
-		}
-		if _, ok := expectedFiles[relativePath]; !ok {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 // syncSkillDirectoryPreservingForeignFiles copies every source-owned entry into
@@ -352,12 +284,13 @@ func syncSkillEntry(sourceDir string, destinationDir string, entry os.DirEntry) 
 }
 
 // removeEntryOfWrongType clears a destination entry whose type does not match
-// the source-owned entry about to be written. Ownership is name-scoped, so
-// whatever occupies an owned name is uloop's to replace — but the replace paths
-// cannot do it themselves: replaceSkillDirectory resolves the occupant with
-// os.Stat, which misclassifies a dangling symlink as absent and then fails the
-// rename with a raw ENOTDIR (and would follow a live symlink), and a plain
-// rename over a directory fails the same way for file entries.
+// the source-owned entry about to be written. Syncs only reach here for skill
+// directories with install evidence, so the occupant is uloop's to replace —
+// but the replace paths cannot do it themselves: replaceSkillDirectory
+// resolves the occupant with os.Stat, which misclassifies a dangling symlink
+// as absent and then fails the rename with a raw ENOTDIR (and would follow a
+// live symlink), and a plain rename over a directory fails the same way for
+// file entries.
 func removeEntryOfWrongType(destinationPath string, wantDir bool) error {
 	// Lstat, not Stat: the occupant itself is what must be examined and
 	// removed; a symlink must never be followed into data outside the store.
@@ -427,18 +360,6 @@ func sourceOwnedEntries(sourceDir string) ([]os.DirEntry, error) {
 	return owned, nil
 }
 
-func sourceOwnedEntryNames(sourceDir string) ([]string, error) {
-	entries, err := sourceOwnedEntries(sourceDir)
-	if err != nil {
-		return nil, err
-	}
-	names := []string{}
-	for _, entry := range entries {
-		names = append(names, entry.Name())
-	}
-	return names, nil
-}
-
 // removeStaleSyncArtifacts deletes leftover temp and backup entries that an
 // interrupted sync can leave behind (SKILL.md.uloop-tmp-*, ...). They carry
 // the uloop namespace marker, so they are uloop's own artifacts by
@@ -475,14 +396,6 @@ func removeStaleSyncArtifacts(skillDir string) (bool, error) {
 func isStaleSyncArtifactName(name string) bool {
 	return strings.Contains(name, skillSyncTempSuffix) ||
 		strings.Contains(name, skillSyncBackupSuffix)
-}
-
-func topLevelPathSegment(relativePath string) string {
-	separatorIndex := strings.IndexRune(relativePath, filepath.Separator)
-	if separatorIndex < 0 {
-		return relativePath
-	}
-	return relativePath[:separatorIndex]
 }
 
 func skillsDirErrorContext() clierrors.ErrorContext {

--- a/cli/dispatcher/internal/dispatcher/skills_dir.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir.go
@@ -150,7 +150,11 @@ func installSkillIntoDir(baseDir string, skill skillDefinition, result *skillIns
 	if state.status == "conflict" {
 		return state.conflictReason, nil
 	}
-	if _, err := removeStaleSyncArtifacts(filepath.Join(baseDir, skill.name)); err != nil {
+	ownedEntries, err := sourceOwnedEntries(skill.sourceDirectory)
+	if err != nil {
+		return "", err
+	}
+	if _, err := removeStaleSyncArtifacts(filepath.Join(baseDir, skill.name), ownedEntries); err != nil {
 		return "", err
 	}
 	if state.status == "installed" {
@@ -201,7 +205,7 @@ func uninstallSkillFromDir(baseDir string, skill skillDefinition) (bool, error) 
 	}
 	// Artifacts carry the uloop namespace marker, so they are uloop's own
 	// debris by construction and are cleaned up regardless of install evidence.
-	artifactsRemoved, err := removeStaleSyncArtifacts(skillDir)
+	artifactsRemoved, err := removeStaleSyncArtifacts(skillDir, ownedEntries)
 	if err != nil {
 		return false, err
 	}
@@ -443,7 +447,7 @@ func sourceOwnedEntries(sourceDir string) ([]os.DirEntry, error) {
 // construction and removing them keeps the foreign-file guarantee intact;
 // left alone they would be treated as foreign forever and keep the skill
 // directory from ever being removed on uninstall.
-func removeStaleSyncArtifacts(skillDir string) (bool, error) {
+func removeStaleSyncArtifacts(skillDir string, ownedEntries []os.DirEntry) (bool, error) {
 	entries, err := os.ReadDir(skillDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -454,6 +458,11 @@ func removeStaleSyncArtifacts(skillDir string) (bool, error) {
 	removedAny := false
 	for _, entry := range entries {
 		if !isStaleSyncArtifactName(entry.Name()) {
+			continue
+		}
+		// Current source-owned names are live managed content, not leftovers,
+		// even when they resemble artifact names.
+		if findExactDirEntry(ownedEntries, entry.Name()) != nil {
 			continue
 		}
 		if err := os.RemoveAll(filepath.Join(skillDir, entry.Name())); err != nil {

--- a/cli/dispatcher/internal/dispatcher/skills_dir_cleanup.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_cleanup.go
@@ -1,0 +1,180 @@
+package dispatcher
+
+// Deletion authorization and cleanup for dir-mode stores. These helpers
+// decide what uninstall and interrupted-sync recovery may remove — source-owned
+// entries, namespaced sync artifacts, and ignorable OS/tool debris — and why
+// a name match alone never authorizes deleting foreign content.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// removeOwnedEntries deletes the owned entries present in the skill directory
+// by exact-name lookup from the ReadDir listing (dangling symlinks included),
+// never a path probe the filesystem could case-fold.
+func removeOwnedEntries(skillDir string, ownedEntries []os.DirEntry, dirEntries []os.DirEntry) (bool, error) {
+	removedAny := false
+	for _, owned := range ownedEntries {
+		if findExactDirEntry(dirEntries, owned.Name()) == nil {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(skillDir, owned.Name())); err != nil {
+			return false, err
+		}
+		removedAny = true
+	}
+	return removedAny, nil
+}
+
+// removeSkillDirWithIgnorableDebris removes an uninstalled skill's directory
+// when the only entries left are ignorable OS/tool debris. Leaving them would
+// ghost the directory in the store forever — and orphaned .meta files make
+// Unity warn — while removing them deletes nothing a skill install could have
+// provided. Any other remaining entry is genuinely foreign and keeps the
+// directory in place.
+func removeSkillDirWithIgnorableDebris(skillDir string, ownedEntries []os.DirEntry) error {
+	entries, err := os.ReadDir(skillDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	for _, entry := range entries {
+		if !isIgnorableStoreDebris(entry, ownedEntries) {
+			return nil
+		}
+	}
+	return os.RemoveAll(skillDir)
+}
+
+// isIgnorableStoreDebris authorizes deleting a leftover entry along with its
+// skill directory: OS junk, plus the Unity .meta stubs minted for entries
+// uloop itself installed. Only regular files qualify — a directory bearing a
+// debris name is user data whose contents uloop never wrote. A user's own
+// .meta data file (dataset.meta) keeps the directory alive. Deliberately
+// separate from shouldSkipSkillFile even though the patterns overlap: that
+// one filters what a sync copies, and widening a copy filter must never
+// silently widen what uninstall may delete.
+func isIgnorableStoreDebris(entry os.DirEntry, ownedEntries []os.DirEntry) bool {
+	if !entry.Type().IsRegular() {
+		return false
+	}
+	name := entry.Name()
+	if name == ".DS_Store" || name == "Thumbs.db" || name == "desktop.ini" {
+		return true
+	}
+	stem, found := strings.CutSuffix(name, ".meta")
+	if !found {
+		return false
+	}
+	return findExactDirEntry(ownedEntries, stem) != nil
+}
+
+// removeSkillDirIfEmpty drops the skill directory only when nothing remains at
+// all — the state removing uloop's own sync artifacts leaves behind when they
+// were the directory's sole content.
+func removeSkillDirIfEmpty(skillDir string) error {
+	entries, err := os.ReadDir(skillDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if len(entries) > 0 {
+		return nil
+	}
+	return os.Remove(skillDir)
+}
+
+// removeEntryOfWrongType clears a destination entry whose type does not match
+// the source-owned entry about to be written. Syncs only reach here for skill
+// directories that carry install evidence or hold nothing at owned names, so
+// the occupant is uloop's to replace — but the replace paths cannot do it
+// themselves: replaceSkillDirectory
+// resolves the occupant with os.Stat, which misclassifies a dangling symlink
+// as absent and then fails the rename with a raw ENOTDIR (and would follow a
+// live symlink), and a plain rename over a directory fails the same way for
+// file entries.
+func removeEntryOfWrongType(destinationPath string, wantDir bool) error {
+	// Lstat, not Stat: the occupant itself is what must be examined and
+	// removed; a symlink must never be followed into data outside the store.
+	info, err := os.Lstat(destinationPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.IsDir() == wantDir {
+		return nil
+	}
+	if info.IsDir() {
+		return os.RemoveAll(destinationPath)
+	}
+	return os.Remove(destinationPath)
+}
+
+// removeStaleSyncArtifacts deletes leftover temp and backup entries that an
+// interrupted sync can leave behind (SKILL.md.uloop-tmp-*, ...). They carry
+// the uloop namespace marker, so they are uloop's own artifacts by
+// construction and removing them keeps the foreign-file guarantee intact;
+// left alone they would be treated as foreign forever and keep the skill
+// directory from ever being removed on uninstall.
+func removeStaleSyncArtifacts(skillDir string, ownedEntries []os.DirEntry) (bool, error) {
+	entries, err := os.ReadDir(skillDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	removedAny := false
+	for _, entry := range entries {
+		if !isStaleSyncArtifactName(entry.Name()) {
+			continue
+		}
+		// Current source-owned names are live managed content, not leftovers,
+		// even when they resemble artifact names.
+		if findExactDirEntry(ownedEntries, entry.Name()) != nil {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(skillDir, entry.Name())); err != nil {
+			return false, err
+		}
+		removedAny = true
+	}
+	return removedAny, nil
+}
+
+// isStaleSyncArtifactName matches the namespaced names the sync helpers mint
+// for temp and backup copies of source-owned entries: the uloop marker
+// followed by the digits os.CreateTemp and os.MkdirTemp append. The marker
+// claims the namespace and the digit tail keeps a human-named file that
+// merely embeds it (my-archive.uloop-tmp-keepme) out of reach. Matching is
+// not restricted to currently owned entry names: debris minted for an entry a
+// newer skill version dropped or renamed must still be cleaned up.
+func isStaleSyncArtifactName(name string) bool {
+	return hasSyncArtifactSuffix(name, skillSyncTempSuffix) ||
+		hasSyncArtifactSuffix(name, skillSyncBackupSuffix)
+}
+
+func hasSyncArtifactSuffix(name string, marker string) bool {
+	markerIndex := strings.LastIndex(name, marker)
+	if markerIndex < 0 {
+		return false
+	}
+	tail := name[markerIndex+len(marker):]
+	if tail == "" {
+		return false
+	}
+	for _, char := range tail {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/cli/dispatcher/internal/dispatcher/skills_dir_fifo_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_fifo_test.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+package dispatcher
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// Tests that dir-mode status never reads foreign file content: a FIFO placed
+// next to SKILL.md would block any read forever, so the listing completing at
+// all proves foreign bytes are not opened.
+func TestRunSkillsDirListIgnoresForeignFifo(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	fifoPath := filepath.Join(destinationDir, "uloop-sample", "queue.pipe")
+	if err := syscall.Mkfifo(fifoPath, 0o644); err != nil {
+		t.Fatalf("failed to create fifo: %v", err)
+	}
+
+	stdout.Reset()
+	code := runSkillsDirList(destinationDir, []skillDefinition{skill}, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dir list failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "uloop-sample (installed)") {
+		t.Fatalf("a foreign FIFO should not change the skill status:\n%s", stdout.String())
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/skills_dir_status.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_status.go
@@ -213,8 +213,9 @@ const (
 	ownedEntryAbsent ownedEntryComparison = iota
 	// ownedEntryEqual: the installed content fully matches the source.
 	ownedEntryEqual
-	// ownedEntryEqualEmpty: both sides hold no comparable files, so the match
-	// is vacuous — it must not count as install evidence.
+	// ownedEntryEqualEmpty: both sides hold no comparable content (an empty
+	// file, or a directory with no comparable files), so the match is
+	// vacuous — it must not count as install evidence.
 	ownedEntryEqualEmpty
 	// ownedEntryDiffers: an entry exists but its type or content differs.
 	ownedEntryDiffers
@@ -269,10 +270,13 @@ func compareOwnedFile(skillDir string, sourceDir string, name string, installed 
 	if err != nil {
 		return ownedEntryUnreadable, nil
 	}
-	if bytes.Equal(
-		normalizeSkillFileContent(name, sourceContent),
-		normalizeSkillFileContent(name, installedContent),
-	) {
+	normalizedSource := normalizeSkillFileContent(name, sourceContent)
+	if bytes.Equal(normalizedSource, normalizeSkillFileContent(name, installedContent)) {
+		// An empty match proves nothing, mirroring the directory branch:
+		// two empty files of the same name must not count as install evidence.
+		if len(normalizedSource) == 0 {
+			return ownedEntryEqualEmpty, nil
+		}
 		return ownedEntryEqual, nil
 	}
 	return ownedEntryDiffers, nil

--- a/cli/dispatcher/internal/dispatcher/skills_dir_status.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_status.go
@@ -1,0 +1,293 @@
+package dispatcher
+
+// Status classification for --output-dir mode. The rules here decide when a
+// destination entry may be replaced or deleted, so they are deliberately
+// conservative: uloop acts on a skill directory only when it holds evidence of
+// a uloop install (see dirSkillHasInstallEvidence), and every name lookup is
+// exact — on a case-insensitive filesystem a user's skill.md or References/
+// must never be claimed as the source-owned SKILL.md or references/.
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hatayama/unity-cli-loop/common/skillscan"
+)
+
+// dirSkillState is the per-skill outcome of a dir-mode status check. A
+// conflict is a state, not an error: one skill whose name is occupied by
+// foreign content must not abort the run for every other skill, so install
+// and list report it per skill and keep going.
+type dirSkillState struct {
+	status         string
+	conflictReason string
+}
+
+func conflictDirSkillState(reason string) dirSkillState {
+	return dirSkillState{status: "conflict", conflictReason: reason}
+}
+
+func getDirSkillState(baseDir string, skill skillDefinition) (dirSkillState, error) {
+	skillDir := filepath.Join(baseDir, skill.name)
+	// Lstat, not Stat: a symlink occupying the skill's name must not be
+	// followed, or install would write through it into a directory outside the
+	// store that uninstall would then delete from.
+	info, err := os.Lstat(skillDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return dirSkillState{status: "not_installed"}, nil
+		}
+		return dirSkillState{}, err
+	}
+	if !info.IsDir() {
+		// A symlink gets its own message: "not a directory" would mislead when
+		// the link points at one — it is the refusal to follow that matters.
+		if info.Mode()&os.ModeSymlink != 0 {
+			return conflictDirSkillState(fmt.Sprintf("cannot manage skill %q: %s is a symlink, which uloop never follows", skill.name, skillDir)), nil
+		}
+		return conflictDirSkillState(fmt.Sprintf("cannot manage skill %q: %s exists but is not a directory", skill.name, skillDir)), nil
+	}
+	ownedEntries, err := sourceOwnedEntries(skill.sourceDirectory)
+	if err != nil {
+		return dirSkillState{}, err
+	}
+	dirEntries, err := os.ReadDir(skillDir)
+	if err != nil {
+		return dirSkillState{}, err
+	}
+	if reason := dirSkillCaseConflictReason(skill, skillDir, ownedEntries, dirEntries); reason != "" {
+		return conflictDirSkillState(reason), nil
+	}
+	skillFileEntry := findExactDirEntry(dirEntries, skillscan.SkillFileName)
+	if skillFileEntry == nil || !skillFileEntry.Type().IsRegular() {
+		return classifyDirSkillWithoutSkillFile(skillDir, skill, ownedEntries, dirEntries)
+	}
+	matches, err := installedSkillFileMatches(skillDir, skill)
+	if err != nil {
+		// An unreadable SKILL.md (permissions) is a conflict, not an abort: dir
+		// mode surfaces the state per skill rather than rewriting an external
+		// store whose files cannot even be read.
+		return conflictDirSkillState(fmt.Sprintf("cannot read %s for skill %q: %v", skillscan.SkillFileName, skill.name, err)), nil
+	}
+	if !matches {
+		return dirSkillState{status: "outdated"}, nil
+	}
+	filesOutdated, err := dirSkillFilesOutdated(skillDir, skill, ownedEntries, dirEntries)
+	if err != nil {
+		return dirSkillState{}, err
+	}
+	if filesOutdated {
+		return dirSkillState{status: "outdated"}, nil
+	}
+	return dirSkillState{status: "installed"}, nil
+}
+
+// classifyDirSkillWithoutSkillFile classifies a skill directory that has no
+// regular SKILL.md at its exact name. Owned entries backed by install evidence
+// mean a partial install worth repairing (outdated); owned names occupied by
+// content uloop never wrote are a conflict — replacing or deleting them would
+// destroy user data in a store uloop may never have installed into.
+func classifyDirSkillWithoutSkillFile(skillDir string, skill skillDefinition, ownedEntries []os.DirEntry, dirEntries []os.DirEntry) (dirSkillState, error) {
+	occupied := ownedNamesPresent(ownedEntries, dirEntries)
+	if len(occupied) == 0 {
+		return dirSkillState{status: "not_installed"}, nil
+	}
+	evidence, err := dirSkillHasInstallEvidence(skillDir, skill, ownedEntries, dirEntries)
+	if err != nil {
+		return dirSkillState{}, err
+	}
+	if evidence {
+		return dirSkillState{status: "outdated"}, nil
+	}
+	return conflictDirSkillState(fmt.Sprintf(
+		"cannot manage skill %q: %s holds entries at source-owned names (%s) that uloop did not install",
+		skill.name, skillDir, strings.Join(occupied, ", "))), nil
+}
+
+// dirSkillHasInstallEvidence reports whether the skill directory shows signs
+// of a uloop install: a regular SKILL.md at its exact name, or an owned entry
+// whose content equals the current source (the orphan a partial removal
+// leaves behind). Name presence alone is never evidence — a hand-authored
+// directory that happens to use a skill's name must stay untouched.
+func dirSkillHasInstallEvidence(skillDir string, skill skillDefinition, ownedEntries []os.DirEntry, dirEntries []os.DirEntry) (bool, error) {
+	for _, owned := range ownedEntries {
+		installed := findExactDirEntry(dirEntries, owned.Name())
+		if installed == nil || installed.IsDir() != owned.IsDir() {
+			continue
+		}
+		if !owned.IsDir() {
+			if installed.Type().IsRegular() && owned.Name() == skillscan.SkillFileName {
+				return true, nil
+			}
+			matches, err := installedOwnedFileMatchesSource(skillDir, skill.sourceDirectory, installed)
+			if err != nil {
+				return false, err
+			}
+			if matches {
+				return true, nil
+			}
+			continue
+		}
+		expected, err := collectOwnedDirFiles(filepath.Join(skill.sourceDirectory, owned.Name()))
+		if err != nil {
+			return false, err
+		}
+		installedFiles, err := collectOwnedDirFiles(filepath.Join(skillDir, owned.Name()))
+		// Unreadable content is not evidence of anything; the entry stays
+		// foreign and therefore untouched.
+		if err != nil {
+			continue
+		}
+		if len(expected) == len(installedFiles) && comparableFilesMatch(expected, installedFiles) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func installedOwnedFileMatchesSource(skillDir string, sourceDir string, installed os.DirEntry) (bool, error) {
+	if !installed.Type().IsRegular() {
+		return false, nil
+	}
+	sourceContent, err := os.ReadFile(filepath.Join(sourceDir, installed.Name()))
+	if err != nil {
+		return false, err
+	}
+	installedContent, err := os.ReadFile(filepath.Join(skillDir, installed.Name()))
+	if err != nil {
+		return false, nil
+	}
+	return bytes.Equal(
+		normalizeSkillFileContent(installed.Name(), sourceContent),
+		normalizeSkillFileContent(installed.Name(), installedContent),
+	), nil
+}
+
+// dirSkillCaseConflictReason reports a conflict when an entry matches a
+// source-owned name only by letter case and the exact name is absent. On a
+// case-insensitive filesystem (macOS, Windows) writing the owned name would
+// silently replace that foreign entry; the refusal applies on every platform
+// so the store behaves the same regardless of where it is synced.
+func dirSkillCaseConflictReason(skill skillDefinition, skillDir string, ownedEntries []os.DirEntry, dirEntries []os.DirEntry) string {
+	for _, owned := range ownedEntries {
+		if findExactDirEntry(dirEntries, owned.Name()) != nil {
+			continue
+		}
+		variant := findCaseVariantDirEntry(dirEntries, owned.Name())
+		if variant == nil {
+			continue
+		}
+		return fmt.Sprintf("cannot manage skill %q: %s contains %q, which matches the source-owned %q only by letter case",
+			skill.name, skillDir, variant.Name(), owned.Name())
+	}
+	return ""
+}
+
+// dirSkillFilesOutdated compares owned entries against the source. It walks
+// only source-owned content, never foreign files: a multi-gigabyte artifact or
+// a FIFO placed next to SKILL.md must not slow down or block the check. An
+// unreadable or wrong-type entry inside an owned directory marks the skill
+// outdated so the next sync repairs it instead of reporting it as installed.
+func dirSkillFilesOutdated(skillDir string, skill skillDefinition, ownedEntries []os.DirEntry, dirEntries []os.DirEntry) (bool, error) {
+	for _, owned := range ownedEntries {
+		if owned.Name() == skillscan.SkillFileName {
+			continue
+		}
+		installed := findExactDirEntry(dirEntries, owned.Name())
+		if installed == nil || installed.IsDir() != owned.IsDir() {
+			return true, nil
+		}
+		if !owned.IsDir() {
+			matches, err := installedOwnedFileMatchesSource(skillDir, skill.sourceDirectory, installed)
+			if err != nil {
+				return false, err
+			}
+			if !matches {
+				return true, nil
+			}
+			continue
+		}
+		expected, err := collectOwnedDirFiles(filepath.Join(skill.sourceDirectory, owned.Name()))
+		if err != nil {
+			return false, err
+		}
+		installedFiles, err := collectOwnedDirFiles(filepath.Join(skillDir, owned.Name()))
+		if err != nil {
+			return true, nil
+		}
+		if len(expected) != len(installedFiles) || !comparableFilesMatch(expected, installedFiles) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// collectOwnedDirFiles is the error-surfacing counterpart of
+// collectComparableSkillFiles, for content uloop owns: inside an owned
+// directory an unreadable file or a non-regular entry (dangling symlink,
+// FIFO) is a broken copy the caller must react to, not something to silently
+// treat as matching.
+func collectOwnedDirFiles(root string) (map[string][]byte, error) {
+	files := map[string][]byte{}
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || shouldSkipSkillFile(entry.Name()) {
+			return nil
+		}
+		if !entry.Type().IsRegular() {
+			return fmt.Errorf("%s is not a regular file", path)
+		}
+		relativePath, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		files[relativePath] = normalizeSkillFileContent(relativePath, content)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+func ownedNamesPresent(ownedEntries []os.DirEntry, dirEntries []os.DirEntry) []string {
+	names := []string{}
+	for _, owned := range ownedEntries {
+		if findExactDirEntry(dirEntries, owned.Name()) != nil {
+			names = append(names, owned.Name())
+		}
+	}
+	return names
+}
+
+// findExactDirEntry matches by the byte-exact stored name. Probing with Lstat
+// would let a case-insensitive filesystem resolve skill.md as SKILL.md and
+// claim a foreign file; ReadDir returns true on-disk names, so exact
+// comparison stays correct on every filesystem.
+func findExactDirEntry(dirEntries []os.DirEntry, name string) os.DirEntry {
+	for _, entry := range dirEntries {
+		if entry.Name() == name {
+			return entry
+		}
+	}
+	return nil
+}
+
+func findCaseVariantDirEntry(dirEntries []os.DirEntry, name string) os.DirEntry {
+	for _, entry := range dirEntries {
+		if entry.Name() != name && strings.EqualFold(entry.Name(), name) {
+			return entry
+		}
+	}
+	return nil
+}

--- a/cli/dispatcher/internal/dispatcher/skills_dir_status.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_status.go
@@ -3,9 +3,10 @@ package dispatcher
 // Status classification for --output-dir mode. The rules here decide when a
 // destination entry may be replaced or deleted, so they are deliberately
 // conservative: uloop acts on a skill directory only when it holds evidence of
-// a uloop install (see dirSkillHasInstallEvidence), and every name lookup is
-// exact — on a case-insensitive filesystem a user's skill.md or References/
-// must never be claimed as the source-owned SKILL.md or references/.
+// a uloop install (see dirSkillHasInstallEvidence), and every name lookup —
+// the skill directory itself included — is exact against ReadDir listings: on
+// a case-insensitive filesystem a path probe would resolve a user's
+// Uloop-Sample/ or skill.md as uloop's own names and claim foreign content.
 
 import (
 	"bytes"
@@ -32,25 +33,11 @@ func conflictDirSkillState(reason string) dirSkillState {
 }
 
 func getDirSkillState(baseDir string, skill skillDefinition) (dirSkillState, error) {
+	state, done, err := storeLevelDirSkillState(baseDir, skill)
+	if err != nil || done {
+		return state, err
+	}
 	skillDir := filepath.Join(baseDir, skill.name)
-	// Lstat, not Stat: a symlink occupying the skill's name must not be
-	// followed, or install would write through it into a directory outside the
-	// store that uninstall would then delete from.
-	info, err := os.Lstat(skillDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return dirSkillState{status: "not_installed"}, nil
-		}
-		return dirSkillState{}, err
-	}
-	if !info.IsDir() {
-		// A symlink gets its own message: "not a directory" would mislead when
-		// the link points at one — it is the refusal to follow that matters.
-		if info.Mode()&os.ModeSymlink != 0 {
-			return conflictDirSkillState(fmt.Sprintf("cannot manage skill %q: %s is a symlink, which uloop never follows", skill.name, skillDir)), nil
-		}
-		return conflictDirSkillState(fmt.Sprintf("cannot manage skill %q: %s exists but is not a directory", skill.name, skillDir)), nil
-	}
 	ownedEntries, err := sourceOwnedEntries(skill.sourceDirectory)
 	if err != nil {
 		return dirSkillState{}, err
@@ -86,11 +73,50 @@ func getDirSkillState(baseDir string, skill skillDefinition) (dirSkillState, err
 	return dirSkillState{status: "installed"}, nil
 }
 
+// storeLevelDirSkillState classifies what occupies the skill's name in the
+// store itself. done=false means a directory exists at the exact name and the
+// caller must inspect its contents. The name is resolved from the ReadDir
+// listing, not a path probe: on a case-insensitive filesystem Lstat would
+// resolve a user's differently-cased directory as the skill's name and adopt
+// it, so a case variant without the exact name is a conflict on every
+// platform.
+func storeLevelDirSkillState(baseDir string, skill skillDefinition) (dirSkillState, bool, error) {
+	baseEntries, err := os.ReadDir(baseDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return dirSkillState{status: "not_installed"}, true, nil
+		}
+		return dirSkillState{}, true, err
+	}
+	skillDirEntry := findExactDirEntry(baseEntries, skill.name)
+	if skillDirEntry == nil {
+		if variant := findCaseVariantDirEntry(baseEntries, skill.name); variant != nil {
+			return conflictDirSkillState(fmt.Sprintf(
+				"cannot manage skill %q: the store contains %q, which matches the skill name only by letter case",
+				skill.name, variant.Name())), true, nil
+		}
+		return dirSkillState{status: "not_installed"}, true, nil
+	}
+	skillDir := filepath.Join(baseDir, skill.name)
+	if !skillDirEntry.IsDir() {
+		// A symlink gets its own message: "not a directory" would mislead when
+		// the link points at one — it is the refusal to follow that matters.
+		if skillDirEntry.Type()&os.ModeSymlink != 0 {
+			return conflictDirSkillState(fmt.Sprintf("cannot manage skill %q: %s is a symlink, which uloop never follows", skill.name, skillDir)), true, nil
+		}
+		return conflictDirSkillState(fmt.Sprintf("cannot manage skill %q: %s exists but is not a directory", skill.name, skillDir)), true, nil
+	}
+	return dirSkillState{}, false, nil
+}
+
 // classifyDirSkillWithoutSkillFile classifies a skill directory that has no
 // regular SKILL.md at its exact name. Owned entries backed by install evidence
 // mean a partial install worth repairing (outdated); owned names occupied by
-// content uloop never wrote are a conflict — replacing or deleting them would
-// destroy user data in a store uloop may never have installed into.
+// content uloop cannot confirm it installed are a conflict — replacing or
+// deleting them could destroy user data in a store uloop may never have
+// installed into. Accepted limitation of the no-manifest design: an orphan of
+// a partial removal whose source has since been updated no longer matches and
+// lands here too, so the message tells the user how to resolve either case.
 func classifyDirSkillWithoutSkillFile(skillDir string, skill skillDefinition, ownedEntries []os.DirEntry, dirEntries []os.DirEntry) (dirSkillState, error) {
 	occupied := ownedNamesPresent(ownedEntries, dirEntries)
 	if len(occupied) == 0 {
@@ -104,7 +130,7 @@ func classifyDirSkillWithoutSkillFile(skillDir string, skill skillDefinition, ow
 		return dirSkillState{status: "outdated"}, nil
 	}
 	return conflictDirSkillState(fmt.Sprintf(
-		"cannot manage skill %q: %s holds entries at source-owned names (%s) that uloop did not install",
+		"cannot manage skill %q: %s holds entries at source-owned names (%s) that uloop cannot confirm it installed; remove or rename them to let uloop manage this skill",
 		skill.name, skillDir, strings.Join(occupied, ", "))), nil
 }
 
@@ -115,56 +141,26 @@ func classifyDirSkillWithoutSkillFile(skillDir string, skill skillDefinition, ow
 // directory that happens to use a skill's name must stay untouched.
 func dirSkillHasInstallEvidence(skillDir string, skill skillDefinition, ownedEntries []os.DirEntry, dirEntries []os.DirEntry) (bool, error) {
 	for _, owned := range ownedEntries {
-		installed := findExactDirEntry(dirEntries, owned.Name())
-		if installed == nil || installed.IsDir() != owned.IsDir() {
-			continue
-		}
-		if !owned.IsDir() {
-			if installed.Type().IsRegular() && owned.Name() == skillscan.SkillFileName {
-				return true, nil
-			}
-			matches, err := installedOwnedFileMatchesSource(skillDir, skill.sourceDirectory, installed)
-			if err != nil {
-				return false, err
-			}
-			if matches {
+		if !owned.IsDir() && owned.Name() == skillscan.SkillFileName {
+			installed := findExactDirEntry(dirEntries, owned.Name())
+			if installed != nil && installed.Type().IsRegular() {
 				return true, nil
 			}
 			continue
 		}
-		expected, err := collectOwnedDirFiles(filepath.Join(skill.sourceDirectory, owned.Name()))
+		comparison, err := compareOwnedEntry(skillDir, skill.sourceDirectory, owned, dirEntries)
 		if err != nil {
 			return false, err
 		}
-		installedFiles, err := collectOwnedDirFiles(filepath.Join(skillDir, owned.Name()))
-		// Unreadable content is not evidence of anything; the entry stays
-		// foreign and therefore untouched.
-		if err != nil {
-			continue
-		}
-		if len(expected) == len(installedFiles) && comparableFilesMatch(expected, installedFiles) {
+		// Only a full content match proves the entry came from uloop; an
+		// empty match (ownedEntryEqualEmpty) proves nothing, and unreadable
+		// content is not evidence of anything — the entry stays foreign and
+		// therefore untouched.
+		if comparison == ownedEntryEqual {
 			return true, nil
 		}
 	}
 	return false, nil
-}
-
-func installedOwnedFileMatchesSource(skillDir string, sourceDir string, installed os.DirEntry) (bool, error) {
-	if !installed.Type().IsRegular() {
-		return false, nil
-	}
-	sourceContent, err := os.ReadFile(filepath.Join(sourceDir, installed.Name()))
-	if err != nil {
-		return false, err
-	}
-	installedContent, err := os.ReadFile(filepath.Join(skillDir, installed.Name()))
-	if err != nil {
-		return false, nil
-	}
-	return bytes.Equal(
-		normalizeSkillFileContent(installed.Name(), sourceContent),
-		normalizeSkillFileContent(installed.Name(), installedContent),
-	), nil
 }
 
 // dirSkillCaseConflictReason reports a conflict when an entry matches a
@@ -197,40 +193,126 @@ func dirSkillFilesOutdated(skillDir string, skill skillDefinition, ownedEntries 
 		if owned.Name() == skillscan.SkillFileName {
 			continue
 		}
-		installed := findExactDirEntry(dirEntries, owned.Name())
-		if installed == nil || installed.IsDir() != owned.IsDir() {
-			return true, nil
-		}
-		if !owned.IsDir() {
-			matches, err := installedOwnedFileMatchesSource(skillDir, skill.sourceDirectory, installed)
-			if err != nil {
-				return false, err
-			}
-			if !matches {
-				return true, nil
-			}
-			continue
-		}
-		expected, err := collectOwnedDirFiles(filepath.Join(skill.sourceDirectory, owned.Name()))
+		comparison, err := compareOwnedEntry(skillDir, skill.sourceDirectory, owned, dirEntries)
 		if err != nil {
 			return false, err
 		}
-		installedFiles, err := collectOwnedDirFiles(filepath.Join(skillDir, owned.Name()))
-		if err != nil {
-			return true, nil
-		}
-		if len(expected) != len(installedFiles) || !comparableFilesMatch(expected, installedFiles) {
+		if comparison != ownedEntryEqual && comparison != ownedEntryEqualEmpty {
 			return true, nil
 		}
 	}
 	return false, nil
 }
 
-// collectOwnedDirFiles is the error-surfacing counterpart of
-// collectComparableSkillFiles, for content uloop owns: inside an owned
-// directory an unreadable file or a non-regular entry (dangling symlink,
-// FIFO) is a broken copy the caller must react to, not something to silently
-// treat as matching.
+// ownedEntryComparison is the outcome of comparing one installed owned entry
+// against its source counterpart.
+type ownedEntryComparison int
+
+const (
+	// ownedEntryAbsent: no entry at the exact owned name.
+	ownedEntryAbsent ownedEntryComparison = iota
+	// ownedEntryEqual: the installed content fully matches the source.
+	ownedEntryEqual
+	// ownedEntryEqualEmpty: both sides hold no comparable files, so the match
+	// is vacuous — it must not count as install evidence.
+	ownedEntryEqualEmpty
+	// ownedEntryDiffers: an entry exists but its type or content differs.
+	ownedEntryDiffers
+	// ownedEntryUnreadable: the installed side cannot be read or contains a
+	// non-regular entry (dangling symlink, FIFO).
+	ownedEntryUnreadable
+)
+
+// compareOwnedEntry is the single definition of "the installed owned entry
+// equals the source entry". Install evidence (may this directory be managed
+// at all?) and staleness (does it need a sync?) both derive from it, so the
+// two authorizations for destructive replacement and deletion cannot drift
+// apart. Source-side read failures are real errors; installed-side failures
+// are a state (ownedEntryUnreadable) for the caller to interpret.
+func compareOwnedEntry(skillDir string, sourceDir string, owned os.DirEntry, dirEntries []os.DirEntry) (ownedEntryComparison, error) {
+	installed := findExactDirEntry(dirEntries, owned.Name())
+	if installed == nil {
+		return ownedEntryAbsent, nil
+	}
+	if installed.IsDir() != owned.IsDir() {
+		return ownedEntryDiffers, nil
+	}
+	if !owned.IsDir() {
+		return compareOwnedFile(skillDir, sourceDir, owned.Name(), installed)
+	}
+	expected, err := collectSourceDirFiles(filepath.Join(sourceDir, owned.Name()))
+	if err != nil {
+		return ownedEntryAbsent, err
+	}
+	installedFiles, err := collectOwnedDirFiles(filepath.Join(skillDir, owned.Name()))
+	if err != nil {
+		return ownedEntryUnreadable, nil
+	}
+	if len(expected) != len(installedFiles) || !comparableFilesMatch(expected, installedFiles) {
+		return ownedEntryDiffers, nil
+	}
+	if len(expected) == 0 {
+		return ownedEntryEqualEmpty, nil
+	}
+	return ownedEntryEqual, nil
+}
+
+func compareOwnedFile(skillDir string, sourceDir string, name string, installed os.DirEntry) (ownedEntryComparison, error) {
+	if !installed.Type().IsRegular() {
+		return ownedEntryDiffers, nil
+	}
+	sourceContent, err := os.ReadFile(filepath.Join(sourceDir, name))
+	if err != nil {
+		return ownedEntryAbsent, err
+	}
+	installedContent, err := os.ReadFile(filepath.Join(skillDir, name))
+	if err != nil {
+		return ownedEntryUnreadable, nil
+	}
+	if bytes.Equal(
+		normalizeSkillFileContent(name, sourceContent),
+		normalizeSkillFileContent(name, installedContent),
+	) {
+		return ownedEntryEqual, nil
+	}
+	return ownedEntryDiffers, nil
+}
+
+// collectSourceDirFiles gathers comparable files from a source-owned
+// directory. Unlike collectOwnedDirFiles it reads through symlinks, because
+// copySkillDirectory does the same when installing: a working symlink in the
+// source is copied as a regular file, so the comparison must see the same
+// content on both sides or the skill would report outdated forever.
+func collectSourceDirFiles(root string) (map[string][]byte, error) {
+	files := map[string][]byte{}
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || shouldSkipSkillFile(entry.Name()) {
+			return nil
+		}
+		relativePath, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		files[relativePath] = normalizeSkillFileContent(relativePath, content)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+// collectOwnedDirFiles is the error-surfacing collector for installed content
+// uloop owns: inside an owned directory an unreadable file or a non-regular
+// entry (dangling symlink, FIFO) is a broken copy the caller must react to,
+// not something to silently treat as matching.
 func collectOwnedDirFiles(root string) (map[string][]byte, error) {
 	files := map[string][]byte{}
 	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -1103,6 +1103,11 @@ func TestPosixStyleOutputDirError(t *testing.T) {
 	if err := posixStyleOutputDirError("linux", "/tmp/skills"); err != nil {
 		t.Fatalf("a POSIX path should be accepted on non-Windows platforms: %v", err)
 	}
+	// A double-slash prefix is a UNC path on Windows, which carries its own
+	// volume and is therefore not ambiguous.
+	if err := posixStyleOutputDirError("windows", "//server/share/skills"); err != nil {
+		t.Fatalf("a UNC path should be accepted on Windows: %v", err)
+	}
 }
 
 // Tests that a store directory matching the skill name only by letter case is
@@ -1357,5 +1362,16 @@ func TestRunSkillsDirUninstallDistinguishesMetaDebrisFromUserMeta(t *testing.T) 
 	}
 	if _, err := os.Stat(installedDir); err != nil {
 		t.Fatalf("a directory holding a user's .meta file must be kept: %v", err)
+	}
+}
+
+// Tests that a whitespace-only --output-dir value (a typical unset shell
+// variable) is rejected as a missing value in both option forms.
+func TestParseSkillsOptionsRejectsWhitespaceOutputDir(t *testing.T) {
+	if _, err := parseSkillsOptions([]string{"--output-dir", " "}); err == nil {
+		t.Fatal("expected error for a whitespace-only --output-dir value")
+	}
+	if _, err := parseSkillsOptions([]string{"--output-dir= "}); err == nil {
+		t.Fatal("expected error for a whitespace-only --output-dir= value")
 	}
 }

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -1575,7 +1575,11 @@ func TestRunSkillsDirSubcommandRejectsOutputDirInsideSkillSource(t *testing.T) {
 	if !strings.Contains(stderr.String(), skillsOutputDirFlagName) {
 		t.Fatalf("error should name --output-dir:\n%s", stderr.String())
 	}
-	if !strings.Contains(stderr.String(), skill.sourceDirectory) && !strings.Contains(stderr.String(), outputDir) {
+	envelope := clierrors.CLIErrorEnvelope{}
+	if err := json.Unmarshal(stderr.Bytes(), &envelope); err != nil {
+		t.Fatalf("parse error envelope: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(envelope.Error.Message, skill.sourceDirectory) && !strings.Contains(envelope.Error.Message, outputDir) {
 		t.Fatalf("error should name the conflicting path:\n%s", stderr.String())
 	}
 	if _, err := os.Stat(outputDir); !os.IsNotExist(err) {

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -1365,6 +1365,45 @@ func TestRunSkillsDirUninstallDistinguishesMetaDebrisFromUserMeta(t *testing.T) 
 	}
 }
 
+// Tests that uninstall does not treat a user directory named like ignorable
+// debris (references.meta) as deletable: only regular files qualify, so the
+// directory, its contents, and the skill directory itself survive.
+func TestRunSkillsDirUninstallPreservesUserDirectoryNamedAsDebris(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	installedDir := filepath.Join(destinationDir, "uloop-sample")
+	userDebrisDir := filepath.Join(installedDir, "references.meta")
+	if err := os.MkdirAll(userDebrisDir, 0o755); err != nil {
+		t.Fatalf("failed to create user debris-named dir: %v", err)
+	}
+	keptFile := filepath.Join(userDebrisDir, "keep.txt")
+	if err := os.WriteFile(keptFile, []byte("keep me\n"), 0o644); err != nil {
+		t.Fatalf("failed to write file inside debris-named dir: %v", err)
+	}
+
+	stdout.Reset()
+	code := runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(userDebrisDir); err != nil {
+		t.Fatalf("user directory named like debris must survive: %v", err)
+	}
+	if _, err := os.Stat(keptFile); err != nil {
+		t.Fatalf("contents of the debris-named directory must survive: %v", err)
+	}
+	if _, err := os.Stat(installedDir); err != nil {
+		t.Fatalf("skill directory holding a user directory must be kept: %v", err)
+	}
+}
+
 // Tests that a whitespace-only --output-dir value (a typical unset shell
 // variable) is rejected as a missing value in both option forms.
 func TestParseSkillsOptionsRejectsWhitespaceOutputDir(t *testing.T) {

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -311,6 +311,144 @@ func TestRunSkillsDirInstallRejectsFileOccupyingSkillName(t *testing.T) {
 	}
 }
 
+// Tests that a symlink occupying a skill's name is never followed: install
+// fails with a clear error and uninstall preserves the symlink target's
+// contents, so operations cannot reach outside the store.
+func TestRunSkillsDirDoesNotFollowSymlinkAtSkillName(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	if err := os.MkdirAll(destinationDir, 0o755); err != nil {
+		t.Fatalf("failed to create destination: %v", err)
+	}
+	curatedDir := filepath.Join(root, "curated", "uloop-sample")
+	curatedFile := filepath.Join(curatedDir, "SKILL.md")
+	if err := os.MkdirAll(curatedDir, 0o755); err != nil {
+		t.Fatalf("failed to create curated dir: %v", err)
+	}
+	if err := os.WriteFile(curatedFile, []byte("user content\n"), 0o644); err != nil {
+		t.Fatalf("failed to write curated file: %v", err)
+	}
+	if err := os.Symlink(curatedDir, filepath.Join(destinationDir, "uloop-sample")); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 1 {
+		t.Fatalf("install through a symlink should fail: code=%d", code)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+	if code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Not found: 1") {
+		t.Fatalf("symlinked skill name should not count as an install:\n%s", stdout.String())
+	}
+	if _, err := os.Stat(curatedFile); err != nil {
+		t.Fatalf("symlink target contents must survive uninstall: %v", err)
+	}
+}
+
+// Tests that an --output-dir destination that exists as a regular file is
+// rejected with a clear error on every platform instead of diverging between
+// a raw ENOTDIR and bogus not-installed statuses.
+func TestRunSkillsDirSubcommandRejectsFileDestination(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationPath := filepath.Join(root, "apm-skills")
+	if err := os.WriteFile(destinationPath, []byte("not a directory\n"), 0o644); err != nil {
+		t.Fatalf("failed to write destination file: %v", err)
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runSkillsDirSubcommand("install", []skillDefinition{skill}, destinationPath, stdout, stderr)
+
+	if code != 1 {
+		t.Fatalf("file destination should fail: code=%d", code)
+	}
+	if !strings.Contains(stderr.String(), "not a directory") {
+		t.Fatalf("error should explain the file destination:\n%s", stderr.String())
+	}
+}
+
+// Tests that uninstall leaves a user-created empty directory bearing a skill
+// name in place when nothing owned was found inside it.
+func TestRunSkillsDirUninstallPreservesEmptyForeignDir(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	scaffoldDir := filepath.Join(destinationDir, "uloop-sample")
+	if err := os.MkdirAll(scaffoldDir, 0o755); err != nil {
+		t.Fatalf("failed to create scaffold dir: %v", err)
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Not found: 1") {
+		t.Fatalf("empty foreign directory should not count as an install:\n%s", stdout.String())
+	}
+	if _, err := os.Stat(scaffoldDir); err != nil {
+		t.Fatalf("empty foreign directory should be preserved: %v", err)
+	}
+}
+
+// Tests that leftover temp and backup artifacts from an interrupted sync are
+// cleaned up by install and uninstall instead of lingering as foreign files.
+func TestRunSkillsDirCleansStaleSyncArtifacts(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	installedDir := filepath.Join(destinationDir, "uloop-sample")
+	staleTemp := filepath.Join(installedDir, "SKILL.md.tmp-1234")
+	staleBackup := filepath.Join(installedDir, "references.backup-5678")
+	if err := os.WriteFile(staleTemp, []byte("partial\n"), 0o644); err != nil {
+		t.Fatalf("failed to write stale temp file: %v", err)
+	}
+	if err := os.MkdirAll(staleBackup, 0o755); err != nil {
+		t.Fatalf("failed to create stale backup dir: %v", err)
+	}
+
+	stdout.Reset()
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("dir install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(staleTemp); !os.IsNotExist(err) {
+		t.Fatalf("stale temp file should be cleaned by install, stat err=%v", err)
+	}
+	if _, err := os.Stat(staleBackup); !os.IsNotExist(err) {
+		t.Fatalf("stale backup dir should be cleaned by install, stat err=%v", err)
+	}
+
+	if err := os.MkdirAll(staleBackup, 0o755); err != nil {
+		t.Fatalf("failed to recreate stale backup dir: %v", err)
+	}
+	stdout.Reset()
+	if code := runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(installedDir); !os.IsNotExist(err) {
+		t.Fatalf("skill directory should be fully removed after cleanup, stat err=%v", err)
+	}
+}
+
 // Tests that uninstall removes a dangling symlink sitting at an owned entry
 // name instead of skipping it as missing.
 func TestRunSkillsDirUninstallRemovesDanglingSymlink(t *testing.T) {

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -1253,6 +1253,47 @@ func TestRunSkillsDirEmptyOwnedDirGrantsNoEvidence(t *testing.T) {
 	}
 }
 
+// Tests that an empty owned top-level file grants no install evidence: a
+// vacuous empty-file match must not authorize uninstall to delete the skill
+// directory or the user's files.
+func TestRunSkillsDirEmptyOwnedFileGrantsNoEvidence(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	if err := os.WriteFile(filepath.Join(skill.sourceDirectory, "notes.md"), []byte{}, 0o644); err != nil {
+		t.Fatalf("failed to write empty source file: %v", err)
+	}
+	destinationDir := filepath.Join(root, "apm-skills")
+	storeDir := filepath.Join(destinationDir, "uloop-sample")
+	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+		t.Fatalf("failed to create store skill dir: %v", err)
+	}
+	emptyNotes := filepath.Join(storeDir, "notes.md")
+	if err := os.WriteFile(emptyNotes, []byte{}, 0o644); err != nil {
+		t.Fatalf("failed to write empty store file: %v", err)
+	}
+	userFile := filepath.Join(storeDir, "mine.md")
+	if err := os.WriteFile(userFile, []byte("mine\n"), 0o644); err != nil {
+		t.Fatalf("failed to write user file: %v", err)
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Not found: 1") {
+		t.Fatalf("an empty owned file should not count as an install:\n%s", stdout.String())
+	}
+	if _, err := os.Stat(emptyNotes); err != nil {
+		t.Fatalf("the matching empty file must survive: %v", err)
+	}
+	if _, err := os.Stat(userFile); err != nil {
+		t.Fatalf("user content must survive: %v", err)
+	}
+}
+
 // Tests that a working symlink inside a source-owned directory does not wedge
 // dir mode: the sync copies the target's content as a regular file, and the
 // status check compares the same content, so the skill reads as installed.

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -334,7 +334,7 @@ func TestRunSkillsDirDoesNotFollowSymlinkAtSkillName(t *testing.T) {
 	}
 	// An artifact-named entry inside the symlink target guards against cleanup
 	// reading through the symlink and deleting outside the store.
-	curatedArtifact := filepath.Join(curatedDir, "SKILL.md.tmp-1234")
+	curatedArtifact := filepath.Join(curatedDir, "SKILL.md.uloop-tmp-1234")
 	if err := os.WriteFile(curatedArtifact, []byte("theirs\n"), 0o644); err != nil {
 		t.Fatalf("failed to write curated artifact-named file: %v", err)
 	}
@@ -426,8 +426,8 @@ func TestRunSkillsDirCleansStaleSyncArtifacts(t *testing.T) {
 		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
 	}
 	installedDir := filepath.Join(destinationDir, "uloop-sample")
-	staleTemp := filepath.Join(installedDir, "SKILL.md.tmp-1234")
-	staleBackup := filepath.Join(installedDir, "references.backup-5678")
+	staleTemp := filepath.Join(installedDir, "SKILL.md.uloop-tmp-1234")
+	staleBackup := filepath.Join(installedDir, "references.uloop-backup-5678")
 	if err := os.WriteFile(staleTemp, []byte("partial\n"), 0o644); err != nil {
 		t.Fatalf("failed to write stale temp file: %v", err)
 	}
@@ -458,9 +458,10 @@ func TestRunSkillsDirCleansStaleSyncArtifacts(t *testing.T) {
 	}
 }
 
-// Tests that user files whose names merely resemble sync artifacts (a temp or
-// backup prefix without the digits-only random suffix) are preserved as
-// foreign by install and uninstall instead of being deleted as uloop debris.
+// Tests that user files whose names merely resemble sync artifacts (temp or
+// backup naming without the uloop namespace marker, digit-suffixed dated
+// backups included) are preserved as foreign by install and uninstall instead
+// of being deleted as uloop debris.
 func TestRunSkillsDirPreservesHumanNamedArtifactLookalikes(t *testing.T) {
 	root := t.TempDir()
 	skill := writeDirModeSkillSource(t, root, "uloop-sample")
@@ -472,9 +473,13 @@ func TestRunSkillsDirPreservesHumanNamedArtifactLookalikes(t *testing.T) {
 	}
 	installedDir := filepath.Join(destinationDir, "uloop-sample")
 	manualBackup := filepath.Join(installedDir, "references.backup-manual")
+	datedBackup := filepath.Join(installedDir, "references.backup-20240115")
 	draftNote := filepath.Join(installedDir, "SKILL.md.tmp-notes")
 	if err := os.MkdirAll(manualBackup, 0o755); err != nil {
 		t.Fatalf("failed to create manual backup dir: %v", err)
+	}
+	if err := os.MkdirAll(datedBackup, 0o755); err != nil {
+		t.Fatalf("failed to create dated backup dir: %v", err)
 	}
 	if err := os.WriteFile(draftNote, []byte("draft\n"), 0o644); err != nil {
 		t.Fatalf("failed to write draft note: %v", err)
@@ -487,6 +492,9 @@ func TestRunSkillsDirPreservesHumanNamedArtifactLookalikes(t *testing.T) {
 	if _, err := os.Stat(manualBackup); err != nil {
 		t.Fatalf("human-named backup dir should survive install: %v", err)
 	}
+	if _, err := os.Stat(datedBackup); err != nil {
+		t.Fatalf("dated backup dir should survive install: %v", err)
+	}
 	if _, err := os.Stat(draftNote); err != nil {
 		t.Fatalf("human-named draft file should survive install: %v", err)
 	}
@@ -498,8 +506,102 @@ func TestRunSkillsDirPreservesHumanNamedArtifactLookalikes(t *testing.T) {
 	if _, err := os.Stat(manualBackup); err != nil {
 		t.Fatalf("human-named backup dir should survive uninstall: %v", err)
 	}
+	if _, err := os.Stat(datedBackup); err != nil {
+		t.Fatalf("dated backup dir should survive uninstall: %v", err)
+	}
 	if _, err := os.Stat(draftNote); err != nil {
 		t.Fatalf("human-named draft file should survive uninstall: %v", err)
+	}
+}
+
+// Tests that install repairs a skill whose source-owned directory name is
+// occupied by an entry of the wrong type: a foreign regular file and a
+// dangling symlink both give way to the source directory instead of failing
+// with a raw rename error or silently corrupting the store.
+func TestRunSkillsDirInstallReplacesWrongTypeEntryAtOwnedName(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	installedReferences := filepath.Join(destinationDir, "uloop-sample", "references")
+	if err := os.RemoveAll(installedReferences); err != nil {
+		t.Fatalf("failed to remove installed references: %v", err)
+	}
+	if err := os.WriteFile(installedReferences, []byte("foreign\n"), 0o644); err != nil {
+		t.Fatalf("failed to write occupying file: %v", err)
+	}
+
+	stdout.Reset()
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("install over an occupying file failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Updated: 1") {
+		t.Fatalf("replacing the occupant should count as updated:\n%s", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(installedReferences, "note.md")); err != nil {
+		t.Fatalf("references should be restored as a directory: %v", err)
+	}
+}
+
+// Tests that install replaces a symlink occupying a source-owned entry name by
+// removing the link itself, never writing through it, so the symlink target's
+// contents survive untouched.
+func TestRunSkillsDirInstallReplacesSymlinkAtOwnedNameWithoutFollowing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	installedReferences := filepath.Join(destinationDir, "uloop-sample", "references")
+	if err := os.RemoveAll(installedReferences); err != nil {
+		t.Fatalf("failed to remove installed references: %v", err)
+	}
+	curatedDir := filepath.Join(root, "curated-refs")
+	curatedFile := filepath.Join(curatedDir, "mine.md")
+	if err := os.MkdirAll(curatedDir, 0o755); err != nil {
+		t.Fatalf("failed to create curated dir: %v", err)
+	}
+	if err := os.WriteFile(curatedFile, []byte("user content\n"), 0o644); err != nil {
+		t.Fatalf("failed to write curated file: %v", err)
+	}
+	if err := os.Symlink(curatedDir, installedReferences); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	stdout.Reset()
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("install over a symlink failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(curatedFile); err != nil {
+		t.Fatalf("symlink target contents must survive install: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(installedReferences, "note.md")); err != nil {
+		t.Fatalf("references should be restored as a real directory: %v", err)
+	}
+
+	danglingTarget := filepath.Join(root, "gone")
+	if err := os.RemoveAll(installedReferences); err != nil {
+		t.Fatalf("failed to remove references for dangling case: %v", err)
+	}
+	if err := os.Symlink(danglingTarget, installedReferences); err != nil {
+		t.Fatalf("failed to create dangling symlink: %v", err)
+	}
+	stdout.Reset()
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("install over a dangling symlink failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(installedReferences, "note.md")); err != nil {
+		t.Fatalf("references should be restored over the dangling symlink: %v", err)
 	}
 }
 

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -1,0 +1,310 @@
+package dispatcher
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeDirModeSkillSource seeds a skill source directory with a SKILL.md and one
+// reference file, returning the definition used by --output-dir mode tests.
+func writeDirModeSkillSource(t *testing.T, root string, name string) skillDefinition {
+	t.Helper()
+	sourceDir := filepath.Join(root, "source", name, "Skill")
+	content := "---\nname: " + name + "\n---\n\n# " + name + "\n"
+	writeSkillFile(t, sourceDir, content)
+	referencesDir := filepath.Join(sourceDir, "references")
+	if err := os.MkdirAll(referencesDir, 0o755); err != nil {
+		t.Fatalf("failed to create references dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(referencesDir, "note.md"), []byte("note\n"), 0o644); err != nil {
+		t.Fatalf("failed to write reference: %v", err)
+	}
+	return skillDefinition{name: name, content: []byte(content), sourceDirectory: sourceDir}
+}
+
+// Tests that --output-dir accepts both the space-separated and equals-sign value forms.
+func TestParseSkillsOptionsParsesDirFlag(t *testing.T) {
+	spaceForm, err := parseSkillsOptions([]string{"--output-dir", "/custom/skills"})
+	if err != nil {
+		t.Fatalf("space form failed: %v", err)
+	}
+	if spaceForm.outputDir != "/custom/skills" {
+		t.Fatalf("space form dir mismatch: %s", spaceForm.outputDir)
+	}
+
+	equalsForm, err := parseSkillsOptions([]string{"--output-dir=/custom/skills"})
+	if err != nil {
+		t.Fatalf("equals form failed: %v", err)
+	}
+	if equalsForm.outputDir != "/custom/skills" {
+		t.Fatalf("equals form dir mismatch: %s", equalsForm.outputDir)
+	}
+}
+
+// Tests that --output-dir without a value is rejected as an argument error.
+func TestParseSkillsOptionsRejectsDirWithoutValue(t *testing.T) {
+	if _, err := parseSkillsOptions([]string{"--output-dir"}); err == nil {
+		t.Fatal("expected error for --output-dir without value")
+	}
+	if _, err := parseSkillsOptions([]string{"--output-dir="}); err == nil {
+		t.Fatal("expected error for --output-dir= without value")
+	}
+}
+
+// Tests that --output-dir cannot be combined with --global or target flags.
+func TestParseSkillsOptionsRejectsDirWithGlobalOrTargets(t *testing.T) {
+	if _, err := parseSkillsOptions([]string{"--output-dir", "/custom", "--global"}); err == nil {
+		t.Fatal("expected error for --output-dir with --global")
+	}
+	if _, err := parseSkillsOptions([]string{"--claude", "--output-dir", "/custom"}); err == nil {
+		t.Fatal("expected error for --output-dir with a target flag")
+	}
+}
+
+// Tests that dir-mode install deploys skills flat into <dir>/<name> without
+// requiring target flags and without printing target guidance.
+func TestRunSkillsSubcommandDirInstallInstallsFlatLayout(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runSkillsSubcommand(
+		"install",
+		root,
+		[]skillDefinition{skill},
+		skillCommandOptions{outputDir: destinationDir},
+		stdout,
+		stderr,
+	)
+
+	if code != 0 {
+		t.Fatalf("dir install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Please specify at least one target") {
+		t.Fatalf("dir install should not print target guidance:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), destinationDir) {
+		t.Fatalf("dir install output should show the destination:\n%s", stdout.String())
+	}
+	installedSkill := filepath.Join(destinationDir, "uloop-sample", "SKILL.md")
+	if _, err := os.Stat(installedSkill); err != nil {
+		t.Fatalf("skill file was not installed: %v", err)
+	}
+	installedReference := filepath.Join(destinationDir, "uloop-sample", "references", "note.md")
+	if _, err := os.Stat(installedReference); err != nil {
+		t.Fatalf("reference file was not installed: %v", err)
+	}
+}
+
+// Tests that dir-mode install refreshes source-owned files while leaving
+// foreign files such as apm.yml untouched, and drops stale reference files.
+func TestRunSkillsDirInstallPreservesForeignFiles(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	installedDir := filepath.Join(destinationDir, "uloop-sample")
+	writeRawSkillFile(t, installedDir, "outdated content\n")
+	if err := os.WriteFile(filepath.Join(installedDir, "apm.yml"), []byte("name: foreign\n"), 0o644); err != nil {
+		t.Fatalf("failed to write foreign file: %v", err)
+	}
+	staleReferencesDir := filepath.Join(installedDir, "references")
+	if err := os.MkdirAll(staleReferencesDir, 0o755); err != nil {
+		t.Fatalf("failed to create stale references dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(staleReferencesDir, "stale.md"), []byte("stale\n"), 0o644); err != nil {
+		t.Fatalf("failed to write stale reference: %v", err)
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dir install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Updated: 1") {
+		t.Fatalf("outdated skill should be counted as updated:\n%s", stdout.String())
+	}
+	installedContent, err := os.ReadFile(filepath.Join(installedDir, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("failed to read installed skill: %v", err)
+	}
+	if !bytes.Equal(installedContent, skill.content) {
+		t.Fatalf("skill file was not refreshed: %s", installedContent)
+	}
+	if _, err := os.Stat(filepath.Join(installedDir, "apm.yml")); err != nil {
+		t.Fatalf("foreign file should be preserved: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(staleReferencesDir, "stale.md")); !os.IsNotExist(err) {
+		t.Fatalf("stale reference should be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(staleReferencesDir, "note.md")); err != nil {
+		t.Fatalf("current reference should be installed: %v", err)
+	}
+}
+
+// Tests that foreign files in the destination do not mark an up-to-date skill
+// outdated, while a stale file inside a source-owned directory does.
+func TestGetDirSkillStatusIgnoresForeignFiles(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	installedDir := filepath.Join(destinationDir, "uloop-sample")
+	if err := os.WriteFile(filepath.Join(installedDir, "apm.yml"), []byte("name: foreign\n"), 0o644); err != nil {
+		t.Fatalf("failed to write foreign file: %v", err)
+	}
+
+	status, err := getDirSkillStatus(destinationDir, skill)
+	if err != nil {
+		t.Fatalf("status check failed: %v", err)
+	}
+	if status != "installed" {
+		t.Fatalf("foreign file should not mark the skill outdated: %s", status)
+	}
+
+	if err := os.WriteFile(filepath.Join(installedDir, "references", "stale.md"), []byte("stale\n"), 0o644); err != nil {
+		t.Fatalf("failed to write stale reference: %v", err)
+	}
+	status, err = getDirSkillStatus(destinationDir, skill)
+	if err != nil {
+		t.Fatalf("status check failed: %v", err)
+	}
+	if status != "outdated" {
+		t.Fatalf("stale file in a source-owned directory should mark the skill outdated: %s", status)
+	}
+}
+
+// Tests that dir-mode uninstall removes only source-owned entries, keeps the
+// directory when foreign files remain, and removes it when it becomes empty.
+func TestRunSkillsDirUninstallRemovesOnlyOwnedFiles(t *testing.T) {
+	root := t.TempDir()
+	skillWithForeign := writeDirModeSkillSource(t, root, "uloop-with-foreign")
+	skillClean := writeDirModeSkillSource(t, root, "uloop-clean")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	skills := []skillDefinition{skillClean, skillWithForeign}
+	if code := runSkillsDirInstall(destinationDir, skills, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	foreignPath := filepath.Join(destinationDir, "uloop-with-foreign", "apm.yml")
+	if err := os.WriteFile(foreignPath, []byte("name: foreign\n"), 0o644); err != nil {
+		t.Fatalf("failed to write foreign file: %v", err)
+	}
+
+	stdout.Reset()
+	code := runSkillsDirUninstall(destinationDir, skills, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Removed: 2") {
+		t.Fatalf("uninstall should report removed skills:\n%s", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(destinationDir, "uloop-with-foreign", "SKILL.md")); !os.IsNotExist(err) {
+		t.Fatalf("owned skill file should be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(foreignPath); err != nil {
+		t.Fatalf("foreign file should survive uninstall: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destinationDir, "uloop-clean")); !os.IsNotExist(err) {
+		t.Fatalf("emptied skill directory should be removed, stat err=%v", err)
+	}
+}
+
+// Tests that dir-mode uninstall counts skills that were never installed.
+func TestRunSkillsDirUninstallCountsMissingSkills(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Not found: 1") {
+		t.Fatalf("uninstall should report missing skills:\n%s", stdout.String())
+	}
+}
+
+// Tests that dir-mode list shows the destination and per-skill statuses.
+func TestRunSkillsDirListShowsStatuses(t *testing.T) {
+	root := t.TempDir()
+	installedSkill := writeDirModeSkillSource(t, root, "uloop-installed")
+	missingSkill := writeDirModeSkillSource(t, root, "uloop-missing")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{installedSkill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	code := runSkillsDirList(destinationDir, []skillDefinition{installedSkill, missingSkill}, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dir list failed: code=%d stderr=%s", code, stderr.String())
+	}
+	output := stdout.String()
+	if !strings.Contains(output, destinationDir) {
+		t.Fatalf("list should show the destination:\n%s", output)
+	}
+	if !strings.Contains(output, "uloop-installed (installed)") {
+		t.Fatalf("list should show installed status:\n%s", output)
+	}
+	if !strings.Contains(output, "uloop-missing (not installed)") {
+		t.Fatalf("list should show not installed status:\n%s", output)
+	}
+}
+
+// Tests that the v3 migration subcommands reject the --output-dir option.
+func TestTryHandleSkillsRequestRejectsDirForV3Migration(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	handled, code := tryHandleSkillsRequest(
+		[]string{"skills", "install-v3-migration", "--output-dir", t.TempDir()},
+		t.TempDir(),
+		"",
+		stdout,
+		stderr,
+	)
+
+	if !handled {
+		t.Fatal("skills request should be handled")
+	}
+	if code != 1 {
+		t.Fatalf("v3 migration with --output-dir should fail: code=%d", code)
+	}
+	if !strings.Contains(stderr.String(), "--output-dir") {
+		t.Fatalf("error should name the rejected option:\n%s", stderr.String())
+	}
+}
+
+// Tests that subcommand help advertises --output-dir for standard subcommands only.
+func TestPrintSkillsSubcommandHelpShowsDirOptionForStandardSubcommands(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	printSkillsSubcommandHelp("install", stdout)
+	if !strings.Contains(stdout.String(), "--output-dir <path>") {
+		t.Fatalf("install help should list --output-dir:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	printSkillsSubcommandHelp("install-v3-migration", stdout)
+	if strings.Contains(stdout.String(), "--output-dir") {
+		t.Fatalf("v3 migration help should not list --output-dir:\n%s", stdout.String())
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -293,8 +293,8 @@ func TestRunSkillsDirInstallRejectsFileOccupyingSkillName(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("install onto an occupying file should fail: code=%d", code)
 	}
-	if !strings.Contains(stderr.String(), "not a directory") {
-		t.Fatalf("error should explain the occupying file:\n%s", stderr.String())
+	if !strings.Contains(stderr.String(), "cannot manage skill") || !strings.Contains(stderr.String(), "not a directory") {
+		t.Fatalf("error should be the crafted cross-platform message, not a raw readdir error:\n%s", stderr.String())
 	}
 
 	stdout.Reset()
@@ -332,6 +332,12 @@ func TestRunSkillsDirDoesNotFollowSymlinkAtSkillName(t *testing.T) {
 	if err := os.WriteFile(curatedFile, []byte("user content\n"), 0o644); err != nil {
 		t.Fatalf("failed to write curated file: %v", err)
 	}
+	// An artifact-named entry inside the symlink target guards against cleanup
+	// reading through the symlink and deleting outside the store.
+	curatedArtifact := filepath.Join(curatedDir, "SKILL.md.tmp-1234")
+	if err := os.WriteFile(curatedArtifact, []byte("theirs\n"), 0o644); err != nil {
+		t.Fatalf("failed to write curated artifact-named file: %v", err)
+	}
 	if err := os.Symlink(curatedDir, filepath.Join(destinationDir, "uloop-sample")); err != nil {
 		t.Fatalf("failed to create symlink: %v", err)
 	}
@@ -353,6 +359,9 @@ func TestRunSkillsDirDoesNotFollowSymlinkAtSkillName(t *testing.T) {
 	}
 	if _, err := os.Stat(curatedFile); err != nil {
 		t.Fatalf("symlink target contents must survive uninstall: %v", err)
+	}
+	if _, err := os.Stat(curatedArtifact); err != nil {
+		t.Fatalf("artifact-named file inside the symlink target must survive: %v", err)
 	}
 }
 
@@ -446,6 +455,51 @@ func TestRunSkillsDirCleansStaleSyncArtifacts(t *testing.T) {
 	}
 	if _, err := os.Stat(installedDir); !os.IsNotExist(err) {
 		t.Fatalf("skill directory should be fully removed after cleanup, stat err=%v", err)
+	}
+}
+
+// Tests that user files whose names merely resemble sync artifacts (a temp or
+// backup prefix without the digits-only random suffix) are preserved as
+// foreign by install and uninstall instead of being deleted as uloop debris.
+func TestRunSkillsDirPreservesHumanNamedArtifactLookalikes(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	installedDir := filepath.Join(destinationDir, "uloop-sample")
+	manualBackup := filepath.Join(installedDir, "references.backup-manual")
+	draftNote := filepath.Join(installedDir, "SKILL.md.tmp-notes")
+	if err := os.MkdirAll(manualBackup, 0o755); err != nil {
+		t.Fatalf("failed to create manual backup dir: %v", err)
+	}
+	if err := os.WriteFile(draftNote, []byte("draft\n"), 0o644); err != nil {
+		t.Fatalf("failed to write draft note: %v", err)
+	}
+
+	stdout.Reset()
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("dir install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(manualBackup); err != nil {
+		t.Fatalf("human-named backup dir should survive install: %v", err)
+	}
+	if _, err := os.Stat(draftNote); err != nil {
+		t.Fatalf("human-named draft file should survive install: %v", err)
+	}
+
+	stdout.Reset()
+	if code := runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(manualBackup); err != nil {
+		t.Fatalf("human-named backup dir should survive uninstall: %v", err)
+	}
+	if _, err := os.Stat(draftNote); err != nil {
+		t.Fatalf("human-named draft file should survive uninstall: %v", err)
 	}
 }
 

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -1511,3 +1511,77 @@ func TestRunSkillsDirInstallPreservesSourceOwnedArtifactNamedFile(t *testing.T) 
 		t.Fatalf("second install changed the store file: %q", secondContent)
 	}
 }
+
+// Tests that --output-dir inside a skill source directory is rejected before
+// install can create a destination that WalkDir would then re-enter.
+func TestRunSkillsDirSubcommandRejectsOutputDirInsideSkillSource(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	outputDir := filepath.Join(skill.sourceDirectory, "nested-store")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runSkillsDirSubcommand("install", []skillDefinition{skill}, outputDir, stdout, stderr)
+
+	if code != 1 {
+		t.Fatalf("output dir inside a skill source should fail: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), skillsOutputDirFlagName) {
+		t.Fatalf("error should name --output-dir:\n%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), skill.sourceDirectory) && !strings.Contains(stderr.String(), outputDir) {
+		t.Fatalf("error should name the conflicting path:\n%s", stderr.String())
+	}
+	if _, err := os.Stat(outputDir); !os.IsNotExist(err) {
+		t.Fatalf("install must not create a directory inside the skill source, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(skill.sourceDirectory, "uloop-sample")); !os.IsNotExist(err) {
+		t.Fatalf("install must not create a skill directory inside the source, stat err=%v", err)
+	}
+}
+
+// Tests that --output-dir which contains a skill source directory is rejected
+// the same way as the reverse containment.
+func TestRunSkillsDirSubcommandRejectsOutputDirContainingSkillSource(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runSkillsDirSubcommand("install", []skillDefinition{skill}, root, stdout, stderr)
+
+	if code != 1 {
+		t.Fatalf("output dir containing a skill source should fail: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), skillsOutputDirFlagName) {
+		t.Fatalf("error should name --output-dir:\n%s", stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(root, "uloop-sample")); !os.IsNotExist(err) {
+		t.Fatalf("install must not create a skill directory in the overlapping dest, stat err=%v", err)
+	}
+}
+
+// Tests that pathContains treats identical and descendant paths as contained
+// and does not treat sibling prefixes such as /a/b versus /a/bc as contained.
+func TestPathContainsDistinguishesDescendantFromSiblingPrefix(t *testing.T) {
+	root := t.TempDir()
+	parent := filepath.Join(root, "b")
+	sibling := filepath.Join(root, "bc")
+	child := filepath.Join(parent, "c")
+
+	if !pathContains(parent, parent) {
+		t.Fatal("identical paths should be contained")
+	}
+	if !pathContains(parent, child) {
+		t.Fatal("a descendant path should be contained")
+	}
+	if pathContains(parent, sibling) {
+		t.Fatal("a sibling prefix path must not be treated as contained")
+	}
+	if pathContains(sibling, parent) {
+		t.Fatal("the reverse sibling prefix must not be treated as contained")
+	}
+	if pathContains(child, parent) {
+		t.Fatal("an ancestor path must not be treated as contained")
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -1472,3 +1472,42 @@ func TestParseSkillsOptionsRejectsWhitespaceOutputDir(t *testing.T) {
 		t.Fatal("expected error for a whitespace-only --output-dir= value")
 	}
 }
+
+// Tests that a source-owned file whose name matches the stale-artifact pattern
+// survives a second install: the first sync copies it, and cleanup must not
+// treat that live managed name as leftover debris and skip the skill.
+func TestRunSkillsDirInstallPreservesSourceOwnedArtifactNamedFile(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	artifactNamedFile := filepath.Join(skill.sourceDirectory, "data.uloop-tmp-123")
+	if err := os.WriteFile(artifactNamedFile, []byte("owned payload\n"), 0o644); err != nil {
+		t.Fatalf("failed to write source-owned artifact-named file: %v", err)
+	}
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("first dir install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	storeFile := filepath.Join(destinationDir, "uloop-sample", "data.uloop-tmp-123")
+	firstContent, err := os.ReadFile(storeFile)
+	if err != nil {
+		t.Fatalf("first install should copy the source-owned artifact-named file: %v", err)
+	}
+	if string(firstContent) != "owned payload\n" {
+		t.Fatalf("store file content = %q, want owned payload", firstContent)
+	}
+
+	stdout.Reset()
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("second dir install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	secondContent, err := os.ReadFile(storeFile)
+	if err != nil {
+		t.Fatalf("second install must keep the source-owned artifact-named file: %v", err)
+	}
+	if string(secondContent) != "owned payload\n" {
+		t.Fatalf("second install changed the store file: %q", secondContent)
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -62,13 +62,16 @@ func TestParseSkillsOptionsRejectsDirWithoutValue(t *testing.T) {
 	}
 }
 
-// Tests that --output-dir cannot be combined with --global or target flags.
+// Tests that --output-dir cannot be combined with --global, target flags, or --flat.
 func TestParseSkillsOptionsRejectsDirWithGlobalOrTargets(t *testing.T) {
 	if _, err := parseSkillsOptions([]string{"--output-dir", "/custom", "--global"}); err == nil {
 		t.Fatal("expected error for --output-dir with --global")
 	}
 	if _, err := parseSkillsOptions([]string{"--claude", "--output-dir", "/custom"}); err == nil {
 		t.Fatal("expected error for --output-dir with a target flag")
+	}
+	if _, err := parseSkillsOptions([]string{"--output-dir", "/custom", "--flat"}); err == nil {
+		t.Fatal("expected error for --output-dir with --flat")
 	}
 }
 

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -458,6 +458,78 @@ func TestRunSkillsDirCleansStaleSyncArtifacts(t *testing.T) {
 	}
 }
 
+// Tests that a leftover artifact minted for an entry the current skill source
+// no longer owns (a renamed or dropped directory) is still cleaned up: the
+// uloop namespace marker alone identifies the debris.
+func TestRunSkillsDirCleansArtifactsOfFormerlyOwnedEntries(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	installedDir := filepath.Join(destinationDir, "uloop-sample")
+	formerBackup := filepath.Join(installedDir, "docs.uloop-backup-1234")
+	if err := os.MkdirAll(formerBackup, 0o755); err != nil {
+		t.Fatalf("failed to create former-entry backup dir: %v", err)
+	}
+
+	stdout.Reset()
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("dir install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(formerBackup); !os.IsNotExist(err) {
+		t.Fatalf("artifact of a formerly owned entry should be cleaned, stat err=%v", err)
+	}
+}
+
+// Tests that uninstall removes the skill directory when only ignorable OS/tool
+// debris (.DS_Store) remains after the owned entries are deleted, but keeps
+// the directory when genuinely foreign content is also present.
+func TestRunSkillsDirUninstallRemovesIgnorableDebrisWithSkillDir(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	installedDir := filepath.Join(destinationDir, "uloop-sample")
+	if err := os.WriteFile(filepath.Join(installedDir, ".DS_Store"), []byte("junk"), 0o644); err != nil {
+		t.Fatalf("failed to write debris file: %v", err)
+	}
+
+	stdout.Reset()
+	if code := runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(installedDir); !os.IsNotExist(err) {
+		t.Fatalf("debris-only skill directory should be removed, stat err=%v", err)
+	}
+
+	stdout.Reset()
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("reinstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	foreignFile := filepath.Join(installedDir, "apm.yml")
+	if err := os.WriteFile(foreignFile, []byte("manifest\n"), 0o644); err != nil {
+		t.Fatalf("failed to write foreign file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(installedDir, ".DS_Store"), []byte("junk"), 0o644); err != nil {
+		t.Fatalf("failed to write debris file again: %v", err)
+	}
+	stdout.Reset()
+	if code := runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(foreignFile); err != nil {
+		t.Fatalf("foreign file should keep the directory and survive: %v", err)
+	}
+}
+
 // Tests that user files whose names merely resemble sync artifacts (temp or
 // backup naming without the uloop namespace marker, digit-suffixed dated
 // backups included) are preserved as foreign by install and uninstall instead

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -1077,3 +1077,18 @@ func TestParseSkillsOptionsRejectsDuplicateOutputDir(t *testing.T) {
 		t.Fatalf("error should call out the duplicate option: %v", err)
 	}
 }
+
+// Tests that a POSIX-style absolute --output-dir is rejected on Windows, where
+// filepath.Abs would silently anchor it under the current drive, and accepted
+// on other platforms and for Windows-style paths.
+func TestPosixStyleOutputDirError(t *testing.T) {
+	if err := posixStyleOutputDirError("windows", "/c/apm/skills"); err == nil {
+		t.Fatal("a POSIX-style path should be rejected on Windows")
+	}
+	if err := posixStyleOutputDirError("windows", `C:\apm\skills`); err != nil {
+		t.Fatalf("a Windows path should be accepted on Windows: %v", err)
+	}
+	if err := posixStyleOutputDirError("linux", "/tmp/skills"); err != nil {
+		t.Fatalf("a POSIX path should be accepted on non-Windows platforms: %v", err)
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -1512,6 +1512,52 @@ func TestRunSkillsDirInstallPreservesSourceOwnedArtifactNamedFile(t *testing.T) 
 	}
 }
 
+// Tests that --output-dir which is a symlink into a skill source (or a
+// not-yet-created path under such a symlink) is rejected, so install cannot
+// write into the source tree through a lexical alias.
+func TestRunSkillsDirSubcommandRejectsOutputDirSymlinkedIntoSkillSource(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	nestedStore := filepath.Join(skill.sourceDirectory, "nested-store")
+	if err := os.MkdirAll(nestedStore, 0o755); err != nil {
+		t.Fatalf("failed to create nested store: %v", err)
+	}
+	storeLink := filepath.Join(root, "store-link")
+	if err := os.Symlink(nestedStore, storeLink); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+	installedInsideSource := filepath.Join(skill.sourceDirectory, "nested-store", "uloop-sample")
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := runSkillsDirSubcommand("install", []skillDefinition{skill}, storeLink, stdout, stderr)
+	if code != 1 {
+		t.Fatalf("symlink into a skill source should fail: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), skillsOutputDirFlagName) {
+		t.Fatalf("error should name --output-dir:\n%s", stderr.String())
+	}
+	if _, err := os.Stat(installedInsideSource); !os.IsNotExist(err) {
+		t.Fatalf("install must not create a skill directory inside the source, stat err=%v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = runSkillsDirSubcommand("install", []skillDefinition{skill}, filepath.Join(storeLink, "sub"), stdout, stderr)
+	if code != 1 {
+		t.Fatalf("non-existing path under a source-pointing symlink should fail: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), skillsOutputDirFlagName) {
+		t.Fatalf("error should name --output-dir:\n%s", stderr.String())
+	}
+	if _, err := os.Stat(installedInsideSource); !os.IsNotExist(err) {
+		t.Fatalf("install must not create a skill directory inside the source, stat err=%v", err)
+	}
+}
+
 // Tests that --output-dir inside a skill source directory is rejected before
 // install can create a destination that WalkDir would then re-enter.
 func TestRunSkillsDirSubcommandRejectsOutputDirInsideSkillSource(t *testing.T) {

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -176,23 +176,23 @@ func TestGetDirSkillStatusIgnoresForeignFiles(t *testing.T) {
 		t.Fatalf("failed to write foreign file: %v", err)
 	}
 
-	status, err := getDirSkillStatus(destinationDir, skill)
+	state, err := getDirSkillState(destinationDir, skill)
 	if err != nil {
 		t.Fatalf("status check failed: %v", err)
 	}
-	if status != "installed" {
-		t.Fatalf("foreign file should not mark the skill outdated: %s", status)
+	if state.status != "installed" {
+		t.Fatalf("foreign file should not mark the skill outdated: %s", state.status)
 	}
 
 	if err := os.WriteFile(filepath.Join(installedDir, "references", "stale.md"), []byte("stale\n"), 0o644); err != nil {
 		t.Fatalf("failed to write stale reference: %v", err)
 	}
-	status, err = getDirSkillStatus(destinationDir, skill)
+	state, err = getDirSkillState(destinationDir, skill)
 	if err != nil {
 		t.Fatalf("status check failed: %v", err)
 	}
-	if status != "outdated" {
-		t.Fatalf("stale file in a source-owned directory should mark the skill outdated: %s", status)
+	if state.status != "outdated" {
+		t.Fatalf("stale file in a source-owned directory should mark the skill outdated: %s", state.status)
 	}
 }
 
@@ -251,12 +251,12 @@ func TestGetDirSkillStatusReportsOrphanedOwnedFilesAsOutdated(t *testing.T) {
 		t.Fatalf("failed to remove installed skill file: %v", err)
 	}
 
-	status, err := getDirSkillStatus(destinationDir, skill)
+	state, err := getDirSkillState(destinationDir, skill)
 	if err != nil {
 		t.Fatalf("status check failed: %v", err)
 	}
-	if status != "outdated" {
-		t.Fatalf("orphaned owned files should read as outdated: %s", status)
+	if state.status != "outdated" {
+		t.Fatalf("orphaned owned files should read as outdated: %s", state.status)
 	}
 
 	stdout.Reset()
@@ -828,5 +828,234 @@ func TestPrintSkillsSubcommandHelpShowsDirOptionForStandardSubcommands(t *testin
 	printSkillsSubcommandHelp("install-v3-migration", stdout)
 	if strings.Contains(stdout.String(), "--output-dir") {
 		t.Fatalf("v3 migration help should not list --output-dir:\n%s", stdout.String())
+	}
+}
+
+// Tests that a hand-authored directory using a skill's name and an owned entry
+// name, in a store uloop never installed into, is preserved: uninstall reports
+// not found and install blocks the skill instead of replacing the content.
+func TestRunSkillsDirPreservesNeverInstalledOwnedNames(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	handAuthoredDir := filepath.Join(destinationDir, "uloop-sample", "references")
+	if err := os.MkdirAll(handAuthoredDir, 0o755); err != nil {
+		t.Fatalf("failed to create hand-authored dir: %v", err)
+	}
+	userNotes := filepath.Join(handAuthoredDir, "mynotes.md")
+	if err := os.WriteFile(userNotes, []byte("my curated notes\n"), 0o644); err != nil {
+		t.Fatalf("failed to write user notes: %v", err)
+	}
+	manifest := filepath.Join(destinationDir, "uloop-sample", "package.json")
+	if err := os.WriteFile(manifest, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Not found: 1") {
+		t.Fatalf("never-installed content should not count as removed:\n%s", stdout.String())
+	}
+	if _, err := os.Stat(userNotes); err != nil {
+		t.Fatalf("hand-authored notes must survive uninstall: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+
+	if code != 1 {
+		t.Fatalf("install onto never-installed owned names should report a failure: code=%d", code)
+	}
+	if !strings.Contains(stderr.String(), "did not install") {
+		t.Fatalf("error should state the content is not a uloop install:\n%s", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Blocked: 1") || !strings.Contains(stdout.String(), "Installed: 0") {
+		t.Fatalf("summary should count the skill as blocked:\n%s", stdout.String())
+	}
+	if _, err := os.Stat(userNotes); err != nil {
+		t.Fatalf("hand-authored notes must survive install: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destinationDir, "uloop-sample", "SKILL.md")); !os.IsNotExist(err) {
+		t.Fatalf("blocked skill must not be written, stat err=%v", err)
+	}
+}
+
+// Tests that one skill blocked by a conflict does not abort the run: the
+// remaining skills still install and the summary still prints.
+func TestRunSkillsDirInstallContinuesPastBlockedSkill(t *testing.T) {
+	root := t.TempDir()
+	blockedSkill := writeDirModeSkillSource(t, root, "uloop-blocked")
+	healthySkill := writeDirModeSkillSource(t, root, "uloop-healthy")
+	destinationDir := filepath.Join(root, "apm-skills")
+	if err := os.MkdirAll(destinationDir, 0o755); err != nil {
+		t.Fatalf("failed to create destination: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(destinationDir, "uloop-blocked"), []byte("foreign\n"), 0o644); err != nil {
+		t.Fatalf("failed to write occupying file: %v", err)
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runSkillsDirInstall(destinationDir, []skillDefinition{blockedSkill, healthySkill}, stdout, stderr)
+
+	if code != 1 {
+		t.Fatalf("a blocked skill should fail the run: code=%d", code)
+	}
+	if !strings.Contains(stdout.String(), "Installed: 1") || !strings.Contains(stdout.String(), "Blocked: 1") {
+		t.Fatalf("summary should show the healthy skill installed and the conflict counted:\n%s", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(destinationDir, "uloop-healthy", "SKILL.md")); err != nil {
+		t.Fatalf("the healthy skill should still be installed: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "cannot manage skill") {
+		t.Fatalf("the conflict should be reported per skill:\n%s", stderr.String())
+	}
+}
+
+// Tests that dir-mode list reports a conflicted skill as a status row and
+// completes the listing instead of aborting midway.
+func TestRunSkillsDirListReportsConflict(t *testing.T) {
+	root := t.TempDir()
+	blockedSkill := writeDirModeSkillSource(t, root, "uloop-blocked")
+	installedSkill := writeDirModeSkillSource(t, root, "uloop-installed")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{installedSkill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if err := os.WriteFile(filepath.Join(destinationDir, "uloop-blocked"), []byte("foreign\n"), 0o644); err != nil {
+		t.Fatalf("failed to write occupying file: %v", err)
+	}
+
+	stdout.Reset()
+	code := runSkillsDirList(destinationDir, []skillDefinition{blockedSkill, installedSkill}, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dir list failed: code=%d stderr=%s", code, stderr.String())
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "uloop-blocked (conflict)") {
+		t.Fatalf("list should show the conflict status:\n%s", output)
+	}
+	if !strings.Contains(output, "uloop-installed (installed)") {
+		t.Fatalf("list should keep reporting the skills after a conflict:\n%s", output)
+	}
+	if !strings.Contains(output, "Total: 2 skills") {
+		t.Fatalf("list should complete instead of aborting midway:\n%s", output)
+	}
+}
+
+// Tests that an entry differing from SKILL.md only by letter case is never
+// claimed: uninstall preserves it and reports not found on every filesystem,
+// case-insensitive ones (where a path probe would resolve it) included.
+func TestRunSkillsDirUninstallPreservesCaseVariantSkillFile(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	skillDir := filepath.Join(destinationDir, "uloop-sample")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("failed to create skill dir: %v", err)
+	}
+	lowercaseSkillFile := filepath.Join(skillDir, "skill.md")
+	if err := os.WriteFile(lowercaseSkillFile, []byte("hand-authored\n"), 0o644); err != nil {
+		t.Fatalf("failed to write lowercase skill file: %v", err)
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Not found: 1") {
+		t.Fatalf("a case-variant file should not count as an install:\n%s", stdout.String())
+	}
+	content, err := os.ReadFile(lowercaseSkillFile)
+	if err != nil || string(content) != "hand-authored\n" {
+		t.Fatalf("the case-variant file must survive untouched: content=%q err=%v", content, err)
+	}
+}
+
+// Tests that install blocks a skill whose owned entry name is present only as
+// a case variant (References/), instead of letting a case-insensitive
+// filesystem replace the foreign entry; the refusal is uniform across
+// platforms so store behavior does not depend on where it is synced.
+func TestRunSkillsDirInstallBlocksCaseVariantOwnedEntry(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	installedDir := filepath.Join(destinationDir, "uloop-sample")
+	if err := os.Rename(filepath.Join(installedDir, "references"), filepath.Join(installedDir, "References")); err != nil {
+		t.Fatalf("failed to rename references dir: %v", err)
+	}
+
+	stdout.Reset()
+	code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+
+	if code != 1 {
+		t.Fatalf("a case-variant owned entry should block the skill: code=%d", code)
+	}
+	if !strings.Contains(stderr.String(), "only by letter case") {
+		t.Fatalf("error should call out the case mismatch:\n%s", stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(installedDir, "References", "note.md")); err != nil {
+		t.Fatalf("the case-variant directory must survive untouched: %v", err)
+	}
+}
+
+// Tests that a broken entry inside an owned directory (a dangling symlink
+// where a reference file should be) marks the skill outdated instead of
+// installed, and that install repairs it.
+func TestRunSkillsDirDetectsBrokenOwnedEntryAsOutdated(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	notePath := filepath.Join(destinationDir, "uloop-sample", "references", "note.md")
+	if err := os.Remove(notePath); err != nil {
+		t.Fatalf("failed to remove reference: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(root, "missing-target"), notePath); err != nil {
+		t.Fatalf("failed to create dangling symlink: %v", err)
+	}
+
+	state, err := getDirSkillState(destinationDir, skill)
+	if err != nil {
+		t.Fatalf("status check failed: %v", err)
+	}
+	if state.status != "outdated" {
+		t.Fatalf("a broken owned entry should read as outdated, got: %s", state.status)
+	}
+
+	stdout.Reset()
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("repair install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Updated: 1") {
+		t.Fatalf("repairing a broken owned entry should count as updated:\n%s", stdout.String())
+	}
+	content, err := os.ReadFile(notePath)
+	if err != nil || string(content) != "note\n" {
+		t.Fatalf("repair should restore the reference file: content=%q err=%v", content, err)
 	}
 }

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -44,13 +44,21 @@ func TestParseSkillsOptionsParsesDirFlag(t *testing.T) {
 	}
 }
 
-// Tests that --output-dir without a value is rejected as an argument error.
+// Tests that --output-dir without a value is rejected as an argument error,
+// including when the next token is another flag that must not be swallowed
+// as the destination path.
 func TestParseSkillsOptionsRejectsDirWithoutValue(t *testing.T) {
 	if _, err := parseSkillsOptions([]string{"--output-dir"}); err == nil {
 		t.Fatal("expected error for --output-dir without value")
 	}
 	if _, err := parseSkillsOptions([]string{"--output-dir="}); err == nil {
 		t.Fatal("expected error for --output-dir= without value")
+	}
+	if _, err := parseSkillsOptions([]string{"--output-dir", "--global"}); err == nil {
+		t.Fatal("expected error when --output-dir is followed by --global instead of a path")
+	}
+	if _, err := parseSkillsOptions([]string{"--output-dir", "--claude"}); err == nil {
+		t.Fatal("expected error when --output-dir is followed by a target flag instead of a path")
 	}
 }
 

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -1059,3 +1059,21 @@ func TestRunSkillsDirDetectsBrokenOwnedEntryAsOutdated(t *testing.T) {
 		t.Fatalf("repair should restore the reference file: content=%q err=%v", content, err)
 	}
 }
+
+// Tests that passing --output-dir more than once is rejected instead of
+// silently letting the last destination win, matching `uloop install --dir`.
+func TestParseSkillsOptionsRejectsDuplicateOutputDir(t *testing.T) {
+	if _, err := parseSkillsOptions([]string{"--output-dir", "/first", "--output-dir", "/second"}); err == nil {
+		t.Fatal("expected error for repeated --output-dir")
+	}
+	if _, err := parseSkillsOptions([]string{"--output-dir=/first", "--output-dir=/second"}); err == nil {
+		t.Fatal("expected error for repeated --output-dir=<path>")
+	}
+	_, err := parseSkillsOptions([]string{"--output-dir", "/first", "--output-dir=/second"})
+	if err == nil {
+		t.Fatal("expected error for mixed-form repeated --output-dir")
+	}
+	if !strings.Contains(err.Error(), "Duplicate") {
+		t.Fatalf("error should call out the duplicate option: %v", err)
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -2,11 +2,14 @@ package dispatcher
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
 )
 
 // writeDirModeSkillSource seeds a skill source directory with a SKILL.md and one
@@ -896,7 +899,8 @@ func TestRunSkillsDirPreservesNeverInstalledOwnedNames(t *testing.T) {
 }
 
 // Tests that one skill blocked by a conflict does not abort the run: the
-// remaining skills still install and the summary still prints.
+// remaining skills still install, the summary still prints, and stderr is the
+// SKILL_STORE_CONFLICT envelope callers parse (SafeToRetry, BlockedCount).
 func TestRunSkillsDirInstallContinuesPastBlockedSkill(t *testing.T) {
 	root := t.TempDir()
 	blockedSkill := writeDirModeSkillSource(t, root, "uloop-blocked")
@@ -924,6 +928,19 @@ func TestRunSkillsDirInstallContinuesPastBlockedSkill(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "cannot manage skill") {
 		t.Fatalf("the conflict should be reported per skill:\n%s", stderr.String())
+	}
+	envelope := clierrors.CLIErrorEnvelope{}
+	if err := json.Unmarshal(stderr.Bytes(), &envelope); err != nil {
+		t.Fatalf("parse error envelope: %v; stderr=%s", err, stderr.String())
+	}
+	if envelope.Error.ErrorCode != "SKILL_STORE_CONFLICT" {
+		t.Fatalf("error code = %q, want SKILL_STORE_CONFLICT", envelope.Error.ErrorCode)
+	}
+	if !envelope.Error.SafeToRetry {
+		t.Fatal("SafeToRetry = false, want true")
+	}
+	if envelope.Error.Details["BlockedCount"] != float64(1) {
+		t.Fatalf("BlockedCount = %#v, want 1", envelope.Error.Details["BlockedCount"])
 	}
 }
 

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -230,6 +230,36 @@ func TestRunSkillsDirUninstallRemovesOnlyOwnedFiles(t *testing.T) {
 	}
 }
 
+// Tests that dir-mode uninstall cleans up owned files left behind after
+// SKILL.md was removed, instead of reporting the skill as not found.
+func TestRunSkillsDirUninstallRemovesOrphanedOwnedFiles(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	installedDir := filepath.Join(destinationDir, "uloop-sample")
+	if err := os.Remove(filepath.Join(installedDir, "SKILL.md")); err != nil {
+		t.Fatalf("failed to remove installed skill file: %v", err)
+	}
+
+	stdout.Reset()
+	code := runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Removed: 1") {
+		t.Fatalf("orphaned owned files should count as removed:\n%s", stdout.String())
+	}
+	if _, err := os.Stat(installedDir); !os.IsNotExist(err) {
+		t.Fatalf("emptied skill directory should be removed, stat err=%v", err)
+	}
+}
+
 // Tests that dir-mode uninstall counts skills that were never installed.
 func TestRunSkillsDirUninstallCountsMissingSkills(t *testing.T) {
 	root := t.TempDir()

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -547,6 +547,9 @@ func TestRunSkillsDirPreservesHumanNamedArtifactLookalikes(t *testing.T) {
 	manualBackup := filepath.Join(installedDir, "references.backup-manual")
 	datedBackup := filepath.Join(installedDir, "references.backup-20240115")
 	draftNote := filepath.Join(installedDir, "SKILL.md.tmp-notes")
+	// Carries the artifact marker but a human-chosen tail: only the all-digit
+	// tails that os.CreateTemp/MkdirTemp mint may be cleaned up.
+	markerLookalike := filepath.Join(installedDir, "my-archive.uloop-tmp-keepme")
 	if err := os.MkdirAll(manualBackup, 0o755); err != nil {
 		t.Fatalf("failed to create manual backup dir: %v", err)
 	}
@@ -555,6 +558,9 @@ func TestRunSkillsDirPreservesHumanNamedArtifactLookalikes(t *testing.T) {
 	}
 	if err := os.WriteFile(draftNote, []byte("draft\n"), 0o644); err != nil {
 		t.Fatalf("failed to write draft note: %v", err)
+	}
+	if err := os.WriteFile(markerLookalike, []byte("keep\n"), 0o644); err != nil {
+		t.Fatalf("failed to write marker lookalike: %v", err)
 	}
 
 	stdout.Reset()
@@ -569,6 +575,9 @@ func TestRunSkillsDirPreservesHumanNamedArtifactLookalikes(t *testing.T) {
 	}
 	if _, err := os.Stat(draftNote); err != nil {
 		t.Fatalf("human-named draft file should survive install: %v", err)
+	}
+	if _, err := os.Stat(markerLookalike); err != nil {
+		t.Fatalf("marker file with a non-digit tail should survive install: %v", err)
 	}
 
 	stdout.Reset()
@@ -872,8 +881,8 @@ func TestRunSkillsDirPreservesNeverInstalledOwnedNames(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("install onto never-installed owned names should report a failure: code=%d", code)
 	}
-	if !strings.Contains(stderr.String(), "did not install") {
-		t.Fatalf("error should state the content is not a uloop install:\n%s", stderr.String())
+	if !strings.Contains(stderr.String(), "cannot confirm it installed") {
+		t.Fatalf("error should state the content is not a confirmed uloop install:\n%s", stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "Blocked: 1") || !strings.Contains(stdout.String(), "Installed: 0") {
 		t.Fatalf("summary should count the skill as blocked:\n%s", stdout.String())
@@ -943,6 +952,9 @@ func TestRunSkillsDirListReportsConflict(t *testing.T) {
 	output := stdout.String()
 	if !strings.Contains(output, "uloop-blocked (conflict)") {
 		t.Fatalf("list should show the conflict status:\n%s", output)
+	}
+	if !strings.Contains(output, "exists but is not a directory") {
+		t.Fatalf("list should print the conflict reason under the status row:\n%s", output)
 	}
 	if !strings.Contains(output, "uloop-installed (installed)") {
 		t.Fatalf("list should keep reporting the skills after a conflict:\n%s", output)
@@ -1090,5 +1102,260 @@ func TestPosixStyleOutputDirError(t *testing.T) {
 	}
 	if err := posixStyleOutputDirError("linux", "/tmp/skills"); err != nil {
 		t.Fatalf("a POSIX path should be accepted on non-Windows platforms: %v", err)
+	}
+}
+
+// Tests that a store directory matching the skill name only by letter case is
+// never adopted: list reports a conflict, install blocks, and uninstall
+// preserves the directory, uniformly on every filesystem.
+func TestRunSkillsDirRejectsCaseVariantSkillDirectory(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	variantDir := filepath.Join(destinationDir, "Uloop-Sample")
+	if err := os.MkdirAll(filepath.Join(variantDir, "references"), 0o755); err != nil {
+		t.Fatalf("failed to create case-variant dir: %v", err)
+	}
+	userNotes := filepath.Join(variantDir, "references", "mynotes.md")
+	if err := os.WriteFile(userNotes, []byte("my curated notes\n"), 0o644); err != nil {
+		t.Fatalf("failed to write user notes: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(variantDir, "SKILL.md"), []byte("hand-authored\n"), 0o644); err != nil {
+		t.Fatalf("failed to write hand-authored skill file: %v", err)
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runSkillsDirList(destinationDir, []skillDefinition{skill}, stdout, stderr)
+	if code != 0 {
+		t.Fatalf("dir list failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "uloop-sample (conflict)") {
+		t.Fatalf("a case-variant store directory should read as a conflict:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	code = runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+	if code != 1 {
+		t.Fatalf("install onto a case-variant store directory should be blocked: code=%d", code)
+	}
+	if !strings.Contains(stderr.String(), "only by letter case") {
+		t.Fatalf("error should call out the case mismatch:\n%s", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+	if code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Not found: 1") {
+		t.Fatalf("a case-variant store directory should not count as an install:\n%s", stdout.String())
+	}
+	content, err := os.ReadFile(userNotes)
+	if err != nil || string(content) != "my curated notes\n" {
+		t.Fatalf("the case-variant directory content must survive untouched: content=%q err=%v", content, err)
+	}
+}
+
+// Tests that an orphan whose source was updated after the partial removal is
+// preserved as a recoverable conflict: the message explains the manual remedy
+// and uninstall does not delete the drifted content.
+func TestRunSkillsDirReportsDriftedOrphanAsRecoverableConflict(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	installedDir := filepath.Join(destinationDir, "uloop-sample")
+	if err := os.Remove(filepath.Join(installedDir, "SKILL.md")); err != nil {
+		t.Fatalf("failed to remove installed skill file: %v", err)
+	}
+	// Simulates a uloop upgrade between the partial removal and the next run.
+	if err := os.WriteFile(filepath.Join(skill.sourceDirectory, "references", "note.md"), []byte("note v2\n"), 0o644); err != nil {
+		t.Fatalf("failed to update source reference: %v", err)
+	}
+
+	state, err := getDirSkillState(destinationDir, skill)
+	if err != nil {
+		t.Fatalf("status check failed: %v", err)
+	}
+	if state.status != "conflict" {
+		t.Fatalf("a drifted orphan should read as a conflict, got: %s", state.status)
+	}
+	if !strings.Contains(state.conflictReason, "remove or rename them") {
+		t.Fatalf("the conflict must explain the manual remedy: %s", state.conflictReason)
+	}
+
+	stdout.Reset()
+	code := runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+	if code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Not found: 1") {
+		t.Fatalf("a drifted orphan should not count as removed:\n%s", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(installedDir, "references", "note.md")); err != nil {
+		t.Fatalf("drifted orphan content must be preserved: %v", err)
+	}
+}
+
+// Tests that an owned directory holding no comparable files grants no install
+// evidence: an empty match proves nothing, so a user's directory of the same
+// name is preserved instead of being claimed and removed.
+func TestRunSkillsDirEmptyOwnedDirGrantsNoEvidence(t *testing.T) {
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source", "uloop-sample", "Skill")
+	content := "---\nname: uloop-sample\n---\n\n# uloop-sample\n"
+	writeSkillFile(t, sourceDir, content)
+	// The owned directory contains only skipped names, so the comparable set
+	// is empty on the source side.
+	if err := os.MkdirAll(filepath.Join(sourceDir, "references"), 0o755); err != nil {
+		t.Fatalf("failed to create source references dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "references", "note.md.meta"), []byte("meta\n"), 0o644); err != nil {
+		t.Fatalf("failed to write skipped source file: %v", err)
+	}
+	skill := skillDefinition{name: "uloop-sample", content: []byte(content), sourceDirectory: sourceDir}
+	destinationDir := filepath.Join(root, "apm-skills")
+	userDir := filepath.Join(destinationDir, "uloop-sample")
+	if err := os.MkdirAll(filepath.Join(userDir, "references"), 0o755); err != nil {
+		t.Fatalf("failed to create user dir: %v", err)
+	}
+	userNotes := filepath.Join(userDir, "notes.md")
+	if err := os.WriteFile(userNotes, []byte("mine\n"), 0o644); err != nil {
+		t.Fatalf("failed to write user notes: %v", err)
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Not found: 1") {
+		t.Fatalf("an empty owned directory should not count as an install:\n%s", stdout.String())
+	}
+	if _, err := os.Stat(userNotes); err != nil {
+		t.Fatalf("user content must survive: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(userDir, "references")); err != nil {
+		t.Fatalf("the user's empty references dir must survive: %v", err)
+	}
+}
+
+// Tests that a working symlink inside a source-owned directory does not wedge
+// dir mode: the sync copies the target's content as a regular file, and the
+// status check compares the same content, so the skill reads as installed.
+func TestRunSkillsDirHandlesSymlinkedSourceReference(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	sharedFile := filepath.Join(root, "shared.md")
+	if err := os.WriteFile(sharedFile, []byte("shared\n"), 0o644); err != nil {
+		t.Fatalf("failed to write shared file: %v", err)
+	}
+	if err := os.Symlink(sharedFile, filepath.Join(skill.sourceDirectory, "references", "linked.md")); err != nil {
+		t.Fatalf("failed to create source symlink: %v", err)
+	}
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("dir install failed: code=%d stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	code := runSkillsDirList(destinationDir, []skillDefinition{skill}, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dir list failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "uloop-sample (installed)") {
+		t.Fatalf("a symlinked source reference should not wedge the status:\n%s", stdout.String())
+	}
+}
+
+// Tests that uninstall in a directory without install evidence removes only
+// uloop's own artifacts: a user's .meta file neither authorizes deleting the
+// directory nor is deleted itself.
+func TestRunSkillsDirUninstallKeepsNoEvidenceDirWithUserMeta(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	skillDir := filepath.Join(destinationDir, "uloop-sample")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("failed to create skill dir: %v", err)
+	}
+	artifact := filepath.Join(skillDir, "leftover.uloop-backup-1234")
+	if err := os.WriteFile(artifact, []byte("partial\n"), 0o644); err != nil {
+		t.Fatalf("failed to write artifact: %v", err)
+	}
+	userMeta := filepath.Join(skillDir, "dataset.meta")
+	if err := os.WriteFile(userMeta, []byte("guid: 1\n"), 0o644); err != nil {
+		t.Fatalf("failed to write user meta file: %v", err)
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(artifact); !os.IsNotExist(err) {
+		t.Fatalf("uloop's artifact should be cleaned, stat err=%v", err)
+	}
+	if _, err := os.Stat(userMeta); err != nil {
+		t.Fatalf("the user's .meta file must survive: %v", err)
+	}
+	if _, err := os.Stat(skillDir); err != nil {
+		t.Fatalf("a directory holding user content must not be removed: %v", err)
+	}
+}
+
+// Tests that uninstall of a real install removes .meta stubs of owned entries
+// along with the directory but keeps a directory holding a user's own .meta
+// data file.
+func TestRunSkillsDirUninstallDistinguishesMetaDebrisFromUserMeta(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	installedDir := filepath.Join(destinationDir, "uloop-sample")
+	// Unity mints .meta stubs for the entries uloop installed; those are
+	// debris, while dataset.meta is the user's own data file.
+	if err := os.WriteFile(filepath.Join(installedDir, "references.meta"), []byte("guid: 1\n"), 0o644); err != nil {
+		t.Fatalf("failed to write owned-entry meta stub: %v", err)
+	}
+	userMeta := filepath.Join(installedDir, "dataset.meta")
+	if err := os.WriteFile(userMeta, []byte("guid: 2\n"), 0o644); err != nil {
+		t.Fatalf("failed to write user meta file: %v", err)
+	}
+
+	stdout.Reset()
+	code := runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Removed: 1") {
+		t.Fatalf("the installed skill should be removed:\n%s", stdout.String())
+	}
+	if _, err := os.Stat(userMeta); err != nil {
+		t.Fatalf("the user's .meta data file must survive: %v", err)
+	}
+	if _, err := os.Stat(installedDir); err != nil {
+		t.Fatalf("a directory holding a user's .meta file must be kept: %v", err)
 	}
 }

--- a/cli/dispatcher/internal/dispatcher/skills_dir_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dir_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -229,6 +230,120 @@ func TestRunSkillsDirUninstallRemovesOnlyOwnedFiles(t *testing.T) {
 		t.Fatalf("foreign file should survive uninstall: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(destinationDir, "uloop-clean")); !os.IsNotExist(err) {
+		t.Fatalf("emptied skill directory should be removed, stat err=%v", err)
+	}
+}
+
+// Tests that a skill directory holding owned files but no SKILL.md is reported
+// outdated, and that install repairs it as an update, so list, install, and
+// uninstall agree on the partially removed state.
+func TestGetDirSkillStatusReportsOrphanedOwnedFilesAsOutdated(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	installedDir := filepath.Join(destinationDir, "uloop-sample")
+	if err := os.Remove(filepath.Join(installedDir, "SKILL.md")); err != nil {
+		t.Fatalf("failed to remove installed skill file: %v", err)
+	}
+
+	status, err := getDirSkillStatus(destinationDir, skill)
+	if err != nil {
+		t.Fatalf("status check failed: %v", err)
+	}
+	if status != "outdated" {
+		t.Fatalf("orphaned owned files should read as outdated: %s", status)
+	}
+
+	stdout.Reset()
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("repair install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Updated: 1") {
+		t.Fatalf("repairing an orphaned skill should count as updated:\n%s", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(installedDir, "SKILL.md")); err != nil {
+		t.Fatalf("repair should restore the skill file: %v", err)
+	}
+}
+
+// Tests that a foreign top-level file occupying a skill's name fails install
+// with a clear error on every platform instead of a raw ENOTDIR, and that
+// uninstall preserves the file and reports the skill as not found.
+func TestRunSkillsDirInstallRejectsFileOccupyingSkillName(t *testing.T) {
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	if err := os.MkdirAll(destinationDir, 0o755); err != nil {
+		t.Fatalf("failed to create destination: %v", err)
+	}
+	occupyingFile := filepath.Join(destinationDir, "uloop-sample")
+	if err := os.WriteFile(occupyingFile, []byte("foreign\n"), 0o644); err != nil {
+		t.Fatalf("failed to write occupying file: %v", err)
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+
+	if code != 1 {
+		t.Fatalf("install onto an occupying file should fail: code=%d", code)
+	}
+	if !strings.Contains(stderr.String(), "not a directory") {
+		t.Fatalf("error should explain the occupying file:\n%s", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+	if code != 0 {
+		t.Fatalf("uninstall should not fail on an occupying file: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Not found: 1") {
+		t.Fatalf("occupying file should not count as an install:\n%s", stdout.String())
+	}
+	if _, err := os.Stat(occupyingFile); err != nil {
+		t.Fatalf("occupying foreign file should be preserved: %v", err)
+	}
+}
+
+// Tests that uninstall removes a dangling symlink sitting at an owned entry
+// name instead of skipping it as missing.
+func TestRunSkillsDirUninstallRemovesDanglingSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+	root := t.TempDir()
+	skill := writeDirModeSkillSource(t, root, "uloop-sample")
+	destinationDir := filepath.Join(root, "apm-skills")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := runSkillsDirInstall(destinationDir, []skillDefinition{skill}, stdout, stderr); code != 0 {
+		t.Fatalf("setup install failed: code=%d stderr=%s", code, stderr.String())
+	}
+	installedDir := filepath.Join(destinationDir, "uloop-sample")
+	referencesPath := filepath.Join(installedDir, "references")
+	if err := os.RemoveAll(referencesPath); err != nil {
+		t.Fatalf("failed to remove references dir: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(root, "missing-target"), referencesPath); err != nil {
+		t.Fatalf("failed to create dangling symlink: %v", err)
+	}
+
+	stdout.Reset()
+	code := runSkillsDirUninstall(destinationDir, []skillDefinition{skill}, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dir uninstall failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Removed: 1") {
+		t.Fatalf("uninstall should count the skill as removed:\n%s", stdout.String())
+	}
+	if _, err := os.Stat(installedDir); !os.IsNotExist(err) {
 		t.Fatalf("emptied skill directory should be removed, stat err=%v", err)
 	}
 }

--- a/cli/dispatcher/internal/dispatcher/skills_dispatch.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dispatch.go
@@ -1,7 +1,9 @@
 package dispatcher
 
 import (
+	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 
 	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
@@ -73,6 +75,18 @@ func runSkillsDirSubcommand(
 		clierrors.WriteClassifiedError(stderr, err, skillsDirErrorContext())
 		return 1
 	}
+	// The destination must be a directory or absent (install creates it).
+	// Checked up front because a file here would otherwise surface as a raw
+	// ENOTDIR on Unix but as bogus not-installed statuses on Windows.
+	info, err := os.Stat(absDir)
+	if err != nil && !os.IsNotExist(err) {
+		clierrors.WriteClassifiedError(stderr, err, skillsDirErrorContext())
+		return 1
+	}
+	if err == nil && !info.IsDir() {
+		clierrors.WriteClassifiedError(stderr, fmt.Errorf("the %s path %s exists but is not a directory", skillsOutputDirFlagName, absDir), skillsDirErrorContext())
+		return 1
+	}
 	switch subcommand {
 	case "list":
 		return runSkillsDirList(absDir, skills, stdout, stderr)
@@ -84,11 +98,11 @@ func runSkillsDirSubcommand(
 		// Routing already rejects unknown and v3-migration subcommands, so this
 		// only fires when a new subcommand is added without dir-mode support.
 		clierrors.WriteClassifiedError(stderr, &clierrors.ArgumentError{
-			Message:     "The " + subcommand + " subcommand does not support --output-dir.",
-			Option:      "--output-dir",
+			Message:     "The " + subcommand + " subcommand does not support " + skillsOutputDirFlagName + ".",
+			Option:      skillsOutputDirFlagName,
 			Command:     clicore.SkillsCommandName,
-			NextActions: []string{"Use --output-dir with the install, uninstall, or list subcommand."},
-		}, clierrors.ErrorContext{Command: clicore.SkillsCommandName})
+			NextActions: []string{"Use " + skillsOutputDirFlagName + " with the install, uninstall, or list subcommand."},
+		}, skillsDirErrorContext())
 		return 1
 	}
 }

--- a/cli/dispatcher/internal/dispatcher/skills_dispatch.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dispatch.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
 
@@ -68,6 +70,10 @@ func runSkillsDirSubcommand(
 	stdout io.Writer,
 	stderr io.Writer,
 ) int {
+	if err := posixStyleOutputDirError(runtime.GOOS, directory); err != nil {
+		clierrors.WriteClassifiedError(stderr, err, skillsDirErrorContext())
+		return 1
+	}
 	// Resolved once here so the three subcommand runners share one absolute
 	// path and one failure path instead of each repeating the resolution.
 	absDir, err := filepath.Abs(directory)
@@ -104,6 +110,24 @@ func runSkillsDirSubcommand(
 			NextActions: []string{"Use " + skillsOutputDirFlagName + " with the install, uninstall, or list subcommand."},
 		}, skillsDirErrorContext())
 		return 1
+	}
+}
+
+// posixStyleOutputDirError rejects a POSIX-style absolute path on Windows
+// (Git Bash's /c/apm or /tmp/skills). Such a path has no volume name, so
+// filepath.Abs would silently anchor it under the current drive and the sync
+// would write to an unintended directory. Rejected rather than normalized:
+// the dispatcher cannot know which drive the shell meant. The goos parameter
+// exists so the rule is testable on every platform.
+func posixStyleOutputDirError(goos string, directory string) error {
+	if goos != "windows" || !strings.HasPrefix(directory, "/") {
+		return nil
+	}
+	return &clierrors.ArgumentError{
+		Message:     "The " + skillsOutputDirFlagName + " path " + directory + " is a POSIX-style path, which is ambiguous on Windows.",
+		Option:      skillsOutputDirFlagName,
+		Command:     clicore.SkillsCommandName,
+		NextActions: []string{"Pass a Windows path such as C:\\path\\to\\skills."},
 	}
 }
 

--- a/cli/dispatcher/internal/dispatcher/skills_dispatch.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dispatch.go
@@ -1,7 +1,6 @@
 package dispatcher
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -89,8 +88,15 @@ func runSkillsDirSubcommand(
 		clierrors.WriteClassifiedError(stderr, err, skillsDirErrorContext())
 		return 1
 	}
+	// An ArgumentError, not a bare error: a file at the destination is a
+	// caller mistake and must not surface as a retryable INTERNAL_ERROR.
 	if err == nil && !info.IsDir() {
-		clierrors.WriteClassifiedError(stderr, fmt.Errorf("the %s path %s exists but is not a directory", skillsOutputDirFlagName, absDir), skillsDirErrorContext())
+		clierrors.WriteClassifiedError(stderr, &clierrors.ArgumentError{
+			Message:     "The " + skillsOutputDirFlagName + " path " + absDir + " exists but is not a directory.",
+			Option:      skillsOutputDirFlagName,
+			Command:     clicore.SkillsCommandName,
+			NextActions: []string{"Pass an existing directory or a creatable path to " + skillsOutputDirFlagName + "."},
+		}, skillsDirErrorContext())
 		return 1
 	}
 	switch subcommand {
@@ -116,11 +122,13 @@ func runSkillsDirSubcommand(
 // posixStyleOutputDirError rejects a POSIX-style absolute path on Windows
 // (Git Bash's /c/apm or /tmp/skills). Such a path has no volume name, so
 // filepath.Abs would silently anchor it under the current drive and the sync
-// would write to an unintended directory. Rejected rather than normalized:
+// would write to an unintended directory. A double-slash prefix is exempt:
+// //server/share is a valid UNC path on Windows (forward slashes are accepted
+// separators) and carries its own volume. Rejected rather than normalized:
 // the dispatcher cannot know which drive the shell meant. The goos parameter
 // exists so the rule is testable on every platform.
 func posixStyleOutputDirError(goos string, directory string) error {
-	if goos != "windows" || !strings.HasPrefix(directory, "/") {
+	if goos != "windows" || !strings.HasPrefix(directory, "/") || strings.HasPrefix(directory, "//") {
 		return nil
 	}
 	return &clierrors.ArgumentError{

--- a/cli/dispatcher/internal/dispatcher/skills_dispatch.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dispatch.go
@@ -73,6 +73,14 @@ func runSkillsDirSubcommand(
 	case "uninstall":
 		return runSkillsDirUninstall(directory, skills, stdout, stderr)
 	default:
+		// Routing already rejects unknown and v3-migration subcommands, so this
+		// only fires when a new subcommand is added without dir-mode support.
+		clierrors.WriteClassifiedError(stderr, &clierrors.ArgumentError{
+			Message:     "The " + subcommand + " subcommand does not support --output-dir.",
+			Option:      "--output-dir",
+			Command:     clicore.SkillsCommandName,
+			NextActions: []string{"Use --output-dir with the install, uninstall, or list subcommand."},
+		}, clierrors.ErrorContext{Command: clicore.SkillsCommandName})
 		return 1
 	}
 }

--- a/cli/dispatcher/internal/dispatcher/skills_dispatch.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dispatch.go
@@ -99,6 +99,10 @@ func runSkillsDirSubcommand(
 		}, skillsDirErrorContext())
 		return 1
 	}
+	if err := outputDirOverlapsSkillSource(absDir, skills); err != nil {
+		clierrors.WriteClassifiedError(stderr, err, skillsDirErrorContext())
+		return 1
+	}
 	switch subcommand {
 	case "list":
 		return runSkillsDirList(absDir, skills, stdout, stderr)
@@ -117,6 +121,42 @@ func runSkillsDirSubcommand(
 		}, skillsDirErrorContext())
 		return 1
 	}
+}
+
+// outputDirOverlapsSkillSource rejects --output-dir when it sits inside a
+// skill source directory or contains one: install would then copy into the
+// tree WalkDir is enumerating (or treat the source as the store).
+func outputDirOverlapsSkillSource(absDir string, skills []skillDefinition) error {
+	for _, skill := range skills {
+		absSource, err := filepath.Abs(skill.sourceDirectory)
+		if err != nil {
+			return err
+		}
+		if pathContains(absSource, absDir) || pathContains(absDir, absSource) {
+			return &clierrors.ArgumentError{
+				Message:     "The " + skillsOutputDirFlagName + " path " + absDir + " overlaps the skill source directory " + absSource + ".",
+				Option:      skillsOutputDirFlagName,
+				Command:     clicore.SkillsCommandName,
+				NextActions: []string{"Pass a directory that is outside every skill source directory to " + skillsOutputDirFlagName + "."},
+			}
+		}
+	}
+	return nil
+}
+
+// pathContains reports whether parent contains child, including when the two
+// paths are the same. Rel distinguishes a real descendant from a sibling that
+// merely shares a prefix (/a/b vs /a/bc).
+func pathContains(parent string, child string) bool {
+	relative, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	if relative == "." {
+		return true
+	}
+	// Rel of an ancestor is ".." (no separator); that is not containment.
+	return relative != ".." && !strings.HasPrefix(relative, ".."+string(os.PathSeparator))
 }
 
 // posixStyleOutputDirError rejects a POSIX-style absolute path on Windows

--- a/cli/dispatcher/internal/dispatcher/skills_dispatch.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dispatch.go
@@ -2,6 +2,7 @@ package dispatcher
 
 import (
 	"io"
+	"path/filepath"
 
 	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
 
@@ -65,13 +66,20 @@ func runSkillsDirSubcommand(
 	stdout io.Writer,
 	stderr io.Writer,
 ) int {
+	// Resolved once here so the three subcommand runners share one absolute
+	// path and one failure path instead of each repeating the resolution.
+	absDir, err := filepath.Abs(directory)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, skillsDirErrorContext())
+		return 1
+	}
 	switch subcommand {
 	case "list":
-		return runSkillsDirList(directory, skills, stdout, stderr)
+		return runSkillsDirList(absDir, skills, stdout, stderr)
 	case "install":
-		return runSkillsDirInstall(directory, skills, stdout, stderr)
+		return runSkillsDirInstall(absDir, skills, stdout, stderr)
 	case "uninstall":
-		return runSkillsDirUninstall(directory, skills, stdout, stderr)
+		return runSkillsDirUninstall(absDir, skills, stdout, stderr)
 	default:
 		// Routing already rejects unknown and v3-migration subcommands, so this
 		// only fires when a new subcommand is added without dir-mode support.

--- a/cli/dispatcher/internal/dispatcher/skills_dispatch.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dispatch.go
@@ -43,6 +43,9 @@ func runSkillsSubcommand(
 	stdout io.Writer,
 	stderr io.Writer,
 ) int {
+	if options.outputDir != "" {
+		return runSkillsDirSubcommand(subcommand, skills, options.outputDir, stdout, stderr)
+	}
 	switch subcommand {
 	case "list":
 		return runSkillsList(projectRoot, skills, options, stdout, stderr)
@@ -50,6 +53,25 @@ func runSkillsSubcommand(
 		return runSkillsInstallWithGuidance(projectRoot, skills, options, stdout, stderr)
 	case "uninstall":
 		return runSkillsUninstallWithGuidance(projectRoot, skills, options, stdout, stderr)
+	default:
+		return 1
+	}
+}
+
+func runSkillsDirSubcommand(
+	subcommand string,
+	skills []skillDefinition,
+	directory string,
+	stdout io.Writer,
+	stderr io.Writer,
+) int {
+	switch subcommand {
+	case "list":
+		return runSkillsDirList(directory, skills, stdout, stderr)
+	case "install":
+		return runSkillsDirInstall(directory, skills, stdout, stderr)
+	case "uninstall":
+		return runSkillsDirUninstall(directory, skills, stdout, stderr)
 	default:
 		return 1
 	}

--- a/cli/dispatcher/internal/dispatcher/skills_dispatch.go
+++ b/cli/dispatcher/internal/dispatcher/skills_dispatch.go
@@ -127,12 +127,14 @@ func runSkillsDirSubcommand(
 // skill source directory or contains one: install would then copy into the
 // tree WalkDir is enumerating (or treat the source as the store).
 func outputDirOverlapsSkillSource(absDir string, skills []skillDefinition) error {
+	resolvedDir := resolveSymlinkedPath(absDir)
 	for _, skill := range skills {
 		absSource, err := filepath.Abs(skill.sourceDirectory)
 		if err != nil {
 			return err
 		}
-		if pathContains(absSource, absDir) || pathContains(absDir, absSource) {
+		resolvedSource := resolveSymlinkedPath(absSource)
+		if pathContains(resolvedSource, resolvedDir) || pathContains(resolvedDir, resolvedSource) {
 			return &clierrors.ArgumentError{
 				Message:     "The " + skillsOutputDirFlagName + " path " + absDir + " overlaps the skill source directory " + absSource + ".",
 				Option:      skillsOutputDirFlagName,
@@ -142,6 +144,26 @@ func outputDirOverlapsSkillSource(absDir string, skills []skillDefinition) error
 		}
 	}
 	return nil
+}
+
+// resolveSymlinkedPath resolves path through symlinks even when the full
+// path does not exist yet. The overlap guard must compare real locations;
+// Abs alone keeps symlink aliases distinct.
+func resolveSymlinkedPath(path string) string {
+	current := path
+	remainder := ""
+	for {
+		resolved, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			return filepath.Join(resolved, remainder)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return path
+		}
+		remainder = filepath.Join(filepath.Base(current), remainder)
+		current = parent
+	}
 }
 
 // pathContains reports whether parent contains child, including when the two

--- a/cli/dispatcher/internal/dispatcher/skills_display.go
+++ b/cli/dispatcher/internal/dispatcher/skills_display.go
@@ -37,6 +37,8 @@ func statusIcon(status string) string {
 		return "+"
 	case "outdated":
 		return "^"
+	case "conflict":
+		return "!"
 	default:
 		return "-"
 	}
@@ -48,6 +50,8 @@ func statusText(status string) string {
 		return "installed"
 	case "outdated":
 		return "outdated"
+	case "conflict":
+		return "conflict"
 	default:
 		return "not installed"
 	}

--- a/cli/dispatcher/internal/dispatcher/skills_display.go
+++ b/cli/dispatcher/internal/dispatcher/skills_display.go
@@ -82,8 +82,8 @@ func printSkillsSubcommandHelp(command string, stdout io.Writer) {
 		clicore.WriteLine(stdout, "")
 	}
 	if skillsSubcommandSupportsOutputDir(command) {
-		clicore.WriteLine(stdout, "With --output-dir, skills sync flat into <path>/<skill-name> with no target")
-		clicore.WriteLine(stdout, "subdirectories. Top-level files uloop does not manage are left untouched,")
+		clicore.WriteLine(stdout, "With --output-dir, skills are managed flat as <path>/<skill-name> with no")
+		clicore.WriteLine(stdout, "target subdirectories. Top-level files uloop does not manage are left untouched,")
 		clicore.WriteLine(stdout, "while source-owned directories such as references/ are replaced wholly on")
 		clicore.WriteLine(stdout, "update. Skills are sourced from the Unity project, so run this inside a")
 		clicore.WriteLine(stdout, "Unity project or pass --project-path.")

--- a/cli/dispatcher/internal/dispatcher/skills_display.go
+++ b/cli/dispatcher/internal/dispatcher/skills_display.go
@@ -84,6 +84,8 @@ func printSkillsSubcommandHelp(command string, stdout io.Writer) {
 	if !isV3MigrationSkillSubcommand(command) {
 		clicore.WriteLine(stdout, "With --output-dir, skills sync flat into <path>/<skill-name> with no target")
 		clicore.WriteLine(stdout, "subdirectories; files uloop does not manage there are left untouched.")
+		clicore.WriteLine(stdout, "Skills are sourced from the Unity project, so run this inside a Unity")
+		clicore.WriteLine(stdout, "project or pass --project-path.")
 		clicore.WriteLine(stdout, "")
 	}
 	if command == "install-v3-migration" {

--- a/cli/dispatcher/internal/dispatcher/skills_display.go
+++ b/cli/dispatcher/internal/dispatcher/skills_display.go
@@ -71,11 +71,19 @@ func printSkillsSubcommandHelp(command string, stdout io.Writer) {
 	clicore.WriteLine(stdout, "Options:")
 	clicore.WriteLine(stdout, "  -g, --global")
 	clicore.WriteLine(stdout, "      --flat")
+	if !isV3MigrationSkillSubcommand(command) {
+		clicore.WriteLine(stdout, "      --output-dir <path>")
+	}
 	printSkillTargetFlagLines(stdout, "      ")
 	clicore.WriteLine(stdout, "")
 	if command == "install" {
 		clicore.WriteLine(stdout, "Targets that already contain uloop skills are refreshed automatically,")
 		clicore.WriteLine(stdout, "even when their flag is omitted, so previously installed copies never go stale.")
+		clicore.WriteLine(stdout, "")
+	}
+	if !isV3MigrationSkillSubcommand(command) {
+		clicore.WriteLine(stdout, "With --output-dir, skills sync flat into <path>/<skill-name> with no target")
+		clicore.WriteLine(stdout, "subdirectories; files uloop does not manage there are left untouched.")
 		clicore.WriteLine(stdout, "")
 	}
 	if command == "install-v3-migration" {
@@ -93,6 +101,10 @@ func printSkillsTargetGuidance(command string, stdout io.Writer) {
 	clicore.WriteFormat(stdout, "\nPlease specify at least one target for '%s':\n\n", command)
 	clicore.WriteLine(stdout, "Available targets:")
 	printSkillTargetFlagLines(stdout, "  ")
+	if !isV3MigrationSkillSubcommand(command) {
+		clicore.WriteLine(stdout, "")
+		clicore.WriteLine(stdout, "Or pass --output-dir <path> to sync skills into a custom directory.")
+	}
 }
 
 // printSkillTargetFlagLines prints one --<id> line per target in the shared

--- a/cli/dispatcher/internal/dispatcher/skills_display.go
+++ b/cli/dispatcher/internal/dispatcher/skills_display.go
@@ -71,8 +71,8 @@ func printSkillsSubcommandHelp(command string, stdout io.Writer) {
 	clicore.WriteLine(stdout, "Options:")
 	clicore.WriteLine(stdout, "  -g, --global")
 	clicore.WriteLine(stdout, "      --flat")
-	if !isV3MigrationSkillSubcommand(command) {
-		clicore.WriteLine(stdout, "      --output-dir <path>")
+	if skillsSubcommandSupportsOutputDir(command) {
+		clicore.WriteLine(stdout, "      "+skillsOutputDirFlagName+" <path>")
 	}
 	printSkillTargetFlagLines(stdout, "      ")
 	clicore.WriteLine(stdout, "")
@@ -81,11 +81,12 @@ func printSkillsSubcommandHelp(command string, stdout io.Writer) {
 		clicore.WriteLine(stdout, "even when their flag is omitted, so previously installed copies never go stale.")
 		clicore.WriteLine(stdout, "")
 	}
-	if !isV3MigrationSkillSubcommand(command) {
+	if skillsSubcommandSupportsOutputDir(command) {
 		clicore.WriteLine(stdout, "With --output-dir, skills sync flat into <path>/<skill-name> with no target")
-		clicore.WriteLine(stdout, "subdirectories; files uloop does not manage there are left untouched.")
-		clicore.WriteLine(stdout, "Skills are sourced from the Unity project, so run this inside a Unity")
-		clicore.WriteLine(stdout, "project or pass --project-path.")
+		clicore.WriteLine(stdout, "subdirectories. Top-level files uloop does not manage are left untouched,")
+		clicore.WriteLine(stdout, "while source-owned directories such as references/ are replaced wholly on")
+		clicore.WriteLine(stdout, "update. Skills are sourced from the Unity project, so run this inside a")
+		clicore.WriteLine(stdout, "Unity project or pass --project-path.")
 		clicore.WriteLine(stdout, "")
 	}
 	if command == "install-v3-migration" {
@@ -103,9 +104,9 @@ func printSkillsTargetGuidance(command string, stdout io.Writer) {
 	clicore.WriteFormat(stdout, "\nPlease specify at least one target for '%s':\n\n", command)
 	clicore.WriteLine(stdout, "Available targets:")
 	printSkillTargetFlagLines(stdout, "  ")
-	if !isV3MigrationSkillSubcommand(command) {
+	if skillsSubcommandSupportsOutputDir(command) {
 		clicore.WriteLine(stdout, "")
-		clicore.WriteLine(stdout, "Or pass --output-dir <path> to sync skills into a custom directory.")
+		clicore.WriteLine(stdout, "Or pass "+skillsOutputDirFlagName+" <path> to sync skills into a custom directory.")
 	}
 }
 

--- a/cli/dispatcher/internal/dispatcher/skills_options.go
+++ b/cli/dispatcher/internal/dispatcher/skills_options.go
@@ -84,19 +84,19 @@ func validateSkillsOptions(options skillCommandOptions) error {
 	if options.outputDir == "" {
 		return nil
 	}
-	conflicting := ""
-	if options.flat {
-		conflicting = "--flat"
+	if len(options.targets) > 0 {
+		return skillsOutputDirConflictError("--" + options.targets[0].id)
 	}
 	if options.global {
-		conflicting = "--global"
+		return skillsOutputDirConflictError("--global")
 	}
-	if len(options.targets) > 0 {
-		conflicting = "--" + options.targets[0].id
+	if options.flat {
+		return skillsOutputDirConflictError("--flat")
 	}
-	if conflicting == "" {
-		return nil
-	}
+	return nil
+}
+
+func skillsOutputDirConflictError(conflicting string) error {
 	return &clierrors.ArgumentError{
 		Message:     "The --output-dir option cannot be combined with " + conflicting + ".",
 		Option:      "--output-dir",

--- a/cli/dispatcher/internal/dispatcher/skills_options.go
+++ b/cli/dispatcher/internal/dispatcher/skills_options.go
@@ -77,13 +77,17 @@ func missingSkillsOutputDirValueError() error {
 }
 
 // validateSkillsOptions rejects flag combinations whose destinations conflict:
-// --output-dir already names one exact destination, so combining it with the location
-// flags (--global or a target flag) would make the request ambiguous.
+// --output-dir already names one exact destination and always installs flat, so
+// combining it with the location flags (--global or a target flag) or the layout
+// flag (--flat) would make the request ambiguous.
 func validateSkillsOptions(options skillCommandOptions) error {
 	if options.outputDir == "" {
 		return nil
 	}
 	conflicting := ""
+	if options.flat {
+		conflicting = "--flat"
+	}
 	if options.global {
 		conflicting = "--global"
 	}

--- a/cli/dispatcher/internal/dispatcher/skills_options.go
+++ b/cli/dispatcher/internal/dispatcher/skills_options.go
@@ -1,0 +1,110 @@
+package dispatcher
+
+// Flag parsing and validation for `uloop skills` subcommands.
+
+import (
+	"strings"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+)
+
+func parseSkillsOptions(args []string) (skillCommandOptions, error) {
+	options := skillCommandOptions{}
+	seenTargets := map[string]bool{}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "-g" || arg == "--global":
+			options.global = true
+		case arg == "--flat":
+			options.flat = true
+		case arg == "--output-dir":
+			if index+1 >= len(args) || args[index+1] == "" {
+				return skillCommandOptions{}, missingSkillsOutputDirValueError()
+			}
+			index++
+			options.outputDir = args[index]
+		case strings.HasPrefix(arg, "--output-dir="):
+			options.outputDir = strings.TrimPrefix(arg, "--output-dir=")
+			if options.outputDir == "" {
+				return skillCommandOptions{}, missingSkillsOutputDirValueError()
+			}
+		default:
+			if err := appendSkillTarget(&options, seenTargets, arg); err != nil {
+				return skillCommandOptions{}, err
+			}
+		}
+	}
+	if err := validateSkillsOptions(options); err != nil {
+		return skillCommandOptions{}, err
+	}
+	return options, nil
+}
+
+func appendSkillTarget(options *skillCommandOptions, seenTargets map[string]bool, arg string) error {
+	targetID, ok := skillTargetIDFromFlag(arg)
+	if !ok {
+		return &clierrors.ArgumentError{
+			Message:     "Unknown skills option: " + arg,
+			Option:      arg,
+			Command:     clicore.SkillsCommandName,
+			NextActions: []string{"Run `uloop skills --help` to inspect supported skills options."},
+		}
+	}
+	if seenTargets[targetID] {
+		return nil
+	}
+	options.targets = append(options.targets, targetConfigs[targetID])
+	seenTargets[targetID] = true
+	return nil
+}
+
+func missingSkillsOutputDirValueError() error {
+	return &clierrors.ArgumentError{
+		Message:     "The --output-dir option requires a directory path value.",
+		Option:      "--output-dir",
+		Command:     clicore.SkillsCommandName,
+		NextActions: []string{"Pass the destination directory, e.g. `uloop skills install --output-dir path/to/skills`."},
+	}
+}
+
+// validateSkillsOptions rejects flag combinations whose destinations conflict:
+// --output-dir already names one exact destination, so combining it with the location
+// flags (--global or a target flag) would make the request ambiguous.
+func validateSkillsOptions(options skillCommandOptions) error {
+	if options.outputDir == "" {
+		return nil
+	}
+	conflicting := ""
+	if options.global {
+		conflicting = "--global"
+	}
+	if len(options.targets) > 0 {
+		conflicting = "--" + options.targets[0].id
+	}
+	if conflicting == "" {
+		return nil
+	}
+	return &clierrors.ArgumentError{
+		Message:     "The --output-dir option cannot be combined with " + conflicting + ".",
+		Option:      "--output-dir",
+		Command:     clicore.SkillsCommandName,
+		NextActions: []string{"Use --output-dir alone, or drop it to install into target directories."},
+	}
+}
+
+// skillTargetIDFromFlag reports the target id for a --<id> flag when it maps to
+// a known entry in targetConfigs. The lookup is driven by targetConfigs so the
+// set of accepted flags stays consistent with the help output.
+func skillTargetIDFromFlag(arg string) (string, bool) {
+	if !strings.HasPrefix(arg, "--") {
+		return "", false
+	}
+	id := strings.TrimPrefix(arg, "--")
+	if _, ok := targetConfigs[id]; !ok {
+		return "", false
+	}
+	return id, true
+}

--- a/cli/dispatcher/internal/dispatcher/skills_options.go
+++ b/cli/dispatcher/internal/dispatcher/skills_options.go
@@ -10,6 +10,11 @@ import (
 	"github.com/hatayama/unity-cli-loop/common/clicore"
 )
 
+// skillsOutputDirFlagName is the single definition of the --output-dir token.
+// Parsing, error construction, routing, and the help option line all reference
+// it so a rename cannot silently miss one of the comparison sites.
+const skillsOutputDirFlagName = "--output-dir"
+
 func parseSkillsOptions(args []string) (skillCommandOptions, error) {
 	options := skillCommandOptions{}
 	seenTargets := map[string]bool{}
@@ -20,7 +25,7 @@ func parseSkillsOptions(args []string) (skillCommandOptions, error) {
 			options.global = true
 		case arg == "--flat":
 			options.flat = true
-		case arg == "--output-dir":
+		case arg == skillsOutputDirFlagName:
 			// A flag-like next token (e.g. --global) must not be swallowed as the
 			// destination, or the mutual-exclusion validation silently misses it.
 			// Paths that genuinely start with a dash go through --output-dir=<path>.
@@ -29,8 +34,8 @@ func parseSkillsOptions(args []string) (skillCommandOptions, error) {
 			}
 			index++
 			options.outputDir = args[index]
-		case strings.HasPrefix(arg, "--output-dir="):
-			options.outputDir = strings.TrimPrefix(arg, "--output-dir=")
+		case strings.HasPrefix(arg, skillsOutputDirFlagName+"="):
+			options.outputDir = strings.TrimPrefix(arg, skillsOutputDirFlagName+"=")
 			if options.outputDir == "" {
 				return skillCommandOptions{}, missingSkillsOutputDirValueError()
 			}
@@ -66,8 +71,8 @@ func appendSkillTarget(options *skillCommandOptions, seenTargets map[string]bool
 
 func missingSkillsOutputDirValueError() error {
 	return &clierrors.ArgumentError{
-		Message: "The --output-dir option requires a directory path value.",
-		Option:  "--output-dir",
+		Message: "The " + skillsOutputDirFlagName + " option requires a directory path value.",
+		Option:  skillsOutputDirFlagName,
 		Command: clicore.SkillsCommandName,
 		NextActions: []string{
 			"Pass the destination directory, e.g. `uloop skills install --output-dir path/to/skills`.",
@@ -98,8 +103,8 @@ func validateSkillsOptions(options skillCommandOptions) error {
 
 func skillsOutputDirConflictError(conflicting string) error {
 	return &clierrors.ArgumentError{
-		Message:     "The --output-dir option cannot be combined with " + conflicting + ".",
-		Option:      "--output-dir",
+		Message:     "The " + skillsOutputDirFlagName + " option cannot be combined with " + conflicting + ".",
+		Option:      skillsOutputDirFlagName,
 		Command:     clicore.SkillsCommandName,
 		NextActions: []string{"Use --output-dir alone, or drop it to install into target directories."},
 	}

--- a/cli/dispatcher/internal/dispatcher/skills_options.go
+++ b/cli/dispatcher/internal/dispatcher/skills_options.go
@@ -21,7 +21,10 @@ func parseSkillsOptions(args []string) (skillCommandOptions, error) {
 		case arg == "--flat":
 			options.flat = true
 		case arg == "--output-dir":
-			if index+1 >= len(args) || args[index+1] == "" {
+			// A flag-like next token (e.g. --global) must not be swallowed as the
+			// destination, or the mutual-exclusion validation silently misses it.
+			// Paths that genuinely start with a dash go through --output-dir=<path>.
+			if index+1 >= len(args) || args[index+1] == "" || strings.HasPrefix(args[index+1], "-") {
 				return skillCommandOptions{}, missingSkillsOutputDirValueError()
 			}
 			index++
@@ -63,10 +66,13 @@ func appendSkillTarget(options *skillCommandOptions, seenTargets map[string]bool
 
 func missingSkillsOutputDirValueError() error {
 	return &clierrors.ArgumentError{
-		Message:     "The --output-dir option requires a directory path value.",
-		Option:      "--output-dir",
-		Command:     clicore.SkillsCommandName,
-		NextActions: []string{"Pass the destination directory, e.g. `uloop skills install --output-dir path/to/skills`."},
+		Message: "The --output-dir option requires a directory path value.",
+		Option:  "--output-dir",
+		Command: clicore.SkillsCommandName,
+		NextActions: []string{
+			"Pass the destination directory, e.g. `uloop skills install --output-dir path/to/skills`.",
+			"Use the --output-dir=<path> form when the destination path starts with a dash.",
+		},
 	}
 }
 

--- a/cli/dispatcher/internal/dispatcher/skills_options.go
+++ b/cli/dispatcher/internal/dispatcher/skills_options.go
@@ -26,6 +26,12 @@ func parseSkillsOptions(args []string) (skillCommandOptions, error) {
 		case arg == "--flat":
 			options.flat = true
 		case arg == skillsOutputDirFlagName:
+			// Rejected rather than letting the last occurrence win, matching
+			// `uloop install --dir`: two destinations in one invocation is
+			// ambiguous, and silently syncing only one of them would hide it.
+			if options.outputDir != "" {
+				return skillCommandOptions{}, duplicateSkillsOutputDirError()
+			}
 			// A flag-like next token (e.g. --global) must not be swallowed as the
 			// destination, or the mutual-exclusion validation silently misses it.
 			// Paths that genuinely start with a dash go through --output-dir=<path>.
@@ -35,6 +41,9 @@ func parseSkillsOptions(args []string) (skillCommandOptions, error) {
 			index++
 			options.outputDir = args[index]
 		case strings.HasPrefix(arg, skillsOutputDirFlagName+"="):
+			if options.outputDir != "" {
+				return skillCommandOptions{}, duplicateSkillsOutputDirError()
+			}
 			options.outputDir = strings.TrimPrefix(arg, skillsOutputDirFlagName+"=")
 			if options.outputDir == "" {
 				return skillCommandOptions{}, missingSkillsOutputDirValueError()
@@ -67,6 +76,15 @@ func appendSkillTarget(options *skillCommandOptions, seenTargets map[string]bool
 	options.targets = append(options.targets, targetConfigs[targetID])
 	seenTargets[targetID] = true
 	return nil
+}
+
+func duplicateSkillsOutputDirError() error {
+	return &clierrors.ArgumentError{
+		Message:     "Duplicate skills option: " + skillsOutputDirFlagName,
+		Option:      skillsOutputDirFlagName,
+		Command:     clicore.SkillsCommandName,
+		NextActions: []string{"Pass the destination directory only once."},
+	}
 }
 
 func missingSkillsOutputDirValueError() error {

--- a/cli/dispatcher/internal/dispatcher/skills_options.go
+++ b/cli/dispatcher/internal/dispatcher/skills_options.go
@@ -25,29 +25,12 @@ func parseSkillsOptions(args []string) (skillCommandOptions, error) {
 			options.global = true
 		case arg == "--flat":
 			options.flat = true
-		case arg == skillsOutputDirFlagName:
-			// Rejected rather than letting the last occurrence win, matching
-			// `uloop install --dir`: two destinations in one invocation is
-			// ambiguous, and silently syncing only one of them would hide it.
-			if options.outputDir != "" {
-				return skillCommandOptions{}, duplicateSkillsOutputDirError()
+		case arg == skillsOutputDirFlagName || strings.HasPrefix(arg, skillsOutputDirFlagName+"="):
+			nextIndex, err := parseOutputDirOption(&options, args, index)
+			if err != nil {
+				return skillCommandOptions{}, err
 			}
-			// A flag-like next token (e.g. --global) must not be swallowed as the
-			// destination, or the mutual-exclusion validation silently misses it.
-			// Paths that genuinely start with a dash go through --output-dir=<path>.
-			if index+1 >= len(args) || args[index+1] == "" || strings.HasPrefix(args[index+1], "-") {
-				return skillCommandOptions{}, missingSkillsOutputDirValueError()
-			}
-			index++
-			options.outputDir = args[index]
-		case strings.HasPrefix(arg, skillsOutputDirFlagName+"="):
-			if options.outputDir != "" {
-				return skillCommandOptions{}, duplicateSkillsOutputDirError()
-			}
-			options.outputDir = strings.TrimPrefix(arg, skillsOutputDirFlagName+"=")
-			if options.outputDir == "" {
-				return skillCommandOptions{}, missingSkillsOutputDirValueError()
-			}
+			index = nextIndex
 		default:
 			if err := appendSkillTarget(&options, seenTargets, arg); err != nil {
 				return skillCommandOptions{}, err
@@ -76,6 +59,34 @@ func appendSkillTarget(options *skillCommandOptions, seenTargets map[string]bool
 	options.targets = append(options.targets, targetConfigs[targetID])
 	seenTargets[targetID] = true
 	return nil
+}
+
+// parseOutputDirOption consumes the --output-dir option at args[index] in
+// either value form and returns the index of the last consumed token.
+func parseOutputDirOption(options *skillCommandOptions, args []string, index int) (int, error) {
+	// Rejected rather than letting the last occurrence win, matching
+	// `uloop install --dir`: two destinations in one invocation is
+	// ambiguous, and silently syncing only one of them would hide it.
+	if options.outputDir != "" {
+		return index, duplicateSkillsOutputDirError()
+	}
+	if value, found := strings.CutPrefix(args[index], skillsOutputDirFlagName+"="); found {
+		if strings.TrimSpace(value) == "" {
+			return index, missingSkillsOutputDirValueError()
+		}
+		options.outputDir = value
+		return index, nil
+	}
+	// A flag-like next token (e.g. --global) must not be swallowed as the
+	// destination, or the mutual-exclusion validation silently misses it, and a
+	// whitespace-only token (an unset shell variable) must not become a
+	// directory literally named after it. Paths that genuinely start with a
+	// dash go through --output-dir=<path>.
+	if index+1 >= len(args) || strings.TrimSpace(args[index+1]) == "" || strings.HasPrefix(args[index+1], "-") {
+		return index, missingSkillsOutputDirValueError()
+	}
+	options.outputDir = args[index+1]
+	return index + 1, nil
 }
 
 func duplicateSkillsOutputDirError() error {

--- a/cli/dispatcher/internal/dispatcher/skills_sync.go
+++ b/cli/dispatcher/internal/dispatcher/skills_sync.go
@@ -10,12 +10,14 @@ import (
 )
 
 // Suffixes appended (before the random digits os.CreateTemp and os.MkdirTemp
-// add) to temp and backup copies created during a sync. The stale-artifact
-// cleanup in dir mode matches these same constants, so the producers and the
-// matcher cannot drift apart.
+// add) to temp and backup copies created during a sync. The uloop marker
+// claims a namespace no user file lands in by accident, so dir-mode
+// stale-artifact cleanup can identify uloop's own debris by name alone without
+// risking human-named backups such as references.backup-2024; the cleanup
+// matches these same constants, so the producers and the matcher cannot drift.
 const (
-	skillSyncTempSuffix   = ".tmp-"
-	skillSyncBackupSuffix = ".backup-"
+	skillSyncTempSuffix   = ".uloop-tmp-"
+	skillSyncBackupSuffix = ".uloop-backup-"
 )
 
 func syncSkillDirectory(sourceDir string, destinationDir string) error {

--- a/cli/dispatcher/internal/dispatcher/skills_sync.go
+++ b/cli/dispatcher/internal/dispatcher/skills_sync.go
@@ -120,13 +120,8 @@ func getSkillStatusWithStat(
 }
 
 func isInstalledSkillOutdated(installedDir string, skill skillDefinition) bool {
-	installedContent, err := os.ReadFile(filepath.Join(installedDir, skillscan.SkillFileName))
-	if err != nil {
-		return true
-	}
-	installedContent = normalizeSkillFileContent(skillscan.SkillFileName, installedContent)
-	expectedContent := normalizeSkillFileContent(skillscan.SkillFileName, skill.content)
-	if !bytes.Equal(installedContent, expectedContent) {
+	matches, err := installedSkillFileMatches(installedDir, skill)
+	if err != nil || !matches {
 		return true
 	}
 
@@ -142,6 +137,19 @@ func isInstalledSkillOutdated(installedDir string, skill skillDefinition) bool {
 		}
 	}
 	return false
+}
+
+// installedSkillFileMatches reports whether the installed SKILL.md equals the
+// source content after normalization. Target-mode and dir-mode status checks
+// both go through here so the comparison rule cannot drift between them.
+func installedSkillFileMatches(installedDir string, skill skillDefinition) (bool, error) {
+	installedContent, err := os.ReadFile(filepath.Join(installedDir, skillscan.SkillFileName))
+	if err != nil {
+		return false, err
+	}
+	installedContent = normalizeSkillFileContent(skillscan.SkillFileName, installedContent)
+	expectedContent := normalizeSkillFileContent(skillscan.SkillFileName, skill.content)
+	return bytes.Equal(installedContent, expectedContent), nil
 }
 
 func collectComparableSkillFiles(root string) map[string][]byte {

--- a/cli/dispatcher/internal/dispatcher/skills_sync.go
+++ b/cli/dispatcher/internal/dispatcher/skills_sync.go
@@ -9,12 +9,21 @@ import (
 	"github.com/hatayama/unity-cli-loop/common/skillscan"
 )
 
+// Suffixes appended (before the random digits os.CreateTemp and os.MkdirTemp
+// add) to temp and backup copies created during a sync. The stale-artifact
+// cleanup in dir mode matches these same constants, so the producers and the
+// matcher cannot drift apart.
+const (
+	skillSyncTempSuffix   = ".tmp-"
+	skillSyncBackupSuffix = ".backup-"
+)
+
 func syncSkillDirectory(sourceDir string, destinationDir string) error {
 	parentDir := filepath.Dir(destinationDir)
 	if err := os.MkdirAll(parentDir, 0o755); err != nil {
 		return err
 	}
-	tempDir, err := os.MkdirTemp(parentDir, filepath.Base(destinationDir)+".tmp-")
+	tempDir, err := os.MkdirTemp(parentDir, filepath.Base(destinationDir)+skillSyncTempSuffix)
 	if err != nil {
 		return err
 	}
@@ -44,7 +53,7 @@ func replaceSkillDirectory(sourceDir string, destinationDir string) error {
 	}
 
 	parentDir := filepath.Dir(destinationDir)
-	backupDir, err := os.MkdirTemp(parentDir, filepath.Base(destinationDir)+".backup-")
+	backupDir, err := os.MkdirTemp(parentDir, filepath.Base(destinationDir)+skillSyncBackupSuffix)
 	if err != nil {
 		return err
 	}

--- a/cli/dispatcher/internal/dispatcher/skills_sync.go
+++ b/cli/dispatcher/internal/dispatcher/skills_sync.go
@@ -130,13 +130,20 @@ func isInstalledSkillOutdated(installedDir string, skill skillDefinition) bool {
 	if len(expectedFiles) != len(installedFiles) {
 		return true
 	}
+	return !comparableFilesMatch(expectedFiles, installedFiles)
+}
+
+// comparableFilesMatch reports whether every expected file exists in installed
+// with equal normalized content. Target-mode and dir-mode staleness checks both
+// go through here so the comparison rule cannot drift between them.
+func comparableFilesMatch(expectedFiles map[string][]byte, installedFiles map[string][]byte) bool {
 	for relativePath, expectedContent := range expectedFiles {
 		installedContent, ok := installedFiles[relativePath]
 		if !ok || !bytes.Equal(expectedContent, installedContent) {
-			return true
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 // installedSkillFileMatches reports whether the installed SKILL.md equals the

--- a/docs/adr/0004-dir-mode-evidence-gated-ownership.md
+++ b/docs/adr/0004-dir-mode-evidence-gated-ownership.md
@@ -1,0 +1,99 @@
+# Dir-Mode Evidence-Gated Ownership
+
+Date: 2026-08-24
+
+## Decision
+
+In dir mode (`uloop skills install|uninstall|list --output-dir <path>`), uloop replaces or
+deletes content inside `<path>/<skill-name>/` only when it holds **install evidence** that
+uloop wrote that content. A name match alone never authorizes destruction.
+
+Evidence is one of:
+
+- an exact-name regular `SKILL.md` inside the skill directory (the sync writes it last, so
+  its presence marks a completed install), or
+- a source-owned entry whose content fully equals the current source (the orphan a partial
+  removal leaves behind; this keeps orphan repair working). A match where both sides are
+  empty — an empty file, or a directory with no comparable files — is vacuous and grants no
+  evidence.
+
+Without evidence, the skill is a per-skill **conflict**, not a fatal error: install reports
+the reason in a `SKILL_STORE_CONFLICT` envelope, counts the skill under `Blocked:`, keeps
+syncing the remaining skills, and exits 1; list prints `! <name> (conflict)` with the
+reason and completes; uninstall preserves the content and reports the skill as not found.
+
+Every lookup — the skill directory itself included — compares exact on-disk names from
+`ReadDir`, never path probes, so case-insensitive filesystems (APFS, NTFS) cannot widen a
+"name match" into claiming a user's `Uloop-Sample/`, `skill.md`, or `References/`.
+
+Two deliberate carve-outs from the evidence rule:
+
+- Names ending in `.uloop-tmp-<digits>` / `.uloop-backup-<digits>` are uloop's reserved
+  artifact namespace (only `os.CreateTemp`/`os.MkdirTemp` mint them) and are cleaned even
+  without evidence — except when the name exactly matches a current source-owned entry,
+  which is live managed content. Only regular files ever qualify as ignorable debris.
+- Target mode (`.claude/`, `.agents/`, ...) keeps plain name-based ownership over
+  `uloop-*` directories. Those directories are uloop's designated output location and the
+  `uloop-` prefix is a namespace claim; user edits inside a `uloop-*` skill directory are
+  explicitly out of scope (accepted 2026-08-24).
+
+## Context
+
+Dir mode serves an external skill store: a directory shared by hand-authored skills, other
+tools, and potentially several Unity projects' uloop installs. Skill names are not confined
+to the first-party `uloop-*` set — custom-command skills carry user-chosen names — so no
+prefix convention reserves `<path>/<skill-name>/` for uloop the way it does in target mode.
+
+The initial dir-mode implementation ported target mode's premise ("name match = uloop's")
+into that shared store. Review round 7 (2026-08) built the branch binary and reproduced
+real data loss in the mode's advertised scenario — an external store with foreign files —
+tracing six blockers to that single premise, plus case-insensitive path probes claiming
+case-variant user entries. The ownership model was rewritten in place to the evidence rule
+above; rounds 9–13 then converged (1–4 findings per round, final round zero adopted),
+each fix landing as a few lines plus a regression test.
+
+The deciding argument over "a same-named user skill is the user's own fault": for user
+responsibility to exist, the user must learn about the collision before the damage.
+Name-based deletion discovers the collision only after `os.RemoveAll` succeeded with exit
+code 0 — silently, for a person who may not be the one who created the colliding tool.
+The conflict report is the mechanism that hands the decision to the user. For a publicly
+distributed CLI, one "uloop deleted my skill directory" issue costs more than the
+protection does.
+
+Related settled points, so they are not relitigated finding by finding:
+
+- **No manifest in the store.** Ownership derives from current skill sources only; uloop
+  writes no metadata into the destination. Consequence (accepted): an entry a future skill
+  version removes or renames is left behind rather than cleaned, and evidence gating cannot
+  protect a user file that sits exactly inside the reserved artifact namespace.
+- **Installed-side read failures are states, not errors.** An unreadable store-side
+  `SKILL.md` is a conflict; an unreadable owned entry is `outdated` (self-repair on next
+  sync). Source-side read failures propagate as real errors (fail fast).
+- **No disabled-tool filtering or deprecated-skill cleanup in dir mode.** The store may
+  serve multiple projects; one project's tool settings must not hide or delete skills from
+  it. A disabled tool is still refused at invocation time by the Unity side.
+- **No cross-process locking.** Concurrent uloop runs against one store are unsynchronized
+  everywhere in the CLI; dir mode adds nothing.
+
+## Alternatives rejected
+
+- **Name-based ownership with a documented contract** ("directories named after skills
+  belong to uloop"): removes `skills_dir_status.go` (~280 SLOC) and ~20 tests, but makes
+  silent, irreversible deletion of user content a specified behavior. Rejected for the
+  responsibility argument above.
+- **A manifest file in the store**: would make ownership exact, but contradicts the
+  no-uloop-metadata-in-store trade-off and still breaks for stores edited by other tools.
+- **Evidence-gating the artifact namespace too**: cleanup would merely be delayed until the
+  first successful install creates evidence, so the same file is deleted one command later;
+  gating adds inconsistency without restoring the guarantee.
+
+## Reversal condition
+
+Reopen this decision only if dir mode gains a store-level metadata channel (for example a
+store that is itself uloop-managed end to end), which would make exact ownership tracking
+possible without polluting shared stores — or if the evidence rules demonstrably block a
+mainstream workflow that conflict reporting cannot resolve manually. Rewriting to
+name-based ownership because the evidence code looks large is not a reversal condition;
+the status logic is contained in `skills_dir_status.go` with one entry point
+(`getDirSkillState`), and the regression tests in `skills_dir_test.go` encode each rule
+above.


### PR DESCRIPTION
## Summary
- `uloop skills install|uninstall|list` now accept `--output-dir <path>` to manage skills in any directory, not just the auto-detected agent folders (`.claude`, `.codex`, ...).
- Files the CLI did not write survive install, update, and uninstall untouched: ownership requires evidence of a uloop install (an exact-name SKILL.md, or owned content matching the current source), never a name match alone.

## User Impact
- Before, skills could only be installed into the fixed agent folders resolved from the Unity project root, so external skill stores (such as a package-manager-managed skills directory) could not be kept in sync with `uloop`.
- Now `uloop skills install --output-dir path/to/skills` deploys every skill flat as `<path>/<skill-name>/`, and repeated runs update only stale skills. Uninstall removes only entries a uloop install actually wrote and keeps foreign files and directories in place — including a hand-authored directory that merely uses a skill's name in a store uloop never installed into.

## Changes
- New directory mode in the dispatcher: install/update, uninstall, and list against an arbitrary destination, routed when `--output-dir` is present.
- Ownership is evidence-gated: replacing or deleting anything inside `<path>/<skill-name>/` requires an exact-name SKILL.md or owned content matching the current source (the orphan a partial removal leaves behind, so orphan repair still works: a partially removed skill reads as outdated in list, is repaired as Updated by install, and counts as Removed by uninstall). Owned entry names occupied by content uloop never wrote are reported as a conflict and preserved.
- All name lookups compare exact on-disk names from ReadDir — the skill directory itself included — so a case-insensitive filesystem (macOS, Windows) can never make uloop claim or delete a user's `skill.md`, `References/`, or a hand-authored `Uloop-Sample/` directory as the source-owned entries; an entry matching an owned name only by letter case blocks the skill uniformly on every platform.
- Conflicts are a per-skill status, not a fatal error: install reports the reason on stderr as a classified `SKILL_STORE_CONFLICT` error envelope, counts the skill under `Blocked:`, keeps syncing the remaining skills, prints the full summary, and exits 1; list shows `! <name> (conflict)` with the reason printed under the status row and completes; uninstall preserves the content and reports the skill as not found. One occupied name can no longer leave the store half-synced with no summary.
- Status comparison walks only source-owned content: foreign files are never opened (a multi-gigabyte artifact no longer slows the run, and a FIFO next to SKILL.md no longer blocks forever), and a broken entry inside an owned directory (dangling symlink, unreadable file) marks the skill outdated so the next sync repairs it instead of reporting it as installed. A single comparison function defines "installed owned entry equals source" for every check, so evidence, outdatedness, and repair can never disagree; an owned entry that matches only because both sides are empty proves nothing and grants no delete rights, and source-side symlinks are compared through their targets, exactly as the sync copies them.
- Sync preserves foreign top-level files per skill; source-owned entries (SKILL.md, references/, ...) are compared and replaced as a unit. Owned directories are replaced through a temp copy plus rename with a backup, top-level files are written through a temp file plus rename, and SKILL.md is written last — an interrupted sync cannot truncate files or pair new metadata with old references, and the skill keeps reporting outdated until repaired.
- Symlinks are never followed: a symlink occupying a skill's name or an owned entry name is treated as the occupant itself (conflict, or replaced as a link inside an evidenced install), so operations cannot write into or delete from directories outside the store. An `--output-dir` destination that exists as a regular file is rejected up front, and an empty user-created directory bearing a skill name survives uninstall.
- Temp and backup copies created during a sync carry a `.uloop-tmp-` / `.uloop-backup-` namespace marker, and leftover artifacts from an interrupted sync are cleaned up by install and uninstall. Cleanup matches only that namespace anchored to the all-digit tail `os.CreateTemp` mints, so user files that merely resemble artifacts (`references.backup-manual`, dated backups, `my-archive.uloop-tmp-keepme`) are always preserved as foreign, and an entry whose name exactly matches a current source-owned entry is live managed content that cleanup never touches. This namespace is the one deliberate carve-out from the evidence rule: a name carrying the marker plus an all-digit tail is reserved for uloop (it is what `os.CreateTemp` mints and nothing else writes), so such leftovers are cleaned even in a directory without install evidence — the alternative, a manifest in the store, was rejected by design, and gating on evidence would only delay the same cleanup until the first successful install creates evidence. After artifact cleanup in a directory without install evidence, the directory itself is removed only when fully empty.
- Uninstall removes the skill directory even when OS/tool debris uloop never installs (`.DS_Store`, `Thumbs.db`, `desktop.ini`, Unity `*.meta` stubs of the entries uloop installed) is all that remains, instead of ghosting the directory in the store; only regular files qualify as debris (a directory or symlink bearing a debris name is user data), and a `.meta` file whose stem is not a source-owned entry is the user's own data and keeps the directory alive. The deletion authorization is a dedicated predicate, deliberately separate from the sync copy filter, so widening the copy filter can never silently widen deletions.
- `--output-dir` is mutually exclusive with `--global`, per-target flags, and `--flat` (dir mode always installs flat), is rejected for v3-migration subcommands, and may be passed only once (a repeated occurrence is rejected instead of letting the last win, matching `uloop install --dir`). A flag-like or whitespace-only token after `--output-dir` (a typical unset shell variable) is rejected as a missing value; paths that genuinely start with a dash go through `--output-dir=<path>`. On Windows a POSIX-style path (Git Bash's `/c/apm`) is rejected with guidance instead of being silently anchored under the current drive, while UNC paths (`//server/share`) pass; a destination that exists as a regular file is an argument error, not a retryable internal one. A destination that sits inside a skill source directory, or contains one, is rejected up front — otherwise the sync would copy into the very tree it is enumerating; the check resolves symlinks on both sides (through the nearest existing ancestor for not-yet-created destinations), so a symlink alias cannot smuggle the store into a source.
- Subcommand help documents that skills are sourced from the Unity project (run inside a project or pass --project-path).
- Disabled-tool filtering and deprecated-skill cleanup deliberately do not run in dir mode: an external store may serve more than one project, so one project's tool settings must not hide skills from it, and only source-owned entries may ever be removed. A disabled tool is still refused at invocation time by the Unity side.
- Known limitation (accepted trade-off): ownership is derived from the current skill sources and no manifest is written into the destination, so a top-level entry that a future skill version removes or renames is left behind rather than cleaned up. This keeps external stores free of uloop metadata.
- Option parsing moved into `skills_options.go`, and dir-mode status classification into `skills_dir_status.go`, to keep files within the file-length limit.
- `--output-dir` is documented in both READMEs, and the ownership model — evidence rules, the artifact-namespace carve-out, rejected alternatives, and the reversal condition — is recorded as ADR 0004 (`docs/adr/0004-dir-mode-evidence-gated-ownership.md`) so the settled design questions are not relitigated later.

## Verification
- `scripts/check-go-cli.sh` (format, vet, lint, tests, rebuild) passes; dispatcher tests cover flag parsing (missing/whitespace values, duplicates, conflicts), flat install, foreign-file preservation, evidence gating (never-installed content preserved by install and uninstall, empty owned directories granting no evidence, drifted orphans preserved as recoverable conflicts), case-variant entries (`skill.md`, `References/`, and the skill directory itself) preserved and blocked, per-skill conflict continuation with summary and reason lines, outdated detection including broken owned entries (dangling symlink repair) and working source symlinks, a foreign FIFO not blocking list, artifact cleanup with lookalike and user-`.meta` preservation, and list statuses including conflicts.
- Manual E2E with the dev binary: installed 20 skills flat into a temp directory, added a foreign manifest file, re-ran (all skipped), corrupted one SKILL.md (only that skill updated, manifest preserved), uninstalled (owned files removed, manifest and its directory kept, clean directories removed).
