### PR TITLE
fix: Windows uloop update can replace a running uloop.exe

### DIFF
--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "8f392166cd57b4612ae661e042dd13ced8ecd09a"
+  "sharedInputsHash": "c989701d11c73f892f4f7df63a423bab45bc61c8"
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "301379ea48e659b2bd66ce7fc2d27ab137e0f960"
+  "sharedInputsHash": "8f392166cd57b4612ae661e042dd13ced8ecd09a"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -570,7 +570,21 @@ set_download_urls
 
 tmp_dir=$(mktemp -d)
 staged_uloop_path=""
-trap 'rm -rf "$tmp_dir"; if [ -n "$staged_uloop_path" ]; then rm -f "$staged_uloop_path"; fi' EXIT
+replaced_uloop_backup_path=""
+final_uloop_path=""
+
+# Why: if the install failed after the old binary was moved aside, put it
+# back so a failed update never leaves the user without a working uloop.
+cleanup_install() {
+  if [ -n "$replaced_uloop_backup_path" ] && [ -n "$final_uloop_path" ] && [ -f "$replaced_uloop_backup_path" ] && [ ! -e "$final_uloop_path" ]; then
+    mv "$replaced_uloop_backup_path" "$final_uloop_path"
+  fi
+  if [ -n "$staged_uloop_path" ]; then
+    rm -f "$staged_uloop_path"
+  fi
+  rm -rf "$tmp_dir"
+}
+trap cleanup_install EXIT
 
 compute_asset_sha256() {
   # Why: install.sh runs on macOS (shasum) and MINGW/MSYS (sha256sum). We do the
@@ -661,7 +675,28 @@ if [ "$legacy_uloop_before_install" = "$final_uloop_path" ] || [ "$legacy_uloop_
   fi
   legacy_uloop_before_install=""
 fi
-mv -f "$staged_uloop_path" "$final_uloop_path"
+
+# Why: earlier installs rename the then-running binary aside; those
+# processes have exited by now, so reclaim the leftovers. A backup whose
+# process is still running stays locked and is skipped silently until a
+# later install can remove it.
+for leftover in "$INSTALL_DIR/$installed_command_name".old-*; do
+  if [ ! -e "$leftover" ]; then
+    continue
+  fi
+  rm -f "$leftover" 2>/dev/null || true
+done
+
+# Why: Windows locks the image file of a running executable against
+# overwrite and delete but still allows rename. `uloop update` runs this
+# script as a child of the running uloop.exe, so overwriting the target
+# in place can never succeed there. Move the existing binary aside first;
+# the EXIT trap restores it if the new binary was not placed.
+if [ -e "$final_uloop_path" ]; then
+  replaced_uloop_backup_path="$final_uloop_path.old-$$-$(date +%s)"
+  mv "$final_uloop_path" "$replaced_uloop_backup_path"
+fi
+mv "$staged_uloop_path" "$final_uloop_path"
 staged_uloop_path=""
 if [ "$native_install_supported" -eq 1 ]; then
   if invoke_uloop_native_install "$final_uloop_path"; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -572,12 +572,21 @@ tmp_dir=$(mktemp -d)
 staged_uloop_path=""
 replaced_uloop_backup_path=""
 final_uloop_path=""
+install_completed=0
 
 # Why: if the install failed after the old binary was moved aside, put it
 # back so a failed update never leaves the user without a working uloop.
+# That includes post-place failures such as --version: the new binary is
+# already at the destination, so remove it first and only then restore.
+# If the new binary cannot be removed, leave the backup in place.
 cleanup_install() {
-  if [ -n "$replaced_uloop_backup_path" ] && [ -n "$final_uloop_path" ] && [ -f "$replaced_uloop_backup_path" ] && [ ! -e "$final_uloop_path" ]; then
-    mv "$replaced_uloop_backup_path" "$final_uloop_path"
+  if [ "$install_completed" -eq 0 ] && [ -n "$replaced_uloop_backup_path" ] && [ -f "$replaced_uloop_backup_path" ]; then
+    if [ -n "$final_uloop_path" ]; then
+      rm -f "$final_uloop_path" 2>/dev/null || true
+    fi
+    if [ -n "$final_uloop_path" ] && [ ! -e "$final_uloop_path" ]; then
+      mv "$replaced_uloop_backup_path" "$final_uloop_path"
+    fi
   fi
   if [ -n "$staged_uloop_path" ]; then
     rm -f "$staged_uloop_path"
@@ -585,6 +594,9 @@ cleanup_install() {
   rm -rf "$tmp_dir"
 }
 trap cleanup_install EXIT
+# Why: POSIX does not run the EXIT trap on INT/HUP/TERM unless the handler
+# exits. Between move-aside and place that would leave uloop missing.
+trap "exit 129" INT HUP TERM
 
 compute_asset_sha256() {
   # Why: install.sh runs on macOS (shasum) and MINGW/MSYS (sha256sum). We do the
@@ -712,3 +724,4 @@ fi
 
 "$INSTALL_DIR/$installed_command_name" --version
 report_path_shadowing
+install_completed=1

--- a/scripts/test-install-release-filter.sh
+++ b/scripts/test-install-release-filter.sh
@@ -242,6 +242,17 @@ cat > "$extract_dir/uloop" <<'ULOOP'
 #!/bin/sh
 set -eu
 
+if [ "${1:-}" = "--version" ] && [ "${MOCK_FINAL_VERSION_FAIL:-0}" = "1" ]; then
+  case $0 in
+    */.uloop-install*)
+      echo "uloop mock version"
+      exit 0
+      ;;
+  esac
+  echo "mock final --version fail" >&2
+  exit 1
+fi
+
 if [ "${1:-}" = "install" ]; then
   if [ "${MOCK_NATIVE_INSTALL_UNSUPPORTED:-0}" = "1" ]; then
     exit 1
@@ -289,6 +300,17 @@ fi
 cat > "$extract_dir/uloop.exe" <<'ULOOP'
 #!/bin/sh
 set -eu
+
+if [ "${1:-}" = "--version" ] && [ "${MOCK_FINAL_VERSION_FAIL:-0}" = "1" ]; then
+  case $0 in
+    */.uloop-install*)
+      echo "uloop mock version"
+      exit 0
+      ;;
+  esac
+  echo "mock final --version fail" >&2
+  exit 1
+fi
 
 if [ "${1:-}" = "install" ]; then
   if [ "${MOCK_NATIVE_INSTALL_UNSUPPORTED:-0}" = "1" ]; then
@@ -1082,6 +1104,41 @@ MOCK_MV
   assert_contains "$install_dir/uloop" "old-binary"
 }
 
+# Verifies a failed post-place --version restores the aside backup instead of
+# leaving a broken new binary at the destination.
+test_posix_restores_uloop_backup_when_final_version_fails() {
+  work_dir="$TMP_DIR/posix-restore-version"
+  mock_bin="$work_dir/bin"
+  install_dir="$work_dir/install"
+  releases_json="$work_dir/releases.json"
+  curl_log="$work_dir/curl.log"
+  npm_log="$work_dir/npm.log"
+  mkdir -p "$work_dir" "$install_dir"
+  : > "$curl_log"
+  : > "$npm_log"
+  printf '%s\n' 'old-binary' > "$install_dir/uloop"
+  chmod +x "$install_dir/uloop"
+  write_releases_json "$releases_json"
+  write_mock_commands "$mock_bin"
+
+  status=0
+  PATH="$mock_bin:$ORIGINAL_PATH" \
+    ULOOP_VERSION=latest \
+    ULOOP_INSTALL_DIR="$install_dir" \
+    RELEASES_JSON="$releases_json" \
+    CURL_LOG="$curl_log" \
+    NPM_LOG="$npm_log" \
+    MOCK_NATIVE_INSTALL_UNSUPPORTED=1 \
+    MOCK_FINAL_VERSION_FAIL=1 \
+    LEGACY_ULOOP="" \
+    "$ROOT_DIR/scripts/install.sh" > "$work_dir/output.txt" 2> "$work_dir/stderr.txt" || status=$?
+  if [ "$status" -eq 0 ]; then
+    echo "Expected replace install to fail when the placed binary --version fails" >&2
+    exit 1
+  fi
+  assert_contains "$install_dir/uloop" "old-binary"
+}
+
 # Verifies install.sh uses move-aside + restore instead of mv -f onto the
 # running destination, without $RANDOM.
 test_posix_installer_moves_existing_uloop_aside() {
@@ -1092,6 +1149,10 @@ test_posix_installer_moves_existing_uloop_aside() {
   assert_not_contains "$ROOT_DIR/scripts/install.sh" '$RANDOM'
   assert_contains "$ROOT_DIR/scripts/install.sh" '`uloop update` runs this'
   assert_contains "$ROOT_DIR/scripts/install.sh" '[ ! -e "$final_uloop_path" ]'
+  assert_contains "$ROOT_DIR/scripts/install.sh" 'install_completed=0'
+  assert_contains "$ROOT_DIR/scripts/install.sh" 'install_completed=1'
+  assert_contains "$ROOT_DIR/scripts/install.sh" 'rm -f "$final_uloop_path" 2>/dev/null || true'
+  assert_contains "$ROOT_DIR/scripts/install.sh" 'trap "exit 129" INT HUP TERM'
 }
 
 # Verifies -UseBasicParsing on the two payload downloads, that the TLS 1.2
@@ -1414,6 +1475,7 @@ test_powershell_latest_skips_prerelease_assets
 test_git_bash_latest_installs_windows_zip_asset
 test_posix_replaces_existing_uloop_by_moving_it_aside
 test_posix_restores_uloop_backup_when_replace_fails
+test_posix_restores_uloop_backup_when_final_version_fails
 test_posix_installer_moves_existing_uloop_aside
 test_powershell_installer_enables_tls12_and_basic_parsing
 test_powershell_installer_avoids_optional_archive_cmdlets

--- a/scripts/test-install-release-filter.sh
+++ b/scripts/test-install-release-filter.sh
@@ -973,6 +973,127 @@ test_git_bash_latest_installs_windows_zip_asset() {
   assert_contains "$work_dir/output.txt" "uloop mock version"
 }
 
+# Verifies install.sh moves an existing destination aside, reclaims stale
+# leftovers, and leaves the backup after a successful replace.
+test_posix_replaces_existing_uloop_by_moving_it_aside() {
+  work_dir="$TMP_DIR/posix-move-aside"
+  mock_bin="$work_dir/bin"
+  install_dir="$work_dir/install"
+  releases_json="$work_dir/releases.json"
+  curl_log="$work_dir/curl.log"
+  npm_log="$work_dir/npm.log"
+  mkdir -p "$work_dir" "$install_dir"
+  : > "$curl_log"
+  : > "$npm_log"
+  printf '%s\n' 'old-binary' > "$install_dir/uloop"
+  chmod +x "$install_dir/uloop"
+  printf '%s\n' 'stale-backup' > "$install_dir/uloop.old-stale"
+  write_releases_json "$releases_json"
+  write_mock_commands "$mock_bin"
+
+  PATH="$mock_bin:$ORIGINAL_PATH" \
+    ULOOP_VERSION=latest \
+    ULOOP_INSTALL_DIR="$install_dir" \
+    RELEASES_JSON="$releases_json" \
+    CURL_LOG="$curl_log" \
+    NPM_LOG="$npm_log" \
+    MOCK_NATIVE_INSTALL_UNSUPPORTED=1 \
+    LEGACY_ULOOP="" \
+    "$ROOT_DIR/scripts/install.sh" > "$work_dir/output.txt" 2> "$work_dir/stderr.txt"
+
+  if [ ! -x "$install_dir/uloop" ]; then
+    echo "Expected replace install to keep an executable uloop: $install_dir/uloop" >&2
+    exit 1
+  fi
+  assert_contains "$work_dir/output.txt" "uloop mock version"
+  if [ -e "$install_dir/uloop.old-stale" ]; then
+    echo "Expected stale leftover $install_dir/uloop.old-stale to be reclaimed" >&2
+    exit 1
+  fi
+  leftover_count=0
+  leftover_path=""
+  for leftover in "$install_dir"/uloop.old-*; do
+    if [ ! -e "$leftover" ]; then
+      continue
+    fi
+    leftover_count=$((leftover_count + 1))
+    leftover_path=$leftover
+  done
+  if [ "$leftover_count" -ne 1 ]; then
+    echo "Expected one leftover backup after a successful replace, found $leftover_count" >&2
+    ls -l "$install_dir" >&2
+    exit 1
+  fi
+  assert_contains "$leftover_path" "old-binary"
+}
+
+# Verifies the EXIT trap restores the aside backup when placing the staged
+# binary fails.
+test_posix_restores_uloop_backup_when_replace_fails() {
+  work_dir="$TMP_DIR/posix-restore-aside"
+  mock_bin="$work_dir/bin"
+  install_dir="$work_dir/install"
+  releases_json="$work_dir/releases.json"
+  curl_log="$work_dir/curl.log"
+  npm_log="$work_dir/npm.log"
+  mkdir -p "$work_dir" "$install_dir"
+  : > "$curl_log"
+  : > "$npm_log"
+  printf '%s\n' 'old-binary' > "$install_dir/uloop"
+  chmod +x "$install_dir/uloop"
+  write_releases_json "$releases_json"
+  write_mock_commands "$mock_bin"
+
+  real_mv=$(command -v mv)
+  cat > "$mock_bin/mv" <<MOCK_MV
+#!/bin/sh
+set -eu
+src=\$1
+dest=\$2
+case \$dest in
+  *.old-*)
+    exec $real_mv "\$src" "\$dest"
+    ;;
+esac
+case \$src in
+  */.uloop-install*)
+    echo "mock mv refusing to place staged binary" >&2
+    exit 1
+    ;;
+esac
+exec $real_mv "\$src" "\$dest"
+MOCK_MV
+  chmod +x "$mock_bin/mv"
+
+  status=0
+  PATH="$mock_bin:$ORIGINAL_PATH" \
+    ULOOP_VERSION=latest \
+    ULOOP_INSTALL_DIR="$install_dir" \
+    RELEASES_JSON="$releases_json" \
+    CURL_LOG="$curl_log" \
+    NPM_LOG="$npm_log" \
+    MOCK_NATIVE_INSTALL_UNSUPPORTED=1 \
+    LEGACY_ULOOP="" \
+    "$ROOT_DIR/scripts/install.sh" > "$work_dir/output.txt" 2> "$work_dir/stderr.txt" || status=$?
+  if [ "$status" -eq 0 ]; then
+    echo "Expected replace install to fail when placing the staged binary is refused" >&2
+    exit 1
+  fi
+  assert_contains "$install_dir/uloop" "old-binary"
+}
+
+# Verifies install.sh uses move-aside + restore instead of mv -f onto the
+# running destination, without $RANDOM.
+test_posix_installer_moves_existing_uloop_aside() {
+  assert_contains "$ROOT_DIR/scripts/install.sh" 'replaced_uloop_backup_path="$final_uloop_path.old-$$-$(date +%s)"'
+  assert_contains "$ROOT_DIR/scripts/install.sh" 'mv "$final_uloop_path" "$replaced_uloop_backup_path"'
+  assert_contains "$ROOT_DIR/scripts/install.sh" 'mv "$staged_uloop_path" "$final_uloop_path"'
+  assert_not_contains "$ROOT_DIR/scripts/install.sh" 'mv -f "$staged_uloop_path" "$final_uloop_path"'
+  assert_not_contains "$ROOT_DIR/scripts/install.sh" '$RANDOM'
+  assert_contains "$ROOT_DIR/scripts/install.sh" '`uloop update` runs this'
+  assert_contains "$ROOT_DIR/scripts/install.sh" '[ ! -e "$final_uloop_path" ]'
+}
+
 # Verifies -UseBasicParsing on the two payload downloads, that the TLS 1.2
 # -bor assignment sits inside the PS 5.1 Major -lt 6 guard, and that that
 # assignment appears before the first Invoke-WebRequest in install.ps1.
@@ -1291,6 +1412,9 @@ test_posix_silences_legacy_cleanup_when_npm_prefix_cannot_be_inferred
 test_posix_removes_npm_package_before_replacing_same_bin_path
 test_powershell_latest_skips_prerelease_assets
 test_git_bash_latest_installs_windows_zip_asset
+test_posix_replaces_existing_uloop_by_moving_it_aside
+test_posix_restores_uloop_backup_when_replace_fails
+test_posix_installer_moves_existing_uloop_aside
 test_powershell_installer_enables_tls12_and_basic_parsing
 test_powershell_installer_avoids_optional_archive_cmdlets
 test_powershell_installer_uses_non_installer_staged_executable_name


### PR DESCRIPTION
## Summary
- `uloop update` on Windows can replace the running `uloop.exe` instead of failing on a locked image file.
- A failed replace puts the previous binary back, so an interrupted update does not leave the command missing.

## User Impact
- Before: the shell installer used `mv -f` onto the destination. Windows locks a running executable against overwrite, so `uloop update` (a child of the running `uloop.exe`) could fail mid-replace.
- After: the existing binary is renamed aside first, the new binary is placed, and the EXIT trap restores the backup if placement fails. Successful updates leave the backup for the next install to reclaim, matching the PowerShell installer.

## Changes
- Replace `mv -f` of the staged binary onto the destination with rename-aside + place + restore-on-failure.
- Reclaim leftover `*.old-*` files from earlier installs before creating a new backup.
- Add installer tests for leftover reclaim, leftover-on-success, and restore-on-failed place.
- Refresh `cli/dispatcher/shared-inputs-stamp.json`.

## Verification
- `sh -n scripts/install.sh` — OK
- `sh scripts/test-install-release-filter.sh` — pass (includes the three new move-aside tests)
- `sh scripts/test-install-pin-manifest.sh` — pass
- `sh scripts/test-install-version-format.sh` — pass
- `sh scripts/test-install-archive-manifest.sh` — pass
- `scripts/stamp-release-inputs.sh` — dispatcher stamp hash only; no `projectRunnerVersion` / `dispatcherVersion` / changelog edits

Fixes #2367


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

