### PR TITLE
docs: explain conditional capture with hit-when in the pause-point skill

### DIFF
--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -100,7 +100,7 @@ Choose the capture mode when enabling a pause point:
 - `continuous` pauses Unity on every hit and remains armed.
 - `trace` remains armed and records each hit without pausing Unity.
 - In every mode, `CapturedVariables` holds the latest hit and `CapturedVariableHistory` holds only strictly older frames, so with a single hit the history is empty (for `single-shot` it always is). When the latest-hit frame is excluded, `CapturedVariableHistoryNote` explains that the latest hit's variables are in `CapturedVariables`.
-- Prefer tracing a line that executes conditionally: a line that runs every frame fills the capped history within a fraction of a second and drops everything recorded before it.
+- Prefer tracing a line that executes conditionally: a line that runs every frame fills the capped history within a fraction of a second and drops everything recorded before it. When only an every-frame line is available, gate it with `--hit-when` (see below).
 - On every Hit, the response carries a StatusNote. In trace mode it says Play Mode was not paused (the marker fired while the game kept running). In single-shot and continuous it says Unity pauses at the next frame boundary, so live reads after the hit reflect post-frame state; use CapturedVariables for at-line values.
 - An Expired response carries a RecommendedNextAction: re-enable the pause point with a longer --timeout-seconds (default 30) and trigger the code path again; clearing the expired marker first is not required.
 - Expired responses include `MethodEntryCount`: `0` means the armed method was never invoked; a positive value means the method ran but never reached the armed line (branch not taken). For `async` and iterator methods the count is state-machine `MoveNext` entries, so each `await` resumption increments it.
@@ -108,6 +108,17 @@ Choose the capture mode when enabling a pause point:
 - For an already-hit `continuous` or `trace` marker, `await-pause-point` waits for a **new** hit after the wait starts (`LastHitSequence` advancing). It does not return the stale hit that is already present. Read the current hit with `pause-point-status` instead. If await times out while waiting for that new hit, the error stays `PAUSE_POINT_WAIT_TIMEOUT` and `Details.Hint` tells you to pass `--resume-play` (or resume Play Mode) so another hit can occur. A freshly enabled marker (including `enable-pause-point --await`) has no prior hit, so the first hit satisfies the wait as before.
 
 `--max-history` defaults to 20 and accepts values from 1 through 100. When the limit is exceeded, the oldest frames are dropped and `HistoryDroppedCount` reports how many were removed. `pause-point-status` returns the current `Mode`, `MaxHistory`, history frames, and dropped count.
+
+### Conditional capture with `--hit-when`
+
+`--hit-when "<name> <op> <literal>"` (file:line markers only) evaluates the named captured variable — a local, parameter, field, or `this` — every time the line executes, and turns only matching executions into hits: non-matching executions do not pause Unity, do not enter `trace` history, and are counted in `HitWhenSkippedCount` instead.
+
+- Operators are `==`, `!=`, `>`, `>=`, `<`, `<=`. Literals are `null`, `true`/`false`, an invariant-culture number, or a quoted string (`'…'` or `"…"`, no escape syntax). Ordering operators require a numeric literal.
+- The comparison runs against the live runtime value, not the serialized `Value` string: string literals compare ordinally to string variables, and numeric literals compare to numeric primitives (enums and chars do not qualify). Numeric comparisons are evaluated in `double`, so `==` on floats or on integers beyond double's exact integer range can miss — prefer `>=`/`<=` ranges there.
+- Evaluation problems fail open: a missing variable name or a type mismatch still captures the hit, and `HitWhenErrorNote` reports the first such error.
+- Responses echo the armed condition in `HitWhen`. When the line executed but nothing matched, `pause-point-status` adds `HitWhenNote`, and `await-pause-point` timeout/expiry errors report the skip count instead of claiming the line never ran.
+
+On a line that runs every frame, raising `--max-history` cannot preserve an arbitrary later frame: at 60 fps even `--max-history 100` holds only about 1.6 seconds before the oldest frames drop. When a condition identifies the frames you care about, arm with `--hit-when` so only matching hits consume history.
 
 Re-enabling the same `file:line` replaces the marker instead of updating it: the
 marker starts a new generation and the previous `CapturedVariableHistory` is

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -100,7 +100,7 @@ Choose the capture mode when enabling a pause point:
 - `continuous` pauses Unity on every hit and remains armed.
 - `trace` remains armed and records each hit without pausing Unity.
 - In every mode, `CapturedVariables` holds the latest hit and `CapturedVariableHistory` holds only strictly older frames, so with a single hit the history is empty (for `single-shot` it always is). When the latest-hit frame is excluded, `CapturedVariableHistoryNote` explains that the latest hit's variables are in `CapturedVariables`.
-- Prefer tracing a line that executes conditionally: a line that runs every frame fills the capped history within a fraction of a second and drops everything recorded before it.
+- Prefer tracing a line that executes conditionally: a line that runs every frame fills the capped history within a fraction of a second and drops everything recorded before it. When only an every-frame line is available, gate it with `--hit-when` (see below).
 - On every Hit, the response carries a StatusNote. In trace mode it says Play Mode was not paused (the marker fired while the game kept running). In single-shot and continuous it says Unity pauses at the next frame boundary, so live reads after the hit reflect post-frame state; use CapturedVariables for at-line values.
 - An Expired response carries a RecommendedNextAction: re-enable the pause point with a longer --timeout-seconds (default 30) and trigger the code path again; clearing the expired marker first is not required.
 - Expired responses include `MethodEntryCount`: `0` means the armed method was never invoked; a positive value means the method ran but never reached the armed line (branch not taken). For `async` and iterator methods the count is state-machine `MoveNext` entries, so each `await` resumption increments it.
@@ -108,6 +108,17 @@ Choose the capture mode when enabling a pause point:
 - For an already-hit `continuous` or `trace` marker, `await-pause-point` waits for a **new** hit after the wait starts (`LastHitSequence` advancing). It does not return the stale hit that is already present. Read the current hit with `pause-point-status` instead. If await times out while waiting for that new hit, the error stays `PAUSE_POINT_WAIT_TIMEOUT` and `Details.Hint` tells you to pass `--resume-play` (or resume Play Mode) so another hit can occur. A freshly enabled marker (including `enable-pause-point --await`) has no prior hit, so the first hit satisfies the wait as before.
 
 `--max-history` defaults to 20 and accepts values from 1 through 100. When the limit is exceeded, the oldest frames are dropped and `HistoryDroppedCount` reports how many were removed. `pause-point-status` returns the current `Mode`, `MaxHistory`, history frames, and dropped count.
+
+### Conditional capture with `--hit-when`
+
+`--hit-when "<name> <op> <literal>"` (file:line markers only) evaluates the named captured variable — a local, parameter, field, or `this` — every time the line executes, and turns only matching executions into hits: non-matching executions do not pause Unity, do not enter `trace` history, and are counted in `HitWhenSkippedCount` instead.
+
+- Operators are `==`, `!=`, `>`, `>=`, `<`, `<=`. Literals are `null`, `true`/`false`, an invariant-culture number, or a quoted string (`'…'` or `"…"`, no escape syntax). Ordering operators require a numeric literal.
+- The comparison runs against the live runtime value, not the serialized `Value` string: string literals compare ordinally to string variables, and numeric literals compare to numeric primitives (enums and chars do not qualify). Numeric comparisons are evaluated in `double`, so `==` on floats or on integers beyond double's exact integer range can miss — prefer `>=`/`<=` ranges there.
+- Evaluation problems fail open: a missing variable name or a type mismatch still captures the hit, and `HitWhenErrorNote` reports the first such error.
+- Responses echo the armed condition in `HitWhen`. When the line executed but nothing matched, `pause-point-status` adds `HitWhenNote`, and `await-pause-point` timeout/expiry errors report the skip count instead of claiming the line never ran.
+
+On a line that runs every frame, raising `--max-history` cannot preserve an arbitrary later frame: at 60 fps even `--max-history 100` holds only about 1.6 seconds before the oldest frames drop. When a condition identifies the frames you care about, arm with `--hit-when` so only matching hits consume history.
 
 Re-enabling the same `file:line` replaces the marker instead of updating it: the
 marker starts a new generation and the previous `CapturedVariableHistory` is

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -100,7 +100,7 @@ Choose the capture mode when enabling a pause point:
 - `continuous` pauses Unity on every hit and remains armed.
 - `trace` remains armed and records each hit without pausing Unity.
 - In every mode, `CapturedVariables` holds the latest hit and `CapturedVariableHistory` holds only strictly older frames, so with a single hit the history is empty (for `single-shot` it always is). When the latest-hit frame is excluded, `CapturedVariableHistoryNote` explains that the latest hit's variables are in `CapturedVariables`.
-- Prefer tracing a line that executes conditionally: a line that runs every frame fills the capped history within a fraction of a second and drops everything recorded before it.
+- Prefer tracing a line that executes conditionally: a line that runs every frame fills the capped history within a fraction of a second and drops everything recorded before it. When only an every-frame line is available, gate it with `--hit-when` (see below).
 - On every Hit, the response carries a StatusNote. In trace mode it says Play Mode was not paused (the marker fired while the game kept running). In single-shot and continuous it says Unity pauses at the next frame boundary, so live reads after the hit reflect post-frame state; use CapturedVariables for at-line values.
 - An Expired response carries a RecommendedNextAction: re-enable the pause point with a longer --timeout-seconds (default 30) and trigger the code path again; clearing the expired marker first is not required.
 - Expired responses include `MethodEntryCount`: `0` means the armed method was never invoked; a positive value means the method ran but never reached the armed line (branch not taken). For `async` and iterator methods the count is state-machine `MoveNext` entries, so each `await` resumption increments it.
@@ -108,6 +108,17 @@ Choose the capture mode when enabling a pause point:
 - For an already-hit `continuous` or `trace` marker, `await-pause-point` waits for a **new** hit after the wait starts (`LastHitSequence` advancing). It does not return the stale hit that is already present. Read the current hit with `pause-point-status` instead. If await times out while waiting for that new hit, the error stays `PAUSE_POINT_WAIT_TIMEOUT` and `Details.Hint` tells you to pass `--resume-play` (or resume Play Mode) so another hit can occur. A freshly enabled marker (including `enable-pause-point --await`) has no prior hit, so the first hit satisfies the wait as before.
 
 `--max-history` defaults to 20 and accepts values from 1 through 100. When the limit is exceeded, the oldest frames are dropped and `HistoryDroppedCount` reports how many were removed. `pause-point-status` returns the current `Mode`, `MaxHistory`, history frames, and dropped count.
+
+### Conditional capture with `--hit-when`
+
+`--hit-when "<name> <op> <literal>"` (file:line markers only) evaluates the named captured variable — a local, parameter, field, or `this` — every time the line executes, and turns only matching executions into hits: non-matching executions do not pause Unity, do not enter `trace` history, and are counted in `HitWhenSkippedCount` instead.
+
+- Operators are `==`, `!=`, `>`, `>=`, `<`, `<=`. Literals are `null`, `true`/`false`, an invariant-culture number, or a quoted string (`'…'` or `"…"`, no escape syntax). Ordering operators require a numeric literal.
+- The comparison runs against the live runtime value, not the serialized `Value` string: string literals compare ordinally to string variables, and numeric literals compare to numeric primitives (enums and chars do not qualify). Numeric comparisons are evaluated in `double`, so `==` on floats or on integers beyond double's exact integer range can miss — prefer `>=`/`<=` ranges there.
+- Evaluation problems fail open: a missing variable name or a type mismatch still captures the hit, and `HitWhenErrorNote` reports the first such error.
+- Responses echo the armed condition in `HitWhen`. When the line executed but nothing matched, `pause-point-status` adds `HitWhenNote`, and `await-pause-point` timeout/expiry errors report the skip count instead of claiming the line never ran.
+
+On a line that runs every frame, raising `--max-history` cannot preserve an arbitrary later frame: at 60 fps even `--max-history 100` holds only about 1.6 seconds before the oldest frames drop. When a condition identifies the frames you care about, arm with `--hit-when` so only matching hits consume history.
 
 Re-enabling the same `file:line` replaces the marker instead of updating it: the
 marker starts a new generation and the previous `CapturedVariableHistory` is


### PR DESCRIPTION
## Summary

- Explain how `--hit-when` conditionally captures pause-point hits from live runtime values.
- Show how conditional capture preserves relevant trace frames on every-frame lines.

## User Impact

Agents can choose a conditional capture expression, understand its comparison rules and precision limits, and interpret skipped-hit diagnostics without mistaking an executed line for an unexecuted one.

## Changes

- Document the closed condition grammar, fail-open evaluation behavior, and response fields.
- Add 60 fps trace-history overflow guidance and regenerate the installed skill copies.

## Verification

- `dist/darwin-arm64/uloop skills install --claude --agents`
- `scripts/sync-tool-docs.sh --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

