### PR TITLE
fix: make control-play-mode report an already-running Play session as a no-op

### DIFF
--- a/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
+++ b/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
@@ -522,8 +522,91 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.Changed, Is.False);
             Assert.That(response.ResumedFromPause, Is.False);
             Assert.That(response.Warning, Is.Empty);
-            Assert.That(editorState.IsPlaying, Is.True);
-            Assert.That(editorState.IsPaused, Is.False);
+            Assert.That(response.IsPlaying, Is.True);
+            Assert.That(response.IsPaused, Is.False);
+            Assert.That(editorState.IsPlayingSetCount, Is.EqualTo(0));
+            Assert.That(editorState.IsPausedSetCount, Is.EqualTo(0));
+            Assert.That(quietSaver.SaveCallCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: Resume while already running and not paused uses the same no-op contract as Play.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenResumeWhileAlreadyRunning_ReportsNoOpWithoutSideEffects()
+        {
+            FakeControlPlayModeEditorStateService editorState = new(isPlaying: true, isPaused: false);
+            StubEditorUnsavedChangesQuietSaver quietSaver = new(
+                saveFailures: System.Array.Empty<string>(),
+                remainingAfterSave: System.Array.Empty<string>());
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
+                new StubCompilationFailureGate(false),
+                quietSaver,
+                editorState,
+                new StubDomainReloadDropStateProvider());
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Resume,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(
+                response.Message,
+                Is.EqualTo("Play mode was already running; nothing to start or resume."));
+            Assert.That(response.Changed, Is.False);
+            Assert.That(response.ResumedFromPause, Is.False);
+            Assert.That(response.Warning, Is.Empty);
+            Assert.That(response.IsPlaying, Is.True);
+            Assert.That(response.IsPaused, Is.False);
+            Assert.That(editorState.IsPlayingSetCount, Is.EqualTo(0));
+            Assert.That(editorState.IsPausedSetCount, Is.EqualTo(0));
+            Assert.That(quietSaver.SaveCallCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: a failed compile gate does not replace the already-running no-op while Play is live.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenPlayWhileAlreadyRunningAndCompileFailed_ReportsNoOpNotCompileBlock()
+        {
+            FakeControlPlayModeEditorStateService editorState = new(isPlaying: true, isPaused: false);
+            StubEditorUnsavedChangesQuietSaver quietSaver = new(
+                saveFailures: System.Array.Empty<string>(),
+                remainingAfterSave: System.Array.Empty<string>());
+            ControlPlayModeCompileError[] compileErrors =
+            {
+                new ControlPlayModeCompileError
+                {
+                    Message = "CS1525: invalid expression",
+                    File = "Assets/Scripts/Sample.cs",
+                    Line = 3
+                }
+            };
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(compileErrors),
+                new StubCompilationFailureGate(true),
+                quietSaver,
+                editorState,
+                new StubDomainReloadDropStateProvider());
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Play,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(
+                response.Message,
+                Is.EqualTo("Play mode was already running; nothing to start or resume."));
+            Assert.That(response.Changed, Is.False);
+            Assert.That(response.ResumedFromPause, Is.False);
+            Assert.That(response.Warning, Is.Empty);
+            Assert.That(response.IsPlaying, Is.True);
+            Assert.That(response.IsPaused, Is.False);
+            Assert.That(response.BlockedByCompileErrors, Is.False);
+            Assert.That(response.CompileErrorCount, Is.EqualTo(0));
             Assert.That(editorState.IsPlayingSetCount, Is.EqualTo(0));
             Assert.That(editorState.IsPausedSetCount, Is.EqualTo(0));
             Assert.That(quietSaver.SaveCallCount, Is.EqualTo(0));

--- a/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
+++ b/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
@@ -493,6 +493,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(quietSaver.SaveCallCount, Is.EqualTo(0));
         }
 
+        /// <summary>
+        /// What: Play while already running and not paused is a no-op with the already-running message.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenPlayWhileAlreadyRunning_ReportsNoOpWithoutSideEffects()
+        {
+            FakeControlPlayModeEditorStateService editorState = new(isPlaying: true, isPaused: false);
+            StubEditorUnsavedChangesQuietSaver quietSaver = new(
+                saveFailures: System.Array.Empty<string>(),
+                remainingAfterSave: System.Array.Empty<string>());
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
+                new StubCompilationFailureGate(false),
+                quietSaver,
+                editorState,
+                new StubDomainReloadDropStateProvider());
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Play,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(
+                response.Message,
+                Is.EqualTo("Play mode was already running; nothing to start or resume."));
+            Assert.That(response.Changed, Is.False);
+            Assert.That(response.ResumedFromPause, Is.False);
+            Assert.That(response.Warning, Is.Empty);
+            Assert.That(editorState.IsPlaying, Is.True);
+            Assert.That(editorState.IsPaused, Is.False);
+            Assert.That(editorState.IsPlayingSetCount, Is.EqualTo(0));
+            Assert.That(editorState.IsPausedSetCount, Is.EqualTo(0));
+            Assert.That(quietSaver.SaveCallCount, Is.EqualTo(0));
+        }
+
         [Test]
         public async Task ExecuteAsync_WhenPlayStartsFreshSession_SetsPlayingAndReportsWarning()
         {

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeConstants.cs
@@ -10,5 +10,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal const string StoppedByCliRunTestsCancel = "cli-run-tests-cancel";
         internal const string StoppedByScriptCompilation = "script-compilation";
         internal const string StoppedByUnknown = "unknown";
+
+        internal const string AlreadyRunningPlayMessage =
+            "Play mode was already running; nothing to start or resume.";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
@@ -173,6 +173,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     true);
             }
 
+            // Why: already-running Play used to report "Play mode started" even when Changed
+            // was false, which made a no-op look like a new session.
+            if (wasPlaying && !wasPaused)
+            {
+                return ControlPlayModeActionResult.FromState(
+                    ControlPlayModeConstants.AlreadyRunningPlayMessage,
+                    false,
+                    false);
+            }
+
             // Why only when entering Play from Edit: SaveScene does not work while already playing,
             // and resume-from-pause must not rewrite Scene assets.
             if (!wasPlaying)


### PR DESCRIPTION
## Summary
- `uloop control-play-mode --action Play` (and `Resume`) on an already-running, unpaused session now reports a no-op instead of looking like a fresh Play start.

## User Impact
- Before: Play/Resume while already playing returned `Message: "Play mode started"` even when `Changed` was false, so a no-op looked like a new session.
- After: the same request returns `Message: "Play mode was already running; nothing to start or resume."` with `Changed: false`, `ResumedFromPause: false`, and no warning. Paused sessions still resume as before (`"Play mode resumed"`). Stopped Editors still start Play as before (`"Play mode started"`).

## Changes
- After the compile-error gate, `wasPlaying && !wasPaused` returns the no-op without mutating editor state.

## Verification
- `scripts/check-file-length.sh`: no files exceeded the 500 SLOC limit.
- `dist/darwin-arm64/uloop compile --project-path "<PROJECT_ROOT>"`: Success, ErrorCount 0.
- Filter `ControlPlayModeUseCaseTests`: TestCount 27, Passed 27, Failed 0.
- Full EditMode: TestCount 3410, Passed 3402, Failed 0, Skipped 8 (suite Status=Skipped because of those skips).

### Changed:true reproduction (required)
Sequence: Play → enable a per-frame pause point (`SpaceHoldPoller.Update` line 16) with `--await` → `clear-pause-point` (auto-resumed; `EditorState.IsPlaying: true`, `IsPaused: false`) → immediately `control-play-mode --action Resume`.

The `Changed: true` anomaly was **not reproduced**. Immediate Resume after clear returned:

```json
{
  "IsPlaying": true,
  "IsPaused": false,
  "Changed": false,
  "WasAlreadyStopped": false,
  "ResumedFromPause": false,
  "BlockedByCompileErrors": false,
  "BlockedByUnsavedChanges": false,
  "CompileErrorCount": 0,
  "CompileErrors": [],
  "Message": "Play mode started",
  "Warning": "",
  "Success": true
}
```

`wasPlaying` was read correctly (`Changed: false`). The remaining problem is the misleading `"Play mode started"` message, which this PR replaces with the already-running no-op sentence.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

