### PR TITLE
feat: warn when the Unity Editor is unfocused in simulate-keyboard, execute-dynamic-code, and control-play-mode responses

### DIFF
--- a/.agents/skills/uloop-control-play-mode/SKILL.md
+++ b/.agents/skills/uloop-control-play-mode/SKILL.md
@@ -31,7 +31,7 @@ Returns JSON with the current play mode state:
 - `WasAlreadyStopped`: Whether `Stop` was requested while Play Mode was already stopped
 - `ResumedFromPause`: Whether `Play` resumed a paused Play Mode session instead of starting a new one
 - `Message`: Description of the action performed
-- `Warning`: Set when the action carries a caveat. A fresh `Play` start always notes that the session started from Edit-time scene state; additionally, when active hot-reload patches or enabled pause points exist and Domain Reload is enabled, it reports how many of them the Play-entry domain reload will discard.
+- `Warning` (string, optional): Set when the action carries a caveat. A fresh `Play` start always notes that the session started from Edit-time scene state; additionally, when active hot-reload patches or enabled pause points exist and Domain Reload is enabled, it reports how many of them the Play-entry domain reload will discard. `Status` also reports when Play Mode is running while the Unity Editor is unfocused, because progress may be throttled; run `uloop focus-window`, or use the `pause-point --await`/`--trigger` flow instead of polling for progress.
 - `StoppedBy` (string, optional): Why Play Mode last stopped: `cli-control-play-mode`, `cli-compile-stop-setting`, `cli-run-tests-cancel`, `script-compilation`, or `unknown`. Present on `Stop` when Play Mode was already stopped, and on `Status` when Play Mode is not running. Omitted when this Editor session has no confirmed stop.
 - `StoppedAt` (string, optional): UTC ISO 8601 timestamp of that stop. Omitted together with `StoppedBy` when no stop is recorded.
 

--- a/.agents/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.agents/skills/uloop-execute-dynamic-code/SKILL.md
@@ -74,5 +74,6 @@ Returns JSON:
 - `UpdatedCode`: string|null — the wrapped form actually compiled (handy when debugging using-statement reordering)
 - `DiagnosticsSummary`: string|null — compact summary when diagnostics are available
 - `Diagnostics`: object[] — structured diagnostics; same shape as `CompilationErrors`, usually populated together with it
+- `Warning` (string, optional): Set when Play Mode is running while the Unity Editor is unfocused. Progress may be throttled; run `uloop focus-window`, or use the `pause-point --await`/`--trigger` flow instead of polling for progress.
 
 On `Success: false`, inspect `CompilationErrors` first. If empty, read `ErrorMessage` (and `Logs` for extra context) — the failure may be a runtime exception, cancellation, or an "execution in progress" rejection, all of which return empty `CompilationErrors`. Both EditMode and PlayMode are supported targets — the snippet runs in whichever mode the Editor is currently in.

--- a/.agents/skills/uloop-simulate-keyboard/SKILL.md
+++ b/.agents/skills/uloop-simulate-keyboard/SKILL.md
@@ -90,6 +90,7 @@ Returns JSON with:
 - `Success` (boolean): Whether the action succeeded (e.g. `KeyDown` on a not-yet-held key, `KeyUp` on a currently-held key, or `Press` round-trip)
 - `Message` (string): Description of what happened or why it failed
 - `Action` (string): The `--action` value that was applied (`Press`, `KeyDown`, `KeyUp`, or `ReleaseAll`)
+- `Warning` (string, optional): Set for a successful `Press` or `KeyDown` whose press edge was not observed while the Unity Editor is unfocused. Run `uloop focus-window` before retrying; queued input may be delivered all at once when the Editor regains focus.
 - `KeyName` (string, nullable): The key that was acted on; may be `null` when the action could not resolve a key
 - `ReleasedKeys` (string list, nullable): Set only for `ReleaseAll`; the key names that were force-released (empty when nothing was held)
 - `ReleasedKeyStates` (list, nullable): Set only for `ReleaseAll`. Each entry is `{ Key, DeviceIsPressedAfterRelease }` from a device readback after the release injection. Empty when nothing was held, or when no keyboard device is present (`KeyStateReadUpdateType` is also omitted then). If tracked keys remain with no keyboard device, `ReleasedKeys` is non-empty while `ReleasedKeyStates` is empty. Omitted (`null`) for other actions. `DeviceIsPressedAfterRelease: true` means the Input System view still reports pressed — do not treat `Success: true` as proof that gameplay polling already sees the key as up

--- a/.claude/skills/uloop-control-play-mode/SKILL.md
+++ b/.claude/skills/uloop-control-play-mode/SKILL.md
@@ -31,7 +31,7 @@ Returns JSON with the current play mode state:
 - `WasAlreadyStopped`: Whether `Stop` was requested while Play Mode was already stopped
 - `ResumedFromPause`: Whether `Play` resumed a paused Play Mode session instead of starting a new one
 - `Message`: Description of the action performed
-- `Warning`: Set when the action carries a caveat. A fresh `Play` start always notes that the session started from Edit-time scene state; additionally, when active hot-reload patches or enabled pause points exist and Domain Reload is enabled, it reports how many of them the Play-entry domain reload will discard.
+- `Warning` (string, optional): Set when the action carries a caveat. A fresh `Play` start always notes that the session started from Edit-time scene state; additionally, when active hot-reload patches or enabled pause points exist and Domain Reload is enabled, it reports how many of them the Play-entry domain reload will discard. `Status` also reports when Play Mode is running while the Unity Editor is unfocused, because progress may be throttled; run `uloop focus-window`, or use the `pause-point --await`/`--trigger` flow instead of polling for progress.
 - `StoppedBy` (string, optional): Why Play Mode last stopped: `cli-control-play-mode`, `cli-compile-stop-setting`, `cli-run-tests-cancel`, `script-compilation`, or `unknown`. Present on `Stop` when Play Mode was already stopped, and on `Status` when Play Mode is not running. Omitted when this Editor session has no confirmed stop.
 - `StoppedAt` (string, optional): UTC ISO 8601 timestamp of that stop. Omitted together with `StoppedBy` when no stop is recorded.
 

--- a/.claude/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.claude/skills/uloop-execute-dynamic-code/SKILL.md
@@ -74,5 +74,6 @@ Returns JSON:
 - `UpdatedCode`: string|null — the wrapped form actually compiled (handy when debugging using-statement reordering)
 - `DiagnosticsSummary`: string|null — compact summary when diagnostics are available
 - `Diagnostics`: object[] — structured diagnostics; same shape as `CompilationErrors`, usually populated together with it
+- `Warning` (string, optional): Set when Play Mode is running while the Unity Editor is unfocused. Progress may be throttled; run `uloop focus-window`, or use the `pause-point --await`/`--trigger` flow instead of polling for progress.
 
 On `Success: false`, inspect `CompilationErrors` first. If empty, read `ErrorMessage` (and `Logs` for extra context) — the failure may be a runtime exception, cancellation, or an "execution in progress" rejection, all of which return empty `CompilationErrors`. Both EditMode and PlayMode are supported targets — the snippet runs in whichever mode the Editor is currently in.

--- a/.claude/skills/uloop-simulate-keyboard/SKILL.md
+++ b/.claude/skills/uloop-simulate-keyboard/SKILL.md
@@ -90,6 +90,7 @@ Returns JSON with:
 - `Success` (boolean): Whether the action succeeded (e.g. `KeyDown` on a not-yet-held key, `KeyUp` on a currently-held key, or `Press` round-trip)
 - `Message` (string): Description of what happened or why it failed
 - `Action` (string): The `--action` value that was applied (`Press`, `KeyDown`, `KeyUp`, or `ReleaseAll`)
+- `Warning` (string, optional): Set for a successful `Press` or `KeyDown` whose press edge was not observed while the Unity Editor is unfocused. Run `uloop focus-window` before retrying; queued input may be delivered all at once when the Editor regains focus.
 - `KeyName` (string, nullable): The key that was acted on; may be `null` when the action could not resolve a key
 - `ReleasedKeys` (string list, nullable): Set only for `ReleaseAll`; the key names that were force-released (empty when nothing was held)
 - `ReleasedKeyStates` (list, nullable): Set only for `ReleaseAll`. Each entry is `{ Key, DeviceIsPressedAfterRelease }` from a device readback after the release injection. Empty when nothing was held, or when no keyboard device is present (`KeyStateReadUpdateType` is also omitted then). If tracked keys remain with no keyboard device, `ReleasedKeys` is non-empty while `ReleasedKeyStates` is empty. Omitted (`null`) for other actions. `DeviceIsPressedAfterRelease: true` means the Input System view still reports pressed — do not treat `Success: true` as proof that gameplay polling already sees the key as up

--- a/Assets/Tests/Editor/ControlPlayModeStoppedByTests.cs
+++ b/Assets/Tests/Editor/ControlPlayModeStoppedByTests.cs
@@ -118,6 +118,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     UnityCliLoopJsonResponseSerializerSettings.Settings));
             Assert.That(omittedJson.Property("StoppedBy"), Is.Null);
             Assert.That(omittedJson.Property("StoppedAt"), Is.Null);
+            Assert.That(omittedJson.Property("Warning"), Is.Null);
 
             ControlPlayModeResponse populated = new ControlPlayModeResponse
             {
@@ -134,6 +135,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     UnityCliLoopJsonResponseSerializerSettings.Settings));
             Assert.That(populatedJson["StoppedBy"]?.Value<string>(), Is.EqualTo("cli-control-play-mode"));
             Assert.That(populatedJson["StoppedAt"]?.Value<string>(), Is.EqualTo("2026-01-01T00:00:00.0000000Z"));
+
+            populated.Warning = "focus editor";
+            JObject warningJson = LoadJsonWithoutDateParsing(
+                JsonConvert.SerializeObject(
+                    populated,
+                    Formatting.None,
+                    UnityCliLoopJsonResponseSerializerSettings.Settings));
+            Assert.That(warningJson["Warning"]?.Value<string>(), Is.EqualTo("focus editor"));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
+++ b/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
@@ -790,6 +790,52 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(editorState.StepCallCount, Is.EqualTo(1));
         }
 
+        /// <summary>
+        /// What: Status returns the exact unfocused Editor hint when Play Mode is active.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenStatusIsPlayingAndEditorIsUnfocused_ReturnsExactHint()
+        {
+            FakeControlPlayModeEditorStateService editorState = new(isPlaying: true, isPaused: false);
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                editorStateService: editorState,
+                editorFocusStateProvider: new FakeEditorFocusStateProvider(false));
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(
+                new ControlPlayModeSchema { Action = PlayModeAction.Status },
+                CancellationToken.None);
+
+            Assert.That(response.Warning, Is.EqualTo("The Unity Editor is unfocused while Play Mode is running, so Play Mode progress may be throttled. Run `uloop focus-window`, or use the `pause-point --await`/`--trigger` flow instead of polling for progress."));
+        }
+
+        /// <summary>
+        /// What: Status does not return the unfocused Editor hint when the Editor is focused.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenStatusEditorIsFocused_ReturnsNoHint()
+        {
+            FakeControlPlayModeEditorStateService editorState = new(isPlaying: true, isPaused: false);
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                editorStateService: editorState,
+                editorFocusStateProvider: new FakeEditorFocusStateProvider(true));
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(
+                new ControlPlayModeSchema { Action = PlayModeAction.Status },
+                CancellationToken.None);
+
+            Assert.That(response.Warning, Is.Empty);
+        }
+
+        private sealed class FakeEditorFocusStateProvider : IEditorFocusStateProvider
+        {
+            public FakeEditorFocusStateProvider(bool isFocused)
+            {
+                IsFocused = isFocused;
+            }
+
+            public bool IsFocused { get; }
+        }
+
         private sealed class FakeControlPlayModeEditorStateService : IControlPlayModeEditorStateService
         {
             private bool _isPlaying;

--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeErrorEditorStateTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeErrorEditorStateTests.cs
@@ -154,6 +154,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
                 Is.EqualTo("{\"EditorPlaying\":true,\"EditorPaused\":true,\"ActivePausePointId\":\"jump\"}"));
         }
 
+        /// <summary>
+        /// What: the dynamic-code Warning is omitted when empty and serialized when present.
+        /// </summary>
+        [Test]
+        public void ExecuteDynamicCodeResponse_WhenWarningChanges_UsesOptionalJsonContract()
+        {
+            ExecuteDynamicCodeResponse response = new();
+            JObject omitted = JObject.Parse(JsonConvert.SerializeObject(response, JsonRpcResponseSerializer.Settings));
+            Assert.That(omitted.Property("Warning"), Is.Null);
+
+            response.Warning = "focus editor";
+            JObject populated = JObject.Parse(JsonConvert.SerializeObject(response, JsonRpcResponseSerializer.Settings));
+            Assert.That(populated["Warning"]?.Value<string>(), Is.EqualTo("focus editor"));
+        }
+
+        /// <summary>
+        /// What: an injected unfocused provider adds the exact hint to a Play Mode response.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenPlayingAndEditorIsUnfocused_ReturnsExactHint()
+        {
+            MarkForegroundWarmupCompleted();
+            ExecuteDynamicCodeUseCase useCase = new ExecuteDynamicCodeUseCase(
+                new FakeDynamicCodeExecutionRuntime(new ExecutionResult { Success = true, Result = "ok" }),
+                new FakeDynamicCodeEditorStateReader(isPlaying: true, isPaused: false),
+                new FakeEditorFocusStateProvider(false));
+
+            ExecuteDynamicCodeResponse response = await useCase.ExecuteAsync(
+                new ExecuteDynamicCodeSchema { Code = "return 1;" },
+                CancellationToken.None);
+
+            Assert.That(response.Warning, Is.EqualTo("The Unity Editor is unfocused while Play Mode is running, so Play Mode progress may be throttled. Run `uloop focus-window`, or use the `pause-point --await`/`--trigger` flow instead of polling for progress."));
+        }
+
         private static ExecuteDynamicCodeUseCase CreateUseCase(IDynamicCodeExecutionRuntime runtime)
         {
             return new ExecuteDynamicCodeUseCase(
@@ -206,6 +240,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             public bool IsPlaying { get; }
 
             public bool IsPaused { get; }
+        }
+
+        private sealed class FakeEditorFocusStateProvider : IEditorFocusStateProvider
+        {
+            public FakeEditorFocusStateProvider(bool isFocused)
+            {
+                IsFocused = isFocused;
+            }
+
+            public bool IsFocused { get; }
         }
 
         private sealed class FakeDynamicCodeExecutionRuntime : IDynamicCodeExecutionRuntime

--- a/Assets/Tests/Editor/EditorUnfocusedWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/EditorUnfocusedWarningBuilderTests.cs
@@ -1,0 +1,135 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies the focused-editor warnings are limited to the affected observations.
+    /// </summary>
+    public sealed class EditorUnfocusedWarningBuilderTests
+    {
+        /// <summary>
+        /// What: an unobserved keyboard press while the Editor is unfocused returns the exact recovery warning.
+        /// </summary>
+        [Test]
+        public void BuildKeyboardInputWarning_WhenPressEdgeIsFalseAndEditorIsUnfocused_ReturnsExactWarning()
+        {
+            string warning = EditorUnfocusedWarningBuilder.BuildKeyboardInputWarning(
+                isEditorFocused: false,
+                isPressAction: true,
+                pressEdgeObserved: false,
+                isSuccessful: true);
+
+            Assert.That(
+                warning,
+                Is.EqualTo(
+                    "Keyboard input was queued while the Unity Editor was unfocused, so the press edge was not observed. Run `uloop focus-window` before retrying; queued input may be delivered all at once when the Editor regains focus."));
+        }
+
+        /// <summary>
+        /// What: a successful press with an omitted edge observation while the Editor is unfocused returns the exact recovery warning.
+        /// </summary>
+        [Test]
+        public void BuildKeyboardInputWarning_WhenPressEdgeIsNullAndEditorIsUnfocused_ReturnsExactWarning()
+        {
+            string warning = EditorUnfocusedWarningBuilder.BuildKeyboardInputWarning(
+                isEditorFocused: false,
+                isPressAction: true,
+                pressEdgeObserved: null,
+                isSuccessful: true);
+
+            Assert.That(
+                warning,
+                Is.EqualTo(
+                    "Keyboard input was queued while the Unity Editor was unfocused, so the press edge was not observed. Run `uloop focus-window` before retrying; queued input may be delivered all at once when the Editor regains focus."));
+        }
+
+        /// <summary>
+        /// What: a focused Editor does not warn about an otherwise unobserved press edge.
+        /// </summary>
+        [Test]
+        public void BuildKeyboardInputWarning_WhenEditorIsFocused_ReturnsEmpty()
+        {
+            string warning = EditorUnfocusedWarningBuilder.BuildKeyboardInputWarning(
+                isEditorFocused: true,
+                isPressAction: true,
+                pressEdgeObserved: false,
+                isSuccessful: true);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: a KeyUp-style action does not warn when its edge observation is contractually omitted.
+        /// </summary>
+        [Test]
+        public void BuildKeyboardInputWarning_WhenActionHasNoPressEdge_ReturnsEmpty()
+        {
+            string warning = EditorUnfocusedWarningBuilder.BuildKeyboardInputWarning(
+                isEditorFocused: false,
+                isPressAction: false,
+                pressEdgeObserved: null,
+                isSuccessful: true);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: a timed-out keyboard action does not claim that an omitted observation was caused by focus.
+        /// </summary>
+        [Test]
+        public void BuildKeyboardInputWarning_WhenActionIsNotSuccessful_ReturnsEmpty()
+        {
+            string warning = EditorUnfocusedWarningBuilder.BuildKeyboardInputWarning(
+                isEditorFocused: false,
+                isPressAction: true,
+                pressEdgeObserved: null,
+                isSuccessful: false);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: an unfocused Editor in Play Mode returns the exact progress hint.
+        /// </summary>
+        [Test]
+        public void BuildPlayModeProgressHint_WhenPlayingAndEditorIsUnfocused_ReturnsExactHint()
+        {
+            string hint = EditorUnfocusedWarningBuilder.BuildPlayModeProgressHint(
+                isPlaying: true,
+                isEditorFocused: false);
+
+            Assert.That(
+                hint,
+                Is.EqualTo(
+                    "The Unity Editor is unfocused while Play Mode is running, so Play Mode progress may be throttled. Run `uloop focus-window`, or use the `pause-point --await`/`--trigger` flow instead of polling for progress."));
+        }
+
+        /// <summary>
+        /// What: Edit Mode does not emit a Play Mode progress hint.
+        /// </summary>
+        [Test]
+        public void BuildPlayModeProgressHint_WhenNotPlaying_ReturnsEmpty()
+        {
+            string hint = EditorUnfocusedWarningBuilder.BuildPlayModeProgressHint(
+                isPlaying: false,
+                isEditorFocused: false);
+
+            Assert.That(hint, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: a focused Editor does not emit a Play Mode progress hint.
+        /// </summary>
+        [Test]
+        public void BuildPlayModeProgressHint_WhenEditorIsFocused_ReturnsEmpty()
+        {
+            string hint = EditorUnfocusedWarningBuilder.BuildPlayModeProgressHint(
+                isPlaying: true,
+                isEditorFocused: true);
+
+            Assert.That(hint, Is.EqualTo(string.Empty));
+        }
+    }
+}

--- a/Assets/Tests/Editor/EditorUnfocusedWarningBuilderTests.cs.meta
+++ b/Assets/Tests/Editor/EditorUnfocusedWarningBuilderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f13db58a4aaff4b00bc2dbc70f0d7f08
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SimulateKeyboardResponseContractTests.cs
+++ b/Assets/Tests/Editor/SimulateKeyboardResponseContractTests.cs
@@ -16,7 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             "{\"Message\":\"\",\"Action\":\"\",\"InterruptedByPausePoint\":false,\"Success\":true}";
 
         private const string PopulatedOptionalFieldsJson =
-            "{\"Message\":\"ok\",\"Action\":\"Press\",\"KeyName\":\"Space\","
+            "{\"Message\":\"ok\",\"Action\":\"Press\",\"Warning\":\"focus editor\",\"KeyName\":\"Space\","
             + "\"InterruptedByPausePoint\":false,\"RejectedByActivePausePointId\":\"marker\","
             + "\"PausePointId\":\"hit\",\"PausePointHitCount\":1,"
             + "\"PausePointHits\":[{\"Id\":\"hit\",\"HitCount\":1}],"
@@ -70,7 +70,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 PressEdgeKeyAlreadyPressedBeforeQueue = false,
                 KeyStateTrackedHeld = true,
                 KeyStateDeviceIsPressed = false,
-                ReleasedKeys = new List<string> { "Space" }
+                ReleasedKeys = new List<string> { "Space" },
+                Warning = "focus editor"
             };
 
             string json = JsonConvert.SerializeObject(

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorFocusStateProvider.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorFocusStateProvider.cs
@@ -1,0 +1,20 @@
+using UnityEditor;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Reads whether the Unity Editor is the active application.
+    /// </summary>
+    public interface IEditorFocusStateProvider
+    {
+        bool IsFocused { get; }
+    }
+
+    /// <summary>
+    /// Reads the current focus state from the Unity Editor API.
+    /// </summary>
+    public sealed class EditorFocusStateProvider : IEditorFocusStateProvider
+    {
+        public bool IsFocused => EditorApplication.isFocused;
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorFocusStateProvider.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorFocusStateProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ed5b0c4d9ac4433cb84885e4ab409af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnfocusedWarningBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnfocusedWarningBuilder.cs
@@ -1,0 +1,43 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Builds response warnings for operations affected by an unfocused Unity Editor.
+    /// </summary>
+    public static class EditorUnfocusedWarningBuilder
+    {
+        private const string KeyboardInputWarning =
+            "Keyboard input was queued while the Unity Editor was unfocused, so the press edge was not observed. Run `uloop focus-window` before retrying; queued input may be delivered all at once when the Editor regains focus.";
+        private const string PlayModeProgressHint =
+            "The Unity Editor is unfocused while Play Mode is running, so Play Mode progress may be throttled. Run `uloop focus-window`, or use the `pause-point --await`/`--trigger` flow instead of polling for progress.";
+
+        /// <summary>
+        /// Builds the keyboard warning when a successful press action lacks an observed edge while unfocused.
+        /// </summary>
+        public static string BuildKeyboardInputWarning(
+            bool isEditorFocused,
+            bool isPressAction,
+            bool? pressEdgeObserved,
+            bool isSuccessful)
+        {
+            if (isEditorFocused || !isPressAction || pressEdgeObserved == true || !isSuccessful)
+            {
+                return string.Empty;
+            }
+
+            return KeyboardInputWarning;
+        }
+
+        /// <summary>
+        /// Builds the Play Mode progress hint when the Editor is unfocused during Play Mode.
+        /// </summary>
+        public static string BuildPlayModeProgressHint(bool isPlaying, bool isEditorFocused)
+        {
+            if (!isPlaying || isEditorFocused)
+            {
+                return string.Empty;
+            }
+
+            return PlayModeProgressHint;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnfocusedWarningBuilder.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnfocusedWarningBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e27f243ed3ff047f68ad1089e533052d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeResponse.cs
@@ -21,6 +21,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string Message { get; set; }
         public string Warning { get; set; } = string.Empty;
 
+        public bool ShouldSerializeWarning()
+        {
+            return !string.IsNullOrEmpty(Warning);
+        }
+
         /// <summary>
         /// Why Play Mode last stopped. Omitted when this Editor session has no confirmed stop.
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
@@ -31,13 +31,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly IEditorUnsavedChangesQuietSaver _unsavedChangesQuietSaver;
         private readonly IControlPlayModeEditorStateService _editorStateService;
         private readonly IControlPlayModeDomainReloadDropStateProvider _domainReloadDropStateProvider;
+        private readonly IEditorFocusStateProvider _editorFocusStateProvider;
 
         public ControlPlayModeUseCase(
             IControlPlayModeCompilationFailureProvider compilationFailureProvider = null,
             IControlPlayModeCompilationFailureGate compilationFailureGate = null,
             IEditorUnsavedChangesQuietSaver unsavedChangesQuietSaver = null,
             IControlPlayModeEditorStateService editorStateService = null,
-            IControlPlayModeDomainReloadDropStateProvider domainReloadDropStateProvider = null)
+            IControlPlayModeDomainReloadDropStateProvider domainReloadDropStateProvider = null,
+            IEditorFocusStateProvider editorFocusStateProvider = null)
         {
             _compilationFailureProvider =
                 compilationFailureProvider ?? ControlPlayModeServices.CompilationFailureProvider;
@@ -49,6 +51,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 editorStateService ?? ControlPlayModeServices.EditorStateService;
             _domainReloadDropStateProvider =
                 domainReloadDropStateProvider ?? ControlPlayModeServices.DomainReloadDropStateProvider;
+            _editorFocusStateProvider = editorFocusStateProvider ?? new EditorFocusStateProvider();
         }
 
         public Task<ControlPlayModeResponse> ExecuteAsync(ControlPlayModeSchema parameters, CancellationToken ct)
@@ -306,7 +309,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ResumedFromPause = resumedFromPause,
                 CompileErrors = Array.Empty<ControlPlayModeCompileError>(),
                 Message = message,
-                Warning = warning
+                Warning = JoinWarnings(
+                    warning,
+                    action == PlayModeAction.Status
+                        ? EditorUnfocusedWarningBuilder.BuildPlayModeProgressHint(
+                            _editorStateService.IsPlaying,
+                            _editorFocusStateProvider.IsFocused)
+                        : string.Empty)
             };
             PlayModeStopReasonResponseFiller.CopyConfirmedIfNeeded(response, action, wasAlreadyStopped);
 

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/Skill/SKILL.md
@@ -31,7 +31,7 @@ Returns JSON with the current play mode state:
 - `WasAlreadyStopped`: Whether `Stop` was requested while Play Mode was already stopped
 - `ResumedFromPause`: Whether `Play` resumed a paused Play Mode session instead of starting a new one
 - `Message`: Description of the action performed
-- `Warning`: Set when the action carries a caveat. A fresh `Play` start always notes that the session started from Edit-time scene state; additionally, when active hot-reload patches or enabled pause points exist and Domain Reload is enabled, it reports how many of them the Play-entry domain reload will discard.
+- `Warning` (string, optional): Set when the action carries a caveat. A fresh `Play` start always notes that the session started from Edit-time scene state; additionally, when active hot-reload patches or enabled pause points exist and Domain Reload is enabled, it reports how many of them the Play-entry domain reload will discard. `Status` also reports when Play Mode is running while the Unity Editor is unfocused, because progress may be throttled; run `uloop focus-window`, or use the `pause-point --await`/`--trigger` flow instead of polling for progress.
 - `StoppedBy` (string, optional): Why Play Mode last stopped: `cli-control-play-mode`, `cli-compile-stop-setting`, `cli-run-tests-cancel`, `script-compilation`, or `unknown`. Present on `Stop` when Play Mode was already stopped, and on `Status` when Play Mode is not running. Omitted when this Editor session has no confirmed stop.
 - `StoppedAt` (string, optional): UTC ISO 8601 timestamp of that stop. Omitted together with `StoppedBy` when no stop is recorded.
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeResponse.cs
@@ -25,6 +25,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string ErrorMessage { get; set; }
 
         /// <summary>
+        /// Optional guidance when the current Editor focus state can affect execution progress.
+        /// </summary>
+        public string Warning { get; set; } = string.Empty;
+
+        /// <summary>
         /// Error message alias for ErrorMessage.
         /// Why keep: documented tool-response JSON field (Skill/SKILL.md); agents and CLI read it.
         /// </summary>
@@ -131,6 +136,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool ShouldSerializeActivePausePointId()
         {
             return !string.IsNullOrEmpty(ActivePausePointId);
+        }
+
+        public bool ShouldSerializeWarning()
+        {
+            return !string.IsNullOrEmpty(Warning);
         }
     }
     

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
@@ -18,14 +18,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly IDynamicCodeExecutionRuntime _runtime;
         private readonly DynamicCodeExecutionResponseFactory _responseFactory;
         private readonly IDynamicCodeEditorStateReader _editorStateReader;
+        private readonly IEditorFocusStateProvider _editorFocusStateProvider;
 
         public ExecuteDynamicCodeUseCase(
             IDynamicCodeExecutionRuntime runtime,
-            IDynamicCodeEditorStateReader editorStateReader = null)
+            IDynamicCodeEditorStateReader editorStateReader = null,
+            IEditorFocusStateProvider editorFocusStateProvider = null)
         {
             _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
             _responseFactory = new DynamicCodeExecutionResponseFactory();
             _editorStateReader = editorStateReader ?? new DynamicCodeEditorStateReader();
+            _editorFocusStateProvider = editorFocusStateProvider ?? new EditorFocusStateProvider();
         }
 
         public async Task<ExecuteDynamicCodeResponse> ExecuteAsync(
@@ -153,6 +156,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 _editorStateReader.IsPaused, UloopPausePointRegistry.GetActivePausePointId());
             response.EditorPaused = editorPaused;
             response.ActivePausePointId = activePausePointId;
+            response.Warning = EditorUnfocusedWarningBuilder.BuildPlayModeProgressHint(
+                response.EditorPlaying,
+                _editorFocusStateProvider.IsFocused);
         }
 
         private static void LogExecutionStart(

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
@@ -74,5 +74,6 @@ Returns JSON:
 - `UpdatedCode`: string|null — the wrapped form actually compiled (handy when debugging using-statement reordering)
 - `DiagnosticsSummary`: string|null — compact summary when diagnostics are available
 - `Diagnostics`: object[] — structured diagnostics; same shape as `CompilationErrors`, usually populated together with it
+- `Warning` (string, optional): Set when Play Mode is running while the Unity Editor is unfocused. Progress may be throttled; run `uloop focus-window`, or use the `pause-point --await`/`--trigger` flow instead of polling for progress.
 
 On `Success: false`, inspect `CompilationErrors` first. If empty, read `ErrorMessage` (and `Logs` for extra context) — the failure may be a runtime exception, cancellation, or an "execution in progress" rejection, all of which return empty `CompilationErrors`. Both EditMode and PlayMode are supported targets — the snippet runs in whichever mode the Editor is currently in.

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/UnityCLILoop.FirstPartyTools.ExecuteDynamicCode.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/UnityCLILoop.FirstPartyTools.ExecuteDynamicCode.Editor.asmdef
@@ -2,6 +2,7 @@
     "name": "UnityCLILoop.FirstPartyTools.ExecuteDynamicCode.Editor",
     "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
     "references": [
+        "GUID:d427b32aad9cb44fc8e962437c9dbcd8",
         "GUID:214998e563c124e8a88199b2dd1f522d",
         "GUID:5c4588558a3624eacbce0f50007cf1eb",
         "GUID:fc3fd32eddbee40e39c2d76dc184957b",

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardResponse.cs
@@ -14,6 +14,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public string Message { get; set; } = "";
         public string Action { get; set; } = "";
+        public string Warning { get; set; } = "";
         // Why per-property Ignore: null optional diagnostics must not serialize as JSON null;
         // agents treat missing vs null inconsistently. Do not change global serializer settings
         // or every tool's wire contract changes. Matches Go omitempty.
@@ -122,6 +123,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool ShouldSerializeDeferredLatchSyncScheduled()
         {
             return DeferredLatchSyncScheduled;
+        }
+
+        public bool ShouldSerializeWarning()
+        {
+            return !string.IsNullOrEmpty(Warning);
         }
 
         public SimulateKeyboardResponse()

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -18,6 +18,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         // Wire-visible fragment of the paused preflight message; tests pin the composed string.
         public const string PausedActionDescription = "simulating keyboard input";
+        private readonly IEditorFocusStateProvider _editorFocusStateProvider;
+
+        public SimulateKeyboardUseCase(IEditorFocusStateProvider? editorFocusStateProvider = null)
+        {
+            _editorFocusStateProvider = editorFocusStateProvider ?? new EditorFocusStateProvider();
+        }
 
 #if !ULOOP_HAS_INPUT_SYSTEM
 #pragma warning disable CS1998
@@ -166,6 +172,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     new { Action = parameters.Action.ToString(), Success = response.Success },
                     correlationId: correlationId
                 );
+
+                await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
+                bool isPressAction = parameters.Action == UnityCliLoopKeyboardAction.Press
+                    || parameters.Action == UnityCliLoopKeyboardAction.KeyDown;
+                response.Warning = EditorUnfocusedWarningBuilder.BuildKeyboardInputWarning(
+                    _editorFocusStateProvider.IsFocused,
+                    isPressAction,
+                    response.PressEdgeObserved,
+                    response.Success);
 
                 return response;
             }

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Skill/SKILL.md
@@ -90,6 +90,7 @@ Returns JSON with:
 - `Success` (boolean): Whether the action succeeded (e.g. `KeyDown` on a not-yet-held key, `KeyUp` on a currently-held key, or `Press` round-trip)
 - `Message` (string): Description of what happened or why it failed
 - `Action` (string): The `--action` value that was applied (`Press`, `KeyDown`, `KeyUp`, or `ReleaseAll`)
+- `Warning` (string, optional): Set for a successful `Press` or `KeyDown` whose press edge was not observed while the Unity Editor is unfocused. Run `uloop focus-window` before retrying; queued input may be delivered all at once when the Editor regains focus.
 - `KeyName` (string, nullable): The key that was acted on; may be `null` when the action could not resolve a key
 - `ReleasedKeys` (string list, nullable): Set only for `ReleaseAll`; the key names that were force-released (empty when nothing was held)
 - `ReleasedKeyStates` (list, nullable): Set only for `ReleaseAll`. Each entry is `{ Key, DeviceIsPressedAfterRelease }` from a device readback after the release injection. Empty when nothing was held, or when no keyboard device is present (`KeyStateReadUpdateType` is also omitted then). If tracked keys remain with no keyboard device, `ReleasedKeys` is non-empty while `ReleasedKeyStates` is empty. Omitted (`null`) for other actions. `DeviceIsPressedAfterRelease: true` means the Input System view still reports pressed — do not treat `Success: true` as proof that gameplay polling already sees the key as up

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/UnityCLILoop.FirstPartyTools.SimulateKeyboard.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/UnityCLILoop.FirstPartyTools.SimulateKeyboard.Editor.asmdef
@@ -2,6 +2,7 @@
     "name": "UnityCLILoop.FirstPartyTools.SimulateKeyboard.Editor",
     "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
     "references": [
+        "GUID:d427b32aad9cb44fc8e962437c9dbcd8",
         "GUID:fc3fd32eddbee40e39c2d76dc184957b",
         "GUID:f1a38fcd7e85047c5a86331a3e37ddfc",
         "GUID:45d3617c96fa64d3e95383450e67f25a",


### PR DESCRIPTION
## Summary

- Surface actionable guidance when an unfocused Unity Editor can delay Play Mode progress or input observation.
- Keep normal focused and observed-input responses free of extra warnings.

## User Impact

When the Unity Editor was unfocused, agents could repeatedly poll for progress or treat queued input as a failure without seeing the cause. The affected responses now direct agents to focus the Editor or use the pause-point await/trigger flow.

## Changes

- Add a shared, testable Editor-focus provider and response-warning builder.
- Add optional response warnings and document them in the affected tool skills.
- Cover warning serialization and Control Play Mode / Execute Dynamic Code wiring with EditMode tests.

## Verification

- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>`: success, 0 errors, 1 existing fixture warning.
- Related EditMode suites: 38/38 and 8/8 passed.
- With Finder frontmost, dynamic code confirmed `EditorApplication.isFocused` was `False`; both `execute-dynamic-code` and `control-play-mode --action Status` returned the new hint.
- In the same unfocused reproduction, `simulate-keyboard --action Press --key Space` returned `PressEdgeObserved: true`, so the missing-edge condition did not reproduce. The false/null handling is covered by fixed-literal builder tests, and the focused observed response was verified to omit `Warning`.

Fixes #2383
Fixes #2238


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

