### PR TITLE
docs: explain HitSequence numbering and hot-reload's supported edit shapes

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uloop-hot-reload
 toolName: hot-reload
-description: "Apply method-body hot reload to edited C# sources in a running Unity Editor without domain reload. Use after small method edits when you need PlayMode/EditMode feedback without uloop compile."
+description: "Hot reload applies method-body edits and can add new methods and fields (added members are visible only to edited code in the same file); new types, signature changes to existing methods, or members other files must reference require 'uloop compile'."
 ---
 
 # uloop hot-reload

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uloop-hot-reload
 toolName: hot-reload
-description: "Hot reload applies method-body edits and can add new methods and fields (added members are visible only to edited code in the same file); new types, signature changes to existing methods, or members other files must reference require 'uloop compile'."
+description: "Hot reload applies method-body edits and can add new methods and fields (added members are visible only to edited code in the same file); it can also change signatures when the same reload covers the old signature's compiled callers. New types, or members other files must reference, require 'uloop compile'."
 ---
 
 # uloop hot-reload

--- a/.agents/skills/uloop-pause-point/references/captured-variables.md
+++ b/.agents/skills/uloop-pause-point/references/captured-variables.md
@@ -92,7 +92,7 @@ For a self-progressing game, arranging a scenario through real input alone is a 
 
 `await-pause-point`'s hit response also carries a top-level `Warning` (omitted when empty): it flags multiple hits, multiple matching logs, or truncated matching logs, so you can tell a single clean hit apart from evidence that needs closer inspection. Enable-time patch diagnostics (for example physics-callback cached dispatch) are not in `Warning`; on `enable-pause-point --await` they appear as `EnableTimeWarning` instead. `MatchingLogs` (log entries whose text contains the marker id) is still embedded, but source-derived ids rarely appear in log text, so treat `CapturedVariables` as the primary variable evidence.
 
-Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or status response to tell a fresh marker from stale evidence with the same id. `RemainingMilliseconds` and `Expired` are returned directly so you do not need to infer marker lifetime from elapsed time. HitSequence numbers come from a session-wide sequence shared by all pause points (they order hits across markers); they are not 1..HitCount for this marker.
+Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or status response to tell a fresh marker from stale evidence with the same id. `RemainingMilliseconds` and `Expired` are returned directly so you do not need to infer marker lifetime from elapsed time. HitSequence numbers come from a sequence shared by all pause points in the current Editor domain (it resets on domain reload); they order hits across markers and are not 1..HitCount for this marker.
 
 ## Caller frames
 

--- a/.agents/skills/uloop-pause-point/references/captured-variables.md
+++ b/.agents/skills/uloop-pause-point/references/captured-variables.md
@@ -92,7 +92,7 @@ For a self-progressing game, arranging a scenario through real input alone is a 
 
 `await-pause-point`'s hit response also carries a top-level `Warning` (omitted when empty): it flags multiple hits, multiple matching logs, or truncated matching logs, so you can tell a single clean hit apart from evidence that needs closer inspection. Enable-time patch diagnostics (for example physics-callback cached dispatch) are not in `Warning`; on `enable-pause-point --await` they appear as `EnableTimeWarning` instead. `MatchingLogs` (log entries whose text contains the marker id) is still embedded, but source-derived ids rarely appear in log text, so treat `CapturedVariables` as the primary variable evidence.
 
-Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or status response to tell a fresh marker from stale evidence with the same id. `RemainingMilliseconds` and `Expired` are returned directly so you do not need to infer marker lifetime from elapsed time.
+Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or status response to tell a fresh marker from stale evidence with the same id. `RemainingMilliseconds` and `Expired` are returned directly so you do not need to infer marker lifetime from elapsed time. HitSequence numbers come from a session-wide sequence shared by all pause points (they order hits across markers); they are not 1..HitCount for this marker.
 
 ## Caller frames
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uloop-hot-reload
 toolName: hot-reload
-description: "Apply method-body hot reload to edited C# sources in a running Unity Editor without domain reload. Use after small method edits when you need PlayMode/EditMode feedback without uloop compile."
+description: "Hot reload applies method-body edits and can add new methods and fields (added members are visible only to edited code in the same file); new types, signature changes to existing methods, or members other files must reference require 'uloop compile'."
 ---
 
 # uloop hot-reload

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uloop-hot-reload
 toolName: hot-reload
-description: "Hot reload applies method-body edits and can add new methods and fields (added members are visible only to edited code in the same file); new types, signature changes to existing methods, or members other files must reference require 'uloop compile'."
+description: "Hot reload applies method-body edits and can add new methods and fields (added members are visible only to edited code in the same file); it can also change signatures when the same reload covers the old signature's compiled callers. New types, or members other files must reference, require 'uloop compile'."
 ---
 
 # uloop hot-reload

--- a/.claude/skills/uloop-pause-point/references/captured-variables.md
+++ b/.claude/skills/uloop-pause-point/references/captured-variables.md
@@ -92,7 +92,7 @@ For a self-progressing game, arranging a scenario through real input alone is a 
 
 `await-pause-point`'s hit response also carries a top-level `Warning` (omitted when empty): it flags multiple hits, multiple matching logs, or truncated matching logs, so you can tell a single clean hit apart from evidence that needs closer inspection. Enable-time patch diagnostics (for example physics-callback cached dispatch) are not in `Warning`; on `enable-pause-point --await` they appear as `EnableTimeWarning` instead. `MatchingLogs` (log entries whose text contains the marker id) is still embedded, but source-derived ids rarely appear in log text, so treat `CapturedVariables` as the primary variable evidence.
 
-Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or status response to tell a fresh marker from stale evidence with the same id. `RemainingMilliseconds` and `Expired` are returned directly so you do not need to infer marker lifetime from elapsed time. HitSequence numbers come from a session-wide sequence shared by all pause points (they order hits across markers); they are not 1..HitCount for this marker.
+Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or status response to tell a fresh marker from stale evidence with the same id. `RemainingMilliseconds` and `Expired` are returned directly so you do not need to infer marker lifetime from elapsed time. HitSequence numbers come from a sequence shared by all pause points in the current Editor domain (it resets on domain reload); they order hits across markers and are not 1..HitCount for this marker.
 
 ## Caller frames
 

--- a/.claude/skills/uloop-pause-point/references/captured-variables.md
+++ b/.claude/skills/uloop-pause-point/references/captured-variables.md
@@ -92,7 +92,7 @@ For a self-progressing game, arranging a scenario through real input alone is a 
 
 `await-pause-point`'s hit response also carries a top-level `Warning` (omitted when empty): it flags multiple hits, multiple matching logs, or truncated matching logs, so you can tell a single clean hit apart from evidence that needs closer inspection. Enable-time patch diagnostics (for example physics-callback cached dispatch) are not in `Warning`; on `enable-pause-point --await` they appear as `EnableTimeWarning` instead. `MatchingLogs` (log entries whose text contains the marker id) is still embedded, but source-derived ids rarely appear in log text, so treat `CapturedVariables` as the primary variable evidence.
 
-Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or status response to tell a fresh marker from stale evidence with the same id. `RemainingMilliseconds` and `Expired` are returned directly so you do not need to infer marker lifetime from elapsed time.
+Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or status response to tell a fresh marker from stale evidence with the same id. `RemainingMilliseconds` and `Expired` are returned directly so you do not need to infer marker lifetime from elapsed time. HitSequence numbers come from a session-wide sequence shared by all pause points (they order hits across markers); they are not 1..HitCount for this marker.
 
 ## Caller frames
 

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/references/captured-variables.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/references/captured-variables.md
@@ -92,7 +92,7 @@ For a self-progressing game, arranging a scenario through real input alone is a 
 
 `await-pause-point`'s hit response also carries a top-level `Warning` (omitted when empty): it flags multiple hits, multiple matching logs, or truncated matching logs, so you can tell a single clean hit apart from evidence that needs closer inspection. Enable-time patch diagnostics (for example physics-callback cached dispatch) are not in `Warning`; on `enable-pause-point --await` they appear as `EnableTimeWarning` instead. `MatchingLogs` (log entries whose text contains the marker id) is still embedded, but source-derived ids rarely appear in log text, so treat `CapturedVariables` as the primary variable evidence.
 
-Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or status response to tell a fresh marker from stale evidence with the same id. `RemainingMilliseconds` and `Expired` are returned directly so you do not need to infer marker lifetime from elapsed time. HitSequence numbers come from a session-wide sequence shared by all pause points (they order hits across markers); they are not 1..HitCount for this marker.
+Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or status response to tell a fresh marker from stale evidence with the same id. `RemainingMilliseconds` and `Expired` are returned directly so you do not need to infer marker lifetime from elapsed time. HitSequence numbers come from a sequence shared by all pause points in the current Editor domain (it resets on domain reload); they order hits across markers and are not 1..HitCount for this marker.
 
 ## Caller frames
 

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/references/captured-variables.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/references/captured-variables.md
@@ -92,7 +92,7 @@ For a self-progressing game, arranging a scenario through real input alone is a 
 
 `await-pause-point`'s hit response also carries a top-level `Warning` (omitted when empty): it flags multiple hits, multiple matching logs, or truncated matching logs, so you can tell a single clean hit apart from evidence that needs closer inspection. Enable-time patch diagnostics (for example physics-callback cached dispatch) are not in `Warning`; on `enable-pause-point --await` they appear as `EnableTimeWarning` instead. `MatchingLogs` (log entries whose text contains the marker id) is still embedded, but source-derived ids rarely appear in log text, so treat `CapturedVariables` as the primary variable evidence.
 
-Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or status response to tell a fresh marker from stale evidence with the same id. `RemainingMilliseconds` and `Expired` are returned directly so you do not need to infer marker lifetime from elapsed time.
+Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or status response to tell a fresh marker from stale evidence with the same id. `RemainingMilliseconds` and `Expired` are returned directly so you do not need to infer marker lifetime from elapsed time. HitSequence numbers come from a session-wide sequence shared by all pause points (they order hits across markers); they are not 1..HitCount for this marker.
 
 ## Caller frames
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uloop-hot-reload
 toolName: hot-reload
-description: "Apply method-body hot reload to edited C# sources in a running Unity Editor without domain reload. Use after small method edits when you need PlayMode/EditMode feedback without uloop compile."
+description: "Hot reload applies method-body edits and can add new methods and fields (added members are visible only to edited code in the same file); new types, signature changes to existing methods, or members other files must reference require 'uloop compile'."
 ---
 
 # uloop hot-reload

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uloop-hot-reload
 toolName: hot-reload
-description: "Hot reload applies method-body edits and can add new methods and fields (added members are visible only to edited code in the same file); new types, signature changes to existing methods, or members other files must reference require 'uloop compile'."
+description: "Hot reload applies method-body edits and can add new methods and fields (added members are visible only to edited code in the same file); it can also change signatures when the same reload covers the old signature's compiled callers. New types, or members other files must reference, require 'uloop compile'."
 ---
 
 # uloop hot-reload

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -754,7 +754,7 @@
     },
     {
       "name": "hot-reload",
-      "description": "Hot reload applies method-body edits and can add new methods and fields (added members are visible only to edited code in the same file); new types, signature changes to existing methods, or members other files must reference require 'uloop compile'.",
+      "description": "Hot reload applies method-body edits and can add new methods and fields (added members are visible only to edited code in the same file); it can also change signatures when the same reload covers the old signature's compiled callers. New types, or members other files must reference, require 'uloop compile'.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -754,7 +754,7 @@
     },
     {
       "name": "hot-reload",
-      "description": "Apply method-body hot reload to edited C# sources in a running Unity Editor without domain reload. Use after small method edits when you need PlayMode/EditMode feedback without uloop compile.",
+      "description": "Hot reload applies method-body edits and can add new methods and fields (added members are visible only to edited code in the same file); new types, signature changes to existing methods, or members other files must reference require 'uloop compile'.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "9fed9a9a549f45ecc91e381f1c780dd4af0f212b"
+  "sharedInputsHash": "2db8de86e896d8fea1f540f80e44cc29b1004740"
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "2db8de86e896d8fea1f540f80e44cc29b1004740"
+  "sharedInputsHash": "057220b1f49759a881862f4fcc38916b3d2bbcff"
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -30,7 +30,7 @@ const (
 
 	// pausePointCapturedVariableHistoryNote explains why the latest hit is absent from
 	// CapturedVariableHistory: repeating it would duplicate CapturedVariables.
-	pausePointCapturedVariableHistoryNote = "CapturedVariableHistory lists hits before the latest one; the latest hit's variables are in CapturedVariables. HitSequence numbers come from a session-wide sequence shared by all pause points (they order hits across markers); they are not 1..HitCount for this marker."
+	pausePointCapturedVariableHistoryNote = "CapturedVariableHistory lists hits before the latest one; the latest hit's variables are in CapturedVariables. HitSequence numbers come from a sequence shared by all pause points in the current Editor domain (it resets on domain reload); they order hits across markers and are not 1..HitCount for this marker."
 
 	// pausePointTraceStatusNote explains that a trace-mode Hit did not pause Play Mode.
 	pausePointTraceStatusNote = "Trace mode does not pause Play Mode; Status 'Hit' records that the marker fired while the game kept running."

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -30,7 +30,7 @@ const (
 
 	// pausePointCapturedVariableHistoryNote explains why the latest hit is absent from
 	// CapturedVariableHistory: repeating it would duplicate CapturedVariables.
-	pausePointCapturedVariableHistoryNote = "CapturedVariableHistory lists hits before the latest one; the latest hit's variables are in CapturedVariables."
+	pausePointCapturedVariableHistoryNote = "CapturedVariableHistory lists hits before the latest one; the latest hit's variables are in CapturedVariables. HitSequence numbers come from a session-wide sequence shared by all pause points (they order hits across markers); they are not 1..HitCount for this marker."
 
 	// pausePointTraceStatusNote explains that a trace-mode Hit did not pause Play Mode.
 	pausePointTraceStatusNote = "Trace mode does not pause Play Mode; Status 'Hit' records that the marker fired while the game kept running."

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -1315,9 +1315,10 @@ func TestPausePointStatusResponseIncludesCapturedVariableHistoryNote(t *testing.
 	if err := json.Unmarshal(rawNote, &note); err != nil {
 		t.Fatalf("unmarshal note failed: %v", err)
 	}
-	if note != "CapturedVariableHistory lists hits before the latest one; the latest hit's variables are in CapturedVariables. HitSequence numbers come from a session-wide sequence shared by all pause points (they order hits across markers); they are not 1..HitCount for this marker." {
+	wantNote := "CapturedVariableHistory lists hits before the latest one; the latest hit's variables are in CapturedVariables. HitSequence numbers come from a sequence shared by all pause points in the current Editor domain (it resets on domain reload); they order hits across markers and are not 1..HitCount for this marker."
+	if note != wantNote {
 		t.Fatalf("CapturedVariableHistoryNote mismatch: got %#v, want %#v",
-			note, pausePointCapturedVariableHistoryNote)
+			note, wantNote)
 	}
 }
 
@@ -1925,9 +1926,10 @@ func TestRunPausePointStatusIncludesCapturedVariableHistoryNoteWhenLatestHitIsFi
 	if err := json.Unmarshal(rawNote, &note); err != nil {
 		t.Fatalf("unmarshal note failed: %v", err)
 	}
-	if note != "CapturedVariableHistory lists hits before the latest one; the latest hit's variables are in CapturedVariables. HitSequence numbers come from a session-wide sequence shared by all pause points (they order hits across markers); they are not 1..HitCount for this marker." {
+	wantNote := "CapturedVariableHistory lists hits before the latest one; the latest hit's variables are in CapturedVariables. HitSequence numbers come from a sequence shared by all pause points in the current Editor domain (it resets on domain reload); they order hits across markers and are not 1..HitCount for this marker."
+	if note != wantNote {
 		t.Fatalf("CapturedVariableHistoryNote mismatch: got %#v, want %#v",
-			note, pausePointCapturedVariableHistoryNote)
+			note, wantNote)
 	}
 }
 

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -1315,7 +1315,7 @@ func TestPausePointStatusResponseIncludesCapturedVariableHistoryNote(t *testing.
 	if err := json.Unmarshal(rawNote, &note); err != nil {
 		t.Fatalf("unmarshal note failed: %v", err)
 	}
-	if note != pausePointCapturedVariableHistoryNote {
+	if note != "CapturedVariableHistory lists hits before the latest one; the latest hit's variables are in CapturedVariables. HitSequence numbers come from a session-wide sequence shared by all pause points (they order hits across markers); they are not 1..HitCount for this marker." {
 		t.Fatalf("CapturedVariableHistoryNote mismatch: got %#v, want %#v",
 			note, pausePointCapturedVariableHistoryNote)
 	}
@@ -1925,7 +1925,7 @@ func TestRunPausePointStatusIncludesCapturedVariableHistoryNoteWhenLatestHitIsFi
 	if err := json.Unmarshal(rawNote, &note); err != nil {
 		t.Fatalf("unmarshal note failed: %v", err)
 	}
-	if note != pausePointCapturedVariableHistoryNote {
+	if note != "CapturedVariableHistory lists hits before the latest one; the latest hit's variables are in CapturedVariables. HitSequence numbers come from a session-wide sequence shared by all pause points (they order hits across markers); they are not 1..HitCount for this marker." {
 		t.Fatalf("CapturedVariableHistoryNote mismatch: got %#v, want %#v",
 			note, pausePointCapturedVariableHistoryNote)
 	}

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "da2a5aa7cd11052b7eeacb3a9d75f68e91043742"
+  "sharedInputsHash": "9ac17f7fa800a193619ef4e1c5da9cd33f7f2259"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "abce606e6b8233345a41199ba7c54c83b906ebb6"
+  "sharedInputsHash": "da2a5aa7cd11052b7eeacb3a9d75f68e91043742"
 }


### PR DESCRIPTION
## Summary
- Pause-point history notes now say `HitSequence` is a session-wide counter shared by all markers, not `1..HitCount` for one marker.
- `uloop hot-reload --help` now states that new methods and fields in the same file can be added, and that new types, signature changes, or members other files must reference still need `uloop compile`.

## User Impact
- Before: agents treated `HitSequence` as a per-marker index, and hot-reload help sounded like method-body-only even though same-file added members already work.
- After: the note and skill text state both facts in the locked wording.

## Changes
- Appended the HitSequence sentence to `CapturedVariableHistoryNote` and the pause-point `captured-variables` skill reference (same English sentence).
- Replaced the hot-reload tool description with the locked sentence that does not deny added methods.
- Regenerated `default-tools.json`, skill copies, and both shared-input stamps in the same commit.
- Pinned the note wording with exact-literal Go tests.

## Verification
- `scripts/check-go-cli.sh`: passed (including `project-runner` tests)
- `scripts/sync-tool-docs.sh` + `uloop skills install --claude --agents` + `scripts/stamp-release-inputs.sh` in the same commit


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

