### PR TITLE
fix: map this-qualified added-field reads to the instance parameter in hot reload shims

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2890,6 +2890,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: reading an added instance field as this.field patches the existing method
+        /// instead of failing shim compile with CS0026.
+        /// </summary>
+        [Test]
+        public async Task Run_ThisQualifiedAddedFieldRead_PatchesExistingMethod()
+        {
+            string fixturePath = ResolveAddedFieldApplyFixturePath();
+            string onDisk = File.ReadAllText(fixturePath);
+            string edited = WithThisQualifiedAddedFieldRead(onDisk);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                WriteEditedSource("ThisQualifiedAddedFieldRead.cs", edited),
+                CancellationToken.None);
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadAddedFieldApplyFixture.ReadAdded));
+            AssertHasPatched(result, nameof(HotReloadAddedFieldApplyFixture.WriteAdded));
+
+            HotReloadAddedFieldApplyFixture host = new HotReloadAddedFieldApplyFixture();
+            host.WriteAdded(7);
+            Assert.That(host.ReadAdded(), Is.EqualTo(7));
+        }
+
+        /// <summary>
         /// What: a shim-compile failure after a successful added-field apply leaves the added-field
         /// ledger intact, even though the failed run reports empty AddedFields.
         /// </summary>
@@ -5922,6 +5947,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return source.Replace(
                 "        private int _secret = 10;",
                 "        private int _secret = 10;\n        public int " + fieldName + ";",
+                StringComparison.Ordinal);
+        }
+
+        private static string WithThisQualifiedAddedFieldRead(string onDisk)
+        {
+            return onDisk.Replace(
+                "        public int ReadAdded()\n        {\n            return 0;\n        }\n\n"
+                + "        [MethodImpl(MethodImplOptions.NoInlining)]\n"
+                + "        public void WriteAdded(int value)\n        {\n        }",
+                "        public int AddedCount;\n\n"
+                + "        [MethodImpl(MethodImplOptions.NoInlining)]\n"
+                + "        public int ReadAdded()\n        {\n            return this.AddedCount;\n        }\n\n"
+                + "        [MethodImpl(MethodImplOptions.NoInlining)]\n"
+                + "        public void WriteAdded(int value)\n        {\n            AddedCount = value;\n        }",
                 StringComparison.Ordinal);
         }
 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -370,9 +370,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
             Assert.That(caller, Is.Not.Null);
             string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
-            Assert.That(slice, Does.Contain("GetOrInit<"));
-            Assert.That(slice, Does.Contain("__uloopInstance"));
-            Assert.That(slice, Does.Not.Contain("this."));
+            const string expectedReturn =
+                "return global::io.github.hatayama.UnityCliLoop.ToolContracts.HotReloadAddedFieldStore.GetOrInit<int>(__uloopInstance, \"io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadAddedMemberHost::AddedCount\", null) + global::io.github.hatayama.UnityCliLoop.ToolContracts.HotReloadAddedFieldStore.GetOrInit<int>(__uloopInstance, \"io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadAddedMemberHost::AddedCount\", null) + value;";
+            Assert.That(slice, Does.Contain(expectedReturn));
+            Assert.That(slice, Does.Not.Contain("(this"));
         }
 
         /// <summary>
@@ -399,9 +400,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
             Assert.That(caller, Is.Not.Null);
             string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
-            Assert.That(slice, Does.Contain("Set<"));
-            Assert.That(slice, Does.Contain("__uloopInstance"));
-            Assert.That(slice, Does.Not.Contain("this."));
+            Assert.That(
+                slice,
+                Does.Contain(
+                    "global::io.github.hatayama.UnityCliLoop.ToolContracts.HotReloadAddedFieldStore.Set<int>(__uloopInstance, \"io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadAddedMemberHost::AddedCount\", value)"));
+            Assert.That(slice, Does.Not.Contain("(this"));
         }
 
         /// <summary>
@@ -430,7 +433,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
             Assert.That(slice, Does.Contain("GetOrInitStatic<"));
             Assert.That(slice, Does.Not.Contain("GetOrInit<"));
-            Assert.That(slice, Does.Not.Contain("this."));
+            Assert.That(slice, Does.Not.Contain("(this"));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -347,6 +347,93 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a method that reads an added field as both this.field and bare field is rewritten
+        /// so both store reads use the instance parameter, not this.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_ThisAndBareAddedFieldRead_BothUseInstanceParameter()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public int AddedCount;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return this.AddedCount + AddedCount + value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("ThisAndBareAddedFieldRead.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null);
+            string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(slice, Does.Contain("GetOrInit<"));
+            Assert.That(slice, Does.Contain("__uloopInstance"));
+            Assert.That(slice, Does.Not.Contain("this."));
+        }
+
+        /// <summary>
+        /// What: assigning this.field on an added instance field still rewrites to Set with the
+        /// instance parameter.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_ThisQualifiedAddedFieldAssignment_UsesInstanceParameter()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public int AddedCount;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            this.AddedCount = value;\n            return value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("ThisQualifiedAddedFieldAssignment.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null);
+            string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(slice, Does.Contain("Set<"));
+            Assert.That(slice, Does.Contain("__uloopInstance"));
+            Assert.That(slice, Does.Not.Contain("this."));
+        }
+
+        /// <summary>
+        /// What: reading a static added field as TypeName.field still uses the static store,
+        /// not an instance receiver.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_TypeQualifiedStaticAddedFieldRead_UsesStaticStore()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public static int AddedStatic;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return HotReloadAddedMemberHost.AddedStatic + value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("TypeQualifiedStaticAddedFieldRead.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(caller, Is.Not.Null);
+            string slice = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(slice, Does.Contain("GetOrInitStatic<"));
+            Assert.That(slice, Does.Not.Contain("GetOrInit<"));
+            Assert.That(slice, Does.Not.Contain("this."));
+        }
+
+        /// <summary>
         /// What: compound assignment and increment on an added field expand to Get then Set.
         /// </summary>
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldShimRewrite.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldShimRewrite.cs
@@ -82,7 +82,15 @@ internal sealed class AddedFieldShimRewrite
             return null;
         }
 
-        return CreateAddedFieldGetOrInit(binding, receiverSyntax).WithTriviaFrom(triviaSource);
+        ExpressionSyntax rewrittenReceiver = receiverSyntax;
+        if (!binding.IsStatic)
+        {
+            // Why: CSharpSyntaxRewriter does not re-visit children of a replacement node, so a
+            // raw ThisExpression left in the store call would survive as `this` in the static shim.
+            rewrittenReceiver = _rewriter.VisitReceiver(receiverSyntax);
+        }
+
+        return CreateAddedFieldGetOrInit(binding, rewrittenReceiver).WithTriviaFrom(triviaSource);
     }
 
     internal SyntaxNode RewriteAddedFieldAssignment(


### PR DESCRIPTION
## Summary
- Hot reload now patches existing methods that read a newly added instance field as `this.field` instead of failing shim compile.

## User Impact
- Before: adding an instance field and reading it as `this.field` from an existing method failed with `CS0026` (`this` is not valid in a static method). Bare assignment of the same field still patched, so the apply looked only partly successful.
- After: `this.field` reads use the shim instance parameter, matching bare reads and `this.field = value` writes.

## Changes
- In the added-field store read path, visit a non-static receiver before embedding it. Replacement nodes are not re-visited, so a raw `this` must be rewritten first.
- Static added-field reads still ignore the receiver.

## Verification
- Red (before the rewriter change): `Run_ThisQualifiedAddedFieldRead_PatchesExistingMethod` failed with `Failed ReadAdded() :: CS0026: Keyword 'this' is not valid in a static property, static method, or static field initializer` while `WriteAdded` stayed `Patched`.
- After the fix: that test plus `Rewrite_ThisAndBareAddedFieldRead_BothUseInstanceParameter`, `Rewrite_ThisQualifiedAddedFieldAssignment_UsesInstanceParameter`, `Rewrite_TypeQualifiedStaticAddedFieldRead_UsesStaticStore`, `Rewrite_AddedFieldReadWriteAndInitializer_UsesStoreAndStaticLambda`, `Rewrite_AddedStaticField_UsesStaticStore`, and `Run_AddedField_AppliesThroughStoreAndKeepsValuesOnReapply` → TestCount=7 PassedCount=7 FailedCount=0
- HotReload assembly: TestCount=508 PassedCount=508 FailedCount=0
- Full EditMode: TestCount=3359 PassedCount=3351 FailedCount=0 SkippedCount=8


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

