### PR TITLE
feat: list all markers when pause-point-status omits --id

### DIFF
--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -219,7 +219,7 @@ is in `SuppressedByHotReloadReason` and surfaced as the status `Warning`. The ma
 not cleared — it fires again once a transition restores its line, or after
 `uloop compile` and a re-enable.
 
-Use `uloop pause-point-status` only when you need to confirm the marker is armed or inspect the current hit state. A file:line marker can be addressed either by its returned `Id` (`--id "Assets/Scripts/Enemy.cs:42"`) or by the original pair (`--file "Assets/Scripts/Enemy.cs" --line 42`) — the same applies to `await-pause-point`. Always pass `--file` and `--line` together, and never combine them with `--id`.
+Run `uloop pause-point-status` with no target to list every registered marker as a compact summary (`Id`, `Status`, `Mode`, `HitCount`, `RemainingMilliseconds`). To inspect one marker in detail — confirming it is armed, or reading its current hit state — address it by its returned `Id` (`--id "Assets/Scripts/Enemy.cs:42"`) or by the original pair (`--file "Assets/Scripts/Enemy.cs" --line 42`); `await-pause-point` accepts the same two addressing forms but always requires a target. Always pass `--file` and `--line` together, and never combine them with `--id`.
 
 For the full diagnosis flow — the `Error.Details` status fields, bisecting with a second marker on the method entry, JIT inlining, physics-callback misses, and delegate bypass — read [references/troubleshooting.md](references/troubleshooting.md).
 

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -219,7 +219,7 @@ is in `SuppressedByHotReloadReason` and surfaced as the status `Warning`. The ma
 not cleared — it fires again once a transition restores its line, or after
 `uloop compile` and a re-enable.
 
-Use `uloop pause-point-status` only when you need to confirm the marker is armed or inspect the current hit state. A file:line marker can be addressed either by its returned `Id` (`--id "Assets/Scripts/Enemy.cs:42"`) or by the original pair (`--file "Assets/Scripts/Enemy.cs" --line 42`) — the same applies to `await-pause-point`. Always pass `--file` and `--line` together, and never combine them with `--id`.
+Run `uloop pause-point-status` with no target to list every registered marker as a compact summary (`Id`, `Status`, `Mode`, `HitCount`, `RemainingMilliseconds`). To inspect one marker in detail — confirming it is armed, or reading its current hit state — address it by its returned `Id` (`--id "Assets/Scripts/Enemy.cs:42"`) or by the original pair (`--file "Assets/Scripts/Enemy.cs" --line 42`); `await-pause-point` accepts the same two addressing forms but always requires a target. Always pass `--file` and `--line` together, and never combine them with `--id`.
 
 For the full diagnosis flow — the `Error.Details` status fields, bisecting with a second marker on the method entry, JIT inlining, physics-callback misses, and delegate bypass — read [references/troubleshooting.md](references/troubleshooting.md).
 

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -303,12 +303,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void GetAllStatuses_WhenMarkersAreRegistered_ReturnsOrdinalIdOrder()
         {
-            UloopPausePointRegistry.Enable("zulu", 30);
-            UloopPausePointRegistry.Enable("alpha", 30);
+            UloopPausePointRegistry.Enable("a", 30);
+            UloopPausePointRegistry.Enable("B", 30);
 
             IReadOnlyList<UloopPausePointSnapshot> snapshots = UloopPausePointRegistry.GetAllStatuses();
 
-            Assert.That(snapshots.Select(snapshot => snapshot.Id), Is.EqualTo(new[] { "alpha", "zulu" }));
+            Assert.That(snapshots.Select(snapshot => snapshot.Id), Is.EqualTo(new[] { "B", "a" }));
             Assert.That(snapshots.Select(snapshot => snapshot.RemainingMilliseconds), Is.EqualTo(new long[] { 30000, 30000 }));
         }
 
@@ -329,6 +329,27 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(snapshots[0].IsEnabled, Is.False);
             Assert.That(snapshots[0].RemainingMilliseconds, Is.EqualTo(0));
             Assert.That(snapshots[0].EditorState.IsPaused, Is.False);
+            Assert.That(_pauseController.ResumeCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// Verifies listing expires every elapsed marker before issuing one editor resume.
+        /// </summary>
+        [Test]
+        public void GetAllStatuses_WhenTwoMarkersHaveExpired_ExpiresBothAndResumesEditorOnce()
+        {
+            UloopPausePointRegistry.Enable("alpha", 1);
+            UloopPausePointRegistry.Enable("zulu", 1);
+            _pauseController.Pause();
+            _nowUtc = _nowUtc.AddSeconds(2);
+
+            IReadOnlyList<UloopPausePointSnapshot> snapshots = UloopPausePointRegistry.GetAllStatuses();
+
+            Assert.That(snapshots.Select(snapshot => snapshot.Status), Is.EqualTo(new[]
+            {
+                UloopPausePointStatus.Expired,
+                UloopPausePointStatus.Expired
+            }));
             Assert.That(_pauseController.ResumeCount, Is.EqualTo(1));
         }
 

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -4,12 +4,15 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
 
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.CompositionRoot;
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.Infrastructure;
 using io.github.hatayama.UnityCliLoop.Runtime;
@@ -281,6 +284,52 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Is.EqualTo("Re-enable the marker with a longer --timeout-seconds and trigger the code path again; clearing the expired marker first is not required."));
             Assert.That(snapshot.IsEnabled, Is.False);
             Assert.That(_pauseController.PauseCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies listing with no registered markers returns an empty collection.
+        /// </summary>
+        [Test]
+        public void GetAllStatuses_WhenNoMarkersAreRegistered_ReturnsEmptyCollection()
+        {
+            IReadOnlyList<UloopPausePointSnapshot> snapshots = UloopPausePointRegistry.GetAllStatuses();
+
+            Assert.That(snapshots, Is.Empty);
+        }
+
+        /// <summary>
+        /// Verifies list status snapshots are ordered by ordinal marker id rather than registry insertion order.
+        /// </summary>
+        [Test]
+        public void GetAllStatuses_WhenMarkersAreRegistered_ReturnsOrdinalIdOrder()
+        {
+            UloopPausePointRegistry.Enable("zulu", 30);
+            UloopPausePointRegistry.Enable("alpha", 30);
+
+            IReadOnlyList<UloopPausePointSnapshot> snapshots = UloopPausePointRegistry.GetAllStatuses();
+
+            Assert.That(snapshots.Select(snapshot => snapshot.Id), Is.EqualTo(new[] { "alpha", "zulu" }));
+            Assert.That(snapshots.Select(snapshot => snapshot.RemainingMilliseconds), Is.EqualTo(new long[] { 30000, 30000 }));
+        }
+
+        /// <summary>
+        /// Verifies listing applies the same expiration transition and editor-resume side effect as a single status query.
+        /// </summary>
+        [Test]
+        public void GetAllStatuses_WhenMarkerHasExpired_ExpiresAndResumesEditor()
+        {
+            UloopPausePointRegistry.Enable("jump", 1);
+            _pauseController.Pause();
+            _nowUtc = _nowUtc.AddSeconds(2);
+
+            IReadOnlyList<UloopPausePointSnapshot> snapshots = UloopPausePointRegistry.GetAllStatuses();
+
+            Assert.That(snapshots, Has.Count.EqualTo(1));
+            Assert.That(snapshots[0].Status, Is.EqualTo(UloopPausePointStatus.Expired));
+            Assert.That(snapshots[0].IsEnabled, Is.False);
+            Assert.That(snapshots[0].RemainingMilliseconds, Is.EqualTo(0));
+            Assert.That(snapshots[0].EditorState.IsPaused, Is.False);
+            Assert.That(_pauseController.ResumeCount, Is.EqualTo(1));
         }
 
         /// <summary>
@@ -1261,6 +1310,52 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.CapturedVariablesTruncated, Is.True);
             Assert.That(response.CapturedVariables.Select(v => v.Name), Is.EquivalentTo(new[] { "speed" }));
             Assert.That(response.CapturedVariables[0].Value, Is.EqualTo("5"));
+        }
+
+        /// <summary>
+        /// Verifies an id-less internal status request routes to the empty list response and keeps its wire JSON fixed.
+        /// </summary>
+        [Test]
+        public void PausePointStatusBridge_ExecuteWithoutId_ReturnsEmptyListWireJson()
+        {
+            UnityCliLoopToolRegistrarService toolRegistrarService =
+                UnityCliLoopToolRegistrarTestFactory.Create(UnityCliLoopToolDiscovery.DiscoverTools);
+
+            UnityCliLoopToolResponse response = InternalBridgeCommandRouter.Execute(
+                UnityCliLoopConstants.COMMAND_NAME_GET_PAUSE_POINT_STATUS,
+                new JObject(),
+                toolRegistrarService);
+            string json = JsonConvert.SerializeObject(
+                response,
+                Formatting.None,
+                UnityCliLoopJsonResponseSerializerSettings.Settings);
+
+            Assert.That(response, Is.TypeOf<PausePointStatusListResponse>());
+            Assert.That(
+                json,
+                Is.EqualTo(
+                    "{\"Success\":true,\"Message\":\"No pause points are registered.\",\"Count\":0,\"PausePoints\":[],\"NextActions\":[\"Enable one with 'uloop enable-pause-point --id <marker-id>' or '--file <project-relative path> --line <line>'.\"]}"));
+        }
+
+        /// <summary>
+        /// Verifies list responses expose only sorted pause point summaries with the approved count guidance wire shape.
+        /// </summary>
+        [Test]
+        public void PausePointStatusBridge_ExecuteList_WhenMarkersAreRegistered_ReturnsSummaryWireJson()
+        {
+            UloopPausePointRegistry.Enable("zulu", 30);
+            UloopPausePointRegistry.Enable("alpha", 30);
+
+            PausePointStatusListResponse response = PausePointStatusBridgeCommand.ExecuteList();
+            string json = JsonConvert.SerializeObject(
+                response,
+                Formatting.None,
+                UnityCliLoopJsonResponseSerializerSettings.Settings);
+
+            Assert.That(
+                json,
+                Is.EqualTo(
+                    "{\"Success\":true,\"Message\":\"2 pause point(s) registered.\",\"Count\":2,\"PausePoints\":[{\"Id\":\"alpha\",\"Status\":\"Enabled\",\"Mode\":\"single-shot\",\"HitCount\":0,\"RemainingMilliseconds\":30000},{\"Id\":\"zulu\",\"Status\":\"Enabled\",\"Mode\":\"single-shot\",\"HitCount\":0,\"RemainingMilliseconds\":30000}],\"NextActions\":[\"Pass --id <marker-id> to inspect one pause point in detail.\"]}"));
         }
 
         [Test]

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -219,7 +219,7 @@ is in `SuppressedByHotReloadReason` and surfaced as the status `Warning`. The ma
 not cleared — it fires again once a transition restores its line, or after
 `uloop compile` and a re-enable.
 
-Use `uloop pause-point-status` only when you need to confirm the marker is armed or inspect the current hit state. A file:line marker can be addressed either by its returned `Id` (`--id "Assets/Scripts/Enemy.cs:42"`) or by the original pair (`--file "Assets/Scripts/Enemy.cs" --line 42`) — the same applies to `await-pause-point`. Always pass `--file` and `--line` together, and never combine them with `--id`.
+Run `uloop pause-point-status` with no target to list every registered marker as a compact summary (`Id`, `Status`, `Mode`, `HitCount`, `RemainingMilliseconds`). To inspect one marker in detail — confirming it is armed, or reading its current hit state — address it by its returned `Id` (`--id "Assets/Scripts/Enemy.cs:42"`) or by the original pair (`--file "Assets/Scripts/Enemy.cs" --line 42`); `await-pause-point` accepts the same two addressing forms but always requires a target. Always pass `--file` and `--line` together, and never combine them with `--id`.
 
 For the full diagnosis flow — the `Error.Details` status fields, bisecting with a second marker on the method entry, JIT inlining, physics-callback misses, and delegate bypass — read [references/troubleshooting.md](references/troubleshooting.md).
 

--- a/Packages/src/Editor/Infrastructure/Api/InternalBridgeCommandRouter.cs
+++ b/Packages/src/Editor/Infrastructure/Api/InternalBridgeCommandRouter.cs
@@ -48,6 +48,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             if (methodName == UnityCliLoopConstants.COMMAND_NAME_GET_PAUSE_POINT_STATUS)
             {
+                if (PausePointStatusBridgeCommand.IsListRequest(paramsToken))
+                {
+                    return PausePointStatusBridgeCommand.ExecuteList();
+                }
+
                 return PausePointStatusBridgeCommand.Execute(paramsToken);
             }
 

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -17,12 +17,40 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private const string IdParamName = "Id";
         private const string ReasonParamName = "Reason";
         private const string MinimumRemainingSecondsParamName = "MinimumRemainingSeconds";
+        private const string EmptyListMessage = "No pause points are registered.";
+        private const string EmptyListNextAction =
+            "Enable one with 'uloop enable-pause-point --id <marker-id>' or '--file <project-relative path> --line <line>'.";
+        private const string NonEmptyListNextAction =
+            "Pass --id <marker-id> to inspect one pause point in detail.";
 
         public static PausePointStatusResponse Execute(JToken paramsToken)
         {
             string id = ReadId(paramsToken);
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.GetStatus(id);
             return PausePointStatusResponse.FromSnapshot(snapshot);
+        }
+
+        public static bool IsListRequest(JToken paramsToken)
+        {
+            return string.IsNullOrEmpty(ReadId(paramsToken));
+        }
+
+        public static PausePointStatusListResponse ExecuteList()
+        {
+            IReadOnlyList<UloopPausePointSnapshot> snapshots = UloopPausePointRegistry.GetAllStatuses();
+            List<PausePointStatusListItemResponse> pausePoints = snapshots
+                .Select(PausePointStatusListItemResponse.FromSnapshot)
+                .ToList();
+            int count = pausePoints.Count;
+            return new PausePointStatusListResponse
+            {
+                Message = count == 0 ? EmptyListMessage : $"{count} pause point(s) registered.",
+                Count = count,
+                PausePoints = pausePoints,
+                NextActions = count == 0
+                    ? new string[] { EmptyListNextAction }
+                    : new string[] { NonEmptyListNextAction }
+            };
         }
 
         // Called once when await-pause-point starts waiting, so a marker enabled well before a
@@ -258,6 +286,54 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return recommendedNextAction ?? string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Summary response returned when pause-point-status does not identify one marker.
+    /// </summary>
+    public class PausePointStatusListResponse : UnityCliLoopToolResponse
+    {
+        [JsonProperty(Order = 1)]
+        public string Message { get; set; } = string.Empty;
+
+        [JsonProperty(Order = 2)]
+        public int Count { get; set; }
+
+        [JsonProperty(Order = 3)]
+        public IReadOnlyList<PausePointStatusListItemResponse> PausePoints { get; set; } =
+            Array.Empty<PausePointStatusListItemResponse>();
+
+        [JsonProperty(Order = 4)]
+        public IReadOnlyList<string> NextActions { get; set; } = Array.Empty<string>();
+    }
+
+    /// <summary>
+    /// Compact pause point data used by the id-less status list.
+    /// </summary>
+    public class PausePointStatusListItemResponse
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+        public string Mode { get; set; } = string.Empty;
+        public int HitCount { get; set; }
+        public long RemainingMilliseconds { get; set; }
+
+        internal static PausePointStatusListItemResponse FromSnapshot(UloopPausePointSnapshot snapshot)
+        {
+            if (snapshot == null)
+            {
+                throw new ArgumentNullException(nameof(snapshot));
+            }
+
+            return new PausePointStatusListItemResponse
+            {
+                Id = snapshot.Id,
+                Status = snapshot.Status,
+                Mode = snapshot.Mode,
+                HitCount = snapshot.HitCount,
+                RemainingMilliseconds = snapshot.RemainingMilliseconds
+            };
         }
     }
 

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -224,6 +224,38 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
 
         /// <summary>
+        /// Returns current snapshots for every registered pause point in deterministic marker-id order.
+        /// </summary>
+        public static IReadOnlyList<UloopPausePointSnapshot> GetAllStatuses()
+        {
+            DateTime now = NowUtc();
+            bool anyExpired = false;
+            List<UloopPausePointEntry> entries = new();
+            foreach (UloopPausePointEntry entry in Entries.Values)
+            {
+                entries.Add(entry);
+                if (TryExpire(entry, now))
+                {
+                    anyExpired = true;
+                }
+            }
+
+            if (anyExpired)
+            {
+                ResumeEditorPause();
+            }
+
+            List<UloopPausePointSnapshot> snapshots = new();
+            foreach (UloopPausePointEntry entry in entries)
+            {
+                snapshots.Add(entry.ToSnapshot(now, _pauseController));
+            }
+
+            snapshots.Sort((left, right) => string.Compare(left.Id, right.Id, StringComparison.Ordinal));
+            return snapshots;
+        }
+
+        /// <summary>
         /// Marks whether an armed marker could not stay live across a hot-reload patch transition.
         /// When <paramref name="suppressed"/> is false, <paramref name="reason"/> is cleared to null.
         /// No-op when the id is unknown.

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -228,31 +228,12 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         /// </summary>
         public static IReadOnlyList<UloopPausePointSnapshot> GetAllStatuses()
         {
-            DateTime now = NowUtc();
-            bool anyExpired = false;
-            List<UloopPausePointEntry> entries = new();
-            foreach (UloopPausePointEntry entry in Entries.Values)
-            {
-                entries.Add(entry);
-                if (TryExpire(entry, now))
-                {
-                    anyExpired = true;
-                }
-            }
-
-            if (anyExpired)
-            {
-                ResumeEditorPause();
-            }
-
-            List<UloopPausePointSnapshot> snapshots = new();
-            foreach (UloopPausePointEntry entry in entries)
-            {
-                snapshots.Add(entry.ToSnapshot(now, _pauseController));
-            }
-
-            snapshots.Sort((left, right) => string.Compare(left.Id, right.Id, StringComparison.Ordinal));
-            return snapshots;
+            return UloopPausePointStatusSnapshotCollector.Collect(
+                Entries.Values,
+                NowUtc(),
+                _pauseController,
+                TryExpire,
+                ResumeEditorPause);
         }
 
         /// <summary>
@@ -448,15 +429,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         /// </summary>
         public static int GetActiveCount()
         {
-            int count = 0;
-            foreach (UloopPausePointEntry entry in Entries.Values)
-            {
-                if (entry.IsEnabled)
-                {
-                    count++;
-                }
-            }
-            return count;
+            return UloopPausePointStatusSnapshotCollector.CountActiveEntries(Entries.Values);
         }
 
         private static UloopPausePointSnapshot HitCore(

--- a/Packages/src/Runtime/PausePoints/UloopPausePointStatusSnapshotCollector.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointStatusSnapshotCollector.cs
@@ -1,0 +1,68 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.Runtime
+{
+    /// <summary>
+    /// Collects the current pause point statuses after synchronizing any elapsed capture windows.
+    /// </summary>
+    internal static class UloopPausePointStatusSnapshotCollector
+    {
+        public static int CountActiveEntries(IEnumerable<UloopPausePointEntry> entries)
+        {
+            Debug.Assert(entries != null, "entries must not be null");
+
+            int count = 0;
+            foreach (UloopPausePointEntry entry in entries)
+            {
+                if (entry.IsEnabled)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        public static IReadOnlyList<UloopPausePointSnapshot> Collect(
+            IEnumerable<UloopPausePointEntry> entries,
+            DateTime now,
+            IUloopPausePointPauseController pauseController,
+            Func<UloopPausePointEntry, DateTime, bool> tryExpire,
+            Action resumeEditorPause)
+        {
+            Debug.Assert(entries != null, "entries must not be null");
+            Debug.Assert(pauseController != null, "pauseController must not be null");
+            Debug.Assert(tryExpire != null, "tryExpire must not be null");
+            Debug.Assert(resumeEditorPause != null, "resumeEditorPause must not be null");
+
+            bool anyExpired = false;
+            List<UloopPausePointEntry> entriesToSnapshot = new();
+            foreach (UloopPausePointEntry entry in entries)
+            {
+                entriesToSnapshot.Add(entry);
+                if (tryExpire(entry, now))
+                {
+                    anyExpired = true;
+                }
+            }
+
+            if (anyExpired)
+            {
+                resumeEditorPause();
+            }
+
+            List<UloopPausePointSnapshot> snapshots = new();
+            foreach (UloopPausePointEntry entry in entriesToSnapshot)
+            {
+                snapshots.Add(entry.ToSnapshot(now, pauseController));
+            }
+
+            snapshots.Sort((left, right) => string.Compare(left.Id, right.Id, StringComparison.Ordinal));
+            return snapshots;
+        }
+    }
+}
+#endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointStatusSnapshotCollector.cs.meta
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointStatusSnapshotCollector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 85bd573987fde4673b4b783ef96658df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/cli/common/clicore/command_registry.go
+++ b/cli/common/clicore/command_registry.go
@@ -34,7 +34,7 @@ var NativeCommands = []NativeCommandEntry{
 	{Name: "sync", Description: "Refresh .uloop/tools.json from the running Editor", Owner: RunnerOwned},
 	{Name: "focus-window", Description: "Bring the Unity Editor window to the foreground", Owner: RunnerOwned},
 	{Name: PausePointAwaitCommandName, Description: "Wait until a named UloopPausePoint.Pause marker pauses Unity", Owner: RunnerOwned},
-	{Name: PausePointStatusUserCommandName, Description: "Show the state of a named UloopPausePoint.Pause marker", Owner: RunnerOwned},
+	{Name: PausePointStatusUserCommandName, Description: "Show one pause point marker's state, or list all registered markers when no target is given", Owner: RunnerOwned},
 	{Name: SkillsCommandName, Description: "List, install, or uninstall agent skills", Owner: DispatcherOwned},
 	{Name: PackageCommandName, Description: "Install or inspect the Unity CLI Loop package in a project", Owner: DispatcherOwned},
 	{Name: InstallCommandName, Description: "Configure the global uloop dispatcher binary", Owner: DispatcherOwned},

--- a/cli/common/clicore/command_registry_test.go
+++ b/cli/common/clicore/command_registry_test.go
@@ -90,3 +90,16 @@ func TestIsRunnerOwnedCommandName(t *testing.T) {
 		}
 	}
 }
+
+// Verifies pause-point-status help describes both a targeted query and an id-less marker list.
+func TestPausePointStatusNativeCommandDescription(t *testing.T) {
+	entry, found := NativeCommand(PausePointStatusUserCommandName)
+	if !found {
+		t.Fatalf("%s must be registered", PausePointStatusUserCommandName)
+	}
+
+	const want = "Show one pause point marker's state, or list all registered markers when no target is given"
+	if entry.Description != want {
+		t.Fatalf("description = %q, want %q", entry.Description, want)
+	}
+}

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "2cc10a7f81e50c0ca051dfffc8f3cf6f7d48bd5d"
+  "sharedInputsHash": "8aa1fcd05d102d1b98cf5c8f77047cadc9ccea2d"
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_ipc.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_ipc.go
@@ -59,6 +59,29 @@ func queryPausePointStatusFromUnity(
 	return sendPausePointStatusCommand(ctx, connection, pausePointStatusCommandName, map[string]any{"Id": id})
 }
 
+func queryPausePointStatusListFromUnity(
+	ctx context.Context,
+	connection unityipc.Connection,
+) (pausePointStatusListResponse, error) {
+	probeContext, cancel := context.WithTimeout(ctx, pausePointStatusProbeTimeout)
+	defer cancel()
+
+	result, err := unityipc.NewClient(connection, clicontract.ProjectRunnerVersion()).Send(
+		probeContext,
+		pausePointStatusCommandName,
+		map[string]any{},
+	)
+	if err != nil {
+		return pausePointStatusListResponse{}, err
+	}
+
+	response := pausePointStatusListResponse{}
+	if err := json.Unmarshal(result, &response); err != nil {
+		return pausePointStatusListResponse{}, err
+	}
+	return response, nil
+}
+
 func clearPausePointStatusFromUnity(
 	ctx context.Context,
 	connection unityipc.Connection,

--- a/cli/project-runner/internal/projectrunner/pause_point_status_list.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_status_list.go
@@ -1,0 +1,40 @@
+package projectrunner
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+)
+
+func runPausePointStatusListCommand(
+	ctx context.Context,
+	connection unityipc.Connection,
+	stdout io.Writer,
+	stderr io.Writer,
+) int {
+	response, err := queryPausePointStatusList(ctx, connection)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
+			ProjectRoot: connection.ProjectRoot,
+			Command:     clicore.PausePointStatusUserCommandName,
+		})
+		return 1
+	}
+
+	result, err := json.Marshal(response)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
+			ProjectRoot: connection.ProjectRoot,
+			Command:     clicore.PausePointStatusUserCommandName,
+		})
+		return 1
+	}
+
+	clicore.WriteJSON(stdout, result)
+	return 0
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_status_list_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_status_list_test.go
@@ -1,0 +1,162 @@
+package projectrunner
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+)
+
+// Verifies the dedicated list query sends no marker parameters and decodes the compact Unity response.
+func TestQueryPausePointStatusListFromUnitySendsEmptyParametersAndDecodesSummary(t *testing.T) {
+	listener := newLoopbackIpcListener(t)
+	requests := make(chan map[string]any, 1)
+	serverErr := make(chan error, 1)
+	go serveSingleIPCResponse(
+		listener,
+		pausePointStatusCommandName,
+		requests,
+		serverErr,
+		`{"Success":true,"Message":"1 pause point(s) registered.","Count":1,"PausePoints":[{"Id":"jump","Status":"Enabled","Mode":"single-shot","HitCount":0,"RemainingMilliseconds":30000}],"NextActions":["Pass --id <marker-id> to inspect one pause point in detail."]}`,
+	)
+
+	connection := unityipc.Connection{
+		Endpoint: unityipc.Endpoint{
+			Network: listener.Addr().Network(),
+			Address: listener.Addr().String(),
+		},
+		ProjectRoot: t.TempDir(),
+	}
+	response, err := queryPausePointStatusListFromUnity(context.Background(), connection)
+	if err != nil {
+		t.Fatalf("queryPausePointStatusListFromUnity failed: %v", err)
+	}
+	if response.Count != 1 || len(response.PausePoints) != 1 || response.PausePoints[0].Id != "jump" {
+		t.Fatalf("response mismatch: %#v", response)
+	}
+
+	params := readIPCRequest(t, requests)
+	if len(params) != 0 {
+		t.Fatalf("expected empty list parameters, got %#v", params)
+	}
+}
+
+// Verifies list mode names the individual per-marker option that cannot apply without a target.
+func TestParsePausePointStatusOptionsListModeRejectsPerMarkerOptions(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantError string
+	}{
+		{
+			name:      "captured variables",
+			args:      []string{"--captured-variables", "full"},
+			wantError: "--captured-variables requires --id or --file with --line.",
+		},
+		{
+			name:      "captured variable names",
+			args:      []string{"--captured-variable-names", "speed"},
+			wantError: "--captured-variable-names requires --id or --file with --line.",
+		},
+		{
+			name:      "expect",
+			args:      []string{"--expect", "speed==5"},
+			wantError: "--expect requires --id or --file with --line.",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := parsePausePointStatusOptions(test.args)
+			if err == nil || err.Error() != test.wantError {
+				t.Fatalf("error = %v, want %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+// Verifies an id-less status command uses the dedicated list query and writes its summary JSON unchanged.
+func TestRunPausePointStatusCommandWithoutTargetWritesListResponse(t *testing.T) {
+	originalQueryPausePointStatus := queryPausePointStatus
+	originalQueryPausePointStatusList := queryPausePointStatusList
+	t.Cleanup(func() {
+		queryPausePointStatus = originalQueryPausePointStatus
+		queryPausePointStatusList = originalQueryPausePointStatusList
+	})
+	queryPausePointStatus = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+	) (pausePointStatusResponse, error) {
+		t.Fatal("single-marker status query must not run in list mode")
+		return pausePointStatusResponse{}, nil
+	}
+	queryPausePointStatusList = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+	) (pausePointStatusListResponse, error) {
+		return pausePointStatusListResponse{
+			Success: true,
+			Message: "2 pause point(s) registered.",
+			Count:   2,
+			PausePoints: []pausePointStatusListItemResponse{
+				{
+					Id:                    "alpha",
+					Status:                pausePointStatusEnabled,
+					Mode:                  "single-shot",
+					HitCount:              0,
+					RemainingMilliseconds: 30000,
+				},
+				{
+					Id:                    "zulu",
+					Status:                pausePointStatusExpired,
+					Mode:                  "trace",
+					HitCount:              4,
+					RemainingMilliseconds: 0,
+				},
+			},
+			NextActions: []string{"Pass --id <marker-id> to inspect one pause point in detail."},
+		}, nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runPausePointStatusCommand(
+		context.Background(),
+		unityipc.Connection{ProjectRoot: "<PROJECT_ROOT>"},
+		[]string{},
+		&stdout,
+		&stderr)
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d with stderr %s", code, stderr.String())
+	}
+	const want = "{\n" +
+		"  \"Success\": true,\n" +
+		"  \"Message\": \"2 pause point(s) registered.\",\n" +
+		"  \"Count\": 2,\n" +
+		"  \"PausePoints\": [\n" +
+		"    {\n" +
+		"      \"Id\": \"alpha\",\n" +
+		"      \"Status\": \"Enabled\",\n" +
+		"      \"Mode\": \"single-shot\",\n" +
+		"      \"HitCount\": 0,\n" +
+		"      \"RemainingMilliseconds\": 30000\n" +
+		"    },\n" +
+		"    {\n" +
+		"      \"Id\": \"zulu\",\n" +
+		"      \"Status\": \"Expired\",\n" +
+		"      \"Mode\": \"trace\",\n" +
+		"      \"HitCount\": 4,\n" +
+		"      \"RemainingMilliseconds\": 0\n" +
+		"    }\n" +
+		"  ],\n" +
+		"  \"NextActions\": [\n" +
+		"    \"Pass --id \\u003cmarker-id\\u003e to inspect one pause point in detail.\"\n" +
+		"  ]\n" +
+		"}\n"
+	if stdout.String() != want {
+		t.Fatalf("stdout = %s, want %s", stdout.String(), want)
+	}
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_status_list_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_status_list_test.go
@@ -64,6 +64,16 @@ func TestParsePausePointStatusOptionsListModeRejectsPerMarkerOptions(t *testing.
 			args:      []string{"--expect", "speed==5"},
 			wantError: "--expect requires --id or --file with --line.",
 		},
+		{
+			name:      "captured variables before expect",
+			args:      []string{"--captured-variables", "full", "--expect", "speed==5"},
+			wantError: "--captured-variables requires --id or --file with --line.",
+		},
+		{
+			name:      "expect before captured variables",
+			args:      []string{"--expect", "speed==5", "--captured-variables", "full"},
+			wantError: "--expect requires --id or --file with --line.",
+		},
 	}
 
 	for _, test := range tests {

--- a/cli/project-runner/internal/projectrunner/pause_point_status_options.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_status_options.go
@@ -1,0 +1,123 @@
+package projectrunner
+
+import (
+	"fmt"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+	"github.com/hatayama/unity-cli-loop/common/tooldocs"
+)
+
+type pausePointStatusOptions struct {
+	id                    string
+	idProvided            bool
+	listMode              bool
+	listModePerMarkerFlag string
+	queryTarget           pausePointQueryTarget
+	capturedVariablesMode pausePointCapturedVariablesMode
+	capturedVariableNames []string
+	expectations          []pausePointExpectation
+}
+
+func parsePausePointStatusOptions(args []string) (pausePointStatusOptions, error) {
+	options := pausePointStatusOptions{capturedVariablesMode: pausePointCapturedVariablesModeFull}
+
+	for index := 0; index < len(args); index++ {
+		name, value, consumedNext, err := clicore.ParseFlagValue(args[index], args, index)
+		if err != nil {
+			return pausePointStatusOptions{}, err
+		}
+
+		if applyErr := applyPausePointStatusFlag(&options, name, value); applyErr != nil {
+			return pausePointStatusOptions{}, applyErr
+		}
+		if consumedNext {
+			index++
+		}
+	}
+
+	if !options.idProvided && !options.queryTarget.hasFile && !options.queryTarget.hasLine {
+		if options.listModePerMarkerFlag != "" {
+			return pausePointStatusOptions{}, pausePointStatusListModeOptionError(options.listModePerMarkerFlag)
+		}
+		options.listMode = true
+		return options, nil
+	}
+
+	queryID, targetErr := resolvePausePointQueryID(
+		options.id,
+		options.idProvided,
+		options.queryTarget,
+		clicore.PausePointStatusUserCommandName)
+	if targetErr != nil {
+		return pausePointStatusOptions{}, targetErr
+	}
+	options.id = queryID
+
+	return options, nil
+}
+
+func applyPausePointStatusFlag(options *pausePointStatusOptions, name string, value string) error {
+	switch name {
+	case PausePointIDFlagName:
+		options.id = value
+		options.idProvided = true
+	case PausePointFileFlagName:
+		options.queryTarget.file = value
+		options.queryTarget.hasFile = true
+	case PausePointLineFlagName:
+		return setPausePointQueryTargetLine(&options.queryTarget, value)
+	case tooldocs.PausePointCapturedVariablesFlagName:
+		return applyPausePointStatusCapturedVariablesFlag(options, name, value)
+	case tooldocs.PausePointCapturedVariableNamesFlagName:
+		options.capturedVariableNames = parsePausePointCapturedVariableNames(value)
+		recordPausePointStatusListModePerMarkerFlag(options, name)
+	case tooldocs.PausePointExpectFlagName:
+		return applyPausePointStatusExpectFlag(options, name, value)
+	default:
+		return pausePointUnknownOptionError(clicore.PausePointStatusUserCommandName, name)
+	}
+
+	return nil
+}
+
+func applyPausePointStatusCapturedVariablesFlag(
+	options *pausePointStatusOptions,
+	name string,
+	value string,
+) error {
+	mode, err := parsePausePointCapturedVariablesMode(value)
+	if err != nil {
+		return err
+	}
+
+	options.capturedVariablesMode = mode
+	recordPausePointStatusListModePerMarkerFlag(options, name)
+	return nil
+}
+
+func applyPausePointStatusExpectFlag(options *pausePointStatusOptions, name string, value string) error {
+	expectation, err := parsePausePointExpectFlagValue(value)
+	if err != nil {
+		return err
+	}
+
+	options.expectations = append(options.expectations, expectation)
+	recordPausePointStatusListModePerMarkerFlag(options, name)
+	return nil
+}
+
+func recordPausePointStatusListModePerMarkerFlag(options *pausePointStatusOptions, flagName string) {
+	if options.listModePerMarkerFlag == "" {
+		options.listModePerMarkerFlag = flagName
+	}
+}
+
+func pausePointStatusListModeOptionError(flagName string) *clierrors.ArgumentError {
+	return &clierrors.ArgumentError{
+		Message: fmt.Sprintf("--%s requires --id or --file with --line.", flagName),
+		Option:  "--" + flagName,
+		Command: clicore.PausePointStatusUserCommandName,
+	}
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_types.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_types.go
@@ -127,6 +127,24 @@ type pausePointStatusResponse struct {
 	TriggerFailed *bool `json:"TriggerFailed,omitempty"`
 }
 
+// pausePointStatusListResponse is the compact response used when no individual marker is queried.
+type pausePointStatusListResponse struct {
+	Success     bool                               `json:"Success"`
+	Message     string                             `json:"Message"`
+	Count       int                                `json:"Count"`
+	PausePoints []pausePointStatusListItemResponse `json:"PausePoints"`
+	NextActions []string                           `json:"NextActions"`
+}
+
+// pausePointStatusListItemResponse keeps id-less status output bounded to the fields needed for selection.
+type pausePointStatusListItemResponse struct {
+	Id                    string `json:"Id"`
+	Status                string `json:"Status"`
+	Mode                  string `json:"Mode"`
+	HitCount              int    `json:"HitCount"`
+	RemainingMilliseconds int64  `json:"RemainingMilliseconds"`
+}
+
 // pausePointStatusResult wraps a status response with the CLI-evaluated --expect verdicts.
 // pause-point-status marshals the Unity response directly, so it needs this wrapper to carry the
 // two extra fields; the names match pausePointWaitResult's so one query shape reads both commands.

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -56,9 +56,10 @@ const (
 )
 
 var (
-	queryPausePointStatus  = queryPausePointStatusFromUnity
-	clearPausePointStatus  = clearPausePointStatusFromUnity
-	extendPausePointExpiry = extendPausePointExpiryFromUnity
+	queryPausePointStatus     = queryPausePointStatusFromUnity
+	queryPausePointStatusList = queryPausePointStatusListFromUnity
+	clearPausePointStatus     = clearPausePointStatusFromUnity
+	extendPausePointExpiry    = extendPausePointExpiryFromUnity
 )
 
 type waitForPausePointOptions struct {
@@ -94,6 +95,8 @@ type waitForPausePointOptions struct {
 type pausePointStatusOptions struct {
 	id                    string
 	idProvided            bool
+	listMode              bool
+	listModePerMarkerFlag string
 	queryTarget           pausePointQueryTarget
 	capturedVariablesMode pausePointCapturedVariablesMode
 	capturedVariableNames []string
@@ -227,6 +230,9 @@ func runPausePointStatusCommand(
 			Command:     clicore.PausePointStatusUserCommandName,
 		})
 		return 1
+	}
+	if options.listMode {
+		return runPausePointStatusListCommand(ctx, connection, stdout, stderr)
 	}
 
 	response, err := queryPausePointStatus(ctx, connection, options.id)
@@ -435,14 +441,23 @@ func parsePausePointStatusOptions(args []string) (pausePointStatusOptions, error
 				return pausePointStatusOptions{}, parseErr
 			}
 			options.capturedVariablesMode = mode
+			if options.listModePerMarkerFlag == "" {
+				options.listModePerMarkerFlag = name
+			}
 		case tooldocs.PausePointCapturedVariableNamesFlagName:
 			options.capturedVariableNames = parsePausePointCapturedVariableNames(value)
+			if options.listModePerMarkerFlag == "" {
+				options.listModePerMarkerFlag = name
+			}
 		case tooldocs.PausePointExpectFlagName:
 			expectation, parseErr := parsePausePointExpectFlagValue(value)
 			if parseErr != nil {
 				return pausePointStatusOptions{}, parseErr
 			}
 			options.expectations = append(options.expectations, expectation)
+			if options.listModePerMarkerFlag == "" {
+				options.listModePerMarkerFlag = name
+			}
 		default:
 			return pausePointStatusOptions{}, pausePointUnknownOptionError(clicore.PausePointStatusUserCommandName, name)
 		}
@@ -450,6 +465,13 @@ func parsePausePointStatusOptions(args []string) (pausePointStatusOptions, error
 		if consumedNext {
 			index++
 		}
+	}
+	if !options.idProvided && !options.queryTarget.hasFile && !options.queryTarget.hasLine {
+		if options.listModePerMarkerFlag != "" {
+			return pausePointStatusOptions{}, pausePointStatusListModeOptionError(options.listModePerMarkerFlag)
+		}
+		options.listMode = true
+		return options, nil
 	}
 
 	queryID, targetErr := resolvePausePointQueryID(
@@ -463,6 +485,42 @@ func parsePausePointStatusOptions(args []string) (pausePointStatusOptions, error
 	options.id = queryID
 
 	return options, nil
+}
+
+func runPausePointStatusListCommand(
+	ctx context.Context,
+	connection unityipc.Connection,
+	stdout io.Writer,
+	stderr io.Writer,
+) int {
+	response, err := queryPausePointStatusList(ctx, connection)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
+			ProjectRoot: connection.ProjectRoot,
+			Command:     clicore.PausePointStatusUserCommandName,
+		})
+		return 1
+	}
+
+	result, err := json.Marshal(response)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
+			ProjectRoot: connection.ProjectRoot,
+			Command:     clicore.PausePointStatusUserCommandName,
+		})
+		return 1
+	}
+
+	clicore.WriteJSON(stdout, result)
+	return 0
+}
+
+func pausePointStatusListModeOptionError(flagName string) *clierrors.ArgumentError {
+	return &clierrors.ArgumentError{
+		Message: fmt.Sprintf("--%s requires --id or --file with --line.", flagName),
+		Option:  "--" + flagName,
+		Command: clicore.PausePointStatusUserCommandName,
+	}
 }
 
 func parsePausePointTimeoutSeconds(value string) (int, error) {

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -92,17 +92,6 @@ type waitForPausePointOptions struct {
 	markerJustEnabled bool
 }
 
-type pausePointStatusOptions struct {
-	id                    string
-	idProvided            bool
-	listMode              bool
-	listModePerMarkerFlag string
-	queryTarget           pausePointQueryTarget
-	capturedVariablesMode pausePointCapturedVariablesMode
-	capturedVariableNames []string
-	expectations          []pausePointExpectation
-}
-
 func normalizePausePointStatusResponse(response pausePointStatusResponse) pausePointStatusResponse {
 	if response.Status == pausePointStatusExpired {
 		response.Expired = true
@@ -411,116 +400,6 @@ func parseWaitForPausePointOptions(args []string) (waitForPausePointOptions, err
 	options.id = queryID
 
 	return options, nil
-}
-
-func parsePausePointStatusOptions(args []string) (pausePointStatusOptions, error) {
-	options := pausePointStatusOptions{capturedVariablesMode: pausePointCapturedVariablesModeFull}
-
-	for index := 0; index < len(args); index++ {
-		arg := args[index]
-		name, value, consumedNext, err := clicore.ParseFlagValue(arg, args, index)
-		if err != nil {
-			return pausePointStatusOptions{}, err
-		}
-
-		switch name {
-		case PausePointIDFlagName:
-			options.id = value
-			options.idProvided = true
-		case PausePointFileFlagName:
-			options.queryTarget.file = value
-			options.queryTarget.hasFile = true
-		case PausePointLineFlagName:
-			parseErr := setPausePointQueryTargetLine(&options.queryTarget, value)
-			if parseErr != nil {
-				return pausePointStatusOptions{}, parseErr
-			}
-		case tooldocs.PausePointCapturedVariablesFlagName:
-			mode, parseErr := parsePausePointCapturedVariablesMode(value)
-			if parseErr != nil {
-				return pausePointStatusOptions{}, parseErr
-			}
-			options.capturedVariablesMode = mode
-			if options.listModePerMarkerFlag == "" {
-				options.listModePerMarkerFlag = name
-			}
-		case tooldocs.PausePointCapturedVariableNamesFlagName:
-			options.capturedVariableNames = parsePausePointCapturedVariableNames(value)
-			if options.listModePerMarkerFlag == "" {
-				options.listModePerMarkerFlag = name
-			}
-		case tooldocs.PausePointExpectFlagName:
-			expectation, parseErr := parsePausePointExpectFlagValue(value)
-			if parseErr != nil {
-				return pausePointStatusOptions{}, parseErr
-			}
-			options.expectations = append(options.expectations, expectation)
-			if options.listModePerMarkerFlag == "" {
-				options.listModePerMarkerFlag = name
-			}
-		default:
-			return pausePointStatusOptions{}, pausePointUnknownOptionError(clicore.PausePointStatusUserCommandName, name)
-		}
-
-		if consumedNext {
-			index++
-		}
-	}
-	if !options.idProvided && !options.queryTarget.hasFile && !options.queryTarget.hasLine {
-		if options.listModePerMarkerFlag != "" {
-			return pausePointStatusOptions{}, pausePointStatusListModeOptionError(options.listModePerMarkerFlag)
-		}
-		options.listMode = true
-		return options, nil
-	}
-
-	queryID, targetErr := resolvePausePointQueryID(
-		options.id,
-		options.idProvided,
-		options.queryTarget,
-		clicore.PausePointStatusUserCommandName)
-	if targetErr != nil {
-		return pausePointStatusOptions{}, targetErr
-	}
-	options.id = queryID
-
-	return options, nil
-}
-
-func runPausePointStatusListCommand(
-	ctx context.Context,
-	connection unityipc.Connection,
-	stdout io.Writer,
-	stderr io.Writer,
-) int {
-	response, err := queryPausePointStatusList(ctx, connection)
-	if err != nil {
-		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
-			ProjectRoot: connection.ProjectRoot,
-			Command:     clicore.PausePointStatusUserCommandName,
-		})
-		return 1
-	}
-
-	result, err := json.Marshal(response)
-	if err != nil {
-		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
-			ProjectRoot: connection.ProjectRoot,
-			Command:     clicore.PausePointStatusUserCommandName,
-		})
-		return 1
-	}
-
-	clicore.WriteJSON(stdout, result)
-	return 0
-}
-
-func pausePointStatusListModeOptionError(flagName string) *clierrors.ArgumentError {
-	return &clierrors.ArgumentError{
-		Message: fmt.Sprintf("--%s requires --id or --file with --line.", flagName),
-		Option:  "--" + flagName,
-		Command: clicore.PausePointStatusUserCommandName,
-	}
 }
 
 func parsePausePointTimeoutSeconds(value string) (int, error) {

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -2681,24 +2681,15 @@ func TestRunPausePointStatusDerivesRemainingTimeFromOlderResponse(t *testing.T) 
 	}
 }
 
-// Verifies pause-point-status requires either a marker id or a complete file:line target.
-func TestParsePausePointStatusOptionsRequiresMarkerTarget(t *testing.T) {
-	_, err := parsePausePointStatusOptions([]string{})
-
-	if err == nil {
-		t.Fatal("expected missing marker target error")
+// Verifies pause-point-status without an id or file:line target selects list mode.
+func TestParsePausePointStatusOptionsWithoutTargetUsesListMode(t *testing.T) {
+	options, err := parsePausePointStatusOptions([]string{})
+	if err != nil {
+		t.Fatalf("expected list mode, got %v", err)
 	}
-	if err.Error() != "Missing required option: --id" {
-		t.Fatalf("error mismatch: %v", err)
+	if options.id != "" || options.idProvided || options.queryTarget.hasFile || options.queryTarget.hasLine {
+		t.Fatalf("expected empty list target, got %#v", options)
 	}
-}
-
-// Verifies the missing-target NextAction explains both id and file:line forms for status.
-func TestParsePausePointStatusOptionsMissingTargetNextActionMentionsFileLineFlags(t *testing.T) {
-	_, err := parsePausePointStatusOptions([]string{})
-	requireNextActions(t, err, []string{
-		"Pass --id <marker-id> matching UloopPausePoint.Pause(\"<marker-id>\"), or the Id returned by enable-pause-point (file:line markers use <project-relative path>:<line>, e.g. Assets/Scripts/Foo.cs:42). Alternatively, query a file:line marker with --file <project-relative path> --line <line>.",
-	})
 }
 
 // Verifies both query commands compose a source marker id from --file and decimal --line values.

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "001a9d0ed5d8e63f18c9eda251c7566cdf9c1be1"
+  "sharedInputsHash": "9134610cc9b680d58d1104bdcef279e707f622fe"
 }


### PR DESCRIPTION
## Summary

- Run `pause-point-status` with no marker target to list every registered marker.
- Keep detailed single-marker status queries unchanged while making lost marker identifiers recoverable.

## User Impact

When a prior command's output no longer shows a marker identifier, agents can now recover by listing compact marker summaries and then selecting one by `--id` or `--file`/`--line`.

## Changes

- Apply normal expiry handling and ordinal identifier ordering to runtime list snapshots.
- Add a bounded list response, dedicated CLI IPC path, and list-mode validation for per-marker flags.
- Document id-less listing in the pause-point skill and regenerate the installed copies.

## Verification

- `scripts/check-go-cli.sh`
- C# compile: 0 errors; only existing fixture warnings.
- Full EditMode run: 3,590 tests; the two new wire-shape tests exposed inherited-property ordering, then passed in a targeted 2/2 rerun after the DTO-only order fix.
- Manual CLI: enabled an id-only marker, ran `pause-point-status` with no target, verified `Count: 1` and its `PausePoints` summary, then cleared the marker.

Relates to #2329.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

