### PR TITLE
feat: accept --file and --line on pause-point-status and await-pause-point

### DIFF
--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -219,7 +219,7 @@ is in `SuppressedByHotReloadReason` and surfaced as the status `Warning`. The ma
 not cleared — it fires again once a transition restores its line, or after
 `uloop compile` and a re-enable.
 
-Use `uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"` only when you need to confirm the marker is armed or inspect the current hit state.
+Use `uloop pause-point-status` only when you need to confirm the marker is armed or inspect the current hit state. A file:line marker can be addressed either by its returned `Id` (`--id "Assets/Scripts/Enemy.cs:42"`) or by the original pair (`--file "Assets/Scripts/Enemy.cs" --line 42`) — the same applies to `await-pause-point`. Always pass `--file` and `--line` together, and never combine them with `--id`.
 
 For the full diagnosis flow — the `Error.Details` status fields, bisecting with a second marker on the method entry, JIT inlining, physics-callback misses, and delegate bypass — read [references/troubleshooting.md](references/troubleshooting.md).
 

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -219,7 +219,7 @@ is in `SuppressedByHotReloadReason` and surfaced as the status `Warning`. The ma
 not cleared — it fires again once a transition restores its line, or after
 `uloop compile` and a re-enable.
 
-Use `uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"` only when you need to confirm the marker is armed or inspect the current hit state.
+Use `uloop pause-point-status` only when you need to confirm the marker is armed or inspect the current hit state. A file:line marker can be addressed either by its returned `Id` (`--id "Assets/Scripts/Enemy.cs:42"`) or by the original pair (`--file "Assets/Scripts/Enemy.cs" --line 42`) — the same applies to `await-pause-point`. Always pass `--file` and `--line` together, and never combine them with `--id`.
 
 For the full diagnosis flow — the `Error.Details` status fields, bisecting with a second marker on the method entry, JIT inlining, physics-callback misses, and delegate bypass — read [references/troubleshooting.md](references/troubleshooting.md).
 

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -219,7 +219,7 @@ is in `SuppressedByHotReloadReason` and surfaced as the status `Warning`. The ma
 not cleared — it fires again once a transition restores its line, or after
 `uloop compile` and a re-enable.
 
-Use `uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"` only when you need to confirm the marker is armed or inspect the current hit state.
+Use `uloop pause-point-status` only when you need to confirm the marker is armed or inspect the current hit state. A file:line marker can be addressed either by its returned `Id` (`--id "Assets/Scripts/Enemy.cs:42"`) or by the original pair (`--file "Assets/Scripts/Enemy.cs" --line 42`) — the same applies to `await-pause-point`. Always pass `--file` and `--line` together, and never combine them with `--id`.
 
 For the full diagnosis flow — the `Error.Details` status fields, bisecting with a second marker on the method entry, JIT inlining, physics-callback misses, and delegate bypass — read [references/troubleshooting.md](references/troubleshooting.md).
 

--- a/cli/common/tooldocs/pause_point_cli_options.go
+++ b/cli/common/tooldocs/pause_point_cli_options.go
@@ -16,6 +16,8 @@ const (
 	PausePointTriggerFlagName               = "trigger"
 	PausePointResumePlayFlagName            = "resume-play"
 	PausePointIDFlagName                    = "id"
+	PausePointFileFlagName                  = "file"
+	PausePointLineFlagName                  = "line"
 	PausePointTimeoutSecondsFlagName        = "timeout-seconds"
 	PausePointMatchingLogsMaxCountFlagName  = "matching-logs-max-count"
 )
@@ -86,6 +88,8 @@ func PausePointEnableCLIOnlyOptions() []PausePointCLIOnlyOption {
 
 const (
 	pausePointIDDescription                    = "Pause-point marker id matching UloopPausePoint.Pause or the id returned by enable-pause-point"
+	pausePointFileDescription                  = "Project-relative source file of a file:line pause point. Requires --line; mutually exclusive with --id"
+	pausePointLineDescription                  = "1-based source line of a file:line pause point. Requires --file; mutually exclusive with --id"
 	pausePointTimeoutSecondsDescription        = "Seconds to wait for a hit before timing out"
 	pausePointMatchingLogsMaxCountDescription  = "Maximum Console logs matching the marker id to include on a hit"
 	pausePointCapturedVariablesDescription     = "How much of each captured variable to include in the response"
@@ -114,6 +118,16 @@ func pausePointSharedQueryCLIOnlyOptions() []PausePointCLIOnlyOption {
 			FlagName:    PausePointIDFlagName,
 			Type:        "string",
 			Description: pausePointIDDescription,
+		},
+		{
+			FlagName:    PausePointFileFlagName,
+			Type:        "string",
+			Description: pausePointFileDescription,
+		},
+		{
+			FlagName:    PausePointLineFlagName,
+			Type:        "integer",
+			Description: pausePointLineDescription,
 		},
 		pausePointCapturedVariablesOption(),
 		{

--- a/cli/common/tooldocs/pause_point_cli_options_test.go
+++ b/cli/common/tooldocs/pause_point_cli_options_test.go
@@ -86,6 +86,30 @@ func TestPausePointAwaitAndStatusCLIOnlyHelpEntries(t *testing.T) {
 	}
 }
 
+// Verifies both query commands describe the file:line target flags with the fixed contract text.
+func TestPausePointQueryCLIOnlyOptionsDescribeFileLineTarget(t *testing.T) {
+	for _, options := range [][]PausePointCLIOnlyOption{
+		PausePointAwaitCLIOnlyOptions(),
+		PausePointStatusCLIOnlyOptions(),
+	} {
+		fileOption, found := findPausePointCLIOnlyOption(options, "file")
+		if !found {
+			t.Fatal("missing --file option")
+		}
+		if fileOption.Description != "Project-relative source file of a file:line pause point. Requires --line; mutually exclusive with --id" {
+			t.Fatalf("--file description = %q", fileOption.Description)
+		}
+
+		lineOption, found := findPausePointCLIOnlyOption(options, "line")
+		if !found {
+			t.Fatal("missing --line option")
+		}
+		if lineOption.Description != "1-based source line of a file:line pause point. Requires --file; mutually exclusive with --id" {
+			t.Fatalf("--line description = %q", lineOption.Description)
+		}
+	}
+}
+
 // Verifies the CLI-only option table is not applied to unrelated tools, which would advertise
 // pause-point orchestration flags on commands that reject them.
 func TestVisibleOptionHelpEntriesOmitPausePointCLIOnlyOptionsForOtherTools(t *testing.T) {
@@ -138,4 +162,16 @@ func findOptionHelpEntry(entries []OptionHelpEntry, name string) (OptionHelpEntr
 		}
 	}
 	return OptionHelpEntry{}, false
+}
+
+func findPausePointCLIOnlyOption(
+	options []PausePointCLIOnlyOption,
+	flagName string,
+) (PausePointCLIOnlyOption, bool) {
+	for _, option := range options {
+		if option.FlagName == flagName {
+			return option, true
+		}
+	}
+	return PausePointCLIOnlyOption{}, false
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "24c0a5e9d0fae0c81224dddc7d0a7a24a63cb34b"
+  "sharedInputsHash": "2cc10a7f81e50c0ca051dfffc8f3cf6f7d48bd5d"
 }

--- a/cli/project-runner/internal/projectrunner/native_command_help.go
+++ b/cli/project-runner/internal/projectrunner/native_command_help.go
@@ -14,6 +14,8 @@ import (
 // The string values are the tooldocs constants so parsers and option tables cannot drift.
 const (
 	PausePointIDFlagName           = tooldocs.PausePointIDFlagName
+	PausePointFileFlagName         = tooldocs.PausePointFileFlagName
+	PausePointLineFlagName         = tooldocs.PausePointLineFlagName
 	PausePointTimeoutFlagName      = tooldocs.PausePointTimeoutSecondsFlagName
 	PausePointLogsMaxCountFlagName = tooldocs.PausePointMatchingLogsMaxCountFlagName
 )

--- a/cli/project-runner/internal/projectrunner/native_command_help_test.go
+++ b/cli/project-runner/internal/projectrunner/native_command_help_test.go
@@ -20,7 +20,7 @@ func TestRunProjectLocalAwaitPausePointHelpListsExpectedFlags(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("await-pause-point --help failed: code=%d stderr=%s", code, stderr.String())
 	}
-	for _, flag := range []string{"--id", "--timeout-seconds", "--matching-logs-max-count", "--captured-variables", "--expect", "--trigger", "--resume-play"} {
+	for _, flag := range []string{"--id", "--file", "--line", "--timeout-seconds", "--matching-logs-max-count", "--captured-variables", "--expect", "--trigger", "--resume-play"} {
 		if !strings.Contains(stdout.String(), flag) {
 			t.Fatalf("await-pause-point --help must list %s: %s", flag, stdout.String())
 		}
@@ -38,7 +38,9 @@ func TestRunProjectLocalAwaitPausePointHelpOptionsSection(t *testing.T) {
   --captured-variable-names <value>  Restrict CapturedVariables to these comma-separated names
   --captured-variables <value>       How much of each captured variable to include in the response; values: full|names
   --expect <value>                   Compare a captured variable against an expected value (repeatable; name=value)
+  --file <value>                     Project-relative source file of a file:line pause point. Requires --line; mutually exclusive with --id
   --id <value>                       Pause-point marker id matching UloopPausePoint.Pause or the id returned by enable-pause-point
+  --line <value>                     1-based source line of a file:line pause point. Requires --file; mutually exclusive with --id
   --matching-logs-max-count <value>  Maximum Console logs matching the marker id to include on a hit
   --resume-play                      After confirming the marker is armed, resume PlayMode if paused (before --trigger), so a paused-arm workflow can fire input in one call
   --timeout-seconds <value>          Seconds to wait for a hit before timing out
@@ -58,7 +60,7 @@ func TestRunProjectLocalPausePointStatusHelpListsExpectedFlags(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("pause-point-status --help failed: code=%d stderr=%s", code, stderr.String())
 	}
-	for _, flag := range []string{"--id", "--captured-variables"} {
+	for _, flag := range []string{"--id", "--file", "--line", "--captured-variables"} {
 		if !strings.Contains(stdout.String(), flag) {
 			t.Fatalf("pause-point-status --help must list %s: %s", flag, stdout.String())
 		}
@@ -75,7 +77,9 @@ func TestRunProjectLocalPausePointStatusHelpOptionsSection(t *testing.T) {
   --captured-variable-names <value>  Restrict CapturedVariables to these comma-separated names
   --captured-variables <value>       How much of each captured variable to include in the response; values: full|names
   --expect <value>                   Compare a captured variable against an expected value (repeatable; name=value)
+  --file <value>                     Project-relative source file of a file:line pause point. Requires --line; mutually exclusive with --id
   --id <value>                       Pause-point marker id matching UloopPausePoint.Pause or the id returned by enable-pause-point
+  --line <value>                     1-based source line of a file:line pause point. Requires --file; mutually exclusive with --id
 `
 	assertNativeCommandHelpOptionsSection(t, "pause-point-status", expectedOptions)
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_cli_options_contract_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_cli_options_contract_test.go
@@ -124,9 +124,11 @@ func TestPausePointSharedHelpOptionsAreAcceptedByTheWaitParser(t *testing.T) {
 // runner-owned native command's --help. A flag added to a tooldocs table without an entry
 // here fails the contract test below rather than silently going unchecked.
 var runnerNativeCommandSampleArgs = map[string][]string{
-	"--" + PausePointIDFlagName:                             {"--id", "marker"},
-	"--" + PausePointTimeoutFlagName:                        {"--timeout-seconds", "5"},
-	"--" + PausePointLogsMaxCountFlagName:                   {"--matching-logs-max-count", "3"},
+	"--" + PausePointIDFlagName:           {"--id", "marker"},
+	"--file":                              {"--file", "Assets/Scripts/Marker.cs", "--line", "42"},
+	"--line":                              {"--file", "Assets/Scripts/Marker.cs", "--line", "42"},
+	"--" + PausePointTimeoutFlagName:      {"--timeout-seconds", "5"},
+	"--" + PausePointLogsMaxCountFlagName: {"--matching-logs-max-count", "3"},
 	"--" + tooldocs.PausePointCapturedVariablesFlagName:     {"--captured-variables", "names"},
 	"--" + tooldocs.PausePointCapturedVariableNamesFlagName: {"--captured-variable-names", "score"},
 	"--" + tooldocs.PausePointExpectFlagName:                {"--expect", "score=1"},
@@ -145,7 +147,7 @@ func TestPausePointStatusHelpOptionsAreAcceptedByTheStatusParser(t *testing.T) {
 			t.Fatalf("no sample argv for %s: add one to runnerNativeCommandSampleArgs", optionName)
 		}
 
-		statusArgs := append([]string{"--" + PausePointIDFlagName, "marker"}, args...)
+		statusArgs := pausePointQuerySampleArgs(optionName, args)
 		if _, err := parsePausePointStatusOptions(statusArgs); err != nil {
 			t.Errorf("pause-point-status parser rejected advertised option %s: %v", optionName, err)
 		}
@@ -161,11 +163,20 @@ func TestPausePointAwaitHelpOptionsAreAcceptedByTheWaitParser(t *testing.T) {
 			t.Fatalf("no sample argv for %s: add one to runnerNativeCommandSampleArgs", optionName)
 		}
 
-		waitArgs := append([]string{"--" + PausePointIDFlagName, "marker"}, args...)
+		waitArgs := pausePointQuerySampleArgs(optionName, args)
 		if _, err := parseWaitForPausePointOptions(waitArgs); err != nil {
 			t.Errorf("await-pause-point parser rejected advertised option %s: %v", optionName, err)
 		}
 	}
+}
+
+// pausePointQuerySampleArgs supplies a complete marker target for each documented query option.
+// File and line must travel together and cannot be combined with --id, unlike every other option.
+func pausePointQuerySampleArgs(optionName string, args []string) []string {
+	if optionName == "--file" || optionName == "--line" {
+		return args
+	}
+	return append([]string{"--" + PausePointIDFlagName, "marker"}, args...)
 }
 
 // pausePointAwaitAdvertisedFlagNames is the await-pause-point advertised flag set. These are
@@ -173,6 +184,8 @@ func TestPausePointAwaitHelpOptionsAreAcceptedByTheWaitParser(t *testing.T) {
 // switch-based parser still accepts the flag.
 var pausePointAwaitAdvertisedFlagNames = []string{
 	"id",
+	"file",
+	"line",
 	"timeout-seconds",
 	"matching-logs-max-count",
 	"captured-variables",
@@ -186,6 +199,8 @@ var pausePointAwaitAdvertisedFlagNames = []string{
 // test-local-literal rule as pausePointAwaitAdvertisedFlagNames.
 var pausePointStatusAdvertisedFlagNames = []string{
 	"id",
+	"file",
+	"line",
 	"captured-variables",
 	"captured-variable-names",
 	"expect",

--- a/cli/project-runner/internal/projectrunner/pause_point_file_line_id.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_file_line_id.go
@@ -1,0 +1,84 @@
+package projectrunner
+
+import (
+	"strconv"
+	"strings"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+)
+
+// pausePointQueryTarget records the file:line form before it is converted into the marker id
+// understood by Unity.
+type pausePointQueryTarget struct {
+	file    string
+	line    int
+	hasFile bool
+	hasLine bool
+}
+
+// composePausePointFileLineID matches Unity's source-location marker id convention.
+func composePausePointFileLineID(file string, line int) string {
+	return strings.ReplaceAll(file, "\\", "/") + ":" + strconv.Itoa(line)
+}
+
+// setPausePointQueryTargetLine parses the source line before marker-id construction so leading
+// zeroes cannot create a different id from the integer line Unity received at enable time.
+func setPausePointQueryTargetLine(target *pausePointQueryTarget, value string) error {
+	line, err := strconv.Atoi(value)
+	if err != nil || line <= 0 {
+		return clierrors.InvalidValueArgumentError("--"+PausePointLineFlagName, value, "positive integer")
+	}
+	target.line = line
+	target.hasLine = true
+	return nil
+}
+
+// resolvePausePointQueryID validates the id and file:line target forms before selecting the id
+// sent to Unity. Keeping the check shared prevents status and await from accepting different forms.
+func resolvePausePointQueryID(
+	id string,
+	idProvided bool,
+	target pausePointQueryTarget,
+	command string,
+) (string, error) {
+	if target.hasFile && !target.hasLine {
+		return "", &clierrors.ArgumentError{
+			Message: "--file requires --line.",
+			Option:  "--" + PausePointFileFlagName,
+			Command: command,
+		}
+	}
+	if target.hasLine && !target.hasFile {
+		return "", &clierrors.ArgumentError{
+			Message: "--line requires --file.",
+			Option:  "--" + PausePointLineFlagName,
+			Command: command,
+		}
+	}
+	if idProvided && (target.hasFile || target.hasLine) {
+		return "", &clierrors.ArgumentError{
+			Message: "--id cannot be combined with --file or --line.",
+			Option:  "--" + PausePointIDFlagName,
+			Command: command,
+		}
+	}
+	if target.hasFile && target.hasLine {
+		return composePausePointFileLineID(target.file, target.line), nil
+	}
+	if id != "" {
+		return id, nil
+	}
+	return "", missingPausePointQueryTargetError(command)
+}
+
+// missingPausePointQueryTargetError preserves the established missing-id wire shape while naming
+// the alternate file:line form that can now identify the same marker.
+func missingPausePointQueryTargetError(command string) *clierrors.ArgumentError {
+	return &clierrors.ArgumentError{
+		Message:      "Missing required option: --id",
+		Option:       "--" + PausePointIDFlagName,
+		ExpectedType: "value",
+		Command:      command,
+		NextActions:  []string{pausePointMissingIDNextAction},
+	}
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_file_line_id.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_file_line_id.go
@@ -41,6 +41,13 @@ func resolvePausePointQueryID(
 	target pausePointQueryTarget,
 	command string,
 ) (string, error) {
+	if idProvided && (target.hasFile || target.hasLine) {
+		return "", &clierrors.ArgumentError{
+			Message: "--id cannot be combined with --file or --line.",
+			Option:  "--" + PausePointIDFlagName,
+			Command: command,
+		}
+	}
 	if target.hasFile && !target.hasLine {
 		return "", &clierrors.ArgumentError{
 			Message: "--file requires --line.",
@@ -52,13 +59,6 @@ func resolvePausePointQueryID(
 		return "", &clierrors.ArgumentError{
 			Message: "--line requires --file.",
 			Option:  "--" + PausePointLineFlagName,
-			Command: command,
-		}
-	}
-	if idProvided && (target.hasFile || target.hasLine) {
-		return "", &clierrors.ArgumentError{
-			Message: "--id cannot be combined with --file or --line.",
-			Option:  "--" + PausePointIDFlagName,
 			Command: command,
 		}
 	}

--- a/cli/project-runner/internal/projectrunner/pause_point_file_line_id_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_file_line_id_test.go
@@ -1,0 +1,36 @@
+package projectrunner
+
+import "testing"
+
+// Verifies file:line marker ids use the same slash normalization and decimal line formatting as
+// source-location enable, so query commands address the marker that Unity registered.
+func TestComposePausePointFileLineIDMatchesSourceEnableConvention(t *testing.T) {
+	tests := []struct {
+		name string
+		file string
+		line int
+		want string
+	}{
+		{
+			name: "backslashes",
+			file: `Assets\Scripts\Marker.cs`,
+			line: 42,
+			want: "Assets/Scripts/Marker.cs:42",
+		},
+		{
+			name: "absolute path",
+			file: "/source/Assets/Scripts/Marker.cs",
+			line: 7,
+			want: "/source/Assets/Scripts/Marker.cs:7",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := composePausePointFileLineID(test.file, test.line)
+			if got != test.want {
+				t.Fatalf("id = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_unknown_option_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_unknown_option_test.go
@@ -32,20 +32,16 @@ func TestParsePausePointStatusUnknownOptionNamesEnableAsTheOwner(t *testing.T) {
 	}
 }
 
-// Verifies an enable-pause-point flag whose value is not carried into this command's response names
-// the owner without claiming a carry-over that does not happen.
-func TestParsePausePointStatusUnknownOptionOmitsCarryOverForNonCarriedFlags(t *testing.T) {
-	_, err := parsePausePointStatusOptions([]string{"--id", "jump", "--line", "42"})
-
-	if err == nil {
-		t.Fatal("expected error for --line passed to pause-point-status")
+// Verifies pause-point-status owns --file and --line, so its parser accepts a file:line target.
+func TestParsePausePointStatusAcceptsFileLineTarget(t *testing.T) {
+	options, err := parsePausePointStatusOptions([]string{
+		"--file", "Assets/Scripts/Marker.cs", "--line", "42",
+	})
+	if err != nil {
+		t.Fatalf("file:line target was rejected: %v", err)
 	}
-	message := err.Error()
-	if !strings.Contains(message, "--line is an enable-pause-point option, not a pause-point-status one.") {
-		t.Errorf("owner sentence missing: %s", message)
-	}
-	if strings.Contains(message, "already applied to the response") {
-		t.Errorf("carry-over sentence must not be claimed for --line: %s", message)
+	if options.id != "Assets/Scripts/Marker.cs:42" {
+		t.Fatalf("id = %q", options.id)
 	}
 }
 

--- a/cli/project-runner/internal/projectrunner/pause_point_unknown_option_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_unknown_option_test.go
@@ -45,6 +45,23 @@ func TestParsePausePointStatusAcceptsFileLineTarget(t *testing.T) {
 	}
 }
 
+// Verifies an enable-only flag that status cannot carry over still names enable as its owner
+// without claiming a response value exists for it.
+func TestParsePausePointStatusUnknownOptionOmitsCarryOverForNonCarriedFlags(t *testing.T) {
+	_, err := parsePausePointStatusOptions([]string{"--id", "jump", "--method", "Player.Jump"})
+
+	if err == nil {
+		t.Fatal("expected error for --method passed to pause-point-status")
+	}
+	message := err.Error()
+	if !strings.Contains(message, "--method is an enable-pause-point option, not a pause-point-status one.") {
+		t.Errorf("owner sentence missing: %s", message)
+	}
+	if strings.Contains(message, "already applied to the response") {
+		t.Errorf("carry-over sentence must not be claimed for --method: %s", message)
+	}
+}
+
 // Verifies a flag owned by another runner-owned command names that command, so a flag borrowed from
 // await-pause-point is not reported as an enable-pause-point one.
 func TestParsePausePointStatusUnknownOptionNamesAwaitAsTheOwner(t *testing.T) {

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -43,10 +43,10 @@ const (
 	// though no capture matched the condition.
 	pausePointHitWhenNoteFormat = "The line executed but no hit matched --hit-when; %d hit(s) were skipped."
 
-	// Shared by await-pause-point and pause-point-status when --id is missing. Why one
-	// constant: the two parsers used to copy the same sentence, and a file:line id is a
-	// valid answer that the old wording never mentioned.
-	pausePointMissingIDNextAction = "Pass --id <marker-id> matching UloopPausePoint.Pause(\"<marker-id>\"), or the Id returned by enable-pause-point (file:line markers use <project-relative path>:<line>, e.g. Assets/Scripts/Foo.cs:42)."
+	// Shared by await-pause-point and pause-point-status when no marker target was supplied. Why
+	// one constant: the two parsers used to copy the same sentence, and the new file:line form
+	// needs the same recovery wording on both commands.
+	pausePointMissingIDNextAction = "Pass --id <marker-id> matching UloopPausePoint.Pause(\"<marker-id>\"), or the Id returned by enable-pause-point (file:line markers use <project-relative path>:<line>, e.g. Assets/Scripts/Foo.cs:42). Alternatively, query a file:line marker with --file <project-relative path> --line <line>."
 
 	// Mode strings mirror UloopPausePointCaptureMode on the Unity side. Await uses an allowlist
 	// (continuous/trace) for the new-hit baseline — never `Mode != "single-shot"` — so an empty
@@ -63,6 +63,8 @@ var (
 
 type waitForPausePointOptions struct {
 	id                    string
+	idProvided            bool
+	queryTarget           pausePointQueryTarget
 	timeoutSeconds        int
 	timeout               time.Duration
 	matchingLogsMaxCount  int
@@ -91,6 +93,8 @@ type waitForPausePointOptions struct {
 
 type pausePointStatusOptions struct {
 	id                    string
+	idProvided            bool
+	queryTarget           pausePointQueryTarget
 	capturedVariablesMode pausePointCapturedVariablesMode
 	capturedVariableNames []string
 	expectations          []pausePointExpectation
@@ -390,15 +394,15 @@ func parseWaitForPausePointOptions(args []string) (waitForPausePointOptions, err
 		}
 	}
 
-	if options.id == "" {
-		return waitForPausePointOptions{}, &clierrors.ArgumentError{
-			Message:      "Missing required option: --id",
-			Option:       "--" + PausePointIDFlagName,
-			ExpectedType: "value",
-			Command:      clicore.PausePointAwaitCommandName,
-			NextActions:  []string{pausePointMissingIDNextAction},
-		}
+	queryID, targetErr := resolvePausePointQueryID(
+		options.id,
+		options.idProvided,
+		options.queryTarget,
+		clicore.PausePointAwaitCommandName)
+	if targetErr != nil {
+		return waitForPausePointOptions{}, targetErr
 	}
+	options.id = queryID
 
 	return options, nil
 }
@@ -416,6 +420,15 @@ func parsePausePointStatusOptions(args []string) (pausePointStatusOptions, error
 		switch name {
 		case PausePointIDFlagName:
 			options.id = value
+			options.idProvided = true
+		case PausePointFileFlagName:
+			options.queryTarget.file = value
+			options.queryTarget.hasFile = true
+		case PausePointLineFlagName:
+			parseErr := setPausePointQueryTargetLine(&options.queryTarget, value)
+			if parseErr != nil {
+				return pausePointStatusOptions{}, parseErr
+			}
 		case tooldocs.PausePointCapturedVariablesFlagName:
 			mode, parseErr := parsePausePointCapturedVariablesMode(value)
 			if parseErr != nil {
@@ -439,15 +452,15 @@ func parsePausePointStatusOptions(args []string) (pausePointStatusOptions, error
 		}
 	}
 
-	if options.id == "" {
-		return pausePointStatusOptions{}, &clierrors.ArgumentError{
-			Message:      "Missing required option: --id",
-			Option:       "--" + PausePointIDFlagName,
-			ExpectedType: "value",
-			Command:      clicore.PausePointStatusUserCommandName,
-			NextActions:  []string{pausePointMissingIDNextAction},
-		}
+	queryID, targetErr := resolvePausePointQueryID(
+		options.id,
+		options.idProvided,
+		options.queryTarget,
+		clicore.PausePointStatusUserCommandName)
+	if targetErr != nil {
+		return pausePointStatusOptions{}, targetErr
 	}
+	options.id = queryID
 
 	return options, nil
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_options.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_options.go
@@ -17,7 +17,15 @@ func applyWaitForPausePointFlag(options *waitForPausePointOptions, name string, 
 	switch name {
 	case PausePointIDFlagName:
 		options.id = value
+		options.idProvided = true
 		return nil
+	case PausePointFileFlagName:
+		options.queryTarget.file = value
+		options.queryTarget.hasFile = true
+		return nil
+	case PausePointLineFlagName:
+		return setPausePointQueryTargetLine(&options.queryTarget, value)
+
 	case PausePointTimeoutFlagName:
 		return applyWaitForPausePointTimeout(options, value)
 	case PausePointLogsMaxCountFlagName:

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -2747,16 +2747,76 @@ func TestParsePausePointQueryOptionsRequireCompleteFileLinePair(t *testing.T) {
 
 // Verifies id and file:line target forms are mutually exclusive for both query commands.
 func TestParsePausePointQueryOptionsRejectCombinedIDAndFileLineTarget(t *testing.T) {
-	args := []string{"--id", "marker", "--file", "Assets/Scripts/Marker.cs", "--line", "42"}
-
-	_, awaitErr := parseWaitForPausePointOptions(args)
-	if awaitErr == nil || awaitErr.Error() != "--id cannot be combined with --file or --line." {
-		t.Fatalf("await combined-target error = %v", awaitErr)
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "complete file line target",
+			args: []string{"--id", "marker", "--file", "Assets/Scripts/Marker.cs", "--line", "42"},
+		},
+		{
+			name: "file only target",
+			args: []string{"--id", "marker", "--file", "Assets/Scripts/Marker.cs"},
+		},
+		{
+			name: "line only target",
+			args: []string{"--id", "marker", "--line", "42"},
+		},
 	}
 
-	_, statusErr := parsePausePointStatusOptions(args)
-	if statusErr == nil || statusErr.Error() != "--id cannot be combined with --file or --line." {
-		t.Fatalf("status combined-target error = %v", statusErr)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, awaitErr := parseWaitForPausePointOptions(test.args)
+			if awaitErr == nil || awaitErr.Error() != "--id cannot be combined with --file or --line." {
+				t.Fatalf("await combined-target error = %v", awaitErr)
+			}
+
+			_, statusErr := parsePausePointStatusOptions(test.args)
+			if statusErr == nil || statusErr.Error() != "--id cannot be combined with --file or --line." {
+				t.Fatalf("status combined-target error = %v", statusErr)
+			}
+		})
+	}
+}
+
+// Verifies both query commands reject non-positive and non-numeric --line values before id composition.
+func TestParsePausePointQueryOptionsRejectInvalidLine(t *testing.T) {
+	tests := []struct {
+		name      string
+		line      string
+		wantError string
+	}{
+		{
+			name:      "non numeric",
+			line:      "forty-two",
+			wantError: "Invalid positive integer value for --line: forty-two",
+		},
+		{
+			name:      "zero",
+			line:      "0",
+			wantError: "Invalid positive integer value for --line: 0",
+		},
+		{
+			name:      "negative",
+			line:      "-42",
+			wantError: "Invalid positive integer value for --line: -42",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args := []string{"--file", "Assets/Scripts/Marker.cs", "--line", test.line}
+			_, awaitErr := parseWaitForPausePointOptions(args)
+			if awaitErr == nil || awaitErr.Error() != test.wantError {
+				t.Fatalf("await line error = %v", awaitErr)
+			}
+
+			_, statusErr := parsePausePointStatusOptions(args)
+			if statusErr == nil || statusErr.Error() != test.wantError {
+				t.Fatalf("status line error = %v", statusErr)
+			}
+		})
 	}
 }
 

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -1873,23 +1873,23 @@ func TestParseUnknownOptionErrorsOmitStaleRunnerHint(t *testing.T) {
 	}
 }
 
-// Verifies await-pause-point requires a marker id.
-func TestParseWaitForPausePointOptionsRequiresID(t *testing.T) {
+// Verifies await-pause-point requires either a marker id or a complete file:line target.
+func TestParseWaitForPausePointOptionsRequiresMarkerTarget(t *testing.T) {
 	_, err := parseWaitForPausePointOptions([]string{"--timeout-seconds", "1"})
 
 	if err == nil {
-		t.Fatal("expected missing id error")
+		t.Fatal("expected missing marker target error")
 	}
-	if !strings.Contains(err.Error(), "Missing required option") {
+	if err.Error() != "Missing required option: --id" {
 		t.Fatalf("error mismatch: %v", err)
 	}
 }
 
-// Verifies the missing --id NextAction names both Pause ids and file:line ids.
-func TestParseWaitForPausePointOptionsMissingIDNextActionMentionsFileLineIds(t *testing.T) {
+// Verifies the missing-target NextAction explains both id and file:line forms for await.
+func TestParseWaitForPausePointOptionsMissingTargetNextActionMentionsFileLineFlags(t *testing.T) {
 	_, err := parseWaitForPausePointOptions([]string{"--timeout-seconds", "1"})
 	requireNextActions(t, err, []string{
-		"Pass --id <marker-id> matching UloopPausePoint.Pause(\"<marker-id>\"), or the Id returned by enable-pause-point (file:line markers use <project-relative path>:<line>, e.g. Assets/Scripts/Foo.cs:42).",
+		"Pass --id <marker-id> matching UloopPausePoint.Pause(\"<marker-id>\"), or the Id returned by enable-pause-point (file:line markers use <project-relative path>:<line>, e.g. Assets/Scripts/Foo.cs:42). Alternatively, query a file:line marker with --file <project-relative path> --line <line>.",
 	})
 }
 
@@ -2681,24 +2681,83 @@ func TestRunPausePointStatusDerivesRemainingTimeFromOlderResponse(t *testing.T) 
 	}
 }
 
-// Verifies pause-point-status requires a marker id.
-func TestParsePausePointStatusOptionsRequiresID(t *testing.T) {
+// Verifies pause-point-status requires either a marker id or a complete file:line target.
+func TestParsePausePointStatusOptionsRequiresMarkerTarget(t *testing.T) {
 	_, err := parsePausePointStatusOptions([]string{})
 
 	if err == nil {
-		t.Fatal("expected missing id error")
+		t.Fatal("expected missing marker target error")
 	}
-	if !strings.Contains(err.Error(), "Missing required option") {
+	if err.Error() != "Missing required option: --id" {
 		t.Fatalf("error mismatch: %v", err)
 	}
 }
 
-// Verifies pause-point-status missing --id uses the same file:line NextAction as await.
-func TestParsePausePointStatusOptionsMissingIDNextActionMentionsFileLineIds(t *testing.T) {
+// Verifies the missing-target NextAction explains both id and file:line forms for status.
+func TestParsePausePointStatusOptionsMissingTargetNextActionMentionsFileLineFlags(t *testing.T) {
 	_, err := parsePausePointStatusOptions([]string{})
 	requireNextActions(t, err, []string{
-		"Pass --id <marker-id> matching UloopPausePoint.Pause(\"<marker-id>\"), or the Id returned by enable-pause-point (file:line markers use <project-relative path>:<line>, e.g. Assets/Scripts/Foo.cs:42).",
+		"Pass --id <marker-id> matching UloopPausePoint.Pause(\"<marker-id>\"), or the Id returned by enable-pause-point (file:line markers use <project-relative path>:<line>, e.g. Assets/Scripts/Foo.cs:42). Alternatively, query a file:line marker with --file <project-relative path> --line <line>.",
 	})
+}
+
+// Verifies both query commands compose a source marker id from --file and decimal --line values.
+func TestParsePausePointQueryOptionsComposeFileLineID(t *testing.T) {
+	awaitOptions, awaitErr := parseWaitForPausePointOptions([]string{
+		"--file", `Assets\Scripts\Marker.cs`, "--line", "0042",
+	})
+	if awaitErr != nil {
+		t.Fatalf("await file:line parse failed: %v", awaitErr)
+	}
+	if awaitOptions.id != "Assets/Scripts/Marker.cs:42" {
+		t.Fatalf("await id = %q", awaitOptions.id)
+	}
+
+	statusOptions, statusErr := parsePausePointStatusOptions([]string{
+		"--file", "/source/Assets/Scripts/Marker.cs", "--line", "7",
+	})
+	if statusErr != nil {
+		t.Fatalf("status file:line parse failed: %v", statusErr)
+	}
+	if statusOptions.id != "/source/Assets/Scripts/Marker.cs:7" {
+		t.Fatalf("status id = %q", statusOptions.id)
+	}
+}
+
+// Verifies file and line must be supplied together for both pause-point query commands.
+func TestParsePausePointQueryOptionsRequireCompleteFileLinePair(t *testing.T) {
+	_, awaitFileErr := parseWaitForPausePointOptions([]string{"--file", "Assets/Scripts/Marker.cs"})
+	if awaitFileErr == nil || awaitFileErr.Error() != "--file requires --line." {
+		t.Fatalf("await file-only error = %v", awaitFileErr)
+	}
+	_, awaitLineErr := parseWaitForPausePointOptions([]string{"--line", "42"})
+	if awaitLineErr == nil || awaitLineErr.Error() != "--line requires --file." {
+		t.Fatalf("await line-only error = %v", awaitLineErr)
+	}
+
+	_, statusFileErr := parsePausePointStatusOptions([]string{"--file", "Assets/Scripts/Marker.cs"})
+	if statusFileErr == nil || statusFileErr.Error() != "--file requires --line." {
+		t.Fatalf("status file-only error = %v", statusFileErr)
+	}
+	_, statusLineErr := parsePausePointStatusOptions([]string{"--line", "42"})
+	if statusLineErr == nil || statusLineErr.Error() != "--line requires --file." {
+		t.Fatalf("status line-only error = %v", statusLineErr)
+	}
+}
+
+// Verifies id and file:line target forms are mutually exclusive for both query commands.
+func TestParsePausePointQueryOptionsRejectCombinedIDAndFileLineTarget(t *testing.T) {
+	args := []string{"--id", "marker", "--file", "Assets/Scripts/Marker.cs", "--line", "42"}
+
+	_, awaitErr := parseWaitForPausePointOptions(args)
+	if awaitErr == nil || awaitErr.Error() != "--id cannot be combined with --file or --line." {
+		t.Fatalf("await combined-target error = %v", awaitErr)
+	}
+
+	_, statusErr := parsePausePointStatusOptions(args)
+	if statusErr == nil || statusErr.Error() != "--id cannot be combined with --file or --line." {
+		t.Fatalf("status combined-target error = %v", statusErr)
+	}
 }
 
 func parsePausePointErrorEnvelope(t *testing.T, payload []byte) clierrors.CLIErrorEnvelope {

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "c530070c11c62411edb2d2cf9d791906467984fd"
+  "sharedInputsHash": "001a9d0ed5d8e63f18c9eda251c7566cdf9c1be1"
 }


### PR DESCRIPTION
## Summary

- Let `pause-point-status` and `await-pause-point` address file:line markers directly with `--file` and `--line`.
- Explain valid marker target forms in help, errors, and pause-point guidance.

## User Impact

- Agents no longer need to reconstruct a returned marker ID to inspect or wait on an existing file:line pause point.
- Existing `--id` usage remains unchanged.

## Changes

- Normalize source paths and compose the same file:line marker ID used during enable.
- Reject incomplete or conflicting target forms with actionable fixed messages.
- Keep the generated skill copies, tool documentation, and shared input stamps in sync.

## Verification

- `scripts/check-go-cli.sh`
- Live editor: enabled a file:line marker, queried it with `pause-point-status --file ... --line ...`, and confirmed the same ID; queried it with `await-pause-point --file ... --line ...` and confirmed the expected timeout response for that ID.

Relates to #2239.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

