### PR TITLE
fix: warn on hot-reloaded new consts and disclose that patched bodies keep compiled const values

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1488,6 +1488,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: adding a const on the holder and hot-reloading holder plus referencing file
+        /// together emits the exact new-const warning.
+        /// </summary>
+        [Test]
+        public async Task Run_HolderAndReferencingFiles_WhenConstIsAdded_WarnsNewConstExactLiteral()
+        {
+            using (MutateSiblingDefinitionsToAddConst())
+            {
+                HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                    new[] { ResolveSiblingConstDefinitionsPath(), ResolveSiblingConstUserPath() },
+                    null,
+                    CancellationToken.None);
+
+                AssertNoFileLevelFailure(result);
+                Assert.That(
+                    result.Warnings,
+                    Has.Some.EqualTo(ExpectedAddedSiblingTuningWarning),
+                    "Expected the new-const warning when the holder and referencing file reload together.\n"
+                    + string.Join("\n", result.Warnings));
+            }
+        }
+
+        /// <summary>
         /// What: passing the holder first, then the referencing file, still emits the sibling
         /// const-drift warning once (reversed input order of the holder+user case).
         /// </summary>
@@ -6076,7 +6099,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         private const string ExpectedSiblingTuningDriftWarning =
-            "const io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadSiblingConstDefinitions.SiblingTuning is 7 in the edited source but 6 in the compiled assembly; edits outside method bodies never take effect through hot reload. Run 'uloop compile' to apply this change.";
+            "const io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadSiblingConstDefinitions.SiblingTuning is 7 in the edited source but 6 in the compiled assembly; edits outside method bodies never take effect through hot reload - a method body patched in the same run still compiles against the compiled assembly and keeps the old value. Run 'uloop compile' to apply this change.";
+
+        private const string ExpectedAddedSiblingTuningWarning =
+            "const io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadSiblingConstDefinitions.AddedSiblingTuning exists only in the edited source, not in the compiled assembly. A method body in this file patched in this same run has the new value folded in, but bodies in other files that reference it fail shim compilation. Run 'uloop compile' to add it to the assemblies.";
 
         private static IDisposable MutateSiblingTuningValue(int newValue)
         {
@@ -6093,6 +6119,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 original.Replace(
                     compiledDeclaration,
                     "public const int SiblingTuning = " + newValue + ";"));
+            return new FileRestoreScope(new[] { path }, new[] { original });
+        }
+
+        private static IDisposable MutateSiblingDefinitionsToAddConst()
+        {
+            string path = ResolveSiblingConstDefinitionsPath();
+            string original = File.ReadAllText(path);
+            string compiledDeclaration = "public const int SiblingTuning = 6;";
+            Assert.That(
+                original.Contains(compiledDeclaration),
+                Is.True,
+                "Precondition: compiled sibling const declaration must still be on disk.");
+            EditorApplication.LockReloadAssemblies();
+            File.WriteAllText(
+                path,
+                original.Replace(
+                    compiledDeclaration,
+                    compiledDeclaration + "\n        public const int AddedSiblingTuning = 9;"));
             return new FileRestoreScope(new[] { path }, new[] { original });
         }
 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -805,13 +805,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 result.Output.siblingConstDriftWarnings,
                 Has.Some.EqualTo(
-                    "const io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadSiblingConstDefinitions.SiblingTuning is 7 in the edited source but 6 in the compiled assembly; edits outside method bodies never take effect through hot reload. Run 'uloop compile' to apply this change."),
+                    "const io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadSiblingConstDefinitions.SiblingTuning is 7 in the edited source but 6 in the compiled assembly; edits outside method bodies never take effect through hot reload - a method body patched in the same run still compiles against the compiled assembly and keeps the old value. Run 'uloop compile' to apply this change."),
                 "Sibling const drift must use the same warning text as an edited-file const drift.\n"
                 + string.Join("\n", result.Output.siblingConstDriftWarnings));
             Assert.That(
                 result.Output.declarationDriftWarnings,
                 Has.None.EqualTo(
-                    "const io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadSiblingConstDefinitions.SiblingTuning is 7 in the edited source but 6 in the compiled assembly; edits outside method bodies never take effect through hot reload. Run 'uloop compile' to apply this change."),
+                    "const io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadSiblingConstDefinitions.SiblingTuning is 7 in the edited source but 6 in the compiled assembly; edits outside method bodies never take effect through hot reload - a method body patched in the same run still compiles against the compiled assembly and keeps the old value. Run 'uloop compile' to apply this change."),
                 "Sibling const-drift warnings must stay on siblingConstDriftWarnings, not declarationDriftWarnings.");
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ConstDriftCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ConstDriftCollector.cs
@@ -17,11 +17,18 @@ using Microsoft.CodeAnalysis.Text;
 
 internal static class ConstDriftCollector
 {
+    internal const string NewConstWarningFormat =
+        "const {0} exists only in the edited source, not in the compiled assembly. A method body in this file patched in this same run has the new value folded in, but bodies in other files that reference it fail shim compilation. Run 'uloop compile' to add it to the assemblies.";
+
+    internal const string ChangedConstWarningFormat =
+        "const {0} is {1} in the edited source but {2} in the compiled assembly; edits outside method bodies never take effect through hot reload - a method body patched in the same run still compiles against the compiled assembly and keeps the old value. Run 'uloop compile' to apply this change.";
+
     /// <summary>
     /// Detects const declarations (including enum members) in the edited source whose values
-    /// differ from the compiled target assembly. C# inlines const values at compile time and
-    /// shims compile against the already-compiled assembly, so such edits silently keep the old
-    /// value at runtime; each drift becomes a response warning instead of a silent no-op.
+    /// differ from the compiled target assembly, and consts that exist only in the edited source.
+    /// C# inlines const values at compile time and shims compile against the already-compiled
+    /// assembly, so value edits silently keep the old value at runtime; new consts fold into
+    /// same-file patched bodies but fail shim compilation in other files.
     /// </summary>
     internal static List<string> CollectConstDriftWarnings(
         CompilationUnitSyntax root,
@@ -76,11 +83,14 @@ internal static class ConstDriftCollector
                     }
                 }
 
+                string constDisplayName = sourceType.ToDisplayString() + "." + sourceField.Name;
                 if (compiledField == null)
                 {
-                    // A const missing from the compiled assembly is a new declaration, not a
-                    // drift; bodies reading it already fail shim compilation with their own
-                    // actionable error.
+                    warnings.Add(
+                        string.Format(
+                            CultureInfo.InvariantCulture,
+                            NewConstWarningFormat,
+                            constDisplayName));
                     continue;
                 }
 
@@ -90,11 +100,12 @@ internal static class ConstDriftCollector
                 }
 
                 warnings.Add(
-                    "const " + sourceType.ToDisplayString() + "." + sourceField.Name
-                    + " is " + FormatConstValue(sourceField.ConstantValue)
-                    + " in the edited source but " + FormatConstValue(compiledField.ConstantValue)
-                    + " in the compiled assembly; edits outside method bodies never take effect "
-                    + "through hot reload. Run 'uloop compile' to apply this change.");
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        ChangedConstWarningFormat,
+                        constDisplayName,
+                        FormatConstValue(sourceField.ConstantValue),
+                        FormatConstValue(compiledField.ConstantValue)));
             }
         }
 


### PR DESCRIPTION
## Summary
- `uloop hot-reload` now warns when a `const` exists only in the edited source, and the existing value-change warning now states that a method body patched in the same run still keeps the compiled const value.

## User Impact
- Before: a newly added const was silent (no drift warning, no outside-body warning, no AddedFields row). A changed const warned that outside-body edits do not take effect, but did not say that a same-run patched body still folds the **compiled** value.
- After: a new const is named in `Warnings` with the compile recovery. A changed const warning includes the extra sentence that same-run patched bodies keep the old compiled value.

## Changes
- `ConstDriftCollector` emits the new-const warning when `compiledField == null` instead of skipping.
- The changed-const warning is the previous sentence plus the same-run patched-body disclosure. Existing full-literal tests were updated in place.
- Added `Run_HolderAndReferencingFiles_WhenConstIsAdded_WarnsNewConstExactLiteral`: holder file gains `AddedSiblingTuning`, both holder and referencing files are hot-reloaded, `Warnings` contains the exact new-const sentence.

## Mutation Red

`Run_HolderAndReferencingFiles_WhenConstIsAdded_WarnsNewConstExactLiteral`:

1. Temporarily skipped the new-const `warnings.Add` (`compiledField == null` continued with no warning).
2. Test failed: expected the exact `AddedSiblingTuning exists only in the edited source...` sentence, but `Warnings` was empty.
3. Restored the warning; the same test passed again.

## Verification
- `dist/darwin-arm64/uloop compile`: Success, ErrorCount 0
- `uloop run-tests` regex covering sibling/new/value const tests: TestCount 7, PassedCount 7, including the new exact-literal test
- `scripts/check-file-length.sh`: no files exceeded the limit


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

