### PR TITLE
feat: name predefined-assembly test methods when run-tests discovers zero tests

### DIFF
--- a/Assets/Tests/Editor/RunTestsPredefinedAssemblyTestScannerTests.cs
+++ b/Assets/Tests/Editor/RunTestsPredefinedAssemblyTestScannerTests.cs
@@ -105,7 +105,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 notice,
                 Is.EqualTo(
-                    " Additionally, 2 NUnit test method(s) are compiled into predefined assemblies rather than any test assembly: Assembly-CSharp: Game.Foo.Alpha, Assembly-CSharp-Editor: Editor.Bar.Beta. Unity Test Runner does not discover tests that live outside a test assembly; move these scripts into a folder whose .asmdef has Test Assemblies enabled (EditMode tests target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests."));
+                    " Additionally, 2 NUnit test method(s) are compiled into predefined assemblies rather than any test assembly, so this run could not discover them: Assembly-CSharp: Game.Foo.Alpha, Assembly-CSharp-Editor: Editor.Bar.Beta. Move these scripts into a folder whose .asmdef has Test Assemblies enabled (EditMode tests target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests."));
         }
 
         /// <summary>
@@ -130,22 +130,70 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 notice,
                 Is.EqualTo(
-                    " Additionally, 7 NUnit test method(s) are compiled into predefined assemblies rather than any test assembly: Assembly-CSharp: Game.One.A, Assembly-CSharp: Game.Two.B, Assembly-CSharp: Game.Three.C, Assembly-CSharp: Game.Four.D, Assembly-CSharp: Game.Five.E (+2 more). Unity Test Runner does not discover tests that live outside a test assembly; move these scripts into a folder whose .asmdef has Test Assemblies enabled (EditMode tests target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests."));
+                    " Additionally, 7 NUnit test method(s) are compiled into predefined assemblies rather than any test assembly, so this run could not discover them: Assembly-CSharp: Game.One.A, Assembly-CSharp: Game.Two.B, Assembly-CSharp: Game.Three.C, Assembly-CSharp: Game.Four.D, Assembly-CSharp: Game.Five.E (+2 more). Move these scripts into a folder whose .asmdef has Test Assemblies enabled (EditMode tests target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests."));
         }
 
         /// <summary>
-        /// What: TypeCache 実経路の煙テスト. This repository's tests live in asmdefs, so Scan returns none.
+        /// What: AppendIfNeeded inserts a period when the current message has no terminator.
         /// </summary>
         [Test]
-        public async Task ScanPredefinedAssemblyTests_WhenRegistryIsLive_ReturnsNoneWithoutThrowing()
+        public void AppendIfNeeded_WhenMessageHasNoTerminator_InsertsPeriodBeforeNotice()
+        {
+            RunTestsPredefinedAssemblyTestFindings findings = RunTestsPredefinedAssemblyTestFindings.Create(
+                1,
+                new[] { "Assembly-CSharp: Game.Foo.Alpha" });
+
+            string message = RunTestsPredefinedAssemblyTestNoticeFormatter.AppendIfNeeded(
+                RunTestsResponse.NoTestsFoundMessage,
+                findings);
+
+            Assert.That(
+                message,
+                Is.EqualTo(
+                    "No tests found matching the specified filter criteria. Additionally, 1 NUnit test method(s) are compiled into predefined assemblies rather than any test assembly, so this run could not discover them: Assembly-CSharp: Game.Foo.Alpha. Move these scripts into a folder whose .asmdef has Test Assemblies enabled (EditMode tests target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests."));
+        }
+
+        /// <summary>
+        /// What: AppendIfNeeded does not insert a second period when the current message already ends with one.
+        /// </summary>
+        [Test]
+        public void AppendIfNeeded_WhenMessageAlreadyEndsWithPeriod_DoesNotInsertExtraPeriod()
+        {
+            RunTestsPredefinedAssemblyTestFindings findings = RunTestsPredefinedAssemblyTestFindings.Create(
+                1,
+                new[] { "Assembly-CSharp: Game.Foo.Alpha" });
+            string messageWithHint =
+                "No tests found matching the specified filter criteria Possible asmdef issues: Assets/Tests/EditMode/Sample.Tests.asmdef: sample finding.";
+
+            string message = RunTestsPredefinedAssemblyTestNoticeFormatter.AppendIfNeeded(
+                messageWithHint,
+                findings);
+
+            Assert.That(
+                message,
+                Is.EqualTo(
+                    "No tests found matching the specified filter criteria Possible asmdef issues: Assets/Tests/EditMode/Sample.Tests.asmdef: sample finding. Additionally, 1 NUnit test method(s) are compiled into predefined assemblies rather than any test assembly, so this run could not discover them: Assembly-CSharp: Game.Foo.Alpha. Move these scripts into a folder whose .asmdef has Test Assemblies enabled (EditMode tests target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests."));
+        }
+
+        /// <summary>
+        /// What: TypeCache 実経路の煙テスト. The Assets/Util probe is compiled into Assembly-CSharp.
+        /// </summary>
+        [Test]
+        public async Task ScanPredefinedAssemblyTests_WhenRegistryIsLive_FindsProbeFixture()
         {
             await MainThreadSwitcher.SwitchToMainThread(CancellationToken.None);
 
             RunTestsPredefinedAssemblyTestFindings findings =
                 UnityTestFrameworkExecutionServiceRegistry.Current.ScanPredefinedAssemblyTests();
 
-            Assert.That(findings.TotalCount, Is.EqualTo(0));
-            Assert.That(findings.SampleEntries, Is.EqualTo(Array.Empty<string>()));
+            Assert.That(findings.TotalCount, Is.EqualTo(1));
+            Assert.That(
+                findings.SampleEntries,
+                Is.EqualTo(
+                    new[]
+                    {
+                        "Assembly-CSharp: UnityCliLoop.RunTestsPredefinedAssemblyProbe.RunTestsPredefinedAssemblyProbe.Marker"
+                    }));
         }
     }
 }

--- a/Assets/Tests/Editor/RunTestsPredefinedAssemblyTestScannerTests.cs
+++ b/Assets/Tests/Editor/RunTestsPredefinedAssemblyTestScannerTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies predefined-assembly test scanning, notice formatting, and registry wiring.
+    /// </summary>
+    public sealed class RunTestsPredefinedAssemblyTestScannerTests
+    {
+        /// <summary>
+        /// What: methods that live only in project test assemblies produce no findings.
+        /// </summary>
+        [Test]
+        public void Build_WithMethodsOnlyInProjectAsmdefAssemblies_ReturnsNone()
+        {
+            (string AssemblyName, string TypeFullName, string MethodName)[] methods =
+            {
+                ("Game.Tests", "Game.Tests.PlayerTests", "Move")
+            };
+
+            RunTestsPredefinedAssemblyTestFindings findings = RunTestsPredefinedAssemblyTestScanner.Build(methods);
+
+            Assert.That(findings.TotalCount, Is.EqualTo(0));
+            Assert.That(findings.SampleEntries, Is.EqualTo(Array.Empty<string>()));
+        }
+
+        /// <summary>
+        /// What: Build keeps predefined assemblies, drops others, deduplicates, sorts, and caps samples.
+        /// </summary>
+        [Test]
+        public void Build_WithPredefinedAssemblyMethods_FiltersSortsAndCaps()
+        {
+            (string AssemblyName, string TypeFullName, string MethodName)[] methods =
+            {
+                ("Game.Tests", "Game.Tests.PlayerTests", "Move"),
+                ("Assembly-CSharp-Editor-firstpass", "Plugin.EditorTests", "Zed"),
+                ("Assembly-CSharp-firstpass", "Plugin.PlayTests", "Yap"),
+                ("Assembly-CSharp-Editor", "Editor.Tests", "Xray"),
+                ("Assembly-CSharp", "Game.Foo", "Alpha"),
+                ("Assembly-CSharp", "Game.Foo", "Alpha"),
+                ("Assembly-CSharp", "Game.Bar", "Beta"),
+                ("Assembly-CSharp", "Game.Baz", "Gamma"),
+                ("Assembly-CSharp", "Game.Qux", "Delta")
+            };
+
+            RunTestsPredefinedAssemblyTestFindings findings = RunTestsPredefinedAssemblyTestScanner.Build(methods);
+
+            Assert.That(findings.TotalCount, Is.EqualTo(7));
+            Assert.That(
+                findings.SampleEntries,
+                Is.EqualTo(
+                    new[]
+                    {
+                        "Assembly-CSharp: Game.Bar.Beta",
+                        "Assembly-CSharp: Game.Baz.Gamma",
+                        "Assembly-CSharp: Game.Foo.Alpha",
+                        "Assembly-CSharp: Game.Qux.Delta",
+                        "Assembly-CSharp-Editor: Editor.Tests.Xray"
+                    }));
+        }
+
+        /// <summary>
+        /// What: the same assembly/type/method triple from overlapping attributes is counted once.
+        /// </summary>
+        [Test]
+        public void Build_WithDuplicateAttributeEntries_CountsMethodOnce()
+        {
+            (string AssemblyName, string TypeFullName, string MethodName)[] methods =
+            {
+                ("Assembly-CSharp", "Game.Foo", "Alpha"),
+                ("Assembly-CSharp", "Game.Foo", "Alpha"),
+                ("Assembly-CSharp", "Game.Foo", "Alpha")
+            };
+
+            RunTestsPredefinedAssemblyTestFindings findings = RunTestsPredefinedAssemblyTestScanner.Build(methods);
+
+            Assert.That(findings.TotalCount, Is.EqualTo(1));
+            Assert.That(
+                findings.SampleEntries,
+                Is.EqualTo(new[] { "Assembly-CSharp: Game.Foo.Alpha" }));
+        }
+
+        /// <summary>
+        /// What: FormatNotice matches the full notice when every finding fits in the sample list.
+        /// </summary>
+        [Test]
+        public void FormatNotice_WhenSampleCoversTotal_MatchesLiteral()
+        {
+            RunTestsPredefinedAssemblyTestFindings findings = RunTestsPredefinedAssemblyTestFindings.Create(
+                2,
+                new[]
+                {
+                    "Assembly-CSharp: Game.Foo.Alpha",
+                    "Assembly-CSharp-Editor: Editor.Bar.Beta"
+                });
+
+            string notice = RunTestsPredefinedAssemblyTestNoticeFormatter.FormatNotice(findings);
+
+            Assert.That(
+                notice,
+                Is.EqualTo(
+                    " Additionally, 2 NUnit test method(s) are compiled into predefined assemblies rather than any test assembly: Assembly-CSharp: Game.Foo.Alpha, Assembly-CSharp-Editor: Editor.Bar.Beta. Unity Test Runner does not discover tests that live outside a test assembly; move these scripts into a folder whose .asmdef has Test Assemblies enabled (EditMode tests target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests."));
+        }
+
+        /// <summary>
+        /// What: FormatNotice appends (+N more) when TotalCount exceeds the sample cap.
+        /// </summary>
+        [Test]
+        public void FormatNotice_WhenTotalExceedsSampleLimit_AppendsMoreSuffix()
+        {
+            RunTestsPredefinedAssemblyTestFindings findings = RunTestsPredefinedAssemblyTestFindings.Create(
+                7,
+                new[]
+                {
+                    "Assembly-CSharp: Game.One.A",
+                    "Assembly-CSharp: Game.Two.B",
+                    "Assembly-CSharp: Game.Three.C",
+                    "Assembly-CSharp: Game.Four.D",
+                    "Assembly-CSharp: Game.Five.E"
+                });
+
+            string notice = RunTestsPredefinedAssemblyTestNoticeFormatter.FormatNotice(findings);
+
+            Assert.That(
+                notice,
+                Is.EqualTo(
+                    " Additionally, 7 NUnit test method(s) are compiled into predefined assemblies rather than any test assembly: Assembly-CSharp: Game.One.A, Assembly-CSharp: Game.Two.B, Assembly-CSharp: Game.Three.C, Assembly-CSharp: Game.Four.D, Assembly-CSharp: Game.Five.E (+2 more). Unity Test Runner does not discover tests that live outside a test assembly; move these scripts into a folder whose .asmdef has Test Assemblies enabled (EditMode tests target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests."));
+        }
+
+        /// <summary>
+        /// What: TypeCache 実経路の煙テスト. This repository's tests live in asmdefs, so Scan returns none.
+        /// </summary>
+        [Test]
+        public async Task ScanPredefinedAssemblyTests_WhenRegistryIsLive_ReturnsNoneWithoutThrowing()
+        {
+            await MainThreadSwitcher.SwitchToMainThread(CancellationToken.None);
+
+            RunTestsPredefinedAssemblyTestFindings findings =
+                UnityTestFrameworkExecutionServiceRegistry.Current.ScanPredefinedAssemblyTests();
+
+            Assert.That(findings.TotalCount, Is.EqualTo(0));
+            Assert.That(findings.SampleEntries, Is.EqualTo(Array.Empty<string>()));
+        }
+    }
+}

--- a/Assets/Tests/Editor/RunTestsPredefinedAssemblyTestScannerTests.cs.meta
+++ b/Assets/Tests/Editor/RunTestsPredefinedAssemblyTestScannerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5fa2b4fff988e40b79c747824c738804
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -888,6 +888,71 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.UnfilteredTestNames, Is.Null);
         }
 
+        /// <summary>
+        /// What: filter-all NoTestsFound appends the predefined-assembly notice after the original message when findings exist.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenFilterAllNoTestsFoundWithPredefinedAssemblyTests_AppendsNotice()
+        {
+            StubTestExecutionService executionService = new StubTestExecutionService
+            {
+                NextResult = CreateNoTestsFoundResult(),
+                PredefinedAssemblyTestFindings = RunTestsPredefinedAssemblyTestFindings.Create(
+                    2,
+                    new[]
+                    {
+                        "Assembly-CSharp: Game.Foo.Alpha",
+                        "Assembly-CSharp-Editor: Editor.Bar.Beta"
+                    })
+            };
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                new StubTestExecutionStateValidationService(ValidationResult.Success()),
+                waitForTestRunnerCleanupAsync: NoCleanupWait,
+                appendNoTestsDiagnostics: PassThroughNoTestsDiagnostics);
+            RunTestsSchema parameters = new RunTestsSchema
+            {
+                TestMode = UnityCliLoopTestMode.EditMode,
+                FilterType = TestFilterType.all
+            };
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(
+                response.Message,
+                Is.EqualTo(
+                    "No tests found matching the specified filter criteria Additionally, 2 NUnit test method(s) are compiled into predefined assemblies rather than any test assembly: Assembly-CSharp: Game.Foo.Alpha, Assembly-CSharp-Editor: Editor.Bar.Beta. Unity Test Runner does not discover tests that live outside a test assembly; move these scripts into a folder whose .asmdef has Test Assemblies enabled (EditMode tests target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests."));
+        }
+
+        /// <summary>
+        /// What: filter-all NoTestsFound keeps the original message when predefined-assembly findings are empty.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenFilterAllNoTestsFoundWithNoPredefinedAssemblyTests_KeepsOriginalMessage()
+        {
+            StubTestExecutionService executionService = new StubTestExecutionService
+            {
+                NextResult = CreateNoTestsFoundResult(),
+                PredefinedAssemblyTestFindings = RunTestsPredefinedAssemblyTestFindings.None()
+            };
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                new StubTestExecutionStateValidationService(ValidationResult.Success()),
+                waitForTestRunnerCleanupAsync: NoCleanupWait,
+                appendNoTestsDiagnostics: PassThroughNoTestsDiagnostics);
+            RunTestsSchema parameters = new RunTestsSchema
+            {
+                TestMode = UnityCliLoopTestMode.EditMode,
+                FilterType = TestFilterType.all
+            };
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
+        }
+
         private static SerializableTestResult CreateNoTestsFoundResult()
         {
             return new SerializableTestResult
@@ -966,6 +1031,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             public RunTestsUnfilteredTestListResult UnfilteredTestListResult { get; set; } =
                 RunTestsUnfilteredTestListResult.NotRetrieved();
 
+            public RunTestsPredefinedAssemblyTestFindings PredefinedAssemblyTestFindings { get; set; } =
+                RunTestsPredefinedAssemblyTestFindings.None();
+
             public override Task<SerializableTestResult> ExecutePlayModeTestAsync(TestExecutionFilter filter, CancellationToken ct)
             {
                 ct.ThrowIfCancellationRequested();
@@ -986,6 +1054,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 ct.ThrowIfCancellationRequested();
                 return Task.FromResult(UnfilteredTestListResult);
+            }
+
+            internal override RunTestsPredefinedAssemblyTestFindings ScanPredefinedAssemblyTests()
+            {
+                return PredefinedAssemblyTestFindings;
             }
         }
 

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -922,7 +922,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 response.Message,
                 Is.EqualTo(
-                    "No tests found matching the specified filter criteria Additionally, 2 NUnit test method(s) are compiled into predefined assemblies rather than any test assembly: Assembly-CSharp: Game.Foo.Alpha, Assembly-CSharp-Editor: Editor.Bar.Beta. Unity Test Runner does not discover tests that live outside a test assembly; move these scripts into a folder whose .asmdef has Test Assemblies enabled (EditMode tests target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests."));
+                    "No tests found matching the specified filter criteria. Additionally, 2 NUnit test method(s) are compiled into predefined assemblies rather than any test assembly, so this run could not discover them: Assembly-CSharp: Game.Foo.Alpha, Assembly-CSharp-Editor: Editor.Bar.Beta. Move these scripts into a folder whose .asmdef has Test Assemblies enabled (EditMode tests target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests."));
+        }
+
+        /// <summary>
+        /// What: filter-all NoTestsFound appends the predefined-assembly notice after a period-terminated asmdef hint without a second period.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenFilterAllNoTestsFoundWithAsmdefHintAndPredefinedAssemblyTests_AppendsNoticeAfterPeriod()
+        {
+            StubTestExecutionService executionService = new StubTestExecutionService
+            {
+                NextResult = CreateNoTestsFoundResult(),
+                PredefinedAssemblyTestFindings = RunTestsPredefinedAssemblyTestFindings.Create(
+                    1,
+                    new[] { "Assembly-CSharp: Game.Foo.Alpha" })
+            };
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                new StubTestExecutionStateValidationService(ValidationResult.Success()),
+                waitForTestRunnerCleanupAsync: NoCleanupWait,
+                appendNoTestsDiagnostics: AppendPeriodTerminatedAsmdefHint);
+            RunTestsSchema parameters = new RunTestsSchema
+            {
+                TestMode = UnityCliLoopTestMode.EditMode,
+                FilterType = TestFilterType.all
+            };
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(
+                response.Message,
+                Is.EqualTo(
+                    "No tests found matching the specified filter criteria Possible asmdef issues: Assets/Tests/EditMode/Sample.Tests.asmdef: sample finding. Additionally, 1 NUnit test method(s) are compiled into predefined assemblies rather than any test assembly, so this run could not discover them: Assembly-CSharp: Game.Foo.Alpha. Move these scripts into a folder whose .asmdef has Test Assemblies enabled (EditMode tests target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests."));
         }
 
         /// <summary>
@@ -970,6 +1003,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 skippedCount = 0,
                 xmlPath = null
             };
+        }
+
+        private static string AppendPeriodTerminatedAsmdefHint(
+            string message,
+            bool noTestsFound,
+            UnityCliLoopTestMode testMode,
+            TestFilterType filterType)
+        {
+            return message + " Possible asmdef issues: Assets/Tests/EditMode/Sample.Tests.asmdef: sample finding.";
         }
 
         private static string PassThroughNoTestsDiagnostics(

--- a/Assets/Util/RunTestsPredefinedAssemblyProbe.cs
+++ b/Assets/Util/RunTestsPredefinedAssemblyProbe.cs
@@ -1,0 +1,23 @@
+#if UNITY_EDITOR
+using NUnit.Framework;
+
+namespace UnityCliLoop.RunTestsPredefinedAssemblyProbe
+{
+    /// <summary>
+    /// NUnit marker compiled into a predefined assembly for the TypeCache smoke test.
+    /// </summary>
+    public sealed class RunTestsPredefinedAssemblyProbe
+    {
+        // Why this file lives under Assets/Util with no .asmdef: deliberately
+        // outside any asmdef so it compiles into predefined Assembly-CSharp;
+        // with this project's default settings (playModeTestRunnerEnabled=0)
+        // neither EditMode nor PlayMode discovery includes it, and only the
+        // TypeCache smoke test references it. #if UNITY_EDITOR keeps NUnit
+        // out of player builds.
+        [Test]
+        public void Marker()
+        {
+        }
+    }
+}
+#endif

--- a/Assets/Util/RunTestsPredefinedAssemblyProbe.cs.meta
+++ b/Assets/Util/RunTestsPredefinedAssemblyProbe.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04ec1ab36aff94774b5171ac7005ef91
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs
@@ -9,6 +9,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public const int UnfilteredTestNamesLimit = 20;
 
+        public const int PredefinedAssemblyTestSampleLimit = 5;
+
+        // Why these four names: Unity compiles scripts with no .asmdef into these
+        // predefined assemblies, and Test Runner never discovers tests that land there.
+        internal const string PredefinedAssemblyCSharpName = "Assembly-CSharp";
+        internal const string PredefinedAssemblyCSharpEditorName = "Assembly-CSharp-Editor";
+        internal const string PredefinedAssemblyCSharpFirstpassName = "Assembly-CSharp-firstpass";
+        internal const string PredefinedAssemblyCSharpEditorFirstpassName = "Assembly-CSharp-Editor-firstpass";
+
+        // Why a leading space: appended after the existing no-tests Message, which
+        // matches NoTestsFoundExplanationText's period-terminated follow-on style
+        // (and the existing asmdef HintPrefix). Why this notice can say Test Runner
+        // does not discover these methods: it is emitted only on zero-discovery
+        // runs. If the runner had found tests, the notice would not appear.
+        internal const string PredefinedAssemblyTestNoticeFormat =
+            " Additionally, {0} NUnit test method(s) are compiled into predefined assemblies rather than any test assembly: {1}. Unity Test Runner does not discover tests that live outside a test assembly; move these scripts into a folder whose .asmdef has Test Assemblies enabled (EditMode tests target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests.";
+
         // Why a listing timeout instead of --timeout-seconds: RetrieveTestList is a catalog
         // callback, not a test run. Waiting the full run timeout would stall a no-tests
         // response for minutes when the callback never arrives.

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs
@@ -12,19 +12,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const int PredefinedAssemblyTestSampleLimit = 5;
 
         // Why these four names: Unity compiles scripts with no .asmdef into these
-        // predefined assemblies, and Test Runner never discovers tests that land there.
+        // predefined assemblies. Tests that land there are the subject of the
+        // zero-discovery notice.
         internal const string PredefinedAssemblyCSharpName = "Assembly-CSharp";
         internal const string PredefinedAssemblyCSharpEditorName = "Assembly-CSharp-Editor";
         internal const string PredefinedAssemblyCSharpFirstpassName = "Assembly-CSharp-firstpass";
         internal const string PredefinedAssemblyCSharpEditorFirstpassName = "Assembly-CSharp-Editor-firstpass";
 
-        // Why a leading space: appended after the existing no-tests Message, which
-        // matches NoTestsFoundExplanationText's period-terminated follow-on style
-        // (and the existing asmdef HintPrefix). Why this notice can say Test Runner
-        // does not discover these methods: it is emitted only on zero-discovery
-        // runs. If the runner had found tests, the notice would not appear.
+        // Why a leading space: appended after the existing no-tests Message and
+        // after any asmdef hints. AppendIfNeeded inserts a period when the current
+        // message has no terminator, so this space stays as-is.
+        // Why "could not discover them" is always true here: this notice is emitted
+        // only on zero-discovery. A PlayMode run with legacy playModeTestRunnerEnabled=1
+        // can discover predefined-assembly tests; that path is not zero-discovery, so
+        // the notice would not appear. The claim is scoped to this run, not a
+        // universal "never discovers".
         internal const string PredefinedAssemblyTestNoticeFormat =
-            " Additionally, {0} NUnit test method(s) are compiled into predefined assemblies rather than any test assembly: {1}. Unity Test Runner does not discover tests that live outside a test assembly; move these scripts into a folder whose .asmdef has Test Assemblies enabled (EditMode tests target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests.";
+            " Additionally, {0} NUnit test method(s) are compiled into predefined assemblies rather than any test assembly, so this run could not discover them: {1}. Move these scripts into a folder whose .asmdef has Test Assemblies enabled (EditMode tests target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests.";
 
         // Why a listing timeout instead of --timeout-seconds: RetrieveTestList is a catalog
         // callback, not a test run. Waiting the full run timeout would stall a no-tests

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsPredefinedAssemblyTestFindings.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsPredefinedAssemblyTestFindings.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Named NUnit test methods compiled into Unity predefined assemblies.
+    /// </summary>
+    internal sealed class RunTestsPredefinedAssemblyTestFindings
+    {
+        public int TotalCount { get; }
+
+        public IReadOnlyList<string> SampleEntries { get; }
+
+        private RunTestsPredefinedAssemblyTestFindings(int totalCount, IReadOnlyList<string> sampleEntries)
+        {
+            TotalCount = totalCount;
+            SampleEntries = sampleEntries;
+        }
+
+        public static RunTestsPredefinedAssemblyTestFindings None()
+        {
+            return new RunTestsPredefinedAssemblyTestFindings(0, Array.Empty<string>());
+        }
+
+        public static RunTestsPredefinedAssemblyTestFindings Create(
+            int totalCount,
+            IReadOnlyList<string> sampleEntries)
+        {
+            Debug.Assert(totalCount >= 0, "totalCount must be >= 0");
+            Debug.Assert(sampleEntries != null, "sampleEntries must not be null");
+            Debug.Assert(
+                sampleEntries.Count <= RunTestsConstants.PredefinedAssemblyTestSampleLimit,
+                "sampleEntries must already be capped");
+            Debug.Assert(
+                totalCount == 0 || sampleEntries.Count > 0,
+                "non-zero totalCount must include at least one sample entry");
+
+            return new RunTestsPredefinedAssemblyTestFindings(totalCount, sampleEntries);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsPredefinedAssemblyTestFindings.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsPredefinedAssemblyTestFindings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56252661053b64dd29b2d26e4a24de0c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsPredefinedAssemblyTestNoticeFormatter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsPredefinedAssemblyTestNoticeFormatter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using UnityEngine;
 
@@ -18,7 +19,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return message;
             }
 
-            return message + FormatNotice(findings);
+            string terminator = string.Empty;
+            if (!message.EndsWith(".", StringComparison.Ordinal))
+            {
+                terminator = ".";
+            }
+
+            return message + terminator + FormatNotice(findings);
         }
 
         internal static string FormatNotice(RunTestsPredefinedAssemblyTestFindings findings)

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsPredefinedAssemblyTestNoticeFormatter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsPredefinedAssemblyTestNoticeFormatter.cs
@@ -1,0 +1,43 @@
+using System.Globalization;
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Formats the no-tests Message suffix that names predefined-assembly test methods.
+    /// </summary>
+    internal static class RunTestsPredefinedAssemblyTestNoticeFormatter
+    {
+        internal static string AppendIfNeeded(string message, RunTestsPredefinedAssemblyTestFindings findings)
+        {
+            Debug.Assert(message != null, "message must not be null");
+            Debug.Assert(findings != null, "findings must not be null");
+
+            if (findings.TotalCount == 0)
+            {
+                return message;
+            }
+
+            return message + FormatNotice(findings);
+        }
+
+        internal static string FormatNotice(RunTestsPredefinedAssemblyTestFindings findings)
+        {
+            Debug.Assert(findings != null, "findings must not be null");
+            Debug.Assert(findings.TotalCount > 0, "FormatNotice requires at least one finding");
+
+            string listed = string.Join(", ", findings.SampleEntries);
+            if (findings.TotalCount > RunTestsConstants.PredefinedAssemblyTestSampleLimit)
+            {
+                int omittedCount = findings.TotalCount - RunTestsConstants.PredefinedAssemblyTestSampleLimit;
+                listed += " (+" + omittedCount.ToString(CultureInfo.InvariantCulture) + " more)";
+            }
+
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                RunTestsConstants.PredefinedAssemblyTestNoticeFormat,
+                findings.TotalCount,
+                listed);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsPredefinedAssemblyTestNoticeFormatter.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsPredefinedAssemblyTestNoticeFormatter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a49f9f02dff0a47ab9b523083d31d58d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -190,7 +190,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             // Why switch here: cleanup waits with ConfigureAwait(false), so this resume is
-            // off-thread. No-tests diagnostics call AssetDatabase.FindAssets, a Unity API.
+            // off-thread. No-tests diagnostics call AssetDatabase.FindAssets, and the
+            // predefined-assembly scan calls TypeCache, both Unity Editor APIs.
             await MainThreadSwitcher.SwitchToMainThread(ct);
             response.Message = RunTestsNoTestsDiagnosticService.AppendDiagnosticsOrOriginalMessage(
                 response.Message,
@@ -199,9 +200,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     response.NoTestsFound,
                     parameters.TestMode,
                     parameters.FilterType));
+            AppendPredefinedAssemblyTestNoticeIfNeeded(response, parameters);
             await ApplyUnfilteredFilterEchoIfNeededAsync(response, parameters, ct)
                 .ConfigureAwait(false);
             return response;
+        }
+
+        private void AppendPredefinedAssemblyTestNoticeIfNeeded(
+            RunTestsResponse response,
+            RunTestsSchema parameters)
+        {
+            Debug.Assert(response != null, "response must not be null");
+            Debug.Assert(parameters != null, "parameters must not be null");
+
+            if (!RunTestsNoTestsDiagnosticService.ShouldAppendDiagnostics(
+                    response.NoTestsFound,
+                    parameters.FilterType))
+            {
+                return;
+            }
+
+            RunTestsPredefinedAssemblyTestFindings findings = _executionService.ScanPredefinedAssemblyTests();
+            response.Message = RunTestsPredefinedAssemblyTestNoticeFormatter.AppendIfNeeded(
+                response.Message,
+                findings);
         }
 
         private async Task ApplyUnfilteredFilterEchoIfNeededAsync(

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionService.cs
@@ -45,6 +45,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ct.ThrowIfCancellationRequested();
             return UnityTestFrameworkExecutionServiceRegistry.Current.RetrieveUnfilteredTestNamesAsync(testMode, ct);
         }
+
+        /// <summary>
+        /// Names NUnit test methods compiled into Unity predefined assemblies.
+        /// </summary>
+        internal virtual RunTestsPredefinedAssemblyTestFindings ScanPredefinedAssemblyTests()
+        {
+            return UnityTestFrameworkExecutionServiceRegistry.Current.ScanPredefinedAssemblyTests();
+        }
     }
 
     internal interface IUnityTestFrameworkExecutionService
@@ -54,6 +62,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         Task<RunTestsUnfilteredTestListResult> RetrieveUnfilteredTestNamesAsync(
             UnityCliLoopTestMode testMode,
             CancellationToken ct);
+        RunTestsPredefinedAssemblyTestFindings ScanPredefinedAssemblyTests();
     }
 
     internal static class UnityTestFrameworkExecutionServiceRegistry
@@ -93,6 +102,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             ct.ThrowIfCancellationRequested();
             return Task.FromResult(RunTestsUnfilteredTestListResult.NotRetrieved());
+        }
+
+        public RunTestsPredefinedAssemblyTestFindings ScanPredefinedAssemblyTests()
+        {
+            return RunTestsPredefinedAssemblyTestFindings.None();
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
@@ -41,6 +41,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             return RunTestsUnfilteredTestListRetriever.RetrieveAsync(testMode, ct);
         }
+
+        public RunTestsPredefinedAssemblyTestFindings ScanPredefinedAssemblyTests()
+        {
+            return RunTestsPredefinedAssemblyTestScanner.Scan();
+        }
     }
 
     public static class PlayModeTestExecuter

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPredefinedAssemblyTestScanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPredefinedAssemblyTestScanner.cs
@@ -21,6 +21,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 MainThreadSwitcher.IsMainThread,
                 "TypeCache.GetMethodsWithAttribute must run on the main thread because TypeCache is a Unity Editor API.");
 
+            // Why scan all four predefined assemblies without TestMode: during an
+            // EditMode run the common accident is a test script landing in runtime
+            // Assembly-CSharp. Filtering by TestMode would hide that case.
+            // Editor-predefined tests are discovered by EditMode, so they do not
+            // share a zero-discovery notice on an EditMode run.
             List<(string AssemblyName, string TypeFullName, string MethodName)> methods =
                 new List<(string AssemblyName, string TypeFullName, string MethodName)>();
             // Why TypeCache instead of Assembly.GetTypes(): GetTypes() throws

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPredefinedAssemblyTestScanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPredefinedAssemblyTestScanner.cs
@@ -1,0 +1,144 @@
+#if ULOOP_HAS_TEST_FRAMEWORK
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Finds NUnit test methods compiled into Unity predefined assemblies.
+    /// </summary>
+    internal static class RunTestsPredefinedAssemblyTestScanner
+    {
+        internal static RunTestsPredefinedAssemblyTestFindings Scan()
+        {
+            Debug.Assert(
+                MainThreadSwitcher.IsMainThread,
+                "TypeCache.GetMethodsWithAttribute must run on the main thread because TypeCache is a Unity Editor API.");
+
+            List<(string AssemblyName, string TypeFullName, string MethodName)> methods =
+                new List<(string AssemblyName, string TypeFullName, string MethodName)>();
+            // Why TypeCache instead of Assembly.GetTypes(): GetTypes() throws
+            // ReflectionTypeLoadException when any type in the assembly fails to load.
+            Collect(TypeCache.GetMethodsWithAttribute<TestAttribute>(), methods);
+            Collect(TypeCache.GetMethodsWithAttribute<TestCaseAttribute>(), methods);
+            Collect(TypeCache.GetMethodsWithAttribute<UnityTestAttribute>(), methods);
+            return Build(methods);
+        }
+
+        internal static RunTestsPredefinedAssemblyTestFindings Build(
+            IReadOnlyList<(string AssemblyName, string TypeFullName, string MethodName)> methods)
+        {
+            Debug.Assert(methods != null, "methods must not be null");
+
+            HashSet<(string AssemblyName, string TypeFullName, string MethodName)> unique =
+                new HashSet<(string AssemblyName, string TypeFullName, string MethodName)>();
+            List<(string AssemblyName, string TypeFullName, string MethodName)> filtered =
+                new List<(string AssemblyName, string TypeFullName, string MethodName)>();
+            for (int index = 0; index < methods.Count; index++)
+            {
+                (string assemblyName, string typeFullName, string methodName) = methods[index];
+                Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty");
+                Debug.Assert(!string.IsNullOrEmpty(typeFullName), "typeFullName must not be null or empty");
+                Debug.Assert(!string.IsNullOrEmpty(methodName), "methodName must not be null or empty");
+
+                if (!IsPredefinedAssembly(assemblyName))
+                {
+                    continue;
+                }
+
+                (string AssemblyName, string TypeFullName, string MethodName) key =
+                    (assemblyName, typeFullName, methodName);
+                if (!unique.Add(key))
+                {
+                    continue;
+                }
+
+                filtered.Add(key);
+            }
+
+            if (filtered.Count == 0)
+            {
+                return RunTestsPredefinedAssemblyTestFindings.None();
+            }
+
+            filtered.Sort(CompareMethods);
+            int sampleCount = filtered.Count;
+            if (sampleCount > RunTestsConstants.PredefinedAssemblyTestSampleLimit)
+            {
+                sampleCount = RunTestsConstants.PredefinedAssemblyTestSampleLimit;
+            }
+
+            string[] sampleEntries = new string[sampleCount];
+            for (int index = 0; index < sampleCount; index++)
+            {
+                (string assemblyName, string typeFullName, string methodName) = filtered[index];
+                sampleEntries[index] = assemblyName + ": " + typeFullName + "." + methodName;
+            }
+
+            return RunTestsPredefinedAssemblyTestFindings.Create(filtered.Count, sampleEntries);
+        }
+
+        private static void Collect(
+            TypeCache.MethodCollection methods,
+            List<(string AssemblyName, string TypeFullName, string MethodName)> destination)
+        {
+            Debug.Assert(destination != null, "destination must not be null");
+
+            foreach (MethodInfo method in methods)
+            {
+                if (method == null || method.DeclaringType == null)
+                {
+                    continue;
+                }
+
+                string assemblyName = method.DeclaringType.Assembly.GetName().Name;
+                if (string.IsNullOrEmpty(assemblyName))
+                {
+                    continue;
+                }
+
+                string typeFullName = method.DeclaringType.FullName;
+                if (string.IsNullOrEmpty(typeFullName))
+                {
+                    typeFullName = method.DeclaringType.Name;
+                }
+
+                destination.Add((assemblyName, typeFullName, method.Name));
+            }
+        }
+
+        private static bool IsPredefinedAssembly(string assemblyName)
+        {
+            return assemblyName == RunTestsConstants.PredefinedAssemblyCSharpName
+                   || assemblyName == RunTestsConstants.PredefinedAssemblyCSharpEditorName
+                   || assemblyName == RunTestsConstants.PredefinedAssemblyCSharpFirstpassName
+                   || assemblyName == RunTestsConstants.PredefinedAssemblyCSharpEditorFirstpassName;
+        }
+
+        private static int CompareMethods(
+            (string AssemblyName, string TypeFullName, string MethodName) left,
+            (string AssemblyName, string TypeFullName, string MethodName) right)
+        {
+            int assemblyCompare = string.CompareOrdinal(left.AssemblyName, right.AssemblyName);
+            if (assemblyCompare != 0)
+            {
+                return assemblyCompare;
+            }
+
+            int typeCompare = string.CompareOrdinal(left.TypeFullName, right.TypeFullName);
+            if (typeCompare != 0)
+            {
+                return typeCompare;
+            }
+
+            return string.CompareOrdinal(left.MethodName, right.MethodName);
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPredefinedAssemblyTestScanner.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPredefinedAssemblyTestScanner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47e636b1ae7b644f8b64c34d95b87b3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- When `uloop run-tests` discovers zero tests and no filter is set, the response Message now names NUnit test methods that compiled into Unity predefined assemblies (`Assembly-CSharp*`) instead of a test assembly.
- Existing asmdef-misconfiguration hints stay unchanged and still come first; this notice is appended after them only when such methods exist.

## User Impact
- Round 15 usage feedback (two 4/10 votes) reported a first `run-tests` after writing a new test script discovering nothing, then succeeding after adding an asmdef. The previous Message only gave generic missing-test-assembly guidance.
- Agents now see a capped list of the actual method names in Message, so the next action is to move those scripts into a folder whose `.asmdef` has Test Assemblies enabled, compile, and rerun.

## Where this notice appears
Measured in this project: an `[Test]` method in `Assembly-CSharp-Editor` is discovered by EditMode, so it never shares a zero-discovery notice on an EditMode run. The notice therefore fires for (1) EditMode zero-discovery of tests that fell into runtime `Assembly-CSharp`, and (2) PlayMode zero-discovery of any predefined-assembly tests (this project's `playModeTestRunnerEnabled=0`). That is why the scanner still walks all four predefined assemblies instead of filtering by TestMode.

## Changes
- Scan predefined assemblies via TypeCache for `[Test]`, `[TestCase]`, and `[UnityTest]` methods; format, dedupe, sort, and cap in a pure helper.
- Append the notice only on zero-discovery with `filter-type=all`. JSON response fields are unchanged.
- `AppendIfNeeded` inserts a period when the current Message has no terminator, and does not insert a second period after an asmdef hint that already ends with `.`.
- The notice says this run could not discover the named methods (not that Test Runner never discovers tests outside a test assembly).
- SKILL.md / tool catalog are unchanged (parameter table did not change; `scripts/sync-tool-docs.sh` produced no diff).

## Verification
- `uloop compile`: Success, ErrorCount 0.
- `uloop run-tests --filter-type regex --filter-value 'RunTests'`: 111 passed (probe is not in that count).
- Mutation Red (separator): removing the conditional period made `AppendIfNeeded_WhenMessageHasNoTerminator_InsertsPeriodBeforeNotice` fail at index 53 (`criteria. Additionally` vs `criteria Additionally`), then restored.
- Probe evidence:
  - (a) `ScanPredefinedAssemblyTests_WhenRegistryIsLive_FindsProbeFixture` passed. TotalCount 1, SampleEntries `["Assembly-CSharp: UnityCliLoop.RunTestsPredefinedAssemblyProbe.RunTestsPredefinedAssemblyProbe.Marker"]`.
  - (b) `uloop run-tests --test-mode EditMode --filter-type exact --filter-value 'UnityCliLoop.RunTestsPredefinedAssemblyProbe.RunTestsPredefinedAssemblyProbe.Marker'` → Status `NoTestsFound`, TestCount 0.
  - (c) Unfiltered EditMode catalog count after this change is 3355. Previous full EditMode was 3352; the +3 are the new AppendIfNeeded / period-hint tests, not the probe.
- `gh pr checks` on the previous commit were all pass. This commit will re-run CI.

## Unrelated EditMode failures (not blockers for this PR)
Recorded from a full EditMode run before this review round (3352 tests, 3342 passed, 2 failed, 8 skipped). Reproduced in isolation. For later triage:

1. `io.github.hatayama.UnityCliLoop.Tests.Editor.StaticFacadeStateGuardTests.ScreenshotUseCase_WhenWindowCaptureTimesOut_PreservesPartialScreenshots`
   Expected string containing `return ScreenshotCaptureResults.CreateTimedOutResult("EditorWindow capture", correlationId, screenshots);` but the current `ScreenshotUseCase.cs` text did not contain that exact call (the assertion dumps the whole file).

2. `io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.TransformWorkerClientTests.Run_WithSelfSnapshotOnHotReloadTestSources_TreatsAllMethodsUnchanged`
   `Self-snapshot must treat every HotReload test source as unchanged: Assets/Tests/Editor/HotReload/HotReloadSiblingConstDefinitions.cs -> unchangedMethods+skipped < 1 (unchanged=0, skipped=0)`
