### PR TITLE
feat: announce pause-point wait start on stderr before the blocking wait

### DIFF
--- a/cli/project-runner/internal/projectrunner/pause_point_enable.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable.go
@@ -343,6 +343,8 @@ func runEnablePausePointAndAwait(
 		markerJustEnabled:     true,
 	}
 
+	announceEnablePausePointAwaitStart(stderr, waitOptions.id, waitOptions.timeoutSeconds)
+
 	return runPausePointWaitAfterEnable(
 		ctx,
 		connection,

--- a/cli/project-runner/internal/projectrunner/pause_point_enable_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable_test.go
@@ -215,7 +215,7 @@ func TestRunEnablePausePointCommandAwaitsAfterSuccessfulEnable(t *testing.T) {
 }
 
 // Verifies enable-pause-point --await prints the armed-wait line to stderr as soon as
-// the marker is armed, and keeps stdout a single JSON object.
+// the marker is armed (before the first status poll), and keeps stdout a single JSON object.
 func TestRunEnablePausePointCommandAnnouncesArmedWaitOnStderr(t *testing.T) {
 	originalQuery := queryPausePointStatus
 	originalPoll := pausePointStatusPoll
@@ -227,12 +227,19 @@ func TestRunEnablePausePointCommandAnnouncesArmedWaitOnStderr(t *testing.T) {
 		fetchMatchingLogs = originalFetch
 	})
 
+	const wantAnnounce = "Pause point armed (Id: jump). Waiting up to 45s for a hit; the JSON response prints only when the wait ends. If this output gets cut off before then, read the outcome with: uloop pause-point-status --id \"jump\"\n"
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
 	statusResponses := []pausePointStatusResponse{
 		{Id: "jump", Status: pausePointStatusEnabled, IsEnabled: true},
 		{Id: "jump", Status: pausePointStatusHit, IsHit: true, HitCount: 1},
 	}
 	statusCallCount := 0
 	queryPausePointStatus = func(ctx context.Context, connection unityipc.Connection, id string) (pausePointStatusResponse, error) {
+		if statusCallCount == 0 && stderr.String() != wantAnnounce {
+			t.Fatalf("announce must appear before the first status poll:\nwant %q\ngot  %q", wantAnnounce, stderr.String())
+		}
 		response := statusResponses[statusCallCount]
 		statusCallCount++
 		return response, nil
@@ -265,8 +272,6 @@ func TestRunEnablePausePointCommandAnnouncesArmedWaitOnStderr(t *testing.T) {
 		ProjectRoot: t.TempDir(),
 	}
 
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
 	code := runEnablePausePointCommand(
 		context.Background(),
 		connection,
@@ -279,8 +284,9 @@ func TestRunEnablePausePointCommandAnnouncesArmedWaitOnStderr(t *testing.T) {
 		t.Fatalf("expected success, got %d with stderr %s", code, stderr.String())
 	}
 	_ = readIPCRequest(t, enableRequests)
-	assertStderrHasExactLine(t, stderr.String(),
-		"Pause point armed (Id: jump). Waiting up to 45s for a hit; the JSON response prints only when the wait ends. If this output gets cut off before then, read the outcome with 'uloop pause-point-status --id jump'.")
+	if stderr.String() != wantAnnounce {
+		t.Fatalf("stderr mismatch:\nwant %q\ngot  %q", wantAnnounce, stderr.String())
+	}
 	assertStdoutIsSingleJSONObject(t, stdout.Bytes())
 
 	var response pausePointWaitResult
@@ -987,6 +993,9 @@ func TestRunEnablePausePointCommandDoesNotAwaitAfterFailedEnable(t *testing.T) {
 	if !strings.Contains(stdout.String(), "Id must not be null or empty.") {
 		t.Fatalf("expected enable failure message in stdout: %s", stdout.String())
 	}
+	if stderr.Len() != 0 {
+		t.Fatalf("failed enable must not announce a wait start, got stderr %q", stderr.String())
+	}
 }
 
 // Verifies enable-pause-point --await's composite wait path mirrors await-pause-point's
@@ -1060,7 +1069,8 @@ func TestRunEnablePausePointCommandAwaitTimeoutIncludesNonFiringHint(t *testing.
 	if code != 1 {
 		t.Fatalf("expected timeout failure, got %d with stdout %s", code, stdout.String())
 	}
-	envelope := parsePausePointErrorEnvelope(t, stderr.Bytes())
+	envelope := parsePausePointErrorEnvelopeAfterAnnounce(t, stderr.Bytes(),
+		"Pause point armed (Id: jump). Waiting up to 1s for a hit; the JSON response prints only when the wait ends. If this output gets cut off before then, read the outcome with: uloop pause-point-status --id \"jump\"")
 	if envelope.Error.Details["Status"] != pausePointStatusCleared {
 		t.Fatalf("status detail mismatch: %#v", envelope.Error.Details)
 	}

--- a/cli/project-runner/internal/projectrunner/pause_point_enable_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_enable_test.go
@@ -214,6 +214,84 @@ func TestRunEnablePausePointCommandAwaitsAfterSuccessfulEnable(t *testing.T) {
 	}
 }
 
+// Verifies enable-pause-point --await prints the armed-wait line to stderr as soon as
+// the marker is armed, and keeps stdout a single JSON object.
+func TestRunEnablePausePointCommandAnnouncesArmedWaitOnStderr(t *testing.T) {
+	originalQuery := queryPausePointStatus
+	originalPoll := pausePointStatusPoll
+	originalFetch := fetchMatchingLogs
+	pausePointStatusPoll = time.Millisecond
+	t.Cleanup(func() {
+		queryPausePointStatus = originalQuery
+		pausePointStatusPoll = originalPoll
+		fetchMatchingLogs = originalFetch
+	})
+
+	statusResponses := []pausePointStatusResponse{
+		{Id: "jump", Status: pausePointStatusEnabled, IsEnabled: true},
+		{Id: "jump", Status: pausePointStatusHit, IsHit: true, HitCount: 1},
+	}
+	statusCallCount := 0
+	queryPausePointStatus = func(ctx context.Context, connection unityipc.Connection, id string) (pausePointStatusResponse, error) {
+		response := statusResponses[statusCallCount]
+		statusCallCount++
+		return response, nil
+	}
+	fetchMatchingLogs = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		searchText string,
+		maxCount int,
+	) (pausePointMatchingLogsResult, error) {
+		return pausePointMatchingLogsResult{SearchText: searchText, Logs: []pausePointMatchingLog{}}, nil
+	}
+
+	listener := newLoopbackIpcListener(t)
+	enableRequests := make(chan map[string]any, 1)
+	serverErr := make(chan error, 1)
+	go serveSingleIPCResponse(
+		listener,
+		pausePointEnableCommandName,
+		enableRequests,
+		serverErr,
+		`{"Success":true,"Id":"jump","Status":"Enabled","IsEnabled":true,"TimeoutSeconds":45}`,
+	)
+
+	connection := unityipc.Connection{
+		Endpoint: unityipc.Endpoint{
+			Network: listener.Addr().Network(),
+			Address: listener.Addr().String(),
+		},
+		ProjectRoot: t.TempDir(),
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runEnablePausePointCommand(
+		context.Background(),
+		connection,
+		[]string{"--id", "jump", "--await"},
+		t.TempDir(),
+		&stdout,
+		&stderr)
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d with stderr %s", code, stderr.String())
+	}
+	_ = readIPCRequest(t, enableRequests)
+	assertStderrHasExactLine(t, stderr.String(),
+		"Pause point armed (Id: jump). Waiting up to 45s for a hit; the JSON response prints only when the wait ends. If this output gets cut off before then, read the outcome with 'uloop pause-point-status --id jump'.")
+	assertStdoutIsSingleJSONObject(t, stdout.Bytes())
+
+	var response pausePointWaitResult
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode stdout: %v\n%s", err, stdout.String())
+	}
+	if response.Status != pausePointStatusHit || response.HitCount != 1 {
+		t.Fatalf("response mismatch: %#v", response)
+	}
+}
+
 // Verifies enable-pause-point --await stdout includes StatusNote on a trace-mode Hit.
 // Removing applyPausePointHitStatusNote from the enable-await hit path makes this test Red.
 func TestRunEnablePausePointCommandIncludesStatusNoteOnTraceHit(t *testing.T) {

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -165,6 +165,7 @@ func runWaitForPausePointCommand(
 	options.startPath = startPath
 
 	extendPausePointExpiryBeforeWait(ctx, connection, options, stderr)
+	announceAwaitPausePointWaitStart(stderr, options.id, options.timeoutSeconds)
 
 	return runWaitForPausePoint(ctx, connection, options, stdout, stderr)
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_announce.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_announce.go
@@ -1,0 +1,26 @@
+package projectrunner
+
+import (
+	"fmt"
+	"io"
+)
+
+const (
+	// pausePointEnableAwaitArmedLineFormat is printed to stderr after enable-pause-point
+	// --await succeeds and the marker is armed, before the blocking wait. Why: some agent
+	// shells cut a foreground call's output window around 30s and drop the wait-end JSON;
+	// this line must appear immediately so the marker Id survives that cutoff.
+	pausePointEnableAwaitArmedLineFormat = "Pause point armed (Id: %s). Waiting up to %ds for a hit; the JSON response prints only when the wait ends. If this output gets cut off before then, read the outcome with 'uloop pause-point-status --id %s'."
+
+	// pausePointAwaitWaitStartLineFormat is printed to stderr when await-pause-point starts
+	// waiting, for the same shell-cutoff reason as the enable --await line.
+	pausePointAwaitWaitStartLineFormat = "Waiting for pause point %s (up to %ds). The JSON response prints only when the wait ends. If this output gets cut off before then, read the outcome with 'uloop pause-point-status --id %s'."
+)
+
+func announceEnablePausePointAwaitStart(stderr io.Writer, id string, timeoutSeconds int) {
+	_, _ = fmt.Fprintln(stderr, fmt.Sprintf(pausePointEnableAwaitArmedLineFormat, id, timeoutSeconds, id))
+}
+
+func announceAwaitPausePointWaitStart(stderr io.Writer, id string, timeoutSeconds int) {
+	_, _ = fmt.Fprintln(stderr, fmt.Sprintf(pausePointAwaitWaitStartLineFormat, id, timeoutSeconds, id))
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_announce.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_announce.go
@@ -10,11 +10,14 @@ const (
 	// --await succeeds and the marker is armed, before the blocking wait. Why: some agent
 	// shells cut a foreground call's output window around 30s and drop the wait-end JSON;
 	// this line must appear immediately so the marker Id survives that cutoff.
-	pausePointEnableAwaitArmedLineFormat = "Pause point armed (Id: %s). Waiting up to %ds for a hit; the JSON response prints only when the wait ends. If this output gets cut off before then, read the outcome with 'uloop pause-point-status --id %s'."
+	// Why %q on the recovery id and no trailing period: source pause-point ids are file:line
+	// and can contain spaces; a period after the quoted id would be parsed as part of the
+	// token (jump. rather than jump).
+	pausePointEnableAwaitArmedLineFormat = "Pause point armed (Id: %s). Waiting up to %ds for a hit; the JSON response prints only when the wait ends. If this output gets cut off before then, read the outcome with: uloop pause-point-status --id %q"
 
 	// pausePointAwaitWaitStartLineFormat is printed to stderr when await-pause-point starts
 	// waiting, for the same shell-cutoff reason as the enable --await line.
-	pausePointAwaitWaitStartLineFormat = "Waiting for pause point %s (up to %ds). The JSON response prints only when the wait ends. If this output gets cut off before then, read the outcome with 'uloop pause-point-status --id %s'."
+	pausePointAwaitWaitStartLineFormat = "Waiting for pause point %s (up to %ds). The JSON response prints only when the wait ends. If this output gets cut off before then, read the outcome with: uloop pause-point-status --id %q"
 )
 
 func announceEnablePausePointAwaitStart(stderr io.Writer, id string, timeoutSeconds int) {

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -133,6 +133,64 @@ func TestRunWaitForPausePointCommandExtendsExpiryBeforePolling(t *testing.T) {
 	}
 }
 
+// Verifies await-pause-point prints the wait-start line to stderr immediately and keeps
+// stdout a single JSON object.
+func TestRunWaitForPausePointCommandAnnouncesWaitStartOnStderr(t *testing.T) {
+	originalExtend := extendPausePointExpiry
+	originalQuery := queryPausePointStatus
+	defer func() {
+		extendPausePointExpiry = originalExtend
+		queryPausePointStatus = originalQuery
+	}()
+
+	extendPausePointExpiry = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+		minimumRemainingSeconds int,
+	) (pausePointStatusResponse, error) {
+		return pausePointStatusResponse{Id: id, Status: pausePointStatusEnabled}, nil
+	}
+	queryPausePointStatus = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+	) (pausePointStatusResponse, error) {
+		return pausePointStatusResponse{
+			Id:          id,
+			Status:      pausePointStatusHit,
+			IsHit:       true,
+			HitCount:    1,
+			EditorState: pausePointEditorState{IsPlaying: true, IsPaused: true, CapturedAt: "PausePointHit"},
+		}, nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runWaitForPausePointCommand(
+		context.Background(),
+		unityipc.Connection{},
+		[]string{"--id", "jump", "--timeout-seconds", "7"},
+		"",
+		&stdout,
+		&stderr)
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d with stderr %s", code, stderr.String())
+	}
+	assertStderrHasExactLine(t, stderr.String(),
+		"Waiting for pause point jump (up to 7s). The JSON response prints only when the wait ends. If this output gets cut off before then, read the outcome with 'uloop pause-point-status --id jump'.")
+	assertStdoutIsSingleJSONObject(t, stdout.Bytes())
+
+	var response pausePointWaitResult
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode stdout: %v\n%s", err, stdout.String())
+	}
+	if response.Status != pausePointStatusHit || response.HitCount != 1 {
+		t.Fatalf("response mismatch: %#v", response)
+	}
+}
+
 // Verifies await-pause-point polls until Unity reports the marker hit.
 func TestWaitForPausePointReturnsHitAfterEnabledStatus(t *testing.T) {
 	originalQuery := queryPausePointStatus
@@ -2394,11 +2452,33 @@ func TestParsePausePointStatusOptionsRequiresID(t *testing.T) {
 func parsePausePointErrorEnvelope(t *testing.T, payload []byte) clierrors.CLIErrorEnvelope {
 	t.Helper()
 
+	jsonStart := bytes.IndexByte(payload, '{')
+	if jsonStart < 0 {
+		t.Fatalf("stderr has no JSON envelope:\n%s", payload)
+	}
+
 	var envelope clierrors.CLIErrorEnvelope
-	if err := json.Unmarshal(payload, &envelope); err != nil {
+	if err := json.Unmarshal(payload[jsonStart:], &envelope); err != nil {
 		t.Fatalf("stderr is not valid JSON: %v\n%s", err, string(payload))
 	}
 	return envelope
+}
+
+func assertStderrHasExactLine(t *testing.T, stderr string, want string) {
+	t.Helper()
+	for _, line := range strings.Split(stderr, "\n") {
+		if line == want {
+			return
+		}
+	}
+	t.Fatalf("stderr missing exact line %q\nstderr:\n%s", want, stderr)
+}
+
+func assertStdoutIsSingleJSONObject(t *testing.T, stdout []byte) {
+	t.Helper()
+	if !json.Valid(bytes.TrimSpace(stdout)) {
+		t.Fatalf("stdout is not a single JSON value:\n%s", stdout)
+	}
 }
 
 // createLaunchTestProject and writeToolSettings are duplicated from

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -133,8 +133,8 @@ func TestRunWaitForPausePointCommandExtendsExpiryBeforePolling(t *testing.T) {
 	}
 }
 
-// Verifies await-pause-point prints the wait-start line to stderr immediately and keeps
-// stdout a single JSON object.
+// Verifies await-pause-point prints the wait-start line to stderr immediately (before the
+// first status poll) and keeps stdout a single JSON object.
 func TestRunWaitForPausePointCommandAnnouncesWaitStartOnStderr(t *testing.T) {
 	originalExtend := extendPausePointExpiry
 	originalQuery := queryPausePointStatus
@@ -142,6 +142,11 @@ func TestRunWaitForPausePointCommandAnnouncesWaitStartOnStderr(t *testing.T) {
 		extendPausePointExpiry = originalExtend
 		queryPausePointStatus = originalQuery
 	}()
+
+	const wantAnnounce = "Waiting for pause point jump (up to 7s). The JSON response prints only when the wait ends. If this output gets cut off before then, read the outcome with: uloop pause-point-status --id \"jump\"\n"
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	statusCallCount := 0
 
 	extendPausePointExpiry = func(
 		ctx context.Context,
@@ -156,6 +161,10 @@ func TestRunWaitForPausePointCommandAnnouncesWaitStartOnStderr(t *testing.T) {
 		connection unityipc.Connection,
 		id string,
 	) (pausePointStatusResponse, error) {
+		if statusCallCount == 0 && stderr.String() != wantAnnounce {
+			t.Fatalf("announce must appear before the first status poll:\nwant %q\ngot  %q", wantAnnounce, stderr.String())
+		}
+		statusCallCount++
 		return pausePointStatusResponse{
 			Id:          id,
 			Status:      pausePointStatusHit,
@@ -165,8 +174,6 @@ func TestRunWaitForPausePointCommandAnnouncesWaitStartOnStderr(t *testing.T) {
 		}, nil
 	}
 
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
 	code := runWaitForPausePointCommand(
 		context.Background(),
 		unityipc.Connection{},
@@ -178,8 +185,9 @@ func TestRunWaitForPausePointCommandAnnouncesWaitStartOnStderr(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("expected success, got %d with stderr %s", code, stderr.String())
 	}
-	assertStderrHasExactLine(t, stderr.String(),
-		"Waiting for pause point jump (up to 7s). The JSON response prints only when the wait ends. If this output gets cut off before then, read the outcome with 'uloop pause-point-status --id jump'.")
+	if stderr.String() != wantAnnounce {
+		t.Fatalf("stderr mismatch:\nwant %q\ngot  %q", wantAnnounce, stderr.String())
+	}
 	assertStdoutIsSingleJSONObject(t, stdout.Bytes())
 
 	var response pausePointWaitResult
@@ -189,6 +197,64 @@ func TestRunWaitForPausePointCommandAnnouncesWaitStartOnStderr(t *testing.T) {
 	if response.Status != pausePointStatusHit || response.HitCount != 1 {
 		t.Fatalf("response mismatch: %#v", response)
 	}
+}
+
+// Verifies await-pause-point quotes a whitespace-containing marker id in the recovery
+// command so the stderr line stays copy-pasteable.
+func TestRunWaitForPausePointCommandQuotesWhitespaceIdOnStderr(t *testing.T) {
+	originalExtend := extendPausePointExpiry
+	originalQuery := queryPausePointStatus
+	defer func() {
+		extendPausePointExpiry = originalExtend
+		queryPausePointStatus = originalQuery
+	}()
+
+	const wantAnnounce = "Waiting for pause point Assets/My Folder/Foo.cs:42 (up to 7s). The JSON response prints only when the wait ends. If this output gets cut off before then, read the outcome with: uloop pause-point-status --id \"Assets/My Folder/Foo.cs:42\"\n"
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	statusCallCount := 0
+
+	extendPausePointExpiry = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+		minimumRemainingSeconds int,
+	) (pausePointStatusResponse, error) {
+		return pausePointStatusResponse{Id: id, Status: pausePointStatusEnabled}, nil
+	}
+	queryPausePointStatus = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+	) (pausePointStatusResponse, error) {
+		if statusCallCount == 0 && stderr.String() != wantAnnounce {
+			t.Fatalf("announce must appear before the first status poll:\nwant %q\ngot  %q", wantAnnounce, stderr.String())
+		}
+		statusCallCount++
+		return pausePointStatusResponse{
+			Id:          id,
+			Status:      pausePointStatusHit,
+			IsHit:       true,
+			HitCount:    1,
+			EditorState: pausePointEditorState{IsPlaying: true, IsPaused: true, CapturedAt: "PausePointHit"},
+		}, nil
+	}
+
+	code := runWaitForPausePointCommand(
+		context.Background(),
+		unityipc.Connection{},
+		[]string{"--id", "Assets/My Folder/Foo.cs:42", "--timeout-seconds", "7"},
+		"",
+		&stdout,
+		&stderr)
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d with stderr %s", code, stderr.String())
+	}
+	if stderr.String() != wantAnnounce {
+		t.Fatalf("stderr mismatch:\nwant %q\ngot  %q", wantAnnounce, stderr.String())
+	}
+	assertStdoutIsSingleJSONObject(t, stdout.Bytes())
 }
 
 // Verifies await-pause-point polls until Unity reports the marker hit.
@@ -2452,26 +2518,20 @@ func TestParsePausePointStatusOptionsRequiresID(t *testing.T) {
 func parsePausePointErrorEnvelope(t *testing.T, payload []byte) clierrors.CLIErrorEnvelope {
 	t.Helper()
 
-	jsonStart := bytes.IndexByte(payload, '{')
-	if jsonStart < 0 {
-		t.Fatalf("stderr has no JSON envelope:\n%s", payload)
-	}
-
 	var envelope clierrors.CLIErrorEnvelope
-	if err := json.Unmarshal(payload[jsonStart:], &envelope); err != nil {
+	if err := json.Unmarshal(payload, &envelope); err != nil {
 		t.Fatalf("stderr is not valid JSON: %v\n%s", err, string(payload))
 	}
 	return envelope
 }
 
-func assertStderrHasExactLine(t *testing.T, stderr string, want string) {
+func parsePausePointErrorEnvelopeAfterAnnounce(t *testing.T, payload []byte, announceLine string) clierrors.CLIErrorEnvelope {
 	t.Helper()
-	for _, line := range strings.Split(stderr, "\n") {
-		if line == want {
-			return
-		}
+	prefix := announceLine + "\n"
+	if !bytes.HasPrefix(payload, []byte(prefix)) {
+		t.Fatalf("stderr missing announce prefix %q\nstderr:\n%s", announceLine, payload)
 	}
-	t.Fatalf("stderr missing exact line %q\nstderr:\n%s", want, stderr)
+	return parsePausePointErrorEnvelope(t, payload[len(prefix):])
 }
 
 func assertStdoutIsSingleJSONObject(t *testing.T, stdout []byte) {


### PR DESCRIPTION
## Summary
- `enable-pause-point --await` and `await-pause-point` now print one stderr progress line as soon as the wait starts, so the marker Id survives if the agent shell cuts off the foreground call before the JSON response.
- stdout stays a single JSON envelope.

## User Impact
- Some agent shells cap a foreground call's output window (often around 30 seconds) regardless of `--timeout-seconds` and report the call as completed with empty output. The wait-end JSON — including the marker Id — was then lost.
- The previous docs workaround (give the wrapper more time than `--timeout-seconds`) does not prevent that cutoff: testers who followed it still lost the response.
- After this change, the armed/waiting line is printed to stderr immediately. If the output is cut off later, the outcome can be read with `uloop pause-point-status --id <id>`.

## Changes
- Print a fixed stderr line after a successful enable when `--await` is used, before the blocking wait, using the enable response's effective timeout.
- Print a fixed stderr line when `await-pause-point` starts waiting, using that command's effective `--timeout-seconds` (default 30).
- Tests assert the full stderr literals and that stdout remains a single JSON object.

## Verification
- `scripts/check-go-cli.sh` passed (gofmt, vet, lint, tests, binary rebuild), including:
  - `TestRunEnablePausePointCommandAnnouncesArmedWaitOnStderr`
  - `TestRunWaitForPausePointCommandAnnouncesWaitStartOnStderr`
- `scripts/check-file-length.sh`: no files exceeded the 500 SLOC limit.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

