### PR TITLE
feat: lead line-resolution warnings with a one-line conclusion

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftTests.cs
@@ -25,12 +25,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             "Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftFixture.cs";
 
         private const string HotReloadCompiledLineMapWarningPrefix =
-            "'Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftFixture.cs' has active "
-            + "hot-reload patches. The resolved method '";
+            "--line resolved against the last compiled source, not the edited file: "
+            + "'Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftFixture.cs' has active "
+            + "hot-reload patches and the resolved method '";
 
         private const string HotReloadCompiledLineMapWarningSuffix =
-            "' is not patched by this reload, so --line resolved against the last compiled "
-            + "source, not the edited file. Verify ResolvedLineText matches the statement you "
+            "' is not patched by this reload. Verify ResolvedLineText matches the statement you "
             + "meant, or run 'uloop compile' and re-enable.";
 
         private const string CompiledSnapshotSentinel = "SENTINEL_COMPILED_LINE_TEXT";

--- a/Assets/Tests/Editor/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilderTests.cs
@@ -31,7 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 warning,
                 Is.EqualTo(
-                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
+                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). This matters for 'enable-pause-point --line' targeting: methods NOT patched in this run still resolve against the last compiled source; patched methods with debug symbols resolve against the edited file. To pin the target, pass --method together with --line."));
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 warning,
                 Is.EqualTo(
-                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 2 lines vs compiled 3). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
+                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 2 lines vs compiled 3). This matters for 'enable-pause-point --line' targeting: methods NOT patched in this run still resolve against the last compiled source; patched methods with debug symbols resolve against the edited file. To pin the target, pass --method together with --line."));
         }
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 warning,
                 Is.EqualTo(
-                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
+                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). This matters for 'enable-pause-point --line' targeting: methods NOT patched in this run still resolve against the last compiled source; patched methods with debug symbols resolve against the edited file. To pin the target, pass --method together with --line."));
         }
 
         /// <summary>
@@ -133,7 +133,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 warnings[0],
                 Is.EqualTo(
-                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
+                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). This matters for 'enable-pause-point --line' targeting: methods NOT patched in this run still resolve against the last compiled source; patched methods with debug symbols resolve against the edited file. To pin the target, pass --method together with --line."));
         }
 
         /// <summary>
@@ -166,7 +166,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 warnings[0],
                 Is.EqualTo(
-                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
+                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). This matters for 'enable-pause-point --line' targeting: methods NOT patched in this run still resolve against the last compiled source; patched methods with debug symbols resolve against the edited file. To pin the target, pass --method together with --line."));
         }
 
         /// <summary>
@@ -196,7 +196,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 warnings[0],
                 Is.EqualTo(
-                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
+                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). This matters for 'enable-pause-point --line' targeting: methods NOT patched in this run still resolve against the last compiled source; patched methods with debug symbols resolve against the edited file. To pin the target, pass --method together with --line."));
         }
 
         /// <summary>
@@ -226,11 +226,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 warnings[0],
                 Is.EqualTo(
-                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
+                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). This matters for 'enable-pause-point --line' targeting: methods NOT patched in this run still resolve against the last compiled source; patched methods with debug symbols resolve against the edited file. To pin the target, pass --method together with --line."));
             Assert.That(
                 warnings[1],
                 Is.EqualTo(
-                    "Assets/Scripts/Enemy.cs: line count differs from the last compiled source (edited 4 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
+                    "Assets/Scripts/Enemy.cs: line count differs from the last compiled source (edited 4 lines vs compiled 2). This matters for 'enable-pause-point --line' targeting: methods NOT patched in this run still resolve against the last compiled source; patched methods with debug symbols resolve against the edited file. To pin the target, pass --method together with --line."));
         }
 
         /// <summary>
@@ -268,7 +268,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Assert.That(
                     response.Warnings[1],
                     Is.EqualTo(
-                        "Library/UloopHotReload/TestSources/line-shift-warning-probe.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file."));
+                        "Library/UloopHotReload/TestSources/line-shift-warning-probe.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). This matters for 'enable-pause-point --line' targeting: methods NOT patched in this run still resolve against the last compiled source; patched methods with debug symbols resolve against the edited file. To pin the target, pass --method together with --line."));
                 Assert.That(
                     response.Message,
                     Is.EqualTo(

--- a/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
+++ b/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
@@ -21,16 +21,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private const string ExampleResolvedMethod = "ExampleType.ExampleMethod";
 
         private const string ExpectedCompiledLineMapWarning =
-            "'Assets/Scripts/Example.cs' has active hot-reload patches. The resolved method "
-            + "'ExampleType.ExampleMethod' is not patched by this reload, so --line resolved "
-            + "against the last compiled source, not the edited file. Verify ResolvedLineText "
+            "--line resolved against the last compiled source, not the edited file: "
+            + "'Assets/Scripts/Example.cs' has active hot-reload patches and the resolved method "
+            + "'ExampleType.ExampleMethod' is not patched by this reload. Verify ResolvedLineText "
             + "matches the statement you meant, or run 'uloop compile' and re-enable.";
 
         private const string ExpectedCompiledLineMapMatchedWarning =
-            "'Assets/Scripts/Example.cs' has active hot-reload patches. The resolved method "
-            + "'ExampleType.ExampleMethod' is not patched by this reload, so --line resolved "
-            + "against the last compiled source, not the edited file. The statement text at "
-            + "the resolved line is identical in the edited file, so no drift is visible at this line.";
+            "No drift is visible at this line: the statement text at the resolved line is "
+            + "identical in the edited file. 'Assets/Scripts/Example.cs' has active hot-reload "
+            + "patches and the resolved method 'ExampleType.ExampleMethod' is not patched by "
+            + "this reload, so --line resolved against the last compiled source, not the edited file.";
 
         private const string ExpectedCompiledLineMapResolveFailureWarning =
             "'Assets/Scripts/Example.cs' has active hot-reload patches. --line resolves against "

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilder.cs
@@ -17,6 +17,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Why "line count differs" not "line numbers have shifted": a trailing newline changes
         // the split count without moving statements. Why "patched methods with debug symbols":
         // PatchedMethodPdbUnavailable still falls through to the compiled line map.
+        // Why conclusion first: the first sentence is the conclusion; usability rounds
+        // showed readers stop at sentence one, so do not restore the explanation-first order.
         public static string Build(string file, string editedSource, string compiledSource)
         {
             if (string.IsNullOrEmpty(file) || editedSource == null || string.IsNullOrEmpty(compiledSource))
@@ -34,7 +36,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string normalizedFile = HotReloadSourcePathNormalizer.ToForwardSlashes(file);
             return string.Format(
                 CultureInfo.InvariantCulture,
-                "{0}: line count differs from the last compiled source (edited {1} lines vs compiled {2}). enable-pause-point --line on methods NOT patched in this run still resolves against the last compiled source; patched methods with debug symbols resolve against the edited file.",
+                "{0}: line count differs from the last compiled source (edited {1} lines vs compiled {2}). This matters for 'enable-pause-point --line' targeting: methods NOT patched in this run still resolve against the last compiled source; patched methods with debug symbols resolve against the edited file. To pin the target, pass --method together with --line.",
                 normalizedFile,
                 editedLineCount,
                 compiledLineCount);

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -237,19 +237,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Why: unpatched methods keep the compiled line map while the editor shows the edited
         // file. Naming the resolved method tells agents the marker is on an unpatched method
         // without a ResolvedMethod comparison (FB9).
+        // Why conclusion first: the first sentence is the conclusion; usability rounds
+        // showed readers stop at sentence one, so do not restore the explanation-first order.
         // Format: file, resolved method display name.
         public const string HotReloadCompiledLineMapWarningFormat =
-            "'{0}' has active hot-reload patches. The resolved method '{1}' is not patched by this reload, "
-            + "so --line resolved against the last compiled source, not the edited file. Verify "
-            + "ResolvedLineText matches the statement you meant, or run 'uloop compile' and re-enable.";
+            "--line resolved against the last compiled source, not the edited file: '{0}' has "
+            + "active hot-reload patches and the resolved method '{1}' is not patched by this "
+            + "reload. Verify ResolvedLineText matches the statement you meant, or run "
+            + "'uloop compile' and re-enable.";
 
         // Why a distinct sentence: comparison already proved the resolved statement is identical,
         // so asking the agent to Verify ResolvedLineText by hand is leftover work.
+        // Why conclusion first: the first sentence is the conclusion; usability rounds
+        // showed readers stop at sentence one, so do not restore the explanation-first order.
         // Format: file, resolved method display name.
         public const string HotReloadCompiledLineMapMatchedWarningFormat =
-            "'{0}' has active hot-reload patches. The resolved method '{1}' is not patched by this reload, "
-            + "so --line resolved against the last compiled source, not the edited file. The statement text "
-            + "at the resolved line is identical in the edited file, so no drift is visible at this line.";
+            "No drift is visible at this line: the statement text at the resolved line is "
+            + "identical in the edited file. '{0}' has active hot-reload patches and the "
+            + "resolved method '{1}' is not patched by this reload, so --line resolved against "
+            + "the last compiled source, not the edited file.";
 
         // Why a separate failure string: resolve failure leaves ResolvedMethod and
         // ResolvedLineText empty, so pointing at those fields is a dead end.


### PR DESCRIPTION
## Summary
- Line-resolution warnings now start with a one-line conclusion so the point is readable without scanning the rest of the message.
- The three voted warning surfaces keep the same facts; only the sentence order changes.

## User Impact
- Before: the first sentence described context (active patches, line counts) and the actionable conclusion came later, so readers who did not need pause-point details saw a long explanation first.
- After: the first sentence states the conclusion. Readers who do not use pause-point can stop there. Readers who do still get the same explanation and next action.

## Changes
- Reorder the hot-reload line-count warning and the two compiled-line-map warnings to conclusion → explanation → next action.
- Keep every previously reported fact. Add the already-supported `--method` + `--line` pin hint on the line-count warning.
- Leave other warning variants unchanged.

Issue #2349 collected 10 votes across R14–R19. The leading direction was "put a one-line conclusion first" (4 votes), with additional votes for information overload, keeping current content, listing affected methods, showing a `--method` example, and a short lead when there is no drift. This change follows the decided policy: **reorder, not shorten**. It answers the `--method` votes with a generic recommendation instead of generating method-name examples.

Fixes #2349

## Verification
- Red: updated the three literal-match test files first. Filtered EditMode run failed 12 tests against the old production strings.
- Green: updated the three production formats and Why comments. Same filter: 74 passed, 0 failed.
- Leftover grep for the old lead fragments returned no matches. Pause-point and hot-reload skill docs paraphrase these warnings and were left unchanged.
- `dist/darwin-arm64/uloop compile`: Success true, ErrorCount 0.
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode` (full suite, single run): TestCount 3362, PassedCount 3354, FailedCount 0, SkippedCount 8 (pre-existing platform `Assert.Ignore` tests). Overall Status was Skipped because of those ignores.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

