### PR TITLE
feat: add arming guidance, re-arm discard warning, and closing-brace warning to enable-pause-point

### DIFF
--- a/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
+++ b/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
@@ -704,7 +704,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                             true)),
                     SourcePausePointConstants.SmallMethodInliningRiskWarning);
                 Assert.That(response.Warning, Is.EqualTo(expectedWarning));
-                Assert.That(response.RecommendedNextAction, Is.EqualTo(string.Empty));
+                string expectedArming =
+                    "Run the code path so the marker can hit, then read the outcome with: uloop pause-point-status --id \""
+                    + ResolveFailureFile
+                    + ":"
+                    + requestedLine
+                    + "\". To arm, trigger, and collect in one call, add --await --resume-play --trigger \"<uloop command>\" next time.";
+                Assert.That(response.RecommendedNextAction, Is.EqualTo(expectedArming));
             }
             finally
             {

--- a/Assets/Tests/Editor/PausePointEnableGuidanceTests.cs
+++ b/Assets/Tests/Editor/PausePointEnableGuidanceTests.cs
@@ -1,0 +1,253 @@
+using System;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.Tests.PausePointToolsFixtures;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies enable-pause-point arming next-action, re-arm discard warning, and closing-brace warning.
+    /// </summary>
+    [TestFixture]
+    public sealed class PausePointEnableGuidanceTests
+    {
+        private const string FixtureFilePath = "Assets/Tests/Editor/PausePointToolsFixture.cs";
+        private const int FixtureStatementLine = 12;
+        private const int FixtureClosingBraceLine = 13;
+
+        private const string ExpectedArmingNextActionForJump =
+            "Run the code path so the marker can hit, then read the outcome with: uloop pause-point-status --id \"jump\". To arm, trigger, and collect in one call, add --await --resume-play --trigger \"<uloop command>\" next time.";
+
+        private const string ExpectedRearmDiscardWarningGeneration1 =
+            "Generation 1 of this pause point had already hit; this re-arm discarded its CapturedVariables and CapturedVariableHistory. Read results with pause-point-status before re-arming when you need them.";
+
+        private const string ExpectedClosingBraceWarningForPlayerMoveLine42 =
+            "--line resolved to the method's closing brace at line 42. Every return path through Player.Move reaches this line, including early returns, so captured variables can reflect a different path than the one you meant. To observe one specific path, target a statement line inside that path.";
+
+        [SetUp]
+        public void SetUp()
+        {
+            UloopPausePointRegistry.ConfigureForTests(new FakePausePointPauseController(), () => DateTime.UtcNow);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            SourcePausePointPatcher.UnpatchAll();
+            UloopPausePointRegistry.ResetForTests();
+        }
+
+        /// <summary>
+        /// What: filling an empty success RecommendedNextAction uses the arming guidance literal.
+        /// </summary>
+        [Test]
+        public void ResolveSuccessEnableRecommendedNextAction_WhenExistingIsEmpty_ReturnsArmingGuidance()
+        {
+            string action = PausePointEnableWarnings.ResolveSuccessEnableRecommendedNextAction(
+                string.Empty,
+                "jump");
+
+            Assert.That(action, Is.EqualTo(ExpectedArmingNextActionForJump));
+        }
+
+        /// <summary>
+        /// What: a non-empty RecommendedNextAction is kept verbatim and is not replaced by arming guidance.
+        /// </summary>
+        [Test]
+        public void ResolveSuccessEnableRecommendedNextAction_WhenExistingIsNonEmpty_KeepsExisting()
+        {
+            const string existing =
+                "Verify ResolvedLineText is the statement you intended. If it is not, run 'uloop compile' "
+                + "and re-enable the pause point.";
+
+            string action = PausePointEnableWarnings.ResolveSuccessEnableRecommendedNextAction(
+                existing,
+                "jump");
+
+            Assert.That(action, Is.EqualTo(existing));
+        }
+
+        /// <summary>
+        /// What: enable by id fills RecommendedNextAction with the arming guidance for that id.
+        /// </summary>
+        [Test]
+        public void Enable_WhenIdPathSucceeds_SetsArmingRecommendedNextAction()
+        {
+            PausePointResponse response = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                Id = "jump",
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.SingleShot
+            });
+
+            Assert.That(response.Success, Is.True, response.ErrorCode + " / " + response.Message);
+            Assert.That(response.RecommendedNextAction, Is.EqualTo(ExpectedArmingNextActionForJump));
+        }
+
+        /// <summary>
+        /// What: enable by file:line fills RecommendedNextAction with arming guidance for the derived id.
+        /// </summary>
+        [Test]
+        public void Enable_WhenFileLinePathSucceeds_SetsArmingRecommendedNextAction()
+        {
+            PausePointResponse response = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureFilePath,
+                Line = FixtureStatementLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.SingleShot
+            });
+
+            Assert.That(
+                response.Success,
+                Is.True,
+                response.ErrorCode + " / " + response.Message);
+            string expected =
+                "Run the code path so the marker can hit, then read the outcome with: uloop pause-point-status --id \""
+                + FixtureFilePath
+                + ":"
+                + FixtureStatementLine
+                + "\". To arm, trigger, and collect in one call, add --await --resume-play --trigger \"<uloop command>\" next time.";
+            Assert.That(response.RecommendedNextAction, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// What: re-arming an id that already hit warns with the previous generation number.
+        /// </summary>
+        [Test]
+        public void Enable_WhenReArmingAfterHit_AppendsDiscardWarning()
+        {
+            PausePointUseCase useCase = new PausePointUseCase();
+            PausePointResponse first = useCase.Enable(new EnablePausePointSchema
+            {
+                Id = "jump",
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.SingleShot
+            });
+            Assert.That(first.Success, Is.True, first.ErrorCode + " / " + first.Message);
+            Assert.That(first.Generation, Is.EqualTo(1));
+            UloopPausePointRegistry.Hit("jump");
+
+            PausePointResponse response = useCase.Enable(new EnablePausePointSchema
+            {
+                Id = "jump",
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.SingleShot
+            });
+
+            Assert.That(response.Success, Is.True, response.ErrorCode + " / " + response.Message);
+            string expectedWarning = PausePointEnableWarnings.MergeWarnings(
+                PausePointEnableWarnings.CreateEnableWarning(),
+                ExpectedRearmDiscardWarningGeneration1);
+            Assert.That(response.Warning, Is.EqualTo(expectedWarning));
+        }
+
+        /// <summary>
+        /// What: re-arming an id that never hit does not add the capture-discard warning.
+        /// </summary>
+        [Test]
+        public void Enable_WhenReArmingBeforeHit_OmitsDiscardWarning()
+        {
+            PausePointUseCase useCase = new PausePointUseCase();
+            PausePointResponse first = useCase.Enable(new EnablePausePointSchema
+            {
+                Id = "jump",
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.SingleShot
+            });
+            Assert.That(first.Success, Is.True, first.ErrorCode + " / " + first.Message);
+
+            PausePointResponse response = useCase.Enable(new EnablePausePointSchema
+            {
+                Id = "jump",
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.SingleShot
+            });
+
+            Assert.That(response.Success, Is.True, response.ErrorCode + " / " + response.Message);
+            Assert.That(response.Warning, Is.EqualTo(PausePointEnableWarnings.CreateEnableWarning()));
+        }
+
+        /// <summary>
+        /// What: a resolved line whose trimmed text is the closing brace uses the closing-brace warning literal.
+        /// </summary>
+        [Test]
+        public void BuildClosingBraceWarningOrEmpty_WhenResolvedLineIsClosingBrace_ReturnsWarning()
+        {
+            string warning = PausePointEnableWarnings.BuildClosingBraceWarningOrEmpty(
+                "}",
+                42,
+                "Player.Move");
+
+            Assert.That(warning, Is.EqualTo(ExpectedClosingBraceWarningForPlayerMoveLine42));
+        }
+
+        /// <summary>
+        /// What: a non-brace resolved line does not produce the closing-brace warning.
+        /// </summary>
+        [Test]
+        public void BuildClosingBraceWarningOrEmpty_WhenResolvedLineIsNotClosingBrace_ReturnsEmpty()
+        {
+            string warning = PausePointEnableWarnings.BuildClosingBraceWarningOrEmpty(
+                "return sum;",
+                12,
+                "EnableBySourceLocationFixture.Add");
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: enabling on the fixture method's closing brace appends the ungated closing-brace warning.
+        /// </summary>
+        [Test]
+        public void Enable_WhenResolvedLineIsMethodClosingBrace_AppendsClosingBraceWarning()
+        {
+            PausePointResponse response = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureFilePath,
+                Line = FixtureClosingBraceLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.SingleShot
+            });
+
+            Assert.That(
+                response.Success,
+                Is.True,
+                response.ErrorCode + " / " + response.Message);
+            Assert.That(response.ResolvedLineText, Is.EqualTo("}"));
+            string expectedClosingBrace =
+                "--line resolved to the method's closing brace at line "
+                + response.ResolvedLine
+                + ". Every return path through "
+                + response.ResolvedMethod
+                + " reaches this line, including early returns, so captured variables can reflect a different path than the one you meant. To observe one specific path, target a statement line inside that path.";
+            string expectedWarning = PausePointEnableWarnings.MergeWarnings(
+                PausePointEnableWarnings.MergeWarnings(
+                    PausePointEnableWarnings.CreateEnableWarning(),
+                    SourcePausePointConstants.SmallMethodInliningRiskWarning),
+                expectedClosingBrace);
+            Assert.That(response.Warning, Is.EqualTo(expectedWarning));
+        }
+
+        private sealed class FakePausePointPauseController : IUloopPausePointPauseController
+        {
+            public int PauseCount { get; private set; }
+            public bool IsPlaying => true;
+            public bool IsPaused => PauseCount > 0;
+
+            public void Pause()
+            {
+                PauseCount++;
+            }
+
+            public void Resume()
+            {
+                PauseCount = 0;
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/PausePointEnableGuidanceTests.cs
+++ b/Assets/Tests/Editor/PausePointEnableGuidanceTests.cs
@@ -25,8 +25,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private const string ExpectedRearmDiscardWarningGeneration1 =
             "Generation 1 of this pause point had already hit; this re-arm discarded its CapturedVariables and CapturedVariableHistory. Read results with pause-point-status before re-arming when you need them.";
 
+        private const string FixtureClosingBraceMethodDisplayName =
+            "System.Int32 io.github.hatayama.UnityCliLoop.Tests.PausePointToolsFixtures.EnableBySourceLocationFixture::Add(System.Int32,System.Int32)";
+
         private const string ExpectedClosingBraceWarningForPlayerMoveLine42 =
             "--line resolved to the method's closing brace at line 42. Every return path through Player.Move reaches this line, including early returns, so captured variables can reflect a different path than the one you meant. To observe one specific path, target a statement line inside that path.";
+
+        private const string ExpectedClosingBraceWarningForFixture =
+            "--line resolved to the method's closing brace at line 13. Every return path through "
+            + FixtureClosingBraceMethodDisplayName
+            + " reaches this line, including early returns, so captured variables can reflect a different path than the one you meant. To observe one specific path, target a statement line inside that path.";
 
         [SetUp]
         public void SetUp()
@@ -173,7 +181,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
-        /// What: a resolved line whose trimmed text is the closing brace uses the closing-brace warning literal.
+        /// What: a resolved closing brace at the compiled method end uses the closing-brace warning literal.
         /// </summary>
         [Test]
         public void BuildClosingBraceWarningOrEmpty_WhenResolvedLineIsClosingBrace_ReturnsWarning()
@@ -181,7 +189,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string warning = PausePointEnableWarnings.BuildClosingBraceWarningOrEmpty(
                 "}",
                 42,
-                "Player.Move");
+                "Player.Move",
+                42,
+                0);
+
+            Assert.That(warning, Is.EqualTo(ExpectedClosingBraceWarningForPlayerMoveLine42));
+        }
+
+        /// <summary>
+        /// What: a closing brace at the edited method end (shim path) uses the same warning literal.
+        /// </summary>
+        [Test]
+        public void BuildClosingBraceWarningOrEmpty_WhenResolvedLineIsEditedMethodEnd_ReturnsWarning()
+        {
+            string warning = PausePointEnableWarnings.BuildClosingBraceWarningOrEmpty(
+                "}",
+                42,
+                "Player.Move",
+                0,
+                42);
 
             Assert.That(warning, Is.EqualTo(ExpectedClosingBraceWarningForPlayerMoveLine42));
         }
@@ -195,13 +221,47 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string warning = PausePointEnableWarnings.BuildClosingBraceWarningOrEmpty(
                 "return sum;",
                 12,
-                "EnableBySourceLocationFixture.Add");
+                "EnableBySourceLocationFixture.Add",
+                13,
+                0);
 
             Assert.That(warning, Is.EqualTo(string.Empty));
         }
 
         /// <summary>
-        /// What: enabling on the fixture method's closing brace appends the ungated closing-brace warning.
+        /// What: a nested closing brace that is not the compiled or edited method end stays silent.
+        /// </summary>
+        [Test]
+        public void BuildClosingBraceWarningOrEmpty_WhenClosingBraceIsNotMethodEnd_ReturnsEmpty()
+        {
+            string warning = PausePointEnableWarnings.BuildClosingBraceWarningOrEmpty(
+                "}",
+                20,
+                "Player.Move",
+                42,
+                40);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: a closing brace with neither compiled nor edited method end available stays silent.
+        /// </summary>
+        [Test]
+        public void BuildClosingBraceWarningOrEmpty_WhenMethodEndIsUnknown_ReturnsEmpty()
+        {
+            string warning = PausePointEnableWarnings.BuildClosingBraceWarningOrEmpty(
+                "}",
+                42,
+                "Player.Move",
+                0,
+                0);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: enabling on the fixture method's closing brace appends the closing-brace warning.
         /// </summary>
         [Test]
         public void Enable_WhenResolvedLineIsMethodClosingBrace_AppendsClosingBraceWarning()
@@ -218,18 +278,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 response.Success,
                 Is.True,
                 response.ErrorCode + " / " + response.Message);
+            Assert.That(response.ResolvedLine, Is.EqualTo(FixtureClosingBraceLine));
             Assert.That(response.ResolvedLineText, Is.EqualTo("}"));
-            string expectedClosingBrace =
-                "--line resolved to the method's closing brace at line "
-                + response.ResolvedLine
-                + ". Every return path through "
-                + response.ResolvedMethod
-                + " reaches this line, including early returns, so captured variables can reflect a different path than the one you meant. To observe one specific path, target a statement line inside that path.";
+            Assert.That(response.ResolvedMethod, Is.EqualTo(FixtureClosingBraceMethodDisplayName));
             string expectedWarning = PausePointEnableWarnings.MergeWarnings(
                 PausePointEnableWarnings.MergeWarnings(
                     PausePointEnableWarnings.CreateEnableWarning(),
                     SourcePausePointConstants.SmallMethodInliningRiskWarning),
-                expectedClosingBrace);
+                ExpectedClosingBraceWarningForFixture);
             Assert.That(response.Warning, Is.EqualTo(expectedWarning));
         }
 

--- a/Assets/Tests/Editor/PausePointEnableGuidanceTests.cs.meta
+++ b/Assets/Tests/Editor/PausePointEnableGuidanceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0a7ec631b60984e97b590ddd96cec906
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -863,7 +863,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // An id-only marker has no resolved source line, so no pre-line timing note applies.
             Assert.That(response.SnapshotTiming, Is.Empty);
             Assert.That(response.EditorState.CapturedAt, Is.EqualTo(UloopPausePointEditorStateCapturedAt.Current));
-            Assert.That(response.RecommendedNextAction, Is.Empty);
+            Assert.That(
+                response.RecommendedNextAction,
+                Is.EqualTo(
+                    "Run the code path so the marker can hit, then read the outcome with: uloop pause-point-status --id \"jump\". To arm, trigger, and collect in one call, add --await --resume-play --trigger \"<uloop command>\" next time."));
         }
 
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEnableWarnings.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEnableWarnings.cs
@@ -64,6 +64,53 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return first + " " + second;
         }
 
+        // Why only when empty: drift and other success-path next-actions must keep their wording.
+        internal static string ResolveSuccessEnableRecommendedNextAction(string existing, string id)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(id), "id must not be empty");
+            if (!string.IsNullOrEmpty(existing))
+            {
+                return existing;
+            }
+
+            return string.Format(
+                SourcePausePointConstants.EnableSuccessArmingRecommendedNextActionFormat,
+                id);
+        }
+
+        // Why HitCount or Hit: Continuous/Trace stay Enabled after a hit, so Status==Hit alone
+        // would miss a re-arm that still discards capture history.
+        internal static string BuildRearmDiscardWarningOrEmpty(UloopPausePointSnapshot previous)
+        {
+            Debug.Assert(previous != null, "previous must not be null");
+            if (previous.HitCount <= 0 && previous.Status != UloopPausePointStatus.Hit)
+            {
+                return string.Empty;
+            }
+
+            return string.Format(
+                SourcePausePointConstants.RearmDiscardCapturedVariablesWarningFormat,
+                previous.Generation);
+        }
+
+        // Why not reuse drift warnings: those are gated on hot-reload patches; a closing brace
+        // is misleading even when the compiled and edited files match.
+        internal static string BuildClosingBraceWarningOrEmpty(
+            string resolvedLineText,
+            int resolvedLine,
+            string resolvedMethod)
+        {
+            if (string.IsNullOrEmpty(resolvedLineText) || resolvedLineText.Trim() != "}")
+            {
+                return string.Empty;
+            }
+
+            return string.Format(
+                SourcePausePointConstants.ClosingBraceResolvedLineWarningFormat,
+                resolvedLine,
+                resolvedMethod);
+        }
+
         // Why Type.Method in the notice: enable's resolved-method string is Cecil FullName, but
         // the warning should name the Unity message the same way agents already read caller frames.
         internal static string BuildPerFrameTraceWarningOrEmpty(

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEnableWarnings.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEnableWarnings.cs
@@ -93,14 +93,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 previous.Generation);
         }
 
-        // Why not reuse drift warnings: those are gated on hot-reload patches; a closing brace
-        // is misleading even when the compiled and edited files match.
+        // Why also match method end: a using/lock Dispose nested "}" has a sequence point, so
+        // Trim()=="}" alone would claim every return path reaches an inner brace.
+        // Why fail-closed when both ends are 0: the "method's closing brace" wording would be a lie.
         internal static string BuildClosingBraceWarningOrEmpty(
             string resolvedLineText,
             int resolvedLine,
-            string resolvedMethod)
+            string resolvedMethod,
+            int compiledMethodEndLine,
+            int editedMethodEndLine)
         {
             if (string.IsNullOrEmpty(resolvedLineText) || resolvedLineText.Trim() != "}")
+            {
+                return string.Empty;
+            }
+
+            bool atCompiledMethodEnd = compiledMethodEndLine > 0 && resolvedLine == compiledMethodEndLine;
+            bool atEditedMethodEnd = editedMethodEndLine > 0 && resolvedLine == editedMethodEndLine;
+            if (!atCompiledMethodEnd && !atEditedMethodEnd)
             {
                 return string.Empty;
             }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
@@ -81,6 +81,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return EnableBySourceLocation(parameters);
             }
 
+            string rearmWarning = PausePointEnableWarnings.BuildRearmDiscardWarningOrEmpty(
+                UloopPausePointRegistry.GetStatus(parameters.Id));
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(
                 parameters.Id,
                 parameters.TimeoutSeconds,
@@ -89,7 +91,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameters.MaxPreviewElements,
                 parameters.MaxCallerFrames);
             PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
-            response.Warning = PausePointEnableWarnings.CreateEnableWarning();
+            response.Warning = PausePointEnableWarnings.MergeWarnings(
+                PausePointEnableWarnings.CreateEnableWarning(),
+                rearmWarning);
+            response.RecommendedNextAction = PausePointEnableWarnings
+                .ResolveSuccessEnableRecommendedNextAction(response.RecommendedNextAction, response.Id);
             LogEnable(response.Id, resolvedMethod: string.Empty, fileLine: string.Empty, response.Mode, response.Warning);
             return response;
         }
@@ -361,6 +367,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int compiledMethodEndLine = 0,
             string patchedMethodPdbUnavailableWarning = "")
         {
+            string rearmWarning = PausePointEnableWarnings.BuildRearmDiscardWarningOrEmpty(
+                UloopPausePointRegistry.GetStatus(id));
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(
                 id,
                 parameters.TimeoutSeconds,
@@ -453,6 +461,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     parameters.Mode,
                     resolvedMethod,
                     snapshot.MaxHistory));
+            response.Warning = PausePointEnableWarnings.MergeWarnings(
+                PausePointEnableWarnings.MergeWarnings(response.Warning, rearmWarning),
+                PausePointEnableWarnings.BuildClosingBraceWarningOrEmpty(
+                    resolvedLineText,
+                    resolvedLine,
+                    resolvedMethod));
+            response.RecommendedNextAction = PausePointEnableWarnings
+                .ResolveSuccessEnableRecommendedNextAction(response.RecommendedNextAction, id);
             LogEnable(response.Id, response.ResolvedMethod, $"{parameters.File}:{response.ResolvedLine}", response.Mode, response.Warning);
 
             if (patchResult.HasPhysicsCallbackWarning)

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
@@ -466,7 +466,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 PausePointEnableWarnings.BuildClosingBraceWarningOrEmpty(
                     resolvedLineText,
                     resolvedLine,
-                    resolvedMethod));
+                    resolvedMethod,
+                    compiledMethodEndLine,
+                    editedMethodEndLine));
             response.RecommendedNextAction = PausePointEnableWarnings
                 .ResolveSuccessEnableRecommendedNextAction(response.RecommendedNextAction, id);
             LogEnable(response.Id, response.ResolvedMethod, $"{parameters.File}:{response.ResolvedLine}", response.Mode, response.Warning);

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -359,5 +359,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             "Hot reload added {1} field(s) to '{0}' ({2}); their values live outside the compiled "
             + "assembly and never appear in CapturedVariables. Read them via a patched method body "
             + "or 'uloop execute-dynamic-code' instead.";
+
+        // Why fill on success: a successful enable currently leaves RecommendedNextAction empty,
+        // so agents arm a marker and then stall instead of running the path or using --await.
+        // Format: marker id.
+        public const string EnableSuccessArmingRecommendedNextActionFormat =
+            "Run the code path so the marker can hit, then read the outcome with: uloop pause-point-status --id \"{0}\". To arm, trigger, and collect in one call, add --await --resume-play --trigger \"<uloop command>\" next time.";
+
+        // Why warn: Registry.Enable replaces the entry and drops CapturedVariables,
+        // CapturedVariableHistory, and hit snapshots. The raw capture holder is kept on purpose.
+        // Format: previous generation number.
+        public const string RearmDiscardCapturedVariablesWarningFormat =
+            "Generation {0} of this pause point had already hit; this re-arm discarded its CapturedVariables and CapturedVariableHistory. Read results with pause-point-status before re-arming when you need them.";
+
+        // Why a new ungated path: existing compiled-line drift warnings only fire when hot-reload
+        // patches are active, but a closing-brace line is misleading even on compiled source.
+        // Format: resolved line, resolved method display name.
+        public const string ClosingBraceResolvedLineWarningFormat =
+            "--line resolved to the method's closing brace at line {0}. Every return path through {1} reaches this line, including early returns, so captured variables can reflect a different path than the one you meant. To observe one specific path, target a statement line inside that path.";
     }
 }


### PR DESCRIPTION
## Summary

- Successful `enable-pause-point` now fills empty `RecommendedNextAction` with arming guidance (`pause-point-status --id` plus the `--await --resume-play --trigger` one-shot path) for both `--id` and `--file/--line`. Existing non-empty next-actions (compiled-line drift) are left unchanged.
- Re-arming an id that already hit warns that this call discarded `CapturedVariables` and `CapturedVariableHistory` (raw capture holder is still kept). Unhit re-arm stays silent.
- When `--line` resolves to a method's closing brace, a warning explains that every return path reaches that line. Detection is `resolvedLineText.Trim() == "}"` **and** `resolvedLine` equals `compiledMethodEndLine` or `editedMethodEndLine`. If neither end is known, the warning is omitted (fail-closed). Nested `using`/`lock` Dispose braces therefore do not get the "every return path" wording.

## Test plan

- [x] `uloop compile` — Success, 0 errors
- [x] EditMode tests: `PausePointEnableGuidanceTests` — 12 passed (includes fixture-literal wiring for the closing-brace warning, helper negatives for end-line mismatch and unknown end)
- [x] Mutation Red (original three gates): inverted `ResolveSuccessEnableRecommendedNextAction` / `BuildRearmDiscardWarningOrEmpty` / `BuildClosingBraceWarningOrEmpty` to no-op. Wiring tests: 3 failed / 0 passed. Restored: 3 passed.
- [x] Mutation Red (method-end gate): forced the compiled/edited end-line check to `if (false)` so any `}` warned. `BuildClosingBraceWarningOrEmpty_WhenClosingBraceIsNotMethodEnd_ReturnsEmpty` and `BuildClosingBraceWarningOrEmpty_WhenMethodEndIsUnknown_ReturnsEmpty`: 2 failed / 0 passed (expected empty, got the closing-brace literal). Restored: `PausePointEnableGuidanceTests` 12 passed.

## User Impact

Agents can arm a marker and immediately know how to hit it and collect the result, instead of stalling after a successful enable. Re-arming after a hit no longer silently drops captured variables, and a closing-brace `--line` no longer looks like a specific-path probe unless it is actually the method end.
