### PR TITLE
feat: name filtered-out candidate tests when run-tests finds nothing with a filter

### DIFF
--- a/Assets/Tests/Editor/RunTestsUnfilteredFilterEchoTests.cs
+++ b/Assets/Tests/Editor/RunTestsUnfilteredFilterEchoTests.cs
@@ -1,0 +1,150 @@
+using System.Collections.Generic;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies unfiltered test-name echo when run-tests finds nothing under a filter.
+    /// </summary>
+    public sealed class RunTestsUnfilteredFilterEchoTests
+    {
+        /// <summary>
+        /// What: a retrieved list appends the exact filter-mismatch sentence and copies echo fields.
+        /// </summary>
+        [Test]
+        public void ApplyIfRetrieved_WhenFilterMisses_AppendsExactMessageAndEchoFields()
+        {
+            RunTestsResponse response = CreateNoTestsResponse();
+            RunTestsUnfilteredTestListResult result = RunTestsUnfilteredTestListResult.Success(
+                new[] { "Example.Tests.Alpha", "Example.Tests.Beta" });
+
+            RunTestsUnfilteredFilterEcho.ApplyIfRetrieved(
+                response,
+                TestFilterType.regex,
+                "Missing.*",
+                result);
+
+            Assert.That(
+                response.Message,
+                Is.EqualTo(
+                    "No tests found matching the specified filter criteria No tests matched FilterType 'regex' with FilterValue 'Missing.*'. 2 test(s) exist in this TestMode without the filter; compare UnfilteredTestNames against the filter value."));
+            Assert.That(response.FilterType, Is.EqualTo("regex"));
+            Assert.That(response.FilterValue, Is.EqualTo("Missing.*"));
+            Assert.That(response.UnfilteredTestCount, Is.EqualTo(2));
+            Assert.That(
+                response.UnfilteredTestNames,
+                Is.EqualTo(new List<string> { "Example.Tests.Alpha", "Example.Tests.Beta" }));
+        }
+
+        /// <summary>
+        /// What: 21 retrieved names keep UnfilteredTestCount at 21 and cap UnfilteredTestNames at 20.
+        /// </summary>
+        [Test]
+        public void ApplyIfRetrieved_WhenTwentyOneNames_CapsListedNamesAndKeepsTotalCount()
+        {
+            List<string> supplied = new List<string>(21);
+            for (int index = 1; index <= 21; index++)
+            {
+                supplied.Add("Example.Tests.Test" + index.ToString("00"));
+            }
+
+            RunTestsResponse response = CreateNoTestsResponse();
+            RunTestsUnfilteredFilterEcho.ApplyIfRetrieved(
+                response,
+                TestFilterType.exact,
+                "Missing.Test",
+                RunTestsUnfilteredTestListResult.Success(supplied));
+
+            List<string> expectedListed = supplied.GetRange(0, 20);
+            Assert.That(response.UnfilteredTestCount, Is.EqualTo(21));
+            Assert.That(response.UnfilteredTestNames, Is.EqualTo(expectedListed));
+            Assert.That(
+                response.Message,
+                Is.EqualTo(
+                    "No tests found matching the specified filter criteria No tests matched FilterType 'exact' with FilterValue 'Missing.Test'. 21 test(s) exist in this TestMode without the filter; compare UnfilteredTestNames against the filter value."));
+        }
+
+        /// <summary>
+        /// What: a failed retrieve leaves the original message and omits echo fields from JSON.
+        /// </summary>
+        [Test]
+        public void ApplyIfRetrieved_WhenNotRetrieved_LeavesMessageAndOmitsEchoFieldsFromJson()
+        {
+            RunTestsResponse response = CreateNoTestsResponse();
+
+            RunTestsUnfilteredFilterEcho.ApplyIfRetrieved(
+                response,
+                TestFilterType.exact,
+                "Missing.Test",
+                RunTestsUnfilteredTestListResult.NotRetrieved());
+
+            Assert.That(response.Message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
+            Assert.That(response.ShouldSerializeFilterType(), Is.EqualTo(false));
+            Assert.That(response.ShouldSerializeFilterValue(), Is.EqualTo(false));
+            Assert.That(response.ShouldSerializeUnfilteredTestNames(), Is.EqualTo(false));
+            Assert.That(response.ShouldSerializeUnfilteredTestCount(), Is.EqualTo(false));
+
+            string json = JsonConvert.SerializeObject(
+                response,
+                Formatting.None,
+                JsonRpcResponseSerializer.Settings);
+            JObject parsed = JObject.Parse(json);
+            Assert.That(parsed.Property("FilterType"), Is.EqualTo(null));
+            Assert.That(parsed.Property("FilterValue"), Is.EqualTo(null));
+            Assert.That(parsed.Property("UnfilteredTestNames"), Is.EqualTo(null));
+            Assert.That(parsed.Property("UnfilteredTestCount"), Is.EqualTo(null));
+        }
+
+        /// <summary>
+        /// What: filter-all NoTestsFound omits echo fields even when an unfiltered list is supplied.
+        /// </summary>
+        [Test]
+        public void ApplyIfRetrieved_WhenFilterTypeIsAll_OmitsEchoFieldsFromJson()
+        {
+            RunTestsResponse response = CreateNoTestsResponse();
+
+            RunTestsUnfilteredFilterEcho.ApplyIfRetrieved(
+                response,
+                TestFilterType.all,
+                "",
+                RunTestsUnfilteredTestListResult.Success(new[] { "Example.Tests.Alpha" }));
+
+            Assert.That(response.Message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
+            Assert.That(response.ShouldSerializeFilterType(), Is.EqualTo(false));
+            Assert.That(response.ShouldSerializeUnfilteredTestNames(), Is.EqualTo(false));
+
+            string json = JsonConvert.SerializeObject(
+                response,
+                Formatting.None,
+                JsonRpcResponseSerializer.Settings);
+            JObject parsed = JObject.Parse(json);
+            Assert.That(parsed.Property("FilterType"), Is.EqualTo(null));
+            Assert.That(parsed.Property("UnfilteredTestNames"), Is.EqualTo(null));
+            Assert.That(parsed.Property("UnfilteredTestCount"), Is.EqualTo(null));
+        }
+
+        private static RunTestsResponse CreateNoTestsResponse()
+        {
+            return new RunTestsResponse(
+                success: false,
+                message: RunTestsResponse.NoTestsFoundMessage,
+                completedAt: "2026-01-01T00:00:00.0000000Z",
+                testCount: 0,
+                passedCount: 0,
+                failedCount: 0,
+                skippedCount: 0,
+                xmlPath: null,
+                status: RunTestsExecutionStatus.NoTestsFound,
+                hasFailures: false,
+                noTestsFound: true,
+                noTestsFoundExplanation: RunTestsResponse.NoTestsFoundExplanationText);
+        }
+    }
+}

--- a/Assets/Tests/Editor/RunTestsUnfilteredFilterEchoTests.cs
+++ b/Assets/Tests/Editor/RunTestsUnfilteredFilterEchoTests.cs
@@ -34,7 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 response.Message,
                 Is.EqualTo(
-                    "No tests found matching the specified filter criteria No tests matched FilterType 'regex' with FilterValue 'Missing.*'. 2 test(s) exist in this TestMode without the filter; compare UnfilteredTestNames against the filter value."));
+                    "No tests found matching the specified filter criteria. No tests matched FilterType 'regex' with FilterValue 'Missing.*'. 2 test(s) exist in this TestMode without the filter; compare UnfilteredTestNames against the filter value."));
             Assert.That(response.FilterType, Is.EqualTo("regex"));
             Assert.That(response.FilterValue, Is.EqualTo("Missing.*"));
             Assert.That(response.UnfilteredTestCount, Is.EqualTo(2));
@@ -68,7 +68,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 response.Message,
                 Is.EqualTo(
-                    "No tests found matching the specified filter criteria No tests matched FilterType 'exact' with FilterValue 'Missing.Test'. 21 test(s) exist in this TestMode without the filter; compare UnfilteredTestNames against the filter value."));
+                    "No tests found matching the specified filter criteria. No tests matched FilterType 'exact' with FilterValue 'Missing.Test'. 21 test(s) exist in this TestMode without the filter; compare UnfilteredTestNames against the filter value."));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/RunTestsUnfilteredFilterEchoTests.cs
+++ b/Assets/Tests/Editor/RunTestsUnfilteredFilterEchoTests.cs
@@ -118,7 +118,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(response.Message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
             Assert.That(response.ShouldSerializeFilterType(), Is.EqualTo(false));
+            Assert.That(response.ShouldSerializeFilterValue(), Is.EqualTo(false));
             Assert.That(response.ShouldSerializeUnfilteredTestNames(), Is.EqualTo(false));
+            Assert.That(response.ShouldSerializeUnfilteredTestCount(), Is.EqualTo(false));
 
             string json = JsonConvert.SerializeObject(
                 response,
@@ -126,6 +128,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 JsonRpcResponseSerializer.Settings);
             JObject parsed = JObject.Parse(json);
             Assert.That(parsed.Property("FilterType"), Is.EqualTo(null));
+            Assert.That(parsed.Property("FilterValue"), Is.EqualTo(null));
             Assert.That(parsed.Property("UnfilteredTestNames"), Is.EqualTo(null));
             Assert.That(parsed.Property("UnfilteredTestCount"), Is.EqualTo(null));
         }

--- a/Assets/Tests/Editor/RunTestsUnfilteredFilterEchoTests.cs.meta
+++ b/Assets/Tests/Editor/RunTestsUnfilteredFilterEchoTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 808d8e8480aba42e6b49eb4dbd635508
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/RunTestsUnfilteredTestListRetrieverTests.cs
+++ b/Assets/Tests/Editor/RunTestsUnfilteredTestListRetrieverTests.cs
@@ -1,0 +1,45 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies TestRunnerApi.RetrieveTestList through the production unfiltered-list retriever.
+    /// </summary>
+    public sealed class RunTestsUnfilteredTestListRetrieverTests
+    {
+        private const string KnownLeafFullName =
+            "io.github.hatayama.UnityCliLoop.Tests.Editor.RunTestsUnfilteredFilterEchoTests.ApplyIfRetrieved_WhenFilterMisses_AppendsExactMessageAndEchoFields";
+
+        /// <summary>
+        /// What: RetrieveTestList for EditMode returns a catalog that includes a known leaf test full name.
+        /// </summary>
+        [Test]
+        public async Task RetrieveAsync_WhenEditModeCatalogIsAvailable_IncludesKnownLeafFullName()
+        {
+            await MainThreadSwitcher.SwitchToMainThread(CancellationToken.None);
+            RunTestsUnfilteredTestListResult result =
+                await RunTestsUnfilteredTestListRetriever.RetrieveAsync(
+                    UnityCliLoopTestMode.EditMode,
+                    CancellationToken.None);
+
+            Assert.That(result.Retrieved, Is.EqualTo(true));
+            bool found = false;
+            for (int index = 0; index < result.FullNames.Count; index++)
+            {
+                if (result.FullNames[index] == KnownLeafFullName)
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            Assert.That(found, Is.EqualTo(true));
+        }
+    }
+}

--- a/Assets/Tests/Editor/RunTestsUnfilteredTestListRetrieverTests.cs.meta
+++ b/Assets/Tests/Editor/RunTestsUnfilteredTestListRetrieverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e2767d65d5fd45778f86eaaaf89a82a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -882,7 +882,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(response.Message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
             Assert.That(response.ShouldSerializeFilterType(), Is.EqualTo(false));
+            Assert.That(response.ShouldSerializeFilterValue(), Is.EqualTo(false));
             Assert.That(response.ShouldSerializeUnfilteredTestNames(), Is.EqualTo(false));
+            Assert.That(response.ShouldSerializeUnfilteredTestCount(), Is.EqualTo(false));
             Assert.That(response.UnfilteredTestNames, Is.Null);
         }
 

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -841,7 +841,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 response.Message,
                 Is.EqualTo(
-                    "No tests found matching the specified filter criteria No tests matched FilterType 'exact' with FilterValue 'Missing.Test'. 2 test(s) exist in this TestMode without the filter; compare UnfilteredTestNames against the filter value."));
+                    "No tests found matching the specified filter criteria. No tests matched FilterType 'exact' with FilterValue 'Missing.Test'. 2 test(s) exist in this TestMode without the filter; compare UnfilteredTestNames against the filter value."));
             Assert.That(response.FilterType, Is.EqualTo("exact"));
             Assert.That(response.FilterValue, Is.EqualTo("Missing.Test"));
             Assert.That(response.UnfilteredTestCount, Is.EqualTo(2));

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -228,6 +229,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.Message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
             Assert.That(response.TestCount, Is.EqualTo(0));
             Assert.That(response.FailedCount, Is.EqualTo(0));
+            Assert.That(response.ShouldSerializeFilterType(), Is.EqualTo(false));
+            Assert.That(response.ShouldSerializeFilterValue(), Is.EqualTo(false));
+            Assert.That(response.ShouldSerializeUnfilteredTestNames(), Is.EqualTo(false));
+            Assert.That(response.ShouldSerializeUnfilteredTestCount(), Is.EqualTo(false));
         }
 
         [Test]
@@ -802,6 +807,113 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(diagnosticCapture.ObservedIsMainThread, Is.True);
         }
 
+        /// <summary>
+        /// What: a filtered NoTestsFound run echoes the filter and stubbed unfiltered names on the response.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenFilteredNoTestsFound_EchoesUnfilteredNamesAndAppendsMessage()
+        {
+            StubTestExecutionService executionService = new StubTestExecutionService
+            {
+                NextResult = CreateNoTestsFoundResult(),
+                UnfilteredTestListResult = RunTestsUnfilteredTestListResult.Success(
+                    new[]
+                    {
+                        "Example.Tests.Alpha",
+                        "Example.Tests.Beta"
+                    })
+            };
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                new StubTestExecutionStateValidationService(ValidationResult.Success()),
+                waitForTestRunnerCleanupAsync: NoCleanupWait);
+            RunTestsSchema parameters = new RunTestsSchema
+            {
+                TestMode = UnityCliLoopTestMode.EditMode,
+                FilterType = TestFilterType.exact,
+                FilterValue = "Missing.Test"
+            };
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.NoTestsFound, Is.EqualTo(true));
+            Assert.That(
+                response.Message,
+                Is.EqualTo(
+                    "No tests found matching the specified filter criteria No tests matched FilterType 'exact' with FilterValue 'Missing.Test'. 2 test(s) exist in this TestMode without the filter; compare UnfilteredTestNames against the filter value."));
+            Assert.That(response.FilterType, Is.EqualTo("exact"));
+            Assert.That(response.FilterValue, Is.EqualTo("Missing.Test"));
+            Assert.That(response.UnfilteredTestCount, Is.EqualTo(2));
+            Assert.That(
+                response.UnfilteredTestNames,
+                Is.EqualTo(new List<string> { "Example.Tests.Alpha", "Example.Tests.Beta" }));
+            Assert.That(response.ShouldSerializeFilterType(), Is.EqualTo(true));
+            Assert.That(response.ShouldSerializeFilterValue(), Is.EqualTo(true));
+            Assert.That(response.ShouldSerializeUnfilteredTestNames(), Is.EqualTo(true));
+            Assert.That(response.ShouldSerializeUnfilteredTestCount(), Is.EqualTo(true));
+        }
+
+        /// <summary>
+        /// What: filter-all NoTestsFound keeps the original message and omits unfiltered echo fields.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenFilterAllNoTestsFound_OmitsUnfilteredEchoFields()
+        {
+            StubTestExecutionService executionService = new StubTestExecutionService
+            {
+                NextResult = CreateNoTestsFoundResult(),
+                UnfilteredTestListResult = RunTestsUnfilteredTestListResult.Success(
+                    new[] { "Example.Tests.Alpha" })
+            };
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                new StubTestExecutionStateValidationService(ValidationResult.Success()),
+                waitForTestRunnerCleanupAsync: NoCleanupWait,
+                appendNoTestsDiagnostics: PassThroughNoTestsDiagnostics);
+            RunTestsSchema parameters = new RunTestsSchema
+            {
+                TestMode = UnityCliLoopTestMode.EditMode,
+                FilterType = TestFilterType.all
+            };
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
+            Assert.That(response.ShouldSerializeFilterType(), Is.EqualTo(false));
+            Assert.That(response.ShouldSerializeUnfilteredTestNames(), Is.EqualTo(false));
+            Assert.That(response.UnfilteredTestNames, Is.Null);
+        }
+
+        private static SerializableTestResult CreateNoTestsFoundResult()
+        {
+            return new SerializableTestResult
+            {
+                success = false,
+                status = RunTestsExecutionStatus.NoTestsFound,
+                hasFailures = false,
+                noTestsFound = true,
+                noTestsFoundExplanation = RunTestsResponse.NoTestsFoundExplanationText,
+                message = RunTestsResponse.NoTestsFoundMessage,
+                completedAt = "2026-01-01T00:00:00.0000000Z",
+                testCount = 0,
+                passedCount = 0,
+                failedCount = 0,
+                skippedCount = 0,
+                xmlPath = null
+            };
+        }
+
+        private static string PassThroughNoTestsDiagnostics(
+            string message,
+            bool noTestsFound,
+            UnityCliLoopTestMode testMode,
+            TestFilterType filterType)
+        {
+            return message;
+        }
+
         private static Task NoCleanupWait(CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
@@ -849,6 +961,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             public override bool IsTestFrameworkAvailable => TestFrameworkAvailable;
 
+            public RunTestsUnfilteredTestListResult UnfilteredTestListResult { get; set; } =
+                RunTestsUnfilteredTestListResult.NotRetrieved();
+
             public override Task<SerializableTestResult> ExecutePlayModeTestAsync(TestExecutionFilter filter, CancellationToken ct)
             {
                 ct.ThrowIfCancellationRequested();
@@ -861,6 +976,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 ct.ThrowIfCancellationRequested();
                 WasCalled = true;
                 return Task.FromResult(NextResult);
+            }
+
+            internal override Task<RunTestsUnfilteredTestListResult> RetrieveUnfilteredTestNamesAsync(
+                UnityCliLoopTestMode testMode,
+                CancellationToken ct)
+            {
+                ct.ThrowIfCancellationRequested();
+                return Task.FromResult(UnfilteredTestListResult);
             }
         }
 

--- a/Assets/Tests/Editor/UnityTestFrameworkOptionalGuardTests.cs
+++ b/Assets/Tests/Editor/UnityTestFrameworkOptionalGuardTests.cs
@@ -32,7 +32,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             "Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs",
             "Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/NUnitXmlResultExporter.cs",
-            "Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/SerializableTestResultConverter.cs"
+            "Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/SerializableTestResultConverter.cs",
+            "Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsUnfilteredTestListRetriever.cs"
         };
 
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs
@@ -7,10 +7,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public const int FailedTestDetailsLimit = 10;
 
+        public const int UnfilteredTestNamesLimit = 20;
+
+        // Why a listing timeout instead of --timeout-seconds: RetrieveTestList is a catalog
+        // callback, not a test run. Waiting the full run timeout would stall a no-tests
+        // response for minutes when the callback never arrives.
+        public const int UnfilteredTestListRetrieveTimeoutMilliseconds = 10000;
+
         // Format: listed count, total failed count. Emitted when FailedCount exceeds the
         // listed cap so the truncation is never silent.
         public const string FailedTestDetailsTruncatedMessageFormat =
             "first {0} of {1} failures listed; see XmlPath for full results.";
+
+        // Format: FilterType, FilterValue, UnfilteredTestCount. Appended to the existing
+        // NoTestsFound message so the original sentence stays unchanged.
+        public const string NoTestsFoundWithFilterMessageFormat =
+            " No tests matched FilterType '{0}' with FilterValue '{1}'. {2} test(s) exist in this TestMode without the filter; compare UnfilteredTestNames against the filter value.";
 
         // Format: active hot-reload change count at test-run start. Policy-form because
         // response construction was measured to run before any deferred domain reload.

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs
@@ -21,8 +21,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         // Format: FilterType, FilterValue, UnfilteredTestCount. Appended to the existing
         // NoTestsFound message so the original sentence stays unchanged.
+        // Why a leading period: NoTestsFoundMessage has no terminator, so a leading space
+        // would fuse the two sentences into one.
         public const string NoTestsFoundWithFilterMessageFormat =
-            " No tests matched FilterType '{0}' with FilterValue '{1}'. {2} test(s) exist in this TestMode without the filter; compare UnfilteredTestNames against the filter value.";
+            ". No tests matched FilterType '{0}' with FilterValue '{1}'. {2} test(s) exist in this TestMode without the filter; compare UnfilteredTestNames against the filter value.";
 
         // Format: active hot-reload change count at test-run start. Policy-form because
         // response construction was measured to run before any deferred domain reload.

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -92,10 +93,53 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         public string Warning { get; set; } = string.Empty;
 
+        /// <summary>
+        /// Effective filter type echoed when NoTestsFound ran with a non-all filter.
+        /// </summary>
+        public string FilterType { get; set; }
+
+        /// <summary>
+        /// Effective filter value echoed when NoTestsFound ran with a non-all filter.
+        /// </summary>
+        public string FilterValue { get; set; }
+
+        /// <summary>
+        /// Leaf test full names discovered in the same TestMode with no filter, capped at
+        /// UnfilteredTestNamesLimit. Null when the unfiltered list was not retrieved.
+        /// </summary>
+        public List<string> UnfilteredTestNames { get; set; }
+
+        /// <summary>
+        /// Total leaf tests discovered without the filter, before the UnfilteredTestNames cap.
+        /// </summary>
+        public int UnfilteredTestCount { get; set; }
+
         // Why omit empty: a clean run with no live patches must not grow a Warning field.
         public bool ShouldSerializeWarning()
         {
             return !string.IsNullOrEmpty(Warning);
+        }
+
+        // Why UnfilteredTestNames != null: UnfilteredTestCount can be 0 after a successful
+        // retrieve, and that zero still needs to appear on the wire.
+        public bool ShouldSerializeFilterType()
+        {
+            return UnfilteredTestNames != null;
+        }
+
+        public bool ShouldSerializeFilterValue()
+        {
+            return UnfilteredTestNames != null;
+        }
+
+        public bool ShouldSerializeUnfilteredTestNames()
+        {
+            return UnfilteredTestNames != null;
+        }
+
+        public bool ShouldSerializeUnfilteredTestCount()
+        {
+            return UnfilteredTestNames != null;
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUnfilteredFilterEcho.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUnfilteredFilterEcho.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Globalization;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Copies unfiltered test names onto a NoTestsFound response when a filter was in effect.
+    /// </summary>
+    internal static class RunTestsUnfilteredFilterEcho
+    {
+        internal static void ApplyIfRetrieved(
+            RunTestsResponse response,
+            TestFilterType filterType,
+            string filterValue,
+            RunTestsUnfilteredTestListResult result)
+        {
+            Debug.Assert(response != null, "response must not be null");
+            Debug.Assert(result != null, "result must not be null");
+            if (!response.NoTestsFound || filterType == TestFilterType.all || !result.Retrieved)
+            {
+                return;
+            }
+
+            string echoFilterType = filterType.ToString();
+            string echoFilterValue = filterValue ?? string.Empty;
+            int totalCount = result.FullNames.Count;
+            int listedCount = totalCount;
+            if (listedCount > RunTestsConstants.UnfilteredTestNamesLimit)
+            {
+                listedCount = RunTestsConstants.UnfilteredTestNamesLimit;
+            }
+
+            List<string> listed = new List<string>(listedCount);
+            for (int index = 0; index < listedCount; index++)
+            {
+                listed.Add(result.FullNames[index]);
+            }
+
+            response.FilterType = echoFilterType;
+            response.FilterValue = echoFilterValue;
+            response.UnfilteredTestNames = listed;
+            response.UnfilteredTestCount = totalCount;
+            response.Message = response.Message + string.Format(
+                CultureInfo.InvariantCulture,
+                RunTestsConstants.NoTestsFoundWithFilterMessageFormat,
+                echoFilterType,
+                echoFilterValue,
+                totalCount);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUnfilteredFilterEcho.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUnfilteredFilterEcho.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7de7856ebd49441fb8ae331f897b57cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUnfilteredTestListResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUnfilteredTestListResult.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Outcome of listing tests in a TestMode with no filter applied.
+    /// </summary>
+    internal sealed class RunTestsUnfilteredTestListResult
+    {
+        public bool Retrieved { get; }
+
+        public IReadOnlyList<string> FullNames { get; }
+
+        private RunTestsUnfilteredTestListResult(bool retrieved, IReadOnlyList<string> fullNames)
+        {
+            Retrieved = retrieved;
+            FullNames = fullNames;
+        }
+
+        public static RunTestsUnfilteredTestListResult NotRetrieved()
+        {
+            return new RunTestsUnfilteredTestListResult(false, Array.Empty<string>());
+        }
+
+        public static RunTestsUnfilteredTestListResult Success(IReadOnlyList<string> fullNames)
+        {
+            Debug.Assert(fullNames != null, "fullNames must not be null");
+            return new RunTestsUnfilteredTestListResult(true, fullNames);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUnfilteredTestListResult.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUnfilteredTestListResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 19f2c8aee57f24e30a214769433989f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -199,7 +199,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     response.NoTestsFound,
                     parameters.TestMode,
                     parameters.FilterType));
-            await ApplyUnfilteredFilterEchoIfNeededAsync(response, parameters, ct);
+            await ApplyUnfilteredFilterEchoIfNeededAsync(response, parameters, ct)
+                .ConfigureAwait(false);
             return response;
         }
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -199,7 +199,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     response.NoTestsFound,
                     parameters.TestMode,
                     parameters.FilterType));
+            await ApplyUnfilteredFilterEchoIfNeededAsync(response, parameters, ct);
             return response;
+        }
+
+        private async Task ApplyUnfilteredFilterEchoIfNeededAsync(
+            RunTestsResponse response,
+            RunTestsSchema parameters,
+            CancellationToken ct)
+        {
+            if (!response.NoTestsFound || parameters.FilterType == TestFilterType.all)
+            {
+                return;
+            }
+
+            RunTestsUnfilteredTestListResult unfiltered =
+                await _executionService.RetrieveUnfilteredTestNamesAsync(parameters.TestMode, ct)
+                    .ConfigureAwait(false);
+            RunTestsUnfilteredFilterEcho.ApplyIfRetrieved(
+                response,
+                parameters.FilterType,
+                parameters.FilterValue,
+                unfiltered);
         }
 
         private static bool IsSupportedTestMode(UnityCliLoopTestMode testMode)

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionService.cs
@@ -34,12 +34,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ct.ThrowIfCancellationRequested();
             return UnityTestFrameworkExecutionServiceRegistry.Current.ExecuteEditModeTestAsync(filter, ct);
         }
+
+        /// <summary>
+        /// Lists leaf test full names for a TestMode with no filter applied.
+        /// </summary>
+        internal virtual Task<RunTestsUnfilteredTestListResult> RetrieveUnfilteredTestNamesAsync(
+            UnityCliLoopTestMode testMode,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            return UnityTestFrameworkExecutionServiceRegistry.Current.RetrieveUnfilteredTestNamesAsync(testMode, ct);
+        }
     }
 
     internal interface IUnityTestFrameworkExecutionService
     {
         Task<SerializableTestResult> ExecutePlayModeTestAsync(TestExecutionFilter filter, CancellationToken ct);
         Task<SerializableTestResult> ExecuteEditModeTestAsync(TestExecutionFilter filter, CancellationToken ct);
+        Task<RunTestsUnfilteredTestListResult> RetrieveUnfilteredTestNamesAsync(
+            UnityCliLoopTestMode testMode,
+            CancellationToken ct);
     }
 
     internal static class UnityTestFrameworkExecutionServiceRegistry
@@ -71,6 +85,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             ct.ThrowIfCancellationRequested();
             return Task.FromResult(SerializableTestResult.CreateTestFrameworkUnavailable());
+        }
+
+        public Task<RunTestsUnfilteredTestListResult> RetrieveUnfilteredTestNamesAsync(
+            UnityCliLoopTestMode testMode,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(RunTestsUnfilteredTestListResult.NotRetrieved());
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
@@ -34,6 +34,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             return PlayModeTestExecuter.ExecuteEditModeTest(filter, ct);
         }
+
+        public Task<RunTestsUnfilteredTestListResult> RetrieveUnfilteredTestNamesAsync(
+            UnityCliLoopTestMode testMode,
+            CancellationToken ct)
+        {
+            return RunTestsUnfilteredTestListRetriever.RetrieveAsync(testMode, ct);
+        }
     }
 
     public static class PlayModeTestExecuter

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsUnfilteredTestListRetriever.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsUnfilteredTestListRetriever.cs
@@ -1,0 +1,102 @@
+#if ULOOP_HAS_TEST_FRAMEWORK
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor.TestTools.TestRunner.Api;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Lists leaf tests in a TestMode with no filter via TestRunnerApi.RetrieveTestList.
+    /// </summary>
+    internal static class RunTestsUnfilteredTestListRetriever
+    {
+        internal static async Task<RunTestsUnfilteredTestListResult> RetrieveAsync(
+            UnityCliLoopTestMode testMode,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            Debug.Assert(
+                MainThreadSwitcher.IsMainThread,
+                "RetrieveTestList must run on the main thread because TestRunnerApi is a Unity API.");
+
+            TestMode unityTestMode = testMode == UnityCliLoopTestMode.PlayMode
+                ? TestMode.PlayMode
+                : TestMode.EditMode;
+
+            TaskCompletionSource<ITestAdaptor> taskCompletionSource =
+                new TaskCompletionSource<ITestAdaptor>(TaskCreationOptions.RunContinuationsAsynchronously);
+            TestRunnerApi testRunnerApi = ScriptableObject.CreateInstance<TestRunnerApi>();
+            List<string> names = null;
+            try
+            {
+                testRunnerApi.RetrieveTestList(
+                    unityTestMode,
+                    adaptor => taskCompletionSource.TrySetResult(adaptor));
+                Task timeoutTask = Task.Delay(
+                    RunTestsConstants.UnfilteredTestListRetrieveTimeoutMilliseconds,
+                    ct);
+                await Task.WhenAny(taskCompletionSource.Task, timeoutTask).ConfigureAwait(false);
+                if (ct.IsCancellationRequested)
+                {
+                    ct.ThrowIfCancellationRequested();
+                }
+
+                if (taskCompletionSource.Task.Status == TaskStatus.RanToCompletion)
+                {
+                    ITestAdaptor root = await taskCompletionSource.Task.ConfigureAwait(false);
+                    if (root != null)
+                    {
+                        names = new List<string>();
+                        CollectLeafFullNames(root, names);
+                    }
+                }
+            }
+            finally
+            {
+                await MainThreadSwitcher.SwitchToMainThread(CancellationToken.None);
+                Object.DestroyImmediate(testRunnerApi);
+            }
+
+            if (names == null)
+            {
+                return RunTestsUnfilteredTestListResult.NotRetrieved();
+            }
+
+            return RunTestsUnfilteredTestListResult.Success(names);
+        }
+
+        private static void CollectLeafFullNames(ITestAdaptor node, List<string> names)
+        {
+            if (node == null)
+            {
+                return;
+            }
+
+            if (!node.HasChildren)
+            {
+                if (!node.IsSuite && !string.IsNullOrEmpty(node.FullName))
+                {
+                    names.Add(node.FullName);
+                }
+
+                return;
+            }
+
+            IEnumerable<ITestAdaptor> children = node.Children;
+            if (children == null)
+            {
+                return;
+            }
+
+            foreach (ITestAdaptor child in children)
+            {
+                CollectLeafFullNames(child, names);
+            }
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsUnfilteredTestListRetriever.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsUnfilteredTestListRetriever.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3306d0cd3e28422ab8daff9ca6427e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- When `run-tests` finds zero tests under a filter, the response now echoes the effective filter and lists tests that exist in that TestMode without the filter.
- Agents can compare `UnfilteredTestNames` against the filter value instead of guessing whether the name was wrong or the assembly is empty.

## User Impact
- Before: a filter miss returned only "No tests found matching the specified filter criteria", with no echo of FilterType/FilterValue and no candidate names.
- After: the original sentence is kept, then a second sentence names the filter and how many tests exist without it. Up to 20 full names are listed; `UnfilteredTestCount` is the uncapped total. Filter-all zero-discovery still uses the existing asmdef diagnostic path and does not add these fields.

## Changes
- Add wire-compatible response fields `FilterType`, `FilterValue`, `UnfilteredTestNames`, and `UnfilteredTestCount`, omitted via `ShouldSerialize` unless a filtered NoTestsFound retrieve succeeded.
- List unfiltered leaf tests through `TestRunnerApi.RetrieveTestList`. Use-case tests stub that listing so they do not nest the Test Runner. An EditMode catalog test calls `RetrieveAsync` directly.
- If the listing callback does not arrive, the new fields stay omitted and the original message is unchanged.
- The appended sentence starts with a period because the existing NoTestsFound message has no terminator.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Success, ErrorCount 0
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value 'RunTestsUnfilteredFilterEchoTests|RunTestsUseCaseTests|RunTestsNoTestsDiagnosticServiceTests'` → TestCount 55, PassedCount 55 (pre-review-fix)
- After review fix: `RunTestsUnfilteredFilterEchoTests|RunTestsUseCaseTests|UnityTestFrameworkOptionalGuardTests` → TestCount 40, PassedCount 40
- `RunTestsUnfilteredTestListRetrieverTests` twice: TestCount 1, PassedCount 1 both times (no stall/flake)
- Mutation Red: removed `ApplyUnfilteredFilterEchoIfNeededAsync` from the use case. `ExecuteAsync_WhenFilteredNoTestsFound_EchoesUnfilteredNamesAndAppendsMessage` failed with `Expected string length 229 but was 53` at index 53. Restored the call; suite passed again.

### Live unmatched-filter run (production RetrieveTestList path)
Command: `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type exact --filter-value Missing.Test`

Excerpt:
- Status: `NoTestsFound`
- Message: `No tests found matching the specified filter criteria. No tests matched FilterType 'exact' with FilterValue 'Missing.Test'. 3344 test(s) exist in this TestMode without the filter; compare UnfilteredTestNames against the filter value.`
- FilterType: `exact`
- FilterValue: `Missing.Test`
- UnfilteredTestCount: `3344`
- UnfilteredTestNames: 20 leaf full names (first: `io.github.hatayama.UnityCliLoop.Tests.Editor.AssemblyDefinitionConsoleErrorValidationServiceTests.AssemblyDefinitionConsoleErrorResult_WhenErrorsExist_ExposesFormattedMessage`)
