### PR TITLE
fix: suggest unknown-option corrections from any kebab token and CLI-only flags

### DIFF
--- a/cli/project-runner/internal/projectrunner/tool_param_suggestions.go
+++ b/cli/project-runner/internal/projectrunner/tool_param_suggestions.go
@@ -108,16 +108,11 @@ func closestOptionNameSuggestion(tool clicore.ToolDefinition, flagName string) (
 }
 
 func sharedTokenOptionSuggestions(tool clicore.ToolDefinition, flagName string) []string {
-	unknownToken := firstKebabToken(flagName)
-	if len(unknownToken) < minSharedKebabTokenLength {
-		return nil
-	}
-
 	unknown := strings.ToLower(flagName)
 	matches := make([]visibleToolOption, 0)
 	bestDistance := -1
 	for _, option := range visibleToolOptions(tool) {
-		if firstKebabToken(option.name) != unknownToken {
+		if !hasSharedKebabToken(flagName, option.name) {
 			continue
 		}
 		distance := levenshteinDistance(unknown, strings.ToLower(option.name))
@@ -157,12 +152,33 @@ func visibleToolOptions(tool clicore.ToolDefinition) []visibleToolOption {
 			property: property,
 		})
 	}
-	return options
+	return appendDynamicCodeFileSuggestionOption(tool, options)
 }
 
-func firstKebabToken(name string) string {
-	token, _, _ := strings.Cut(strings.ToLower(name), "-")
-	return token
+func appendDynamicCodeFileSuggestionOption(tool clicore.ToolDefinition, options []visibleToolOption) []visibleToolOption {
+	if tool.Name != clicore.ExecuteDynamicCodeCommandName {
+		return options
+	}
+	for _, option := range options {
+		if option.name == tooldocs.DynamicCodeFileFlagName {
+			return options
+		}
+	}
+	return append(options, visibleToolOption{name: tooldocs.DynamicCodeFileFlagName})
+}
+
+func hasSharedKebabToken(left string, right string) bool {
+	for _, leftToken := range strings.Split(strings.ToLower(left), "-") {
+		if len(leftToken) < minSharedKebabTokenLength {
+			continue
+		}
+		for _, rightToken := range strings.Split(strings.ToLower(right), "-") {
+			if leftToken == rightToken {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func prependSuggestions(suggestions []string, fallback string) []string {

--- a/cli/project-runner/internal/projectrunner/tool_param_suggestions.go
+++ b/cli/project-runner/internal/projectrunner/tool_param_suggestions.go
@@ -152,19 +152,34 @@ func visibleToolOptions(tool clicore.ToolDefinition) []visibleToolOption {
 			property: property,
 		})
 	}
-	return appendDynamicCodeFileSuggestionOption(tool, options)
+	options = appendDynamicCodeFileSuggestionOption(tool, options)
+	return appendPausePointEnableSuggestionOptions(tool, options)
 }
 
 func appendDynamicCodeFileSuggestionOption(tool clicore.ToolDefinition, options []visibleToolOption) []visibleToolOption {
 	if tool.Name != clicore.ExecuteDynamicCodeCommandName {
 		return options
 	}
+	return appendSuggestionOption(options, tooldocs.DynamicCodeFileFlagName)
+}
+
+func appendPausePointEnableSuggestionOptions(tool clicore.ToolDefinition, options []visibleToolOption) []visibleToolOption {
+	if tool.Name != pausePointEnableCommandName {
+		return options
+	}
+	for _, option := range tooldocs.PausePointEnableCLIOnlyOptions() {
+		options = appendSuggestionOption(options, option.FlagName)
+	}
+	return options
+}
+
+func appendSuggestionOption(options []visibleToolOption, name string) []visibleToolOption {
 	for _, option := range options {
-		if option.name == tooldocs.DynamicCodeFileFlagName {
+		if option.name == name {
 			return options
 		}
 	}
-	return append(options, visibleToolOption{name: tooldocs.DynamicCodeFileFlagName})
+	return append(options, visibleToolOption{name: name})
 }
 
 func hasSharedKebabToken(left string, right string) bool {

--- a/cli/project-runner/internal/projectrunner/tool_params_test.go
+++ b/cli/project-runner/internal/projectrunner/tool_params_test.go
@@ -294,6 +294,20 @@ func TestBuildToolParamsUnknownOptionSuggestsTestModeFromSharedLaterToken(t *tes
 	})
 }
 
+// Verifies enable-pause-point suggests its CLI-only trigger option when a supplied flag is a close typo.
+func TestBuildToolParamsUnknownOptionSuggestsPausePointTrigger(t *testing.T) {
+	tool, ok := clicore.FindTool(clicore.LoadDefaultTools(), pausePointEnableCommandName)
+	if !ok {
+		t.Fatal("enable-pause-point was not found in default tools")
+	}
+
+	_, _, err := buildToolParams([]string{"--triger"}, tool)
+	requireNextActions(t, err, []string{
+		"Did you mean: uloop enable-pause-point --trigger",
+		"Run `uloop enable-pause-point --help` to inspect supported options.",
+	})
+}
+
 // Verifies an unrelated unknown flag keeps only the --help NextAction.
 func TestBuildToolParamsUnknownOptionWithoutSuggestionKeepsHelpNextAction(t *testing.T) {
 	_, _, err := buildToolParams([]string{"--zzzzzzzz"}, toolParamsSuggestionTool())

--- a/cli/project-runner/internal/projectrunner/tool_params_test.go
+++ b/cli/project-runner/internal/projectrunner/tool_params_test.go
@@ -266,6 +266,34 @@ func TestBuildToolParamsUnknownOptionSuggestsSharedKebabToken(t *testing.T) {
 	})
 }
 
+// Verifies execute-dynamic-code suggests its CLI-only code-file option when a supplied flag shares a later kebab token.
+func TestBuildToolParamsUnknownOptionSuggestsDynamicCodeFileFromSharedLaterToken(t *testing.T) {
+	tool, ok := clicore.FindTool(clicore.LoadDefaultTools(), clicore.ExecuteDynamicCodeCommandName)
+	if !ok {
+		t.Fatal("execute-dynamic-code was not found in default tools")
+	}
+
+	_, _, err := buildToolParams([]string{"--file"}, tool)
+	requireNextActions(t, err, []string{
+		"Did you mean: uloop execute-dynamic-code --code-file",
+		"Run `uloop execute-dynamic-code --help` to inspect supported options.",
+	})
+}
+
+// Verifies run-tests suggests test-mode when a supplied flag shares a later kebab token.
+func TestBuildToolParamsUnknownOptionSuggestsTestModeFromSharedLaterToken(t *testing.T) {
+	tool, ok := clicore.FindTool(clicore.LoadDefaultTools(), "run-tests")
+	if !ok {
+		t.Fatal("run-tests was not found in default tools")
+	}
+
+	_, _, err := buildToolParams([]string{"--mode"}, tool)
+	requireNextActions(t, err, []string{
+		"Did you mean: uloop run-tests --test-mode",
+		"Run `uloop run-tests --help` to inspect supported options.",
+	})
+}
+
 // Verifies an unrelated unknown flag keeps only the --help NextAction.
 func TestBuildToolParamsUnknownOptionWithoutSuggestionKeepsHelpNextAction(t *testing.T) {
 	_, _, err := buildToolParams([]string{"--zzzzzzzz"}, toolParamsSuggestionTool())


### PR DESCRIPTION
## Summary

- Suggest likely corrections when a supplied option shares any meaningful kebab-case token with a supported option.
- Include CLI-only options in suggestions for the commands that accept them.

## User Impact

Unknown options now point directly to the supported command form, avoiding an extra help lookup and retry.

## Verification

- `scripts/check-go-cli.sh`
- Rebuilt development CLI responses for the affected unknown-option cases.

Fixes #2389


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

