### PR TITLE
chore: streamline release recovery guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,8 +106,7 @@ When a native CLI release has a tag commit that differs from the `sourceReposito
 asset attestations, the dispatcher refuses to download it. Roll forward to the next version —
 never retag, rerun, or otherwise revive the broken one; a new run can only attest its own head
 commit. Diagnosis commands, the narrow conditions under which rerunning *is* valid, and the
-deliberately preserved mismatch specimen (`uloop-project-runner-v3.0.0-beta.48`, which must not
-be deleted): `docs/release-recovery-runbook.md`.
+roll-forward procedure are documented in `docs/release-recovery-runbook.md`.
 
 ## Windows Compatibility Guardrails
 

--- a/docs/release-recovery-runbook.md
+++ b/docs/release-recovery-runbook.md
@@ -34,11 +34,6 @@ do not try to repair the broken release in place.
      | jq -r '.[].verificationResult.signature.certificate.sourceRepositoryDigest'
    ```
 
-The 2026-07-17 recovery followed this procedure: runner beta.48 was left
-broken, the next release-please PR produced runner beta.49, and the following
-package release pinned beta.49. The normal publish run, tag, and attestations
-all resolved to the same commit.
-
 ## Why a broken release cannot be revived
 
 Do not create a new tag, draft, or publish run for the historical version.
@@ -53,9 +48,9 @@ Revival is structurally impossible for three independent reasons:
    approved event commit. A new run for a historical version therefore fails
    before it can create a tag or publish assets.
 
-For example, beta.48's tag pointed at `2d8d1b94` while its published asset
-attestations carried `2c73c6ac`. Reusing that version would preserve the same
-invariant violation.
+Reusing an affected version cannot repair this invariant: its tag and asset
+attestations would still identify different commits. Recovery must move to a
+new version whose release data agrees.
 
 ## When rerun recovery is valid
 
@@ -102,18 +97,6 @@ that version. Recovery is limited to two paths:
   this change.
 
 ## Operational notes
-
-### Preserved negative attestation specimen
-
-Do not delete `uloop-project-runner-v3.0.0-beta.48`. It is an intentionally
-preserved broken release: its tag commit is `2d8d1b94`, while its asset
-attestations carry `2c73c6ac`.
-
-This is the only current production specimen that can prove attestation
-mismatches fail against real release data. Use it to verify each of the
-following rejects a mismatched release: the publish workflow digest check,
-sync's `verify_cli_release_attestations`, and the dispatcher download-time
-verification. Do not pin this version; use beta.49 or later.
 
 - Do not start a new workflow run to publish a historical release. A later run
   cannot produce valid attestations for an earlier commit.


### PR DESCRIPTION
## Summary

- Keep release recovery guidance focused on the actions operators need during an attestation mismatch.
- Direct contributors to the diagnosis, rerun conditions, and roll-forward procedure.

## Changes

- Remove non-actionable recovery anecdotes and test implementation inventory.
- Keep the verification commands, retry paths, and operational safeguards needed during recovery.

## Verification

- `go test ./attestation -run 'TestVerify_HappyPath|TestVerifySubjects_CommitMismatchFailsClosed' -count=1`
- `go test ./internal/dispatcher -run 'TestDownloadDispatcherRealCLIFailsClosedOnAttestationError' -count=1`
- `scripts/test-sync-release-please-package-releases.sh`
- `scripts/test-native-cli-publish-workflow.sh`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

