### PR TITLE
feat: compile pending script changes before running tests

### DIFF
--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -8,7 +8,7 @@ description: "Run Unity Test Runner and report detailed results. Use for EditMod
 
 Execute Unity Test Runner. When tests fail, NUnit XML results with error messages and stack traces are automatically saved. Read the XML file at `XmlPath` for detailed failure diagnosis.
 
-Before running tests, run `uloop compile` first if you created, deleted, renamed, moved, or edited C# files, test files, `.asmdef`/`.asmref`, or package manifests since the last successful compile. This refreshes the AssetDatabase and surfaces compile errors before test execution.
+`uloop run-tests` automatically compiles pending script changes before running tests. Pass `--skip-compile` only while validating active hot-reload patches, because the compile clears those patches; otherwise let the default compile surface errors and run against current scripts.
 
 Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
 
@@ -32,6 +32,7 @@ uloop run-tests [options]
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
 | `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
+| `--skip-compile` | flag | - | Skip the automatic compile before running tests; use only while validating active hot-reload patches. |
 | `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
 
 exact matches the full test name (Namespace.Class.Method); use regex to run a whole test class, e.g. --filter-type regex --filter 'MyGame\.Tests\.PlayerTests\.'
@@ -55,6 +56,7 @@ Returns JSON with:
 - `ClearedPausePointIds` (string[], optional): IDs of pause points that were cleared before test execution. Omitted from JSON when no pause points were active.
 - `FailedTests` (array, optional): Up to 10 failed leaf tests with `FullName`, `Message`, and when the stack trace contains a path:line location, `File` and `Line`. Omitted when no tests failed. When `FailedCount` is greater than 10, `Message` ends with `first 10 of N failures listed; see XmlPath for full results.`
 - `SkippedTests` (string[], optional): Up to 10 full names of skipped leaf tests. Omitted when no tests were skipped. When `SkippedCount` is greater than 10, only the first 10 names are listed.
+- `CompileNote` (string, optional): States that the automatic compile ran and succeeded before the tests and names `--skip-compile` as the opt-out. Omitted when `--skip-compile` was passed; a failed compile returns the compile error response instead.
 
 ### XML Result File
 

--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -8,7 +8,7 @@ description: "Run Unity Test Runner and report detailed results. Use for EditMod
 
 Execute Unity Test Runner. When tests fail, NUnit XML results with error messages and stack traces are automatically saved. Read the XML file at `XmlPath` for detailed failure diagnosis.
 
-Before running tests, run `uloop compile` first if you created, deleted, renamed, moved, or edited C# files, test files, `.asmdef`/`.asmref`, or package manifests since the last successful compile. This refreshes the AssetDatabase and surfaces compile errors before test execution.
+`uloop run-tests` automatically compiles pending script changes before running tests. Pass `--skip-compile` only while validating active hot-reload patches, because the compile clears those patches; otherwise let the default compile surface errors and run against current scripts.
 
 Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
 
@@ -32,6 +32,7 @@ uloop run-tests [options]
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
 | `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
+| `--skip-compile` | flag | - | Skip the automatic compile before running tests; use only while validating active hot-reload patches. |
 | `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
 
 exact matches the full test name (Namespace.Class.Method); use regex to run a whole test class, e.g. --filter-type regex --filter 'MyGame\.Tests\.PlayerTests\.'
@@ -55,6 +56,7 @@ Returns JSON with:
 - `ClearedPausePointIds` (string[], optional): IDs of pause points that were cleared before test execution. Omitted from JSON when no pause points were active.
 - `FailedTests` (array, optional): Up to 10 failed leaf tests with `FullName`, `Message`, and when the stack trace contains a path:line location, `File` and `Line`. Omitted when no tests failed. When `FailedCount` is greater than 10, `Message` ends with `first 10 of N failures listed; see XmlPath for full results.`
 - `SkippedTests` (string[], optional): Up to 10 full names of skipped leaf tests. Omitted when no tests were skipped. When `SkippedCount` is greater than 10, only the first 10 names are listed.
+- `CompileNote` (string, optional): States that the automatic compile ran and succeeded before the tests and names `--skip-compile` as the opt-out. Omitted when `--skip-compile` was passed; a failed compile returns the compile error response instead.
 
 ### XML Result File
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
@@ -8,7 +8,7 @@ description: "Run Unity Test Runner and report detailed results. Use for EditMod
 
 Execute Unity Test Runner. When tests fail, NUnit XML results with error messages and stack traces are automatically saved. Read the XML file at `XmlPath` for detailed failure diagnosis.
 
-Before running tests, run `uloop compile` first if you created, deleted, renamed, moved, or edited C# files, test files, `.asmdef`/`.asmref`, or package manifests since the last successful compile. This refreshes the AssetDatabase and surfaces compile errors before test execution.
+`uloop run-tests` automatically compiles pending script changes before running tests. Pass `--skip-compile` only while validating active hot-reload patches, because the compile clears those patches; otherwise let the default compile surface errors and run against current scripts.
 
 Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
 
@@ -32,6 +32,7 @@ uloop run-tests [options]
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
 | `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
+| `--skip-compile` | flag | - | Skip the automatic compile before running tests; use only while validating active hot-reload patches. |
 | `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
 
 exact matches the full test name (Namespace.Class.Method); use regex to run a whole test class, e.g. --filter-type regex --filter 'MyGame\.Tests\.PlayerTests\.'
@@ -55,6 +56,7 @@ Returns JSON with:
 - `ClearedPausePointIds` (string[], optional): IDs of pause points that were cleared before test execution. Omitted from JSON when no pause points were active.
 - `FailedTests` (array, optional): Up to 10 failed leaf tests with `FullName`, `Message`, and when the stack trace contains a path:line location, `File` and `Line`. Omitted when no tests failed. When `FailedCount` is greater than 10, `Message` ends with `first 10 of N failures listed; see XmlPath for full results.`
 - `SkippedTests` (string[], optional): Up to 10 full names of skipped leaf tests. Omitted when no tests were skipped. When `SkippedCount` is greater than 10, only the first 10 names are listed.
+- `CompileNote` (string, optional): States that the automatic compile ran and succeeded before the tests and names `--skip-compile` as the opt-out. Omitted when `--skip-compile` was passed; a failed compile returns the compile error response instead.
 
 ### XML Result File
 

--- a/cli/common/clicore/tool_catalog_test.go
+++ b/cli/common/clicore/tool_catalog_test.go
@@ -82,6 +82,35 @@ func TestVisibleOptionHelpEntriesIncludesExecuteDynamicCodeCodeFile(t *testing.T
 	}
 }
 
+// Tests that run-tests help and option discovery expose its CLI-only compile bypass with the
+// approved fixed description.
+func TestVisibleOptionEntriesIncludeRunTestsSkipCompile(t *testing.T) {
+	tool, ok := FindTool(LoadDefaultTools(), RunTestsCommandName)
+	if !ok {
+		t.Fatal("run-tests was not found in default tools")
+	}
+
+	options := tooldocs.VisibleOptionNamesForTool(tool)
+	if !slices.Contains(options, tooldocs.RunTestsSkipCompileOptionName) {
+		t.Fatalf("run-tests skip-compile option was not listed: %#v", options)
+	}
+
+	entries := tooldocs.VisibleOptionHelpEntriesForTool(tool)
+	for _, entry := range entries {
+		if entry.Name != tooldocs.RunTestsSkipCompileOptionName {
+			continue
+		}
+		if entry.Usage != tooldocs.RunTestsSkipCompileOptionUsage {
+			t.Fatalf("skip-compile usage mismatch: %#v", entry)
+		}
+		if entry.Description != "Skip the automatic compile before running tests; use only while validating active hot-reload patches." {
+			t.Fatalf("skip-compile description mismatch: %#v", entry)
+		}
+		return
+	}
+	t.Fatalf("run-tests help is missing %s: %#v", tooldocs.RunTestsSkipCompileOptionName, entries)
+}
+
 // Tests that cached tool loading hides tools whose source skills are internal.
 func TestLoadToolsFiltersInternalSkillToolsFromCache(t *testing.T) {
 	projectRoot := t.TempDir()

--- a/cli/common/tooldocs/tool_option_help.go
+++ b/cli/common/tooldocs/tool_option_help.go
@@ -19,6 +19,14 @@ const (
 
 const DynamicCodeFileOptionDescription = "Read C# code from a file instead of --code when shell quoting would alter multiline code"
 
+const (
+	RunTestsSkipCompileFlagName    = "skip-compile"
+	RunTestsSkipCompileOptionName  = "--" + RunTestsSkipCompileFlagName
+	RunTestsSkipCompileOptionUsage = RunTestsSkipCompileOptionName
+)
+
+const RunTestsSkipCompileOptionDescription = "Skip the automatic compile before running tests; use only while validating active hot-reload patches."
+
 // optionValuesSeparator joins the accepted values of an option in help output.
 const optionValuesSeparator = "|"
 
@@ -52,6 +60,7 @@ func VisibleOptionHelpEntriesForTool(tool tools.ToolDefinition) []OptionHelpEntr
 	}
 
 	entries = appendDynamicCodeFileOptionHelpEntry(tool, entries)
+	entries = appendRunTestsSkipCompileOptionHelpEntry(tool, entries)
 	entries = appendPausePointEnableCLIOnlyOptionHelpEntries(tool.Name, entries)
 	sort.Slice(entries, func(i int, j int) bool {
 		return entries[i].Name < entries[j].Name
@@ -155,5 +164,19 @@ func appendDynamicCodeFileOptionHelpEntry(tool tools.ToolDefinition, entries []O
 		Name:        DynamicCodeFileOptionName,
 		Usage:       DynamicCodeFileOptionUsage,
 		Description: DynamicCodeFileOptionDescription,
+	})
+}
+
+func appendRunTestsSkipCompileOptionHelpEntry(tool tools.ToolDefinition, entries []OptionHelpEntry) []OptionHelpEntry {
+	if tool.Name != runTestsCommandName {
+		return entries
+	}
+	if hasOptionHelpEntry(entries, RunTestsSkipCompileOptionName) {
+		return entries
+	}
+	return append(entries, OptionHelpEntry{
+		Name:        RunTestsSkipCompileOptionName,
+		Usage:       RunTestsSkipCompileOptionUsage,
+		Description: RunTestsSkipCompileOptionDescription,
 	})
 }

--- a/cli/common/tooldocs/tool_options.go
+++ b/cli/common/tooldocs/tool_options.go
@@ -58,8 +58,21 @@ func VisibleOptionNamesForTool(tool tools.ToolDefinition) []string {
 		options = append(options, "--"+OptionNameForProperty(tool.Name, propertyName, property))
 	}
 	options = appendDynamicCodeFileOptionName(tool, options)
+	options = appendRunTestsSkipCompileOptionName(tool, options)
 	sort.Strings(options)
 	return options
+}
+
+func appendRunTestsSkipCompileOptionName(tool tools.ToolDefinition, options []string) []string {
+	if tool.Name != runTestsCommandName {
+		return options
+	}
+	for _, option := range options {
+		if option == RunTestsSkipCompileOptionName {
+			return options
+		}
+	}
+	return append(options, RunTestsSkipCompileOptionName)
 }
 
 func IsBooleanProperty(property tools.ToolProperty) bool {

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "c4a8a220c3a1d2123d14fef749d9040bc3f3c34b"
+  "sharedInputsHash": "be063bcac2f9e292ae5d4f8f7d65dbf3ff32fe42"
 }

--- a/cli/project-runner/internal/projectrunner/compile_attach.go
+++ b/cli/project-runner/internal/projectrunner/compile_attach.go
@@ -38,20 +38,19 @@ func tryAttachToPendingCompile(
 	connection unityipc.Connection,
 	params map[string]any,
 	waitTimeout time.Duration,
-	stdout io.Writer,
 	stderr io.Writer,
 	deps compileWaitDeps,
-) (bool, int) {
+) (bool, compileExecutionResult) {
 	record, ok := readCompilePendingRecord(connection.ProjectRoot)
 	if !ok {
-		return false, 0
+		return false, compileExecutionResult{}
 	}
 
 	status, probed := probePendingCompileStatus(ctx, connection, record.RequestID, deps)
 	if !probed {
 		// Why keep the record: probe failures during domain reload are transient and
 		// do not prove the in-flight compile is gone.
-		return false, 0
+		return false, compileExecutionResult{}
 	}
 
 	// Why HasResult first: Ready is editor-wide (!compiling/!updating/!reload), not
@@ -61,17 +60,17 @@ func tryAttachToPendingCompile(
 	if status.HasResult && len(status.Result) > 0 {
 		if compileForceRecompileEnabled(params) {
 			clearCompilePendingRecord(connection.ProjectRoot)
-			return false, 0
+			return false, compileExecutionResult{}
 		}
-		return true, returnAttachedStoredCompileResult(ctx, connection, record, status.Result, stdout, stderr)
+		return true, returnAttachedStoredCompileResult(ctx, connection, record, status.Result, stderr)
 	}
 
 	if !status.Ready {
-		return attachWaitForPendingCompile(ctx, connection, record, params, waitTimeout, stdout, stderr, deps)
+		return attachWaitForPendingCompile(ctx, connection, record, params, waitTimeout, stderr, deps)
 	}
 
 	clearCompilePendingRecord(connection.ProjectRoot)
-	return false, 0
+	return false, compileExecutionResult{}
 }
 
 func probePendingCompileStatus(
@@ -120,10 +119,9 @@ func attachWaitForPendingCompile(
 	record compilePendingRecord,
 	params map[string]any,
 	waitTimeout time.Duration,
-	stdout io.Writer,
 	stderr io.Writer,
 	deps compileWaitDeps,
-) (bool, int) {
+) (bool, compileExecutionResult) {
 	if compileForceRecompileEnabled(params) {
 		_, _ = fmt.Fprintf(
 			stderr,
@@ -155,7 +153,7 @@ func attachWaitForPendingCompile(
 			ProjectRoot: connection.ProjectRoot,
 			Command:     clicore.CompileCommandName,
 		})
-		return true, 1
+		return true, compileExecutionResult{exitCode: 1}
 	}
 
 	switch outcome {
@@ -163,7 +161,7 @@ func attachWaitForPendingCompile(
 		spinner.Stop()
 		clearCompilePendingRecord(connection.ProjectRoot)
 		logCompileAttachResult(connection, record.RequestID, "disappeared", true)
-		return false, 0
+		return false, compileExecutionResult{}
 	case attachWaitTimedOut:
 		spinner.Stop()
 		// Why not refresh TimedOutAtUtc: stale expiry must stay anchored to the first timeout.
@@ -178,15 +176,15 @@ func attachWaitForPendingCompile(
 			time.Since(waitStartedAt),
 			retentionRemaining,
 		))
-		return true, 1
+		return true, compileExecutionResult{exitCode: 1}
 	case attachWaitCompleted:
 		clearCompilePendingRecord(connection.ProjectRoot)
 		logCompileAttachResult(connection, record.RequestID, "completed", true)
-		return true, completeCompileResultOutput(ctx, connection, result, stdout, stderr, spinner, startedAt, unityipc.UnitySendOutcome{})
+		return true, completeCompileResult(ctx, connection, result, stderr, spinner, startedAt, unityipc.UnitySendOutcome{})
 	default:
 		spinner.Stop()
 		logCompileAttachResult(connection, record.RequestID, "error", false)
-		return true, 1
+		return true, compileExecutionResult{exitCode: 1}
 	}
 }
 
@@ -256,27 +254,25 @@ func returnAttachedStoredCompileResult(
 	connection unityipc.Connection,
 	record compilePendingRecord,
 	result json.RawMessage,
-	stdout io.Writer,
 	stderr io.Writer,
-) int {
+) compileExecutionResult {
 	startedAt := time.Now()
 	logCompileAttachStart(connection, record.RequestID, "stored_result")
 	spinner := clicore.NewToolSpinner(stderr, clicore.CompileCommandName)
 	clearCompilePendingRecord(connection.ProjectRoot)
 	logCompileAttachResult(connection, record.RequestID, "stored_result", true)
-	return completeCompileResultOutput(ctx, connection, result, stdout, stderr, spinner, startedAt, unityipc.UnitySendOutcome{})
+	return completeCompileResult(ctx, connection, result, stderr, spinner, startedAt, unityipc.UnitySendOutcome{})
 }
 
-func completeCompileResultOutput(
+func completeCompileResult(
 	ctx context.Context,
 	connection unityipc.Connection,
 	result json.RawMessage,
-	stdout io.Writer,
 	stderr io.Writer,
 	spinner *ui.TerminalSpinner,
 	startedAt time.Time,
 	outcome unityipc.UnitySendOutcome,
-) int {
+) compileExecutionResult {
 	switch compileResultReadinessWaitMode(result) {
 	case compileReadinessWaitWarmup:
 		spinner.Update("Warming execute-dynamic-code after compile...")
@@ -286,9 +282,8 @@ func completeCompileResultOutput(
 		}
 	}
 	spinner.Stop()
-	clicore.WriteJSON(stdout, result)
 	writeDebugTiming(stderr, clicore.CompileCommandName, time.Since(startedAt), outcome)
-	return toolEnvelopeExitCode(result)
+	return compileExecutionResult{result: result, exitCode: toolEnvelopeExitCode(result)}
 }
 
 func persistCompilePendingRecordOrWarn(projectRoot string, requestID string, stderr io.Writer) {

--- a/cli/project-runner/internal/projectrunner/list_output.go
+++ b/cli/project-runner/internal/projectrunner/list_output.go
@@ -89,6 +89,7 @@ func listOptionsForTool(tool clicore.ToolDefinition) []listOption {
 	}
 
 	options = appendDynamicCodeFileListOption(tool, options)
+	options = appendRunTestsSkipCompileListOption(tool, options)
 	options = appendPausePointEnableAwaitListOptions(tool, options)
 	sort.Slice(options, func(i int, j int) bool {
 		return options[i].Name < options[j].Name
@@ -136,6 +137,17 @@ func appendDynamicCodeFileListOption(tool clicore.ToolDefinition, options []list
 		Name:        tooldocs.DynamicCodeFileOptionName,
 		Type:        "string",
 		Description: tooldocs.DynamicCodeFileOptionDescription,
+	})
+}
+
+func appendRunTestsSkipCompileListOption(tool clicore.ToolDefinition, options []listOption) []listOption {
+	if tool.Name != clicore.RunTestsCommandName || hasListOption(options, tooldocs.RunTestsSkipCompileOptionName) {
+		return options
+	}
+	return append(options, listOption{
+		Name:        tooldocs.RunTestsSkipCompileOptionName,
+		Type:        "boolean",
+		Description: tooldocs.RunTestsSkipCompileOptionDescription,
 	})
 }
 

--- a/cli/project-runner/internal/projectrunner/list_output_test.go
+++ b/cli/project-runner/internal/projectrunner/list_output_test.go
@@ -84,6 +84,13 @@ func TestNewListCatalogUsesSpecialOptionAliases(t *testing.T) {
 		t.Fatalf("fail-on-unsaved-changes default mismatch: %#v", failOnUnsavedChanges)
 	}
 	assertListOptionMissing(t, runTestsTool, "--no-save-before-run")
+	skipCompile := findListOption(t, runTestsTool, tooldocs.RunTestsSkipCompileOptionName)
+	if skipCompile.Type != "boolean" {
+		t.Fatalf("skip-compile type mismatch: %#v", skipCompile)
+	}
+	if skipCompile.Description != "Skip the automatic compile before running tests; use only while validating active hot-reload patches." {
+		t.Fatalf("skip-compile description mismatch: %#v", skipCompile)
+	}
 
 	compileTool := findListTool(t, catalog, clicore.CompileCommandName)
 	stopOnExternalSceneChanges := findListOption(t, compileTool, "--stop-on-external-scene-changes")

--- a/cli/project-runner/internal/projectrunner/run.go
+++ b/cli/project-runner/internal/projectrunner/run.go
@@ -76,6 +76,19 @@ func runTool(ctx context.Context, connection unityipc.Connection, command string
 		return runControlPlayModeWithStateWait(ctx, connection, params, stdout, stderr)
 	}
 
+	result := runPlainTool(ctx, connection, command, params, stderr)
+	if len(result.result) > 0 {
+		clicore.WriteJSON(stdout, result.result)
+	}
+	return result.exitCode
+}
+
+type toolExecutionResult struct {
+	result   json.RawMessage
+	exitCode int
+}
+
+func runPlainTool(ctx context.Context, connection unityipc.Connection, command string, params map[string]any, stderr io.Writer) toolExecutionResult {
 	applyDebugTimingParams(command, params)
 	startedAt := time.Now()
 	spinner := clicore.NewToolSpinner(stderr, command)
@@ -93,12 +106,11 @@ func runTool(ctx context.Context, connection unityipc.Connection, command string
 			ProjectRoot: connection.ProjectRoot,
 			Command:     command,
 		})
-		return 1
+		return toolExecutionResult{exitCode: 1}
 	}
 	result := stripDebugTimingResult(command, outcome.Result)
-	clicore.WriteJSON(stdout, result)
 	writeDebugTiming(stderr, command, time.Since(startedAt), outcome)
-	return toolEnvelopeExitCode(result)
+	return toolExecutionResult{result: result, exitCode: toolEnvelopeExitCode(result)}
 }
 
 func runExecuteDynamicCodeWithDomainReloadWait(ctx context.Context, connection unityipc.Connection, params map[string]any, stdout io.Writer, stderr io.Writer) int {
@@ -165,13 +177,38 @@ func runCompileWithDomainReloadWaitWithDeps(
 	stderr io.Writer,
 	compileWait compileWaitDeps,
 ) int {
+	result := runCompileWithDomainReloadWaitResultWithDeps(ctx, connection, params, stderr, compileWait)
+	return writeCompileExecutionResult(stdout, result)
+}
+
+// compileExecutionResult keeps compile's Unity response available to a composing command until
+// that command decides its single final stdout payload.
+type compileExecutionResult struct {
+	result   json.RawMessage
+	exitCode int
+}
+
+func writeCompileExecutionResult(stdout io.Writer, result compileExecutionResult) int {
+	if len(result.result) > 0 {
+		clicore.WriteJSON(stdout, result.result)
+	}
+	return result.exitCode
+}
+
+func runCompileWithDomainReloadWaitResultWithDeps(
+	ctx context.Context,
+	connection unityipc.Connection,
+	params map[string]any,
+	stderr io.Writer,
+	compileWait compileWaitDeps,
+) compileExecutionResult {
 	waitTimeout, timeoutErr := compileWaitTimeoutFromParams(params)
 	if timeoutErr != nil {
 		clierrors.WriteClassifiedError(stderr, timeoutErr, clierrors.ErrorContext{
 			ProjectRoot: connection.ProjectRoot,
 			Command:     clicore.CompileCommandName,
 		})
-		return 1
+		return compileExecutionResult{exitCode: 1}
 	}
 	if waitTimeout > time.Duration(compileWaitTimeoutRetentionWarningSeconds)*time.Second {
 		_, _ = fmt.Fprintf(
@@ -180,11 +217,11 @@ func runCompileWithDomainReloadWaitWithDeps(
 		)
 	}
 
-	if handled, code := tryAttachToPendingCompile(ctx, connection, params, waitTimeout, stdout, stderr, compileWait); handled {
-		return code
+	if handled, result := tryAttachToPendingCompile(ctx, connection, params, waitTimeout, stderr, compileWait); handled {
+		return result
 	}
 
-	return runFreshCompileWithDomainReloadWaitWithDeps(ctx, connection, params, stdout, stderr, compileWait)
+	return runFreshCompileWithDomainReloadWaitResultWithDeps(ctx, connection, params, stderr, compileWait)
 }
 
 func runFreshCompileWithDomainReloadWaitWithDeps(
@@ -195,13 +232,24 @@ func runFreshCompileWithDomainReloadWaitWithDeps(
 	stderr io.Writer,
 	compileWait compileWaitDeps,
 ) int {
+	result := runFreshCompileWithDomainReloadWaitResultWithDeps(ctx, connection, params, stderr, compileWait)
+	return writeCompileExecutionResult(stdout, result)
+}
+
+func runFreshCompileWithDomainReloadWaitResultWithDeps(
+	ctx context.Context,
+	connection unityipc.Connection,
+	params map[string]any,
+	stderr io.Writer,
+	compileWait compileWaitDeps,
+) compileExecutionResult {
 	waitTimeout, timeoutErr := compileWaitTimeoutFromParams(params)
 	if timeoutErr != nil {
 		clierrors.WriteClassifiedError(stderr, timeoutErr, clierrors.ErrorContext{
 			ProjectRoot: connection.ProjectRoot,
 			Command:     clicore.CompileCommandName,
 		})
-		return 1
+		return compileExecutionResult{exitCode: 1}
 	}
 
 	requestID, err := prepareCompileWaitParams(params)
@@ -210,7 +258,7 @@ func runFreshCompileWithDomainReloadWaitWithDeps(
 			ProjectRoot: connection.ProjectRoot,
 			Command:     clicore.CompileCommandName,
 		})
-		return 1
+		return compileExecutionResult{exitCode: 1}
 	}
 
 	logCliDebugModeResolved(connection, clicore.CompileCommandName)
@@ -236,7 +284,7 @@ func runFreshCompileWithDomainReloadWaitWithDeps(
 			ProjectRoot: connection.ProjectRoot,
 			Command:     clicore.CompileCommandName,
 		})
-		return 1
+		return compileExecutionResult{exitCode: 1}
 	}
 
 	spinner.Update("Waiting for domain reload to complete...")
@@ -255,7 +303,7 @@ func runFreshCompileWithDomainReloadWaitWithDeps(
 			ProjectRoot: connection.ProjectRoot,
 			Command:     clicore.CompileCommandName,
 		})
-		return 1
+		return compileExecutionResult{exitCode: 1}
 	}
 	if !completed {
 		spinner.Stop()
@@ -267,9 +315,9 @@ func runFreshCompileWithDomainReloadWaitWithDeps(
 			time.Since(waitStartedAt),
 			compilePendingRecordLifetime-waitTimeout,
 		))
-		return 1
+		return compileExecutionResult{exitCode: 1}
 	}
-	return completeCompileResultOutput(ctx, connection, result, stdout, stderr, spinner, startedAt, outcome)
+	return completeCompileResult(ctx, connection, result, stderr, spinner, startedAt, outcome)
 }
 
 func writePostCompileWarmupWarning(stderr io.Writer, err error) {

--- a/cli/project-runner/internal/projectrunner/run_tests_implicit_compile.go
+++ b/cli/project-runner/internal/projectrunner/run_tests_implicit_compile.go
@@ -1,0 +1,86 @@
+package projectrunner
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+	"github.com/hatayama/unity-cli-loop/common/tooldocs"
+
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+)
+
+const runTestsCompileNote = "A compile ran before the tests and succeeded. Pass --skip-compile to run the tests without this compile step."
+
+var runTestsImplicitCompile = runTestsImplicitCompileDefault
+
+// runTestsWithImplicitCompile compiles before resolving the run-tests schema so an imported user
+// script cannot leave this invocation using a stale cached parameter definition.
+func runTestsWithImplicitCompile(
+	ctx context.Context,
+	connection unityipc.Connection,
+	commandArgs []string,
+	startPath string,
+	stdout io.Writer,
+	stderr io.Writer,
+) int {
+	remainingArgs, skipCompile := extractRunTestsSkipCompileFlag(commandArgs)
+	if skipCompile {
+		return runDynamicProjectToolWithCompileNote(ctx, connection, clicore.RunTestsCommandName, remainingArgs, startPath, stdout, stderr, false)
+	}
+
+	compileResult := runTestsImplicitCompile(ctx, connection, stderr)
+	if compileResult.exitCode != 0 {
+		return writeCompileExecutionResult(stdout, compileResult)
+	}
+
+	return runDynamicProjectToolWithCompileNote(ctx, connection, clicore.RunTestsCommandName, remainingArgs, startPath, stdout, stderr, true)
+}
+
+func runTestsImplicitCompileDefault(
+	ctx context.Context,
+	connection unityipc.Connection,
+	stderr io.Writer,
+) compileExecutionResult {
+	return runCompileWithDomainReloadWaitResultWithDeps(
+		ctx,
+		connection,
+		map[string]any{},
+		stderr,
+		defaultCompileWaitDeps())
+}
+
+func extractRunTestsSkipCompileFlag(args []string) ([]string, bool) {
+	remaining := make([]string, 0, len(args))
+	skipCompile := false
+	for _, arg := range args {
+		if arg == "--"+tooldocs.RunTestsSkipCompileFlagName {
+			skipCompile = true
+			continue
+		}
+		remaining = append(remaining, arg)
+	}
+	return remaining, skipCompile
+}
+
+func injectRunTestsCompileNote(raw []byte) ([]byte, error) {
+	fields := map[string]json.RawMessage{}
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, err
+	}
+	note, err := json.Marshal(runTestsCompileNote)
+	if err != nil {
+		return nil, err
+	}
+	fields["CompileNote"] = note
+	return json.Marshal(fields)
+}
+
+func writeRunTestsCompileNoteError(stderr io.Writer, connection unityipc.Connection, err error) {
+	clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
+		ProjectRoot: connection.ProjectRoot,
+		Command:     clicore.RunTestsCommandName,
+	})
+}

--- a/cli/project-runner/internal/projectrunner/run_tests_implicit_compile.go
+++ b/cli/project-runner/internal/projectrunner/run_tests_implicit_compile.go
@@ -3,6 +3,7 @@ package projectrunner
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 
 	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
@@ -69,6 +70,9 @@ func injectRunTestsCompileNote(raw []byte) ([]byte, error) {
 	fields := map[string]json.RawMessage{}
 	if err := json.Unmarshal(raw, &fields); err != nil {
 		return nil, err
+	}
+	if fields == nil {
+		return nil, errors.New("run-tests response must be a JSON object")
 	}
 	note, err := json.Marshal(runTestsCompileNote)
 	if err != nil {

--- a/cli/project-runner/internal/projectrunner/run_tests_implicit_compile_test.go
+++ b/cli/project-runner/internal/projectrunner/run_tests_implicit_compile_test.go
@@ -1,0 +1,221 @@
+package projectrunner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+	"github.com/hatayama/unity-cli-loop/common/clitest"
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+)
+
+// Verifies the CLI-only flag is removed before generic schema parsing while unrelated flags remain.
+func TestExtractRunTestsSkipCompileFlagRemovesOnlyItsFlag(t *testing.T) {
+	remaining, skipCompile := extractRunTestsSkipCompileFlag([]string{"--skip-compile", "--test-mode", "EditMode"})
+	if !skipCompile {
+		t.Fatal("expected --skip-compile to be extracted")
+	}
+	if len(remaining) != 2 || remaining[0] != "--test-mode" || remaining[1] != "EditMode" {
+		t.Fatalf("remaining arguments mismatch: %#v", remaining)
+	}
+}
+
+// Verifies run-tests compiles first, resolves the live catalog after that compile, and adds its
+// native-only CompileNote to the one final test response.
+func TestRunTestsWithImplicitCompileRunsCompileThenUsesLiveCatalog(t *testing.T) {
+	projectRoot := t.TempDir()
+	listener := newLoopbackIpcListener(t)
+	requests := make(chan map[string]any, 1)
+	serverErr := make(chan error, 1)
+	go serveSingleIPCResponse(listener, clicore.RunTestsCommandName, requests, serverErr, `{"Success":true,"Status":"Passed","Message":"Test execution completed with status: Passed"}`)
+
+	original := runTestsImplicitCompile
+	compileCalls := 0
+	runTestsImplicitCompile = func(context.Context, unityipc.Connection, io.Writer) compileExecutionResult {
+		compileCalls++
+		writeRunTestsCompileToolCache(t, projectRoot)
+		return compileExecutionResult{result: json.RawMessage(`{"Success":true}`), exitCode: 0}
+	}
+	t.Cleanup(func() {
+		runTestsImplicitCompile = original
+	})
+
+	connection := unityipc.Connection{
+		Endpoint:    unityipc.Endpoint{Network: listener.Addr().Network(), Address: listener.Addr().String()},
+		ProjectRoot: projectRoot,
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := runTestsWithImplicitCompile(context.Background(), connection, nil, projectRoot, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run-tests failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if compileCalls != 1 {
+		t.Fatalf("compile call count mismatch: %d", compileCalls)
+	}
+	readIPCRequest(t, requests)
+	assertSingleRunTestsJSON(t, stdout.Bytes(), true)
+	assertServerDidNotFail(t, serverErr)
+}
+
+// Verifies CompileNote remains present when the compile succeeds but the test response reports failures.
+func TestRunTestsWithImplicitCompileAddsCompileNoteToFailedTestResponse(t *testing.T) {
+	projectRoot := t.TempDir()
+	writeRunTestsCompileToolCache(t, projectRoot)
+	listener := newLoopbackIpcListener(t)
+	requests := make(chan map[string]any, 1)
+	serverErr := make(chan error, 1)
+	go serveSingleIPCResponse(listener, clicore.RunTestsCommandName, requests, serverErr, `{"Success":false,"Status":"Failed","Message":"Test execution completed with status: Failed"}`)
+
+	original := runTestsImplicitCompile
+	runTestsImplicitCompile = func(context.Context, unityipc.Connection, io.Writer) compileExecutionResult {
+		return compileExecutionResult{result: json.RawMessage(`{"Success":true}`), exitCode: 0}
+	}
+	t.Cleanup(func() {
+		runTestsImplicitCompile = original
+	})
+
+	connection := unityipc.Connection{
+		Endpoint:    unityipc.Endpoint{Network: listener.Addr().Network(), Address: listener.Addr().String()},
+		ProjectRoot: projectRoot,
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := runTestsWithImplicitCompile(context.Background(), connection, nil, projectRoot, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("failed test response exit code mismatch: %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	readIPCRequest(t, requests)
+	assertSingleRunTestsJSON(t, stdout.Bytes(), true)
+	assertServerDidNotFail(t, serverErr)
+}
+
+// Verifies --skip-compile bypasses the compile seam and omits CompileNote from the test response.
+func TestRunTestsWithImplicitCompileSkipCompileOmitsCompileNote(t *testing.T) {
+	projectRoot := t.TempDir()
+	writeRunTestsCompileToolCache(t, projectRoot)
+	listener := newLoopbackIpcListener(t)
+	requests := make(chan map[string]any, 1)
+	serverErr := make(chan error, 1)
+	go serveSingleIPCResponse(listener, clicore.RunTestsCommandName, requests, serverErr, `{"Success":true,"Status":"Passed","Message":"Test execution completed with status: Passed"}`)
+
+	original := runTestsImplicitCompile
+	compileCalls := 0
+	runTestsImplicitCompile = func(context.Context, unityipc.Connection, io.Writer) compileExecutionResult {
+		compileCalls++
+		return compileExecutionResult{}
+	}
+	t.Cleanup(func() {
+		runTestsImplicitCompile = original
+	})
+
+	connection := unityipc.Connection{
+		Endpoint:    unityipc.Endpoint{Network: listener.Addr().Network(), Address: listener.Addr().String()},
+		ProjectRoot: projectRoot,
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := runTestsWithImplicitCompile(context.Background(), connection, []string{"--skip-compile"}, projectRoot, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run-tests failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if compileCalls != 0 {
+		t.Fatalf("--skip-compile must not invoke compile: %d", compileCalls)
+	}
+	readIPCRequest(t, requests)
+	assertSingleRunTestsJSON(t, stdout.Bytes(), false)
+	assertServerDidNotFail(t, serverErr)
+}
+
+// Verifies a failed implicit compile is the only output and prevents the test IPC request.
+func TestRunTestsWithImplicitCompileFailsFastWithCompileResponse(t *testing.T) {
+	projectRoot := t.TempDir()
+	compileResponse := json.RawMessage(`{"Success":false,"ErrorCount":1,"WarningCount":0}`)
+	compileResult := compileExecutionResult{result: compileResponse, exitCode: 1}
+	var compileStdout bytes.Buffer
+	if code := writeCompileExecutionResult(&compileStdout, compileResult); code != 1 {
+		t.Fatalf("compile presenter exit code mismatch: %d", code)
+	}
+	original := runTestsImplicitCompile
+	runTestsImplicitCompile = func(context.Context, unityipc.Connection, io.Writer) compileExecutionResult {
+		return compileResult
+	}
+	t.Cleanup(func() {
+		runTestsImplicitCompile = original
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	connection := unityipc.Connection{ProjectRoot: projectRoot}
+
+	code := runTestsWithImplicitCompile(context.Background(), connection, nil, projectRoot, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("compile failure exit code mismatch: %d", code)
+	}
+	if stdout.String() != compileStdout.String() {
+		t.Fatalf("run-tests compile failure must match compile output:\ncompile: %s\nrun-tests: %s", compileStdout.String(), stdout.String())
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("CompileNote")) {
+		t.Fatalf("compile failure must not include CompileNote: %s", stdout.String())
+	}
+}
+
+func writeRunTestsCompileToolCache(t *testing.T, projectRoot string) {
+	t.Helper()
+	clitest.WriteProjectFile(t, projectRoot, filepath.Join(clicore.CacheDirectoryName, clicore.CacheFileName), `{
+  "tools": [
+    {
+      "name": "run-tests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  ]
+}`)
+}
+
+func assertSingleRunTestsJSON(t *testing.T, output []byte, expectCompileNote bool) {
+	t.Helper()
+	decoder := json.NewDecoder(bytes.NewReader(output))
+	fields := map[string]json.RawMessage{}
+	if err := decoder.Decode(&fields); err != nil {
+		t.Fatalf("stdout must contain JSON: %v\n%s", err, output)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		t.Fatalf("stdout must contain one JSON response: %s", output)
+	}
+
+	compileNote, present := fields["CompileNote"]
+	if present != expectCompileNote {
+		t.Fatalf("CompileNote presence mismatch: expect=%t fields=%s", expectCompileNote, output)
+	}
+	if !expectCompileNote {
+		return
+	}
+
+	var note string
+	if err := json.Unmarshal(compileNote, &note); err != nil {
+		t.Fatalf("CompileNote must be a string: %v", err)
+	}
+	if note != runTestsCompileNote {
+		t.Fatalf("CompileNote mismatch: %q", note)
+	}
+}
+
+func assertServerDidNotFail(t *testing.T, serverErr <-chan error) {
+	t.Helper()
+	select {
+	case err := <-serverErr:
+		t.Fatalf("IPC server failed: %v", err)
+	default:
+	}
+}

--- a/cli/project-runner/internal/projectrunner/run_tests_implicit_compile_test.go
+++ b/cli/project-runner/internal/projectrunner/run_tests_implicit_compile_test.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/hatayama/unity-cli-loop/common/clicore"
 	"github.com/hatayama/unity-cli-loop/common/clitest"
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
 	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
 
@@ -28,6 +30,7 @@ func TestExtractRunTestsSkipCompileFlagRemovesOnlyItsFlag(t *testing.T) {
 // native-only CompileNote to the one final test response.
 func TestRunTestsWithImplicitCompileRunsCompileThenUsesLiveCatalog(t *testing.T) {
 	projectRoot := t.TempDir()
+	writeRunTestsCompileToolCache(t, projectRoot)
 	listener := newLoopbackIpcListener(t)
 	requests := make(chan map[string]any, 1)
 	serverErr := make(chan error, 1)
@@ -37,7 +40,46 @@ func TestRunTestsWithImplicitCompileRunsCompileThenUsesLiveCatalog(t *testing.T)
 	compileCalls := 0
 	runTestsImplicitCompile = func(context.Context, unityipc.Connection, io.Writer) compileExecutionResult {
 		compileCalls++
-		writeRunTestsCompileToolCache(t, projectRoot)
+		writeRunTestsCompileToolCacheWithTestMode(t, projectRoot)
+		return compileExecutionResult{result: json.RawMessage(`{"Success":true}`), exitCode: 0}
+	}
+	t.Cleanup(func() {
+		runTestsImplicitCompile = original
+	})
+
+	connection := unityipc.Connection{
+		Endpoint:    unityipc.Endpoint{Network: listener.Addr().Network(), Address: listener.Addr().String()},
+		ProjectRoot: projectRoot,
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := runTestsWithImplicitCompile(context.Background(), connection, []string{"--test-mode", "EditMode"}, projectRoot, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run-tests failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if compileCalls != 1 {
+		t.Fatalf("compile call count mismatch: %d", compileCalls)
+	}
+	request := readIPCRequest(t, requests)
+	if request["TestMode"] != "EditMode" {
+		t.Fatalf("live TestMode parameter mismatch: %#v", request)
+	}
+	assertSingleRunTestsJSON(t, stdout.Bytes(), true)
+	assertServerDidNotFail(t, serverErr)
+}
+
+// Verifies a literal null Unity response is classified instead of panicking during CompileNote injection.
+func TestRunTestsWithImplicitCompileClassifiesNullTestResponse(t *testing.T) {
+	projectRoot := t.TempDir()
+	writeRunTestsCompileToolCache(t, projectRoot)
+	listener := newLoopbackIpcListener(t)
+	requests := make(chan map[string]any, 1)
+	serverErr := make(chan error, 1)
+	go serveSingleIPCResponse(listener, clicore.RunTestsCommandName, requests, serverErr, "null")
+
+	original := runTestsImplicitCompile
+	runTestsImplicitCompile = func(context.Context, unityipc.Connection, io.Writer) compileExecutionResult {
 		return compileExecutionResult{result: json.RawMessage(`{"Success":true}`), exitCode: 0}
 	}
 	t.Cleanup(func() {
@@ -52,14 +94,24 @@ func TestRunTestsWithImplicitCompileRunsCompileThenUsesLiveCatalog(t *testing.T)
 	var stderr bytes.Buffer
 
 	code := runTestsWithImplicitCompile(context.Background(), connection, nil, projectRoot, &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("run-tests failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	if code != 1 {
+		t.Fatalf("null response exit code mismatch: %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if compileCalls != 1 {
-		t.Fatalf("compile call count mismatch: %d", compileCalls)
+	if stdout.Len() != 0 {
+		t.Fatalf("null response must not write stdout: %s", stdout.String())
+	}
+
+	var envelope clierrors.CLIErrorEnvelope
+	if err := json.Unmarshal(stderr.Bytes(), &envelope); err != nil {
+		t.Fatalf("null response stderr must be a classified error: %v\n%s", err, stderr.String())
+	}
+	if envelope.Error.ErrorCode != clierrors.ErrorCodeInternalError {
+		t.Fatalf("null response error code mismatch: %#v", envelope.Error)
+	}
+	if envelope.Error.Message != "run-tests response must be a JSON object" {
+		t.Fatalf("null response error message mismatch: %#v", envelope.Error)
 	}
 	readIPCRequest(t, requests)
-	assertSingleRunTestsJSON(t, stdout.Bytes(), true)
 	assertServerDidNotFail(t, serverErr)
 }
 
@@ -137,6 +189,10 @@ func TestRunTestsWithImplicitCompileSkipCompileOmitsCompileNote(t *testing.T) {
 // Verifies a failed implicit compile is the only output and prevents the test IPC request.
 func TestRunTestsWithImplicitCompileFailsFastWithCompileResponse(t *testing.T) {
 	projectRoot := t.TempDir()
+	listener := newLoopbackIpcListener(t)
+	requests := make(chan map[string]any, 1)
+	serverErr := make(chan error, 1)
+	go serveSingleIPCResponse(listener, clicore.RunTestsCommandName, requests, serverErr, `{"Success":true,"Status":"Passed"}`)
 	compileResponse := json.RawMessage(`{"Success":false,"ErrorCount":1,"WarningCount":0}`)
 	compileResult := compileExecutionResult{result: compileResponse, exitCode: 1}
 	var compileStdout bytes.Buffer
@@ -153,7 +209,10 @@ func TestRunTestsWithImplicitCompileFailsFastWithCompileResponse(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	connection := unityipc.Connection{ProjectRoot: projectRoot}
+	connection := unityipc.Connection{
+		Endpoint:    unityipc.Endpoint{Network: listener.Addr().Network(), Address: listener.Addr().String()},
+		ProjectRoot: projectRoot,
+	}
 
 	code := runTestsWithImplicitCompile(context.Background(), connection, nil, projectRoot, &stdout, &stderr)
 	if code != 1 {
@@ -165,6 +224,8 @@ func TestRunTestsWithImplicitCompileFailsFastWithCompileResponse(t *testing.T) {
 	if bytes.Contains(stdout.Bytes(), []byte("CompileNote")) {
 		t.Fatalf("compile failure must not include CompileNote: %s", stdout.String())
 	}
+	assertNoIPCRequest(t, requests)
+	assertServerDidNotFail(t, serverErr)
 }
 
 func writeRunTestsCompileToolCache(t *testing.T, projectRoot string) {
@@ -176,6 +237,25 @@ func writeRunTestsCompileToolCache(t *testing.T, projectRoot string) {
       "inputSchema": {
         "type": "object",
         "properties": {}
+      }
+    }
+  ]
+}`)
+}
+
+func writeRunTestsCompileToolCacheWithTestMode(t *testing.T, projectRoot string) {
+	t.Helper()
+	clitest.WriteProjectFile(t, projectRoot, filepath.Join(clicore.CacheDirectoryName, clicore.CacheFileName), `{
+  "tools": [
+    {
+      "name": "run-tests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "TestMode": {
+            "type": "string"
+          }
+        }
       }
     }
   ]
@@ -206,8 +286,17 @@ func assertSingleRunTestsJSON(t *testing.T, output []byte, expectCompileNote boo
 	if err := json.Unmarshal(compileNote, &note); err != nil {
 		t.Fatalf("CompileNote must be a string: %v", err)
 	}
-	if note != runTestsCompileNote {
+	if note != "A compile ran before the tests and succeeded. Pass --skip-compile to run the tests without this compile step." {
 		t.Fatalf("CompileNote mismatch: %q", note)
+	}
+}
+
+func assertNoIPCRequest(t *testing.T, requests <-chan map[string]any) {
+	t.Helper()
+	select {
+	case request := <-requests:
+		t.Fatalf("compile failure must not send run-tests: %#v", request)
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 

--- a/cli/project-runner/internal/projectrunner/runner_commands.go
+++ b/cli/project-runner/internal/projectrunner/runner_commands.go
@@ -52,6 +52,22 @@ func runDynamicProjectTool(
 	stdout io.Writer,
 	stderr io.Writer,
 ) int {
+	if command == clicore.RunTestsCommandName {
+		return runTestsWithImplicitCompile(ctx, connection, commandArgs, startPath, stdout, stderr)
+	}
+	return runDynamicProjectToolWithCompileNote(ctx, connection, command, commandArgs, startPath, stdout, stderr, false)
+}
+
+func runDynamicProjectToolWithCompileNote(
+	ctx context.Context,
+	connection unityipc.Connection,
+	command string,
+	commandArgs []string,
+	startPath string,
+	stdout io.Writer,
+	stderr io.Writer,
+	includeCompileNote bool,
+) int {
 	tool, cache, ok, err := clicore.FindToolForCommand(connection.ProjectRoot, command)
 	if err != nil {
 		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{ProjectRoot: connection.ProjectRoot, Command: command})
@@ -86,7 +102,21 @@ func runDynamicProjectTool(
 		}).ToCLIError(clierrors.ErrorContext{ProjectRoot: connection.ProjectRoot, Command: command}))
 		return 1
 	}
-	return runTool(ctx, connection, command, params, stdout, stderr)
+	if !includeCompileNote {
+		return runTool(ctx, connection, command, params, stdout, stderr)
+	}
+
+	result := runPlainTool(ctx, connection, command, params, stderr)
+	if len(result.result) == 0 {
+		return result.exitCode
+	}
+	withCompileNote, err := injectRunTestsCompileNote(result.result)
+	if err != nil {
+		writeRunTestsCompileNoteError(stderr, connection, err)
+		return 1
+	}
+	clicore.WriteJSON(stdout, withCompileNote)
+	return result.exitCode
 }
 
 func prepareDynamicToolParams(

--- a/cli/project-runner/internal/projectrunner/tool_param_suggestions.go
+++ b/cli/project-runner/internal/projectrunner/tool_param_suggestions.go
@@ -153,6 +153,7 @@ func visibleToolOptions(tool clicore.ToolDefinition) []visibleToolOption {
 		})
 	}
 	options = appendDynamicCodeFileSuggestionOption(tool, options)
+	options = appendRunTestsSkipCompileSuggestionOption(tool, options)
 	return appendPausePointEnableSuggestionOptions(tool, options)
 }
 
@@ -161,6 +162,13 @@ func appendDynamicCodeFileSuggestionOption(tool clicore.ToolDefinition, options 
 		return options
 	}
 	return appendSuggestionOption(options, tooldocs.DynamicCodeFileFlagName)
+}
+
+func appendRunTestsSkipCompileSuggestionOption(tool clicore.ToolDefinition, options []visibleToolOption) []visibleToolOption {
+	if tool.Name != clicore.RunTestsCommandName {
+		return options
+	}
+	return appendSuggestionOption(options, tooldocs.RunTestsSkipCompileFlagName)
 }
 
 func appendPausePointEnableSuggestionOptions(tool clicore.ToolDefinition, options []visibleToolOption) []visibleToolOption {

--- a/cli/project-runner/internal/projectrunner/tool_params_test.go
+++ b/cli/project-runner/internal/projectrunner/tool_params_test.go
@@ -294,6 +294,20 @@ func TestBuildToolParamsUnknownOptionSuggestsTestModeFromSharedLaterToken(t *tes
 	})
 }
 
+// Verifies run-tests suggests its CLI-only compile bypass when a supplied flag is a close typo.
+func TestBuildToolParamsUnknownOptionSuggestsRunTestsSkipCompile(t *testing.T) {
+	tool, ok := clicore.FindTool(clicore.LoadDefaultTools(), clicore.RunTestsCommandName)
+	if !ok {
+		t.Fatal("run-tests was not found in default tools")
+	}
+
+	_, _, err := buildToolParams([]string{"--skip-compil"}, tool)
+	requireNextActions(t, err, []string{
+		"Did you mean: uloop run-tests --skip-compile",
+		"Run `uloop run-tests --help` to inspect supported options.",
+	})
+}
+
 // Verifies enable-pause-point suggests its CLI-only trigger option when a supplied flag is a close typo.
 func TestBuildToolParamsUnknownOptionSuggestsPausePointTrigger(t *testing.T) {
 	tool, ok := clicore.FindTool(clicore.LoadDefaultTools(), pausePointEnableCommandName)

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "9794fbf0dc564b53088f87a24d100a316eccfa25"
+  "sharedInputsHash": "05e6f510ba0450be9dfd9204fc2cbebb74bf7352"
 }

--- a/cli/release-automation/internal/automation/tool_docs_sync.go
+++ b/cli/release-automation/internal/automation/tool_docs_sync.go
@@ -38,6 +38,14 @@ var toolsWithoutParameterTable = map[string]bool{
 	"focus-window": true,
 }
 
+// cliOnlyParameterTableOptions records options parsed by the native runner before Unity sees a
+// schema. Keeping this narrow lets the generator reject every other stale skill-table row.
+var cliOnlyParameterTableOptions = map[string]map[string]bool{
+	"run-tests": {
+		tooldocs.RunTestsSkipCompileFlagName: true,
+	},
+}
+
 // descriptionKey identifies one description in the catalog. Property is empty for the tool's own
 // description.
 type descriptionKey struct {
@@ -183,6 +191,9 @@ func collectToolReplacements(
 func unknownTableRowProblems(toolName string, docs skilldocs.ToolDocs, documentedOptions map[string]bool) []string {
 	unknown := []string{}
 	for optionName := range docs.ParamDescriptions {
+		if cliOnlyParameterTableOptions[toolName][optionName] {
+			continue
+		}
 		if !documentedOptions[optionName] {
 			unknown = append(unknown, "--"+optionName)
 		}


### PR DESCRIPTION
Fixes #2417

## Summary

- `uloop run-tests` now compiles pending script changes before it resolves parameters and starts the Test Runner.
- `--skip-compile` is available for validating active hot-reload patches, with help, list, suggestions, and skill guidance.
- A successful automatic compile adds `CompileNote`; a compile failure is returned unchanged and prevents test dispatch.

## Rationale

The Unity contract has no observation fields that can truthfully distinguish no-change, recompilation, or domain reload outcomes. `CompileNote` therefore states only that the CLI compile step ran and succeeded, including when the tests later fail. This intentionally does not add a three-way outcome.

After a successful compile, the runner resolves the live run-tests catalog before building parameters. This applies to pending user script changes; changing the run-tests schema itself is outside this scope.

## Verification

- `scripts/check-go-cli.sh` (exit 0)
- `scripts/sync-tool-docs.sh` (catalog already up to date) and `scripts/stamp-release-inputs.sh`
- Development-binary live checks: an automatic-compile run completed one changed EditMode test with `CompileNote`; `--skip-compile` completed one test without the note while a hot-reload patch remained active; a temporary C# syntax error returned only the compile error envelope and did not start tests.
- Final development-binary compile: `ErrorCount: 0`, `WarningCount: 0`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

