### PR TITLE
fix: teach missing-id and unexpected-argument NextActions about file:line ids and comma lists

### DIFF
--- a/cli/project-runner/internal/projectrunner/pause_point_errors.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors.go
@@ -281,6 +281,11 @@ func parsePausePointFileLineID(id string) (string, int, bool) {
 	if err != nil {
 		return "", 0, false
 	}
+	// Why reject 0: C# only builds file:line ids from Line > 0, so `--line 0` is always
+	// rejected by enable-pause-point. Digits-only parsing makes this a zero check.
+	if line <= 0 {
+		return "", 0, false
+	}
 	return path, line, true
 }
 

--- a/cli/project-runner/internal/projectrunner/pause_point_errors.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors.go
@@ -2,6 +2,8 @@ package projectrunner
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
@@ -231,15 +233,23 @@ func pausePointStateError(
 		SafeToRetry: retryable,
 		ProjectRoot: projectRoot,
 		Command:     clicore.PausePointAwaitCommandName,
-		NextActions: pausePointStateNextActions(response),
+		NextActions: pausePointStateNextActions(options.id, response),
 		Details:     pausePointStateErrorDetails(options, response),
 	}
 }
 
-func pausePointStateNextActions(response pausePointStatusResponse) []string {
+func pausePointStateNextActions(id string, response pausePointStatusResponse) []string {
+	rearmAction := "Run `uloop enable-pause-point --id <marker-id>` before waiting."
+	confirmAction := "Confirm the code path calls `UloopPausePoint.Pause(\"<marker-id>\")` with the same id."
+	if path, line, ok := parsePausePointFileLineID(id); ok {
+		rearmAction = fmt.Sprintf(
+			"Re-arm it with uloop enable-pause-point --file %q --line %d before waiting.", path, line)
+		confirmAction = fmt.Sprintf(
+			"Confirm the code path executes line %d of %s while the marker is armed.", line, path)
+	}
 	nextActions := []string{
-		"Run `uloop enable-pause-point --id <marker-id>` before waiting.",
-		"Confirm the code path calls `UloopPausePoint.Pause(\"<marker-id>\")` with the same id.",
+		rearmAction,
+		confirmAction,
 		"Check `Details.Status`, `Details.EditorState`, `Details.ElapsedSinceEnabledMilliseconds`, and `Details.RemainingMilliseconds` to distinguish a missed code path from an already-paused Editor.",
 		"If the marker is inside a custom asmdef, add a reference to `UnityCLILoop.PausePoints.Runtime`.",
 	}
@@ -247,6 +257,31 @@ func pausePointStateNextActions(response pausePointStatusResponse) []string {
 		return nextActions
 	}
 	return append([]string{response.RecommendedNextAction}, nextActions...)
+}
+
+// parsePausePointFileLineID reports a file:line marker id that ends in `.cs:<digits>`.
+// Why this suffix only: code-marker ids can contain colons, so a generic last-colon split
+// would rewrite Pause("scene:jump") guidance into a --file/--line command that cannot arm it.
+func parsePausePointFileLineID(id string) (string, int, bool) {
+	suffixIndex := strings.LastIndex(id, ".cs:")
+	if suffixIndex < 0 {
+		return "", 0, false
+	}
+	path := id[:suffixIndex+len(".cs")]
+	lineText := id[suffixIndex+len(".cs:"):]
+	if lineText == "" {
+		return "", 0, false
+	}
+	for _, r := range lineText {
+		if r < '0' || r > '9' {
+			return "", 0, false
+		}
+	}
+	line, err := strconv.Atoi(lineText)
+	if err != nil {
+		return "", 0, false
+	}
+	return path, line, true
 }
 
 func pausePointStateErrorDetails(

--- a/cli/project-runner/internal/projectrunner/pause_point_errors_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors_test.go
@@ -1,6 +1,9 @@
 package projectrunner
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 // Verifies that a suppressed marker short-circuits timeout diagnosis even when the
 // response would otherwise look like an already-hit continuous wait or an enabled-but-never-hit marker.
@@ -188,5 +191,44 @@ func TestPausePointStateError_DetailsIncludeClearedReasonAndStatusBeforeClear(t 
 	}
 	if err.Details["StatusBeforeClear"] != pausePointStatusEnabled {
 		t.Fatalf("StatusBeforeClear mismatch: %#v", err.Details)
+	}
+}
+
+// Verifies file:line ids replace re-arm and confirm NextActions with --file/--line wording.
+func TestPausePointStateNextActionsReplacesFileLineGuidance(t *testing.T) {
+	got := pausePointStateNextActions("Assets/Scripts/Foo.cs:42", pausePointStatusResponse{})
+	want := []string{
+		"Re-arm it with uloop enable-pause-point --file \"Assets/Scripts/Foo.cs\" --line 42 before waiting.",
+		"Confirm the code path executes line 42 of Assets/Scripts/Foo.cs while the marker is armed.",
+		"Check `Details.Status`, `Details.EditorState`, `Details.ElapsedSinceEnabledMilliseconds`, and `Details.RemainingMilliseconds` to distinguish a missed code path from an already-paused Editor.",
+		"If the marker is inside a custom asmdef, add a reference to `UnityCLILoop.PausePoints.Runtime`.",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("NextActions mismatch:\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// Verifies a code-marker id keeps the Pause(...) NextActions wording.
+func TestPausePointStateNextActionsKeepsCodeMarkerGuidance(t *testing.T) {
+	got := pausePointStateNextActions("jump", pausePointStatusResponse{})
+	want := []string{
+		"Run `uloop enable-pause-point --id <marker-id>` before waiting.",
+		"Confirm the code path calls `UloopPausePoint.Pause(\"<marker-id>\")` with the same id.",
+		"Check `Details.Status`, `Details.EditorState`, `Details.ElapsedSinceEnabledMilliseconds`, and `Details.RemainingMilliseconds` to distinguish a missed code path from an already-paused Editor.",
+		"If the marker is inside a custom asmdef, add a reference to `UnityCLILoop.PausePoints.Runtime`.",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("NextActions mismatch:\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// Verifies a code-marker id that contains a colon is not treated as file:line.
+func TestPausePointStateNextActionsKeepsCodeMarkerGuidanceWhenIdContainsColon(t *testing.T) {
+	got := pausePointStateNextActions("scene:jump", pausePointStatusResponse{})
+	if got[0] != "Run `uloop enable-pause-point --id <marker-id>` before waiting." {
+		t.Fatalf("re-arm NextAction mismatch: %#v", got[0])
+	}
+	if got[1] != "Confirm the code path calls `UloopPausePoint.Pause(\"<marker-id>\")` with the same id." {
+		t.Fatalf("confirm NextAction mismatch: %#v", got[1])
 	}
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_errors_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors_test.go
@@ -232,3 +232,18 @@ func TestPausePointStateNextActionsKeepsCodeMarkerGuidanceWhenIdContainsColon(t 
 		t.Fatalf("confirm NextAction mismatch: %#v", got[1])
 	}
 }
+
+// Verifies a `.cs:0` suffix is not treated as a file:line id, because enable-pause-point
+// rejects --line 0 and C# never emits that id.
+func TestPausePointStateNextActionsKeepsCodeMarkerGuidanceForZeroLine(t *testing.T) {
+	got := pausePointStateNextActions("scene.cs:0", pausePointStatusResponse{})
+	want := []string{
+		"Run `uloop enable-pause-point --id <marker-id>` before waiting.",
+		"Confirm the code path calls `UloopPausePoint.Pause(\"<marker-id>\")` with the same id.",
+		"Check `Details.Status`, `Details.EditorState`, `Details.ElapsedSinceEnabledMilliseconds`, and `Details.RemainingMilliseconds` to distinguish a missed code path from an already-paused Editor.",
+		"If the marker is inside a custom asmdef, add a reference to `UnityCLILoop.PausePoints.Runtime`.",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("NextActions mismatch:\n got: %#v\nwant: %#v", got, want)
+	}
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -39,6 +39,11 @@ const (
 	// pause are already post-frame; agents otherwise treat them as at-line evidence.
 	pausePointHitFrameBoundaryStatusNote = "Unity pauses at the next frame boundary; the rest of the hit frame already ran. Read at-line values from CapturedVariables; live reads via execute-dynamic-code reflect post-frame state."
 
+	// Shared by await-pause-point and pause-point-status when --id is missing. Why one
+	// constant: the two parsers used to copy the same sentence, and a file:line id is a
+	// valid answer that the old wording never mentioned.
+	pausePointMissingIDNextAction = "Pass --id <marker-id> matching UloopPausePoint.Pause(\"<marker-id>\"), or the Id returned by enable-pause-point (file:line markers use <project-relative path>:<line>, e.g. Assets/Scripts/Foo.cs:42)."
+
 	// Mode strings mirror UloopPausePointCaptureMode on the Unity side. Await uses an allowlist
 	// (continuous/trace) for the new-hit baseline — never `Mode != "single-shot"` — so an empty
 	// Mode from an older package keeps the historical immediate-Hit success path.
@@ -374,7 +379,7 @@ func parseWaitForPausePointOptions(args []string) (waitForPausePointOptions, err
 			Option:       "--" + PausePointIDFlagName,
 			ExpectedType: "value",
 			Command:      clicore.PausePointAwaitCommandName,
-			NextActions:  []string{"Pass `--id <marker-id>` matching UloopPausePoint.Pause(\"<marker-id>\")."},
+			NextActions:  []string{pausePointMissingIDNextAction},
 		}
 	}
 
@@ -423,7 +428,7 @@ func parsePausePointStatusOptions(args []string) (pausePointStatusOptions, error
 			Option:       "--" + PausePointIDFlagName,
 			ExpectedType: "value",
 			Command:      clicore.PausePointStatusUserCommandName,
-			NextActions:  []string{"Pass `--id <marker-id>` matching UloopPausePoint.Pause(\"<marker-id>\")."},
+			NextActions:  []string{pausePointMissingIDNextAction},
 		}
 	}
 

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -626,6 +626,33 @@ func TestPausePointExpiredErrorOmitsEmptyRecommendedNextAction(t *testing.T) {
 	}
 }
 
+// Verifies an Expired error for a file:line id uses --file/--line NextActions, not Pause(...) wording.
+func TestPausePointExpiredErrorUsesFileLineNextActions(t *testing.T) {
+	response := pausePointStatusResponse{
+		Id:          "Assets/Scripts/Foo.cs:42",
+		Status:      pausePointStatusExpired,
+		Expired:     true,
+		EditorState: pausePointEditorState{IsPlaying: true, CapturedAt: "Current"},
+		Message:     "Pause point expired before it was hit.",
+	}
+
+	cliErr := pausePointWaitError("/tmp/MyProject", waitForPausePointOptions{
+		id:             "Assets/Scripts/Foo.cs:42",
+		timeoutSeconds: 1,
+	}, response, pausePointWaitStateExpired, false, false)
+
+	wantNextActions := []string{
+		"Re-arm it with uloop enable-pause-point --file \"Assets/Scripts/Foo.cs\" --line 42 before waiting.",
+		"Confirm the code path executes line 42 of Assets/Scripts/Foo.cs while the marker is armed.",
+		"Check `Details.Status`, `Details.EditorState`, `Details.ElapsedSinceEnabledMilliseconds`, and `Details.RemainingMilliseconds` to distinguish a missed code path from an already-paused Editor.",
+		"If the marker is inside a custom asmdef, add a reference to `UnityCLILoop.PausePoints.Runtime`.",
+	}
+	if !reflect.DeepEqual(cliErr.NextActions, wantNextActions) {
+		t.Fatalf("NextActions mismatch:\n got: %#v\nwant: %#v",
+			cliErr.NextActions, wantNextActions)
+	}
+}
+
 // Verifies recovery details use the marker lifetime instead of the wait deadline.
 func TestPausePointExpiredErrorReportsMarkerTimeoutSeconds(t *testing.T) {
 	response := pausePointStatusResponse{
@@ -1777,6 +1804,14 @@ func TestParseWaitForPausePointOptionsRequiresID(t *testing.T) {
 	}
 }
 
+// Verifies the missing --id NextAction names both Pause ids and file:line ids.
+func TestParseWaitForPausePointOptionsMissingIDNextActionMentionsFileLineIds(t *testing.T) {
+	_, err := parseWaitForPausePointOptions([]string{"--timeout-seconds", "1"})
+	requireNextActions(t, err, []string{
+		"Pass --id <marker-id> matching UloopPausePoint.Pause(\"<marker-id>\"), or the Id returned by enable-pause-point (file:line markers use <project-relative path>:<line>, e.g. Assets/Scripts/Foo.cs:42).",
+	})
+}
+
 // Verifies pause-point-status reports the current marker state without waiting for a hit.
 func TestRunPausePointStatusReturnsCurrentStatus(t *testing.T) {
 	originalQuery := queryPausePointStatus
@@ -2513,6 +2548,14 @@ func TestParsePausePointStatusOptionsRequiresID(t *testing.T) {
 	if !strings.Contains(err.Error(), "Missing required option") {
 		t.Fatalf("error mismatch: %v", err)
 	}
+}
+
+// Verifies pause-point-status missing --id uses the same file:line NextAction as await.
+func TestParsePausePointStatusOptionsMissingIDNextActionMentionsFileLineIds(t *testing.T) {
+	_, err := parsePausePointStatusOptions([]string{})
+	requireNextActions(t, err, []string{
+		"Pass --id <marker-id> matching UloopPausePoint.Pause(\"<marker-id>\"), or the Id returned by enable-pause-point (file:line markers use <project-relative path>:<line>, e.g. Assets/Scripts/Foo.cs:42).",
+	})
 }
 
 func parsePausePointErrorEnvelope(t *testing.T, payload []byte) clierrors.CLIErrorEnvelope {

--- a/cli/project-runner/internal/projectrunner/tool_param_suggestions.go
+++ b/cli/project-runner/internal/projectrunner/tool_param_suggestions.go
@@ -1,6 +1,7 @@
 package projectrunner
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -19,12 +20,21 @@ type visibleToolOption struct {
 	property clicore.ToolProperty
 }
 
-func unexpectedArgumentError(tool clicore.ToolDefinition, arg string) *clierrors.ArgumentError {
+func unexpectedArgumentError(tool clicore.ToolDefinition, arg string, lastConsumedArrayOption string) *clierrors.ArgumentError {
+	suggestions := enumValueOptionSuggestions(tool, arg)
+	if lastConsumedArrayOption != "" {
+		suggestions = append([]string{
+			fmt.Sprintf(
+				"Pass multiple values as one comma-separated list: %s value1,value2",
+				lastConsumedArrayOption,
+			),
+		}, suggestions...)
+	}
 	return &clierrors.ArgumentError{
 		Message:     "Unexpected argument: " + arg,
 		Received:    arg,
 		Command:     tool.Name,
-		NextActions: prependSuggestions(enumValueOptionSuggestions(tool, arg), "Pass tool inputs as `--option value` pairs."),
+		NextActions: prependSuggestions(suggestions, "Pass tool inputs as `--option value` pairs."),
 	}
 }
 

--- a/cli/project-runner/internal/projectrunner/tool_params.go
+++ b/cli/project-runner/internal/projectrunner/tool_params.go
@@ -15,11 +15,12 @@ import (
 func buildToolParams(args []string, tool clicore.ToolDefinition) (map[string]any, string, error) {
 	params := map[string]any{}
 	projectPath := ""
+	lastConsumedArrayOption := ""
 
 	for index := 0; index < len(args); index++ {
 		arg := args[index]
 		if !strings.HasPrefix(arg, "--") {
-			return nil, "", unexpectedArgumentError(tool, arg)
+			return nil, "", unexpectedArgumentError(tool, arg, lastConsumedArrayOption)
 		}
 
 		flag, err := parseToolFlag(arg)
@@ -33,6 +34,7 @@ func buildToolParams(args []string, tool clicore.ToolDefinition) (map[string]any
 				return nil, "", err
 			}
 			projectPath = value
+			lastConsumedArrayOption = ""
 			if consumedNext {
 				index++
 			}
@@ -53,6 +55,7 @@ func buildToolParams(args []string, tool clicore.ToolDefinition) (map[string]any
 				return nil, "", booleanValueArgumentError(option, args[index+1])
 			}
 			params[propertyName] = !negated
+			lastConsumedArrayOption = ""
 			continue
 		}
 
@@ -69,6 +72,7 @@ func buildToolParams(args []string, tool clicore.ToolDefinition) (map[string]any
 			return nil, "", err
 		}
 		params[propertyName] = converted
+		lastConsumedArrayOption = consumedArrayOptionName(option, property)
 	}
 
 	return params, projectPath, nil
@@ -201,6 +205,13 @@ func convertObjectValue(value string, option string) (map[string]any, error) {
 		return nil, clierrors.InvalidValueArgumentError(option, value, "object")
 	}
 	return parsed, nil
+}
+
+func consumedArrayOptionName(option string, property clicore.ToolProperty) string {
+	if strings.EqualFold(property.Type, "array") {
+		return option
+	}
+	return ""
 }
 
 func booleanValueArgumentError(option string, received string) *clierrors.ArgumentError {

--- a/cli/project-runner/internal/projectrunner/tool_params_test.go
+++ b/cli/project-runner/internal/projectrunner/tool_params_test.go
@@ -163,6 +163,32 @@ func TestBuildToolParamsUnexpectedArgumentWithoutEnumMatchKeepsOriginalNextActio
 	})
 }
 
+// Verifies a leftover token after an array option suggests a comma-separated list for that option.
+func TestBuildToolParamsUnexpectedArgumentAfterArraySuggestsCommaSeparatedList(t *testing.T) {
+	tool := clicore.ToolDefinition{
+		Name: "sample-tool",
+		InputSchema: clicore.InputSchema{
+			Properties: map[string]clicore.ToolProperty{
+				"Tags": {Type: "array"},
+			},
+		},
+	}
+
+	_, _, err := buildToolParams([]string{"--tags", "alpha", "beta"}, tool)
+	requireNextActions(t, err, []string{
+		"Pass multiple values as one comma-separated list: --tags value1,value2",
+		"Pass tool inputs as `--option value` pairs.",
+	})
+}
+
+// Verifies a leftover token after a non-array option does not suggest a comma-separated list.
+func TestBuildToolParamsUnexpectedArgumentAfterStringOmitsCommaSeparatedList(t *testing.T) {
+	_, _, err := buildToolParams([]string{"--output-directory", "out", "extra"}, toolParamsSuggestionTool())
+	requireNextActions(t, err, []string{
+		"Pass tool inputs as `--option value` pairs.",
+	})
+}
+
 // Verifies an unknown flag whose name matches an option enum value suggests that option and value.
 func TestBuildToolParamsUnknownOptionSuggestsMatchingEnumValue(t *testing.T) {
 	_, _, err := buildToolParams([]string{"--status"}, toolParamsSuggestionTool())

--- a/cli/project-runner/internal/projectrunner/tool_params_test.go
+++ b/cli/project-runner/internal/projectrunner/tool_params_test.go
@@ -189,6 +189,56 @@ func TestBuildToolParamsUnexpectedArgumentAfterStringOmitsCommaSeparatedList(t *
 	})
 }
 
+func arrayResetContractTool() clicore.ToolDefinition {
+	return clicore.ToolDefinition{
+		Name: "sample-tool",
+		InputSchema: clicore.InputSchema{
+			Properties: map[string]clicore.ToolProperty{
+				"Tags":            {Type: "array"},
+				"OutputDirectory": {Type: "string"},
+				"Enabled":         {Type: "boolean"},
+			},
+		},
+	}
+}
+
+// Verifies an array option's comma-list NextAction is cleared by each later non-array
+// consumption path (valued option, boolean, --project-path). Why a later option is
+// required: tests that start from a blank lastConsumedArrayOption cannot catch a
+// mutation that skips the overwrite and keeps a previous array option.
+func TestBuildToolParamsUnexpectedArgumentAfterArrayThenLaterOptionOmitsCommaSeparatedList(t *testing.T) {
+	tool := arrayResetContractTool()
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "non-array value",
+			args: []string{"--tags", "alpha", "--output-directory", "out", "extra"},
+		},
+		{
+			// Why -extra: a bare positional after a boolean is rejected as a boolean
+			// value before the reset assignment runs, so that error cannot observe it.
+			name: "boolean",
+			args: []string{"--tags", "alpha", "--enabled", "-extra"},
+		},
+		{
+			name: "project-path",
+			args: []string{"--tags", "alpha", "--project-path", "/tmp/project", "extra"},
+		},
+	}
+
+	want := []string{
+		"Pass tool inputs as `--option value` pairs.",
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, _, err := buildToolParams(testCase.args, tool)
+			requireNextActions(t, err, want)
+		})
+	}
+}
+
 // Verifies an unknown flag whose name matches an option enum value suggests that option and value.
 func TestBuildToolParamsUnknownOptionSuggestsMatchingEnumValue(t *testing.T) {
 	_, _, err := buildToolParams([]string{"--status"}, toolParamsSuggestionTool())


### PR DESCRIPTION
## Summary
- Missing `--id` now tells callers that enable-pause-point ids can be `file:line` (`Assets/Scripts/Foo.cs:42`), not only `UloopPausePoint.Pause("<marker-id>")`.
- Wait errors for a file:line id now say to re-arm with `--file` / `--line` and to confirm that line ran, instead of repeating Pause(...) wording that cannot arm that marker.
- A leftover token after an array option now starts with a comma-separated list hint for that option.
- A `.cs:0` suffix is treated as a code-marker id, not `--line 0`, because enable-pause-point rejects line 0 and C# never emits that file:line id.

## User Impact
- Before: `await-pause-point` / `pause-point-status` without `--id` only mentioned Pause ids. After a wait failed on a file:line marker, NextActions still said to `enable-pause-point --id <marker-id>` and to call `UloopPausePoint.Pause(...)`. Passing a second value after an array option only said to use `--option value` pairs.
- After: missing `--id` names both Pause ids and file:line ids. File:line wait errors expand the real path and line. Code-marker ids keep the previous Pause(...) wording. Array leftovers suggest `--option value1,value2`.

## Changes
- Deduplicate the two missing-`--id` NextAction copies into `pausePointMissingIDNextAction`.
- Pass the wait id into `pausePointStateNextActions`. Ids ending in `.cs:<digits>` with line > 0 swap the re-arm and confirm lines; other ids keep the current sentences.
- `buildToolParams` remembers whether the last consumed option was `array` and prepends the comma-list NextAction when the next token is unexpected.

## Tests
Exact full-literal NextActions matches for:
- missing `--id` on await and status
- file:line id vs code-marker id (`jump`, and `scene:jump` so a colon alone is not treated as file:line)
- `scene.cs:0` keeps the Pause(...) wording (not `--line 0`)
- leftover token after `--tags` (array) vs after `--output-directory` (string)
- array then a later option then leftover, asserting the comma-list hint is absent: non-array value (`--output-directory`), boolean (`--enabled` then `-extra`, because a bare positional after a boolean is a boolean-value error before the reset runs), and `--project-path`

## Mutation Red evidence
1. `parsePausePointFileLineID` always returned false → `TestPausePointStateNextActionsReplacesFileLineGuidance` and `TestPausePointExpiredErrorUsesFileLineNextActions` failed: got Pause(...) wording, want `--file "Assets/Scripts/Foo.cs" --line 42`.
2. Array prepend gated with `if false && lastConsumedArrayOption != ""` → `TestBuildToolParamsUnexpectedArgumentAfterArraySuggestsCommaSeparatedList` failed: got only the generic option-value-pairs sentence, want the comma-separated `--tags` line first.
3. Missing-id constant reverted to the old Pause-only sentence → `TestParseWaitForPausePointOptionsMissingIDNextActionMentionsFileLineIds` and `TestParsePausePointStatusOptionsMissingIDNextActionMentionsFileLineIds` failed (got the old sentence, want the file:line sentence).
4. Keep stale array state on non-array consume (`if name := consumedArrayOptionName(...); name != "" { lastConsumedArrayOption = name }`, so a later string option does not overwrite) → existing AfterArray / AfterString tests still passed; `TestBuildToolParamsUnexpectedArgumentAfterArrayThenLaterOptionOmitsCommaSeparatedList/non-array_value` failed: got the `--tags` comma-list line plus the generic sentence, want only the generic option-value-pairs sentence. Boolean and project-path subtests stayed green.
5. Drop `lastConsumedArrayOption = ""` on the boolean path only → only the `/boolean` subtest failed, same got/want as (4).
6. Drop `lastConsumedArrayOption = ""` on the `--project-path` path only → only the `/project-path` subtest failed, same got/want as (4).
7. Drop the `line <= 0` guard after Atoi → `TestPausePointStateNextActionsKeepsCodeMarkerGuidanceForZeroLine` failed: got `--file "scene.cs" --line 0` wording, want the Pause(...) code-marker sentences. Existing positive-line tests stayed green.

Mutations were reverted before commit.

## Verification
- `scripts/check-go-cli.sh` (pass)
