### PR TITLE
feat: disclose hot-reload patches discarded by a test run's deferred domain reload

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -301,7 +301,7 @@ a pause is not evidence either way.
   behavior converges by construction.
 - Patches and loaded shim assemblies are static Editor state and disappear on the next
   domain reload — that includes entering Play Mode with Domain Reload enabled (the
-  default), not just `uloop compile`. `uloop control-play-mode --action Play` warns with
+  default), `uloop compile`, and `uloop run-tests`. `uloop control-play-mode --action Play` warns with
   the counts when it is about to drop patches or pause points. There is no persistence
   and no automatic re-apply.
 - Never reflected by hot reload: initializer changes on compiled fields and new

--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -14,6 +14,8 @@ Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and
 
 Active pause points are automatically cleared (the underlying code patches are removed as well) before test execution begins. Cleared IDs are reported in the response's `ClearedPausePointIds` field.
 
+A test run can end by discarding active hot-reload changes: script edits imported during the run are compiled when the test runner releases its assembly-reload lock, and that deferred domain reload wipes the patches even though the tests themselves ran patched. The response's Warning field reports this; re-apply 'uloop hot-reload' or bake the edits in with 'uloop compile' before the next Play or test run.
+
 `NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints.
 
 ## Usage
@@ -31,6 +33,8 @@ uloop run-tests [options]
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
 | `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
 | `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
+
+exact matches the full test name (Namespace.Class.Method); use regex to run a whole test class, e.g. --filter-type regex --filter 'MyGame\.Tests\.PlayerTests\.'
 
 ## Output
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -301,7 +301,7 @@ a pause is not evidence either way.
   behavior converges by construction.
 - Patches and loaded shim assemblies are static Editor state and disappear on the next
   domain reload — that includes entering Play Mode with Domain Reload enabled (the
-  default), not just `uloop compile`. `uloop control-play-mode --action Play` warns with
+  default), `uloop compile`, and `uloop run-tests`. `uloop control-play-mode --action Play` warns with
   the counts when it is about to drop patches or pause points. There is no persistence
   and no automatic re-apply.
 - Never reflected by hot reload: initializer changes on compiled fields and new

--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -14,6 +14,8 @@ Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and
 
 Active pause points are automatically cleared (the underlying code patches are removed as well) before test execution begins. Cleared IDs are reported in the response's `ClearedPausePointIds` field.
 
+A test run can end by discarding active hot-reload changes: script edits imported during the run are compiled when the test runner releases its assembly-reload lock, and that deferred domain reload wipes the patches even though the tests themselves ran patched. The response's Warning field reports this; re-apply 'uloop hot-reload' or bake the edits in with 'uloop compile' before the next Play or test run.
+
 `NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints.
 
 ## Usage
@@ -31,6 +33,8 @@ uloop run-tests [options]
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
 | `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
 | `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
+
+exact matches the full test name (Namespace.Class.Method); use regex to run a whole test class, e.g. --filter-type regex --filter 'MyGame\.Tests\.PlayerTests\.'
 
 ## Output
 

--- a/Assets/Tests/Editor/RunTestsHotReloadDiscardWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/RunTestsHotReloadDiscardWarningBuilderTests.cs
@@ -1,0 +1,38 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies the run-tests hot-reload discard Warning uses the policy-form literal
+    /// and stays empty when no patches were live at test-run start.
+    /// </summary>
+    public sealed class RunTestsHotReloadDiscardWarningBuilderTests
+    {
+        /// <summary>
+        /// What: a positive live-change count formats the exact policy-form Warning.
+        /// </summary>
+        [Test]
+        public void Build_WhenActiveChangeCountIsTwo_ReturnsExactPolicyFormWarning()
+        {
+            string warning = RunTestsHotReloadDiscardWarningBuilder.Build(2);
+
+            Assert.That(
+                warning,
+                Is.EqualTo(
+                    "2 active hot-reload change(s) were live during this test run. If script changes were imported during the run, the deferred domain reload that follows it discards active patches - check 'uloop hot-reload --status' and re-apply, or run 'uloop compile' to bake them in."));
+        }
+
+        /// <summary>
+        /// What: a zero live-change count produces no Warning text.
+        /// </summary>
+        [Test]
+        public void Build_WhenActiveChangeCountIsZero_ReturnsEmpty()
+        {
+            string warning = RunTestsHotReloadDiscardWarningBuilder.Build(0);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+    }
+}

--- a/Assets/Tests/Editor/RunTestsHotReloadDiscardWarningBuilderTests.cs.meta
+++ b/Assets/Tests/Editor/RunTestsHotReloadDiscardWarningBuilderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0758afb7a4f814b688a3208f7cb6b1a4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/RunTestsResponseContractTests.cs
+++ b/Assets/Tests/Editor/RunTestsResponseContractTests.cs
@@ -81,5 +81,70 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(first.Property("File"), Is.Null);
             Assert.That(first.Property("Line"), Is.Null);
         }
+
+        /// <summary>
+        /// What: an empty Warning is omitted from production JSON so the key cannot reappear unnoticed.
+        /// </summary>
+        [Test]
+        public void RunTestsResponse_WhenWarningIsEmpty_OmitsWarningPropertyFromJson()
+        {
+            RunTestsResponse response = new RunTestsResponse(
+                success: true,
+                message: "Test execution completed with status: Passed",
+                completedAt: "2026-01-01T00:00:00.0000000Z",
+                testCount: 1,
+                passedCount: 1,
+                failedCount: 0,
+                skippedCount: 0,
+                xmlPath: string.Empty,
+                status: RunTestsExecutionStatus.Passed,
+                hasFailures: false,
+                noTestsFound: false,
+                noTestsFoundExplanation: string.Empty);
+
+            JObject parsed = JObject.Parse(
+                JsonConvert.SerializeObject(
+                    response,
+                    Formatting.None,
+                    UnityCliLoopJsonResponseSerializerSettings.Settings));
+
+            Assert.That(parsed.Property("Warning"), Is.Null);
+        }
+
+        /// <summary>
+        /// What: a set Warning serializes under Warning with the exact policy-form sentence.
+        /// </summary>
+        [Test]
+        public void RunTestsResponse_WhenWarningIsSet_SerializesExactPolicyFormSentence()
+        {
+            RunTestsResponse response = new RunTestsResponse(
+                success: true,
+                message: "Test execution completed with status: Passed",
+                completedAt: "2026-01-01T00:00:00.0000000Z",
+                testCount: 1,
+                passedCount: 1,
+                failedCount: 0,
+                skippedCount: 0,
+                xmlPath: string.Empty,
+                status: RunTestsExecutionStatus.Passed,
+                hasFailures: false,
+                noTestsFound: false,
+                noTestsFoundExplanation: string.Empty)
+            {
+                Warning =
+                    "2 active hot-reload change(s) were live during this test run. If script changes were imported during the run, the deferred domain reload that follows it discards active patches - check 'uloop hot-reload --status' and re-apply, or run 'uloop compile' to bake them in."
+            };
+
+            JObject parsed = JObject.Parse(
+                JsonConvert.SerializeObject(
+                    response,
+                    Formatting.None,
+                    UnityCliLoopJsonResponseSerializerSettings.Settings));
+
+            Assert.That(
+                parsed.Value<string>("Warning"),
+                Is.EqualTo(
+                    "2 active hot-reload change(s) were live during this test run. If script changes were imported during the run, the deferred domain reload that follows it discards active patches - check 'uloop hot-reload --status' and re-apply, or run 'uloop compile' to bake them in."));
+        }
     }
 }

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -612,6 +612,81 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.FailedTests, Is.Null);
         }
 
+        /// <summary>
+        /// What: live hot-reload changes at test-run start copy the exact policy-form Warning onto the response.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenHotReloadChangesAreLive_AssignsExactPolicyFormWarning()
+        {
+            StubTestExecutionService executionService = new StubTestExecutionService();
+            StubTestExecutionStateValidationService validationService =
+                new StubTestExecutionStateValidationService(ValidationResult.Success());
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                waitForTestRunnerCleanupAsync: NoCleanupWait,
+                getActiveHotReloadChangeCount: () => 2);
+            RunTestsSchema parameters = new RunTestsSchema();
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(
+                response.Warning,
+                Is.EqualTo(
+                    "2 active hot-reload change(s) were live during this test run. If script changes were imported during the run, the deferred domain reload that follows it discards active patches - check 'uloop hot-reload --status' and re-apply, or run 'uloop compile' to bake them in."));
+        }
+
+        /// <summary>
+        /// What: a test run with no live hot-reload changes leaves Warning empty.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenNoHotReloadChangesAreLive_LeavesWarningEmpty()
+        {
+            StubTestExecutionService executionService = new StubTestExecutionService();
+            StubTestExecutionStateValidationService validationService =
+                new StubTestExecutionStateValidationService(ValidationResult.Success());
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                waitForTestRunnerCleanupAsync: NoCleanupWait,
+                getActiveHotReloadChangeCount: () => 0);
+            RunTestsSchema parameters = new RunTestsSchema();
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: fail-fast validation does not query the live hot-reload change count.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenValidationFails_DoesNotQueryHotReloadChangeCount()
+        {
+            bool getterCalled = false;
+            StubTestExecutionService executionService = new StubTestExecutionService();
+            StubTestExecutionStateValidationService validationService =
+                new StubTestExecutionStateValidationService(
+                    ValidationResult.Failure("EditMode tests cannot run during play mode"));
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                waitForTestRunnerCleanupAsync: NoCleanupWait,
+                getActiveHotReloadChangeCount: () =>
+                {
+                    getterCalled = true;
+                    return 2;
+                });
+            RunTestsSchema parameters = new RunTestsSchema();
+
+            await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(getterCalled, Is.False);
+        }
+
         [Test]
         public async Task ExecuteAsync_WithUnsupportedFilterType_ShouldNotClearPausePoints()
         {

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -685,6 +686,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             await useCase.ExecuteAsync(parameters, CancellationToken.None);
 
             Assert.That(getterCalled, Is.False);
+        }
+
+        /// <summary>
+        /// What: the default getter path reads HotReloadPausePointCoordination.GetActiveHotReloadPatchCount
+        /// into the exact policy-form Warning (stubs keep this from nesting Test Runner).
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenDefaultCoordinationGetterReturnsThree_AssignsExactPolicyFormWarning()
+        {
+            Func<int> originalGetter = HotReloadPausePointCoordination.GetActiveHotReloadPatchCount;
+            HotReloadPausePointCoordination.GetActiveHotReloadPatchCount = () => 3;
+            try
+            {
+                StubTestExecutionService executionService = new StubTestExecutionService();
+                StubTestExecutionStateValidationService validationService =
+                    new StubTestExecutionStateValidationService(ValidationResult.Success());
+                RunTestsUseCase useCase = new RunTestsUseCase(
+                    new TestFilterCreationService(),
+                    executionService,
+                    validationService,
+                    waitForTestRunnerCleanupAsync: NoCleanupWait);
+                RunTestsSchema parameters = new RunTestsSchema();
+
+                RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+                Assert.That(
+                    response.Warning,
+                    Is.EqualTo(
+                        "3 active hot-reload change(s) were live during this test run. If script changes were imported during the run, the deferred domain reload that follows it discards active patches - check 'uloop hot-reload --status' and re-apply, or run 'uloop compile' to bake them in."));
+            }
+            finally
+            {
+                HotReloadPausePointCoordination.GetActiveHotReloadPatchCount = originalGetter;
+            }
         }
 
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -301,7 +301,7 @@ a pause is not evidence either way.
   behavior converges by construction.
 - Patches and loaded shim assemblies are static Editor state and disappear on the next
   domain reload — that includes entering Play Mode with Domain Reload enabled (the
-  default), not just `uloop compile`. `uloop control-play-mode --action Play` warns with
+  default), `uloop compile`, and `uloop run-tests`. `uloop control-play-mode --action Play` warns with
   the counts when it is about to drop patches or pause points. There is no persistence
   and no automatic re-apply.
 - Never reflected by hot reload: initializer changes on compiled fields and new

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs
@@ -11,5 +11,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // listed cap so the truncation is never silent.
         public const string FailedTestDetailsTruncatedMessageFormat =
             "first {0} of {1} failures listed; see XmlPath for full results.";
+
+        // Format: active hot-reload change count at test-run start. Policy-form because
+        // response construction was measured to run before any deferred domain reload.
+        public const string HotReloadDiscardWarningFormat =
+            "{0} active hot-reload change(s) were live during this test run. If script changes were imported during the run, the deferred domain reload that follows it discards active patches - check 'uloop hot-reload --status' and re-apply, or run 'uloop compile' to bake them in.";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsHotReloadDiscardWarningBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsHotReloadDiscardWarningBuilder.cs
@@ -1,0 +1,25 @@
+using System.Globalization;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Builds the run-tests Warning when hot-reload changes were live at the start of the
+    /// run: a deferred domain reload after UnlockReloadAssemblies can discard those patches,
+    /// but the response is assembled before that reload so the wording stays policy-form.
+    /// </summary>
+    internal static class RunTestsHotReloadDiscardWarningBuilder
+    {
+        public static string Build(int activeChangeCountAtStart)
+        {
+            if (activeChangeCountAtStart <= 0)
+            {
+                return string.Empty;
+            }
+
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                RunTestsConstants.HotReloadDiscardWarningFormat,
+                activeChangeCountAtStart);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsHotReloadDiscardWarningBuilder.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsHotReloadDiscardWarningBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb2f080fa23b4455abd80f70065b833a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
@@ -87,6 +87,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public SerializableTestResult.FailedTestDetail[] FailedTests { get; set; }
 
         /// <summary>
+        /// Policy warning when hot-reload changes were live at test-run start. Empty when none
+        /// were active; omitted from JSON via ShouldSerializeWarning.
+        /// </summary>
+        public string Warning { get; set; } = string.Empty;
+
+        // Why omit empty: a clean run with no live patches must not grow a Warning field.
+        public bool ShouldSerializeWarning()
+        {
+            return !string.IsNullOrEmpty(Warning);
+        }
+
+        /// <summary>
         /// Create a new RunTestsResponse. Every field is required so classification decisions
         /// stay at the call site (the Unity Test Runner adapter and use-case), not in this DTO.
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -22,6 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly Func<string, bool, UnityCliLoopTestMode, TestFilterType, string> _appendNoTestsDiagnostics;
         private readonly Func<string[]> _clearActivePausePoints;
         private readonly Func<CancellationToken, Task> _waitForTestRunnerCleanupAsync;
+        private readonly Func<int> _getActiveHotReloadChangeCount;
         private const int TestRunnerCleanupFallbackDelayMilliseconds = 3000;
 
         public RunTestsUseCase()
@@ -38,7 +39,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             TestExecutionStateValidationService validationService,
             Func<string[]> clearActivePausePoints = null,
             Func<CancellationToken, Task> waitForTestRunnerCleanupAsync = null,
-            Func<string, bool, UnityCliLoopTestMode, TestFilterType, string> appendNoTestsDiagnostics = null)
+            Func<string, bool, UnityCliLoopTestMode, TestFilterType, string> appendNoTestsDiagnostics = null,
+            Func<int> getActiveHotReloadChangeCount = null)
         {
             Debug.Assert(filterService != null, "filterService must not be null");
             Debug.Assert(executionService != null, "executionService must not be null");
@@ -52,6 +54,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     noTestsDiagnosticService.AppendDiagnosticsIfNeeded(message, noTestsFound, testMode, filterType));
             _clearActivePausePoints = clearActivePausePoints ?? ClearActivePausePointsDefault;
             _waitForTestRunnerCleanupAsync = waitForTestRunnerCleanupAsync ?? WaitForTestRunnerCleanupAsync;
+            _getActiveHotReloadChangeCount = getActiveHotReloadChangeCount ?? ReadActiveHotReloadChangeCount;
         }
 
         /// <summary>
@@ -103,6 +106,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             string[] clearedPausePointIds = _clearActivePausePoints();
+            int activeHotReloadChangeCountAtStart = _getActiveHotReloadChangeCount();
 
             // 2. Test execution
             // Why ConfigureAwait(false) is paired with SwitchToMainThread inside execution helpers:
@@ -172,6 +176,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 response.FailedTests = result.failedTests;
             }
 
+            response.Warning = RunTestsHotReloadDiscardWarningBuilder.Build(activeHotReloadChangeCountAtStart);
+
             if (result.failedCount > RunTestsConstants.FailedTestDetailsLimit)
             {
                 response.Message = response.Message
@@ -226,6 +232,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return null;
             }
             return result.ClearedIds;
+        }
+
+        private static int ReadActiveHotReloadChangeCount()
+        {
+            Func<int> getter = HotReloadPausePointCoordination.GetActiveHotReloadPatchCount;
+            if (getter == null)
+            {
+                return 0;
+            }
+
+            return getter.Invoke();
         }
 
         private static async Task WaitForTestRunnerCleanupAsync(CancellationToken ct)

--- a/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
@@ -14,6 +14,8 @@ Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and
 
 Active pause points are automatically cleared (the underlying code patches are removed as well) before test execution begins. Cleared IDs are reported in the response's `ClearedPausePointIds` field.
 
+A test run can end by discarding active hot-reload changes: script edits imported during the run are compiled when the test runner releases its assembly-reload lock, and that deferred domain reload wipes the patches even though the tests themselves ran patched. The response's Warning field reports this; re-apply 'uloop hot-reload' or bake the edits in with 'uloop compile' before the next Play or test run.
+
 `NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints.
 
 ## Usage
@@ -31,6 +33,8 @@ uloop run-tests [options]
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
 | `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
 | `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
+
+exact matches the full test name (Namespace.Class.Method); use regex to run a whole test class, e.g. --filter-type regex --filter 'MyGame\.Tests\.PlayerTests\.'
 
 ## Output
 


### PR DESCRIPTION
## Summary
- `uloop run-tests` now reports a `Warning` when hot-reload changes were live at the start of the run, so agents can re-apply patches or compile instead of discovering the discard on the next Play or test run.
- Empty `Warning` is omitted from JSON (`ShouldSerializeWarning`), matching other optional response fields.

## User Impact
- Before: EditMode test completion can unlock a deferred domain reload that wipes active hot-reload patches while the tests themselves still ran patched. The response had no field for this, so the discard was silent.
- After: when at least one hot-reload change was live at test-run start, the response includes the policy-form `Warning` naming `uloop hot-reload --status`, re-apply, and `uloop compile`. Runs with no live patches omit the key.

## Changes
- Added `RunTestsResponse.Warning` (default empty; omitted when empty). Additive wire field; protocol version unchanged.
- `RunTestsUseCase` records the live change count at test-run start via `HotReloadPausePointCoordination.GetActiveHotReloadPatchCount` and assigns the warning after tests complete.
- Policy-form wording is used because response construction was measured to run **before** any deferred domain reload. Completed-form ("this test run's completion discarded N changes") would be a lie on the measured path.
- Skill docs: run-tests explains the discard and the `Warning` field, plus the exact/regex filter note; hot-reload patch lifetime now lists `uloop run-tests` alongside Play entry and compile.
- Generated `.claude/` / `.agents/` skill copies regenerated with `uloop skills install --claude --agents`.
- Default-wiring test: `HotReloadPausePointCoordination.GetActiveHotReloadPatchCount` is swapped to `() => 3` (restored in `try-finally`) and `RunTestsUseCase` is constructed **without** injecting `getActiveHotReloadChangeCount`, so `ReadActiveHotReloadChangeCount` is the path under test. Execution is still stubbed so this does not nest Unity Test Runner.

## Timing measurement (policy-form rationale)

Temporary probes logged `activeChangeCount` at `before_tests`, `after_execution_before_cleanup`, and `response_construction`, plus domain-reload start/complete.

Repro: method-body edit on `Assets/Editor/CustomCommandSamples/HelloWorld/HelloWorldTool.cs` → `uloop hot-reload` (`ActivePatchTotal=1`) → `uloop run-tests` (1 EditMode test). Probes removed before this PR.

Observed during the run-tests command:

```
phase=before_tests                  activeChangeCount=1  isCompiling=False
phase=after_execution_before_cleanup activeChangeCount=1  isCompiling=False
phase=response_construction         activeChangeCount=1  isCompiling=False
```

No `domain_reload_start` fired during that command. After the command returned, `uloop hot-reload --status` still reported `ActivePatchTotal=1`. Response construction therefore happens before (and in this run, without) the deferred domain reload, so the warning is policy-form.

## Mutation Red

Wiring test `ExecuteAsync_WhenHotReloadChangesAreLive_AssignsExactPolicyFormWarning`:

1. Temporarily assigned `response.Warning = string.Empty` immediately after `RunTestsHotReloadDiscardWarningBuilder.Build(...)`.
2. Test failed: `Expected string length 266 but was 0` (expected the exact policy-form sentence, was empty).
3. Restored the assignment; the same test passed again.

Default-wiring test `ExecuteAsync_WhenDefaultCoordinationGetterReturnsThree_AssignsExactPolicyFormWarning`:

1. Temporarily changed `ReadActiveHotReloadChangeCount` to `return 0`.
2. Test failed: `Expected string length 266 but was 0` (expected `"3 active hot-reload change(s) were live during this test run...."`, was empty).
3. Restored the coordination lookup; the same test passed again.

## Verification
- `scripts/build-go-cli.sh` then `dist/darwin-arm64/uloop compile` (Success, ErrorCount 0)
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode` with regex `io\.github\.hatayama\.UnityCliLoop\.Tests\.Editor\.RunTests`: TestCount 70, PassedCount 70
- After the default-wiring test: `uloop compile` Success; the default-wiring test Passed; after mutation Red restore, 5 related tests Passed (2 builder + 2 injected wiring + 1 default wiring)
- `scripts/check-file-length.sh`: no files exceeded the limit
- New tests actually executed (including builder, JSON contract, UseCase injected wiring, and default coordination wiring)
