### PR TITLE
fix: validate hot-reload entries before mutating patch state

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -272,11 +272,11 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | Usually a stale assembly; run `uloop compile`. In-file renames and signature changes are classified as added members before reaching this point |
 | Shim compile error (e.g. the body calls a member that does not exist yet) | Failing methods are isolated: each reports `Failed` with its own compiler errors (plus the `uloop compile` hint when they indicate a missing member). When errors cannot be attributed per method, the whole file reports one `(shim-compile)` entry; if only one method was edited, the failure is attributed to that method's name instead |
-| Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error; other methods in the run still apply |
+| Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 | The signature-change gate could not finish the run safely — the retry that skips a gated change failed, or shim-compile isolation dropped an edited caller that had covered a change | Per-file entry with `Method` = `(signature-change-gate)` carrying the specific cause; nothing from the file is applied — fix the failing edit or run `uloop compile` |
 
-When a file's shim compilation fails, nothing from that file is applied; patches from earlier reloads stay active.
+A reload applies each file all-or-nothing: when any method in a file fails to compile or validate, nothing from that file is applied and patches from earlier reloads stay active. The one exception is a Harmony patch-engine failure in the middle of applying a validated file; that run reports itself as partially applied and recommends 'uloop hot-reload --revert-all'.
 
 ## When a patch reports `Patched` but behavior does not change
 

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -272,11 +272,11 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | Usually a stale assembly; run `uloop compile`. In-file renames and signature changes are classified as added members before reaching this point |
 | Shim compile error (e.g. the body calls a member that does not exist yet) | Failing methods are isolated: each reports `Failed` with its own compiler errors (plus the `uloop compile` hint when they indicate a missing member). When errors cannot be attributed per method, the whole file reports one `(shim-compile)` entry; if only one method was edited, the failure is attributed to that method's name instead |
-| Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error; other methods in the run still apply |
+| Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 | The signature-change gate could not finish the run safely — the retry that skips a gated change failed, or shim-compile isolation dropped an edited caller that had covered a change | Per-file entry with `Method` = `(signature-change-gate)` carrying the specific cause; nothing from the file is applied — fix the failing edit or run `uloop compile` |
 
-When a file's shim compilation fails, nothing from that file is applied; patches from earlier reloads stay active.
+A reload applies each file all-or-nothing: when any method in a file fails to compile or validate, nothing from that file is applied and patches from earlier reloads stay active. The one exception is a Harmony patch-engine failure in the middle of applying a validated file; that run reports itself as partially applied and recommends 'uloop hot-reload --revert-all'.
 
 ## When a patch reports `Patched` but behavior does not change
 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2487,6 +2487,95 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a match failure among multiple apply entries fails that entry, skips the rest
+        /// with AtomicFileSkipReason, and does not begin a shim / added-member / added-field
+        /// generation for the file.
+        /// </summary>
+        [Test]
+        public void ApplyEntries_MatchFailureAmongMultipleEntries_SkipsRestWithoutRegistryGeneration()
+        {
+            const string projectRelativePath = "Assets/Tests/Editor/HotReload/PreflightMatchFailure.cs";
+            const string missingMethodName = "DoesNotExistInCompiledAssembly";
+            string typeName = typeof(HotReloadE2EFixture).FullName;
+            string expectedFailedLabel = HotReloadPatcher.FormatMethodKeyParts(
+                typeName,
+                missingMethodName,
+                new[] { typeof(int).FullName },
+                genericArity: 0);
+            string expectedFailedReason =
+                "No method '" + missingMethodName
+                + "' with the given parameter types was found on '" + typeName + "'.";
+            string[] addedFieldNames =
+            {
+                typeName + ".PreflightScratch"
+            };
+            TransformWorkerEntryDto[] entries =
+            {
+                new TransformWorkerEntryDto
+                {
+                    typeMetadataName = typeName,
+                    methodName = missingMethodName,
+                    parameterTypeFullNames = new[] { typeof(int).FullName },
+                    genericArity = 0,
+                    shimTypeName = "UnusedShim",
+                    shimMethodName = "Unused",
+                    patchKind = string.Empty
+                },
+                new TransformWorkerEntryDto
+                {
+                    typeMetadataName = typeName,
+                    methodName = nameof(HotReloadE2EFixture.ComputeWithPrivate),
+                    parameterTypeFullNames = new[] { typeof(int).FullName },
+                    genericArity = 0,
+                    shimTypeName = "UnusedShim",
+                    shimMethodName = "Unused",
+                    patchKind = string.Empty
+                }
+            };
+            TransformWorkerOutputDto workerOutput = new TransformWorkerOutputDto
+            {
+                entries = entries,
+                addedFieldNames = addedFieldNames,
+                sourceContentSha256 = "preflight-match-failure"
+            };
+
+            HotReloadOrchestrator.HotReloadFileProcessResult fileResult =
+                HotReloadEntryApplier.ApplyEntriesAndBuildResult(
+                    typeof(HotReloadE2EFixture).Assembly.GetName().Name,
+                    projectRelativePath,
+                    projectRelativePath,
+                    HotReloadShimCompileResult.SuccessResult(
+                        typeof(HotReloadEntryApplier).Assembly,
+                        new byte[] { 1 },
+                        Array.Empty<byte>()),
+                    entries,
+                    addedFieldNames,
+                    workerOutput,
+                    new HashSet<string>(),
+                    new HashSet<string>(),
+                    new List<HotReloadMethodOutcome>(),
+                    new List<string>(),
+                    new List<string>(),
+                    new List<string>(),
+                    unchangedMethodCount: 0);
+
+            HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
+                fileResult.Outcomes,
+                fileResult.Warnings,
+                fileResult.PatchedCount,
+                activePatchTotal: 0);
+            Assert.That(fileResult.Outcomes.Count, Is.EqualTo(2));
+            Assert.That(fileResult.Outcomes[0].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Failed));
+            Assert.That(fileResult.Outcomes[0].Method, Is.EqualTo(expectedFailedLabel));
+            Assert.That(fileResult.Outcomes[0].Reason, Is.EqualTo(expectedFailedReason));
+            AssertHasAtomicFileSkip(result, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+            AssertNoPatchedOrAddedOutcomes(result);
+            Assert.That(HotReloadShimRegistry.HasGeneration(projectRelativePath), Is.False);
+            Assert.That(HotReloadAddedMemberRegistry.HasGeneration(projectRelativePath), Is.False);
+            Assert.That(HotReloadAddedFieldRegistry.GetFieldsForType(typeName), Is.Empty);
+        }
+
+        /// <summary>
         /// What: an added method plus its caller plus an unrelated shim-compile failure still
         /// isolates per-method (the file is not collapsed to a single (shim-compile) Failed)
         /// and skips survivors instead of patching them.

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -2573,6 +2574,262 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(HotReloadShimRegistry.HasGeneration(projectRelativePath), Is.False);
             Assert.That(HotReloadAddedMemberRegistry.HasGeneration(projectRelativePath), Is.False);
             Assert.That(HotReloadAddedFieldRegistry.GetFieldsForType(typeName), Is.Empty);
+        }
+
+        /// <summary>
+        /// What: a match failure at a non-leading entry still reports every entry: earlier
+        /// resolved methods become Skipped with AtomicFileSkipReason, the failed entry stays
+        /// Failed, later entries are Skipped, and outcomes.Count equals the entry count.
+        /// </summary>
+        [Test]
+        public void ApplyEntries_MatchFailureAfterResolvedEntry_SkipsPriorAndRestWithoutRegistryGeneration()
+        {
+            const string projectRelativePath = "Assets/Tests/Editor/HotReload/PreflightMatchFailureMid.cs";
+            const string missingMethodName = "DoesNotExistInCompiledAssembly";
+            string typeName = typeof(HotReloadCoreFixture).FullName;
+            string expectedPriorLabel = HotReloadPatcher.FormatMethodKeyParts(
+                typeName,
+                nameof(HotReloadCoreFixture.ReplaceableCompute),
+                new[] { typeof(int).FullName },
+                genericArity: 0);
+            string expectedFailedLabel = HotReloadPatcher.FormatMethodKeyParts(
+                typeName,
+                missingMethodName,
+                new[] { typeof(int).FullName },
+                genericArity: 0);
+            string expectedTrailingLabel = HotReloadPatcher.FormatMethodKeyParts(
+                typeName,
+                nameof(HotReloadCoreFixture.StaticPing),
+                Array.Empty<string>(),
+                genericArity: 0);
+            string expectedFailedReason =
+                "No method '" + missingMethodName
+                + "' with the given parameter types was found on '" + typeName + "'.";
+            TransformWorkerEntryDto[] entries =
+            {
+                CreateExistingMethodEntry(
+                    typeName,
+                    nameof(HotReloadCoreFixture.ReplaceableCompute),
+                    new[] { typeof(int).FullName },
+                    nameof(HotReloadHandwrittenShims),
+                    nameof(HotReloadHandwrittenShims.ReplaceableCompute__shim0)),
+                CreateExistingMethodEntry(
+                    typeName,
+                    missingMethodName,
+                    new[] { typeof(int).FullName },
+                    nameof(HotReloadHandwrittenShims),
+                    nameof(HotReloadHandwrittenShims.StaticPing__shim0)),
+                CreateExistingMethodEntry(
+                    typeName,
+                    nameof(HotReloadCoreFixture.StaticPing),
+                    Array.Empty<string>(),
+                    nameof(HotReloadHandwrittenShims),
+                    nameof(HotReloadHandwrittenShims.StaticPing__shim0))
+            };
+
+            HotReloadOrchestrator.HotReloadFileProcessResult fileResult = ApplyEntriesDirect(
+                projectRelativePath,
+                entries);
+            HotReloadOrchestratorResult result = ToOrchestratorResult(fileResult);
+
+            Assert.That(fileResult.Outcomes.Count, Is.EqualTo(entries.Length));
+            Assert.That(fileResult.Outcomes[0].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Skipped));
+            Assert.That(fileResult.Outcomes[0].Method, Is.EqualTo(expectedPriorLabel));
+            Assert.That(fileResult.Outcomes[0].Reason, Is.EqualTo(HotReloadConstants.AtomicFileSkipReason));
+            Assert.That(fileResult.Outcomes[1].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Failed));
+            Assert.That(fileResult.Outcomes[1].Method, Is.EqualTo(expectedFailedLabel));
+            Assert.That(fileResult.Outcomes[1].Reason, Is.EqualTo(expectedFailedReason));
+            Assert.That(fileResult.Outcomes[2].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Skipped));
+            Assert.That(fileResult.Outcomes[2].Method, Is.EqualTo(expectedTrailingLabel));
+            Assert.That(fileResult.Outcomes[2].Reason, Is.EqualTo(HotReloadConstants.AtomicFileSkipReason));
+            AssertNoPatchedOrAddedOutcomes(result);
+            Assert.That(HotReloadShimRegistry.HasGeneration(projectRelativePath), Is.False);
+            Assert.That(HotReloadAddedMemberRegistry.HasGeneration(projectRelativePath), Is.False);
+        }
+
+        /// <summary>
+        /// What: a Harmony apply-engine failure after Added and Patched stops the file, skips
+        /// the trailing entry with AtomicFileSkipReason, and warns with applied count 2.
+        /// </summary>
+        [Test]
+        public void ApplyEntries_HarmonyEngineFailureAfterAddedAndPatched_WarnsWithAppliedCountTwo()
+        {
+            const string projectRelativePath = "Assets/Tests/Editor/HotReload/ApplyEngineFailurePartial.cs";
+            string typeName = typeof(HotReloadCoreFixture).FullName;
+            const string addedMethodName = "AddedPing";
+            string expectedWarning = string.Format(
+                HotReloadConstants.PartialApplyAfterPatchEngineFailureWarningFormat,
+                2);
+            TransformWorkerEntryDto[] entries =
+            {
+                CreateAddedMethodEntry(
+                    typeName,
+                    addedMethodName,
+                    nameof(HotReloadHandwrittenShims),
+                    nameof(HotReloadHandwrittenShims.StaticPing__shim0)),
+                CreateExistingMethodEntry(
+                    typeName,
+                    nameof(HotReloadCoreFixture.VoidBump),
+                    Array.Empty<string>(),
+                    nameof(HotReloadHandwrittenShims),
+                    nameof(HotReloadHandwrittenShims.VoidBump__shim0)),
+                CreateExistingMethodEntry(
+                    typeName,
+                    nameof(HotReloadCoreFixture.ReplaceableCompute),
+                    new[] { typeof(int).FullName },
+                    nameof(HotReloadOrchestratorTests),
+                    nameof(ApplyEngineFailureExternShim)),
+                CreateExistingMethodEntry(
+                    typeName,
+                    nameof(HotReloadCoreFixture.StaticPing),
+                    Array.Empty<string>(),
+                    nameof(HotReloadHandwrittenShims),
+                    nameof(HotReloadHandwrittenShims.StaticPing__shim0))
+            };
+
+            try
+            {
+                HotReloadOrchestrator.HotReloadFileProcessResult fileResult = ApplyEntriesDirect(
+                    projectRelativePath,
+                    entries);
+                HotReloadOrchestratorResult result = ToOrchestratorResult(fileResult);
+
+                Assert.That(fileResult.Outcomes.Count, Is.EqualTo(entries.Length));
+                Assert.That(fileResult.Outcomes[0].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Added));
+                Assert.That(fileResult.Outcomes[1].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Patched));
+                Assert.That(fileResult.Outcomes[2].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Failed));
+                AssertHasAtomicFileSkip(result, nameof(HotReloadCoreFixture.StaticPing));
+                Assert.That(fileResult.Warnings.Count, Is.EqualTo(1));
+                Assert.That(fileResult.Warnings[0], Is.EqualTo(expectedWarning));
+            }
+            finally
+            {
+                HotReloadPatcher.RevertAll();
+            }
+        }
+
+        /// <summary>
+        /// What: a Harmony apply-engine failure on the first entry skips the rest with
+        /// AtomicFileSkipReason and does not emit the partial-apply warning.
+        /// </summary>
+        [Test]
+        public void ApplyEntries_HarmonyEngineFailureOnFirstEntry_SkipsRestWithoutPartialWarning()
+        {
+            const string projectRelativePath = "Assets/Tests/Editor/HotReload/ApplyEngineFailureFirst.cs";
+            string typeName = typeof(HotReloadCoreFixture).FullName;
+            TransformWorkerEntryDto[] entries =
+            {
+                CreateExistingMethodEntry(
+                    typeName,
+                    nameof(HotReloadCoreFixture.ReplaceableCompute),
+                    new[] { typeof(int).FullName },
+                    nameof(HotReloadOrchestratorTests),
+                    nameof(ApplyEngineFailureExternShim)),
+                CreateExistingMethodEntry(
+                    typeName,
+                    nameof(HotReloadCoreFixture.VoidBump),
+                    Array.Empty<string>(),
+                    nameof(HotReloadHandwrittenShims),
+                    nameof(HotReloadHandwrittenShims.VoidBump__shim0))
+            };
+
+            try
+            {
+                HotReloadOrchestrator.HotReloadFileProcessResult fileResult = ApplyEntriesDirect(
+                    projectRelativePath,
+                    entries);
+                HotReloadOrchestratorResult result = ToOrchestratorResult(fileResult);
+
+                Assert.That(fileResult.Outcomes.Count, Is.EqualTo(entries.Length));
+                Assert.That(fileResult.Outcomes[0].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Failed));
+                AssertHasAtomicFileSkip(result, nameof(HotReloadCoreFixture.VoidBump));
+                AssertNoPatchedOrAddedOutcomes(result);
+                Assert.That(fileResult.Warnings, Is.Empty);
+            }
+            finally
+            {
+                HotReloadPatcher.RevertAll();
+            }
+        }
+
+        [DllImport("__Internal")]
+        public static extern int ApplyEngineFailureExternShim(int value);
+
+        private static TransformWorkerEntryDto CreateExistingMethodEntry(
+            string typeMetadataName,
+            string methodName,
+            string[] parameterTypeFullNames,
+            string shimTypeName,
+            string shimMethodName)
+        {
+            return new TransformWorkerEntryDto
+            {
+                typeMetadataName = typeMetadataName,
+                methodName = methodName,
+                parameterTypeFullNames = parameterTypeFullNames,
+                genericArity = 0,
+                shimTypeName = shimTypeName,
+                shimMethodName = shimMethodName,
+                patchKind = string.Empty
+            };
+        }
+
+        private static TransformWorkerEntryDto CreateAddedMethodEntry(
+            string typeMetadataName,
+            string methodName,
+            string shimTypeName,
+            string shimMethodName)
+        {
+            return new TransformWorkerEntryDto
+            {
+                typeMetadataName = typeMetadataName,
+                methodName = methodName,
+                parameterTypeFullNames = Array.Empty<string>(),
+                genericArity = 0,
+                shimTypeName = shimTypeName,
+                shimMethodName = shimMethodName,
+                patchKind = HotReloadConstants.PatchKindAddedMethod
+            };
+        }
+
+        private static HotReloadOrchestrator.HotReloadFileProcessResult ApplyEntriesDirect(
+            string projectRelativePath,
+            TransformWorkerEntryDto[] entries)
+        {
+            TransformWorkerOutputDto workerOutput = new TransformWorkerOutputDto
+            {
+                entries = entries,
+                addedFieldNames = Array.Empty<string>(),
+                sourceContentSha256 = "direct-apply-preflight"
+            };
+            return HotReloadEntryApplier.ApplyEntriesAndBuildResult(
+                typeof(HotReloadCoreFixture).Assembly.GetName().Name,
+                projectRelativePath,
+                projectRelativePath,
+                HotReloadShimCompileResult.SuccessResult(
+                    typeof(HotReloadOrchestratorTests).Assembly,
+                    new byte[] { 1 },
+                    Array.Empty<byte>()),
+                entries,
+                Array.Empty<string>(),
+                workerOutput,
+                new HashSet<string>(),
+                new HashSet<string>(),
+                new List<HotReloadMethodOutcome>(),
+                new List<string>(),
+                new List<string>(),
+                new List<string>(),
+                unchangedMethodCount: 0);
+        }
+
+        private static HotReloadOrchestratorResult ToOrchestratorResult(
+            HotReloadOrchestrator.HotReloadFileProcessResult fileResult)
+        {
+            return new HotReloadOrchestratorResult(
+                fileResult.Outcomes,
+                fileResult.Warnings,
+                fileResult.PatchedCount,
+                activePatchTotal: 0);
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAddedMemberRegistry.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAddedMemberRegistry.cs
@@ -61,6 +61,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return generation.Members.ContainsKey(methodKey);
         }
 
+        // Why a generation probe: BeginFileGeneration writes an empty map, so an empty
+        // key list cannot tell a preflight skip from an applied-then-empty generation.
+        internal static bool HasGeneration(string projectRelativePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+            return GenerationsByPath.ContainsKey(projectRelativePath);
+        }
+
         public static IReadOnlyList<string> ListActiveMethodKeys(string projectRelativePath)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -281,6 +281,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string AtomicFileSkipReason =
             "Skipped: hot reload applies each file all-or-nothing, and another method in this file failed. Nothing from this file was applied; patches from earlier reloads are untouched. Fix the failed methods and rerun, or run 'uloop compile'.";
 
+        // Format: count of Patched + Added entries already applied in this file before a
+        // Harmony patch-engine failure. Used only when that count is at least 1.
+        public const string PartialApplyAfterPatchEngineFailureWarningFormat =
+            "A Harmony patch failed after {0} method(s) in this file were already applied by this run; the file is partially applied. Run 'uloop hot-reload --revert-all' and re-apply your edits, or run 'uloop compile'.";
+
         public const string FailedWithNoApplyRecommendedNextAction =
             "Fix the failed methods and rerun, or run 'uloop compile'.";
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
@@ -15,9 +15,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class HotReloadEntryApplier
     {
-        // Why before ApplyEntry: OnHotReloadPatchStateChanged(true) runs inside Apply and
-        // pause-point retarget reads the shim registration — it must already see this
-        // generation's bytes/methods.
+        // Why preflight before BeginFileGeneration: a match/bind/CheckPatchable failure
+        // must not replace the file's shim or added-member generation.
         internal static HotReloadOrchestrator.HotReloadFileProcessResult ApplyEntriesAndBuildResult(
             string assemblyName,
             string assemblyResolvePath,
@@ -34,6 +33,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> retargetedPausePointIds,
             int unchangedMethodCount)
         {
+            HotReloadEntryResolution.Result resolution = HotReloadEntryResolution.ResolveEntries(
+                assemblyName,
+                assemblyResolvePath,
+                compileResult.Assembly,
+                entriesToPatch);
+            if (!resolution.AllResolved)
+            {
+                outcomes.AddRange(resolution.FailureOutcomes);
+                return FinishFileResult(
+                    outcomes,
+                    warnings,
+                    snapshotLabels,
+                    snapshotAddedLabels,
+                    projectRelativePath,
+                    workerOutput,
+                    suppressedPausePointIds,
+                    retargetedPausePointIds,
+                    unchangedMethodCount,
+                    patchedCount: 0,
+                    addedFieldNames: null);
+            }
+
             HotReloadShimRegistry.BeginFileGeneration(
                 projectRelativePath,
                 compileResult.AssemblyBytes,
@@ -41,29 +62,50 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 compileResult.Assembly);
             HotReloadAddedMemberRegistry.BeginFileGeneration(projectRelativePath);
             CommitAddedFieldsForFile(projectRelativePath, addedFieldNames);
-            Dictionary<string, string> bindFailureReasonByShimTypeName =
-                BindShimAccessors(compileResult.Assembly);
+            // Why bind again: phase 1 already bound to detect failures; phase 2 keeps the
+            // historical apply order so a successful preflight still runs Bind before Patch.
+            BindShimAccessors(compileResult.Assembly);
             List<string> inlineRiskMethodLabels = new List<string>();
-            int patchedCount = 0;
-            foreach (TransformWorkerEntryDto entry in entriesToPatch)
-            {
-                HotReloadMethodOutcome outcome = ApplyEntry(
-                    entry,
-                    assemblyName,
-                    compileResult.Assembly,
-                    bindFailureReasonByShimTypeName,
-                    assemblyResolvePath,
-                    projectRelativePath,
-                    inlineRiskMethodLabels,
-                    suppressedPausePointIds,
-                    retargetedPausePointIds);
-                outcomes.Add(outcome);
-                if (outcome.Kind == HotReloadMethodOutcomeKind.Patched)
-                {
-                    patchedCount++;
-                }
-            }
+            int patchedCount = ApplyResolvedEntries(
+                resolution.ResolvedEntries,
+                entriesToPatch,
+                assemblyResolvePath,
+                projectRelativePath,
+                outcomes,
+                warnings,
+                inlineRiskMethodLabels,
+                suppressedPausePointIds,
+                retargetedPausePointIds);
 
+            return FinishFileResult(
+                outcomes,
+                warnings,
+                snapshotLabels,
+                snapshotAddedLabels,
+                projectRelativePath,
+                workerOutput,
+                suppressedPausePointIds,
+                retargetedPausePointIds,
+                unchangedMethodCount,
+                patchedCount,
+                addedFieldNames,
+                inlineRiskMethodLabels);
+        }
+
+        private static HotReloadOrchestrator.HotReloadFileProcessResult FinishFileResult(
+            List<HotReloadMethodOutcome> outcomes,
+            List<string> warnings,
+            HashSet<string> snapshotLabels,
+            HashSet<string> snapshotAddedLabels,
+            string projectRelativePath,
+            TransformWorkerOutputDto workerOutput,
+            List<string> suppressedPausePointIds,
+            List<string> retargetedPausePointIds,
+            int unchangedMethodCount,
+            int patchedCount,
+            string[] addedFieldNames,
+            List<string> inlineRiskMethodLabels = null)
+        {
             // Why here as well as the empty-entries return: apply can drop a still-declared
             // added member by not re-Registering it after BeginFileGeneration.
             HotReloadAppliedSourceLifecycle.AppendDeactivatedPatchesWarning(
@@ -78,11 +120,69 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 warnings,
                 patchedCount,
                 suppressedPausePointIds,
-                inlineRiskMethodLabels,
+                inlineRiskMethodLabels ?? new List<string>(),
                 unchangedMethodCount,
                 retargetedPausePointIds,
                 addedFieldNames,
                 workerOutput.sourceContentSha256);
+        }
+
+        private static int ApplyResolvedEntries(
+            IReadOnlyList<HotReloadEntryResolution.ResolvedEntry> resolvedEntries,
+            TransformWorkerEntryDto[] entriesToPatch,
+            string assemblyResolvePath,
+            string projectRelativePath,
+            List<HotReloadMethodOutcome> outcomes,
+            List<string> warnings,
+            List<string> inlineRiskMethodLabels,
+            List<string> suppressedPausePointIds,
+            List<string> retargetedPausePointIds)
+        {
+            int patchedCount = 0;
+            int appliedThisRun = 0;
+            for (int index = 0; index < resolvedEntries.Count; index++)
+            {
+                HotReloadMethodOutcome outcome = ApplyResolvedEntry(
+                    resolvedEntries[index],
+                    projectRelativePath,
+                    inlineRiskMethodLabels,
+                    suppressedPausePointIds,
+                    retargetedPausePointIds);
+                outcomes.Add(outcome);
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Patched
+                    || outcome.Kind == HotReloadMethodOutcomeKind.Added)
+                {
+                    appliedThisRun++;
+                    if (outcome.Kind == HotReloadMethodOutcomeKind.Patched)
+                    {
+                        patchedCount++;
+                    }
+
+                    continue;
+                }
+
+                if (outcome.Kind != HotReloadMethodOutcomeKind.Failed)
+                {
+                    continue;
+                }
+
+                HotReloadEntryResolution.AppendAtomicSkipOutcomes(
+                    outcomes,
+                    entriesToPatch,
+                    index + 1,
+                    assemblyResolvePath);
+                if (appliedThisRun >= 1)
+                {
+                    warnings.Add(
+                        string.Format(
+                            HotReloadConstants.PartialApplyAfterPatchEngineFailureWarningFormat,
+                            appliedThisRun));
+                }
+
+                break;
+            }
+
+            return patchedCount;
         }
 
         // Why only here and the empty-entries deactivation: a failed worker or shim compile
@@ -133,101 +233,52 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        private static HotReloadMethodOutcome ApplyEntry(
-            TransformWorkerEntryDto entry,
-            string assemblyName,
-            Assembly shimAssembly,
-            IReadOnlyDictionary<string, string> bindFailureReasonByShimTypeName,
-            string filePath,
+        private static HotReloadMethodOutcome ApplyResolvedEntry(
+            HotReloadEntryResolution.ResolvedEntry resolved,
             string projectRelativePath,
             List<string> inlineRiskMethodLabels,
             List<string> suppressedPausePointIds,
             List<string> retargetedPausePointIds)
         {
-            string[] parameterTypeFullNames = entry.parameterTypeFullNames ?? Array.Empty<string>();
-            // Pre-Resolve label: same shape as --status (params + nested '+' normalization).
-            // After Resolve, prefer FormatMethodKey(MethodBase) so reflection ToString() wins.
-            string methodLabel = HotReloadPatcher.FormatMethodKeyParts(
-                entry.typeMetadataName,
-                entry.methodName,
-                parameterTypeFullNames,
-                entry.genericArity);
-
-            if (entry.patchKind == HotReloadConstants.PatchKindAddedMethod)
+            if (resolved.IsAddedMethod)
             {
-                return ApplyAddedMethodEntry(
-                    entry,
-                    methodLabel,
-                    shimAssembly,
-                    bindFailureReasonByShimTypeName,
-                    filePath,
-                    projectRelativePath);
-            }
-
-            // Only "delegation" selects the forwarding patch; null/empty/anything else is transplant.
-            HotReloadPatchShape patchShape = entry.patchKind == HotReloadConstants.PatchKindDelegation
-                ? HotReloadPatchShape.Delegation
-                : HotReloadPatchShape.Transplant;
-
-            // Transplant entries never read accessor delegates, so a sibling bind failure in the
-            // same shim type must not take them down; only delegation entries depend on the bind.
-            if (patchShape == HotReloadPatchShape.Delegation
-                && bindFailureReasonByShimTypeName.TryGetValue(entry.shimTypeName ?? string.Empty, out string bindFailureReason))
-            {
-                return HotReloadMethodOutcome.Failed(methodLabel, bindFailureReason, filePath);
-            }
-
-            HotReloadMethodMatchResult matchResult = HotReloadMethodMatcher.Resolve(
-                assemblyName,
-                entry.typeMetadataName,
-                entry.methodName,
-                parameterTypeFullNames,
-                entry.genericArity);
-            if (!matchResult.Success)
-            {
-                return HotReloadMethodOutcome.Failed(methodLabel, matchResult.ErrorMessage, filePath);
-            }
-
-            methodLabel = HotReloadPatcher.FormatMethodKey(matchResult.Method);
-
-            Type shimType = FindShimType(shimAssembly, entry.shimTypeName);
-            if (shimType == null)
-            {
-                return HotReloadMethodOutcome.Failed(
-                    methodLabel,
-                    "Shim type not found in compiled shim assembly: " + entry.shimTypeName,
-                    filePath);
-            }
-
-            (MethodInfo shimMethod, string shimLookupError) = FindShimMethod(shimType, entry.shimMethodName);
-            if (shimMethod == null)
-            {
-                return HotReloadMethodOutcome.Failed(methodLabel, shimLookupError, filePath);
+                HotReloadAddedMemberRegistry.Register(
+                    projectRelativePath,
+                    resolved.MethodLabel,
+                    resolved.ShimMethod,
+                    resolved.FilePath);
+                return HotReloadMethodOutcome.Added(
+                    resolved.MethodLabel,
+                    resolved.FilePath,
+                    resolved.Entry.lifecycleNote);
             }
 
             // Why before Apply: Apply notifies OnHotReloadPatchStateChanged(true) after the
             // ledger write; registration must already expose this method's shim for retarget.
             HotReloadShimRegistry.RegisterMethod(
                 projectRelativePath,
-                matchResult.Method,
+                resolved.OriginalMethod,
                 new HotReloadShimRegistry.MethodEntry(
-                    shimMethod,
-                    patchShape == HotReloadPatchShape.Delegation,
-                    entry.sourceStartLine,
-                    entry.sourceEndLine));
+                    resolved.ShimMethod,
+                    resolved.PatchShape == HotReloadPatchShape.Delegation,
+                    resolved.Entry.sourceStartLine,
+                    resolved.Entry.sourceEndLine));
             HotReloadPatchResult patchResult = HotReloadPatcher.Apply(
-                matchResult.Method,
-                shimMethod,
-                patchShape,
+                resolved.OriginalMethod,
+                resolved.ShimMethod,
+                resolved.PatchShape,
                 projectRelativePath);
             if (!patchResult.Success)
             {
-                HotReloadShimRegistry.RemoveMethod(matchResult.Method);
-                return HotReloadMethodOutcome.Failed(methodLabel, patchResult.ErrorMessage, filePath);
+                HotReloadShimRegistry.RemoveMethod(resolved.OriginalMethod);
+                return HotReloadMethodOutcome.Failed(
+                    resolved.MethodLabel,
+                    patchResult.ErrorMessage,
+                    resolved.FilePath);
             }
 
             AppendPausePointTransitionIds(
-                matchResult.Method,
+                resolved.OriginalMethod,
                 suppressedPausePointIds,
                 retargetedPausePointIds);
 
@@ -235,74 +286,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Warnings stay readable when many tiny methods are patched together.
             if (patchResult.InlineRiskDetected)
             {
-                inlineRiskMethodLabels.Add(methodLabel);
+                inlineRiskMethodLabels.Add(resolved.MethodLabel);
             }
 
-            return HotReloadMethodOutcome.Patched(methodLabel, filePath, entry.lifecycleNote);
-        }
-
-        private static HotReloadMethodOutcome ApplyAddedMethodEntry(
-            TransformWorkerEntryDto entry,
-            string methodLabel,
-            Assembly shimAssembly,
-            IReadOnlyDictionary<string, string> bindFailureReasonByShimTypeName,
-            string filePath,
-            string projectRelativePath)
-        {
-            // Added methods with accessors share the shim type's __BindAccessors; a bind
-            // failure leaves those delegates unbound, so the entry must not be registered.
-            if (bindFailureReasonByShimTypeName.TryGetValue(
-                    entry.shimTypeName ?? string.Empty,
-                    out string bindFailureReason))
-            {
-                return HotReloadMethodOutcome.Failed(methodLabel, bindFailureReason, filePath);
-            }
-
-            Type shimType = FindShimType(shimAssembly, entry.shimTypeName);
-            if (shimType == null)
-            {
-                return HotReloadMethodOutcome.Failed(
-                    methodLabel,
-                    "Shim type not found in compiled shim assembly: " + entry.shimTypeName,
-                    filePath);
-            }
-
-            (MethodInfo shimMethod, string shimLookupError) = FindShimMethod(shimType, entry.shimMethodName);
-            if (shimMethod == null)
-            {
-                return HotReloadMethodOutcome.Failed(methodLabel, shimLookupError, filePath);
-            }
-
-            HotReloadAddedMemberRegistry.Register(
-                projectRelativePath,
-                methodLabel,
-                shimMethod,
-                filePath);
-            return HotReloadMethodOutcome.Added(methodLabel, filePath, entry.lifecycleNote);
-        }
-
-        private static (MethodInfo ShimMethod, string ErrorMessage) FindShimMethod(
-            Type shimType,
-            string shimMethodName)
-        {
-            MethodInfo shimMethod = shimType.GetMethod(
-                shimMethodName,
-                BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
-            if (shimMethod == null)
-            {
-                // Fall back to a broader lookup — DeclaredOnly can miss when the compiler emits
-                // unexpected metadata flags, but still prefer public static.
-                shimMethod = shimType.GetMethod(
-                    shimMethodName,
-                    BindingFlags.Public | BindingFlags.Static);
-            }
-
-            if (shimMethod == null)
-            {
-                return (null, "Shim method not found: " + shimType.Name + "." + shimMethodName);
-            }
-
-            return (shimMethod, null);
+            return HotReloadMethodOutcome.Patched(
+                resolved.MethodLabel,
+                resolved.FilePath,
+                resolved.Entry.lifecycleNote);
         }
 
         // What: after Apply (+ retarget handler), splits armed markers into retargeted vs suppressed.
@@ -398,32 +388,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return failureReasonByShimTypeName;
-        }
-
-        private static Type FindShimType(Assembly shimAssembly, string shimTypeName)
-        {
-            if (string.IsNullOrEmpty(shimTypeName))
-            {
-                return null;
-            }
-
-            // Prefer the short-name lookup used when shims are in the global namespace; fall back
-            // to scanning because production emits shims into the original type's namespace.
-            Type direct = shimAssembly.GetType(shimTypeName);
-            if (direct != null)
-            {
-                return direct;
-            }
-
-            foreach (Type candidate in shimAssembly.GetTypes())
-            {
-                if (candidate.Name == shimTypeName)
-                {
-                    return candidate;
-                }
-            }
-
-            return null;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryResolution.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryResolution.cs
@@ -37,16 +37,39 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     filePath);
                 if (failure != null)
                 {
-                    List<HotReloadMethodOutcome> failureOutcomes = new List<HotReloadMethodOutcome>();
-                    failureOutcomes.Add(failure);
-                    AppendAtomicSkipOutcomes(failureOutcomes, entriesToPatch, index + 1, filePath);
-                    return Result.Failed(failureOutcomes);
+                    return Result.Failed(
+                        BuildAtomicFailureOutcomes(entriesToPatch, index, failure, filePath));
                 }
 
                 resolvedEntries.Add(resolved);
             }
 
             return Result.Succeeded(resolvedEntries);
+        }
+
+        // Why every non-failed entry, including those already resolved: a later
+        // preflight failure must not drop earlier methods from the response.
+        private static List<HotReloadMethodOutcome> BuildAtomicFailureOutcomes(
+            TransformWorkerEntryDto[] entries,
+            int failedIndex,
+            HotReloadMethodOutcome failure,
+            string filePath)
+        {
+            Debug.Assert(entries != null, "entries must not be null.");
+            Debug.Assert(failedIndex >= 0, "failedIndex must not be negative.");
+            Debug.Assert(failedIndex < entries.Length, "failedIndex must be inside entries.");
+            Debug.Assert(failure != null, "failure must not be null.");
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be empty.");
+
+            List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
+            for (int index = 0; index < failedIndex; index++)
+            {
+                outcomes.Add(CreateAtomicSkipOutcome(entries[index], filePath));
+            }
+
+            outcomes.Add(failure);
+            AppendAtomicSkipOutcomes(outcomes, entries, failedIndex + 1, filePath);
+            return outcomes;
         }
 
         internal static void AppendAtomicSkipOutcomes(
@@ -62,12 +85,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             for (int index = startIndex; index < entries.Length; index++)
             {
-                outcomes.Add(
-                    HotReloadMethodOutcome.Skipped(
-                        FormatEntryLabel(entries[index]),
-                        HotReloadConstants.AtomicFileSkipReason,
-                        filePath));
+                outcomes.Add(CreateAtomicSkipOutcome(entries[index], filePath));
             }
+        }
+
+        private static HotReloadMethodOutcome CreateAtomicSkipOutcome(
+            TransformWorkerEntryDto entry,
+            string filePath)
+        {
+            return HotReloadMethodOutcome.Skipped(
+                FormatEntryLabel(entry),
+                HotReloadConstants.AtomicFileSkipReason,
+                filePath);
         }
 
         private static (ResolvedEntry Resolved, HotReloadMethodOutcome Failure) TryResolveEntry(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryResolution.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryResolution.cs
@@ -1,0 +1,308 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using UnityEngine;
+
+using Assembly = System.Reflection.Assembly;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Preflight resolution of worker entries: bind, match, shim lookup, and CheckPatchable
+    /// with no registry writes and no Harmony Patch.
+    /// </summary>
+    internal static class HotReloadEntryResolution
+    {
+        internal static Result ResolveEntries(
+            string assemblyName,
+            string filePath,
+            Assembly shimAssembly,
+            TransformWorkerEntryDto[] entriesToPatch)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be empty.");
+            Debug.Assert(shimAssembly != null, "shimAssembly must not be null.");
+            Debug.Assert(entriesToPatch != null, "entriesToPatch must not be null.");
+
+            Dictionary<string, string> bindFailures = HotReloadEntryApplier.BindShimAccessors(shimAssembly);
+            List<ResolvedEntry> resolvedEntries = new List<ResolvedEntry>();
+            for (int index = 0; index < entriesToPatch.Length; index++)
+            {
+                (ResolvedEntry resolved, HotReloadMethodOutcome failure) = TryResolveEntry(
+                    entriesToPatch[index],
+                    assemblyName,
+                    shimAssembly,
+                    bindFailures,
+                    filePath);
+                if (failure != null)
+                {
+                    List<HotReloadMethodOutcome> failureOutcomes = new List<HotReloadMethodOutcome>();
+                    failureOutcomes.Add(failure);
+                    AppendAtomicSkipOutcomes(failureOutcomes, entriesToPatch, index + 1, filePath);
+                    return Result.Failed(failureOutcomes);
+                }
+
+                resolvedEntries.Add(resolved);
+            }
+
+            return Result.Succeeded(resolvedEntries);
+        }
+
+        internal static void AppendAtomicSkipOutcomes(
+            List<HotReloadMethodOutcome> outcomes,
+            TransformWorkerEntryDto[] entries,
+            int startIndex,
+            string filePath)
+        {
+            Debug.Assert(outcomes != null, "outcomes must not be null.");
+            Debug.Assert(entries != null, "entries must not be null.");
+            Debug.Assert(startIndex >= 0, "startIndex must not be negative.");
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be empty.");
+
+            for (int index = startIndex; index < entries.Length; index++)
+            {
+                outcomes.Add(
+                    HotReloadMethodOutcome.Skipped(
+                        FormatEntryLabel(entries[index]),
+                        HotReloadConstants.AtomicFileSkipReason,
+                        filePath));
+            }
+        }
+
+        private static (ResolvedEntry Resolved, HotReloadMethodOutcome Failure) TryResolveEntry(
+            TransformWorkerEntryDto entry,
+            string assemblyName,
+            Assembly shimAssembly,
+            IReadOnlyDictionary<string, string> bindFailures,
+            string filePath)
+        {
+            string methodLabel = FormatEntryLabel(entry);
+            if (entry.patchKind == HotReloadConstants.PatchKindAddedMethod)
+            {
+                return TryResolveAddedMethod(entry, methodLabel, shimAssembly, bindFailures, filePath);
+            }
+
+            return TryResolveExistingMethod(
+                entry,
+                methodLabel,
+                assemblyName,
+                shimAssembly,
+                bindFailures,
+                filePath);
+        }
+
+        private static (ResolvedEntry Resolved, HotReloadMethodOutcome Failure) TryResolveAddedMethod(
+            TransformWorkerEntryDto entry,
+            string methodLabel,
+            Assembly shimAssembly,
+            IReadOnlyDictionary<string, string> bindFailures,
+            string filePath)
+        {
+            if (bindFailures.TryGetValue(entry.shimTypeName ?? string.Empty, out string bindFailureReason))
+            {
+                return (null, HotReloadMethodOutcome.Failed(methodLabel, bindFailureReason, filePath));
+            }
+
+            (MethodInfo shimMethod, string shimError) = FindShimMethod(shimAssembly, entry);
+            if (shimMethod == null)
+            {
+                return (null, HotReloadMethodOutcome.Failed(methodLabel, shimError, filePath));
+            }
+
+            return (
+                new ResolvedEntry(
+                    entry,
+                    methodLabel,
+                    filePath,
+                    HotReloadPatchShape.Transplant,
+                    originalMethod: null,
+                    shimMethod,
+                    isAddedMethod: true),
+                null);
+        }
+
+        private static (ResolvedEntry Resolved, HotReloadMethodOutcome Failure) TryResolveExistingMethod(
+            TransformWorkerEntryDto entry,
+            string methodLabel,
+            string assemblyName,
+            Assembly shimAssembly,
+            IReadOnlyDictionary<string, string> bindFailures,
+            string filePath)
+        {
+            HotReloadPatchShape patchShape = entry.patchKind == HotReloadConstants.PatchKindDelegation
+                ? HotReloadPatchShape.Delegation
+                : HotReloadPatchShape.Transplant;
+            if (patchShape == HotReloadPatchShape.Delegation
+                && bindFailures.TryGetValue(entry.shimTypeName ?? string.Empty, out string bindFailureReason))
+            {
+                return (null, HotReloadMethodOutcome.Failed(methodLabel, bindFailureReason, filePath));
+            }
+
+            string[] parameterTypeFullNames = entry.parameterTypeFullNames ?? Array.Empty<string>();
+            HotReloadMethodMatchResult matchResult = HotReloadMethodMatcher.Resolve(
+                assemblyName,
+                entry.typeMetadataName,
+                entry.methodName,
+                parameterTypeFullNames,
+                entry.genericArity);
+            if (!matchResult.Success)
+            {
+                return (null, HotReloadMethodOutcome.Failed(methodLabel, matchResult.ErrorMessage, filePath));
+            }
+
+            methodLabel = HotReloadPatcher.FormatMethodKey(matchResult.Method);
+            (MethodInfo shimMethod, string shimError) = FindShimMethod(shimAssembly, entry);
+            if (shimMethod == null)
+            {
+                return (null, HotReloadMethodOutcome.Failed(methodLabel, shimError, filePath));
+            }
+
+            HotReloadPatchResult patchability = HotReloadPatcher.CheckPatchable(matchResult.Method);
+            if (!patchability.Success)
+            {
+                return (null, HotReloadMethodOutcome.Failed(methodLabel, patchability.ErrorMessage, filePath));
+            }
+
+            return (
+                new ResolvedEntry(
+                    entry,
+                    methodLabel,
+                    filePath,
+                    patchShape,
+                    matchResult.Method,
+                    shimMethod,
+                    isAddedMethod: false),
+                null);
+        }
+
+        private static (MethodInfo ShimMethod, string ErrorMessage) FindShimMethod(
+            Assembly shimAssembly,
+            TransformWorkerEntryDto entry)
+        {
+            Type shimType = FindShimType(shimAssembly, entry.shimTypeName);
+            if (shimType == null)
+            {
+                return (null, "Shim type not found in compiled shim assembly: " + entry.shimTypeName);
+            }
+
+            MethodInfo shimMethod = shimType.GetMethod(
+                entry.shimMethodName,
+                BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+            if (shimMethod == null)
+            {
+                shimMethod = shimType.GetMethod(
+                    entry.shimMethodName,
+                    BindingFlags.Public | BindingFlags.Static);
+            }
+
+            if (shimMethod == null)
+            {
+                return (null, "Shim method not found: " + shimType.Name + "." + entry.shimMethodName);
+            }
+
+            return (shimMethod, null);
+        }
+
+        private static Type FindShimType(Assembly shimAssembly, string shimTypeName)
+        {
+            if (string.IsNullOrEmpty(shimTypeName))
+            {
+                return null;
+            }
+
+            Type direct = shimAssembly.GetType(shimTypeName);
+            if (direct != null)
+            {
+                return direct;
+            }
+
+            foreach (Type candidate in shimAssembly.GetTypes())
+            {
+                if (candidate.Name == shimTypeName)
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
+        }
+
+        private static string FormatEntryLabel(TransformWorkerEntryDto entry)
+        {
+            return HotReloadPatcher.FormatMethodKeyParts(
+                entry.typeMetadataName,
+                entry.methodName,
+                entry.parameterTypeFullNames ?? Array.Empty<string>(),
+                entry.genericArity);
+        }
+
+        /// <summary>
+        /// One preflight-resolved entry ready for registry writes and Harmony Patch.
+        /// </summary>
+        internal sealed class ResolvedEntry
+        {
+            public TransformWorkerEntryDto Entry { get; }
+            public string MethodLabel { get; }
+            public string FilePath { get; }
+            public HotReloadPatchShape PatchShape { get; }
+            public MethodBase OriginalMethod { get; }
+            public MethodInfo ShimMethod { get; }
+            public bool IsAddedMethod { get; }
+
+            public ResolvedEntry(
+                TransformWorkerEntryDto entry,
+                string methodLabel,
+                string filePath,
+                HotReloadPatchShape patchShape,
+                MethodBase originalMethod,
+                MethodInfo shimMethod,
+                bool isAddedMethod)
+            {
+                Entry = entry;
+                MethodLabel = methodLabel;
+                FilePath = filePath;
+                PatchShape = patchShape;
+                OriginalMethod = originalMethod;
+                ShimMethod = shimMethod;
+                IsAddedMethod = isAddedMethod;
+            }
+        }
+
+        /// <summary>
+        /// All-resolved entries for apply, or the Failed + AtomicFileSkip outcomes for a file.
+        /// </summary>
+        internal sealed class Result
+        {
+            public bool AllResolved { get; }
+            public IReadOnlyList<ResolvedEntry> ResolvedEntries { get; }
+            public IReadOnlyList<HotReloadMethodOutcome> FailureOutcomes { get; }
+
+            private Result(
+                bool allResolved,
+                IReadOnlyList<ResolvedEntry> resolvedEntries,
+                IReadOnlyList<HotReloadMethodOutcome> failureOutcomes)
+            {
+                AllResolved = allResolved;
+                ResolvedEntries = resolvedEntries ?? Array.Empty<ResolvedEntry>();
+                FailureOutcomes = failureOutcomes ?? Array.Empty<HotReloadMethodOutcome>();
+            }
+
+            public static Result Succeeded(List<ResolvedEntry> resolvedEntries)
+            {
+                return new Result(
+                    true,
+                    resolvedEntries,
+                    Array.Empty<HotReloadMethodOutcome>());
+            }
+
+            public static Result Failed(List<HotReloadMethodOutcome> failureOutcomes)
+            {
+                return new Result(
+                    false,
+                    Array.Empty<ResolvedEntry>(),
+                    failureOutcomes);
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryResolution.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryResolution.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b2005effd20d4323a41a9e1756ce577
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -214,8 +214,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return HotReloadPatchResult.Failure(
                     HotReloadPatchFailureReason.ApplyFailed,
                     $"Applying the patch to '{method}' failed: " +
-                    $"{exception.GetType().Name}: {exception.Message}{rootCauseSuffix} " +
-                    "Other methods in this run are unaffected.");
+                    $"{exception.GetType().Name}: {exception.Message}{rootCauseSuffix}");
             }
             finally
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -533,7 +533,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return _pendingShimMethod;
         }
 
-        private static HotReloadPatchResult CheckPatchable(MethodBase method)
+        // Why internal: preflight validation must run these five checks before any
+        // registry write or Harmony Patch. The method itself has no side effects.
+        internal static HotReloadPatchResult CheckPatchable(MethodBase method)
         {
             if (method.IsAbstract)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimRegistry.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimRegistry.cs
@@ -82,6 +82,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             GenerationsByPath.Clear();
         }
 
+        // Why a generation probe: BeginFileGeneration writes an empty map, so method-list
+        // emptiness cannot tell a preflight skip from an applied-then-empty generation.
+        internal static bool HasGeneration(string projectRelativePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+            return FindGenerationForPath(projectRelativePath) != null;
+        }
+
         private static string LoadVerifiedSnapshotSourceForFile(string requestedPath)
         {
             if (string.IsNullOrEmpty(requestedPath))

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -272,11 +272,11 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | Source file fails to parse | Per-file entry carrying the parse errors |
 | Method signature not found in the loaded assembly | Usually a stale assembly; run `uloop compile`. In-file renames and signature changes are classified as added members before reaching this point |
 | Shim compile error (e.g. the body calls a member that does not exist yet) | Failing methods are isolated: each reports `Failed` with its own compiler errors (plus the `uloop compile` hint when they indicate a missing member). When errors cannot be attributed per method, the whole file reports one `(shim-compile)` entry; if only one method was edited, the failure is attributed to that method's name instead |
-| Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error; other methods in the run still apply |
+| Patch rejected or crashed at apply time (e.g. `[BurstCompile]`, a patch-engine emit failure) | The entry carries the rejection reason or the underlying engine error |
 | Accessor binding failed for a shim type | The source references a member the compiled assembly does not have yet; every delegation-patched method in that shim type reports the binder error — run `uloop compile` and retry |
 | The signature-change gate could not finish the run safely — the retry that skips a gated change failed, or shim-compile isolation dropped an edited caller that had covered a change | Per-file entry with `Method` = `(signature-change-gate)` carrying the specific cause; nothing from the file is applied — fix the failing edit or run `uloop compile` |
 
-When a file's shim compilation fails, nothing from that file is applied; patches from earlier reloads stay active.
+A reload applies each file all-or-nothing: when any method in a file fails to compile or validate, nothing from that file is applied and patches from earlier reloads stay active. The one exception is a Harmony patch-engine failure in the middle of applying a validated file; that run reports itself as partially applied and recommends 'uloop hot-reload --revert-all'.
 
 ## When a patch reports `Patched` but behavior does not change
 


### PR DESCRIPTION
## Summary
- `uloop hot-reload` now validates every method in a file before it writes patch state, so a bind, match, shim-lookup, or patchability failure applies nothing from that file.
- Earlier-run patches stay active. The only remaining partial apply is a Harmony patch-engine failure after validation, which now stops the rest of the file and says so.

## User Impact
- Before: a method that failed at apply time could still leave sibling methods in the same file patched, so a failed reload could change running behavior.
- After: validation failures skip the rest of the file and do not start a new shim or added-member generation. A mid-apply Harmony engine failure reports a partial apply and recommends `uloop hot-reload --revert-all`.

## Changes
- Split apply into a side-effect-free preflight (including the five `CheckPatchable` checks) and a mutate-then-patch phase.
- On the first Harmony patch-engine failure, skip remaining entries and add a warning when this run already applied one or more methods (Patched + Added).
- Document the all-or-nothing rule in the hot-reload skill. The synthetic Patched+Failed / Added+Failed response tests stay, because that residual case is still real.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>` → `ErrorCount: 0`
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value "HotReload"` → `539 passed / 0 failed`
- Full EditMode suite is still pending before merge


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

