### PR TITLE
feat: add hit-when condition parser and evaluator for pause points

### DIFF
--- a/Assets/Tests/Editor/UloopPausePointHitWhenConditionTests.cs
+++ b/Assets/Tests/Editor/UloopPausePointHitWhenConditionTests.cs
@@ -1,0 +1,256 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Runtime;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies parsing and captured-variable evaluation for pause-point hit conditions.
+    /// </summary>
+    [TestFixture]
+    public sealed class UloopPausePointHitWhenConditionTests
+    {
+        /// <summary>
+        /// Verifies each supported operator and literal form parses into a reusable condition.
+        /// </summary>
+        [TestCase("speed == 1")]
+        [TestCase("speed != 1")]
+        [TestCase("speed > 1")]
+        [TestCase("speed >= 1")]
+        [TestCase("speed < 1")]
+        [TestCase("speed <= 1")]
+        [TestCase("value == null")]
+        [TestCase("value != null")]
+        [TestCase("enabled == true")]
+        [TestCase("enabled != false")]
+        [TestCase("label == \"alpha\"")]
+        [TestCase("label != 'beta'")]
+        public void Parse_WhenExpressionUsesSupportedOperatorAndLiteral_Succeeds(string expression)
+        {
+            UloopPausePointHitWhenParseResult result = UloopPausePointHitWhenCondition.Parse(expression);
+
+            Assert.That(result.Condition, Is.Not.Null);
+            Assert.That(result.Condition.Expression, Is.EqualTo(expression));
+            Assert.That(result.ErrorMessage, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// Verifies malformed expressions explain the accepted hit-when grammar.
+        /// </summary>
+        [TestCase("")]
+        [TestCase("speed ~~ 1")]
+        [TestCase("player.speed == 1")]
+        public void Parse_WhenExpressionDoesNotMatchGrammar_ReturnsGrammarError(string expression)
+        {
+            UloopPausePointHitWhenParseResult result = UloopPausePointHitWhenCondition.Parse(expression);
+
+            Assert.That(result.Condition, Is.Null);
+            Assert.That(
+                result.ErrorMessage,
+                Is.EqualTo("--hit-when must use '<name> <op> <literal>' where name is an identifier or this and op is ==, !=, >, >=, <, or <=."));
+        }
+
+        /// <summary>
+        /// Verifies unsupported literal text is rejected before the pause point is armed.
+        /// </summary>
+        [Test]
+        public void Parse_WhenLiteralIsNotSupported_ReturnsLiteralError()
+        {
+            UloopPausePointHitWhenParseResult result = UloopPausePointHitWhenCondition.Parse("speed == fast");
+
+            Assert.That(result.Condition, Is.Null);
+            Assert.That(
+                result.ErrorMessage,
+                Is.EqualTo("--hit-when literal must be null, true, false, an invariant number, or a quoted string."));
+        }
+
+        /// <summary>
+        /// Verifies non-numeric literals reject ordering operators at parse time.
+        /// </summary>
+        [TestCase("enabled > true")]
+        [TestCase("label <= \"alpha\"")]
+        [TestCase("value >= null")]
+        public void Parse_WhenNonNumericLiteralUsesOrderingOperator_ReturnsOperatorError(string expression)
+        {
+            UloopPausePointHitWhenParseResult result = UloopPausePointHitWhenCondition.Parse(expression);
+
+            Assert.That(result.Condition, Is.Null);
+            Assert.That(
+                result.ErrorMessage,
+                Is.EqualTo("--hit-when ordering operators require a numeric literal."));
+        }
+
+        /// <summary>
+        /// Verifies numeric primitive values compare through invariant double promotion.
+        /// </summary>
+        [Test]
+        public void Evaluate_WhenNumericPrimitiveValuesMeetCondition_MatchesAcrossNumericTypes()
+        {
+            UloopPausePointHitWhenCondition condition = ParseCondition("value >= 2.5");
+            UloopPausePointHitWhenEvaluation integerEvaluation = condition.Evaluate(CreateEntries("value", 3));
+            UloopPausePointHitWhenEvaluation floatEvaluation = condition.Evaluate(CreateEntries("value", 3f));
+            UloopPausePointHitWhenEvaluation doubleEvaluation = condition.Evaluate(CreateEntries("value", 3d));
+            UloopPausePointHitWhenEvaluation nonMatchEvaluation = condition.Evaluate(CreateEntries("value", 2));
+
+            Assert.That(integerEvaluation.Matched, Is.True);
+            Assert.That(integerEvaluation.ErrorMessage, Is.EqualTo(string.Empty));
+            Assert.That(floatEvaluation.Matched, Is.True);
+            Assert.That(floatEvaluation.ErrorMessage, Is.EqualTo(string.Empty));
+            Assert.That(doubleEvaluation.Matched, Is.True);
+            Assert.That(doubleEvaluation.ErrorMessage, Is.EqualTo(string.Empty));
+            Assert.That(nonMatchEvaluation.Matched, Is.False);
+            Assert.That(nonMatchEvaluation.ErrorMessage, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// Verifies boolean comparisons require and compare Boolean captured values.
+        /// </summary>
+        [Test]
+        public void Evaluate_WhenBooleanValueMatchesCondition_ReturnsMatch()
+        {
+            UloopPausePointHitWhenCondition condition = ParseCondition("enabled != false");
+            UloopPausePointHitWhenEvaluation evaluation = condition.Evaluate(CreateEntries("enabled", true));
+
+            Assert.That(evaluation.Matched, Is.True);
+            Assert.That(evaluation.ErrorMessage, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// Verifies string comparisons use ordinal matching rather than case-insensitive matching.
+        /// </summary>
+        [Test]
+        public void Evaluate_WhenStringComparisonDiffersByCase_DoesNotMatch()
+        {
+            UloopPausePointHitWhenCondition condition = ParseCondition("state == \"ready\"");
+            UloopPausePointHitWhenEvaluation evaluation = condition.Evaluate(CreateEntries("state", "Ready"));
+
+            Assert.That(evaluation.Matched, Is.False);
+            Assert.That(evaluation.ErrorMessage, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// Verifies null conditions compare only whether the captured value is null.
+        /// </summary>
+        [Test]
+        public void Evaluate_WhenNullValueMatchesNullLiteral_ReturnsMatch()
+        {
+            UloopPausePointHitWhenCondition condition = ParseCondition("value == null");
+            UloopPausePointHitWhenEvaluation evaluation = condition.Evaluate(CreateEntries("value", null));
+
+            Assert.That(evaluation.Matched, Is.True);
+            Assert.That(evaluation.ErrorMessage, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// Verifies a missing captured variable returns an evaluation error instead of throwing.
+        /// </summary>
+        [Test]
+        public void Evaluate_WhenVariableIsMissing_ReturnsLookupError()
+        {
+            UloopPausePointHitWhenCondition condition = ParseCondition("value == 1");
+            UloopPausePointHitWhenEvaluation evaluation = condition.Evaluate(new List<UloopPausePointCapturedVariableEntry>());
+
+            Assert.That(evaluation.Matched, Is.False);
+            Assert.That(
+                evaluation.ErrorMessage,
+                Is.EqualTo("--hit-when could not find variable 'value' in the captured frame."));
+        }
+
+        /// <summary>
+        /// Verifies Boolean conditions report a type error for non-Boolean captured values.
+        /// </summary>
+        [Test]
+        public void Evaluate_WhenBooleanConditionReceivesNonBooleanValue_ReturnsTypeError()
+        {
+            UloopPausePointHitWhenCondition condition = ParseCondition("enabled == true");
+            UloopPausePointHitWhenEvaluation evaluation = condition.Evaluate(CreateEntries("enabled", "true"));
+
+            Assert.That(evaluation.Matched, Is.False);
+            Assert.That(
+                evaluation.ErrorMessage,
+                Is.EqualTo("--hit-when expected variable 'enabled' to be Boolean."));
+        }
+
+        /// <summary>
+        /// Verifies numeric conditions reject non-numeric primitive values such as char.
+        /// </summary>
+        [Test]
+        public void Evaluate_WhenNumericConditionReceivesChar_ReturnsTypeError()
+        {
+            UloopPausePointHitWhenCondition condition = ParseCondition("value > 1");
+            UloopPausePointHitWhenEvaluation evaluation = condition.Evaluate(CreateEntries("value", '1'));
+
+            Assert.That(evaluation.Matched, Is.False);
+            Assert.That(
+                evaluation.ErrorMessage,
+                Is.EqualTo("--hit-when expected variable 'value' to be a numeric primitive."));
+        }
+
+        /// <summary>
+        /// Verifies string conditions report a type error for non-string captured values.
+        /// </summary>
+        [Test]
+        public void Evaluate_WhenStringConditionReceivesNonStringValue_ReturnsTypeError()
+        {
+            UloopPausePointHitWhenCondition condition = ParseCondition("state == \"ready\"");
+            UloopPausePointHitWhenEvaluation evaluation = condition.Evaluate(CreateEntries("state", 1));
+
+            Assert.That(evaluation.Matched, Is.False);
+            Assert.That(
+                evaluation.ErrorMessage,
+                Is.EqualTo("--hit-when expected variable 'state' to be String."));
+        }
+
+        /// <summary>
+        /// Verifies the synthetic this entry is available as a valid condition name.
+        /// </summary>
+        [Test]
+        public void Evaluate_WhenThisEntryMatchesNullLiteral_ReturnsMatch()
+        {
+            UloopPausePointHitWhenCondition condition = ParseCondition("this == null");
+            UloopPausePointHitWhenEvaluation evaluation = condition.Evaluate(CreateEntries("this", null));
+
+            Assert.That(evaluation.Matched, Is.True);
+            Assert.That(evaluation.ErrorMessage, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// Verifies duplicate names use the first captured entry, preserving collector precedence.
+        /// </summary>
+        [Test]
+        public void Evaluate_WhenVariableNameIsDuplicated_UsesFirstCapturedEntry()
+        {
+            UloopPausePointHitWhenCondition condition = ParseCondition("score == 1");
+            List<UloopPausePointCapturedVariableEntry> entries = new List<UloopPausePointCapturedVariableEntry>
+            {
+                new UloopPausePointCapturedVariableEntry("score", UloopCapturedVariableScope.Local, 1),
+                new UloopPausePointCapturedVariableEntry("score", UloopCapturedVariableScope.InstanceField, 2),
+            };
+            UloopPausePointHitWhenEvaluation evaluation = condition.Evaluate(entries);
+
+            Assert.That(evaluation.Matched, Is.True);
+            Assert.That(evaluation.ErrorMessage, Is.EqualTo(string.Empty));
+        }
+
+        // Keeps test setup concise while preserving the same local scope used by collected variables.
+        private static List<UloopPausePointCapturedVariableEntry> CreateEntries(string name, object value)
+        {
+            return new List<UloopPausePointCapturedVariableEntry>
+            {
+                new UloopPausePointCapturedVariableEntry(name, UloopCapturedVariableScope.Local, value),
+            };
+        }
+
+        // Fails immediately when a parser test accidentally exercises an invalid expression.
+        private static UloopPausePointHitWhenCondition ParseCondition(string expression)
+        {
+            UloopPausePointHitWhenParseResult result = UloopPausePointHitWhenCondition.Parse(expression);
+
+            Assert.That(result.ErrorMessage, Is.EqualTo(string.Empty));
+            Assert.That(result.Condition, Is.Not.Null);
+            return result.Condition;
+        }
+    }
+}

--- a/Assets/Tests/Editor/UloopPausePointHitWhenConditionTests.cs
+++ b/Assets/Tests/Editor/UloopPausePointHitWhenConditionTests.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 
 using NUnit.Framework;
 
+using UnityEngine;
+
 using io.github.hatayama.UnityCliLoop.Runtime;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
@@ -59,6 +61,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void Parse_WhenLiteralIsNotSupported_ReturnsLiteralError()
         {
             UloopPausePointHitWhenParseResult result = UloopPausePointHitWhenCondition.Parse("speed == fast");
+
+            Assert.That(result.Condition, Is.Null);
+            Assert.That(
+                result.ErrorMessage,
+                Is.EqualTo("--hit-when literal must be null, true, false, an invariant number, or a quoted string."));
+        }
+
+        /// <summary>
+        /// Verifies unescaped delimiter characters inside quoted literals are rejected.
+        /// </summary>
+        [TestCase("label == \"a\" \"b\"")]
+        [TestCase("label == 'a' 'b'")]
+        public void Parse_WhenQuotedLiteralContainsItsDelimiter_ReturnsLiteralError(string expression)
+        {
+            UloopPausePointHitWhenParseResult result = UloopPausePointHitWhenCondition.Parse(expression);
 
             Assert.That(result.Condition, Is.Null);
             Assert.That(
@@ -141,6 +158,47 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(evaluation.Matched, Is.True);
             Assert.That(evaluation.ErrorMessage, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// Verifies destroyed Unity objects use Unity fake-null semantics for null conditions.
+        /// </summary>
+        [Test]
+        public void Evaluate_WhenUnityObjectWasDestroyed_MatchesNullLiteral()
+        {
+            ScriptableObject destroyedObject = ScriptableObject.CreateInstance<ScriptableObject>();
+            Object.DestroyImmediate(destroyedObject);
+            UloopPausePointHitWhenCondition condition = ParseCondition("value == null");
+            UloopPausePointHitWhenEvaluation evaluation = condition.Evaluate(CreateEntries("value", destroyedObject));
+
+            Assert.That(evaluation.Matched, Is.True);
+            Assert.That(evaluation.ErrorMessage, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// Verifies every numeric comparison operator distinguishes matching and non-matching values.
+        /// </summary>
+        [TestCase("value == 5", 5, true, 4, false)]
+        [TestCase("value != 5", 4, true, 5, false)]
+        [TestCase("value > 5", 6, true, 5, false)]
+        [TestCase("value >= 5", 5, true, 4, false)]
+        [TestCase("value < 5", 4, true, 5, false)]
+        [TestCase("value <= 5", 5, true, 6, false)]
+        public void Evaluate_WhenNumericOperatorIsUsed_ReturnsExpectedMatchStates(
+            string expression,
+            int matchingValue,
+            bool expectedMatch,
+            int nonMatchingValue,
+            bool expectedNonMatch)
+        {
+            UloopPausePointHitWhenCondition condition = ParseCondition(expression);
+            UloopPausePointHitWhenEvaluation matchingEvaluation = condition.Evaluate(CreateEntries("value", matchingValue));
+            UloopPausePointHitWhenEvaluation nonMatchingEvaluation = condition.Evaluate(CreateEntries("value", nonMatchingValue));
+
+            Assert.That(matchingEvaluation.Matched, Is.EqualTo(expectedMatch));
+            Assert.That(matchingEvaluation.ErrorMessage, Is.EqualTo(string.Empty));
+            Assert.That(nonMatchingEvaluation.Matched, Is.EqualTo(expectedNonMatch));
+            Assert.That(nonMatchingEvaluation.ErrorMessage, Is.EqualTo(string.Empty));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/UloopPausePointHitWhenConditionTests.cs.meta
+++ b/Assets/Tests/Editor/UloopPausePointHitWhenConditionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe3c02ee5bb5a4793b46f649852fe088
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Runtime/PausePoints/UloopPausePointHitWhenCondition.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointHitWhenCondition.cs
@@ -1,0 +1,354 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace io.github.hatayama.UnityCliLoop.Runtime
+{
+    /// <summary>
+    /// Holds either a parsed hit condition or the error that prevented arming it.
+    /// </summary>
+    internal sealed class UloopPausePointHitWhenParseResult
+    {
+        public UloopPausePointHitWhenParseResult(UloopPausePointHitWhenCondition condition, string errorMessage)
+        {
+            Condition = condition;
+            ErrorMessage = errorMessage ?? string.Empty;
+        }
+
+        public UloopPausePointHitWhenCondition Condition { get; }
+        public string ErrorMessage { get; }
+    }
+
+    /// <summary>
+    /// Holds the match decision or a recoverable error from evaluating a captured frame.
+    /// </summary>
+    internal sealed class UloopPausePointHitWhenEvaluation
+    {
+        public UloopPausePointHitWhenEvaluation(bool matched, string errorMessage)
+        {
+            Matched = matched;
+            ErrorMessage = errorMessage ?? string.Empty;
+        }
+
+        public bool Matched { get; }
+        public string ErrorMessage { get; }
+    }
+
+    /// <summary>
+    /// Parses and evaluates the intentionally small hit-when condition language.
+    /// </summary>
+    internal sealed class UloopPausePointHitWhenCondition
+    {
+        private const string GrammarError = "--hit-when must use '<name> <op> <literal>' where name is an identifier or this and op is ==, !=, >, >=, <, or <=.";
+        private const string LiteralError = "--hit-when literal must be null, true, false, an invariant number, or a quoted string.";
+        private const string OrderingOperatorError = "--hit-when ordering operators require a numeric literal.";
+        private static readonly Regex ExpressionPattern = new Regex(
+            "^\\s*(this|[A-Za-z_][A-Za-z0-9_]*)\\s*(==|!=|>=|<=|>|<)\\s*(.+?)\\s*$",
+            RegexOptions.CultureInvariant);
+
+        private readonly string _variableName;
+        private readonly UloopPausePointHitWhenOperator _operator;
+        private readonly UloopPausePointHitWhenLiteralKind _literalKind;
+        private readonly bool _booleanLiteral;
+        private readonly double _numericLiteral;
+        private readonly string _stringLiteral;
+
+        private UloopPausePointHitWhenCondition(
+            string expression,
+            string variableName,
+            UloopPausePointHitWhenOperator comparisonOperator,
+            UloopPausePointHitWhenLiteralKind literalKind,
+            bool booleanLiteral,
+            double numericLiteral,
+            string stringLiteral)
+        {
+            Expression = expression;
+            _variableName = variableName;
+            _operator = comparisonOperator;
+            _literalKind = literalKind;
+            _booleanLiteral = booleanLiteral;
+            _numericLiteral = numericLiteral;
+            _stringLiteral = stringLiteral;
+        }
+
+        public string Expression { get; }
+
+        /// <summary>
+        /// Parses the condition before it is attached to an enabled pause point.
+        /// </summary>
+        public static UloopPausePointHitWhenParseResult Parse(string expression)
+        {
+            if (string.IsNullOrWhiteSpace(expression))
+            {
+                return new UloopPausePointHitWhenParseResult(null, GrammarError);
+            }
+
+            Match match = ExpressionPattern.Match(expression);
+            if (!match.Success)
+            {
+                return new UloopPausePointHitWhenParseResult(null, GrammarError);
+            }
+
+            string variableName = match.Groups[1].Value;
+            string operatorText = match.Groups[2].Value;
+            string literalText = match.Groups[3].Value;
+            UloopPausePointHitWhenOperator comparisonOperator = ParseOperator(operatorText);
+            UloopPausePointHitWhenLiteralKind literalKind = UloopPausePointHitWhenLiteralKind.None;
+            bool booleanLiteral = false;
+            double numericLiteral = 0;
+            string stringLiteral = string.Empty;
+
+            if (string.Equals(literalText, "null", StringComparison.Ordinal))
+            {
+                literalKind = UloopPausePointHitWhenLiteralKind.Null;
+            }
+            else if (string.Equals(literalText, "true", StringComparison.Ordinal))
+            {
+                literalKind = UloopPausePointHitWhenLiteralKind.Boolean;
+                booleanLiteral = true;
+            }
+            else if (string.Equals(literalText, "false", StringComparison.Ordinal))
+            {
+                literalKind = UloopPausePointHitWhenLiteralKind.Boolean;
+            }
+            else if (IsQuotedString(literalText))
+            {
+                literalKind = UloopPausePointHitWhenLiteralKind.String;
+                stringLiteral = literalText.Substring(1, literalText.Length - 2);
+            }
+            else if (double.TryParse(
+                         literalText,
+                         NumberStyles.Float,
+                         CultureInfo.InvariantCulture,
+                         out double parsedNumber))
+            {
+                literalKind = UloopPausePointHitWhenLiteralKind.Number;
+                numericLiteral = parsedNumber;
+            }
+            else
+            {
+                return new UloopPausePointHitWhenParseResult(null, LiteralError);
+            }
+
+            if (literalKind != UloopPausePointHitWhenLiteralKind.Number
+                && IsOrderingOperator(comparisonOperator))
+            {
+                return new UloopPausePointHitWhenParseResult(null, OrderingOperatorError);
+            }
+
+            UloopPausePointHitWhenCondition condition = new UloopPausePointHitWhenCondition(
+                expression,
+                variableName,
+                comparisonOperator,
+                literalKind,
+                booleanLiteral,
+                numericLiteral,
+                stringLiteral);
+            return new UloopPausePointHitWhenParseResult(condition, string.Empty);
+        }
+
+        /// <summary>
+        /// Evaluates this condition against captured variables in their collector-defined precedence order.
+        /// </summary>
+        public UloopPausePointHitWhenEvaluation Evaluate(IReadOnlyList<UloopPausePointCapturedVariableEntry> entries)
+        {
+            UloopPausePointCapturedVariableEntry entry = FindEntry(entries);
+            if (entry == null)
+            {
+                return new UloopPausePointHitWhenEvaluation(
+                    false,
+                    $"--hit-when could not find variable '{_variableName}' in the captured frame.");
+            }
+
+            if (_literalKind == UloopPausePointHitWhenLiteralKind.Null)
+            {
+                return EvaluateEquality(entry.Value == null);
+            }
+
+            if (_literalKind == UloopPausePointHitWhenLiteralKind.Boolean)
+            {
+                if (!(entry.Value is bool))
+                {
+                    return new UloopPausePointHitWhenEvaluation(
+                        false,
+                        $"--hit-when expected variable '{_variableName}' to be Boolean.");
+                }
+
+                bool capturedBoolean = (bool)entry.Value;
+                return EvaluateEquality(capturedBoolean == _booleanLiteral);
+            }
+
+            if (_literalKind == UloopPausePointHitWhenLiteralKind.String)
+            {
+                if (!(entry.Value is string))
+                {
+                    return new UloopPausePointHitWhenEvaluation(
+                        false,
+                        $"--hit-when expected variable '{_variableName}' to be String.");
+                }
+
+                string capturedString = (string)entry.Value;
+                return EvaluateEquality(string.Equals(capturedString, _stringLiteral, StringComparison.Ordinal));
+            }
+
+            if (!IsNumericPrimitive(entry.Value))
+            {
+                return new UloopPausePointHitWhenEvaluation(
+                    false,
+                    $"--hit-when expected variable '{_variableName}' to be a numeric primitive.");
+            }
+
+            double capturedNumber = Convert.ToDouble(entry.Value, CultureInfo.InvariantCulture);
+            return EvaluateNumber(capturedNumber);
+        }
+
+        // Keeps operator parsing explicit because the grammar accepts a closed set and should not
+        // silently begin accepting enum spellings or future operators.
+        private static UloopPausePointHitWhenOperator ParseOperator(string operatorText)
+        {
+            if (string.Equals(operatorText, "==", StringComparison.Ordinal))
+            {
+                return UloopPausePointHitWhenOperator.Equal;
+            }
+
+            if (string.Equals(operatorText, "!=", StringComparison.Ordinal))
+            {
+                return UloopPausePointHitWhenOperator.NotEqual;
+            }
+
+            if (string.Equals(operatorText, ">", StringComparison.Ordinal))
+            {
+                return UloopPausePointHitWhenOperator.GreaterThan;
+            }
+
+            if (string.Equals(operatorText, ">=", StringComparison.Ordinal))
+            {
+                return UloopPausePointHitWhenOperator.GreaterThanOrEqual;
+            }
+
+            if (string.Equals(operatorText, "<", StringComparison.Ordinal))
+            {
+                return UloopPausePointHitWhenOperator.LessThan;
+            }
+
+            return UloopPausePointHitWhenOperator.LessThanOrEqual;
+        }
+
+        // The parse-time literal rule makes this check the single authority for rejecting ordering
+        // comparisons that cannot be evaluated consistently across runtime value types.
+        private static bool IsOrderingOperator(UloopPausePointHitWhenOperator comparisonOperator)
+        {
+            return comparisonOperator == UloopPausePointHitWhenOperator.GreaterThan
+                || comparisonOperator == UloopPausePointHitWhenOperator.GreaterThanOrEqual
+                || comparisonOperator == UloopPausePointHitWhenOperator.LessThan
+                || comparisonOperator == UloopPausePointHitWhenOperator.LessThanOrEqual;
+        }
+
+        // Quoted strings intentionally have no escape syntax, keeping this arm-time filter small
+        // and avoiding a second language with string interpolation or member access semantics.
+        private static bool IsQuotedString(string literalText)
+        {
+            if (literalText.Length < 2)
+            {
+                return false;
+            }
+
+            char firstCharacter = literalText[0];
+            char lastCharacter = literalText[literalText.Length - 1];
+            return (firstCharacter == '\'' || firstCharacter == '"') && firstCharacter == lastCharacter;
+        }
+
+        // Convert.ToDouble is safe only after this exact primitive whitelist, so enums, chars,
+        // strings, and arbitrary objects become recoverable evaluation errors instead of throws.
+        private static bool IsNumericPrimitive(object value)
+        {
+            return value is sbyte
+                || value is byte
+                || value is short
+                || value is ushort
+                || value is int
+                || value is uint
+                || value is long
+                || value is ulong
+                || value is float
+                || value is double
+                || value is decimal;
+        }
+
+        // The collector already orders locals, parameters, and fields. Stopping at the first name
+        // preserves that precedence instead of introducing a separate condition-specific lookup rule.
+        private UloopPausePointCapturedVariableEntry FindEntry(
+            IReadOnlyList<UloopPausePointCapturedVariableEntry> entries)
+        {
+            foreach (UloopPausePointCapturedVariableEntry entry in entries)
+            {
+                if (string.Equals(entry.Name, _variableName, StringComparison.Ordinal))
+                {
+                    return entry;
+                }
+            }
+
+            return null;
+        }
+
+        private UloopPausePointHitWhenEvaluation EvaluateEquality(bool valuesAreEqual)
+        {
+            bool matched = _operator == UloopPausePointHitWhenOperator.Equal
+                ? valuesAreEqual
+                : !valuesAreEqual;
+            return new UloopPausePointHitWhenEvaluation(matched, string.Empty);
+        }
+
+        private UloopPausePointHitWhenEvaluation EvaluateNumber(double capturedNumber)
+        {
+            if (_operator == UloopPausePointHitWhenOperator.Equal)
+            {
+                return new UloopPausePointHitWhenEvaluation(capturedNumber == _numericLiteral, string.Empty);
+            }
+
+            if (_operator == UloopPausePointHitWhenOperator.NotEqual)
+            {
+                return new UloopPausePointHitWhenEvaluation(capturedNumber != _numericLiteral, string.Empty);
+            }
+
+            if (_operator == UloopPausePointHitWhenOperator.GreaterThan)
+            {
+                return new UloopPausePointHitWhenEvaluation(capturedNumber > _numericLiteral, string.Empty);
+            }
+
+            if (_operator == UloopPausePointHitWhenOperator.GreaterThanOrEqual)
+            {
+                return new UloopPausePointHitWhenEvaluation(capturedNumber >= _numericLiteral, string.Empty);
+            }
+
+            if (_operator == UloopPausePointHitWhenOperator.LessThan)
+            {
+                return new UloopPausePointHitWhenEvaluation(capturedNumber < _numericLiteral, string.Empty);
+            }
+
+            return new UloopPausePointHitWhenEvaluation(capturedNumber <= _numericLiteral, string.Empty);
+        }
+
+        private enum UloopPausePointHitWhenOperator
+        {
+            Equal,
+            NotEqual,
+            GreaterThan,
+            GreaterThanOrEqual,
+            LessThan,
+            LessThanOrEqual,
+        }
+
+        private enum UloopPausePointHitWhenLiteralKind
+        {
+            None,
+            Null,
+            Boolean,
+            Number,
+            String,
+        }
+    }
+}
+#endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointHitWhenCondition.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointHitWhenCondition.cs
@@ -164,7 +164,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
             if (_literalKind == UloopPausePointHitWhenLiteralKind.Null)
             {
-                return EvaluateEquality(entry.Value == null);
+                return EvaluateEquality(IsNullValue(entry.Value));
             }
 
             if (_literalKind == UloopPausePointHitWhenLiteralKind.Boolean)
@@ -246,8 +246,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 || comparisonOperator == UloopPausePointHitWhenOperator.LessThanOrEqual;
         }
 
-        // Quoted strings intentionally have no escape syntax, keeping this arm-time filter small
-        // and avoiding a second language with string interpolation or member access semantics.
+        // Quoted strings intentionally have no escape syntax, so embedded delimiters are rejected
+        // instead of being silently interpreted as a second unmodelled literal language.
         private static bool IsQuotedString(string literalText)
         {
             if (literalText.Length < 2)
@@ -257,7 +257,25 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
             char firstCharacter = literalText[0];
             char lastCharacter = literalText[literalText.Length - 1];
-            return (firstCharacter == '\'' || firstCharacter == '"') && firstCharacter == lastCharacter;
+            if ((firstCharacter != '\'' && firstCharacter != '"') || firstCharacter != lastCharacter)
+            {
+                return false;
+            }
+
+            string content = literalText.Substring(1, literalText.Length - 2);
+            return content.IndexOf(firstCharacter) < 0;
+        }
+
+        // UnityEngine.Object overloads equality to report destroyed objects as null, while the
+        // object-typed captured value would otherwise use reference equality and invert that result.
+        private static bool IsNullValue(object value)
+        {
+            if (value is UnityEngine.Object unityObject)
+            {
+                return unityObject == null;
+            }
+
+            return value == null;
         }
 
         // Convert.ToDouble is safe only after this exact primitive whitelist, so enums, chars,

--- a/Packages/src/Runtime/PausePoints/UloopPausePointHitWhenCondition.cs.meta
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointHitWhenCondition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b3646a46b1b684de7a004b74359feeb8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- Add a constrained parser and evaluator for pause-point `--hit-when` conditions.
- Support identifier or `this` names, comparison operators, and null, Boolean, numeric, and quoted-string literals.
- Return parse and evaluation errors as result data so future capture wiring can handle them without dynamic expression compilation.

## Verification

- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value 'UloopPausePointHitWhenConditionTests' --timeout-seconds 600` (29 passed)
- Full EditMode suite executed as a single Test Runner session.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

