### PR TITLE
test: fix stale screenshot guard literal and method-less fixture in self-snapshot sweep

### DIFF
--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -26,9 +26,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             "System.Collections.Generic.List`1/Enumerator<System.Int32>";
 
         // Why: a method-less type is correctly reported as unchanged=0/skipped=0, so it
-        // cannot satisfy the "at least one recognized method" invariant. Listing a file
-        // here is a deliberate review of that exception; a new method-less fixture must
-        // be added to this list rather than skipped silently by a heuristic.
+        // cannot satisfy the "at least one recognized method" invariant. The allow-list
+        // waives only that count check; the worker still runs. A new method-less fixture
+        // must be added here rather than skipped silently by a heuristic.
         private static readonly string[] SelfSnapshotMethodlessTypeAllowList =
         {
             "HotReloadSiblingConstDefinitions.cs",
@@ -527,10 +527,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     continue;
                 }
 
-                if (IsSelfSnapshotMethodlessTypeAllowListed(Path.GetFileName(fullPath)))
-                {
-                    continue;
-                }
+                bool isMethodlessTypeAllowListed =
+                    IsSelfSnapshotMethodlessTypeAllowListed(Path.GetFileName(fullPath));
 
                 TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
                     fullPath,
@@ -565,7 +563,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 int unchangedCount =
                     result.Output.unchangedMethods != null ? result.Output.unchangedMethods.Length : 0;
                 int skippedCount = result.Output.skipped != null ? result.Output.skipped.Length : 0;
-                if (unchangedCount + skippedCount < 1)
+                if (!isMethodlessTypeAllowListed && unchangedCount + skippedCount < 1)
                 {
                     fileFailures.Add(
                         "unchangedMethods+skipped < 1 (unchanged="

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -25,6 +25,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string ExpectedListEnumeratorFullName =
             "System.Collections.Generic.List`1/Enumerator<System.Int32>";
 
+        // Why: a method-less type is correctly reported as unchanged=0/skipped=0, so it
+        // cannot satisfy the "at least one recognized method" invariant. Listing a file
+        // here is a deliberate review of that exception; a new method-less fixture must
+        // be added to this list rather than skipped silently by a heuristic.
+        private static readonly string[] SelfSnapshotMethodlessTypeAllowList =
+        {
+            "HotReloadSiblingConstDefinitions.cs",
+        };
+
         /// <summary>
         /// What: bootstrap compiles (or reuses a cached) worker.dll, then running the worker on the
         /// e2e fixture source returns shim entries and the expected skip reasons — including bare
@@ -486,11 +495,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a self-snapshot of every method-bearing .cs file under
-        /// Assets/Tests/Editor/HotReload/ yields Success, empty
-        /// parseErrors/entries/declarationDriftWarnings, and at least one unchanged or skipped
-        /// method (proves the worker recognized the file). Permanent guard that identical source
-        /// never false-patches after the unannotated-baseline fix.
+        /// What: a self-snapshot of every .cs file under Assets/Tests/Editor/HotReload/ yields
+        /// Success, empty parseErrors/entries/declarationDriftWarnings, and at least one
+        /// unchanged or skipped method (proves the worker recognized the file), except
+        /// global-using-only files and the reviewed method-less allow-list. Permanent guard
+        /// that identical source never false-patches after the unannotated-baseline fix.
         /// </summary>
         [Test]
         public async Task Run_WithSelfSnapshotOnHotReloadTestSources_TreatsAllMethodsUnchanged()
@@ -518,11 +527,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     continue;
                 }
 
-                // Why skip: a type-only file with no method, constructor, or property accessor
-                // (const holder, for example) is also correctly reported as unchanged=0/skipped=0.
-                // Including it would fail the "at least one recognized method" invariant even
-                // though the worker behaved correctly.
-                if (!ContainsMethodOrAccessorDeclaration(onDisk))
+                if (IsSelfSnapshotMethodlessTypeAllowListed(Path.GetFileName(fullPath)))
                 {
                     continue;
                 }
@@ -2298,20 +2303,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 || sourceText.IndexOf(" record ", StringComparison.Ordinal) >= 0;
         }
 
-        private static bool ContainsMethodOrAccessorDeclaration(string sourceText)
+        private static bool IsSelfSnapshotMethodlessTypeAllowListed(string fileName)
         {
-            if (sourceText.IndexOf('(') >= 0)
-            {
-                return true;
-            }
-
-            return sourceText.IndexOf(" get;", StringComparison.Ordinal) >= 0
-                || sourceText.IndexOf(" get ", StringComparison.Ordinal) >= 0
-                || sourceText.IndexOf(" set;", StringComparison.Ordinal) >= 0
-                || sourceText.IndexOf(" set ", StringComparison.Ordinal) >= 0
-                || sourceText.IndexOf(" init;", StringComparison.Ordinal) >= 0
-                || sourceText.IndexOf(" init ", StringComparison.Ordinal) >= 0
-                || sourceText.IndexOf(" =>", StringComparison.Ordinal) >= 0;
+            return Array.IndexOf(SelfSnapshotMethodlessTypeAllowList, fileName) >= 0;
         }
 
         private static string ResolveE2EFixturePath()

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -486,10 +486,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a self-snapshot of every .cs file under Assets/Tests/Editor/HotReload/ yields
-        /// Success, empty parseErrors/entries/declarationDriftWarnings, and at least one
-        /// unchanged or skipped method (proves the worker recognized the file). Permanent guard
-        /// that identical source never false-patches after the unannotated-baseline fix.
+        /// What: a self-snapshot of every method-bearing .cs file under
+        /// Assets/Tests/Editor/HotReload/ yields Success, empty
+        /// parseErrors/entries/declarationDriftWarnings, and at least one unchanged or skipped
+        /// method (proves the worker recognized the file). Permanent guard that identical source
+        /// never false-patches after the unannotated-baseline fix.
         /// </summary>
         [Test]
         public async Task Run_WithSelfSnapshotOnHotReloadTestSources_TreatsAllMethodsUnchanged()
@@ -513,6 +514,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 // Why skip: a global-using-only file has no methods to mark unchanged; the worker
                 // correctly emits empty entries/skipped/unchanged for it.
                 if (!ContainsTypeDeclaration(onDisk))
+                {
+                    continue;
+                }
+
+                // Why skip: a type-only file with no method, constructor, or property accessor
+                // (const holder, for example) is also correctly reported as unchanged=0/skipped=0.
+                // Including it would fail the "at least one recognized method" invariant even
+                // though the worker behaved correctly.
+                if (!ContainsMethodOrAccessorDeclaration(onDisk))
                 {
                     continue;
                 }
@@ -2286,6 +2296,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 || sourceText.IndexOf(" interface ", StringComparison.Ordinal) >= 0
                 || sourceText.IndexOf(" enum ", StringComparison.Ordinal) >= 0
                 || sourceText.IndexOf(" record ", StringComparison.Ordinal) >= 0;
+        }
+
+        private static bool ContainsMethodOrAccessorDeclaration(string sourceText)
+        {
+            if (sourceText.IndexOf('(') >= 0)
+            {
+                return true;
+            }
+
+            return sourceText.IndexOf(" get;", StringComparison.Ordinal) >= 0
+                || sourceText.IndexOf(" get ", StringComparison.Ordinal) >= 0
+                || sourceText.IndexOf(" set;", StringComparison.Ordinal) >= 0
+                || sourceText.IndexOf(" set ", StringComparison.Ordinal) >= 0
+                || sourceText.IndexOf(" init;", StringComparison.Ordinal) >= 0
+                || sourceText.IndexOf(" init ", StringComparison.Ordinal) >= 0
+                || sourceText.IndexOf(" =>", StringComparison.Ordinal) >= 0;
         }
 
         private static string ResolveE2EFixturePath()

--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -302,7 +302,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 useCaseSource,
                 Does.Contain(
-                    "return ScreenshotCaptureResults.CreateTimedOutResult(\"EditorWindow capture\", correlationId, screenshots);"));
+                    "ScreenshotResponse captureTimedOut = ScreenshotCaptureResults.CreateTimedOutResult(\n"
+                    + "                            \"EditorWindow capture\",\n"
+                    + "                            correlationId,\n"
+                    + "                            screenshots);"));
             Assert.That(resultsSource, Does.Contain("Screenshots = screenshots,"));
         }
 


### PR DESCRIPTION
## Summary
- Restore a green full EditMode suite by updating two tests that drifted from current production behavior.
- Closes #2355
- Closes #2356

## User Impact
- Before: the scheduled full EditMode run failed on a stale screenshot timeout source guard and on a const-only hot-reload fixture that the worker correctly reports as having no methods.
- After: those two tests match the current sources, so the suite can stay green (0 failures) without weakening checks on method-bearing files.

## Changes
- Update the screenshot window-capture timeout guard to the current multi-line `CreateTimedOutResult(..., screenshots)` call so the test still requires partial screenshots on timeout.
- Exclude type-only files that have no method, constructor, or property accessor from the hot-reload self-snapshot sweep. Method-bearing files still require unchanged+skipped ≥ 1.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → Success, ErrorCount=0
- Named tests: `ScreenshotUseCase_WhenWindowCaptureTimesOut_PreservesPartialScreenshots` and `Run_WithSelfSnapshotOnHotReloadTestSources_TreatsAllMethodsUnchanged` → TestCount=2, PassedCount=2, FailedCount=0
- Full EditMode: TestCount=3355, PassedCount=3347, FailedCount=0, SkippedCount=8 (Status=Skipped so Success=false; no failures)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

