### PR TITLE
feat: focus Unity when a compile stalls before compilation starts

### DIFF
--- a/cli/project-runner/internal/projectrunner/compile_wait.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait.go
@@ -223,7 +223,11 @@ func waitForCompileCompletionWithDeps(
 		}
 		logCompileStatusPollObservedIfChanged(options, startedAt, attempts, status, err, &lastObservationKey)
 		observeCompileWaitInterim(&interim, deps, status, err)
-		maybeAttemptCompileStartStallFocus(ctx, startedAt, activityObserved, lastErr, focusController, deps)
+		// Why: queryCompileStatus can return after the wait deadline. Focusing then
+		// would steal window order for a wait that has already timed out.
+		if time.Now().Before(deadline) {
+			maybeAttemptCompileStartStallFocus(ctx, startedAt, activityObserved, lastErr, focusController, deps)
+		}
 
 		select {
 		case <-ctx.Done():

--- a/cli/project-runner/internal/projectrunner/compile_wait.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait.go
@@ -37,6 +37,10 @@ const (
 	compileWaitPollInterval      = clicore.ToolReadinessPoll
 	compileStatusProbeTimeout    = clicore.ToolReadinessProbeTimeout
 	compileResponseTimeout       = 2 * time.Second
+	// Why 10s: AutoTickPump keeps Unity ticking while idle, but cannot lift OS
+	// background throttling. After this long with no compile activity, focusing
+	// the Editor is the only recovery that has been observed to work.
+	compileStartStallFocusThreshold = 10 * time.Second
 )
 
 type compileCompletionOptions struct {
@@ -179,8 +183,19 @@ func waitForCompileCompletionWithDeps(
 	attempts := 0
 	var lastStatus compileStatusResponse
 	observedStatus := false
+	activityObserved := false
 	var lastErr error
 	lastObservationKey := ""
+	focusController := newConnectionRetryFocusController(
+		options.connection,
+		clicore.CompileCommandName,
+		compileWaitFocusDeps(deps),
+	)
+	defer func() {
+		restoreContext, cancel := context.WithTimeout(context.Background(), focusRestoreTimeout)
+		defer cancel()
+		focusController.restore(restoreContext)
+	}()
 
 	logCompileStatusPollStart(options, startedAt, deadline)
 	interim := newCompileWaitInterimState(compileWaitNow(deps))
@@ -196,6 +211,7 @@ func waitForCompileCompletionWithDeps(
 		attempts++
 		status, err := deps.queryCompileStatus(ctx, options.connection, options.requestID)
 		lastErr = err
+		activityObserved = noteCompileActivityStarted(status, err, activityObserved)
 		if err == nil && status.Ready && status.HasResult && len(status.Result) > 0 {
 			logCompileStatusPollObservedIfChanged(options, startedAt, attempts, status, nil, &lastObservationKey)
 			logCompileStatusPollComplete(options, startedAt, attempts, status)
@@ -207,6 +223,7 @@ func waitForCompileCompletionWithDeps(
 		}
 		logCompileStatusPollObservedIfChanged(options, startedAt, attempts, status, err, &lastObservationKey)
 		observeCompileWaitInterim(&interim, deps, status, err)
+		maybeAttemptCompileStartStallFocus(ctx, startedAt, activityObserved, lastErr, focusController, deps)
 
 		select {
 		case <-ctx.Done():

--- a/cli/project-runner/internal/projectrunner/compile_wait_deps.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_deps.go
@@ -25,6 +25,27 @@ type compileWaitDeps struct {
 	now                    func() time.Time
 	interimReportInterval  time.Duration
 	reportInterim          compileWaitInterimReporter
+	// Zero keeps compileStartStallFocusThreshold. Tests shorten it so they do not wait 10s.
+	startStallFocusThreshold time.Duration
+	focus                    connectionRetryDeps
+}
+
+func compileStartStallFocusThresholdFor(deps compileWaitDeps) time.Duration {
+	if deps.startStallFocusThreshold > 0 {
+		return deps.startStallFocusThreshold
+	}
+	return compileStartStallFocusThreshold
+}
+
+func compileWaitFocusDeps(deps compileWaitDeps) connectionRetryDeps {
+	merged := defaultConnectionRetryDeps()
+	if deps.focus.findRunningUnityProcess != nil {
+		merged.findRunningUnityProcess = deps.focus.findRunningUnityProcess
+	}
+	if deps.focus.focusUnityProcess != nil {
+		merged.focusUnityProcess = deps.focus.focusUnityProcess
+	}
+	return merged
 }
 
 func compileSendOrDefault(deps compileWaitDeps) compileSendFunc {

--- a/cli/project-runner/internal/projectrunner/compile_wait_focus.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_focus.go
@@ -1,0 +1,43 @@
+package projectrunner
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var errCompileStartStallNoActivity = errors.New("compile status has not shown activity")
+
+func compileActivityHasStarted(status compileStatusResponse) bool {
+	return status.IsCompiling || status.IsUpdating || status.IsDomainReloadInProgress || status.HasResult
+}
+
+func noteCompileActivityStarted(status compileStatusResponse, err error, activityObserved bool) bool {
+	if err != nil || activityObserved {
+		return activityObserved
+	}
+	return compileActivityHasStarted(status)
+}
+
+func maybeAttemptCompileStartStallFocus(
+	ctx context.Context,
+	startedAt time.Time,
+	activityObserved bool,
+	lastErr error,
+	controller *connectionRetryFocusController,
+	deps compileWaitDeps,
+) {
+	// Why: domain-reload silence after compile has started is normal. Focusing then
+	// would steal window order from the user for a healthy wait.
+	if activityObserved {
+		return
+	}
+	if time.Since(startedAt) < compileStartStallFocusThresholdFor(deps) {
+		return
+	}
+	cause := lastErr
+	if cause == nil {
+		cause = errCompileStartStallNoActivity
+	}
+	controller.tryFocus(ctx, focusReasonCompileStartStall, cause)
+}

--- a/cli/project-runner/internal/projectrunner/compile_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_test.go
@@ -959,6 +959,164 @@ func TestWaitForCompileCompletionReturnsLastStatusOnTimeout(t *testing.T) {
 	}
 }
 
+// Verifies all-idle compile status past the start-stall threshold focuses Unity once
+// with reason compile_start_stall.
+func TestWaitForCompileCompletionFocusesOnceWhenStatusStaysIdle(t *testing.T) {
+	enableCliVibeLog(t)
+	connection := compileWaitTestConnection(t)
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		return compileStatusResponse{}, nil
+	})
+	probe := attachCompileWaitFocusProbe(&deps)
+
+	_, completed, _, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
+		connection:   connection,
+		requestID:    "compile_start_stall_idle",
+		timeout:      200 * time.Millisecond,
+		pollInterval: 5 * time.Millisecond,
+	}, deps)
+	if err != nil {
+		t.Fatalf("waitForCompileCompletion failed: %v", err)
+	}
+	if completed {
+		t.Fatal("idle compile wait should time out")
+	}
+	if probe.focusCount != 1 {
+		t.Fatalf("focus attempts mismatch: got %d want 1", probe.focusCount)
+	}
+
+	logContent := readOnlyCliVibeLog(t, connection.ProjectRoot)
+	attemptEntries := cliVibeEntriesForOperation(t, logContent, "cli_connection_retry_focus_attempt")
+	if len(attemptEntries) != 1 {
+		t.Fatalf("expected exactly 1 focus attempt log, got %d:\n%s", len(attemptEntries), logContent)
+	}
+	reason := vibeLogContextString(t, attemptEntries[0], "reason")
+	expectedReason := "compile_start_stall"
+	if reason != expectedReason {
+		t.Fatalf("focus reason mismatch: got %q want %q", reason, expectedReason)
+	}
+}
+
+// Verifies observing IsCompiling before the threshold suppresses focus even when later polls fail.
+func TestWaitForCompileCompletionDoesNotFocusAfterActivityStarted(t *testing.T) {
+	connection := compileWaitTestConnection(t)
+	callCount := 0
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		callCount++
+		if callCount == 1 {
+			return compileStatusResponse{IsCompiling: true}, nil
+		}
+		return compileStatusResponse{}, fmt.Errorf("status poll failed")
+	})
+	probe := attachCompileWaitFocusProbe(&deps)
+
+	_, completed, _, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
+		connection:   connection,
+		requestID:    "compile_start_stall_activity",
+		timeout:      200 * time.Millisecond,
+		pollInterval: 5 * time.Millisecond,
+	}, deps)
+	if err != nil {
+		t.Fatalf("waitForCompileCompletion failed: %v", err)
+	}
+	if completed {
+		t.Fatal("compile wait should time out after activity then silence")
+	}
+	if probe.focusCount != 0 {
+		t.Fatalf("focus attempts mismatch: got %d want 0", probe.focusCount)
+	}
+}
+
+// Verifies probe errors alone past the threshold still focus Unity once.
+func TestWaitForCompileCompletionFocusesOnceWhenProbesKeepFailing(t *testing.T) {
+	connection := compileWaitTestConnection(t)
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		return compileStatusResponse{}, fmt.Errorf("status probe timeout")
+	})
+	probe := attachCompileWaitFocusProbe(&deps)
+
+	_, completed, _, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
+		connection:   connection,
+		requestID:    "compile_start_stall_probe_error",
+		timeout:      200 * time.Millisecond,
+		pollInterval: 5 * time.Millisecond,
+	}, deps)
+	if err != nil {
+		t.Fatalf("waitForCompileCompletion failed: %v", err)
+	}
+	if completed {
+		t.Fatal("probe-error compile wait should time out")
+	}
+	if probe.focusCount != 1 {
+		t.Fatalf("focus attempts mismatch: got %d want 1", probe.focusCount)
+	}
+}
+
+// Verifies a compile wait that focused Unity restores the previous front window on completion.
+func TestWaitForCompileCompletionRestoresFocusOnCompletion(t *testing.T) {
+	connection := compileWaitTestConnection(t)
+	callCount := 0
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		callCount++
+		if callCount < 8 {
+			return compileStatusResponse{}, nil
+		}
+		return compileStatusResponse{
+			Ready:     true,
+			HasResult: true,
+			Result:    json.RawMessage(`{"Success":true}`),
+		}, nil
+	})
+	probe := attachCompileWaitFocusProbe(&deps)
+
+	result, completed, _, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
+		connection:   connection,
+		requestID:    "compile_start_stall_restore",
+		timeout:      200 * time.Millisecond,
+		pollInterval: 5 * time.Millisecond,
+	}, deps)
+	if err != nil {
+		t.Fatalf("waitForCompileCompletion failed: %v", err)
+	}
+	if !completed {
+		t.Fatal("compile wait should complete after the stall")
+	}
+	if string(result) != `{"Success":true}` {
+		t.Fatalf("result mismatch: %s", result)
+	}
+	if probe.focusCount != 1 {
+		t.Fatalf("focus attempts mismatch: got %d want 1", probe.focusCount)
+	}
+	if probe.restoreCount != 1 {
+		t.Fatalf("restore calls mismatch: got %d want 1", probe.restoreCount)
+	}
+}
+
+// Verifies compile activity is any of IsCompiling, IsUpdating, domain reload, or HasResult,
+// and that Ready alone does not count.
+func TestCompileActivityHasStarted(t *testing.T) {
+	cases := []struct {
+		name   string
+		status compileStatusResponse
+		want   bool
+	}{
+		{name: "all false", status: compileStatusResponse{}, want: false},
+		{name: "IsCompiling", status: compileStatusResponse{IsCompiling: true}, want: true},
+		{name: "IsUpdating", status: compileStatusResponse{IsUpdating: true}, want: true},
+		{name: "IsDomainReloadInProgress", status: compileStatusResponse{IsDomainReloadInProgress: true}, want: true},
+		{name: "HasResult", status: compileStatusResponse{HasResult: true}, want: true},
+		{name: "Ready alone is not activity", status: compileStatusResponse{Ready: true}, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := compileActivityHasStarted(tc.status)
+			if got != tc.want {
+				t.Fatalf("compileActivityHasStarted mismatch: got %v want %v status=%#v", got, tc.want, tc.status)
+			}
+		})
+	}
+}
+
 // assertCompileWaitTimeoutEnvelopeDetails checks the run/attach wiring that passes
 // lastStatus and WaitedMs into the COMPILE_WAIT_TIMEOUT stderr envelope.
 func assertCompileWaitTimeoutEnvelopeDetails(t *testing.T, stderr []byte, wantCompiling bool) {
@@ -1010,4 +1168,39 @@ func compileWaitTestDeps(
 		attachProbeInterval:    5 * time.Millisecond,
 		attachWaitPollInterval: 5 * time.Millisecond,
 	}
+}
+
+type compileWaitFocusProbe struct {
+	focusCount   int
+	restoreCount int
+}
+
+func attachCompileWaitFocusProbe(deps *compileWaitDeps) *compileWaitFocusProbe {
+	probe := &compileWaitFocusProbe{}
+	deps.startStallFocusThreshold = 20 * time.Millisecond
+	deps.focus = defaultConnectionRetryDeps()
+	deps.focus.findRunningUnityProcess = func(context.Context, string) (*clicore.UnityProcess, error) {
+		return &clicore.UnityProcess{Pid: 4242}, nil
+	}
+	deps.focus.focusUnityProcess = func(context.Context, int) (clicore.RestoreFocusFunc, error) {
+		probe.focusCount++
+		return func(context.Context) error {
+			probe.restoreCount++
+			return nil
+		}, nil
+	}
+	return probe
+}
+
+func vibeLogContextString(t *testing.T, entry map[string]any, key string) string {
+	t.Helper()
+	contextMap, ok := entry["context"].(map[string]any)
+	if !ok {
+		t.Fatalf("vibe log context missing: %#v", entry)
+	}
+	value, ok := contextMap[key].(string)
+	if !ok {
+		t.Fatalf("vibe log context %s mismatch: %#v", key, contextMap[key])
+	}
+	return value
 }

--- a/cli/project-runner/internal/projectrunner/compile_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_test.go
@@ -1092,6 +1092,32 @@ func TestWaitForCompileCompletionRestoresFocusOnCompletion(t *testing.T) {
 	}
 }
 
+// Verifies a status probe that returns after the wait deadline does not focus Unity.
+func TestWaitForCompileCompletionDoesNotFocusAfterDeadline(t *testing.T) {
+	connection := compileWaitTestConnection(t)
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+		time.Sleep(250 * time.Millisecond)
+		return compileStatusResponse{}, nil
+	})
+	probe := attachCompileWaitFocusProbe(&deps)
+
+	_, completed, _, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
+		connection:   connection,
+		requestID:    "compile_start_stall_after_deadline",
+		timeout:      200 * time.Millisecond,
+		pollInterval: 5 * time.Millisecond,
+	}, deps)
+	if err != nil {
+		t.Fatalf("waitForCompileCompletion failed: %v", err)
+	}
+	if completed {
+		t.Fatal("deadline-crossing probe should time out")
+	}
+	if probe.focusCount != 0 {
+		t.Fatalf("focus attempts mismatch: got %d want 0", probe.focusCount)
+	}
+}
+
 // Verifies compile activity is any of IsCompiling, IsUpdating, domain reload, or HasResult,
 // and that Ready alone does not count.
 func TestCompileActivityHasStarted(t *testing.T) {

--- a/cli/project-runner/internal/projectrunner/connection_retry.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry.go
@@ -47,6 +47,7 @@ const (
 	focusReasonHeartbeatSilenceTimeout       connectionRetryFocusReason = "heartbeat_silence_timeout"
 	focusReasonFinalResponseTimeout          connectionRetryFocusReason = "final_response_timeout"
 	focusReasonBusyStall                     connectionRetryFocusReason = "busy_stall"
+	focusReasonCompileStartStall             connectionRetryFocusReason = "compile_start_stall"
 )
 
 // Why: domain reload on large projects can keep the IPC endpoint down well past the


### PR DESCRIPTION
## Summary
- `uloop compile` now brings Unity to the front when compilation never starts because the Editor is background-throttled.
- After the wait ends, the previously frontmost window is restored.
- Focus is skipped if a status probe returns after the wait deadline.

## User Impact
- Before: a background Unity process could sit with `is_compiling=false` for tens of seconds (main-loop ticks of 4–5s) before compile even began. Focusing the Editor recovered it immediately; the CLI had no way to do that during status polling.
- After: if 10 seconds of compile-status polls show no compile activity (`IsCompiling`, `IsUpdating`, domain reload, or a stored result), the CLI focuses Unity once. Activity after that point never triggers another focus, so a normal domain reload does not shuffle windows. A probe that returns after the wait deadline also does not focus.

## Changes
- Compile-status wait reuses the connection-retry focus controller with reason `compile_start_stall`.
- Focus is attempted at most once, only before any compile activity is observed, only while `time.Now()` is still before the wait deadline, and restored when the wait returns.
- Probe timeouts and all-idle successful polls both count as "no activity"; `IsCompiling=true` (or the other activity flags) before the threshold suppresses focus for the rest of the wait.

## Verification
- `scripts/check-go-cli.sh` passed (project-runner tests included).
- New tests:
  - idle status past the threshold → exactly one focus, reason `compile_start_stall`
  - `IsCompiling=true` before the threshold → zero focus despite later probe errors
  - probe errors only past the threshold → exactly one focus
  - focused wait that then completes → restore is called once
  - status probe sleeps 250ms with timeout 200ms / threshold 20ms → `focusCount == 0`

## Mutation Red
1. Inverted the activity gate in `maybeAttemptCompileStartStallFocus` from `if activityObserved { return }` to `if !activityObserved { return }`, then re-ran the new tests:

```
--- FAIL: TestWaitForCompileCompletionFocusesOnceWhenStatusStaysIdle
    focus attempts mismatch: got 0 want 1
--- FAIL: TestWaitForCompileCompletionDoesNotFocusAfterActivityStarted
    focus attempts mismatch: got 1 want 0
--- FAIL: TestWaitForCompileCompletionFocusesOnceWhenProbesKeepFailing
    focus attempts mismatch: got 0 want 1
--- FAIL: TestWaitForCompileCompletionRestoresFocusOnCompletion
    focus attempts mismatch: got 0 want 1
```

Restored the original gate; tests passed again.

2. Removed the `if time.Now().Before(deadline)` guard around `maybeAttemptCompileStartStallFocus`, then ran `TestWaitForCompileCompletionDoesNotFocusAfterDeadline`:

```
--- FAIL: TestWaitForCompileCompletionDoesNotFocusAfterDeadline (0.25s)
    compile_wait_test.go:1117: focus attempts mismatch: got 1 want 0
```

Restored the guard; the test passed again.
