### PR TITLE
docs: state the brand-new-script compile requirement up front in the hot-reload skill

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -24,6 +24,10 @@ uloop hot-reload --revert-all
 Multiple files are passed as one comma-separated value (or a JSON array); array options
 consume exactly one value token.
 
+A brand-new script — or any script under a brand-new `.asmdef` — cannot be hot-reloaded
+before its first import: Unity has not compiled it into any assembly yet. Run
+`uloop compile` once to import new files, then iterate on them with hot reload.
+
 ## Parameters
 
 | Parameter | Type | Default | Description |

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -24,6 +24,10 @@ uloop hot-reload --revert-all
 Multiple files are passed as one comma-separated value (or a JSON array); array options
 consume exactly one value token.
 
+A brand-new script — or any script under a brand-new `.asmdef` — cannot be hot-reloaded
+before its first import: Unity has not compiled it into any assembly yet. Run
+`uloop compile` once to import new files, then iterate on them with hot reload.
+
 ## Parameters
 
 | Parameter | Type | Default | Description |

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -24,6 +24,10 @@ uloop hot-reload --revert-all
 Multiple files are passed as one comma-separated value (or a JSON array); array options
 consume exactly one value token.
 
+A brand-new script — or any script under a brand-new `.asmdef` — cannot be hot-reloaded
+before its first import: Unity has not compiled it into any assembly yet. Run
+`uloop compile` once to import new files, then iterate on them with hot reload.
+
 ## Parameters
 
 | Parameter | Type | Default | Description |


### PR DESCRIPTION
## Summary
- The hot-reload skill now says up front that a brand-new script (or a script under a brand-new `.asmdef`) cannot be hot-reloaded until Unity has imported and compiled it once.

## User Impact
- Before: that requirement lived only in the troubleshooting table, so a first pass on a new file always failed.
- After: Usage tells you to run `uloop compile` once to import the file, then iterate with hot reload.

## Changes
- Appended the brand-new-script compile requirement after the comma-separated `--files` note in the hot-reload skill source.
- Regenerated the tracked `.claude/` and `.agents/` copies with `uloop skills install --claude --agents`. Parameter table and description are unchanged, so the tool catalog was not regenerated.

## Verification
```
rg -n 'A brand-new script' \
  Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md \
  .claude/skills/uloop-hot-reload/SKILL.md \
  .agents/skills/uloop-hot-reload/SKILL.md
```

```
Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md:27:A brand-new script — or any script under a brand-new `.asmdef` — cannot be hot-reloaded
.claude/skills/uloop-hot-reload/SKILL.md:27:A brand-new script — or any script under a brand-new `.asmdef` — cannot be hot-reloaded
.agents/skills/uloop-hot-reload/SKILL.md:27:A brand-new script — or any script under a brand-new `.asmdef` — cannot be hot-reloaded
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

