### PR TITLE
feat: name the assembly that declares an unresolved namespace in compile NextActions

### DIFF
--- a/Assets/Tests/Editor/CompileErrorNextActionsComposerTests.cs
+++ b/Assets/Tests/Editor/CompileErrorNextActionsComposerTests.cs
@@ -70,6 +70,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private const string NUnitCs0234Error =
             "error CS0234: The type or namespace name 'Framework' does not exist in the namespace 'NUnit' (are you missing an assembly reference?)";
 
+        private const string NUnitFrameworkNextAction =
+            "error CS0234: 'NUnit.Framework' is declared in assembly 'nunit.framework'. Add the assembly to the failing script's .asmdef references and run 'uloop compile' again. If the failing script has no .asmdef, the declaring assembly may have Auto Referenced disabled or its package may not be installed.";
+
         private const string UnknownCs0234Error =
             "error CS0234: The type or namespace name 'NoSuchInner' does not exist in the namespace 'NoSuchOuter' (are you missing an assembly reference?)";
 
@@ -461,10 +464,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             CompileErrorNextActionsComposer.Apply(response, new[] { CreateError(NUnitCs0234Error) });
 
-            Assert.That(response.NextActions, Is.Not.Null);
-            Assert.That(response.NextActions, Has.Length.EqualTo(2));
-            Assert.That(response.NextActions[0], Is.EqualTo(ExistingNextAction));
-            Assert.That(response.NextActions[1], Does.Contain("nunit.framework"));
+            Assert.That(
+                response.NextActions,
+                Is.EqualTo(new[] { ExistingNextAction, NUnitFrameworkNextAction }));
         }
 
         /// <summary>
@@ -480,9 +482,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 forceRecompile: false,
                 pausePointWarning: null);
 
-            Assert.That(response.NextActions, Is.Not.Null);
-            Assert.That(response.NextActions, Has.Length.EqualTo(1));
-            Assert.That(response.NextActions[0], Does.Contain("nunit.framework"));
+            Assert.That(response.NextActions, Is.EqualTo(new[] { NUnitFrameworkNextAction }));
         }
 
         /// <summary>
@@ -538,10 +538,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 forceRecompile: false,
                 pausePointWarning: null);
 
-            Assert.That(response.NextActions, Is.Not.Null);
-            Assert.That(response.NextActions, Has.Length.EqualTo(2));
-            Assert.That(response.NextActions[0], Is.EqualTo(ApiUpdaterNextAction));
-            Assert.That(response.NextActions[1], Does.Contain("nunit.framework"));
+            Assert.That(
+                response.NextActions,
+                Is.EqualTo(new[] { ApiUpdaterNextAction, NUnitFrameworkNextAction }));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/CompileErrorNextActionsComposerTests.cs
+++ b/Assets/Tests/Editor/CompileErrorNextActionsComposerTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEditor.Compilation;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
@@ -46,6 +48,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
         private const string ApiUpdaterNextAction =
             "Fix the obsolete API usages reported in Errors, or ask the user to accept the Script Updating Consent dialog in an interactive Unity session.";
+
+        private const string InputSystemCs0234Error =
+            "error CS0234: The type or namespace name 'InputSystem' does not exist in the namespace 'UnityEngine' (are you missing an assembly reference?)";
+
+        private const string PrefixlessInputSystemCs0234Error =
+            "CS0234: The type or namespace name 'InputSystem' does not exist in the namespace 'UnityEngine' (are you missing an assembly reference?)";
+
+        private const string InputSystemNextAction =
+            "error CS0234: 'UnityEngine.InputSystem' is declared in assembly 'Unity.InputSystem'. Add the assembly to the failing script's .asmdef references and run 'uloop compile' again. If the failing script has no .asmdef, the declaring assembly may have Auto Referenced disabled or its package may not be installed.";
+
+        private const string DualAssemblyNextAction =
+            "error CS0234: 'UnityEngine.InputSystem' is declared in assemblies 'Alpha.Assembly', 'Zebra.Assembly'. Add the assembly to the failing script's .asmdef references and run 'uloop compile' again. If the failing script has no .asmdef, the declaring assembly may have Auto Referenced disabled or its package may not be installed.";
+
+        private const string TripleAssemblyNextAction =
+            "error CS0234: 'UnityEngine.InputSystem' is declared in assemblies 'A.Assembly', 'B.Assembly', 'C.Assembly'. Add the assembly to the failing script's .asmdef references and run 'uloop compile' again. If the failing script has no .asmdef, the declaring assembly may have Auto Referenced disabled or its package may not be installed.";
+
+        private const string Cs0246Error =
+            "error CS0246: The type or namespace name 'InputSystem' could not be found (are you missing a using directive or an assembly reference?)";
+
+        private const string NUnitCs0234Error =
+            "error CS0234: The type or namespace name 'Framework' does not exist in the namespace 'NUnit' (are you missing an assembly reference?)";
+
+        private const string UnknownCs0234Error =
+            "error CS0234: The type or namespace name 'NoSuchInner' does not exist in the namespace 'NoSuchOuter' (are you missing an assembly reference?)";
 
         /// <summary>
         /// What: a language-version error produces the pinned-rewrite NextAction as an exact literal.
@@ -296,6 +322,252 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 response.NextActions,
                 Is.EqualTo(new[] { ApiUpdaterNextAction, FileScopedNamespaceNextAction }));
+        }
+
+        /// <summary>
+        /// What: a CS0234 error produces the declaring-assembly NextAction from the injected lookup.
+        /// </summary>
+        [Test]
+        public void Build_WhenCs0234Error_ReturnsDeclaringAssemblyAction()
+        {
+            string[] nextActions = CompileErrorNextActionsBuilder.Build(
+                new[] { InputSystemCs0234Error },
+                searchName => searchName == "UnityEngine.InputSystem"
+                    ? new[] { "Unity.InputSystem" }
+                    : Array.Empty<string>());
+
+            Assert.That(nextActions, Is.EqualTo(new[] { InputSystemNextAction }));
+        }
+
+        /// <summary>
+        /// What: a prefix-less CS0234 message still produces the declaring-assembly NextAction.
+        /// </summary>
+        [Test]
+        public void Build_WhenPrefixlessCs0234Error_ReturnsDeclaringAssemblyAction()
+        {
+            string[] nextActions = CompileErrorNextActionsBuilder.Build(
+                new[] { PrefixlessInputSystemCs0234Error },
+                searchName => new[] { "Unity.InputSystem" });
+
+            Assert.That(nextActions, Is.EqualTo(new[] { InputSystemNextAction }));
+        }
+
+        /// <summary>
+        /// What: CS0246 never produces a missing-reference NextAction.
+        /// </summary>
+        [Test]
+        public void Build_WhenCs0246Error_ReturnsEmpty()
+        {
+            int lookupCalls = 0;
+            string[] nextActions = CompileErrorNextActionsBuilder.Build(
+                new[] { Cs0246Error },
+                searchName =>
+                {
+                    lookupCalls++;
+                    return new[] { "Unity.InputSystem" };
+                });
+
+            Assert.That(nextActions, Is.EqualTo(Array.Empty<string>()));
+            Assert.That(lookupCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: a CS0234 match with zero declaring assemblies stays fail-open.
+        /// </summary>
+        [Test]
+        public void Build_WhenCs0234LookupReturnsEmpty_ReturnsEmpty()
+        {
+            string[] nextActions = CompileErrorNextActionsBuilder.Build(
+                new[] { InputSystemCs0234Error },
+                searchName => Array.Empty<string>());
+
+            Assert.That(nextActions, Is.EqualTo(Array.Empty<string>()));
+        }
+
+        /// <summary>
+        /// What: multiple declaring assemblies are named in ordinal order.
+        /// </summary>
+        [Test]
+        public void Build_WhenCs0234HasMultipleAssemblies_NamesThemInOrdinalOrder()
+        {
+            string[] nextActions = CompileErrorNextActionsBuilder.Build(
+                new[] { InputSystemCs0234Error },
+                searchName => new[] { "Zebra.Assembly", "Alpha.Assembly" });
+
+            Assert.That(nextActions, Is.EqualTo(new[] { DualAssemblyNextAction }));
+        }
+
+        /// <summary>
+        /// What: more than three declaring assemblies are truncated after the first three sorted names.
+        /// </summary>
+        [Test]
+        public void Build_WhenCs0234HasMoreThanThreeAssemblies_NamesAtMostThree()
+        {
+            string[] nextActions = CompileErrorNextActionsBuilder.Build(
+                new[] { InputSystemCs0234Error },
+                searchName => new[] { "D.Assembly", "C.Assembly", "B.Assembly", "A.Assembly" });
+
+            Assert.That(nextActions, Is.EqualTo(new[] { TripleAssemblyNextAction }));
+        }
+
+        /// <summary>
+        /// What: identical CS0234 NextActions are appended only once.
+        /// </summary>
+        [Test]
+        public void Build_WhenDuplicateCs0234Actions_Dedups()
+        {
+            string[] nextActions = CompileErrorNextActionsBuilder.Build(
+                new[] { InputSystemCs0234Error, PrefixlessInputSystemCs0234Error },
+                searchName => new[] { "Unity.InputSystem" });
+
+            Assert.That(nextActions, Is.EqualTo(new[] { InputSystemNextAction }));
+        }
+
+        /// <summary>
+        /// What: language-version and CS0234 actions are appended in B-then-A order.
+        /// </summary>
+        [Test]
+        public void Build_WhenLanguageVersionAndCs0234_AppendsLanguageVersionFirst()
+        {
+            string[] nextActions = CompileErrorNextActionsBuilder.Build(
+                new[] { FileScopedNamespaceError, InputSystemCs0234Error },
+                searchName => new[] { "Unity.InputSystem" });
+
+            Assert.That(nextActions, Is.EqualTo(new[] { FileScopedNamespaceNextAction, InputSystemNextAction }));
+        }
+
+        /// <summary>
+        /// What: a CS0234 with no declaring assembly leaves existing NextActions unchanged.
+        /// </summary>
+        [Test]
+        public void Apply_WhenCs0234HasNoDeclaringAssembly_LeavesExistingNextActionsUnchanged()
+        {
+            CompileResponse response = CreateResponse(success: false);
+            response.NextActions = new[] { ExistingNextAction };
+
+            CompileErrorNextActionsComposer.Apply(response, new[] { CreateError(UnknownCs0234Error) });
+
+            Assert.That(response.NextActions, Is.EqualTo(new[] { ExistingNextAction }));
+        }
+
+        /// <summary>
+        /// What: existing NextActions are kept and a resolved CS0234 action is appended at the end.
+        /// </summary>
+        [Test]
+        public void Apply_WhenExistingNextActionsAndResolvedCs0234_AppendsDeclaringAssemblyAction()
+        {
+            CompileResponse response = CreateResponse(success: false);
+            response.NextActions = new[] { ExistingNextAction };
+
+            CompileErrorNextActionsComposer.Apply(response, new[] { CreateError(NUnitCs0234Error) });
+
+            Assert.That(response.NextActions, Is.Not.Null);
+            Assert.That(response.NextActions, Has.Length.EqualTo(2));
+            Assert.That(response.NextActions[0], Is.EqualTo(ExistingNextAction));
+            Assert.That(response.NextActions[1], Does.Contain("nunit.framework"));
+        }
+
+        /// <summary>
+        /// What: CreateResponse names nunit.framework for a real CS0234 against NUnit.Framework.
+        /// </summary>
+        [Test]
+        public void CreateResponse_WhenCs0234ForNUnitFramework_IncludesNunitFrameworkAssembly()
+        {
+            CompileResult result = CreateFailedResult(CreateError(NUnitCs0234Error));
+
+            CompileResponse response = CompileResponseFactory.CreateResponse(
+                result,
+                forceRecompile: false,
+                pausePointWarning: null);
+
+            Assert.That(response.NextActions, Is.Not.Null);
+            Assert.That(response.NextActions, Has.Length.EqualTo(1));
+            Assert.That(response.NextActions[0], Does.Contain("nunit.framework"));
+        }
+
+        /// <summary>
+        /// What: CreateResponse stays fail-open when CS0234 names a namespace TypeCache does not declare.
+        /// </summary>
+        [Test]
+        public void CreateResponse_WhenCs0234HasNoDeclaringAssembly_ReturnsNoNextActions()
+        {
+            CompileResult result = CreateFailedResult(CreateError(UnknownCs0234Error));
+
+            CompileResponse response = CompileResponseFactory.CreateResponse(
+                result,
+                forceRecompile: false,
+                pausePointWarning: null);
+
+            Assert.That(response.NextActions, Is.Null);
+        }
+
+        /// <summary>
+        /// What: CreateResponse does not add a missing-reference NextAction for CS0246.
+        /// </summary>
+        [Test]
+        public void CreateResponse_WhenCs0246Error_ReturnsNoNextActions()
+        {
+            CompileResult result = CreateFailedResult(CreateError(Cs0246Error));
+
+            CompileResponse response = CompileResponseFactory.CreateResponse(
+                result,
+                forceRecompile: false,
+                pausePointWarning: null);
+
+            Assert.That(response.NextActions, Is.Null);
+        }
+
+        /// <summary>
+        /// What: CreateResponse appends the TypeCache CS0234 action after the API Updater action.
+        /// </summary>
+        [Test]
+        public void CreateResponse_WhenCs0234AndConsentDeclined_AppendsAfterExistingNextActions()
+        {
+            CompileResult result = new CompileResult(
+                success: false,
+                errorCount: 1,
+                warningCount: 0,
+                completedAt: DateTime.Now,
+                messages: Array.Empty<CompilerMessage>(),
+                errors: new[] { CreateError(NUnitCs0234Error) },
+                warnings: Array.Empty<CompilerMessage>(),
+                apiUpdaterConsentDeclined: true);
+
+            CompileResponse response = CompileResponseFactory.CreateResponse(
+                result,
+                forceRecompile: false,
+                pausePointWarning: null);
+
+            Assert.That(response.NextActions, Is.Not.Null);
+            Assert.That(response.NextActions, Has.Length.EqualTo(2));
+            Assert.That(response.NextActions[0], Is.EqualTo(ApiUpdaterNextAction));
+            Assert.That(response.NextActions[1], Does.Contain("nunit.framework"));
+        }
+
+        /// <summary>
+        /// What: TypeCache.GetTypesDerivedFrom(typeof(object)) lists NUnit.Framework types in nunit.framework.
+        /// </summary>
+        [Test]
+        public void TypeCache_GetTypesDerivedFromObject_IncludesNunitFrameworkForNUnitFrameworkNamespace()
+        {
+            List<string> assemblyNames = new List<string>();
+            foreach (Type type in TypeCache.GetTypesDerivedFrom(typeof(object)))
+            {
+                if (type.Namespace != "NUnit.Framework")
+                {
+                    continue;
+                }
+
+                string assemblyName = type.Assembly.GetName().Name;
+                if (assemblyNames.Contains(assemblyName))
+                {
+                    continue;
+                }
+
+                assemblyNames.Add(assemblyName);
+            }
+
+            Assert.That(assemblyNames, Does.Contain("nunit.framework"));
         }
 
         private static CompileResponse CreateResponse(bool success)

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileErrorNextActionsBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileErrorNextActionsBuilder.cs
@@ -17,10 +17,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             CompileErrorNextActionsConstants.LanguageVersionFeaturePattern,
             RegexOptions.CultureInvariant);
 
+        private static readonly Regex MissingNamespaceRegex = new Regex(
+            CompileErrorNextActionsConstants.MissingNamespacePattern,
+            RegexOptions.CultureInvariant);
+
         /// <summary>
         /// Returns up to three deduplicated NextActions for the first ten error messages.
         /// </summary>
-        internal static string[] Build(string[] errorMessages)
+        internal static string[] Build(
+            string[] errorMessages,
+            Func<string, string[]> findAssemblyNames = null)
         {
             if (errorMessages == null)
             {
@@ -36,21 +42,39 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     break;
                 }
 
-                string nextAction = TryBuildLanguageVersionNextAction(errorMessages[index]);
-                if (nextAction == null)
-                {
-                    continue;
-                }
-
-                if (additions.Contains(nextAction))
-                {
-                    continue;
-                }
-
-                additions.Add(nextAction);
+                AppendFromMessage(additions, errorMessages[index], findAssemblyNames);
             }
 
             return additions.ToArray();
+        }
+
+        private static void AppendFromMessage(
+            List<string> additions,
+            string message,
+            Func<string, string[]> findAssemblyNames)
+        {
+            TryAdd(additions, TryBuildLanguageVersionNextAction(message));
+            if (additions.Count >= CompileErrorNextActionsConstants.MaxNextActionsToAppend)
+            {
+                return;
+            }
+
+            TryAdd(additions, TryBuildMissingReferenceNextAction(message, findAssemblyNames));
+        }
+
+        private static void TryAdd(List<string> additions, string nextAction)
+        {
+            if (nextAction == null)
+            {
+                return;
+            }
+
+            if (additions.Contains(nextAction))
+            {
+                return;
+            }
+
+            additions.Add(nextAction);
         }
 
         /// <summary>
@@ -82,6 +106,76 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 errorCodeMatch.Groups[1].Value,
                 featureMatch.Groups["feature"].Value,
                 featureMatch.Groups["version"].Value);
+        }
+
+        /// <summary>
+        /// Why: Unity's "are you missing an assembly reference?" names the problem but not the
+        /// assembly; agents burned a round-trip discovering which asmdef reference to add.
+        /// </summary>
+        private static string TryBuildMissingReferenceNextAction(
+            string message,
+            Func<string, string[]> findAssemblyNames)
+        {
+            if (findAssemblyNames == null || string.IsNullOrEmpty(message))
+            {
+                return null;
+            }
+
+            Match errorCodeMatch = ErrorCodeRegex.Match(message);
+            if (!errorCodeMatch.Success)
+            {
+                return null;
+            }
+
+            if (errorCodeMatch.Groups[1].Value != CompileErrorNextActionsConstants.Cs0234ErrorCode)
+            {
+                return null;
+            }
+
+            Match namespaceMatch = MissingNamespaceRegex.Match(message);
+            if (!namespaceMatch.Success)
+            {
+                return null;
+            }
+
+            string searchName = namespaceMatch.Groups["outer"].Value + "." + namespaceMatch.Groups["inner"].Value;
+            string[] assemblyNames = findAssemblyNames(searchName);
+            string declaringAssemblies = FormatDeclaringAssemblies(assemblyNames);
+            if (declaringAssemblies == null)
+            {
+                return null;
+            }
+
+            return string.Format(
+                CompileErrorNextActionsConstants.MissingAssemblyReferenceNextActionFormat,
+                errorCodeMatch.Groups[1].Value,
+                searchName,
+                declaringAssemblies);
+        }
+
+        private static string FormatDeclaringAssemblies(string[] assemblyNames)
+        {
+            if (assemblyNames == null || assemblyNames.Length == 0)
+            {
+                return null;
+            }
+
+            string[] sorted = new string[assemblyNames.Length];
+            Array.Copy(assemblyNames, sorted, assemblyNames.Length);
+            Array.Sort(sorted, StringComparer.Ordinal);
+            int count = Math.Min(sorted.Length, CompileErrorNextActionsConstants.MaxDeclaringAssembliesToName);
+            string[] selected = new string[count];
+            Array.Copy(sorted, selected, count);
+            if (selected.Length == 1)
+            {
+                return string.Format(
+                    CompileErrorNextActionsConstants.SingleDeclaringAssemblyFormat,
+                    selected[0]);
+            }
+
+            return string.Format(
+                CompileErrorNextActionsConstants.MultipleDeclaringAssembliesFormat,
+                string.Join("', '", selected));
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileErrorNextActionsComposer.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileErrorNextActionsComposer.cs
@@ -31,7 +31,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 messages[index] = errors[index].message;
             }
 
-            string[] additions = CompileErrorNextActionsBuilder.Build(messages);
+            string[] additions = CompileErrorNextActionsBuilder.Build(
+                messages,
+                CompileMissingReferenceAssemblyLookup.CreateLazyFinder());
             if (additions.Length == 0)
             {
                 return;

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileErrorNextActionsConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileErrorNextActionsConstants.cs
@@ -13,8 +13,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string LanguageVersionFeaturePattern =
             @"Feature '(?<feature>[^']+)' is not available in C# (?<version>[0-9]+(\.[0-9]+)?)";
 
+        public const string MissingAssemblyReferenceNextActionFormat =
+            "error {0}: '{1}' is declared in {2}. Add the assembly to the failing script's .asmdef references and run 'uloop compile' again. If the failing script has no .asmdef, the declaring assembly may have Auto Referenced disabled or its package may not be installed.";
+
+        public const string MissingNamespacePattern =
+            @"The type or namespace name '(?<inner>[^']+)' does not exist in the namespace '(?<outer>[^']+)'";
+
+        public const string Cs0234ErrorCode = "CS0234";
+
+        public const string SingleDeclaringAssemblyFormat = "assembly '{0}'";
+
+        public const string MultipleDeclaringAssembliesFormat = "assemblies '{0}'";
+
         public const int MaxErrorsToScan = 10;
 
         public const int MaxNextActionsToAppend = 3;
+
+        public const int MaxDeclaringAssembliesToName = 3;
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileMissingReferenceAssemblyLookup.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileMissingReferenceAssemblyLookup.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using UnityEditor;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Resolves declaring assembly names for a namespace by scanning TypeCache once per Apply.
+    /// </summary>
+    internal static class CompileMissingReferenceAssemblyLookup
+    {
+        /// <summary>
+        /// Why not scan eagerly: unmatched compiles must stay fail-open and skip TypeCache entirely.
+        /// Why TypeCache only: Assembly.GetTypes() needs try-catch for ReflectionTypeLoadException.
+        /// </summary>
+        internal static Func<string, string[]> CreateLazyFinder()
+        {
+            Dictionary<string, string[]> index = null;
+            return searchName =>
+            {
+                if (index == null)
+                {
+                    index = BuildIndex();
+                }
+
+                if (searchName == null)
+                {
+                    return Array.Empty<string>();
+                }
+
+                if (index.TryGetValue(searchName, out string[] assemblyNames))
+                {
+                    return assemblyNames;
+                }
+
+                return Array.Empty<string>();
+            };
+        }
+
+        private static Dictionary<string, string[]> BuildIndex()
+        {
+            Debug.Assert(
+                MainThreadSwitcher.IsMainThread,
+                "TypeCache.GetTypesDerivedFrom must run on the Unity main thread.");
+
+            Dictionary<string, SortedSet<string>> grouped =
+                new Dictionary<string, SortedSet<string>>(StringComparer.Ordinal);
+            foreach (Type type in TypeCache.GetTypesDerivedFrom(typeof(object)))
+            {
+                string namespaceName = type.Namespace;
+                if (string.IsNullOrEmpty(namespaceName))
+                {
+                    continue;
+                }
+
+                string assemblyName = type.Assembly.GetName().Name;
+                if (!grouped.TryGetValue(namespaceName, out SortedSet<string> assemblyNames))
+                {
+                    assemblyNames = new SortedSet<string>(StringComparer.Ordinal);
+                    grouped.Add(namespaceName, assemblyNames);
+                }
+
+                assemblyNames.Add(assemblyName);
+            }
+
+            Dictionary<string, string[]> index =
+                new Dictionary<string, string[]>(grouped.Count, StringComparer.Ordinal);
+            foreach (KeyValuePair<string, SortedSet<string>> pair in grouped)
+            {
+                string[] assemblyNames = new string[pair.Value.Count];
+                pair.Value.CopyTo(assemblyNames);
+                index.Add(pair.Key, assemblyNames);
+            }
+
+            return index;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileMissingReferenceAssemblyLookup.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileMissingReferenceAssemblyLookup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c995cdd05dfc049baba04e9098f32998
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
@@ -175,6 +175,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 activePausePointCountAtRequestStart);
             ct.ThrowIfCancellationRequested();
             CompileResult result = await _executeCompilationAsync(request, pausePointWarning, ct).ConfigureAwait(false);
+            // Why: CreateResponse may query TypeCache for missing-reference NextActions, and
+            // TypeCache is a Unity Editor API that must run on the main thread.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
 
             // 4. Result formatting
             CompileResponse successResponse =


### PR DESCRIPTION
## Summary
- Failed `uloop compile` results that report CS0234 now append a NextAction that names the assembly declaring the unresolved namespace, so the agent can add the correct `.asmdef` reference without an extra discovery round-trip.

## User Impact
- Round 20 usability feedback (6/10 + 3/10 testers) showed agents seeing `The type or namespace name 'InputSystem' does not exist in the namespace 'UnityEngine' (are you missing an assembly reference?)` and still needing a round-trip to learn which assembly to reference.
- After this change, compile keeps existing NextActions and appends a fail-open hint that names the declaring assembly or assemblies. CS0246 is intentionally ignored because it is also a missing-using case. Zero TypeCache hits produce no hint, so plain typos stay fail-open.

## Changes
- Detect CS0234 with the namespace-qualified pattern, resolve `{outer}.{inner}` through `TypeCache.GetTypesDerivedFrom(typeof(object))`, and append at most three distinct assembly names in ordinal order.
- Scan TypeCache at most once per `Apply`, and only when a CS0234 message is present.
- Switch `CompileUseCase` back to the main thread after `ConfigureAwait(false)` before `CreateResponse`, because TypeCache is a Unity Editor API. The delayed SessionState path (`CompileResultSessionRecorder` via `CompileController` compilation-finished callbacks) already runs on the Editor main thread after compile or domain reload.
- Factory wiring tests fail if the composer `Apply` call is removed. The live TypeCache path is covered by resolving `NUnit.Framework` to `nunit.framework`.

## Verification
- Premise gate: `TypeCache_GetTypesDerivedFromObject_IncludesNunitFrameworkForNUnitFrameworkNamespace` → 1/1 Passed.
- Filter `CompileErrorNextActionsComposerTests` → 30/30 Passed.
- `uloop compile` → 0 errors, 0 warnings.
- `uloop run-tests --test-mode EditMode` (single invocation) → 3392 tests, 3384 passed, 0 failed, 8 skipped (existing Windows-only / optional-assembly ignores).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

