### PR TITLE
feat: state the preview cap and history cost when a captured value is clipped

### DIFF
--- a/cli/project-runner/internal/projectrunner/pause_point_captured_variable_preview_note.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_captured_variable_preview_note.go
@@ -1,9 +1,12 @@
 package projectrunner
 
+import "fmt"
+
 const (
 	// pausePointCapturedVariablePreviewNote explains how to recover a clipped captured
-	// value: raise the enable-time preview cap, or read the live value while paused.
-	pausePointCapturedVariablePreviewNote = "a captured value was clipped; re-enable with a larger --max-preview-elements, or read the full value while paused via UloopPausePoint.TryGetCapturedValue in execute-dynamic-code."
+	// value: raise the enable-time preview cap after preserving evidence, or read the live value
+	// while paused.
+	pausePointCapturedVariablePreviewNoteFormat = "a captured value was clipped at the current --max-preview-elements cap of %d elements; re-enable with a larger cap to widen future previews, but first read any CapturedVariables and CapturedVariableHistory you still need with pause-point-status, because re-enabling starts a new generation and discards them. While Unity is still paused, UloopPausePoint.TryGetCapturedValue in execute-dynamic-code returns the full live value."
 )
 
 // applyPausePointCapturedVariablePreviewNote records that a listed captured value was
@@ -16,6 +19,8 @@ func applyPausePointCapturedVariablePreviewNote(
 		return response
 	}
 
-	response.CapturedVariablePreviewNote = pausePointCapturedVariablePreviewNote
+	response.CapturedVariablePreviewNote = fmt.Sprintf(
+		pausePointCapturedVariablePreviewNoteFormat,
+		response.MaxPreviewElements)
 	return response
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_captured_variable_preview_note_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_captured_variable_preview_note_test.go
@@ -6,7 +6,11 @@ import (
 	"testing"
 )
 
-const wantCapturedVariablePreviewNote = "a captured value was clipped; re-enable with a larger --max-preview-elements, or read the full value while paused via UloopPausePoint.TryGetCapturedValue in execute-dynamic-code."
+const wantCapturedVariablePreviewNoteAtSevenElements = "a captured value was clipped at the current --max-preview-elements cap of 7 elements; re-enable with a larger cap to widen future previews, but first read any CapturedVariables and CapturedVariableHistory you still need with pause-point-status, because re-enabling starts a new generation and discards them. While Unity is still paused, UloopPausePoint.TryGetCapturedValue in execute-dynamic-code returns the full live value."
+
+const wantCapturedVariablePreviewNoteAtTwentyThreeElements = "a captured value was clipped at the current --max-preview-elements cap of 23 elements; re-enable with a larger cap to widen future previews, but first read any CapturedVariables and CapturedVariableHistory you still need with pause-point-status, because re-enabling starts a new generation and discards them. While Unity is still paused, UloopPausePoint.TryGetCapturedValue in execute-dynamic-code returns the full live value."
+
+const wantCapturedVariablePreviewNoteAtFortyTwoElements = "a captured value was clipped at the current --max-preview-elements cap of 42 elements; re-enable with a larger cap to widen future previews, but first read any CapturedVariables and CapturedVariableHistory you still need with pause-point-status, because re-enabling starts a new generation and discards them. While Unity is still paused, UloopPausePoint.TryGetCapturedValue in execute-dynamic-code returns the full live value."
 
 // TestApplyPausePointCapturedVariablePreviewNote verifies the CLI note is added only when a
 // remaining captured variable (current or history) is truncated, and that the wording is pinned
@@ -14,11 +18,12 @@ const wantCapturedVariablePreviewNote = "a captured value was clipped; re-enable
 func TestApplyPausePointCapturedVariablePreviewNote(t *testing.T) {
 	t.Run("note is set when a current variable is truncated", func(t *testing.T) {
 		result := applyPausePointCapturedVariablePreviewNote(pausePointStatusResponse{
+			MaxPreviewElements: 7,
 			CapturedVariables: []pausePointCapturedVariable{
 				{Name: "board", Truncated: true},
 			},
 		})
-		if result.CapturedVariablePreviewNote != wantCapturedVariablePreviewNote {
+		if result.CapturedVariablePreviewNote != wantCapturedVariablePreviewNoteAtSevenElements {
 			t.Fatalf("expected preview-clip note: %q", result.CapturedVariablePreviewNote)
 		}
 	})
@@ -37,6 +42,7 @@ func TestApplyPausePointCapturedVariablePreviewNote(t *testing.T) {
 
 	t.Run("note is set when only a history variable is truncated", func(t *testing.T) {
 		result := applyPausePointCapturedVariablePreviewNote(pausePointStatusResponse{
+			MaxPreviewElements: 23,
 			CapturedVariables: []pausePointCapturedVariable{
 				{Name: "health"},
 			},
@@ -48,7 +54,7 @@ func TestApplyPausePointCapturedVariablePreviewNote(t *testing.T) {
 				},
 			},
 		})
-		if result.CapturedVariablePreviewNote != wantCapturedVariablePreviewNote {
+		if result.CapturedVariablePreviewNote != wantCapturedVariablePreviewNoteAtTwentyThreeElements {
 			t.Fatalf("expected preview-clip note for a truncated history survivor: %q", result.CapturedVariablePreviewNote)
 		}
 	})
@@ -58,7 +64,7 @@ func TestApplyPausePointCapturedVariablePreviewNote(t *testing.T) {
 // survives json.Marshal under that exact key.
 func TestPausePointStatusResponseIncludesCapturedVariablePreviewNote(t *testing.T) {
 	marshaled, err := json.Marshal(pausePointStatusResponse{
-		CapturedVariablePreviewNote: pausePointCapturedVariablePreviewNote,
+		CapturedVariablePreviewNote: wantCapturedVariablePreviewNoteAtFortyTwoElements,
 	})
 	if err != nil {
 		t.Fatalf("marshal failed: %v", err)
@@ -78,8 +84,8 @@ func TestPausePointStatusResponseIncludesCapturedVariablePreviewNote(t *testing.
 	if err := json.Unmarshal(rawNote, &note); err != nil {
 		t.Fatalf("unmarshal note failed: %v", err)
 	}
-	if note != wantCapturedVariablePreviewNote {
-		t.Fatalf("note mismatch: got %#v, want %#v", note, wantCapturedVariablePreviewNote)
+	if note != wantCapturedVariablePreviewNoteAtFortyTwoElements {
+		t.Fatalf("note mismatch: got %#v, want %#v", note, wantCapturedVariablePreviewNoteAtFortyTwoElements)
 	}
 }
 

--- a/cli/project-runner/internal/projectrunner/pause_point_captured_variable_preview_note_wiring_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_captured_variable_preview_note_wiring_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
 
-func stubPausePointStatusHitWithTruncatedCapturedVariable(t *testing.T) {
+func stubPausePointStatusHitWithTruncatedCapturedVariable(t *testing.T, maxPreviewElements int) {
 	t.Helper()
 
 	originalQuery := queryPausePointStatus
@@ -24,13 +24,14 @@ func stubPausePointStatusHitWithTruncatedCapturedVariable(t *testing.T) {
 		id string,
 	) (pausePointStatusResponse, error) {
 		return pausePointStatusResponse{
-			Success:     true,
-			Id:          id,
-			Status:      pausePointStatusHit,
-			IsEnabled:   true,
-			IsHit:       true,
-			HitCount:    1,
-			EditorState: pausePointEditorState{IsPlaying: true, IsPaused: true, CapturedAt: "PausePointHit"},
+			Success:            true,
+			Id:                 id,
+			Status:             pausePointStatusHit,
+			IsEnabled:          true,
+			IsHit:              true,
+			HitCount:           1,
+			MaxPreviewElements: maxPreviewElements,
+			EditorState:        pausePointEditorState{IsPlaying: true, IsPaused: true, CapturedAt: "PausePointHit"},
 			CapturedVariables: []pausePointCapturedVariable{
 				{
 					Name:      "board",
@@ -63,32 +64,34 @@ func capturedVariablePreviewNoteFromStdout(t *testing.T, output string) string {
 	return note
 }
 
-func assertStdoutCapturedVariablePreviewNote(t *testing.T, output string) {
+func assertStdoutCapturedVariablePreviewNote(t *testing.T, output string, want string) {
 	t.Helper()
 
 	note := capturedVariablePreviewNoteFromStdout(t, output)
-	if note != wantCapturedVariablePreviewNote {
-		t.Fatalf("CapturedVariablePreviewNote mismatch: got %#v, want %#v", note, wantCapturedVariablePreviewNote)
+	if note != want {
+		t.Fatalf("CapturedVariablePreviewNote mismatch: got %#v, want %#v", note, want)
 	}
 }
 
 // Verifies pause-point-status stdout includes CapturedVariablePreviewNote when a remaining
 // captured variable is truncated, so dropping the status-command apply call fails this test.
 func TestRunPausePointStatusCommandIncludesCapturedVariablePreviewNote(t *testing.T) {
-	stubPausePointStatusHitWithTruncatedCapturedVariable(t)
+	const want = "a captured value was clipped at the current --max-preview-elements cap of 13 elements; re-enable with a larger cap to widen future previews, but first read any CapturedVariables and CapturedVariableHistory you still need with pause-point-status, because re-enabling starts a new generation and discards them. While Unity is still paused, UloopPausePoint.TryGetCapturedValue in execute-dynamic-code returns the full live value."
+	stubPausePointStatusHitWithTruncatedCapturedVariable(t, 13)
 
 	code, output := runPausePointStatusForExpect(t, []string{"--id", "jump"})
 
 	if code != 0 {
 		t.Fatalf("expected success, got %d: %s", code, output)
 	}
-	assertStdoutCapturedVariablePreviewNote(t, output)
+	assertStdoutCapturedVariablePreviewNote(t, output, want)
 }
 
 // Verifies await-pause-point stdout includes CapturedVariablePreviewNote on a truncated hit, so
 // dropping the plain-await apply call fails this test.
 func TestRunWaitForPausePointIncludesCapturedVariablePreviewNote(t *testing.T) {
-	stubPausePointStatusHitWithTruncatedCapturedVariable(t)
+	const want = "a captured value was clipped at the current --max-preview-elements cap of 37 elements; re-enable with a larger cap to widen future previews, but first read any CapturedVariables and CapturedVariableHistory you still need with pause-point-status, because re-enabling starts a new generation and discards them. While Unity is still paused, UloopPausePoint.TryGetCapturedValue in execute-dynamic-code returns the full live value."
+	stubPausePointStatusHitWithTruncatedCapturedVariable(t, 37)
 	stubPausePointMatchingLogs(t, nil)
 
 	var stdout bytes.Buffer
@@ -109,13 +112,14 @@ func TestRunWaitForPausePointIncludesCapturedVariablePreviewNote(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("expected success, got %d: %s", code, stdout.String())
 	}
-	assertStdoutCapturedVariablePreviewNote(t, stdout.String())
+	assertStdoutCapturedVariablePreviewNote(t, stdout.String(), want)
 }
 
 // Verifies enable-pause-point --await stdout includes CapturedVariablePreviewNote on a truncated
 // hit, so dropping the enable-await apply call fails this test.
 func TestRunPausePointWaitAfterEnableIncludesCapturedVariablePreviewNote(t *testing.T) {
-	stubPausePointStatusHitWithTruncatedCapturedVariable(t)
+	const want = "a captured value was clipped at the current --max-preview-elements cap of 91 elements; re-enable with a larger cap to widen future previews, but first read any CapturedVariables and CapturedVariableHistory you still need with pause-point-status, because re-enabling starts a new generation and discards them. While Unity is still paused, UloopPausePoint.TryGetCapturedValue in execute-dynamic-code returns the full live value."
+	stubPausePointStatusHitWithTruncatedCapturedVariable(t, 91)
 	stubPausePointMatchingLogs(t, nil)
 	stubPausePointTriggerDispatch(t, `{"Success":true}`)
 
@@ -124,5 +128,5 @@ func TestRunPausePointWaitAfterEnableIncludesCapturedVariablePreviewNote(t *test
 	if code != 0 {
 		t.Fatalf("expected success, got %d: %s", code, output)
 	}
-	assertStdoutCapturedVariablePreviewNote(t, output)
+	assertStdoutCapturedVariablePreviewNote(t, output, want)
 }


### PR DESCRIPTION
## Summary
- Include the active --max-preview-elements cap in clipped captured-value guidance.
- Explain that re-enabling starts a new generation and discards captured variables and history.
- Cover two cap values and all status/await output paths with full-literal tests.

## Verification
- scripts/check-go-cli.sh
- Manual trace hit with cap 2: confirmed a truncated captured value and the full CLI preview note in pause-point-status output.

Fixes #2391

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

