### PR TITLE
feat: default hot-reload --files to sources changed since the last compile

### DIFF
--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -33,11 +33,11 @@ before its first import: Unity has not compiled it into any assembly yet. Run
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. When omitted on apply, selects every `.cs` source whose bytes changed since the last compile snapshot; run `uloop compile` first when no snapshot exists, or pass explicit paths when no changed source is found |
+| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. When omitted or empty on apply, selects the `.cs` sources whose bytes changed since the last compile snapshot, capped at 50 changed files per assembly with a warning when the cap trims the list; run `uloop compile` first when no snapshot exists, or pass explicit paths when no changed source is found |
 | `--revert-all` | flag | - | Remove every active hot-reload patch and clear the patch ledger. When set, `--files` is ignored |
 | `--status` | flag | - | Lists the currently active changes (patched methods and added members) without applying or reverting anything. |
 
-When `--files` is omitted, a source is selected only when its compilation assembly has a
+When `--files` is omitted or empty, a source is selected only when its compilation assembly has a
 snapshot directory and that source has its own snapshot file. A missing per-file snapshot is
 left out rather than guessed as changed, so pass the file explicitly or run `uloop compile`
 to establish a complete baseline.

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -18,6 +18,7 @@ or `Failed`; one unpatchable method never aborts the rest of the run.
 ```bash
 uloop hot-reload --files Assets/Scripts/Enemy.cs
 uloop hot-reload --files Assets/Scripts/Enemy.cs,Assets/Scripts/Boss.cs
+uloop hot-reload
 uloop hot-reload --revert-all
 ```
 
@@ -32,9 +33,14 @@ before its first import: Unity has not compiled it into any assembly yet. Run
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when neither `--revert-all` nor `--status` is set |
+| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. When omitted on apply, selects every `.cs` source whose bytes changed since the last compile snapshot; run `uloop compile` first when no snapshot exists, or pass explicit paths when no changed source is found |
 | `--revert-all` | flag | - | Remove every active hot-reload patch and clear the patch ledger. When set, `--files` is ignored |
 | `--status` | flag | - | Lists the currently active changes (patched methods and added members) without applying or reverting anything. |
+
+When `--files` is omitted, a source is selected only when its compilation assembly has a
+snapshot directory and that source has its own snapshot file. A missing per-file snapshot is
+left out rather than guessed as changed, so pass the file explicitly or run `uloop compile`
+to establish a complete baseline.
 
 ## Checking what is currently patched
 
@@ -372,7 +378,7 @@ cached dispatch can bypass a hot-reload patch too.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `ErrorCode` (string, optional): Present on parameter validation failure. Values are `HOT_RELOAD_FILES_REQUIRED` when apply needs `--files`, `HOT_RELOAD_INVALID_FILES` when `--files` contains a null or empty path, and `HOT_RELOAD_STATUS_CONFLICT` when `--status` is combined with `--files` or `--revert-all`.
+- `ErrorCode` (string, optional): Present on parameter validation failure. Values are `HOT_RELOAD_FILES_REQUIRED` when an omitted apply has no compile snapshots, `HOT_RELOAD_NO_CHANGED_FILES` when snapshots contain no changed `.cs` files, `HOT_RELOAD_INVALID_FILES` when `--files` contains a null or empty path, and `HOT_RELOAD_STATUS_CONFLICT` when `--status` is combined with `--files` or `--revert-all`.
 - `NextActions` (array, optional): Ordered recovery steps, present only with `ErrorCode` on a parameter validation failure. Omitted from every other response, including successful apply, plain `--status`, and `--revert-all` runs.
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last fully applied reload (a run with no Skipped or Failed outcomes), so the existing patch was left in place and the row carries the live `InvocationCount`. `InvocationCount` is meaningful on `Active` rows and `AlreadyActive` apply rows (calls since the current patch was applied); it is `0` on other apply/revert outcomes. On `--status`, an `Active` row with `InvocationCount` 0 sets `Reason` to explain that the method has not run since the patch: finished calls do not re-run, the patched body takes effect on the next call, and how to retrigger an initialization-only path. Added-member rows always show InvocationCount 0 — added-member calls are not instrumented, and the row's Reason says so. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`), or when every compiled caller of the patched method is such a message; empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "Added-member calls are not instrumented, so InvocationCount is always 0 for this row.", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
 - `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods at risk of being already JIT-inlined into existing callers — those marked `[AggressiveInlining]`, plus (only when Code Optimization is Release) those with tiny pre-patch bodies — meaning the change may not show at those call sites, the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits". When a run carries two or more warnings and all of them are hot reload warnings, the Message ends with "A single 'uloop compile' clears all of them at once." — read it as the shortest recovery, not as an obligation to compile immediately. Pause-point warnings carry their own recovery steps, so that line does not appear when they are present.

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -33,11 +33,11 @@ before its first import: Unity has not compiled it into any assembly yet. Run
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. When omitted on apply, selects every `.cs` source whose bytes changed since the last compile snapshot; run `uloop compile` first when no snapshot exists, or pass explicit paths when no changed source is found |
+| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. When omitted or empty on apply, selects the `.cs` sources whose bytes changed since the last compile snapshot, capped at 50 changed files per assembly with a warning when the cap trims the list; run `uloop compile` first when no snapshot exists, or pass explicit paths when no changed source is found |
 | `--revert-all` | flag | - | Remove every active hot-reload patch and clear the patch ledger. When set, `--files` is ignored |
 | `--status` | flag | - | Lists the currently active changes (patched methods and added members) without applying or reverting anything. |
 
-When `--files` is omitted, a source is selected only when its compilation assembly has a
+When `--files` is omitted or empty, a source is selected only when its compilation assembly has a
 snapshot directory and that source has its own snapshot file. A missing per-file snapshot is
 left out rather than guessed as changed, so pass the file explicitly or run `uloop compile`
 to establish a complete baseline.

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -18,6 +18,7 @@ or `Failed`; one unpatchable method never aborts the rest of the run.
 ```bash
 uloop hot-reload --files Assets/Scripts/Enemy.cs
 uloop hot-reload --files Assets/Scripts/Enemy.cs,Assets/Scripts/Boss.cs
+uloop hot-reload
 uloop hot-reload --revert-all
 ```
 
@@ -32,9 +33,14 @@ before its first import: Unity has not compiled it into any assembly yet. Run
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when neither `--revert-all` nor `--status` is set |
+| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. When omitted on apply, selects every `.cs` source whose bytes changed since the last compile snapshot; run `uloop compile` first when no snapshot exists, or pass explicit paths when no changed source is found |
 | `--revert-all` | flag | - | Remove every active hot-reload patch and clear the patch ledger. When set, `--files` is ignored |
 | `--status` | flag | - | Lists the currently active changes (patched methods and added members) without applying or reverting anything. |
+
+When `--files` is omitted, a source is selected only when its compilation assembly has a
+snapshot directory and that source has its own snapshot file. A missing per-file snapshot is
+left out rather than guessed as changed, so pass the file explicitly or run `uloop compile`
+to establish a complete baseline.
 
 ## Checking what is currently patched
 
@@ -372,7 +378,7 @@ cached dispatch can bypass a hot-reload patch too.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `ErrorCode` (string, optional): Present on parameter validation failure. Values are `HOT_RELOAD_FILES_REQUIRED` when apply needs `--files`, `HOT_RELOAD_INVALID_FILES` when `--files` contains a null or empty path, and `HOT_RELOAD_STATUS_CONFLICT` when `--status` is combined with `--files` or `--revert-all`.
+- `ErrorCode` (string, optional): Present on parameter validation failure. Values are `HOT_RELOAD_FILES_REQUIRED` when an omitted apply has no compile snapshots, `HOT_RELOAD_NO_CHANGED_FILES` when snapshots contain no changed `.cs` files, `HOT_RELOAD_INVALID_FILES` when `--files` contains a null or empty path, and `HOT_RELOAD_STATUS_CONFLICT` when `--status` is combined with `--files` or `--revert-all`.
 - `NextActions` (array, optional): Ordered recovery steps, present only with `ErrorCode` on a parameter validation failure. Omitted from every other response, including successful apply, plain `--status`, and `--revert-all` runs.
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last fully applied reload (a run with no Skipped or Failed outcomes), so the existing patch was left in place and the row carries the live `InvocationCount`. `InvocationCount` is meaningful on `Active` rows and `AlreadyActive` apply rows (calls since the current patch was applied); it is `0` on other apply/revert outcomes. On `--status`, an `Active` row with `InvocationCount` 0 sets `Reason` to explain that the method has not run since the patch: finished calls do not re-run, the patched body takes effect on the next call, and how to retrigger an initialization-only path. Added-member rows always show InvocationCount 0 — added-member calls are not instrumented, and the row's Reason says so. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`), or when every compiled caller of the patched method is such a message; empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "Added-member calls are not instrumented, so InvocationCount is always 0 for this row.", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
 - `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods at risk of being already JIT-inlined into existing callers — those marked `[AggressiveInlining]`, plus (only when Code Optimization is Release) those with tiny pre-patch bodies — meaning the change may not show at those call sites, the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits". When a run carries two or more warnings and all of them are hot reload warnings, the Message ends with "A single 'uloop compile' clears all of them at once." — read it as the shortest recovery, not as an obligation to compile immediately. Pause-point warnings carry their own recovery steps, so that line does not appear when they are present.

--- a/Assets/Tests/Editor/HotReload/HotReloadChangedFileAggregatorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadChangedFileAggregatorTests.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for aggregating changed sources from compile-snapshot assemblies.
+    /// </summary>
+    public class HotReloadChangedFileAggregatorTests
+    {
+        /// <summary>
+        /// What: changed paths from overlapping assemblies are unioned, deduplicated, and ordinally sorted.
+        /// </summary>
+        [Test]
+        public void DetectFromSnapshotDirectories_WhenAssembliesOverlap_UnionsDedupesAndSortsPaths()
+        {
+            string projectRoot = CreateTempProjectRoot();
+            try
+            {
+                string sharedPath = "Assets/Shared.cs";
+                string firstPath = "Assets/Zeta.cs";
+                string secondPath = "Assets/Alpha.cs";
+                WriteChangedSource(projectRoot, "Assembly-A-mvid", sharedPath);
+                WriteChangedSource(projectRoot, "Assembly-A-mvid", firstPath);
+                WriteChangedSource(projectRoot, "Assembly-B-mvid", sharedPath);
+                WriteChangedSource(projectRoot, "Assembly-B-mvid", secondPath);
+
+                HotReloadChangedFileAggregationResult result =
+                    HotReloadChangedFileAggregator.DetectFromSnapshotDirectories(
+                        projectRoot,
+                        new[]
+                        {
+                            new HotReloadSnapshotAssembly(
+                                "Assembly-A-mvid",
+                                new[] { firstPath, sharedPath }),
+                            new HotReloadSnapshotAssembly(
+                                "Assembly-B-mvid",
+                                new[] { sharedPath, secondPath })
+                        });
+
+                Assert.That(result.HasBaseline, Is.True);
+                Assert.That(
+                    result.ChangedProjectRelativePaths,
+                    Is.EqualTo(new[] { secondPath, sharedPath, firstPath }));
+                Assert.That(result.ScanLimitWarnings, Is.Empty);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// What: an assembly scan cap warning is retained by the aggregate result.
+        /// </summary>
+        [Test]
+        public void DetectFromSnapshotDirectories_WhenAssemblyScanIsLimited_CollectsTheWarning()
+        {
+            string projectRoot = CreateTempProjectRoot();
+            try
+            {
+                const int changedSourceCount = 51;
+                string[] sourcePaths = new string[changedSourceCount];
+                for (int index = 0; index < changedSourceCount; index++)
+                {
+                    string sourcePath = "Assets/Source" + index.ToString(CultureInfo.InvariantCulture) + ".cs";
+                    sourcePaths[index] = sourcePath;
+                    WriteChangedSource(projectRoot, "Assembly-A-mvid", sourcePath);
+                }
+
+                HotReloadChangedFileAggregationResult result =
+                    HotReloadChangedFileAggregator.DetectFromSnapshotDirectories(
+                        projectRoot,
+                        new[] { new HotReloadSnapshotAssembly("Assembly-A-mvid", sourcePaths) });
+
+                Assert.That(result.HasBaseline, Is.True);
+                Assert.That(result.ChangedProjectRelativePaths, Has.Count.EqualTo(50));
+                Assert.That(
+                    result.ScanLimitWarnings,
+                    Is.EqualTo(
+                        new[]
+                        {
+                            "sibling const-drift scan limited to first 50 changed files (51 total)"
+                        }));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// What: a baseline in any one assembly keeps the aggregate result distinguishable from no baseline.
+        /// </summary>
+        [Test]
+        public void DetectFromSnapshotDirectories_WhenOnlyOneAssemblyHasBaseline_ReportsBaselineAvailable()
+        {
+            string projectRoot = CreateTempProjectRoot();
+            try
+            {
+                string baselinePath = "Assets/Baseline.cs";
+                string missingBaselinePath = "Assets/MissingBaseline.cs";
+                WriteProjectFile(projectRoot, baselinePath, "same");
+                WriteSnapshot(projectRoot, "Assembly-WithBaseline-mvid", baselinePath, "same");
+                WriteProjectFile(projectRoot, missingBaselinePath, "changed");
+
+                HotReloadChangedFileAggregationResult result =
+                    HotReloadChangedFileAggregator.DetectFromSnapshotDirectories(
+                        projectRoot,
+                        new[]
+                        {
+                            new HotReloadSnapshotAssembly(
+                                "Assembly-WithBaseline-mvid",
+                                new[] { baselinePath }),
+                            new HotReloadSnapshotAssembly(
+                                "Assembly-WithoutBaseline-mvid",
+                                new[] { missingBaselinePath })
+                        });
+
+                Assert.That(result.HasBaseline, Is.True);
+                Assert.That(result.ChangedProjectRelativePaths, Is.Empty);
+                Assert.That(result.ScanLimitWarnings, Is.Empty);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// What: no assembly snapshot directories reports that no compile baseline exists.
+        /// </summary>
+        [Test]
+        public void DetectFromSnapshotDirectories_WhenNoAssemblyHasBaseline_ReportsNoBaseline()
+        {
+            string projectRoot = CreateTempProjectRoot();
+            try
+            {
+                string sourcePath = "Assets/Source.cs";
+                WriteProjectFile(projectRoot, sourcePath, "changed");
+
+                HotReloadChangedFileAggregationResult result =
+                    HotReloadChangedFileAggregator.DetectFromSnapshotDirectories(
+                        projectRoot,
+                        new[] { new HotReloadSnapshotAssembly("Assembly-mvid", new[] { sourcePath }) });
+
+                Assert.That(result.HasBaseline, Is.False);
+                Assert.That(result.ChangedProjectRelativePaths, Is.Empty);
+                Assert.That(result.ScanLimitWarnings, Is.Empty);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        private static string CreateTempProjectRoot()
+        {
+            string projectRoot = Path.Combine(
+                Path.GetTempPath(),
+                "hot-reload-file-aggregate-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectRoot);
+            return projectRoot;
+        }
+
+        private static void WriteChangedSource(
+            string projectRoot,
+            string assemblySnapshotDirectoryName,
+            string projectRelativePath)
+        {
+            WriteProjectFile(projectRoot, projectRelativePath, "disk");
+            WriteSnapshot(projectRoot, assemblySnapshotDirectoryName, projectRelativePath, "snapshot");
+        }
+
+        private static void WriteProjectFile(string projectRoot, string projectRelativePath, string contents)
+        {
+            string absolutePath = AbsoluteProjectPath(projectRoot, projectRelativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(absolutePath));
+            File.WriteAllText(absolutePath, contents, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        }
+
+        private static void WriteSnapshot(
+            string projectRoot,
+            string assemblySnapshotDirectoryName,
+            string projectRelativePath,
+            string contents)
+        {
+            string snapshotDirectory = Path.Combine(
+                projectRoot,
+                HotReloadConstants.SourceSnapshotRelativeDirectory,
+                assemblySnapshotDirectoryName);
+            Directory.CreateDirectory(snapshotDirectory);
+            string snapshotPath = Path.Combine(
+                snapshotDirectory,
+                HotReloadSourceSnapshotter.HashProjectRelativePath(projectRelativePath.Replace('\\', '/')) + ".cs");
+            File.WriteAllBytes(
+                snapshotPath,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetBytes(contents));
+        }
+
+        private static string AbsoluteProjectPath(string projectRoot, string projectRelativePath)
+        {
+            return Path.GetFullPath(
+                Path.Combine(projectRoot, projectRelativePath.Replace('/', Path.DirectorySeparatorChar)));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadChangedFileAggregatorTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadChangedFileAggregatorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 55a6b61677aea415aa234672cfc82f84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadChangedSourceDetectorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadChangedSourceDetectorTests.cs
@@ -72,6 +72,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: an assembly snapshot directory without the source's own snapshot keeps the baseline
+        /// and fails closed instead of treating the source as changed.
+        /// </summary>
+        [Test]
+        public void DetectAllChangedFromSnapshotDirectory_WhenSourceSnapshotIsMissing_ReportsBaselineWithoutChanges()
+        {
+            string projectRoot = CreateTempProjectRoot();
+            try
+            {
+                string sourcePath = "Assets/Source.cs";
+                string snapshotDirectory = Path.Combine(
+                    projectRoot,
+                    HotReloadConstants.SourceSnapshotRelativeDirectory,
+                    "Assembly-mvid");
+                WriteProjectFile(projectRoot, sourcePath, "disk-changed");
+                Directory.CreateDirectory(snapshotDirectory);
+
+                HotReloadChangedSourceScanResult result =
+                    HotReloadChangedSiblingSourceDetector.DetectAllChangedFromSnapshotDirectory(
+                        projectRoot,
+                        "Assembly-mvid",
+                        new[] { sourcePath });
+
+                Assert.That(result.HasBaseline, Is.True);
+                Assert.That(result.ChangedProjectRelativePaths, Is.Empty);
+                Assert.That(result.ScanLimitWarning, Is.EqualTo(string.Empty));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        /// <summary>
         /// What: every snapshot-mismatched source is returned without requiring an edited-file exclusion.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/HotReloadChangedSourceDetectorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadChangedSourceDetectorTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for whole-assembly source change detection from compile snapshots.
+    /// </summary>
+    public class HotReloadChangedSourceDetectorTests
+    {
+        /// <summary>
+        /// What: a missing snapshot directory reports no baseline instead of conflating it with no changes.
+        /// </summary>
+        [Test]
+        public void DetectAllChangedFromSnapshotDirectory_WhenSnapshotDirectoryMissing_ReportsNoBaseline()
+        {
+            string projectRoot = CreateTempProjectRoot();
+            try
+            {
+                string sourcePath = "Assets/Source.cs";
+                WriteProjectFile(projectRoot, sourcePath, "disk");
+
+                HotReloadChangedSourceScanResult result =
+                    HotReloadChangedSiblingSourceDetector.DetectAllChangedFromSnapshotDirectory(
+                        projectRoot,
+                        "Assembly-mvid",
+                        new[] { sourcePath });
+
+                Assert.That(result.HasBaseline, Is.False);
+                Assert.That(result.ChangedProjectRelativePaths, Is.Empty);
+                Assert.That(result.ScanLimitWarning, Is.EqualTo(string.Empty));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// What: an existing snapshot directory with byte-identical sources reports a baseline and no changes.
+        /// </summary>
+        [Test]
+        public void DetectAllChangedFromSnapshotDirectory_WhenSourcesMatchSnapshot_ReportsNoChanges()
+        {
+            string projectRoot = CreateTempProjectRoot();
+            try
+            {
+                string sourcePath = "Assets/Source.cs";
+                WriteProjectFile(projectRoot, sourcePath, "same");
+                WriteSnapshot(projectRoot, "Assembly-mvid", sourcePath, "same");
+
+                HotReloadChangedSourceScanResult result =
+                    HotReloadChangedSiblingSourceDetector.DetectAllChangedFromSnapshotDirectory(
+                        projectRoot,
+                        "Assembly-mvid",
+                        new[] { sourcePath });
+
+                Assert.That(result.HasBaseline, Is.True);
+                Assert.That(result.ChangedProjectRelativePaths, Is.Empty);
+                Assert.That(result.ScanLimitWarning, Is.EqualTo(string.Empty));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// What: every snapshot-mismatched source is returned without requiring an edited-file exclusion.
+        /// </summary>
+        [Test]
+        public void DetectAllChangedFromSnapshotDirectory_WhenSourcesDiffer_ReturnsProjectRelativePaths()
+        {
+            string projectRoot = CreateTempProjectRoot();
+            try
+            {
+                string changedPath = "Assets/Changed.cs";
+                string unchangedPath = "Assets/Unchanged.cs";
+                WriteProjectFile(projectRoot, changedPath, "disk-changed");
+                WriteProjectFile(projectRoot, unchangedPath, "same");
+                WriteSnapshot(projectRoot, "Assembly-mvid", changedPath, "snapshot-changed");
+                WriteSnapshot(projectRoot, "Assembly-mvid", unchangedPath, "same");
+
+                HotReloadChangedSourceScanResult result =
+                    HotReloadChangedSiblingSourceDetector.DetectAllChangedFromSnapshotDirectory(
+                        projectRoot,
+                        "Assembly-mvid",
+                        new[] { changedPath, unchangedPath });
+
+                Assert.That(result.HasBaseline, Is.True);
+                Assert.That(result.ChangedProjectRelativePaths, Is.EqualTo(new[] { changedPath }));
+                Assert.That(result.ScanLimitWarning, Is.EqualTo(string.Empty));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// What: more changed sources than the cap keeps the first 50 and reports the fixed cap warning.
+        /// </summary>
+        [Test]
+        public void DetectAllChangedFromSnapshotDirectory_WhenMoreThanLimitChanged_TruncatesAndWarns()
+        {
+            string projectRoot = CreateTempProjectRoot();
+            try
+            {
+                const int changedSourceCount = 51;
+                string[] sourcePaths = new string[changedSourceCount];
+                for (int index = 0; index < changedSourceCount; index++)
+                {
+                    string sourcePath = "Assets/Source" + index.ToString(CultureInfo.InvariantCulture) + ".cs";
+                    sourcePaths[index] = sourcePath;
+                    WriteProjectFile(projectRoot, sourcePath, "disk-" + index.ToString(CultureInfo.InvariantCulture));
+                    WriteSnapshot(
+                        projectRoot,
+                        "Assembly-mvid",
+                        sourcePath,
+                        "snapshot-" + index.ToString(CultureInfo.InvariantCulture));
+                }
+
+                HotReloadChangedSourceScanResult result =
+                    HotReloadChangedSiblingSourceDetector.DetectAllChangedFromSnapshotDirectory(
+                        projectRoot,
+                        "Assembly-mvid",
+                        sourcePaths);
+
+                Assert.That(result.HasBaseline, Is.True);
+                Assert.That(result.ChangedProjectRelativePaths, Has.Count.EqualTo(50));
+                Assert.That(
+                    result.ScanLimitWarning,
+                    Is.EqualTo("sibling const-drift scan limited to first 50 changed files (51 total)"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        private static string CreateTempProjectRoot()
+        {
+            string projectRoot = Path.Combine(
+                Path.GetTempPath(),
+                "hot-reload-source-scan-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectRoot);
+            return projectRoot;
+        }
+
+        private static void WriteProjectFile(string projectRoot, string projectRelativePath, string contents)
+        {
+            string absolutePath = AbsoluteProjectPath(projectRoot, projectRelativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(absolutePath));
+            File.WriteAllText(absolutePath, contents, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        }
+
+        private static void WriteSnapshot(
+            string projectRoot,
+            string assemblySnapshotDirectoryName,
+            string projectRelativePath,
+            string contents)
+        {
+            string snapshotDirectory = Path.Combine(
+                projectRoot,
+                HotReloadConstants.SourceSnapshotRelativeDirectory,
+                assemblySnapshotDirectoryName);
+            Directory.CreateDirectory(snapshotDirectory);
+            string snapshotPath = Path.Combine(
+                snapshotDirectory,
+                HotReloadSourceSnapshotter.HashProjectRelativePath(projectRelativePath.Replace('\\', '/')) + ".cs");
+            File.WriteAllBytes(
+                snapshotPath,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetBytes(contents));
+        }
+
+        private static string AbsoluteProjectPath(string projectRoot, string projectRelativePath)
+        {
+            return Path.GetFullPath(
+                Path.Combine(projectRoot, projectRelativePath.Replace('/', Path.DirectorySeparatorChar)));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadChangedSourceDetectorTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadChangedSourceDetectorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3756cc6de5eca405c8971ce0935b2086
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadDefaultFilesTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadDefaultFilesTests.cs
@@ -35,7 +35,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: omitting --files applies the sorted changed sources and prefixes the exact selection message.
+        /// What: production seam defaults remain wired to the real detector and private apply method.
+        /// </summary>
+        [Test]
+        public void StaticSeams_UseProductionDefaults()
+        {
+            Assert.That(
+                HotReloadTool.DetectChangedFilesForTesting,
+                Is.EqualTo(
+                    (Func<HotReloadChangedFileAggregationResult>)HotReloadChangedFileAggregator.Detect));
+            Assert.That(HotReloadTool.RunApplyAsyncForTesting.Method.Name, Is.EqualTo("RunApplyAsync"));
+            Assert.That(
+                HotReloadTool.RunApplyAsyncForTesting.Method.DeclaringType,
+                Is.EqualTo(typeof(HotReloadTool)));
+        }
+
+        /// <summary>
+        /// What: omitting --files retains existing warnings, appends selection warnings, and prefixes
+        /// the exact selection message.
         /// </summary>
         [Test]
         public async Task ExecuteAsync_WhenFilesAreOmittedAndChangesExist_AppliesSelectedFilesAndPrefixesMessage()
@@ -55,7 +72,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         {
                             HotReloadMethodOutcome.Patched("Host.Selected()", "Assets/Selected.cs")
                         },
-                        new List<string>(),
+                        new List<string> { "orchestrator warning" },
                         patchedTotal: 1,
                         activePatchTotal: 1));
             };
@@ -67,8 +84,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 response.Message,
                 Is.EqualTo(
                     "--files was omitted; 1 changed file(s) since the last compile were selected: Assets/Selected.cs. "
-                    + "Hot reload applied. PatchedTotal=1, ActivePatchTotal=1. 1 warning(s). See Warnings."));
-            Assert.That(response.Warnings, Is.EqualTo(new[] { "scan limit warning" }));
+                    + "Hot reload applied. PatchedTotal=1, ActivePatchTotal=1. 2 warning(s). See Warnings. "
+                    + "A single 'uloop compile' clears all of them at once."));
+            Assert.That(
+                response.Warnings,
+                Is.EqualTo(new[] { "orchestrator warning", "scan limit warning" }));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadDefaultFilesTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadDefaultFilesTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json.Linq;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for defaulting omitted hot-reload files from compile snapshot changes.
+    /// </summary>
+    public class HotReloadDefaultFilesTests
+    {
+        private Func<HotReloadChangedFileAggregationResult> _previousDetector;
+        private Func<IReadOnlyList<string>, CancellationToken, Task<HotReloadOrchestratorResult>> _previousApply;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _previousDetector = HotReloadTool.DetectChangedFilesForTesting;
+            _previousApply = HotReloadTool.RunApplyAsyncForTesting;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadTool.DetectChangedFilesForTesting = _previousDetector;
+            HotReloadTool.RunApplyAsyncForTesting = _previousApply;
+        }
+
+        /// <summary>
+        /// What: omitting --files applies the sorted changed sources and prefixes the exact selection message.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenFilesAreOmittedAndChangesExist_AppliesSelectedFilesAndPrefixesMessage()
+        {
+            HotReloadTool.DetectChangedFilesForTesting = () =>
+                new HotReloadChangedFileAggregationResult(
+                    hasBaseline: true,
+                    changedProjectRelativePaths: new List<string> { "Assets/Selected.cs" },
+                    scanLimitWarnings: new List<string> { "scan limit warning" });
+            List<string> appliedFiles = null;
+            HotReloadTool.RunApplyAsyncForTesting = (files, ignoredCt) =>
+            {
+                appliedFiles = new List<string>(files);
+                return Task.FromResult(
+                    new HotReloadOrchestratorResult(
+                        new List<HotReloadMethodOutcome>
+                        {
+                            HotReloadMethodOutcome.Patched("Host.Selected()", "Assets/Selected.cs")
+                        },
+                        new List<string>(),
+                        patchedTotal: 1,
+                        activePatchTotal: 1));
+            };
+
+            HotReloadResponse response = await ExecuteAsync(new JObject());
+
+            Assert.That(appliedFiles, Is.EqualTo(new[] { "Assets/Selected.cs" }));
+            Assert.That(
+                response.Message,
+                Is.EqualTo(
+                    "--files was omitted; 1 changed file(s) since the last compile were selected: Assets/Selected.cs. "
+                    + "Hot reload applied. PatchedTotal=1, ActivePatchTotal=1. 1 warning(s). See Warnings."));
+            Assert.That(response.Warnings, Is.EqualTo(new[] { "scan limit warning" }));
+        }
+
+        /// <summary>
+        /// What: a compile baseline with no changed sources returns the no-changed-files validation failure.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenFilesAreOmittedAndNoChangesExist_ReturnsNoChangedFilesFailure()
+        {
+            HotReloadTool.DetectChangedFilesForTesting = () =>
+                new HotReloadChangedFileAggregationResult(
+                    hasBaseline: true,
+                    changedProjectRelativePaths: new List<string>(),
+                    scanLimitWarnings: new List<string>());
+            HotReloadTool.RunApplyAsyncForTesting = FailIfApplyRuns;
+
+            HotReloadResponse response = await ExecuteAsync(new JObject());
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(
+                response.Message,
+                Is.EqualTo(
+                    "No .cs files changed since the last compile were found; pass explicit paths with --files."));
+            Assert.That(response.ErrorCode, Is.EqualTo(HotReloadValidationErrorCodes.NoChangedFiles));
+            Assert.That(
+                response.NextActions,
+                Is.EqualTo(
+                    new[]
+                    {
+                        "Save the edited .cs files to disk, then run 'uloop hot-reload' again.",
+                        "Pass project-relative .cs paths with --files."
+                    }));
+        }
+
+        /// <summary>
+        /// What: --status and --revert-all bypass changed-source detection when --files is omitted.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenStatusOrRevertAll_IsSet_DoesNotDetectChangedFiles()
+        {
+            int detectorCallCount = 0;
+            HotReloadTool.DetectChangedFilesForTesting = () =>
+            {
+                detectorCallCount++;
+                return new HotReloadChangedFileAggregationResult(
+                    hasBaseline: false,
+                    changedProjectRelativePaths: new List<string>(),
+                    scanLimitWarnings: new List<string>());
+            };
+
+            HotReloadResponse statusResponse = await ExecuteAsync(new JObject { ["Status"] = true });
+            HotReloadResponse revertResponse = await ExecuteAsync(new JObject { ["RevertAll"] = true });
+
+            Assert.That(statusResponse.Success, Is.True);
+            Assert.That(revertResponse.Success, Is.True);
+            Assert.That(detectorCallCount, Is.EqualTo(0));
+        }
+
+        private static Task<HotReloadOrchestratorResult> FailIfApplyRuns(
+            IReadOnlyList<string> files,
+            CancellationToken ct)
+        {
+            throw new AssertionException("Apply must not run for a default-file validation failure.");
+        }
+
+        private static async Task<HotReloadResponse> ExecuteAsync(JObject parameters)
+        {
+            HotReloadTool tool = new HotReloadTool();
+            UnityCliLoopToolResponse baseResponse =
+                await tool.ExecuteAsync(parameters, CancellationToken.None);
+            HotReloadResponse response = baseResponse as HotReloadResponse;
+            Assert.That(response, Is.Not.Null);
+            return response;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadDefaultFilesTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadDefaultFilesTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 451e4907ae91b4113984630b2e9191d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -43,34 +43,46 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: calling hot-reload with neither --files, --revert-all, nor --status names
-        /// --files and returns a structured recovery action.
+        /// What: omitting --files without compile snapshots returns the required-files code and recovery actions.
         /// </summary>
         [Test]
-        public async Task ExecuteAsync_WithoutFilesOrRevertAll_ReturnsValidationFailure()
+        public async Task ExecuteAsync_WithoutFilesAndWithoutBaseline_ReturnsValidationFailure()
         {
-            HotReloadTool tool = new HotReloadTool();
-            JObject parameters = new JObject();
+            Func<HotReloadChangedFileAggregationResult> previousDetector =
+                HotReloadTool.DetectChangedFilesForTesting;
+            try
+            {
+                HotReloadTool.DetectChangedFilesForTesting = () =>
+                    new HotReloadChangedFileAggregationResult(
+                        hasBaseline: false,
+                        changedProjectRelativePaths: new List<string>(),
+                        scanLimitWarnings: new List<string>());
 
-            UnityCliLoopToolResponse baseResponse =
-                await tool.ExecuteAsync(parameters, CancellationToken.None);
-            HotReloadResponse response = baseResponse as HotReloadResponse;
+                HotReloadTool tool = new HotReloadTool();
+                UnityCliLoopToolResponse baseResponse =
+                    await tool.ExecuteAsync(new JObject(), CancellationToken.None);
+                HotReloadResponse response = baseResponse as HotReloadResponse;
 
-            Assert.That(response, Is.Not.Null);
-            Assert.That(response.Success, Is.False);
-            Assert.That(
-                response.Message,
-                Is.EqualTo(
-                    "Files is required unless --revert-all or --status is set. Pass project-relative .cs paths with --files, e.g. 'uloop hot-reload --files Assets/Scripts/Player.cs'."));
-            Assert.That(response.ErrorCode, Is.EqualTo(HotReloadValidationErrorCodes.FilesRequired));
-            Assert.That(
-                response.NextActions,
-                Is.EqualTo(
-                    new[]
-                    {
-                        "Pass project-relative .cs paths with --files.",
-                        "Run 'uloop hot-reload --status' to inspect active patches."
-                    }));
+                Assert.That(response, Is.Not.Null);
+                Assert.That(response.Success, Is.False);
+                Assert.That(
+                    response.Message,
+                    Is.EqualTo(
+                        "No compile snapshots exist yet. Run 'uloop compile' first or pass project-relative .cs paths with --files."));
+                Assert.That(response.ErrorCode, Is.EqualTo(HotReloadValidationErrorCodes.FilesRequired));
+                Assert.That(
+                    response.NextActions,
+                    Is.EqualTo(
+                        new[]
+                        {
+                            "Run 'uloop compile' to create source snapshots.",
+                            "Pass project-relative .cs paths with --files."
+                        }));
+            }
+            finally
+            {
+                HotReloadTool.DetectChangedFilesForTesting = previousDetector;
+            }
         }
 
         /// <summary>
@@ -238,10 +250,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: an empty Files list returns the required-files code and recovery actions.
+        /// What: an empty Files list leaves selection to the compile-snapshot default path.
         /// </summary>
         [Test]
-        public void ValidateApplyParameters_MissingFiles_ReturnsErrorNamingFilesOption()
+        public void ValidateApplyParameters_EmptyFiles_LeavesSelectionToExecuteAsync()
         {
             HotReloadSchema schema = new HotReloadSchema
             {
@@ -250,19 +262,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             HotReloadValidationFailure failure = HotReloadTool.ValidateApplyParameters(schema);
 
-            Assert.That(
-                failure.Message,
-                Is.EqualTo(
-                    "Files is required unless --revert-all or --status is set. Pass project-relative .cs paths with --files, e.g. 'uloop hot-reload --files Assets/Scripts/Player.cs'."));
-            Assert.That(failure.ErrorCode, Is.EqualTo(HotReloadValidationErrorCodes.FilesRequired));
-            Assert.That(
-                failure.NextActions,
-                Is.EqualTo(
-                    new[]
-                    {
-                        "Pass project-relative .cs paths with --files.",
-                        "Run 'uloop hot-reload --status' to inspect active patches."
-                    }));
+            Assert.That(failure, Is.Null);
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadValidationResponseTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadValidationResponseTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,29 +20,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     public sealed class HotReloadValidationResponseTests
     {
         /// <summary>
-        /// What: a validation failure serializes its structured error code and recovery actions.
+        /// What: an omitted apply without a baseline serializes its structured error code and recovery actions.
         /// </summary>
         [Test]
-        public async Task ExecuteAsync_WhenFilesAreMissing_SerializesStructuredValidationFields()
+        public async Task ExecuteAsync_WhenFilesAreMissingAndNoBaseline_SerializesStructuredValidationFields()
         {
-            HotReloadTool tool = new HotReloadTool();
-            UnityCliLoopToolResponse baseResponse =
-                await tool.ExecuteAsync(new JObject(), CancellationToken.None);
-            HotReloadResponse response = baseResponse as HotReloadResponse;
-            JObject json = SerializeResponse(response);
-            JArray nextActions = json["NextActions"] as JArray;
+            Func<HotReloadChangedFileAggregationResult> previousDetector =
+                HotReloadTool.DetectChangedFilesForTesting;
+            try
+            {
+                HotReloadTool.DetectChangedFilesForTesting = () =>
+                    new HotReloadChangedFileAggregationResult(
+                        hasBaseline: false,
+                        changedProjectRelativePaths: new List<string>(),
+                        scanLimitWarnings: new List<string>());
 
-            Assert.That(response, Is.Not.Null);
-            Assert.That(json.Value<string>("ErrorCode"), Is.EqualTo("HOT_RELOAD_FILES_REQUIRED"));
-            Assert.That(nextActions, Is.Not.Null);
-            Assert.That(
-                nextActions.ToObject<string[]>(),
-                Is.EqualTo(
-                    new[]
-                    {
-                        "Pass project-relative .cs paths with --files.",
-                        "Run 'uloop hot-reload --status' to inspect active patches."
-                    }));
+                HotReloadResponse response = await ExecuteAsync(new JObject());
+                JObject json = SerializeResponse(response);
+                JArray nextActions = json["NextActions"] as JArray;
+
+                Assert.That(json.Value<string>("ErrorCode"), Is.EqualTo("HOT_RELOAD_FILES_REQUIRED"));
+                Assert.That(nextActions, Is.Not.Null);
+                Assert.That(
+                    nextActions.ToObject<string[]>(),
+                    Is.EqualTo(
+                        new[]
+                        {
+                            "Run 'uloop compile' to create source snapshots.",
+                            "Pass project-relative .cs paths with --files."
+                        }));
+            }
+            finally
+            {
+                HotReloadTool.DetectChangedFilesForTesting = previousDetector;
+            }
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedFileAggregator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedFileAggregator.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using UnityEditor.Compilation;
+
+using UnityEngine;
+
+using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Snapshot-directory metadata needed to scan one compilation assembly's source files.
+    /// </summary>
+    internal sealed class HotReloadSnapshotAssembly
+    {
+        internal string SnapshotDirectoryName { get; }
+
+        internal string[] SourceFiles { get; }
+
+        internal HotReloadSnapshotAssembly(string snapshotDirectoryName, string[] sourceFiles)
+        {
+            Debug.Assert(
+                !string.IsNullOrEmpty(snapshotDirectoryName),
+                "snapshotDirectoryName must not be null or empty.");
+            SnapshotDirectoryName = snapshotDirectoryName;
+            SourceFiles = sourceFiles ?? Array.Empty<string>();
+        }
+    }
+
+    /// <summary>
+    /// All changed sources selected from the available compilation snapshot directories.
+    /// </summary>
+    internal sealed class HotReloadChangedFileAggregationResult
+    {
+        internal bool HasBaseline { get; }
+
+        internal List<string> ChangedProjectRelativePaths { get; }
+
+        internal List<string> ScanLimitWarnings { get; }
+
+        internal HotReloadChangedFileAggregationResult(
+            bool hasBaseline,
+            List<string> changedProjectRelativePaths,
+            List<string> scanLimitWarnings)
+        {
+            HasBaseline = hasBaseline;
+            ChangedProjectRelativePaths = changedProjectRelativePaths ?? new List<string>();
+            ScanLimitWarnings = scanLimitWarnings ?? new List<string>();
+        }
+    }
+
+    /// <summary>
+    /// Aggregates changed sources from every mutable compilation assembly that has a snapshot candidate.
+    /// </summary>
+    internal static class HotReloadChangedFileAggregator
+    {
+        /// <summary>
+        /// Detects changed sources using the same compilation-assembly eligibility rules as snapshot capture.
+        /// </summary>
+        internal static HotReloadChangedFileAggregationResult Detect()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            List<HotReloadSnapshotAssembly> snapshotAssemblies = CollectSnapshotAssemblies(projectRoot);
+            return DetectFromSnapshotDirectories(projectRoot, snapshotAssemblies);
+        }
+
+        // Why an internal adapter: CompilePipeline assemblies cannot be planted in EditMode fixtures,
+        // while snapshot directory names and source files fully determine the pure aggregation behavior.
+        internal static HotReloadChangedFileAggregationResult DetectFromSnapshotDirectories(
+            string projectRoot,
+            IReadOnlyList<HotReloadSnapshotAssembly> snapshotAssemblies)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty.");
+            Debug.Assert(snapshotAssemblies != null, "snapshotAssemblies must not be null.");
+
+            bool hasBaseline = false;
+            HashSet<string> changedPathSet = new HashSet<string>(GetProjectRelativePathComparer());
+            List<string> scanLimitWarnings = new List<string>();
+            HashSet<string> warningSet = new HashSet<string>(StringComparer.Ordinal);
+            for (int index = 0; index < snapshotAssemblies.Count; index++)
+            {
+                HotReloadSnapshotAssembly assembly = snapshotAssemblies[index];
+                HotReloadChangedSourceScanResult scan =
+                    HotReloadChangedSiblingSourceDetector.DetectAllChangedFromSnapshotDirectory(
+                        projectRoot,
+                        assembly.SnapshotDirectoryName,
+                        assembly.SourceFiles);
+                hasBaseline |= scan.HasBaseline;
+
+                for (int pathIndex = 0; pathIndex < scan.ChangedProjectRelativePaths.Count; pathIndex++)
+                {
+                    changedPathSet.Add(scan.ChangedProjectRelativePaths[pathIndex]);
+                }
+
+                if (!string.IsNullOrEmpty(scan.ScanLimitWarning)
+                    && warningSet.Add(scan.ScanLimitWarning))
+                {
+                    scanLimitWarnings.Add(scan.ScanLimitWarning);
+                }
+            }
+
+            List<string> changedProjectRelativePaths = new List<string>(changedPathSet);
+            changedProjectRelativePaths.Sort(GetProjectRelativePathComparer());
+            scanLimitWarnings.Sort(StringComparer.Ordinal);
+            return new HotReloadChangedFileAggregationResult(
+                hasBaseline,
+                changedProjectRelativePaths,
+                scanLimitWarnings);
+        }
+
+        private static List<HotReloadSnapshotAssembly> CollectSnapshotAssemblies(string projectRoot)
+        {
+            List<HotReloadSnapshotAssembly> snapshotAssemblies = new List<HotReloadSnapshotAssembly>();
+            foreach (UnityCompilationAssembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                string[] sourceFiles = assembly.sourceFiles;
+                if (sourceFiles == null || sourceFiles.Length == 0)
+                {
+                    continue;
+                }
+
+                if (HotReloadSourceSnapshotter.ShouldSkipImmutablePackageSources(sourceFiles))
+                {
+                    continue;
+                }
+
+                string dllPath = Path.Combine(
+                    projectRoot,
+                    HotReloadConstants.ScriptAssembliesRelativeDirectory,
+                    assembly.name + HotReloadConstants.CompiledAssemblyExtension);
+                string pdbPath = Path.ChangeExtension(dllPath, ".pdb");
+                if (!File.Exists(dllPath) || !File.Exists(pdbPath))
+                {
+                    continue;
+                }
+
+                string mvid = HotReloadSourceSnapshotter.ReadAssemblyMvid(dllPath);
+                snapshotAssemblies.Add(
+                    new HotReloadSnapshotAssembly(assembly.name + "-" + mvid, sourceFiles));
+            }
+
+            return snapshotAssemblies;
+        }
+
+        private static StringComparer GetProjectRelativePathComparer()
+        {
+            return Path.DirectorySeparatorChar == '\\'
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedFileAggregator.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedFileAggregator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d916ccec9a85842879897c6309d42aed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSiblingSourceDetector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSiblingSourceDetector.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// Finds compilation-assembly siblings whose on-disk bytes differ from the last compile snapshot.
+    /// Finds compilation-assembly sources whose on-disk bytes differ from the last compile snapshot.
     /// </summary>
     internal static class HotReloadChangedSiblingSourceDetector
     {
@@ -69,37 +69,86 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return HotReloadChangedSiblingScanResult.Empty;
             }
 
+            HotReloadChangedSourceScanResult sourceScan = DetectChangedFromSnapshotDirectory(
+                projectRoot,
+                assemblySnapshotDirectoryName,
+                sourceFiles,
+                editedProjectRelativePath);
+            List<string> changedSiblingAbsolutePaths = new List<string>(
+                sourceScan.ChangedProjectRelativePaths.Count);
+            for (int index = 0; index < sourceScan.ChangedProjectRelativePaths.Count; index++)
+            {
+                changedSiblingAbsolutePaths.Add(
+                    ToAbsoluteProjectPath(projectRoot, sourceScan.ChangedProjectRelativePaths[index]));
+            }
+
+            return new HotReloadChangedSiblingScanResult(
+                changedSiblingAbsolutePaths.ToArray(),
+                sourceScan.ScanLimitWarning);
+        }
+
+        /// <summary>
+        /// Returns every changed project-relative source path for one snapshot directory.
+        /// </summary>
+        internal static HotReloadChangedSourceScanResult DetectAllChangedFromSnapshotDirectory(
+            string projectRoot,
+            string assemblySnapshotDirectoryName,
+            string[] sourceFiles)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty.");
+            Debug.Assert(
+                !string.IsNullOrEmpty(assemblySnapshotDirectoryName),
+                "assemblySnapshotDirectoryName must not be null or empty.");
+
+            return DetectChangedFromSnapshotDirectory(
+                projectRoot,
+                assemblySnapshotDirectoryName,
+                sourceFiles,
+                excludedProjectRelativePath: null);
+        }
+
+        private static HotReloadChangedSourceScanResult DetectChangedFromSnapshotDirectory(
+            string projectRoot,
+            string assemblySnapshotDirectoryName,
+            string[] sourceFiles,
+            string excludedProjectRelativePath)
+        {
             string snapshotDirectory = Path.Combine(
                 projectRoot,
                 HotReloadConstants.SourceSnapshotRelativeDirectory,
                 assemblySnapshotDirectoryName);
             if (!Directory.Exists(snapshotDirectory))
             {
-                return HotReloadChangedSiblingScanResult.Empty;
+                return new HotReloadChangedSourceScanResult(false, new List<string>(), string.Empty);
             }
 
-            List<string> changedSiblingAbsolutePaths = new List<string>();
+            List<string> changedProjectRelativePaths = new List<string>();
+            if (sourceFiles == null || sourceFiles.Length == 0)
+            {
+                return new HotReloadChangedSourceScanResult(true, changedProjectRelativePaths, string.Empty);
+            }
+
             for (int index = 0; index < sourceFiles.Length; index++)
             {
-                string changedPath = TryResolveChangedSiblingAbsolutePath(
+                string changedPath = TryResolveChangedProjectRelativePath(
                     projectRoot,
                     snapshotDirectory,
                     sourceFiles[index],
-                    editedProjectRelativePath);
+                    excludedProjectRelativePath);
                 if (changedPath != null)
                 {
-                    changedSiblingAbsolutePaths.Add(changedPath);
+                    changedProjectRelativePaths.Add(changedPath);
                 }
             }
 
-            return LimitChangedSiblings(changedSiblingAbsolutePaths);
+            return LimitChangedSources(changedProjectRelativePaths);
         }
 
-        private static string TryResolveChangedSiblingAbsolutePath(
+        private static string TryResolveChangedProjectRelativePath(
             string projectRoot,
             string snapshotDirectory,
             string projectRelativeSourcePath,
-            string editedProjectRelativePath)
+            string excludedProjectRelativePath)
         {
             if (string.IsNullOrEmpty(projectRelativeSourcePath))
             {
@@ -107,13 +156,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             string normalizedRelativePath = projectRelativeSourcePath.Replace('\\', '/');
-            if (IsSameProjectRelativePath(normalizedRelativePath, editedProjectRelativePath))
+            if (!string.IsNullOrEmpty(excludedProjectRelativePath)
+                && IsSameProjectRelativePath(normalizedRelativePath, excludedProjectRelativePath))
             {
                 return null;
             }
 
-            string absoluteSourcePath = Path.GetFullPath(
-                Path.Combine(projectRoot, normalizedRelativePath.Replace('/', Path.DirectorySeparatorChar)));
+            string absoluteSourcePath = ToAbsoluteProjectPath(projectRoot, normalizedRelativePath);
             if (!File.Exists(absoluteSourcePath))
             {
                 return null;
@@ -134,27 +183,37 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return null;
             }
 
-            return absoluteSourcePath;
+            // Why project-relative: the default --files path must work across machines and is the CLI contract.
+            return normalizedRelativePath;
         }
 
-        private static HotReloadChangedSiblingScanResult LimitChangedSiblings(List<string> changedSiblingAbsolutePaths)
+        private static HotReloadChangedSourceScanResult LimitChangedSources(
+            List<string> changedProjectRelativePaths)
         {
-            int totalChanged = changedSiblingAbsolutePaths.Count;
+            int totalChanged = changedProjectRelativePaths.Count;
             if (totalChanged <= HotReloadConstants.SiblingConstDriftScanFileLimit)
             {
-                return new HotReloadChangedSiblingScanResult(
-                    changedSiblingAbsolutePaths.ToArray(),
+                return new HotReloadChangedSourceScanResult(
+                    true,
+                    changedProjectRelativePaths,
                     string.Empty);
             }
 
-            string[] limited = new string[HotReloadConstants.SiblingConstDriftScanFileLimit];
-            changedSiblingAbsolutePaths.CopyTo(0, limited, 0, HotReloadConstants.SiblingConstDriftScanFileLimit);
+            List<string> limited = changedProjectRelativePaths.GetRange(
+                0,
+                HotReloadConstants.SiblingConstDriftScanFileLimit);
             string warning = string.Format(
                 CultureInfo.InvariantCulture,
                 HotReloadConstants.SiblingConstDriftScanLimitedWarningFormat,
                 HotReloadConstants.SiblingConstDriftScanFileLimit,
                 totalChanged);
-            return new HotReloadChangedSiblingScanResult(limited, warning);
+            return new HotReloadChangedSourceScanResult(true, limited, warning);
+        }
+
+        private static string ToAbsoluteProjectPath(string projectRoot, string projectRelativePath)
+        {
+            return Path.GetFullPath(
+                Path.Combine(projectRoot, projectRelativePath.Replace('/', Path.DirectorySeparatorChar)));
         }
 
         private static bool IsSameProjectRelativePath(string left, string right)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSourceScanResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSourceScanResult.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Changed project-relative source paths and baseline availability for one compilation assembly.
+    /// </summary>
+    internal sealed class HotReloadChangedSourceScanResult
+    {
+        internal bool HasBaseline { get; }
+
+        internal List<string> ChangedProjectRelativePaths { get; }
+
+        internal string ScanLimitWarning { get; }
+
+        internal HotReloadChangedSourceScanResult(
+            bool hasBaseline,
+            List<string> changedProjectRelativePaths,
+            string scanLimitWarning)
+        {
+            HasBaseline = hasBaseline;
+            ChangedProjectRelativePaths = changedProjectRelativePaths ?? new List<string>();
+            ScanLimitWarning = scanLimitWarning ?? string.Empty;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSourceScanResult.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSourceScanResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92e12a3a44a8e4c8cb569832c307f70e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDefaultFileSelection.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDefaultFileSelection.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Files and response details chosen when callers omit the hot-reload files parameter.
+    /// </summary>
+    internal sealed class HotReloadDefaultFileSelection
+    {
+        internal IReadOnlyList<string> Files { get; }
+
+        internal IReadOnlyList<string> ScanLimitWarnings { get; }
+
+        internal string SelectionMessage { get; }
+
+        internal HotReloadValidationFailure ValidationFailure { get; }
+
+        internal HotReloadDefaultFileSelection(
+            IReadOnlyList<string> files,
+            IReadOnlyList<string> scanLimitWarnings,
+            string selectionMessage,
+            HotReloadValidationFailure validationFailure)
+        {
+            Files = files ?? Array.Empty<string>();
+            ScanLimitWarnings = scanLimitWarnings ?? Array.Empty<string>();
+            SelectionMessage = selectionMessage ?? string.Empty;
+            ValidationFailure = validationFailure;
+        }
+    }
+
+    /// <summary>
+    /// Resolves omitted hot-reload files from compile snapshots without mixing selection with apply execution.
+    /// </summary>
+    internal static class HotReloadDefaultFileSelector
+    {
+        internal static HotReloadDefaultFileSelection Resolve(
+            string[] files,
+            Func<HotReloadChangedFileAggregationResult> changedFileDetector)
+        {
+            Debug.Assert(changedFileDetector != null, "changedFileDetector must not be null.");
+
+            if (files != null && files.Length > 0)
+            {
+                return new HotReloadDefaultFileSelection(
+                    files,
+                    Array.Empty<string>(),
+                    string.Empty,
+                    validationFailure: null);
+            }
+
+            return SelectChangedFiles(changedFileDetector());
+        }
+
+        private static HotReloadDefaultFileSelection SelectChangedFiles(
+            HotReloadChangedFileAggregationResult changedFiles)
+        {
+            Debug.Assert(changedFiles != null, "changedFiles must not be null.");
+
+            if (!changedFiles.HasBaseline)
+            {
+                return new HotReloadDefaultFileSelection(
+                    Array.Empty<string>(),
+                    Array.Empty<string>(),
+                    string.Empty,
+                    new HotReloadValidationFailure(
+                        "No compile snapshots exist yet. Run 'uloop compile' first or pass project-relative .cs paths with --files.",
+                        HotReloadValidationErrorCodes.FilesRequired,
+                        new[]
+                        {
+                            "Run 'uloop compile' to create source snapshots.",
+                            "Pass project-relative .cs paths with --files."
+                        }));
+            }
+
+            if (changedFiles.ChangedProjectRelativePaths.Count == 0)
+            {
+                return new HotReloadDefaultFileSelection(
+                    Array.Empty<string>(),
+                    Array.Empty<string>(),
+                    string.Empty,
+                    new HotReloadValidationFailure(
+                        "No .cs files changed since the last compile were found; pass explicit paths with --files.",
+                        HotReloadValidationErrorCodes.NoChangedFiles,
+                        new[]
+                        {
+                            "Save the edited .cs files to disk, then run 'uloop hot-reload' again.",
+                            "Pass project-relative .cs paths with --files."
+                        }));
+            }
+
+            string selectionMessage = "--files was omitted; "
+                + changedFiles.ChangedProjectRelativePaths.Count
+                + " changed file(s) since the last compile were selected: "
+                + string.Join(", ", changedFiles.ChangedProjectRelativePaths)
+                + ".";
+            return new HotReloadDefaultFileSelection(
+                changedFiles.ChangedProjectRelativePaths,
+                changedFiles.ScanLimitWarnings,
+                selectionMessage,
+                validationFailure: null);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDefaultFileSelection.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDefaultFileSelection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b81730f5654df4dec83cc92e481427c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -119,6 +119,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     [UnityCliLoopTool]
     public class HotReloadTool : UnityCliLoopTool<HotReloadSchema, HotReloadResponse>
     {
+        // Why internal seams: compile-pipeline enumeration and apply execution cannot use planted
+        // fixtures, so tests substitute them while production keeps these default implementations.
+        internal static Func<HotReloadChangedFileAggregationResult> DetectChangedFilesForTesting =
+            HotReloadChangedFileAggregator.Detect;
+
+        internal static Func<IReadOnlyList<string>, CancellationToken, Task<HotReloadOrchestratorResult>>
+            RunApplyAsyncForTesting = RunApplyAsync;
+
         public override string ToolName => UnityCliLoopConstants.TOOL_NAME_HOT_RELOAD;
 
         protected override async Task<HotReloadResponse> ExecuteAsync(
@@ -158,14 +166,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return CreateValidationFailure(validationFailure);
             }
 
-            HotReloadOrchestratorResult result = await HotReloadOrchestrator
-                .RunAsync(parameters.Files, contentPathOverride: null, ct)
+            HotReloadDefaultFileSelection selection = HotReloadDefaultFileSelector.Resolve(
+                parameters.Files,
+                DetectChangedFilesForTesting);
+            if (selection.ValidationFailure != null)
+            {
+                return CreateValidationFailure(selection.ValidationFailure);
+            }
+
+            HotReloadOrchestratorResult result = await RunApplyAsyncForTesting(selection.Files, ct)
                 .ConfigureAwait(false);
             // Why switch back: SessionState for Play-entry drop recovery is a Unity Editor API.
             await MainThreadSwitcher.SwitchToMainThread(ct);
             HotReloadPlayModeEntryDropRecorder.NotifyApplyRecovered(result.Methods);
 
-            return BuildApplyResponse(result);
+            HotReloadResponse response = BuildApplyResponse(result, selection.ScanLimitWarnings);
+            if (!string.IsNullOrEmpty(selection.SelectionMessage))
+            {
+                response.Message = selection.SelectionMessage + " " + response.Message;
+            }
+
+            return response;
         }
 
         private static HotReloadResponse ExecuteRevertAll()
@@ -255,19 +276,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        // Returns structured validation details so the response does not infer an error code from Message text.
+        // Validates supplied files so omitted files can use the compile-snapshot default path.
         internal static HotReloadValidationFailure ValidateApplyParameters(HotReloadSchema parameters)
         {
-            if (parameters.Files == null || parameters.Files.Length == 0)
+            if (parameters.Files == null)
             {
-                return new HotReloadValidationFailure(
-                    "Files is required unless --revert-all or --status is set. Pass project-relative .cs paths with --files, e.g. 'uloop hot-reload --files Assets/Scripts/Player.cs'.",
-                    HotReloadValidationErrorCodes.FilesRequired,
-                    new[]
-                    {
-                        "Pass project-relative .cs paths with --files.",
-                        "Run 'uloop hot-reload --status' to inspect active patches."
-                    });
+                return null;
             }
 
             for (int index = 0; index < parameters.Files.Length; index++)
@@ -288,7 +302,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return null;
         }
 
-        internal static HotReloadResponse BuildApplyResponse(HotReloadOrchestratorResult result)
+        internal static HotReloadResponse BuildApplyResponse(
+            HotReloadOrchestratorResult result,
+            IReadOnlyList<string> additionalWarnings = null)
         {
             Debug.Assert(result != null, "result must not be null.");
 
@@ -317,6 +333,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             List<string> warnings = new List<string>(result.Warnings);
+            if (additionalWarnings != null)
+            {
+                warnings.AddRange(additionalWarnings);
+            }
+
             // Why before the pause-point extras: this warning is cleared by compile, so it must
             // count toward the single-compile resolution suffix instead of suppressing it.
             HotReloadUnpatchedMethodLineShiftWarningBuilder.Append(
@@ -592,6 +613,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return addedCount;
+        }
+
+        private static Task<HotReloadOrchestratorResult> RunApplyAsync(
+            IReadOnlyList<string> files,
+            CancellationToken ct)
+        {
+            return HotReloadOrchestrator.RunAsync(files, contentPathOverride: null, ct);
         }
 
         private static HotReloadResponse CreateValidationFailure(HotReloadValidationFailure failure)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -16,7 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     public class HotReloadSchema : UnityCliLoopToolSchema
     {
         /// <summary>
-        /// Project-relative source file paths to hot-reload. Required when RevertAll is false.
+        /// Project-relative source file paths to hot-reload. Omitted or empty apply values select sources changed since the last compile snapshot; --status rejects a nonempty value and --revert-all ignores it.
         /// </summary>
         public string[] Files { get; set; } = Array.Empty<string>();
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadValidationErrorCodes.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadValidationErrorCodes.cs
@@ -8,5 +8,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal const string FilesRequired = "HOT_RELOAD_FILES_REQUIRED";
         internal const string InvalidFiles = "HOT_RELOAD_INVALID_FILES";
         internal const string StatusConflict = "HOT_RELOAD_STATUS_CONFLICT";
+        internal const string NoChangedFiles = "HOT_RELOAD_NO_CHANGED_FILES";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -33,11 +33,11 @@ before its first import: Unity has not compiled it into any assembly yet. Run
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. When omitted on apply, selects every `.cs` source whose bytes changed since the last compile snapshot; run `uloop compile` first when no snapshot exists, or pass explicit paths when no changed source is found |
+| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. When omitted or empty on apply, selects the `.cs` sources whose bytes changed since the last compile snapshot, capped at 50 changed files per assembly with a warning when the cap trims the list; run `uloop compile` first when no snapshot exists, or pass explicit paths when no changed source is found |
 | `--revert-all` | flag | - | Remove every active hot-reload patch and clear the patch ledger. When set, `--files` is ignored |
 | `--status` | flag | - | Lists the currently active changes (patched methods and added members) without applying or reverting anything. |
 
-When `--files` is omitted, a source is selected only when its compilation assembly has a
+When `--files` is omitted or empty, a source is selected only when its compilation assembly has a
 snapshot directory and that source has its own snapshot file. A missing per-file snapshot is
 left out rather than guessed as changed, so pass the file explicitly or run `uloop compile`
 to establish a complete baseline.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -18,6 +18,7 @@ or `Failed`; one unpatchable method never aborts the rest of the run.
 ```bash
 uloop hot-reload --files Assets/Scripts/Enemy.cs
 uloop hot-reload --files Assets/Scripts/Enemy.cs,Assets/Scripts/Boss.cs
+uloop hot-reload
 uloop hot-reload --revert-all
 ```
 
@@ -32,9 +33,14 @@ before its first import: Unity has not compiled it into any assembly yet. Run
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. Required when neither `--revert-all` nor `--status` is set |
+| `--files` | array | - | Project-relative `.cs` paths whose method bodies should be hot-reloaded. When omitted on apply, selects every `.cs` source whose bytes changed since the last compile snapshot; run `uloop compile` first when no snapshot exists, or pass explicit paths when no changed source is found |
 | `--revert-all` | flag | - | Remove every active hot-reload patch and clear the patch ledger. When set, `--files` is ignored |
 | `--status` | flag | - | Lists the currently active changes (patched methods and added members) without applying or reverting anything. |
+
+When `--files` is omitted, a source is selected only when its compilation assembly has a
+snapshot directory and that source has its own snapshot file. A missing per-file snapshot is
+left out rather than guessed as changed, so pass the file explicitly or run `uloop compile`
+to establish a complete baseline.
 
 ## Checking what is currently patched
 
@@ -372,7 +378,7 @@ cached dispatch can bypass a hot-reload patch too.
 Returns JSON with:
 
 - `Success` (boolean): `false` on parameter validation failure or when any method outcome is `Failed`. `Skipped` outcomes alone never force `false`
-- `ErrorCode` (string, optional): Present on parameter validation failure. Values are `HOT_RELOAD_FILES_REQUIRED` when apply needs `--files`, `HOT_RELOAD_INVALID_FILES` when `--files` contains a null or empty path, and `HOT_RELOAD_STATUS_CONFLICT` when `--status` is combined with `--files` or `--revert-all`.
+- `ErrorCode` (string, optional): Present on parameter validation failure. Values are `HOT_RELOAD_FILES_REQUIRED` when an omitted apply has no compile snapshots, `HOT_RELOAD_NO_CHANGED_FILES` when snapshots contain no changed `.cs` files, `HOT_RELOAD_INVALID_FILES` when `--files` contains a null or empty path, and `HOT_RELOAD_STATUS_CONFLICT` when `--status` is combined with `--files` or `--revert-all`.
 - `NextActions` (array, optional): Ordered recovery steps, present only with `ErrorCode` on a parameter validation failure. Omitted from every other response, including successful apply, plain `--status`, and `--revert-all` runs.
 - `Methods` (array): Per-method `{ Kind, Method, Reason, FilePath, InvocationCount, LifecycleNote }` where `Kind` is `Patched`, `Skipped`, `Failed`, `Added`, or `AlreadyActive` on apply runs, and `Active` or `Added` on `--status` runs; empty on `--revert-all` runs. `AlreadyActive` means this file's source matched the last fully applied reload (a run with no Skipped or Failed outcomes), so the existing patch was left in place and the row carries the live `InvocationCount`. `InvocationCount` is meaningful on `Active` rows and `AlreadyActive` apply rows (calls since the current patch was applied); it is `0` on other apply/revert outcomes. On `--status`, an `Active` row with `InvocationCount` 0 sets `Reason` to explain that the method has not run since the patch: finished calls do not re-run, the patched body takes effect on the next call, and how to retrigger an initialization-only path. Added-member rows always show InvocationCount 0 — added-member calls are not instrumented, and the row's Reason says so. `LifecycleNote` is set when a patched method is a Unity one-shot lifecycle message (`private void Awake`/`Start`/`OnEnable`/`OnDisable`/`OnDestroy` on a `MonoBehaviour`), or when every compiled caller of the patched method is such a message; empty otherwise — it does not change `Kind`. `Added` rows carry the added member's signature and file; their `InvocationCount` is always `0` (added-member calls are not instrumented). Example `--status` row: `{ "Kind": "Added", "Method": "Ns.Host.NewHelper(System.Int32)", "Reason": "Added-member calls are not instrumented, so InvocationCount is always 0 for this row.", "FilePath": "Assets/Scripts/Host.cs", "InvocationCount": 0, "LifecycleNote": "" }`
 - `Warnings` (array): Non-fatal notes — one aggregated line listing the patched methods at risk of being already JIT-inlined into existing callers — those marked `[AggressiveInlining]`, plus (only when Code Optimization is Release) those with tiny pre-patch bodies — meaning the change may not show at those call sites, the pause-point interaction above, and the const drift, outside-body drift, and missing-baseline entries described in "Scope and limits". When a run carries two or more warnings and all of them are hot reload warnings, the Message ends with "A single 'uloop compile' clears all of them at once." — read it as the shortest recovery, not as an obligation to compile immediately. Pause-point warnings carry their own recovery steps, so that line does not appear when they are present.

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -764,7 +764,7 @@
         "properties": {
           "Files": {
             "type": "array",
-            "description": "Project-relative .cs paths whose method bodies should be hot-reloaded. Required when neither --revert-all nor --status is set",
+            "description": "Project-relative .cs paths whose method bodies should be hot-reloaded. When omitted on apply, selects every .cs source whose bytes changed since the last compile snapshot; run uloop compile first when no snapshot exists, or pass explicit paths when no changed source is found",
             "items": {
               "type": "string"
             }

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -764,7 +764,7 @@
         "properties": {
           "Files": {
             "type": "array",
-            "description": "Project-relative .cs paths whose method bodies should be hot-reloaded. When omitted on apply, selects every .cs source whose bytes changed since the last compile snapshot; run uloop compile first when no snapshot exists, or pass explicit paths when no changed source is found",
+            "description": "Project-relative .cs paths whose method bodies should be hot-reloaded. When omitted or empty on apply, selects the .cs sources whose bytes changed since the last compile snapshot, capped at 50 changed files per assembly with a warning when the cap trims the list; run uloop compile first when no snapshot exists, or pass explicit paths when no changed source is found",
             "items": {
               "type": "string"
             }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "24c0a5e9d0fae0c81224dddc7d0a7a24a63cb34b"
+  "sharedInputsHash": "6ebd614e3226ef1675336463cf17f4714c88c4ea"
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "09cff37680b9ab0f5b026863b7ca1bf3cfb2fde7"
+  "sharedInputsHash": "17394515af818fc0b82a3eebf772217db55d1f0e"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "daded28c5c7052ba4690bb95b886f0717af4342e"
+  "sharedInputsHash": "08fa54fd6df00dbafe40514704768383ab7e9e98"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "c530070c11c62411edb2d2cf9d791906467984fd"
+  "sharedInputsHash": "23baf5350a499301b30d774ecc6941854680a57e"
 }


### PR DESCRIPTION
## Summary

- Default an omitted `--files` value to project sources changed since the last compile snapshot.
- Return distinct validation failures when no snapshot baseline exists or no changed source is found.
- Preserve explicit-file, `--status`, and `--revert-all` behavior, and document the new contract.

## User Impact

After editing saved source files, `uloop hot-reload` can select the changed files automatically. The response states exactly which files were selected. Callers receive a stable error code and recovery actions when automatic selection cannot proceed.

## Changes

- Added whole-assembly snapshot aggregation with stable sorting, deduplication, baseline detection, and scan-warning collection.
- Added an internal test seam for deterministic tool-level coverage without changing the public or wire API.
- Updated the hot-reload skill and generated tool catalog for the omitted-files behavior and `HOT_RELOAD_NO_CHANGED_FILES`.

## Verification

- Unity compile: ErrorCount 0
- Focused EditMode fixtures: 61 passed
- File-length and C# complexity gates passed
- Verified the real CLI returns `HOT_RELOAD_NO_CHANGED_FILES` when snapshots match, and selects and patches a changed source when `--files` is omitted


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

