### PR TITLE
fix: omit null simulate-keyboard fields and surface pause-point reading notes before captured variables

### DIFF
--- a/Assets/Tests/Editor/SimulateKeyboardResponseContractTests.cs
+++ b/Assets/Tests/Editor/SimulateKeyboardResponseContractTests.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Pins simulate-keyboard JSON so null optional diagnostics are omitted and set values stay present.
+    /// </summary>
+    public sealed class SimulateKeyboardResponseContractTests
+    {
+        private const string OmittedOptionalFieldsJson =
+            "{\"Message\":\"\",\"Action\":\"\",\"InterruptedByPausePoint\":false,\"Success\":true}";
+
+        private const string PopulatedOptionalFieldsJson =
+            "{\"Message\":\"ok\",\"Action\":\"Press\",\"KeyName\":\"Space\","
+            + "\"InterruptedByPausePoint\":false,\"RejectedByActivePausePointId\":\"marker\","
+            + "\"PausePointId\":\"hit\",\"PausePointHitCount\":1,"
+            + "\"PausePointHits\":[{\"Id\":\"hit\",\"HitCount\":1}],"
+            + "\"PressEdgeObserved\":true,\"PressHoldExtendedFrames\":2,"
+            + "\"PressEdgeConsumedByUpdateType\":\"Dynamic\","
+            + "\"PressEdgeAnyDynamicUpdateObserved\":true,"
+            + "\"PressEdgeKeyAlreadyPressedBeforeQueue\":false,"
+            + "\"KeyStateTrackedHeld\":true,\"KeyStateDeviceIsPressed\":false,"
+            + "\"ReleasedKeys\":[\"Space\"],\"Success\":true}";
+
+        /// <summary>
+        /// What: null optional simulate-keyboard fields are absent from production JSON, not serialized as null.
+        /// </summary>
+        [Test]
+        public void SimulateKeyboardResponse_WhenOptionalFieldsAreNull_OmitsThoseKeysFromJson()
+        {
+            SimulateKeyboardResponse response = new SimulateKeyboardResponse();
+
+            string json = JsonConvert.SerializeObject(
+                response,
+                Formatting.None,
+                JsonRpcResponseSerializer.Settings);
+
+            Assert.That(json, Is.EqualTo(OmittedOptionalFieldsJson));
+        }
+
+        /// <summary>
+        /// What: non-null optional simulate-keyboard fields serialize under their exact production keys.
+        /// </summary>
+        [Test]
+        public void SimulateKeyboardResponse_WhenOptionalFieldsAreSet_IncludesThoseKeysInJson()
+        {
+            SimulateKeyboardResponse response = new SimulateKeyboardResponse
+            {
+                Success = true,
+                Message = "ok",
+                Action = "Press",
+                KeyName = "Space",
+                InterruptedByPausePoint = false,
+                RejectedByActivePausePointId = "marker",
+                PausePointId = "hit",
+                PausePointHitCount = 1,
+                PausePointHits = new List<UnityCliLoopPausePointHit>
+                {
+                    new UnityCliLoopPausePointHit { Id = "hit", HitCount = 1 }
+                },
+                PressEdgeObserved = true,
+                PressHoldExtendedFrames = 2,
+                PressEdgeConsumedByUpdateType = "Dynamic",
+                PressEdgeAnyDynamicUpdateObserved = true,
+                PressEdgeKeyAlreadyPressedBeforeQueue = false,
+                KeyStateTrackedHeld = true,
+                KeyStateDeviceIsPressed = false,
+                ReleasedKeys = new List<string> { "Space" }
+            };
+
+            string json = JsonConvert.SerializeObject(
+                response,
+                Formatting.None,
+                JsonRpcResponseSerializer.Settings);
+
+            Assert.That(json, Is.EqualTo(PopulatedOptionalFieldsJson));
+        }
+    }
+}

--- a/Assets/Tests/Editor/SimulateKeyboardResponseContractTests.cs.meta
+++ b/Assets/Tests/Editor/SimulateKeyboardResponseContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c10e924c50b9c413a8aa2855e0cc900e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardResponse.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
@@ -13,6 +14,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public string Message { get; set; } = "";
         public string Action { get; set; } = "";
+        // Why per-property Ignore: null optional diagnostics must not serialize as JSON null;
+        // agents treat missing vs null inconsistently. Do not change global serializer settings
+        // or every tool's wire contract changes. Matches Go omitempty.
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string? KeyName { get; set; }
         public bool InterruptedByPausePoint { get; set; }
         /// <summary>
@@ -21,17 +26,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// no input was injected at all, so a caller reading only Success would miss that the action
         /// never happened. The CLI's --trigger diagnosis compares this against the marker it awaits.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string? RejectedByActivePausePointId { get; set; }
 
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string? PausePointId { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public int? PausePointHitCount { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public List<UnityCliLoopPausePointHit>? PausePointHits { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public bool? PressEdgeObserved { get; set; }
 
         /// <summary>
         /// Extra observation frames spent holding the key after the normal duration window
         /// while waiting for wasPressedThisFrame. Null when release was not delayed.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public int? PressHoldExtendedFrames { get; set; }
 
         // The following three PressEdge* fields are diagnostics set only when PressEdgeObserved
@@ -42,17 +53,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Which Input System update type (if any) consumed the key-down event, or null if it
         /// was never consumed.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string? PressEdgeConsumedByUpdateType { get; set; }
 
         /// <summary>
         /// Whether any Dynamic update ran while waiting for the press edge to be observed.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public bool? PressEdgeAnyDynamicUpdateObserved { get; set; }
 
         /// <summary>
         /// Whether the key was already pressed before this action was queued, meaning no press
         /// transition could have occurred.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public bool? PressEdgeKeyAlreadyPressedBeforeQueue { get; set; }
 
         // KeyStateTrackedHeld / KeyStateDeviceIsPressed are set on KeyDown "already held"
@@ -63,17 +77,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Whether Unity CLI Loop's own key-hold tracker (not the Input System device) considered
         /// the key held at the moment of the diagnostic read.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public bool? KeyStateTrackedHeld { get; set; }
 
         /// <summary>
         /// Whether the Input System device (<c>keyboard[key].isPressed</c>) reported the key as
         /// pressed at the moment of the diagnostic read.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public bool? KeyStateDeviceIsPressed { get; set; }
 
         /// <summary>
         /// Key names released by the ReleaseAll action (bookkeeping and/or device). Null for other actions.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public List<string>? ReleasedKeys { get; set; }
 
         /// <summary>

--- a/cli/project-runner/internal/projectrunner/pause_point_status_response_key_order_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_status_response_key_order_test.go
@@ -1,0 +1,207 @@
+package projectrunner
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"testing"
+)
+
+// Verifies pause-point stdout key order places SnapshotTiming and StatusNote
+// immediately before CapturedVariables so agents read those notes before the
+// variable dump. Mutating the struct declarations back to the old positions
+// (CapturedVariables first, notes after ResolvedMethod / history notes) makes
+// this test Red.
+func TestPausePointStatusResponseMarshalsReadingNotesBeforeCapturedVariables(t *testing.T) {
+	raw, err := json.Marshal(fullyPopulatedPausePointStatusResponse())
+	if err != nil {
+		t.Fatalf("marshal pausePointStatusResponse: %v", err)
+	}
+
+	actual, err := collectTopLevelJSONObjectKeys(raw)
+	if err != nil {
+		t.Fatalf("collect top-level keys: %v\npayload: %s", err, raw)
+	}
+
+	expected := []string{
+		"Success",
+		"ErrorCode",
+		"Id",
+		"Status",
+		"IsEnabled",
+		"IsHit",
+		"HitCount",
+		"TimeoutSeconds",
+		"Mode",
+		"MaxHistory",
+		"MaxPreviewElements",
+		"MaxCallerFrames",
+		"CapturedVariableHistory",
+		"HistoryDroppedCount",
+		"Expired",
+		"EnabledAtUtc",
+		"ElapsedSinceEnabledMilliseconds",
+		"RemainingMilliseconds",
+		"Generation",
+		"EditorState",
+		"FirstHitAtUtc",
+		"LastHitAtUtc",
+		"FirstHitSequence",
+		"LastHitSequence",
+		"Message",
+		"RecommendedNextAction",
+		"SnapshotTiming",
+		"StatusNote",
+		"CapturedVariables",
+		"CallerFrames",
+		"CapturedVariablesTruncated",
+		"TruncatedVariableNames",
+		"TruncatedVariableCount",
+		"CapturedVariablesTruncatedNote",
+		"CapturedVariablePreviewNote",
+		"ClearedReason",
+		"StatusBeforeClear",
+		"LateHitDiscardedAfterClear",
+		"SuppressedByHotReload",
+		"RetargetedToHotReloadPatch",
+		"SuppressedByHotReloadReason",
+		"Warning",
+		"ResolvedLine",
+		"ResolvedLineText",
+		"ResolvedMethod",
+		"CapturedVariableNameFilterNoMatch",
+		"CapturedVariableNamesNotFound",
+		"CapturedVariableHistoryNote",
+		"TriggerResult",
+		"ResumePlayResult",
+		"TriggerFailed",
+	}
+	if !slices.Equal(actual, expected) {
+		t.Fatalf("top-level JSON key order mismatch\nexpected: %#v\nactual:   %#v", expected, actual)
+	}
+}
+
+func fullyPopulatedPausePointStatusResponse() pausePointStatusResponse {
+	triggerFailed := true
+	return pausePointStatusResponse{
+		Success:                           true,
+		ErrorCode:                         "NONE",
+		Id:                                "Assets/Foo.cs:10",
+		Status:                            "Hit",
+		IsEnabled:                         true,
+		IsHit:                             true,
+		HitCount:                          1,
+		TimeoutSeconds:                    30,
+		Mode:                              "single-shot",
+		MaxHistory:                        8,
+		MaxPreviewElements:                16,
+		MaxCallerFrames:                   4,
+		CapturedVariableHistory:           []pausePointCapturedHistoryFrame{{HitSequence: 1, FrameCount: 2, HitAtUtc: "t", CapturedVariables: []pausePointCapturedVariable{{Name: "n", Scope: "Local", TypeName: "System.Int32", Value: pausePointVariableValue("1")}}, Truncated: true, CallerFrames: []pausePointCallerFrame{{Method: "M"}}}},
+		HistoryDroppedCount:               1,
+		Expired:                           true,
+		EnabledAtUtc:                      "t",
+		ElapsedSinceEnabledMilliseconds:   1,
+		RemainingMilliseconds:             1,
+		Generation:                        1,
+		EditorState:                       pausePointEditorState{IsPlaying: true, IsPaused: true, CapturedAt: "t"},
+		FirstHitAtUtc:                     "t",
+		LastHitAtUtc:                      "t",
+		FirstHitSequence:                  1,
+		LastHitSequence:                   1,
+		Message:                           "m",
+		RecommendedNextAction:             "a",
+		SnapshotTiming:                    "OnEnter",
+		StatusNote:                        "read CapturedVariables",
+		CapturedVariables:                 []pausePointCapturedVariable{{Name: "n", Scope: "Local", TypeName: "System.Int32", Value: pausePointVariableValue("1"), UnityObjectKind: "GameObject", UnityObjectPath: "/x", UnityObjectInstanceId: 1, Truncated: true}},
+		CallerFrames:                      []pausePointCallerFrame{{Method: "M", File: "Assets/Foo.cs", Line: 10, Note: "n"}},
+		CapturedVariablesTruncated:        true,
+		TruncatedVariableNames:            []string{"n"},
+		TruncatedVariableCount:            1,
+		CapturedVariablesTruncatedNote:    "note",
+		CapturedVariablePreviewNote:       "preview",
+		ClearedReason:                     "ExplicitClear",
+		StatusBeforeClear:                 "Hit",
+		LateHitDiscardedAfterClear:        true,
+		SuppressedByHotReload:             true,
+		RetargetedToHotReloadPatch:        true,
+		SuppressedByHotReloadReason:       "reason",
+		Warning:                           "w",
+		ResolvedLine:                      10,
+		ResolvedLineText:                  "return;",
+		ResolvedMethod:                    "Foo.Bar",
+		CapturedVariableNameFilterNoMatch: true,
+		CapturedVariableNamesNotFound:     []string{"missing"},
+		CapturedVariableHistoryNote:       "history",
+		TriggerResult: &pausePointTriggerResult{
+			Command:     "simulate-keyboard",
+			Completed:   true,
+			Response:    json.RawMessage(`{"Success":true}`),
+			Error:       "e",
+			Explanation: "x",
+		},
+		ResumePlayResult: &pausePointResumePlayResult{
+			WasPaused:    true,
+			Resumed:      true,
+			Error:        "e",
+			Repaused:     true,
+			RepauseError: "e",
+		},
+		TriggerFailed: &triggerFailed,
+	}
+}
+
+func collectTopLevelJSONObjectKeys(raw []byte) ([]string, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '{' {
+		return nil, fmt.Errorf("expected JSON object, got %v", token)
+	}
+
+	keys := make([]string, 0)
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected object key, got %v", keyToken)
+		}
+		keys = append(keys, key)
+		if err := skipJSONValue(decoder); err != nil {
+			return nil, err
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, err
+	}
+	return keys, nil
+}
+
+func skipJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	for decoder.More() {
+		if delim == '{' {
+			if _, err := decoder.Token(); err != nil {
+				return err
+			}
+		}
+		if err := skipJSONValue(decoder); err != nil {
+			return err
+		}
+	}
+	_, err = decoder.Token()
+	return err
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_types.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_types.go
@@ -27,11 +27,25 @@ type pausePointStatusResponse struct {
 	LastHitSequence                 int                              `json:"LastHitSequence"`
 	Message                         string                           `json:"Message"`
 	RecommendedNextAction           string                           `json:"RecommendedNextAction"`
-	CapturedVariables               []pausePointCapturedVariable     `json:"CapturedVariables"`
-	CallerFrames                    []pausePointCallerFrame          `json:"CallerFrames"`
-	CapturedVariablesTruncated      bool                             `json:"CapturedVariablesTruncated"`
-	TruncatedVariableNames          []string                         `json:"TruncatedVariableNames"`
-	TruncatedVariableCount          int                              `json:"TruncatedVariableCount"`
+
+	// SnapshotTiming is still enable-only on the Unity status DTO today, so --await copies it
+	// from the enable response on both hit and Expired. Method-name arms leave it empty, so
+	// omitempty keeps the historical await schema unchanged for those cases.
+	// Why before CapturedVariables: JSON object key order follows this struct, and agents
+	// should read SnapshotTiming and StatusNote before the variable dump.
+	SnapshotTiming string `json:"SnapshotTiming,omitempty"`
+
+	// StatusNote is set by the CLI, not Unity, when Status is Hit. Trace mode explains
+	// that Play Mode was not paused; other modes explain the frame-boundary pause.
+	// omitempty keeps the field off non-Hit statuses so the shared status contract
+	// fixture stays unchanged.
+	StatusNote string `json:"StatusNote,omitempty"`
+
+	CapturedVariables          []pausePointCapturedVariable `json:"CapturedVariables"`
+	CallerFrames               []pausePointCallerFrame      `json:"CallerFrames"`
+	CapturedVariablesTruncated bool                         `json:"CapturedVariablesTruncated"`
+	TruncatedVariableNames     []string                     `json:"TruncatedVariableNames"`
+	TruncatedVariableCount     int                          `json:"TruncatedVariableCount"`
 
 	// CapturedVariablesTruncatedNote is set by the CLI, not Unity, when
 	// --captured-variable-names dropped every truncated variable so the remaining
@@ -62,14 +76,12 @@ type pausePointStatusResponse struct {
 	// ResolvedLine / ResolvedLineText are merged as a pair on the --await hit path and the
 	// --await Expired path: when status carries a non-zero ResolvedLine (retarget-updated),
 	// both fields come from status; otherwise both fall back to the enable-pause-point response.
-	// ResolvedMethod / SnapshotTiming are still enable-only on the Unity status DTO today, so
-	// --await copies them from the enable response on both hit and Expired. Method-name arms
-	// leave them empty on the Unity side, so omitempty keeps the historical await schema
-	// unchanged for those cases.
+	// ResolvedMethod is still enable-only on the Unity status DTO today, so --await copies it
+	// from the enable response on both hit and Expired. Method-name arms leave it empty on the
+	// Unity side, so omitempty keeps the historical await schema unchanged for those cases.
 	ResolvedLine     int    `json:"ResolvedLine,omitempty"`
 	ResolvedLineText string `json:"ResolvedLineText,omitempty"`
 	ResolvedMethod   string `json:"ResolvedMethod,omitempty"`
-	SnapshotTiming   string `json:"SnapshotTiming,omitempty"`
 
 	// CapturedVariableNameFilterNoMatch is set by the CLI, not Unity, when
 	// --captured-variable-names was passed but none of the requested names matched any
@@ -88,12 +100,6 @@ type pausePointStatusResponse struct {
 	// frame was dropped from CapturedVariableHistory because CapturedVariables already
 	// carries that hit. omitempty keeps the field off 0-hit and unfiltered responses.
 	CapturedVariableHistoryNote string `json:"CapturedVariableHistoryNote,omitempty"`
-
-	// StatusNote is set by the CLI, not Unity, when Status is Hit. Trace mode explains
-	// that Play Mode was not paused; other modes explain the frame-boundary pause.
-	// omitempty keeps the field off non-Hit statuses so the shared status contract
-	// fixture stays unchanged.
-	StatusNote string `json:"StatusNote,omitempty"`
 
 	// TriggerResult is set by the CLI, not Unity, only when --trigger was passed. It is omitted
 	// entirely otherwise, so callers that never use --trigger see no schema change at all.


### PR DESCRIPTION
## Summary
- simulate-keyboard JSON no longer emits null optional diagnostic fields, so missing and unused fields stay absent instead of showing up as JSON null.
- pause-point-status and await stdout now put SnapshotTiming and StatusNote immediately before CapturedVariables, so reading notes appear before the variable dump.

## User Impact
- Before: unused simulate-keyboard diagnostics serialized as `"KeyName": null` (and the same for the other optional fields), and pause-point Hit payloads dumped CapturedVariables before the notes that explain how to read them.
- After: null optional simulate-keyboard fields are omitted; SnapshotTiming and StatusNote sit directly above CapturedVariables in the remarshaled CLI JSON. Wire-compatible (key presence/order only; no protocol version bump).

## Changes
- Mark the 13 nullable simulate-keyboard response properties with per-property `[JsonProperty(NullValueHandling = NullValueHandling.Ignore)]`. Global serializer settings are unchanged.
- Move `SnapshotTiming` and `StatusNote` in the Go `pausePointStatusResponse` struct to immediately before `CapturedVariables`. JSON tags and omitempty are unchanged. C# status DTOs are untouched (CLI stdout is Go remarshal; StatusNote stays CLI-only).

## Verification
- `scripts/check-go-cli.sh`: pass, including `project-runner/internal/projectrunner` (17.542s).
- `uloop compile`: Success, ErrorCount 0.
- `uloop run-tests --test-mode EditMode` filtered to `SimulateKeyboardResponseContractTests|PausePointRejectionResponseFieldTests`: 7 passed / 0 failed.

## Mutation Red
- Go key order: restore the previous struct field positions (CapturedVariables after RecommendedNextAction; SnapshotTiming after ResolvedMethod; StatusNote after CapturedVariableHistoryNote). `TestPausePointStatusResponseMarshalsReadingNotesBeforeCapturedVariables` failed with actual keys `..., "RecommendedNextAction", "CapturedVariables", ..., "ResolvedMethod", "SnapshotTiming", ..., "CapturedVariableHistoryNote", "StatusNote", ...` against the expected `..., "SnapshotTiming", "StatusNote", "CapturedVariables", ...`. Restoring the move made the test pass.
- C# null omit: remove `[JsonProperty(NullValueHandling = NullValueHandling.Ignore)]` from `KeyName` only. `SimulateKeyboardResponse_WhenOptionalFieldsAreNull_OmitsThoseKeysFromJson` failed because the payload gained `"KeyName":null` (expected length 73, actual 88). Restoring the attribute made the 7-test filter pass again.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

