### PR TITLE
feat: focus a freshly launched Unity while waiting for readiness

### DIFF
--- a/cli/dispatcher/internal/dispatcher/launch.go
+++ b/cli/dispatcher/internal/dispatcher/launch.go
@@ -29,10 +29,13 @@ const (
 	launchReadinessTimeout    = 10 * time.Minute
 	launchV2ServerReadyPoll   = 500 * time.Millisecond
 	launchV2ServerDialTimeout = 1 * time.Second
-	projectVersionFilePath    = "ProjectSettings/ProjectVersion.txt"
-	recoveryDirectoryPath     = "Assets/_Recovery"
-	launchTempDirectoryName   = "Temp"
-	unityLockfileName         = "UnityLockfile"
+	// Why 2s: the UnityLockfile can appear before System Events knows the process.
+	// One retry is enough; more retries would delay a launch that already succeeded.
+	launchFreshFocusRetryDelay = 2 * time.Second
+	projectVersionFilePath     = "ProjectSettings/ProjectVersion.txt"
+	recoveryDirectoryPath      = "Assets/_Recovery"
+	launchTempDirectoryName    = "Temp"
+	unityLockfileName          = "UnityLockfile"
 )
 
 var editorVersionPattern = regexp.MustCompile(`(?m)^m_EditorVersion:\s*(.+)$`)
@@ -293,6 +296,7 @@ func startUnityAndWaitForReadiness(
 		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{ProjectRoot: projectRoot, Command: clicore.LaunchCommandName})
 		return 1
 	}
+	logLaunchFreshFocusWithDeps(ctx, projectRoot, currentPid, deps)
 	writeLaunchReadinessWait(stdout, spinner)
 	if err := waitForLaunchReadinessWithDeps(ctx, projectRoot, deps); err != nil {
 		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{ProjectRoot: projectRoot, Command: clicore.LaunchCommandName})

--- a/cli/dispatcher/internal/dispatcher/launch_deps.go
+++ b/cli/dispatcher/internal/dispatcher/launch_deps.go
@@ -20,6 +20,7 @@ type launchDeps struct {
 	waitForV2ServerReady       func(context.Context, string, string, time.Duration, time.Duration) error
 	waitForToolReadiness       func(context.Context, string, time.Duration) error
 	probeProjectIpcFallback    func(context.Context, string) error
+	sleep                      func(time.Duration)
 }
 
 func defaultLaunchDeps() launchDeps {
@@ -37,5 +38,6 @@ func defaultLaunchDeps() launchDeps {
 		},
 		waitForToolReadiness:    clicore.WaitForToolReadinessWithTimeout,
 		probeProjectIpcFallback: clicore.ProbeToolReadinessSequence,
+		sleep:                   time.Sleep,
 	}
 }

--- a/cli/dispatcher/internal/dispatcher/launch_focus_log.go
+++ b/cli/dispatcher/internal/dispatcher/launch_focus_log.go
@@ -2,6 +2,7 @@ package dispatcher
 
 import (
 	"context"
+	"time"
 
 	"github.com/hatayama/unity-cli-loop/common/vibelog"
 
@@ -108,4 +109,71 @@ func logLaunchV2FocusFailure(projectRoot string, pid int, focusErr error, correl
 		},
 		CorrelationID: correlationID,
 	})
+}
+
+func logLaunchFreshFocusWithDeps(ctx context.Context, projectRoot string, pid int, deps launchDeps) {
+	if attemptLaunchFreshFocus(ctx, projectRoot, pid, deps) {
+		return
+	}
+	launchSleep(deps, launchFreshFocusRetryDelay)
+	_ = attemptLaunchFreshFocus(ctx, projectRoot, pid, deps)
+}
+
+func attemptLaunchFreshFocus(ctx context.Context, projectRoot string, pid int, deps launchDeps) bool {
+	correlationID := vibelog.NewCLIVibeCorrelationID()
+	logLaunchFreshFocusAttempt(projectRoot, pid, correlationID)
+	if err := deps.focusUnityProcess(ctx, pid); err != nil {
+		logLaunchFreshFocusFailure(projectRoot, pid, err, correlationID)
+		return false
+	}
+	logLaunchFreshFocusSuccess(projectRoot, pid, correlationID)
+	return true
+}
+
+func logLaunchFreshFocusAttempt(projectRoot string, pid int, correlationID string) {
+	_ = vibelog.WriteCLIVibeLog(projectRoot, vibelog.CLIVibeLogEntry{
+		Level:     "INFO",
+		Operation: "cli_launch_fresh_focus_attempt",
+		Message:   "Attempting to focus the newly launched Unity process.",
+		Context: map[string]any{
+			"command": "launch",
+			"pid":     pid,
+		},
+		CorrelationID: correlationID,
+	})
+}
+
+func logLaunchFreshFocusSuccess(projectRoot string, pid int, correlationID string) {
+	_ = vibelog.WriteCLIVibeLog(projectRoot, vibelog.CLIVibeLogEntry{
+		Level:     "INFO",
+		Operation: "cli_launch_fresh_focus_success",
+		Message:   "Focused the newly launched Unity process.",
+		Context: map[string]any{
+			"command": "launch",
+			"pid":     pid,
+		},
+		CorrelationID: correlationID,
+	})
+}
+
+func logLaunchFreshFocusFailure(projectRoot string, pid int, focusErr error, correlationID string) {
+	_ = vibelog.WriteCLIVibeLog(projectRoot, vibelog.CLIVibeLogEntry{
+		Level:     "WARNING",
+		Operation: "cli_launch_fresh_focus_failure",
+		Message:   "Failed to focus the newly launched Unity process.",
+		Context: map[string]any{
+			"command":    "launch",
+			"pid":        pid,
+			"focusError": clicore.ErrorMessage(focusErr),
+		},
+		CorrelationID: correlationID,
+	})
+}
+
+func launchSleep(deps launchDeps, delay time.Duration) {
+	if deps.sleep != nil {
+		deps.sleep(delay)
+		return
+	}
+	time.Sleep(delay)
 }

--- a/cli/dispatcher/internal/dispatcher/launch_test.go
+++ b/cli/dispatcher/internal/dispatcher/launch_test.go
@@ -366,6 +366,9 @@ func TestRunLaunchWritesReadyResponseAfterToolReadiness(t *testing.T) {
 	deps.waitForToolReadiness = func(context.Context, string, time.Duration) error {
 		return nil
 	}
+	deps.focusUnityProcess = func(context.Context, int) error {
+		return nil
+	}
 
 	projectRoot := createLaunchTestProject(t)
 	var stdout bytes.Buffer
@@ -813,6 +816,9 @@ func TestRunLaunchRestartWritesProcessTransitionResponse(t *testing.T) {
 	deps.waitForToolReadiness = func(context.Context, string, time.Duration) error {
 		return nil
 	}
+	deps.focusUnityProcess = func(context.Context, int) error {
+		return nil
+	}
 
 	projectRoot := createLaunchTestProject(t)
 	var stdout bytes.Buffer
@@ -979,6 +985,9 @@ func TestRunLaunchWritesExistingFocusSuccessVibeLog(t *testing.T) {
 			t.Fatalf("CLI Vibe log missing %q:\n%s", expected, logContent)
 		}
 	}
+	if strings.Contains(logContent, `"operation":"cli_launch_fresh_focus_attempt"`) {
+		t.Fatalf("existing launch must not write a fresh-focus vibe log:\n%s", logContent)
+	}
 }
 
 // Verifies launch logs focus failures without changing its existing success behavior.
@@ -1023,6 +1032,109 @@ func TestRunLaunchWritesExistingFocusFailureVibeLog(t *testing.T) {
 		if !strings.Contains(logContent, expected) {
 			t.Fatalf("CLI Vibe log missing %q:\n%s", expected, logContent)
 		}
+	}
+}
+
+func TestRunLaunchFocusesFreshUnityAfterStartupMarker(t *testing.T) {
+	enableCliVibeLog(t)
+	deps := defaultLaunchDeps()
+	focusedPids := []int{}
+	deps.findRunningUnityProcess = func(context.Context, string) (*clicore.UnityProcess, error) {
+		return nil, nil
+	}
+	deps.resolveUnityExecutablePath = func(string) (string, error) {
+		return fakeUnityExecutablePath(t), nil
+	}
+	deps.waitForUnityStartupMarker = func(context.Context, string, time.Duration, time.Duration) error {
+		return nil
+	}
+	deps.waitForToolReadiness = func(context.Context, string, time.Duration) error {
+		return nil
+	}
+	deps.focusUnityProcess = func(_ context.Context, pid int) error {
+		focusedPids = append(focusedPids, pid)
+		return nil
+	}
+
+	projectRoot := createLaunchTestProject(t)
+	var stdout bytes.Buffer
+	code := runLaunchWithDeps(
+		context.Background(),
+		launchOptions{projectPath: projectRoot, editorVersion: "6000.0.0f1"},
+		projectRoot,
+		&stdout,
+		io.Discard,
+		deps,
+	)
+	if code != 0 {
+		t.Fatalf("exit code mismatch: %d", code)
+	}
+	if len(focusedPids) != 1 {
+		t.Fatalf("focus calls mismatch: got %d want 1 pids=%v", len(focusedPids), focusedPids)
+	}
+	response := decodeLaunchResponseFromOutput(t, stdout.String())
+	if response.CurrentProcessId == nil || *response.CurrentProcessId != focusedPids[0] {
+		t.Fatalf("focused pid mismatch: focused=%v current=%#v", focusedPids, response.CurrentProcessId)
+	}
+	logContent := readOnlyCliVibeLog(t, projectRoot)
+	expectedAttempt := `"operation":"cli_launch_fresh_focus_attempt"`
+	expectedSuccess := `"operation":"cli_launch_fresh_focus_success"`
+	if !strings.Contains(logContent, expectedAttempt) {
+		t.Fatalf("CLI Vibe log missing %q:\n%s", expectedAttempt, logContent)
+	}
+	if !strings.Contains(logContent, expectedSuccess) {
+		t.Fatalf("CLI Vibe log missing %q:\n%s", expectedSuccess, logContent)
+	}
+}
+
+func TestRunLaunchSucceedsWhenFreshFocusFails(t *testing.T) {
+	enableCliVibeLog(t)
+	deps := defaultLaunchDeps()
+	focusCount := 0
+	var slept time.Duration
+	deps.findRunningUnityProcess = func(context.Context, string) (*clicore.UnityProcess, error) {
+		return nil, nil
+	}
+	deps.resolveUnityExecutablePath = func(string) (string, error) {
+		return fakeUnityExecutablePath(t), nil
+	}
+	deps.waitForUnityStartupMarker = func(context.Context, string, time.Duration, time.Duration) error {
+		return nil
+	}
+	deps.waitForToolReadiness = func(context.Context, string, time.Duration) error {
+		return nil
+	}
+	deps.focusUnityProcess = func(context.Context, int) error {
+		focusCount++
+		return errors.New("system events not ready")
+	}
+	deps.sleep = func(d time.Duration) {
+		slept = d
+	}
+
+	projectRoot := createLaunchTestProject(t)
+	var stdout bytes.Buffer
+	code := runLaunchWithDeps(
+		context.Background(),
+		launchOptions{projectPath: projectRoot, editorVersion: "6000.0.0f1"},
+		projectRoot,
+		&stdout,
+		io.Discard,
+		deps,
+	)
+	if code != 0 {
+		t.Fatalf("fresh focus failure must not fail launch: code=%d", code)
+	}
+	if focusCount != 2 {
+		t.Fatalf("focus attempts mismatch: got %d want 2", focusCount)
+	}
+	if slept != launchFreshFocusRetryDelay {
+		t.Fatalf("retry delay mismatch: got %s want %s", slept, launchFreshFocusRetryDelay)
+	}
+	logContent := readOnlyCliVibeLog(t, projectRoot)
+	expectedFailure := `"operation":"cli_launch_fresh_focus_failure"`
+	if !strings.Contains(logContent, expectedFailure) {
+		t.Fatalf("CLI Vibe log missing %q:\n%s", expectedFailure, logContent)
 	}
 }
 

--- a/cli/dispatcher/internal/dispatcher/launch_test.go
+++ b/cli/dispatcher/internal/dispatcher/launch_test.go
@@ -1039,6 +1039,7 @@ func TestRunLaunchFocusesFreshUnityAfterStartupMarker(t *testing.T) {
 	enableCliVibeLog(t)
 	deps := defaultLaunchDeps()
 	focusedPids := []int{}
+	events := []string{}
 	deps.findRunningUnityProcess = func(context.Context, string) (*clicore.UnityProcess, error) {
 		return nil, nil
 	}
@@ -1046,12 +1047,14 @@ func TestRunLaunchFocusesFreshUnityAfterStartupMarker(t *testing.T) {
 		return fakeUnityExecutablePath(t), nil
 	}
 	deps.waitForUnityStartupMarker = func(context.Context, string, time.Duration, time.Duration) error {
+		events = append(events, "startup_marker")
 		return nil
 	}
 	deps.waitForToolReadiness = func(context.Context, string, time.Duration) error {
 		return nil
 	}
 	deps.focusUnityProcess = func(_ context.Context, pid int) error {
+		events = append(events, "focus")
 		focusedPids = append(focusedPids, pid)
 		return nil
 	}
@@ -1071,6 +1074,10 @@ func TestRunLaunchFocusesFreshUnityAfterStartupMarker(t *testing.T) {
 	}
 	if len(focusedPids) != 1 {
 		t.Fatalf("focus calls mismatch: got %d want 1 pids=%v", len(focusedPids), focusedPids)
+	}
+	expectedEvents := []string{"startup_marker", "focus"}
+	if !slices.Equal(events, expectedEvents) {
+		t.Fatalf("call order mismatch: got %v want %v", events, expectedEvents)
 	}
 	response := decodeLaunchResponseFromOutput(t, stdout.String())
 	if response.CurrentProcessId == nil || *response.CurrentProcessId != focusedPids[0] {


### PR DESCRIPTION
## Summary
- `uloop launch` now brings a newly started Unity Editor to the front while waiting for readiness.
- Focus failure does not fail the launch; the CLI retries once after 2 seconds and then continues.

## User Impact
- Before: a fresh Unity process was spawned in the background. On a busy machine it could sit unfocused until the user clicked the window, delaying lockfile/readiness.
- After: once the startup marker (UnityLockfile) appears, launch focuses that new PID. If System Events has not registered the process yet, it retries once after 2 seconds. An already-running Editor still uses the existing focus path.

## Changes
- After `waitForUnityStartupMarker` succeeds, call a new fresh-focus helper on `command.Process.Pid` with no restore (launch is an explicit user action).
- Vibe logs: `cli_launch_fresh_focus_attempt` / `_success` / `_failure`.
- V2 fresh launch already focuses after the lockfile via `cli_launch_v2_focus_*`; this PR leaves that path unchanged.

## Verification
- `scripts/check-go-cli.sh` passed (dispatcher tests included).
- `TestRunLaunchFocusesFreshUnityAfterStartupMarker`: exactly one focus on `CurrentProcessId`, vibe ops `cli_launch_fresh_focus_attempt` and `_success`, and call order `[]string{"startup_marker", "focus"}`.
- `TestRunLaunchSucceedsWhenFreshFocusFails`: launch exit 0, two focus attempts, retry delay `2s`, vibe op `cli_launch_fresh_focus_failure`.
- Existing-instance vibe test still records `cli_launch_existing_focus_*` and not `cli_launch_fresh_focus_attempt`.

## Mutation Red
1. Removed `logLaunchFreshFocusWithDeps(...)` after the startup-marker wait and re-ran the new tests:

```
--- FAIL: TestRunLaunchFocusesFreshUnityAfterStartupMarker
    focus calls mismatch: got 0 want 1 pids=[]
--- FAIL: TestRunLaunchSucceedsWhenFreshFocusFails
    focus attempts mismatch: got 0 want 2
```

Restored the call; tests passed again.

2. Moved `logLaunchFreshFocusWithDeps(...)` to before `waitForUnityStartupMarker` and re-ran `TestRunLaunchFocusesFreshUnityAfterStartupMarker`:

```
--- FAIL: TestRunLaunchFocusesFreshUnityAfterStartupMarker (0.00s)
    launch_test.go:1080: call order mismatch: got [focus startup_marker] want [startup_marker focus]
```

Restored the original order; the test passed again.
