### PR TITLE
fix: report a fully passing test suite with skipped tests as passed

### DIFF
--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -54,6 +54,7 @@ Returns JSON with:
 - `XmlPath` (string): Path to NUnit XML result file. Empty string when no XML was saved (typically on `Success: true`); populated only when tests failed and the XML file exists on disk.
 - `ClearedPausePointIds` (string[], optional): IDs of pause points that were cleared before test execution. Omitted from JSON when no pause points were active.
 - `FailedTests` (array, optional): Up to 10 failed leaf tests with `FullName`, `Message`, and when the stack trace contains a path:line location, `File` and `Line`. Omitted when no tests failed. When `FailedCount` is greater than 10, `Message` ends with `first 10 of N failures listed; see XmlPath for full results.`
+- `SkippedTests` (string[], optional): Up to 10 full names of skipped leaf tests. Omitted when no tests were skipped. When `SkippedCount` is greater than 10, only the first 10 names are listed.
 
 ### XML Result File
 

--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -54,6 +54,7 @@ Returns JSON with:
 - `XmlPath` (string): Path to NUnit XML result file. Empty string when no XML was saved (typically on `Success: true`); populated only when tests failed and the XML file exists on disk.
 - `ClearedPausePointIds` (string[], optional): IDs of pause points that were cleared before test execution. Omitted from JSON when no pause points were active.
 - `FailedTests` (array, optional): Up to 10 failed leaf tests with `FullName`, `Message`, and when the stack trace contains a path:line location, `File` and `Line`. Omitted when no tests failed. When `FailedCount` is greater than 10, `Message` ends with `first 10 of N failures listed; see XmlPath for full results.`
+- `SkippedTests` (string[], optional): Up to 10 full names of skipped leaf tests. Omitted when no tests were skipped. When `SkippedCount` is greater than 10, only the first 10 names are listed.
 
 ### XML Result File
 

--- a/Assets/Tests/Editor/RunTestsResponseContractTests.cs
+++ b/Assets/Tests/Editor/RunTestsResponseContractTests.cs
@@ -8,7 +8,7 @@ using io.github.hatayama.UnityCliLoop.ToolContracts;
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
     /// <summary>
-    /// Verifies run-tests JSON omits null FailedTests and null File/Line keys.
+    /// Verifies run-tests JSON optional test-detail fields and null File/Line keys.
     /// </summary>
     public sealed class RunTestsResponseContractTests
     {
@@ -80,6 +80,63 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(first["Message"]?.Value<string>(), Is.EqualTo("Expected 2 But was: 1"));
             Assert.That(first.Property("File"), Is.Null);
             Assert.That(first.Property("Line"), Is.Null);
+        }
+
+        /// <summary>
+        /// What: SkippedTests is omitted without skipped leaves and serializes each full name when present.
+        /// </summary>
+        [Test]
+        public void RunTestsResponse_WhenSerialized_OmitsOrIncludesSkippedTestsByPresence()
+        {
+            RunTestsResponse zeroSkippedTests = new RunTestsResponse(
+                success: true,
+                message: "Test execution completed with status: Passed",
+                completedAt: "2026-01-01T00:00:00.0000000Z",
+                testCount: 1,
+                passedCount: 1,
+                failedCount: 0,
+                skippedCount: 0,
+                xmlPath: string.Empty,
+                status: RunTestsExecutionStatus.Passed,
+                hasFailures: false,
+                noTestsFound: false,
+                noTestsFoundExplanation: string.Empty);
+
+            JObject zeroSkippedTestsJson = JObject.Parse(
+                JsonConvert.SerializeObject(
+                    zeroSkippedTests,
+                    Formatting.None,
+                    UnityCliLoopJsonResponseSerializerSettings.Settings));
+
+            Assert.That(zeroSkippedTestsJson.Property("SkippedTests"), Is.Null);
+
+            RunTestsResponse populated = new RunTestsResponse(
+                success: true,
+                message: "Test execution completed with status: Passed",
+                completedAt: "2026-01-01T00:00:00.0000000Z",
+                testCount: 2,
+                passedCount: 1,
+                failedCount: 0,
+                skippedCount: 1,
+                xmlPath: string.Empty,
+                status: RunTestsExecutionStatus.Passed,
+                hasFailures: false,
+                noTestsFound: false,
+                noTestsFoundExplanation: string.Empty)
+            {
+                SkippedTests = new[] { "Example.Tests.SkippedTest" }
+            };
+
+            JObject populatedJson = JObject.Parse(
+                JsonConvert.SerializeObject(
+                    populated,
+                    Formatting.None,
+                    UnityCliLoopJsonResponseSerializerSettings.Settings));
+            JArray skippedTests = (JArray)populatedJson["SkippedTests"];
+
+            Assert.That(skippedTests, Is.Not.Null);
+            Assert.That(skippedTests.Count, Is.EqualTo(1));
+            Assert.That(skippedTests[0].Value<string>(), Is.EqualTo("Example.Tests.SkippedTest"));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/RunTestsTestFrameworkResultTests.cs
+++ b/Assets/Tests/Editor/RunTestsTestFrameworkResultTests.cs
@@ -251,11 +251,76 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             SerializableTestResult result = SerializableTestResultConverter.FromTestResult(resultAdaptor);
 
+            Assert.That(result.success, Is.False);
+            Assert.That(result.status, Is.EqualTo("Skipped"));
+            Assert.That(result.message, Is.EqualTo("Test execution completed with status: Skipped"));
             Assert.That(result.skippedCount, Is.EqualTo(11));
             Assert.That(result.skippedTests, Is.Not.Null);
             Assert.That(result.skippedTests.Length, Is.EqualTo(10));
             Assert.That(result.skippedTests[0], Is.EqualTo("Example.Tests.SkippedTest0"));
             Assert.That(result.skippedTests[9], Is.EqualTo("Example.Tests.SkippedTest9"));
+        }
+
+        /// <summary>
+        /// What: passed and skipped leaves use the all-green aggregation when the root is Inconclusive.
+        /// </summary>
+        [Test]
+        public void FromTestResult_WhenPassedAndSkippedLeavesHaveInconclusiveRoot_ReturnsPassedSuccess()
+        {
+            ITestResultAdaptor resultAdaptor = CreateTestSuite(
+                "RootSuite",
+                TestResultStatus.Inconclusive,
+                0.1,
+                new List<ITestResultAdaptor>
+                {
+                    CreateTestCase("PassingTest", TestResultStatus.Passed, 0.1),
+                    CreateTestCase("SkippedTest", TestResultStatus.Skipped, 0.1)
+                });
+
+            SerializableTestResult result = SerializableTestResultConverter.FromTestResult(resultAdaptor);
+
+            Assert.That(result.success, Is.True);
+            Assert.That(result.status, Is.EqualTo("Passed"));
+            Assert.That(result.message, Is.EqualTo("Test execution completed with status: Passed"));
+        }
+
+        /// <summary>
+        /// What: skipped full names preserve depth-first result-tree order across nested suites.
+        /// </summary>
+        [Test]
+        public void FromTestResult_WhenSkippedLeavesSpanNestedSuites_CollectsAllNamesInTraversalOrder()
+        {
+            ITestResultAdaptor resultAdaptor = CreateTestSuite(
+                "RootSuite",
+                TestResultStatus.Skipped,
+                0.1,
+                new List<ITestResultAdaptor>
+                {
+                    CreateTestCase("SkippedBefore", TestResultStatus.Skipped, 0.1),
+                    CreateTestSuite(
+                        "NestedSuite",
+                        TestResultStatus.Skipped,
+                        0.1,
+                        new List<ITestResultAdaptor>
+                        {
+                            CreateTestCase("SkippedNestedFirst", TestResultStatus.Skipped, 0.1),
+                            CreateTestCase("SkippedNestedSecond", TestResultStatus.Skipped, 0.1)
+                        }),
+                    CreateTestCase("SkippedAfter", TestResultStatus.Skipped, 0.1)
+                });
+
+            SerializableTestResult result = SerializableTestResultConverter.FromTestResult(resultAdaptor);
+
+            Assert.That(
+                result.skippedTests,
+                Is.EqualTo(
+                    new[]
+                    {
+                        "Example.Tests.SkippedBefore",
+                        "Example.Tests.SkippedNestedFirst",
+                        "Example.Tests.SkippedNestedSecond",
+                        "Example.Tests.SkippedAfter"
+                    }));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/RunTestsTestFrameworkResultTests.cs
+++ b/Assets/Tests/Editor/RunTestsTestFrameworkResultTests.cs
@@ -186,6 +186,148 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: passed and skipped leaves with a skipped root aggregate are reported as a passed run.
+        /// </summary>
+        [Test]
+        public void FromTestResult_WhenPassedAndSkippedLeavesHaveSkippedRoot_ReturnsPassedSuccess()
+        {
+            ITestResultAdaptor resultAdaptor = CreateTestSuite(
+                "RootSuite",
+                TestResultStatus.Skipped,
+                0.1,
+                new List<ITestResultAdaptor>
+                {
+                    CreateTestCase("PassingTest", TestResultStatus.Passed, 0.1),
+                    CreateTestCase("SkippedTest", TestResultStatus.Skipped, 0.1)
+                });
+
+            SerializableTestResult result = SerializableTestResultConverter.FromTestResult(resultAdaptor);
+
+            Assert.That(result.success, Is.True);
+            Assert.That(result.status, Is.EqualTo("Passed"));
+            Assert.That(result.message, Is.EqualTo("Test execution completed with status: Passed"));
+        }
+
+        /// <summary>
+        /// What: a skipped leaf is exposed by full name alongside a fully passed classification.
+        /// </summary>
+        [Test]
+        public void FromTestResult_WhenPassedAndSkippedLeavesHaveSkippedRoot_CollectsSkippedTestFullNames()
+        {
+            ITestResultAdaptor resultAdaptor = CreateTestSuite(
+                "RootSuite",
+                TestResultStatus.Skipped,
+                0.1,
+                new List<ITestResultAdaptor>
+                {
+                    CreateTestCase("PassingTest", TestResultStatus.Passed, 0.1),
+                    CreateTestCase("SkippedTest", TestResultStatus.Skipped, 0.1)
+                });
+
+            SerializableTestResult result = SerializableTestResultConverter.FromTestResult(resultAdaptor);
+
+            Assert.That(result.skippedCount, Is.EqualTo(1));
+            Assert.That(result.skippedTests, Is.EqualTo(new[] { "Example.Tests.SkippedTest" }));
+        }
+
+        /// <summary>
+        /// What: only the first 10 skipped leaves are listed while SkippedCount retains the full count.
+        /// </summary>
+        [Test]
+        public void FromTestResult_WhenElevenTestsAreSkipped_ListsFirstTenSkippedFullNames()
+        {
+            List<ITestResultAdaptor> children = new List<ITestResultAdaptor>();
+            for (int index = 0; index < 11; index++)
+            {
+                string suffix = index.ToString(CultureInfo.InvariantCulture);
+                children.Add(CreateTestCase("SkippedTest" + suffix, TestResultStatus.Skipped, 0.1));
+            }
+
+            ITestResultAdaptor resultAdaptor = CreateTestSuite(
+                "RootSuite",
+                TestResultStatus.Skipped,
+                0.1,
+                children);
+
+            SerializableTestResult result = SerializableTestResultConverter.FromTestResult(resultAdaptor);
+
+            Assert.That(result.skippedCount, Is.EqualTo(11));
+            Assert.That(result.skippedTests, Is.Not.Null);
+            Assert.That(result.skippedTests.Length, Is.EqualTo(10));
+            Assert.That(result.skippedTests[0], Is.EqualTo("Example.Tests.SkippedTest0"));
+            Assert.That(result.skippedTests[9], Is.EqualTo("Example.Tests.SkippedTest9"));
+        }
+
+        /// <summary>
+        /// What: a root Passed aggregate containing an inconclusive leaf remains a successful run.
+        /// </summary>
+        [Test]
+        public void FromTestResult_WhenPassedAndInconclusiveLeavesHavePassedRoot_PreservesPassedSuccess()
+        {
+            ITestResultAdaptor resultAdaptor = CreateTestSuite(
+                "RootSuite",
+                TestResultStatus.Passed,
+                0.1,
+                new List<ITestResultAdaptor>
+                {
+                    CreateTestCase("PassingTest", TestResultStatus.Passed, 0.1),
+                    CreateTestCase("InconclusiveTest", TestResultStatus.Inconclusive, 0.1)
+                });
+
+            SerializableTestResult result = SerializableTestResultConverter.FromTestResult(resultAdaptor);
+
+            Assert.That(result.success, Is.True);
+            Assert.That(result.status, Is.EqualTo("Passed"));
+            Assert.That(result.message, Is.EqualTo("Test execution completed with status: Passed"));
+        }
+
+        /// <summary>
+        /// What: a non-Passed root aggregate containing an inconclusive leaf remains non-successful.
+        /// </summary>
+        [Test]
+        public void FromTestResult_WhenPassedAndInconclusiveLeavesHaveInconclusiveRoot_ReturnsRootStatusFailure()
+        {
+            ITestResultAdaptor resultAdaptor = CreateTestSuite(
+                "RootSuite",
+                TestResultStatus.Inconclusive,
+                0.1,
+                new List<ITestResultAdaptor>
+                {
+                    CreateTestCase("PassingTest", TestResultStatus.Passed, 0.1),
+                    CreateTestCase("InconclusiveTest", TestResultStatus.Inconclusive, 0.1)
+                });
+
+            SerializableTestResult result = SerializableTestResultConverter.FromTestResult(resultAdaptor);
+
+            Assert.That(result.success, Is.False);
+            Assert.That(result.status, Is.EqualTo("Inconclusive"));
+            Assert.That(result.message, Is.EqualTo("Test execution completed with status: Inconclusive"));
+        }
+
+        /// <summary>
+        /// What: a failed leaf takes precedence over a root Passed aggregate for all response fields.
+        /// </summary>
+        [Test]
+        public void FromTestResult_WhenPassedAndFailedLeavesHavePassedRoot_ReturnsFailedClassification()
+        {
+            ITestResultAdaptor resultAdaptor = CreateTestSuite(
+                "RootSuite",
+                TestResultStatus.Passed,
+                0.1,
+                new List<ITestResultAdaptor>
+                {
+                    CreateTestCase("PassingTest", TestResultStatus.Passed, 0.1),
+                    CreateTestCase("FailingTest", TestResultStatus.Failed, 0.1)
+                });
+
+            SerializableTestResult result = SerializableTestResultConverter.FromTestResult(resultAdaptor);
+
+            Assert.That(result.success, Is.False);
+            Assert.That(result.status, Is.EqualTo("Failed"));
+            Assert.That(result.message, Is.EqualTo("Test execution completed with status: Failed"));
+        }
+
+        /// <summary>
         /// What: a failed leaf copies FullName, Message, and File/Line parsed from (at path:line).
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -493,6 +493,66 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: skipped full names from the execution result are copied onto the response.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenTestsAreSkipped_CopiesSkippedTestFullNamesOntoResponse()
+        {
+            StubTestExecutionService executionService = new StubTestExecutionService
+            {
+                NextResult = new SerializableTestResult
+                {
+                    success = true,
+                    status = RunTestsExecutionStatus.Passed,
+                    hasFailures = false,
+                    noTestsFound = false,
+                    noTestsFoundExplanation = string.Empty,
+                    message = "Test execution completed with status: Passed",
+                    completedAt = "2026-01-01T00:00:00.0000000Z",
+                    testCount = 2,
+                    passedCount = 1,
+                    failedCount = 0,
+                    skippedCount = 1,
+                    xmlPath = null,
+                    skippedTests = new[] { "Example.Tests.SkippedTest" }
+                }
+            };
+            StubTestExecutionStateValidationService validationService =
+                new StubTestExecutionStateValidationService(ValidationResult.Success());
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                waitForTestRunnerCleanupAsync: NoCleanupWait);
+            RunTestsSchema parameters = new RunTestsSchema();
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.SkippedTests, Is.EqualTo(new[] { "Example.Tests.SkippedTest" }));
+        }
+
+        /// <summary>
+        /// What: an execution result without skipped leaves leaves SkippedTests null on the response.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenNoTestsAreSkipped_LeavesSkippedTestsNull()
+        {
+            StubTestExecutionService executionService = new StubTestExecutionService();
+            StubTestExecutionStateValidationService validationService =
+                new StubTestExecutionStateValidationService(ValidationResult.Success());
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                waitForTestRunnerCleanupAsync: NoCleanupWait);
+            RunTestsSchema parameters = new RunTestsSchema();
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.SkippedTests, Is.Null);
+        }
+
+        /// <summary>
         /// What: FailedCount above 10 appends the fixed-literal truncation note to Message.
         /// </summary>
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
@@ -88,6 +88,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public SerializableTestResult.FailedTestDetail[] FailedTests { get; set; }
 
         /// <summary>
+        /// Skipped leaf test full names, omitted from JSON when none were skipped.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string[] SkippedTests { get; set; }
+
+        /// <summary>
         /// Policy warning when hot-reload changes were live at test-run start. Empty when none
         /// were active; omitted from JSON via ShouldSerializeWarning.
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -176,6 +176,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 response.FailedTests = result.failedTests;
             }
 
+            if (result.skippedTests != null && result.skippedTests.Length > 0)
+            {
+                response.SkippedTests = result.skippedTests;
+            }
+
             response.Warning = RunTestsHotReloadDiscardWarningBuilder.Build(activeHotReloadChangeCountAtStart);
 
             if (result.failedCount > RunTestsConstants.FailedTestDetailsLimit)

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -171,15 +171,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 response.ClearedPausePointIds = clearedPausePointIds;
             }
 
-            if (result.failedTests != null && result.failedTests.Length > 0)
-            {
-                response.FailedTests = result.failedTests;
-            }
-
-            if (result.skippedTests != null && result.skippedTests.Length > 0)
-            {
-                response.SkippedTests = result.skippedTests;
-            }
+            CopyTestDetails(result, response);
 
             response.Warning = RunTestsHotReloadDiscardWarningBuilder.Build(activeHotReloadChangeCountAtStart);
 
@@ -209,6 +201,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             await ApplyUnfilteredFilterEchoIfNeededAsync(response, parameters, ct)
                 .ConfigureAwait(false);
             return response;
+        }
+
+        private void CopyTestDetails(SerializableTestResult result, RunTestsResponse response)
+        {
+            if (result.failedTests != null && result.failedTests.Length > 0)
+            {
+                response.FailedTests = result.failedTests;
+            }
+
+            if (result.skippedTests != null && result.skippedTests.Length > 0)
+            {
+                response.SkippedTests = result.skippedTests;
+            }
         }
 
         private void AppendPredefinedAssemblyTestNoticeIfNeeded(

--- a/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
@@ -54,6 +54,7 @@ Returns JSON with:
 - `XmlPath` (string): Path to NUnit XML result file. Empty string when no XML was saved (typically on `Success: true`); populated only when tests failed and the XML file exists on disk.
 - `ClearedPausePointIds` (string[], optional): IDs of pause points that were cleared before test execution. Omitted from JSON when no pause points were active.
 - `FailedTests` (array, optional): Up to 10 failed leaf tests with `FullName`, `Message`, and when the stack trace contains a path:line location, `File` and `Line`. Omitted when no tests failed. When `FailedCount` is greater than 10, `Message` ends with `first 10 of N failures listed; see XmlPath for full results.`
+- `SkippedTests` (string[], optional): Up to 10 full names of skipped leaf tests. Omitted when no tests were skipped. When `SkippedCount` is greater than 10, only the first 10 names are listed.
 
 ### XML Result File
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/SerializableTestResultConverter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/SerializableTestResultConverter.cs
@@ -10,6 +10,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class SerializableTestResultConverter
     {
+        private enum RunTestsResultClassification
+        {
+            NoTestsFound,
+            HasFailures,
+            FullyPassed,
+            RootStatus
+        }
+
         public static SerializableTestResult FromTestResult(ITestResultAdaptor result)
         {
             if (result == null)
@@ -38,9 +46,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int skippedTests = CountSkippedTests(result);
             bool noTestsFound = totalTests == 0;
             bool hasFailures = failedTests > 0;
-            bool success = totalTests > 0 && result.TestStatus == TestStatus.Passed;
-            string message = CreateMessage(result, totalTests);
-            string status = CreateStatus(result, noTestsFound, hasFailures);
+            RunTestsResultClassification classification = Classify(
+                result,
+                totalTests,
+                passedTests,
+                failedTests,
+                skippedTests,
+                noTestsFound,
+                hasFailures);
+            bool success = classification == RunTestsResultClassification.FullyPassed;
+            string status = CreateStatus(result, classification);
+            string message = CreateMessage(status, classification);
             string noTestsFoundExplanation = noTestsFound
                 ? RunTestsResponse.NoTestsFoundExplanationText
                 : string.Empty;
@@ -59,23 +75,56 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 failedCount = failedTests,
                 skippedCount = skippedTests,
                 xmlPath = null,
-                failedTests = CollectFailedTestDetails(result)
+                failedTests = CollectFailedTestDetails(result),
+                skippedTests = CollectSkippedTestFullNames(result)
             };
         }
 
-        private static string CreateStatus(ITestResultAdaptor result, bool noTestsFound, bool hasFailures)
+        private static RunTestsResultClassification Classify(
+            ITestResultAdaptor result,
+            int totalTests,
+            int passedTests,
+            int failedTests,
+            int skippedTests,
+            bool noTestsFound,
+            bool hasFailures)
         {
             if (noTestsFound)
             {
-                return RunTestsExecutionStatus.NoTestsFound;
+                return RunTestsResultClassification.NoTestsFound;
             }
 
             if (hasFailures)
             {
+                return RunTestsResultClassification.HasFailures;
+            }
+
+            if (totalTests > 0
+                && failedTests == 0
+                && (result.TestStatus == TestStatus.Passed
+                    || (passedTests > 0 && passedTests + skippedTests == totalTests)))
+            {
+                return RunTestsResultClassification.FullyPassed;
+            }
+
+            return RunTestsResultClassification.RootStatus;
+        }
+
+        private static string CreateStatus(
+            ITestResultAdaptor result,
+            RunTestsResultClassification classification)
+        {
+            if (classification == RunTestsResultClassification.NoTestsFound)
+            {
+                return RunTestsExecutionStatus.NoTestsFound;
+            }
+
+            if (classification == RunTestsResultClassification.HasFailures)
+            {
                 return RunTestsExecutionStatus.Failed;
             }
 
-            if (result.TestStatus == TestStatus.Passed)
+            if (classification == RunTestsResultClassification.FullyPassed)
             {
                 return RunTestsExecutionStatus.Passed;
             }
@@ -83,14 +132,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return result.TestStatus.ToString();
         }
 
-        private static string CreateMessage(ITestResultAdaptor result, int totalTests)
+        private static string CreateMessage(
+            string status,
+            RunTestsResultClassification classification)
         {
-            if (totalTests == 0)
+            if (classification == RunTestsResultClassification.NoTestsFound)
             {
                 return RunTestsResponse.NoTestsFoundMessage;
             }
 
-            return $"Test execution completed with status: {result.TestStatus}";
+            return $"Test execution completed with status: {status}";
         }
 
         private static int CountTotalTests(ITestResultAdaptor result)
@@ -200,6 +251,52 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 File = file,
                 Line = line
             };
+        }
+
+        private static string[] CollectSkippedTestFullNames(ITestResultAdaptor result)
+        {
+            List<string> fullNames = new List<string>();
+            AppendSkippedTestFullNames(result, fullNames);
+            if (fullNames.Count == 0)
+            {
+                return null;
+            }
+
+            return fullNames.ToArray();
+        }
+
+        private static void AppendSkippedTestFullNames(
+            ITestResultAdaptor result,
+            List<string> fullNames)
+        {
+            if (fullNames.Count >= RunTestsConstants.FailedTestDetailsLimit)
+            {
+                return;
+            }
+
+            if (!result.Test.IsSuite)
+            {
+                if (result.TestStatus == TestStatus.Skipped)
+                {
+                    fullNames.Add(result.Test.FullName);
+                }
+
+                return;
+            }
+
+            if (result.Children == null)
+            {
+                return;
+            }
+
+            foreach (ITestResultAdaptor child in result.Children)
+            {
+                AppendSkippedTestFullNames(child, fullNames);
+                if (fullNames.Count >= RunTestsConstants.FailedTestDetailsLimit)
+                {
+                    return;
+                }
+            }
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestRunner/SerializableTestResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestRunner/SerializableTestResult.cs
@@ -29,6 +29,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public FailedTestDetail[] failedTests;
 
         /// <summary>
+        /// Skipped leaf test full names, capped for the JSON response. Null when none skipped.
+        /// </summary>
+        public string[] skippedTests;
+
+        /// <summary>
         /// One failed test leaf included in a run-tests response.
         /// </summary>
         [Serializable]


### PR DESCRIPTION
Fixes #2416

## Summary

- Report test runs that contain only passed and skipped leaves as `Passed` with `Success: true`.
- Include an optional, capped `SkippedTests` list so skipped leaf tests are visible without opening the XML result.

## User Impact

Platform-conditional skips no longer make an otherwise fully passing test run return a failing exit code. The response now identifies the skipped tests directly.

## Changes

- Centralized the test-result classification used by `Success`, `Status`, and `Message`, while preserving existing root-`Passed` behavior.
- Propagated skipped test full names through the saved result, response DTO, JSON contract, and run-tests skill.

## Verification

- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` - 0 errors, 0 warnings.
- Focused EditMode run for the three run-tests suites - 52 passed.
- Full EditMode run - exit 0; 3620 total, 3612 passed, 0 failed, 8 skipped; `Status: Passed` and `Success: true`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

