### PR TITLE
fix: force TLS 1.2 and basic parsing for PowerShell installer downloads

### DIFF
--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "8db2b4ce9e3caa87c04ca9f5c44d803940c83309"
+  "sharedInputsHash": "d099c36f25b969fa96b984e90d4cd3ebc9a5fee1"
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "d099c36f25b969fa96b984e90d4cd3ebc9a5fee1"
+  "sharedInputsHash": "301379ea48e659b2bd66ce7fc2d27ab137e0f960"
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,9 +1,12 @@
 $ErrorActionPreference = "Stop"
 
 # Why: Windows PowerShell 5.1 does not enable TLS 1.2 by default on some
-# hosts, so GitHub downloads fail before any retry can help. -bor keeps
-# protocols the host already enabled.
-[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+# hosts. Gate to Major -lt 6 because pwsh 6+ reports SecurityProtocol as
+# SystemDefault (0); 0 -bor Tls12 becomes Tls12-only and would restrict
+# later connections in the iex host session.
+if ($PSVersionTable.PSVersion.Major -lt 6) {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+}
 
 $Repository = "hatayama/unity-cli-loop"
 $Version = if ($env:ULOOP_VERSION) { $env:ULOOP_VERSION } else { "latest" }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,5 +1,10 @@
 $ErrorActionPreference = "Stop"
 
+# Why: Windows PowerShell 5.1 does not enable TLS 1.2 by default on some
+# hosts, so GitHub downloads fail before any retry can help. -bor keeps
+# protocols the host already enabled.
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
 $Repository = "hatayama/unity-cli-loop"
 $Version = if ($env:ULOOP_VERSION) { $env:ULOOP_VERSION } else { "latest" }
 $LatestVersion = "latest"
@@ -609,8 +614,8 @@ try {
     $ArchivePath = Join-Path $TempDir $AssetName
     $ChecksumPath = Join-Path $TempDir "$AssetName.sha256"
     Write-Host "Downloading uloop dispatcher archive..."
-    Invoke-WebRequest -Uri $DownloadUrl -OutFile $ArchivePath
-    Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumPath
+    Invoke-WebRequest -UseBasicParsing -Uri $DownloadUrl -OutFile $ArchivePath
+    Invoke-WebRequest -UseBasicParsing -Uri $ChecksumUrl -OutFile $ChecksumPath
     Write-Host "Verifying uloop dispatcher archive..."
     $ExpectedHash = ((Get-Content -Path $ChecksumPath -Raw) -split "\s+")[0].ToLowerInvariant()
     $ActualHash = Get-UloopSha256Hash -Path $ArchivePath

--- a/scripts/test-install-release-filter.sh
+++ b/scripts/test-install-release-filter.sh
@@ -973,17 +973,34 @@ test_git_bash_latest_installs_windows_zip_asset() {
   assert_contains "$work_dir/output.txt" "uloop mock version"
 }
 
-# Verifies -UseBasicParsing on the two payload downloads, the PS 5.1-only
-# TLS 1.2 -bor assignment, and that that assignment appears before the first
-# Invoke-WebRequest in install.ps1.
+# Verifies -UseBasicParsing on the two payload downloads, that the TLS 1.2
+# -bor assignment sits inside the PS 5.1 Major -lt 6 guard, and that that
+# assignment appears before the first Invoke-WebRequest in install.ps1.
 test_powershell_installer_enables_tls12_and_basic_parsing() {
-  assert_contains "$ROOT_DIR/scripts/install.ps1" 'if ($PSVersionTable.PSVersion.Major -lt 6) {'
-  assert_contains "$ROOT_DIR/scripts/install.ps1" '[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12'
   assert_contains "$ROOT_DIR/scripts/install.ps1" 'Invoke-WebRequest -UseBasicParsing -Uri $DownloadUrl -OutFile $ArchivePath'
   assert_contains "$ROOT_DIR/scripts/install.ps1" 'Invoke-WebRequest -UseBasicParsing -Uri $ChecksumUrl -OutFile $ChecksumPath'
   assert_not_contains "$ROOT_DIR/scripts/install.ps1" 'Invoke-WebRequest -Uri'
 
-  tls_line=$(grep -n -F '[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12' "$ROOT_DIR/scripts/install.ps1" | head -n 1 | cut -d: -f1)
+  tls_assignment='[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12'
+  tls_guard_block=$(awk '
+    index($0, "if ($PSVersionTable.PSVersion.Major -lt 6) {") {
+      capture = 1
+    }
+    capture {
+      print
+    }
+    capture && index($0, "}") {
+      exit
+    }
+  ' "$ROOT_DIR/scripts/install.ps1")
+  if [ -z "$tls_guard_block" ]; then
+    echo "Expected a PS 5.1 Major -lt 6 guard in install.ps1" >&2
+    exit 1
+  fi
+  printf '%s\n' "$tls_guard_block" > "$TMP_DIR/tls-guard.ps1"
+  assert_contains "$TMP_DIR/tls-guard.ps1" "$tls_assignment"
+
+  tls_line=$(grep -n -F "$tls_assignment" "$ROOT_DIR/scripts/install.ps1" | head -n 1 | cut -d: -f1)
   first_web_request_line=$(grep -n -F 'Invoke-WebRequest' "$ROOT_DIR/scripts/install.ps1" | head -n 1 | cut -d: -f1)
   if [ -z "$tls_line" ] || [ -z "$first_web_request_line" ]; then
     echo "Expected TLS 1.2 assignment and Invoke-WebRequest line numbers in install.ps1" >&2

--- a/scripts/test-install-release-filter.sh
+++ b/scripts/test-install-release-filter.sh
@@ -973,14 +973,26 @@ test_git_bash_latest_installs_windows_zip_asset() {
   assert_contains "$work_dir/output.txt" "uloop mock version"
 }
 
-# Verifies payload downloads use -UseBasicParsing and TLS 1.2 is enabled
-# before any network call, so Windows PowerShell 5.1 can download on hosts
-# that still default to TLS 1.0.
+# Verifies -UseBasicParsing on the two payload downloads, the PS 5.1-only
+# TLS 1.2 -bor assignment, and that that assignment appears before the first
+# Invoke-WebRequest in install.ps1.
 test_powershell_installer_enables_tls12_and_basic_parsing() {
+  assert_contains "$ROOT_DIR/scripts/install.ps1" 'if ($PSVersionTable.PSVersion.Major -lt 6) {'
   assert_contains "$ROOT_DIR/scripts/install.ps1" '[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12'
   assert_contains "$ROOT_DIR/scripts/install.ps1" 'Invoke-WebRequest -UseBasicParsing -Uri $DownloadUrl -OutFile $ArchivePath'
   assert_contains "$ROOT_DIR/scripts/install.ps1" 'Invoke-WebRequest -UseBasicParsing -Uri $ChecksumUrl -OutFile $ChecksumPath'
   assert_not_contains "$ROOT_DIR/scripts/install.ps1" 'Invoke-WebRequest -Uri'
+
+  tls_line=$(grep -n -F '[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12' "$ROOT_DIR/scripts/install.ps1" | head -n 1 | cut -d: -f1)
+  first_web_request_line=$(grep -n -F 'Invoke-WebRequest' "$ROOT_DIR/scripts/install.ps1" | head -n 1 | cut -d: -f1)
+  if [ -z "$tls_line" ] || [ -z "$first_web_request_line" ]; then
+    echo "Expected TLS 1.2 assignment and Invoke-WebRequest line numbers in install.ps1" >&2
+    exit 1
+  fi
+  if [ "$tls_line" -ge "$first_web_request_line" ]; then
+    echo "Expected TLS 1.2 assignment at line $tls_line to precede first Invoke-WebRequest at line $first_web_request_line" >&2
+    exit 1
+  fi
 }
 
 test_powershell_installer_avoids_optional_archive_cmdlets() {

--- a/scripts/test-install-release-filter.sh
+++ b/scripts/test-install-release-filter.sh
@@ -973,6 +973,16 @@ test_git_bash_latest_installs_windows_zip_asset() {
   assert_contains "$work_dir/output.txt" "uloop mock version"
 }
 
+# Verifies payload downloads use -UseBasicParsing and TLS 1.2 is enabled
+# before any network call, so Windows PowerShell 5.1 can download on hosts
+# that still default to TLS 1.0.
+test_powershell_installer_enables_tls12_and_basic_parsing() {
+  assert_contains "$ROOT_DIR/scripts/install.ps1" '[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12'
+  assert_contains "$ROOT_DIR/scripts/install.ps1" 'Invoke-WebRequest -UseBasicParsing -Uri $DownloadUrl -OutFile $ArchivePath'
+  assert_contains "$ROOT_DIR/scripts/install.ps1" 'Invoke-WebRequest -UseBasicParsing -Uri $ChecksumUrl -OutFile $ChecksumPath'
+  assert_not_contains "$ROOT_DIR/scripts/install.ps1" 'Invoke-WebRequest -Uri'
+}
+
 test_powershell_installer_avoids_optional_archive_cmdlets() {
   assert_contains "$ROOT_DIR/scripts/install.ps1" 'function Get-UloopSha256Hash'
   assert_contains "$ROOT_DIR/scripts/install.ps1" '[System.Security.Cryptography.SHA256]::Create()'
@@ -1252,6 +1262,7 @@ test_posix_silences_legacy_cleanup_when_npm_prefix_cannot_be_inferred
 test_posix_removes_npm_package_before_replacing_same_bin_path
 test_powershell_latest_skips_prerelease_assets
 test_git_bash_latest_installs_windows_zip_asset
+test_powershell_installer_enables_tls12_and_basic_parsing
 test_powershell_installer_avoids_optional_archive_cmdlets
 test_powershell_installer_uses_non_installer_staged_executable_name
 test_powershell_native_probe_restores_error_action_preference


### PR DESCRIPTION
## Summary
- Windows PowerShell 5.1 can download the uloop installer archive and checksum from GitHub again, including on hosts that still default to TLS 1.0.
- Payload downloads now use basic parsing so they no longer depend on Internet Explorer.

## User Impact
- Before: `install.ps1` could fail while fetching the dispatcher zip or its checksum on Windows PowerShell 5.1, because TLS 1.2 was not enabled and `Invoke-WebRequest` used the IE engine.
- After: the installer enables TLS 1.2 without disabling other protocols, and downloads the archive and checksum with `-UseBasicParsing`.

## Changes
- Enable TLS 1.2 with `-bor` before any network call in `scripts/install.ps1`.
- Add `-UseBasicParsing` to the archive and checksum `Invoke-WebRequest` calls (the pin fetch already had it).
- Lock the new download flags with installer script assertions.
- Refresh `cli/dispatcher/shared-inputs-stamp.json` so the installer change trips the dispatcher release trigger.

## Verification
- `sh scripts/test-install-release-filter.sh` — pass (includes new TLS / `-UseBasicParsing` assertions)
- `sh scripts/test-install-pin-manifest.sh` — pass
- `sh scripts/test-install-version-format.sh` — pass
- `sh scripts/test-install-archive-manifest.sh` — pass
- `pwsh -NoProfile -Command '$null = [scriptblock]::Create((Get-Content -Raw -Encoding UTF8 scripts/install.ps1))'` — `pwsh parse: OK`
- `pwsh -NoProfile -File scripts/test-install-pin-resolution.ps1` — pass
- `scripts/stamp-release-inputs.sh` — dispatcher stamp hash only; no `projectRunnerVersion` / `dispatcherVersion` / changelog edits

Fixes #2366


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

