### PR TITLE
feat: return opted-in partial results when dynamic code throws

### DIFF
--- a/.agents/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.agents/skills/uloop-execute-dynamic-code/SKILL.md
@@ -69,11 +69,20 @@ Returns JSON:
 - `Success`: boolean — overall execution success
 - `Result`: string — value of the snippet's `return` statement (empty when omitted)
 - `Logs`: string[] — execution messages from the dynamic-code tool; read Unity Console `Debug.Log` output with `get-logs`
+- `PartialResults` (object, optional): values that a snippet explicitly saves before it completes or fails
 - `CompilationErrors`: object[] — Roslyn diagnostics with `Message`, `Line`, `Column`, `ErrorCode`, optional `Hint` and `Suggestions`
 - `Error` / `ErrorMessage`: string — top-level failure summary (empty on success)
 - `UpdatedCode`: string|null — the wrapped form actually compiled (handy when debugging using-statement reordering)
 - `DiagnosticsSummary`: string|null — compact summary when diagnostics are available
 - `Diagnostics`: object[] — structured diagnostics; same shape as `CompilationErrors`, usually populated together with it
 - `Warning` (string, optional): Set when Play Mode is running while the Unity Editor is unfocused. Progress may be throttled; run `uloop focus-window`, or use the `pause-point --await`/`--trigger` flow instead of polling for progress.
+
+To retain an intermediate value across a later exception, opt in before the risky code:
+
+```csharp
+UloopDynamicCodePartialResults.Set("completedSteps", completedSteps);
+```
+
+`PartialResults` contains only values explicitly saved this way. Ordinary local variables cannot be recovered after an exception unwinds the snippet. A cancellation that occurs before the snippet produces an execution result also returns no `PartialResults`.
 
 On `Success: false`, inspect `CompilationErrors` first. If empty, read `ErrorMessage` (and `Logs` for extra context) — the failure may be a runtime exception, cancellation, or an "execution in progress" rejection, all of which return empty `CompilationErrors`. Both EditMode and PlayMode are supported targets — the snippet runs in whichever mode the Editor is currently in.

--- a/.claude/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.claude/skills/uloop-execute-dynamic-code/SKILL.md
@@ -69,11 +69,20 @@ Returns JSON:
 - `Success`: boolean — overall execution success
 - `Result`: string — value of the snippet's `return` statement (empty when omitted)
 - `Logs`: string[] — execution messages from the dynamic-code tool; read Unity Console `Debug.Log` output with `get-logs`
+- `PartialResults` (object, optional): values that a snippet explicitly saves before it completes or fails
 - `CompilationErrors`: object[] — Roslyn diagnostics with `Message`, `Line`, `Column`, `ErrorCode`, optional `Hint` and `Suggestions`
 - `Error` / `ErrorMessage`: string — top-level failure summary (empty on success)
 - `UpdatedCode`: string|null — the wrapped form actually compiled (handy when debugging using-statement reordering)
 - `DiagnosticsSummary`: string|null — compact summary when diagnostics are available
 - `Diagnostics`: object[] — structured diagnostics; same shape as `CompilationErrors`, usually populated together with it
 - `Warning` (string, optional): Set when Play Mode is running while the Unity Editor is unfocused. Progress may be throttled; run `uloop focus-window`, or use the `pause-point --await`/`--trigger` flow instead of polling for progress.
+
+To retain an intermediate value across a later exception, opt in before the risky code:
+
+```csharp
+UloopDynamicCodePartialResults.Set("completedSteps", completedSteps);
+```
+
+`PartialResults` contains only values explicitly saved this way. Ordinary local variables cannot be recovered after an exception unwinds the snippet. A cancellation that occurs before the snippet produces an execution result also returns no `PartialResults`.
 
 On `Success: false`, inspect `CompilationErrors` first. If empty, read `ErrorMessage` (and `Logs` for extra context) — the failure may be a runtime exception, cancellation, or an "execution in progress" rejection, all of which return empty `CompilationErrors`. Both EditMode and PlayMode are supported targets — the snippet runs in whichever mode the Editor is currently in.

--- a/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerCancellationTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerCancellationTests.cs
@@ -69,6 +69,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         [Test]
         public async Task ExecuteAsync_WhenCommandSucceeds_CapturesOnlyCurrentPartialResults()
         {
+            UloopDynamicCodePartialResults.OpenExecutionScope();
             UloopDynamicCodePartialResults.Set("stale", "previous request");
             WrappedDynamicCommandState.PrepareReturningCommandWithPartialResult(
                 "ready",
@@ -97,6 +98,46 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.That(result.Success, Is.False);
             Assert.That(result.ErrorMessage, Is.EqualTo("planned failure"));
             Assert.That(result.PartialResults["beforeThrow"], Is.EqualTo("saved"));
+        }
+
+        /// <summary>
+        /// What: a late Set from a cancelled request cannot appear in the next request's partial results.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenCancelledRequestCompletesLate_DropsItsPartialResultsFromNextRequest()
+        {
+            WrappedDynamicCommandState.PrepareCancelledRequestThenNextRequestSequence();
+            CommandRunner runner = new();
+            using CancellationTokenSource cancellationTokenSource = new();
+
+            try
+            {
+                Task<ExecutionResult> cancelledRequest = runner.ExecuteAsync(
+                    CreateContext(cancellationTokenSource.Token));
+                await AwaitCancelledRequestStartWithinTimeoutAsync();
+
+                cancellationTokenSource.Cancel();
+
+                ExecutionResult cancelledResult = await AwaitResultWithinTimeoutAsync(cancelledRequest);
+                Assert.That(cancelledResult.PartialResults["phase"], Is.EqualTo("running"));
+
+                Task<ExecutionResult> nextRequest = runner.ExecuteAsync(CreateContext(CancellationToken.None));
+                await AwaitNextRequestStartWithinTimeoutAsync();
+
+                WrappedDynamicCommandState.ReleaseCancelledRequest();
+                await AwaitLatePartialResultWithinTimeoutAsync();
+                WrappedDynamicCommandState.CompleteNextRequest();
+
+                ExecutionResult nextResult = await AwaitResultWithinTimeoutAsync(nextRequest);
+                Assert.That(nextResult.Success, Is.True);
+                Assert.That(nextResult.PartialResults["currentRequest"], Is.EqualTo("ready"));
+                Assert.That(nextResult.PartialResults.ContainsKey("lateFromCancelledRequest"), Is.False);
+            }
+            finally
+            {
+                WrappedDynamicCommandState.ReleaseCancelledRequest();
+                WrappedDynamicCommandState.CompleteNextRequest();
+            }
         }
 
         [Test]
@@ -179,6 +220,39 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             await startedTask;
         }
 
+        private static async Task AwaitCancelledRequestStartWithinTimeoutAsync()
+        {
+            await AwaitSignalWithinTimeoutAsync(
+                WrappedDynamicCommandState.CancelledRequestStartedTask,
+                "CommandRunner did not invoke the cancelled dynamic command before the timeout.");
+        }
+
+        private static async Task AwaitNextRequestStartWithinTimeoutAsync()
+        {
+            await AwaitSignalWithinTimeoutAsync(
+                WrappedDynamicCommandState.NextRequestStartedTask,
+                "CommandRunner did not invoke the next dynamic command before the timeout.");
+        }
+
+        private static async Task AwaitLatePartialResultWithinTimeoutAsync()
+        {
+            await AwaitSignalWithinTimeoutAsync(
+                WrappedDynamicCommandState.LatePartialResultSetTask,
+                "The cancelled dynamic command did not attempt its late partial result before the timeout.");
+        }
+
+        private static async Task AwaitSignalWithinTimeoutAsync(Task signalTask, string timeoutMessage)
+        {
+            Task timeoutTask = Task.Delay(CancellationPropagationTimeout);
+            Task completedTask = await Task.WhenAny(signalTask, timeoutTask);
+            if (completedTask == timeoutTask)
+            {
+                Assert.Fail(timeoutMessage);
+            }
+
+            await signalTask;
+        }
+
         private static async Task AwaitFaultObservationWithinTimeoutAsync(Task observationTask)
         {
             Task timeoutTask = Task.Delay(CancellationPropagationTimeout);
@@ -200,19 +274,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         private static string _returnValue = "";
         private static bool _shouldComplete;
         private static bool _shouldThrow;
+        private static bool _runCancelledRequestThenNextRequestSequence;
+        private static int _sequenceInvocationCount;
         private static string _partialResultName = string.Empty;
         private static object _partialResultValue;
         private static TaskCompletionSource<object> _blockingCompletionSource =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
         private static TaskCompletionSource<bool> _startedCompletionSource =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private static TaskCompletionSource<object> _cancelledRequestCompletionSource =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private static TaskCompletionSource<object> _nextRequestCompletionSource =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private static TaskCompletionSource<bool> _cancelledRequestStartedCompletionSource =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private static TaskCompletionSource<bool> _nextRequestStartedCompletionSource =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private static TaskCompletionSource<bool> _latePartialResultSetCompletionSource =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public static Task StartedTask => _startedCompletionSource.Task;
+
+        public static Task CancelledRequestStartedTask => _cancelledRequestStartedCompletionSource.Task;
+
+        public static Task NextRequestStartedTask => _nextRequestStartedCompletionSource.Task;
+
+        public static Task LatePartialResultSetTask => _latePartialResultSetCompletionSource.Task;
 
         public static void PrepareBlockingCommand()
         {
             _shouldComplete = false;
             _shouldThrow = false;
+            _runCancelledRequestThenNextRequestSequence = false;
             _returnValue = "";
             _partialResultName = "phase";
             _partialResultValue = "running";
@@ -226,6 +319,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             _shouldComplete = true;
             _shouldThrow = false;
+            _runCancelledRequestThenNextRequestSequence = false;
             _returnValue = returnValue;
             _partialResultName = string.Empty;
             _partialResultValue = null;
@@ -240,6 +334,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             _shouldComplete = true;
             _shouldThrow = false;
+            _runCancelledRequestThenNextRequestSequence = false;
             _returnValue = returnValue;
             _partialResultName = partialResultName;
             _partialResultValue = partialResultValue;
@@ -251,10 +346,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             _shouldComplete = false;
             _shouldThrow = true;
+            _runCancelledRequestThenNextRequestSequence = false;
             _returnValue = string.Empty;
             _partialResultName = partialResultName;
             _partialResultValue = partialResultValue;
             _startedCompletionSource = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public static void PrepareCancelledRequestThenNextRequestSequence()
+        {
+            _shouldComplete = false;
+            _shouldThrow = false;
+            _runCancelledRequestThenNextRequestSequence = true;
+            _sequenceInvocationCount = 0;
+            _returnValue = string.Empty;
+            _partialResultName = string.Empty;
+            _partialResultValue = null;
+            _cancelledRequestCompletionSource = new TaskCompletionSource<object>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _nextRequestCompletionSource = new TaskCompletionSource<object>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _cancelledRequestStartedCompletionSource = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _nextRequestStartedCompletionSource = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _latePartialResultSetCompletionSource = new TaskCompletionSource<bool>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
         }
 
@@ -263,8 +380,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             _blockingCompletionSource.TrySetResult(null);
         }
 
+        public static void ReleaseCancelledRequest()
+        {
+            _cancelledRequestCompletionSource.TrySetResult(null);
+        }
+
+        public static void CompleteNextRequest()
+        {
+            _nextRequestCompletionSource.TrySetResult(null);
+        }
+
         public static Task<object> ExecuteAsync(CancellationToken ct)
         {
+            if (_runCancelledRequestThenNextRequestSequence)
+            {
+                return ExecuteCancelledRequestThenNextRequestSequenceAsync();
+            }
+
             // This intentionally ignores ct because the regression occurs when user code does not observe it.
             _startedCompletionSource.TrySetResult(true);
             if (!string.IsNullOrEmpty(_partialResultName))
@@ -283,6 +415,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             }
 
             return _blockingCompletionSource.Task;
+        }
+
+        private static async Task<object> ExecuteCancelledRequestThenNextRequestSequenceAsync()
+        {
+            int invocation = Interlocked.Increment(ref _sequenceInvocationCount);
+            if (invocation == 1)
+            {
+                UloopDynamicCodePartialResults.Set("phase", "running");
+                _cancelledRequestStartedCompletionSource.TrySetResult(true);
+                await _cancelledRequestCompletionSource.Task;
+                UloopDynamicCodePartialResults.Set("lateFromCancelledRequest", "late");
+                _latePartialResultSetCompletionSource.TrySetResult(true);
+                return "cancelled request completed";
+            }
+
+            System.Diagnostics.Debug.Assert(invocation == 2, "The test sequence supports exactly two requests.");
+            UloopDynamicCodePartialResults.Set("currentRequest", "ready");
+            _nextRequestStartedCompletionSource.TrySetResult(true);
+            return await _nextRequestCompletionSource.Task;
         }
     }
 }

--- a/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerCancellationTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerCancellationTests.cs
@@ -17,6 +17,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
     {
         private static readonly TimeSpan CancellationPropagationTimeout = TimeSpan.FromSeconds(1);
 
+        [TearDown]
+        public void TearDown()
+        {
+            UloopDynamicCodePartialResults.Clear();
+        }
+
+        /// <summary>
+        /// What: cancellation returns partial results captured before the command's task outlives the request.
+        /// </summary>
         [Test]
         public async Task ExecuteAsync_WhenAsyncResultIgnoresCancellation_ShouldCancelAndAllowNextExecution()
         {
@@ -36,6 +45,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
                 ExecutionResult firstResult = await AwaitResultWithinTimeoutAsync(firstExecution);
                 Assert.That(firstResult.Success, Is.False);
                 Assert.That(firstResult.ErrorMessage, Is.EqualTo(UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_CANCELLED));
+                Assert.That(firstResult.PartialResults["phase"], Is.EqualTo("running"));
                 Assert.That(runner.IsRunning, Is.False);
 
                 WrappedDynamicCommandState.PrepareReturningCommand("ready");
@@ -51,6 +61,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             {
                 WrappedDynamicCommandState.CompleteBlockingCommand();
             }
+        }
+
+        /// <summary>
+        /// What: a successful command replaces stale entries with the values it opted in to report.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenCommandSucceeds_CapturesOnlyCurrentPartialResults()
+        {
+            UloopDynamicCodePartialResults.Set("stale", "previous request");
+            WrappedDynamicCommandState.PrepareReturningCommandWithPartialResult(
+                "ready",
+                "completed",
+                3);
+            CommandRunner runner = new();
+
+            ExecutionResult result = await runner.ExecuteAsync(CreateContext(CancellationToken.None));
+
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.PartialResults, Has.Count.EqualTo(1));
+            Assert.That(result.PartialResults["completed"], Is.EqualTo("3"));
+        }
+
+        /// <summary>
+        /// What: an invocation exception retains values captured before the exception was thrown.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenCommandThrows_CapturesPartialResults()
+        {
+            WrappedDynamicCommandState.PrepareThrowingCommand("beforeThrow", "saved");
+            CommandRunner runner = new();
+
+            ExecutionResult result = await runner.ExecuteAsync(CreateContext(CancellationToken.None));
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Is.EqualTo("planned failure"));
+            Assert.That(result.PartialResults["beforeThrow"], Is.EqualTo("saved"));
         }
 
         [Test]
@@ -153,6 +199,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
     {
         private static string _returnValue = "";
         private static bool _shouldComplete;
+        private static bool _shouldThrow;
+        private static string _partialResultName = string.Empty;
+        private static object _partialResultValue;
         private static TaskCompletionSource<object> _blockingCompletionSource =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
         private static TaskCompletionSource<bool> _startedCompletionSource =
@@ -163,7 +212,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         public static void PrepareBlockingCommand()
         {
             _shouldComplete = false;
+            _shouldThrow = false;
             _returnValue = "";
+            _partialResultName = "phase";
+            _partialResultValue = "running";
             _blockingCompletionSource = new TaskCompletionSource<object>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
             _startedCompletionSource = new TaskCompletionSource<bool>(
@@ -173,7 +225,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         public static void PrepareReturningCommand(string returnValue)
         {
             _shouldComplete = true;
+            _shouldThrow = false;
             _returnValue = returnValue;
+            _partialResultName = string.Empty;
+            _partialResultValue = null;
+            _startedCompletionSource = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public static void PrepareReturningCommandWithPartialResult(
+            string returnValue,
+            string partialResultName,
+            object partialResultValue)
+        {
+            _shouldComplete = true;
+            _shouldThrow = false;
+            _returnValue = returnValue;
+            _partialResultName = partialResultName;
+            _partialResultValue = partialResultValue;
+            _startedCompletionSource = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public static void PrepareThrowingCommand(string partialResultName, object partialResultValue)
+        {
+            _shouldComplete = false;
+            _shouldThrow = true;
+            _returnValue = string.Empty;
+            _partialResultName = partialResultName;
+            _partialResultValue = partialResultValue;
             _startedCompletionSource = new TaskCompletionSource<bool>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
         }
@@ -187,6 +267,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             // This intentionally ignores ct because the regression occurs when user code does not observe it.
             _startedCompletionSource.TrySetResult(true);
+            if (!string.IsNullOrEmpty(_partialResultName))
+            {
+                UloopDynamicCodePartialResults.Set(_partialResultName, _partialResultValue);
+            }
+
+            if (_shouldThrow)
+            {
+                throw new InvalidOperationException("planned failure");
+            }
+
             if (_shouldComplete)
             {
                 return Task.FromResult<object>(_returnValue);

--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeErrorEditorStateTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeErrorEditorStateTests.cs
@@ -170,6 +170,45 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
+        /// What: opted-in partial results flow from ExecutionResult through the response serializer.
+        /// </summary>
+        [Test]
+        public void ConvertExecutionResultToResponse_WhenPartialResultsExist_SerializesTheirValues()
+        {
+            DynamicCodeExecutionResponseFactory factory = new();
+            ExecutionResult result = new()
+            {
+                Success = false,
+                ErrorMessage = "execution failed",
+                PartialResults = new Dictionary<string, string>
+                {
+                    ["completedSteps"] = "2"
+                }
+            };
+
+            ExecuteDynamicCodeResponse response = factory.ConvertExecutionResultToResponse(result);
+            JObject serialized = JObject.Parse(
+                JsonConvert.SerializeObject(response, JsonRpcResponseSerializer.Settings));
+
+            Assert.That(response.PartialResults["completedSteps"], Is.EqualTo("2"));
+            Assert.That(serialized["PartialResults"]?["completedSteps"]?.Value<string>(), Is.EqualTo("2"));
+        }
+
+        /// <summary>
+        /// What: empty partial results remain absent from the dynamic-code JSON contract.
+        /// </summary>
+        [Test]
+        public void ExecuteDynamicCodeResponse_WhenPartialResultsAreEmpty_OmitsTheirJsonKey()
+        {
+            ExecuteDynamicCodeResponse response = new();
+
+            JObject serialized = JObject.Parse(
+                JsonConvert.SerializeObject(response, JsonRpcResponseSerializer.Settings));
+
+            Assert.That(serialized.Property("PartialResults"), Is.Null);
+        }
+
+        /// <summary>
         /// What: an injected unfocused provider adds the exact hint to a Play Mode response.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeUseCaseTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeUseCaseTests.cs
@@ -51,6 +51,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.That(serializedResponse["DomainReloadWaitRequired"], Is.Null);
         }
 
+        /// <summary>
+        /// What: a cancelled ExecutionResult retains partial results in the dedicated cancellation response.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenResultIsCancelled_MapsPartialResults()
+        {
+            MarkForegroundWarmupCompleted();
+            ExecuteDynamicCodeUseCase useCase = new(
+                new FakeDynamicCodeExecutionRuntime(
+                    new ExecutionResult
+                    {
+                        Success = false,
+                        ErrorMessage = UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_CANCELLED,
+                        PartialResults = new Dictionary<string, string>
+                        {
+                            ["beforeCancel"] = "saved"
+                        }
+                    }));
+
+            ExecuteDynamicCodeResponse response = await useCase.ExecuteAsync(
+                new ExecuteDynamicCodeSchema { Code = "return 1;" },
+                CancellationToken.None);
+
+            Assert.That(response.PartialResults["beforeCancel"], Is.EqualTo("saved"));
+        }
+
         [Test]
         public void ExecuteDynamicCodeResponse_WhenSerializedWithInternalSignals_KeepsControlFieldNames()
         {

--- a/Assets/Tests/Editor/DynamicCodeToolTests/UloopDynamicCodePartialResultsTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/UloopDynamicCodePartialResultsTests.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
+{
+    /// <summary>
+    /// Verifies the opt-in dynamic-code partial-results holder.
+    /// </summary>
+    [TestFixture]
+    public sealed class UloopDynamicCodePartialResultsTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            UloopDynamicCodePartialResults.Clear();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UloopDynamicCodePartialResults.Clear();
+        }
+
+        /// <summary>
+        /// What: Set records string values and represents null as the literal null string.
+        /// </summary>
+        [Test]
+        public void Set_WhenValuesAreProvided_SnapshotPreservesStringAndNullValues()
+        {
+            UloopDynamicCodePartialResults.Set("count", 42);
+            UloopDynamicCodePartialResults.Set("optional", null);
+
+            Dictionary<string, string> snapshot = UloopDynamicCodePartialResults.Snapshot();
+
+            Assert.That(snapshot, Has.Count.EqualTo(2));
+            Assert.That(snapshot["count"], Is.EqualTo("42"));
+            Assert.That(snapshot["optional"], Is.EqualTo("null"));
+        }
+
+        /// <summary>
+        /// What: Clear removes entries before the next dynamic-code execution begins.
+        /// </summary>
+        [Test]
+        public void Clear_AfterValuesAreSet_SnapshotIsEmpty()
+        {
+            UloopDynamicCodePartialResults.Set("result", "captured");
+
+            UloopDynamicCodePartialResults.Clear();
+
+            Dictionary<string, string> snapshot = UloopDynamicCodePartialResults.Snapshot();
+            Assert.That(snapshot, Is.Empty);
+        }
+    }
+}

--- a/Assets/Tests/Editor/DynamicCodeToolTests/UloopDynamicCodePartialResultsTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/UloopDynamicCodePartialResultsTests.cs
@@ -15,7 +15,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         [SetUp]
         public void SetUp()
         {
-            UloopDynamicCodePartialResults.Clear();
+            UloopDynamicCodePartialResults.OpenExecutionScope();
         }
 
         [TearDown]

--- a/Assets/Tests/Editor/DynamicCodeToolTests/UloopDynamicCodePartialResultsTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/UloopDynamicCodePartialResultsTests.cs
@@ -21,6 +21,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         [TearDown]
         public void TearDown()
         {
+            UloopDynamicCodePartialResults.AfterGenerationValidatedForTesting = null;
             UloopDynamicCodePartialResults.Clear();
         }
 
@@ -52,6 +53,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
 
             Dictionary<string, string> snapshot = UloopDynamicCodePartialResults.Snapshot();
             Assert.That(snapshot, Is.Empty);
+        }
+
+        /// <summary>
+        /// What: Snapshot excludes a stale write that resumes after the next execution scope opens.
+        /// </summary>
+        [Test]
+        public void Snapshot_WhenStaleSetResumesAfterNextScopeOpens_ExcludesStaleEntryAndKeepsCurrentEntries()
+        {
+            UloopDynamicCodePartialResults.AfterGenerationValidatedForTesting = () =>
+            {
+                UloopDynamicCodePartialResults.AfterGenerationValidatedForTesting = null;
+                UloopDynamicCodePartialResults.OpenExecutionScope();
+                UloopDynamicCodePartialResults.Set("currentRequest", "ready");
+            };
+
+            UloopDynamicCodePartialResults.Set("lateFromCancelledRequest", "late");
+
+            Dictionary<string, string> snapshot = UloopDynamicCodePartialResults.Snapshot();
+            Assert.That(snapshot["currentRequest"], Is.EqualTo("ready"));
+            Assert.That(snapshot.ContainsKey("lateFromCancelledRequest"), Is.False);
         }
     }
 }

--- a/Assets/Tests/Editor/DynamicCodeToolTests/UloopDynamicCodePartialResultsTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/UloopDynamicCodePartialResultsTests.cs
@@ -74,5 +74,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.That(snapshot["currentRequest"], Is.EqualTo("ready"));
             Assert.That(snapshot.ContainsKey("lateFromCancelledRequest"), Is.False);
         }
+
+        /// <summary>
+        /// What: Snapshot preserves a successor value when a stale execution writes the same name.
+        /// </summary>
+        [Test]
+        public void Snapshot_WhenStaleSetResumesWithCurrentName_KeepsCurrentEntry()
+        {
+            UloopDynamicCodePartialResults.AfterGenerationValidatedForTesting = () =>
+            {
+                UloopDynamicCodePartialResults.AfterGenerationValidatedForTesting = null;
+                UloopDynamicCodePartialResults.OpenExecutionScope();
+                UloopDynamicCodePartialResults.Set("sharedResult", "successor value");
+            };
+
+            UloopDynamicCodePartialResults.Set("sharedResult", "stale value");
+
+            Dictionary<string, string> snapshot = UloopDynamicCodePartialResults.Snapshot();
+            Assert.That(snapshot["sharedResult"], Is.EqualTo("successor value"));
+        }
     }
 }

--- a/Assets/Tests/Editor/DynamicCodeToolTests/UloopDynamicCodePartialResultsTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/UloopDynamicCodePartialResultsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ce95980921fd465ea9b9fbc8620f62d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
@@ -39,7 +39,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     StringComparison.Ordinal);
         }
 
-        internal static ExecuteDynamicCodeResponse CreateCancelledResponse()
+        internal static ExecuteDynamicCodeResponse CreateCancelledResponse(ExecutionResult executionResult = null)
         {
             return new ExecuteDynamicCodeResponse
             {
@@ -47,7 +47,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Result = string.Empty,
                 Logs = new List<string> { "Execution cancelled" },
                 CompilationErrors = new List<CompilationErrorDto>(),
-                ErrorMessage = UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_CANCELLED
+                ErrorMessage = UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_CANCELLED,
+                PartialResults = executionResult?.PartialResults != null
+                    ? new Dictionary<string, string>(executionResult.PartialResults)
+                    : new Dictionary<string, string>()
             };
         }
 
@@ -90,6 +93,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Logs = result.Logs ?? new List<string>(),
                 CompilationErrors = new List<CompilationErrorDto>(),
                 ErrorMessage = result.ErrorMessage ?? string.Empty,
+                PartialResults = result.PartialResults != null
+                    ? new Dictionary<string, string>(result.PartialResults)
+                    : new Dictionary<string, string>(),
                 Timings = result.Timings != null ? new List<string>(result.Timings) : new List<string>()
             };
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeResponse.cs
@@ -17,6 +17,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         
         /// <summary>Log messages</summary>
         public List<string> Logs { get; set; } = new();
+
+        /// <summary>
+        /// Values a dynamic-code snippet explicitly saved before its execution completed or failed.
+        /// </summary>
+        public Dictionary<string, string> PartialResults { get; set; } = new();
         
         /// <summary>Compilation errors</summary>
         public List<CompilationErrorDto> CompilationErrors { get; set; } = new();
@@ -111,6 +116,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool ShouldSerializeTimings()
         {
             return EmitTimingsInJsonResponse && Timings != null && Timings.Count > 0;
+        }
+
+        public bool ShouldSerializePartialResults()
+        {
+            return PartialResults != null && PartialResults.Count > 0;
         }
 
         public bool ShouldSerializeEmitTimingsInJsonResponse()

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
@@ -83,7 +83,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (DynamicCodeExecutionResponseFactory.IsCancelledResult(finalResult))
                 {
                     ExecuteDynamicCodeResponse cancelledResponse =
-                        DynamicCodeExecutionResponseFactory.CreateCancelledResponse();
+                        DynamicCodeExecutionResponseFactory.CreateCancelledResponse(finalResult);
                     cancelledResponse.Logs = finalResult.Logs ?? cancelledResponse.Logs;
                     cancelledResponse.Timings = finalResult.Timings != null
                         ? new List<string>(finalResult.Timings)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
@@ -91,16 +91,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             catch (OperationCanceledException)
             {
                 await MainThreadSwitcher.SwitchToMainThread();
-                return CreateCancelledResult();
+                return CapturePartialResults(CreateCancelledResult());
             }
             catch (Exception ex)
             {
                 LogExecutionError(ex, correlationId);
                 await MainThreadSwitcher.SwitchToMainThread();
 
-                return CreateErrorResult(
-                    ex.Message,
-                    new List<string> { $"Exception: {ex.Message}" });
+                return CapturePartialResults(
+                    CreateErrorResult(
+                        ex.Message,
+                        new List<string> { $"Exception: {ex.Message}" }));
             }
             finally
             {
@@ -181,6 +182,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
+        private static ExecutionResult CapturePartialResults(ExecutionResult result)
+        {
+            System.Diagnostics.Debug.Assert(result != null, "result must not be null");
+            result.PartialResults = UloopDynamicCodePartialResults.Snapshot();
+            return result;
+        }
+
         private static object CreateInstance(Type targetType)
         {
             return Activator.CreateInstance(targetType);
@@ -198,9 +206,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private ExecutionResult ExecuteInternal(ExecutionContext context, CancellationToken cancellationToken)
         {
+            UloopDynamicCodePartialResults.Clear();
             if (context.CompiledAssembly == null)
             {
-                return CreateErrorResult(UnityCliLoopConstants.ERROR_MESSAGE_NO_COMPILED_ASSEMBLY);
+                return CapturePartialResults(
+                    CreateErrorResult(UnityCliLoopConstants.ERROR_MESSAGE_NO_COMPILED_ASSEMBLY));
             }
 
             try
@@ -211,16 +221,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 
                 if (targetType == null || executeMethod == null)
                 {
-                    return CreateErrorResult(
-                        UnityCliLoopConstants.ERROR_MESSAGE_NO_EXECUTE_METHOD,
-                        new List<string> { "Assembly types checked but no Execute method found" });
+                    return CapturePartialResults(
+                        CreateErrorResult(
+                            UnityCliLoopConstants.ERROR_MESSAGE_NO_EXECUTE_METHOD,
+                            new List<string> { "Assembly types checked but no Execute method found" }));
                 }
 
                 // Create instance
                 object instance = CreateInstance(targetType);
                 if (instance == null)
                 {
-                    return CreateErrorResult(UnityCliLoopConstants.ERROR_MESSAGE_FAILED_TO_CREATE_INSTANCE);
+                    return CapturePartialResults(
+                        CreateErrorResult(UnityCliLoopConstants.ERROR_MESSAGE_FAILED_TO_CREATE_INSTANCE));
                 }
 
                 // Check cancellation
@@ -238,13 +250,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     // Convert result to string
                     string resultString = executionResult?.ToString() ?? "";
                     
-                    return CreateSuccessResult(resultString);
+                    return CapturePartialResults(CreateSuccessResult(resultString));
                 }
                 catch (NotSupportedException ex)
                 {
-                    return CreateErrorResult(
-                        UnityCliLoopConstants.ERROR_MESSAGE_UNSUPPORTED_SIGNATURE,
-                        new List<string> { ex.Message });
+                    return CapturePartialResults(
+                        CreateErrorResult(
+                            UnityCliLoopConstants.ERROR_MESSAGE_UNSUPPORTED_SIGNATURE,
+                            new List<string> { ex.Message }));
                 }
             }
             catch (OperationCanceledException)
@@ -260,31 +273,35 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     throw innerException;
                 }
                 
-                return CreateErrorResult(
-                    innerException.Message,
-                    new List<string> 
-                    { 
-                        $"Target invocation exception: {innerException.Message}",
-                        $"Stack trace: {innerException.StackTrace}"
-                    });
+                return CapturePartialResults(
+                    CreateErrorResult(
+                        innerException.Message,
+                        new List<string>
+                        {
+                            $"Target invocation exception: {innerException.Message}",
+                            $"Stack trace: {innerException.StackTrace}"
+                        }));
             }
             catch (Exception ex)
             {
-                return CreateErrorResult(
-                    ex.Message,
-                    new List<string> 
-                    { 
-                        $"Execution exception: {ex.Message}",
-                        $"Stack trace: {ex.StackTrace}"
-                    });
+                return CapturePartialResults(
+                    CreateErrorResult(
+                        ex.Message,
+                        new List<string>
+                        {
+                            $"Execution exception: {ex.Message}",
+                            $"Stack trace: {ex.StackTrace}"
+                        }));
             }
         }
 
         private async Task<ExecutionResult> ExecuteInternalAsync(ExecutionContext context, CancellationToken cancellationToken)
         {
+            UloopDynamicCodePartialResults.Clear();
             if (context.CompiledAssembly == null)
             {
-                return CreateErrorResult(UnityCliLoopConstants.ERROR_MESSAGE_NO_COMPILED_ASSEMBLY);
+                return CapturePartialResults(
+                    CreateErrorResult(UnityCliLoopConstants.ERROR_MESSAGE_NO_COMPILED_ASSEMBLY));
             }
 
             try
@@ -297,7 +314,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     object instance = CreateInstance(asyncType);
                     if (instance == null)
                     {
-                        return CreateErrorResult(UnityCliLoopConstants.ERROR_MESSAGE_FAILED_TO_CREATE_INSTANCE);
+                        return CapturePartialResults(
+                            CreateErrorResult(UnityCliLoopConstants.ERROR_MESSAGE_FAILED_TO_CREATE_INSTANCE));
                     }
 
                     cancellationToken.ThrowIfCancellationRequested();
@@ -311,7 +329,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     object awaitedResult = await AwaitableHelper.AwaitIfNeeded(invoked, cancellationToken).ConfigureAwait(false);
                     string resultString = awaitedResult?.ToString() ?? "";
 
-                    return CreateSuccessResult(resultString);
+                    return CapturePartialResults(CreateSuccessResult(resultString));
                 }
 
                 // Fallback to sync path if no async method found
@@ -330,23 +348,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     throw innerException;
                 }
 
-                return CreateErrorResult(
-                    innerException.Message,
-                    new List<string>
-                    {
-                        $"Target invocation exception: {innerException.Message}",
-                        $"Stack trace: {innerException.StackTrace}"
-                    });
+                return CapturePartialResults(
+                    CreateErrorResult(
+                        innerException.Message,
+                        new List<string>
+                        {
+                            $"Target invocation exception: {innerException.Message}",
+                            $"Stack trace: {innerException.StackTrace}"
+                        }));
             }
             catch (Exception ex)
             {
-                return CreateErrorResult(
-                    ex.Message,
-                    new List<string>
-                    {
-                        $"Execution exception: {ex.Message}",
-                        $"Stack trace: {ex.StackTrace}"
-                    });
+                return CapturePartialResults(
+                    CreateErrorResult(
+                        ex.Message,
+                        new List<string>
+                        {
+                            $"Execution exception: {ex.Message}",
+                            $"Stack trace: {ex.StackTrace}"
+                        }));
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
@@ -206,7 +206,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private ExecutionResult ExecuteInternal(ExecutionContext context, CancellationToken cancellationToken)
         {
-            UloopDynamicCodePartialResults.Clear();
+            UloopDynamicCodePartialResults.OpenExecutionScope();
             if (context.CompiledAssembly == null)
             {
                 return CapturePartialResults(
@@ -297,7 +297,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private async Task<ExecutionResult> ExecuteInternalAsync(ExecutionContext context, CancellationToken cancellationToken)
         {
-            UloopDynamicCodePartialResults.Clear();
+            UloopDynamicCodePartialResults.OpenExecutionScope();
             if (context.CompiledAssembly == null)
             {
                 return CapturePartialResults(

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Models/ExecutionResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Models/ExecutionResult.cs
@@ -29,6 +29,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public List<string> Logs { get; set; } = new();
 
         /// <summary>
+        /// Values explicitly saved by a dynamic-code snippet before execution completed or failed.
+        /// </summary>
+        public Dictionary<string, string> PartialResults { get; set; } = new();
+
+        /// <summary>
         /// Structured compilation errors when compilation failed.
         /// Preserved to enable rich diagnostics formatting at the tool layer.
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
@@ -69,11 +69,20 @@ Returns JSON:
 - `Success`: boolean — overall execution success
 - `Result`: string — value of the snippet's `return` statement (empty when omitted)
 - `Logs`: string[] — execution messages from the dynamic-code tool; read Unity Console `Debug.Log` output with `get-logs`
+- `PartialResults` (object, optional): values that a snippet explicitly saves before it completes or fails
 - `CompilationErrors`: object[] — Roslyn diagnostics with `Message`, `Line`, `Column`, `ErrorCode`, optional `Hint` and `Suggestions`
 - `Error` / `ErrorMessage`: string — top-level failure summary (empty on success)
 - `UpdatedCode`: string|null — the wrapped form actually compiled (handy when debugging using-statement reordering)
 - `DiagnosticsSummary`: string|null — compact summary when diagnostics are available
 - `Diagnostics`: object[] — structured diagnostics; same shape as `CompilationErrors`, usually populated together with it
 - `Warning` (string, optional): Set when Play Mode is running while the Unity Editor is unfocused. Progress may be throttled; run `uloop focus-window`, or use the `pause-point --await`/`--trigger` flow instead of polling for progress.
+
+To retain an intermediate value across a later exception, opt in before the risky code:
+
+```csharp
+UloopDynamicCodePartialResults.Set("completedSteps", completedSteps);
+```
+
+`PartialResults` contains only values explicitly saved this way. Ordinary local variables cannot be recovered after an exception unwinds the snippet. A cancellation that occurs before the snippet produces an execution result also returns no `PartialResults`.
 
 On `Success: false`, inspect `CompilationErrors` first. If empty, read `ErrorMessage` (and `Logs` for extra context) — the failure may be a runtime exception, cancellation, or an "execution in progress" rejection, all of which return empty `CompilationErrors`. Both EditMode and PlayMode are supported targets — the snippet runs in whichever mode the Editor is currently in.

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/UloopDynamicCodePartialResults.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/UloopDynamicCodePartialResults.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
@@ -9,6 +10,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     public static class UloopDynamicCodePartialResults
     {
         private static readonly ConcurrentDictionary<string, string> Entries = new();
+        private static readonly AsyncLocal<int> ExecutionGeneration = new();
+        private static int _currentGeneration;
 
         /// <summary>
         /// Records a value that remains available if the current dynamic-code execution later fails.
@@ -18,7 +21,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             System.Diagnostics.Debug.Assert(
                 !string.IsNullOrWhiteSpace(name),
                 "Partial result names must not be null, empty, or whitespace.");
+            int currentGeneration = Volatile.Read(ref _currentGeneration);
+            if (currentGeneration == 0 || ExecutionGeneration.Value != currentGeneration)
+            {
+                return;
+            }
+
             Entries[name] = value?.ToString() ?? "null";
+        }
+
+        /// <summary>
+        /// Starts an isolated holder lifetime for one dynamic-code execution.
+        /// </summary>
+        internal static void OpenExecutionScope()
+        {
+            int nextGeneration = Interlocked.Increment(ref _currentGeneration);
+            ExecutionGeneration.Value = nextGeneration;
+            Entries.Clear();
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/UloopDynamicCodePartialResults.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/UloopDynamicCodePartialResults.cs
@@ -1,0 +1,40 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Holds values that dynamic-code snippets explicitly preserve for a later response.
+    /// </summary>
+    public static class UloopDynamicCodePartialResults
+    {
+        private static readonly ConcurrentDictionary<string, string> Entries = new();
+
+        /// <summary>
+        /// Records a value that remains available if the current dynamic-code execution later fails.
+        /// </summary>
+        public static void Set(string name, object value)
+        {
+            System.Diagnostics.Debug.Assert(
+                !string.IsNullOrWhiteSpace(name),
+                "Partial result names must not be null, empty, or whitespace.");
+            Entries[name] = value?.ToString() ?? "null";
+        }
+
+        /// <summary>
+        /// Copies the values captured by the current dynamic-code execution.
+        /// </summary>
+        internal static Dictionary<string, string> Snapshot()
+        {
+            return new Dictionary<string, string>(Entries);
+        }
+
+        /// <summary>
+        /// Removes values captured by the preceding dynamic-code execution.
+        /// </summary>
+        internal static void Clear()
+        {
+            Entries.Clear();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/UloopDynamicCodePartialResults.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/UloopDynamicCodePartialResults.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
@@ -9,9 +10,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public static class UloopDynamicCodePartialResults
     {
-        private static readonly ConcurrentDictionary<string, string> Entries = new();
+        private static readonly ConcurrentDictionary<string, PartialResultEntry> Entries = new();
         private static readonly AsyncLocal<int> ExecutionGeneration = new();
         private static int _currentGeneration;
+
+        /// <summary>
+        /// Invoked after Set validates its generation and before it records the entry.
+        /// Why: tests need to deterministically reproduce a stale execution resuming after a successor scope opens.
+        /// </summary>
+        internal static Action AfterGenerationValidatedForTesting { get; set; }
 
         /// <summary>
         /// Records a value that remains available if the current dynamic-code execution later fails.
@@ -27,7 +34,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return;
             }
 
-            Entries[name] = value?.ToString() ?? "null";
+            AfterGenerationValidatedForTesting?.Invoke();
+            Entries[name] = new PartialResultEntry(currentGeneration, value?.ToString() ?? "null");
         }
 
         /// <summary>
@@ -45,7 +53,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         internal static Dictionary<string, string> Snapshot()
         {
-            return new Dictionary<string, string>(Entries);
+            int currentGeneration = Volatile.Read(ref _currentGeneration);
+            Dictionary<string, string> snapshot = new();
+            foreach (KeyValuePair<string, PartialResultEntry> entry in Entries)
+            {
+                if (entry.Value.Generation != currentGeneration)
+                {
+                    continue;
+                }
+
+                snapshot[entry.Key] = entry.Value.Value;
+            }
+
+            // A cancelled execution can write after a successor scope opens, so this projection,
+            // not the Set-side check, defines which entries belong to the returned response.
+            return snapshot;
         }
 
         /// <summary>
@@ -54,6 +76,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal static void Clear()
         {
             Entries.Clear();
+        }
+
+        private sealed class PartialResultEntry
+        {
+            public PartialResultEntry(int generation, string value)
+            {
+                Generation = generation;
+                Value = value;
+            }
+
+            public int Generation { get; }
+
+            public string Value { get; }
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/UloopDynamicCodePartialResults.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/UloopDynamicCodePartialResults.cs
@@ -35,7 +35,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             AfterGenerationValidatedForTesting?.Invoke();
-            Entries[name] = new PartialResultEntry(currentGeneration, value?.ToString() ?? "null");
+            PartialResultEntry entry = new(currentGeneration, value?.ToString() ?? "null");
+            // ConcurrentDictionary reruns this factory after contention, so the comparison always sees
+            // the latest entry. A get-then-set would let a stale execution replace a newer result.
+            Entries.AddOrUpdate(
+                name,
+                entry,
+                (_, existingEntry) => existingEntry.Generation > currentGeneration
+                    ? existingEntry
+                    : entry);
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/UloopDynamicCodePartialResults.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/UloopDynamicCodePartialResults.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f6aa01eac9dbe49d99ae2b28378f0c49
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- Let dynamic-code snippets opt in to retaining named intermediate values when they later fail.
- Return those values in the optional `PartialResults` response field alongside the error details.

## User Impact

Agents no longer lose explicitly saved progress when a dynamic-code snippet throws. Values are included only when the snippet saves them, so ordinary successful responses keep their existing shape.

## Changes

- Added a thread-safe opt-in holder and propagated its snapshots through successful, failed, and execution-result cancellation responses.
- Documented the opt-in API and its exception/cancellation boundary.
- Added response-wire, cancellation, success, exception, null-value, and stale-value isolation coverage.

## Verification

- `dist/darwin-arm64/uloop compile --project-path <project>`: 0 errors; 3 pre-existing fixture warnings.
- Focused EditMode suites: 47 passed across the changed fixtures.
- Live snippet that saves `completedSteps` and then throws returned both `ErrorMessage: "planned failure"` and `PartialResults: {"completedSteps":"2"}`.
- `scripts/sync-tool-docs.sh --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

