### PR TITLE
feat!: align CLI option names across first-party tools

### DIFF
--- a/.agents/skills/uloop-compile/SKILL.md
+++ b/.agents/skills/uloop-compile/SKILL.md
@@ -11,7 +11,7 @@ Execute Unity project compilation.
 ## Usage
 
 ```bash
-uloop compile [--force-recompile] [--no-wait-for-domain-reload] [--stop-on-external-scene-changes] [--compile-wait-timeout-seconds <seconds>]
+uloop compile [--force-recompile] [--no-wait-for-domain-reload] [--stop-on-external-scene-changes] [--timeout-seconds <seconds>]
 ```
 
 ## Parameters
@@ -21,7 +21,7 @@ uloop compile [--force-recompile] [--no-wait-for-domain-reload] [--stop-on-exter
 | `--force-recompile` | flag | - | Full recompile plus domain reload. Almost never needed: a plain compile already detects externally edited files, and the forced reload can freeze large projects and come back as `COMPILE_RESULT_UNKNOWN`. |
 | `--no-wait-for-domain-reload` | flag | - | Return before Domain Reload completion |
 | `--stop-on-external-scene-changes` | flag | - | Stop before compilation if open Scene files changed externally instead of auto-reloading them |
-| `--compile-wait-timeout-seconds` | integer | 600 | Maximum seconds the CLI waits for the compile to finish before returning COMPILE_WAIT_TIMEOUT (default 600). Values above 1200 exceed the Unity-side result retention window (20 minutes) and weaken post-timeout recovery. |
+| `--timeout-seconds` | integer | 600 | Maximum seconds the CLI waits for the compile to finish before returning COMPILE_WAIT_TIMEOUT (default 600). Values above 1200 exceed the Unity-side result retention window (20 minutes) and weaken post-timeout recovery. |
 
 ## When to use --force-recompile
 

--- a/.agents/skills/uloop-find-game-objects/SKILL.md
+++ b/.agents/skills/uloop-find-game-objects/SKILL.md
@@ -25,7 +25,7 @@ uloop find-game-objects [options]
 | `--required-components` | array | - | Required components |
 | `--tag` | string | - | Tag filter |
 | `--layer` | integer | - | Layer filter (layer number) |
-| `--max-results` | integer | `20` | Maximum number of results |
+| `--max-count` | integer | `20` | Maximum number of results |
 | `--include-inactive` | flag | - | Include inactive GameObjects |
 | `--include-inherited-properties` | flag | - | Include inherited properties in results |
 
@@ -50,7 +50,7 @@ Returns JSON with:
   - `Tag` (string): GameObject tag
   - `Layer` (number): Layer index
   - `Components` (array): Each entry has `Type` (short name, e.g., `Rigidbody`), `FullTypeName` (e.g., `UnityEngine.Rigidbody`), and `Properties` (array of Inspector-visible `{Name, Type, Value}` pairs)
-- `TotalFound` (number): Results returned (after `--max-results` clipping). For multi-selection file export, this is the number exported.
+- `TotalFound` (number): Results returned (after `--max-count` clipping). For multi-selection file export, this is the number exported.
 - `ErrorMessage` (string): Top-level failure summary (empty on success)
 - `ProcessingErrors` (array): Selected-mode per-GameObject serialization failures, each `{GameObjectName, GameObjectPath, Error}`. Omitted/null or empty on clean runs.
 

--- a/.claude/skills/uloop-compile/SKILL.md
+++ b/.claude/skills/uloop-compile/SKILL.md
@@ -11,7 +11,7 @@ Execute Unity project compilation.
 ## Usage
 
 ```bash
-uloop compile [--force-recompile] [--no-wait-for-domain-reload] [--stop-on-external-scene-changes] [--compile-wait-timeout-seconds <seconds>]
+uloop compile [--force-recompile] [--no-wait-for-domain-reload] [--stop-on-external-scene-changes] [--timeout-seconds <seconds>]
 ```
 
 ## Parameters
@@ -21,7 +21,7 @@ uloop compile [--force-recompile] [--no-wait-for-domain-reload] [--stop-on-exter
 | `--force-recompile` | flag | - | Full recompile plus domain reload. Almost never needed: a plain compile already detects externally edited files, and the forced reload can freeze large projects and come back as `COMPILE_RESULT_UNKNOWN`. |
 | `--no-wait-for-domain-reload` | flag | - | Return before Domain Reload completion |
 | `--stop-on-external-scene-changes` | flag | - | Stop before compilation if open Scene files changed externally instead of auto-reloading them |
-| `--compile-wait-timeout-seconds` | integer | 600 | Maximum seconds the CLI waits for the compile to finish before returning COMPILE_WAIT_TIMEOUT (default 600). Values above 1200 exceed the Unity-side result retention window (20 minutes) and weaken post-timeout recovery. |
+| `--timeout-seconds` | integer | 600 | Maximum seconds the CLI waits for the compile to finish before returning COMPILE_WAIT_TIMEOUT (default 600). Values above 1200 exceed the Unity-side result retention window (20 minutes) and weaken post-timeout recovery. |
 
 ## When to use --force-recompile
 

--- a/.claude/skills/uloop-find-game-objects/SKILL.md
+++ b/.claude/skills/uloop-find-game-objects/SKILL.md
@@ -25,7 +25,7 @@ uloop find-game-objects [options]
 | `--required-components` | array | - | Required components |
 | `--tag` | string | - | Tag filter |
 | `--layer` | integer | - | Layer filter (layer number) |
-| `--max-results` | integer | `20` | Maximum number of results |
+| `--max-count` | integer | `20` | Maximum number of results |
 | `--include-inactive` | flag | - | Include inactive GameObjects |
 | `--include-inherited-properties` | flag | - | Include inherited properties in results |
 
@@ -50,7 +50,7 @@ Returns JSON with:
   - `Tag` (string): GameObject tag
   - `Layer` (number): Layer index
   - `Components` (array): Each entry has `Type` (short name, e.g., `Rigidbody`), `FullTypeName` (e.g., `UnityEngine.Rigidbody`), and `Properties` (array of Inspector-visible `{Name, Type, Value}` pairs)
-- `TotalFound` (number): Results returned (after `--max-results` clipping). For multi-selection file export, this is the number exported.
+- `TotalFound` (number): Results returned (after `--max-count` clipping). For multi-selection file export, this is the number exported.
 - `ErrorMessage` (string): Top-level failure summary (empty on success)
 - `ProcessingErrors` (array): Selected-mode per-GameObject serialization failures, each `{GameObjectName, GameObjectPath, Error}`. Omitted/null or empty on clean runs.
 

--- a/Assets/Editor/FindGameObjects/FindGameObjectsTestMenu.cs
+++ b/Assets/Editor/FindGameObjects/FindGameObjectsTestMenu.cs
@@ -20,7 +20,7 @@ namespace io.github.hatayama.UnityCliLoop.Dev
             
             JObject parameters = new()            {
                 ["RequiredComponents"] = new JArray { "Camera" },
-                ["MaxResults"] = 1,
+                ["MaxCount"] = 1,
                 ["IncludeInheritedProperties"] = true
             };
             
@@ -63,7 +63,7 @@ namespace io.github.hatayama.UnityCliLoop.Dev
             JObject parameters = new()            {
                 ["NamePattern"] = "Main Camera",
                 ["SearchMode"] = "Path",
-                ["MaxResults"] = 1
+                ["MaxCount"] = 1
             };
             
             try

--- a/Assets/Tests/Editor/FindGameObjectsToolTests.cs
+++ b/Assets/Tests/Editor/FindGameObjectsToolTests.cs
@@ -392,9 +392,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
         
         [Test]
-        public async Task ExecuteAsync_WithMaxResults_LimitsReturnedObjects()
+        public async Task ExecuteAsync_WithMaxCount_LimitsReturnedObjects()
         {
-            // Arrange
+            // Verifies the MaxCount wire parameter limits the returned GameObjects.
             // Create many GameObjects
             GameObject[] manyObjects = new GameObject[20];
             for (int i = 0; i < 20; i++)
@@ -405,7 +405,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             JObject paramsJson = new()            {
                 ["NamePattern"] = "ManyObject",
                 ["SearchMode"] = "Contains",
-                ["MaxResults"] = 5
+                ["MaxCount"] = 5
             };
             
             try

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -9,7 +9,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         // Why: the runtime IPC gate compares this contract generation, not release numbers.
         // Bump it together with cli/common/clicontract/contract.json protocolVersion only when this package can
         // no longer interoperate with a different CLI protocol generation.
-        public const int REQUIRED_CLI_PROTOCOL_VERSION = 4;
+        public const int REQUIRED_CLI_PROTOCOL_VERSION = 5;
         public const string VERSION_FLAG = "--version";
         public const string SHORT_VERSION_FLAG = "-v";
         public const string JSON_FLAG = "--json";

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileSchema.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileSchema.cs
@@ -31,7 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Why no [Description]: first-party schema properties must keep long-form agent guidance
         /// in skill files (see FirstPartyToolSchemaMetadataTests), not runtime metadata.
         /// </summary>
-        public int CompileWaitTimeoutSeconds { get; set; } = 600;
+        public int TimeoutSeconds { get; set; } = 600;
 
         /// <summary>
         /// Internal request identifier used for delayed result recovery across domain reload.

--- a/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
@@ -11,7 +11,7 @@ Execute Unity project compilation.
 ## Usage
 
 ```bash
-uloop compile [--force-recompile] [--no-wait-for-domain-reload] [--stop-on-external-scene-changes] [--compile-wait-timeout-seconds <seconds>]
+uloop compile [--force-recompile] [--no-wait-for-domain-reload] [--stop-on-external-scene-changes] [--timeout-seconds <seconds>]
 ```
 
 ## Parameters
@@ -21,7 +21,7 @@ uloop compile [--force-recompile] [--no-wait-for-domain-reload] [--stop-on-exter
 | `--force-recompile` | flag | - | Full recompile plus domain reload. Almost never needed: a plain compile already detects externally edited files, and the forced reload can freeze large projects and come back as `COMPILE_RESULT_UNKNOWN`. |
 | `--no-wait-for-domain-reload` | flag | - | Return before Domain Reload completion |
 | `--stop-on-external-scene-changes` | flag | - | Stop before compilation if open Scene files changed externally instead of auto-reloading them |
-| `--compile-wait-timeout-seconds` | integer | 600 | Maximum seconds the CLI waits for the compile to finish before returning COMPILE_WAIT_TIMEOUT (default 600). Values above 1200 exceed the Unity-side result retention window (20 minutes) and weaken post-timeout recovery. |
+| `--timeout-seconds` | integer | 600 | Maximum seconds the CLI waits for the compile to finish before returning COMPILE_WAIT_TIMEOUT (default 600). Values above 1200 exceed the Unity-side result retention window (20 minutes) and weaken post-timeout recovery. |
 
 ## When to use --force-recompile
 

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/FindGameObjectsSchema.cs
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/FindGameObjectsSchema.cs
@@ -17,7 +17,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool IncludeInactive { get; set; } = false;
         
         // Result control
-        public int MaxResults { get; set; } = 20;  // Reduced from 100 to prevent performance issues
+        public int MaxCount { get; set; } = 20;  // Reduced from 100 to prevent performance issues
         public bool IncludeInheritedProperties { get; set; } = false;
     }
     

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/FindGameObjectsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/FindGameObjectsUseCase.cs
@@ -63,7 +63,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     Tag = parameters.Tag,
                     Layer = parameters.Layer,
                     IncludeInactive = parameters.IncludeInactive,
-                    MaxResults = parameters.MaxResults
+                    MaxCount = parameters.MaxCount
                 };
                 
                 GameObjectDetails[] foundObjects = _finderService.FindGameObjectsAdvanced(options);

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/GameObjectFinder/GameObjectFinderService.cs
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/GameObjectFinder/GameObjectFinderService.cs
@@ -66,7 +66,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     
                     results.Add(details);
                     
-                    if (results.Count >= options.MaxResults)
+                    if (results.Count >= options.MaxCount)
                         break;
                 }
             }

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/GameObjectFinder/GameObjectSearchOptions.cs
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/GameObjectFinder/GameObjectSearchOptions.cs
@@ -12,6 +12,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string Tag { get; set; } = "";
         public int? Layer { get; set; } = null;
         public bool IncludeInactive { get; set; } = false;
-        public int MaxResults { get; set; } = 100;
+        public int MaxCount { get; set; } = 100;
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/Skill/SKILL.md
@@ -25,7 +25,7 @@ uloop find-game-objects [options]
 | `--required-components` | array | - | Required components |
 | `--tag` | string | - | Tag filter |
 | `--layer` | integer | - | Layer filter (layer number) |
-| `--max-results` | integer | `20` | Maximum number of results |
+| `--max-count` | integer | `20` | Maximum number of results |
 | `--include-inactive` | flag | - | Include inactive GameObjects |
 | `--include-inherited-properties` | flag | - | Include inherited properties in results |
 
@@ -50,7 +50,7 @@ Returns JSON with:
   - `Tag` (string): GameObject tag
   - `Layer` (number): Layer index
   - `Components` (array): Each entry has `Type` (short name, e.g., `Rigidbody`), `FullTypeName` (e.g., `UnityEngine.Rigidbody`), and `Properties` (array of Inspector-visible `{Name, Type, Value}` pairs)
-- `TotalFound` (number): Results returned (after `--max-results` clipping). For multi-selection file export, this is the number exported.
+- `TotalFound` (number): Results returned (after `--max-count` clipping). For multi-selection file export, this is the number exported.
 - `ErrorMessage` (string): Top-level failure summary (empty on success)
 - `ProcessingErrors` (array): Selected-mode per-GameObject serialization failures, each `{GameObjectName, GameObjectPath, Error}`. Omitted/null or empty on clean runs.
 

--- a/cli/common/clicontract/contract.json
+++ b/cli/common/clicontract/contract.json
@@ -1,4 +1,4 @@
 {
-  "protocolVersion": 4,
+  "protocolVersion": 5,
   "projectRunnerVersion": "3.0.0-beta.66"
 }

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -20,7 +20,7 @@
             "description": "Stop before compilation if open Scene files changed externally instead of auto-reloading them",
             "default": true
           },
-          "CompileWaitTimeoutSeconds": {
+          "TimeoutSeconds": {
             "type": "integer",
             "description": "Maximum seconds the CLI waits for the compile to finish before returning COMPILE_WAIT_TIMEOUT (default 600). Values above 1200 exceed the Unity-side result retention window (20 minutes) and weaken post-timeout recovery.",
             "default": 600
@@ -213,7 +213,7 @@
             "type": "integer",
             "description": "Layer filter (layer number)"
           },
-          "MaxResults": {
+          "MaxCount": {
             "type": "integer",
             "description": "Maximum number of results",
             "default": 20

--- a/cli/dispatcher/internal/dispatcher/help_test.go
+++ b/cli/dispatcher/internal/dispatcher/help_test.go
@@ -203,6 +203,7 @@ func TestRunDispatcherCompileHelpDoesNotRequireUnityProject(t *testing.T) {
 		"Usage:",
 		"uloop compile",
 		"--force-recompile",
+		"--timeout-seconds",
 		"--no-wait-for-domain-reload",
 		"--stop-on-external-scene-changes",
 		"Stop before compilation if open Scene files changed externally instead of auto-reloading them",
@@ -214,6 +215,25 @@ func TestRunDispatcherCompileHelpDoesNotRequireUnityProject(t *testing.T) {
 	}
 	if strings.Contains(output, "--wait-for-domain-reload") {
 		t.Fatalf("compile help exposed removed wait flag:\n%s", output)
+	}
+}
+
+// Verifies embedded help exposes the renamed maximum result count option.
+func TestRunDispatcherFindGameObjectsHelpShowsMaxCount(t *testing.T) {
+	t.Chdir(t.TempDir())
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := RunDispatcher(context.Background(), []string{"find-game-objects", "--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("find-game-objects help failed: code=%d stderr=%s", code, stderr.String())
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "--max-count") {
+		t.Fatalf("find-game-objects help missing --max-count:\n%s", output)
+	}
+	if strings.Contains(output, "--max-results") {
+		t.Fatalf("find-game-objects help still exposes --max-results:\n%s", output)
 	}
 }
 

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "be063bcac2f9e292ae5d4f8f7d65dbf3ff32fe42"
+  "sharedInputsHash": "cc6bf14a69cb4911c57fd7dffc9a8277ac874f1d"
 }

--- a/cli/project-runner/internal/projectrunner/compile_wait.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait.go
@@ -22,7 +22,7 @@ const (
 	compileRequestIDParam    = "RequestId"
 	compileWaitParam         = clicore.DomainReloadWaitParam
 	compileForceParam        = "ForceRecompile"
-	compileWaitTimeoutParam  = "CompileWaitTimeoutSeconds"
+	compileWaitTimeoutParam  = "TimeoutSeconds"
 	// Why separate from ToolReadinessTimeout (180s): launch readiness stays short.
 	// Why 10m: worst-case blind block beats headroom. Why ≤ C# CompileResultLifetime (20m):
 	// timed-out clients can still retrieve results by retrying uloop compile ~10m more.
@@ -78,7 +78,7 @@ func prepareCompileWaitParams(params map[string]any) (string, error) {
 	return requestID, nil
 }
 
-// compileWaitTimeoutFromParams reads CompileWaitTimeoutSeconds from tool params.
+// compileWaitTimeoutFromParams reads TimeoutSeconds from tool params.
 // Missing values keep the default compileWaitTimeout (10m). Non-positive or non-integer
 // values are rejected before a compile request is sent.
 func compileWaitTimeoutFromParams(params map[string]any) (time.Duration, error) {
@@ -90,7 +90,7 @@ func compileWaitTimeoutFromParams(params map[string]any) (time.Duration, error) 
 	seconds, ok := positiveInt64FromAny(value)
 	if !ok || seconds > compileWaitTimeoutMaxSeconds {
 		return 0, clierrors.InvalidValueArgumentError(
-			"--compile-wait-timeout-seconds",
+			"--timeout-seconds",
 			fmt.Sprint(value),
 			"positive integer",
 		)

--- a/cli/project-runner/internal/projectrunner/compile_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_test.go
@@ -465,7 +465,7 @@ func TestRunCompileWithDomainReloadWaitWritesRequestLifecycleVibeLogs(t *testing
 	}
 }
 
-// Verifies runCompileWithDomainReloadWaitWithDeps wires CompileWaitTimeoutSeconds into
+// Verifies runCompileWithDomainReloadWaitWithDeps wires TimeoutSeconds into
 // the wait deadline and COMPILE_WAIT_TIMEOUT message (not only the wait helper itself).
 func TestRunCompileWithDomainReloadWaitUsesConfiguredTimeout(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -514,7 +514,7 @@ func TestRunCompileWithDomainReloadWaitUsesConfiguredTimeout(t *testing.T) {
 	}
 }
 
-// Verifies invalid CompileWaitTimeoutSeconds fails before a compile request is dispatched.
+// Verifies invalid TimeoutSeconds fails before a compile request is dispatched.
 func TestRunCompileWithDomainReloadWaitRejectsNonPositiveTimeout(t *testing.T) {
 	enableCliVibeLog(t)
 	projectRoot := t.TempDir()
@@ -695,7 +695,7 @@ func TestWritePostCompileWarmupWarningReportsNonFatalFailure(t *testing.T) {
 	}
 }
 
-// Verifies CompileWaitTimeoutSeconds is parsed from tool params with the default
+// Verifies TimeoutSeconds is parsed from tool params with the default
 // kept when absent and non-positive or non-integer values rejected.
 func TestCompileWaitTimeoutFromParams(t *testing.T) {
 	cases := []struct {
@@ -772,6 +772,17 @@ func TestCompileWaitTimeoutFromParams(t *testing.T) {
 				t.Fatalf("timeout mismatch: got %v want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// Verifies the renamed TimeoutSeconds parameter controls the compile wait deadline.
+func TestCompileWaitTimeoutFromParamsReadsTimeoutSeconds(t *testing.T) {
+	actual, err := compileWaitTimeoutFromParams(map[string]any{"TimeoutSeconds": 45})
+	if err != nil {
+		t.Fatalf("TimeoutSeconds failed: %v", err)
+	}
+	if actual != 45*time.Second {
+		t.Fatalf("TimeoutSeconds mismatch: %s", actual)
 	}
 }
 

--- a/cli/project-runner/internal/projectrunner/run.go
+++ b/cli/project-runner/internal/projectrunner/run.go
@@ -213,7 +213,7 @@ func runCompileWithDomainReloadWaitResultWithDeps(
 	if waitTimeout > time.Duration(compileWaitTimeoutRetentionWarningSeconds)*time.Second {
 		_, _ = fmt.Fprintf(
 			stderr,
-			"warning: --compile-wait-timeout-seconds exceeds the Unity-side compile result retention window (20 minutes); if the wait times out, the result may expire before a retry can recover it.\n",
+			"warning: --timeout-seconds exceeds the Unity-side compile result retention window (20 minutes); if the wait times out, the result may expire before a retry can recover it.\n",
 		)
 	}
 

--- a/cli/project-runner/internal/projectrunner/tool_params_test.go
+++ b/cli/project-runner/internal/projectrunner/tool_params_test.go
@@ -308,6 +308,89 @@ func TestBuildToolParamsUnknownOptionSuggestsRunTestsSkipCompile(t *testing.T) {
 	})
 }
 
+// Verifies renamed options emit their new JSON-RPC parameter keys.
+func TestBuildToolParamsConvertsRenamedFirstPartyToolOptions(t *testing.T) {
+	cases := []struct {
+		command   string
+		args      []string
+		paramName string
+		want      int
+	}{
+		{
+			command:   clicore.CompileCommandName,
+			args:      []string{"--timeout-seconds", "45"},
+			paramName: "TimeoutSeconds",
+			want:      45,
+		},
+		{
+			command:   "find-game-objects",
+			args:      []string{"--max-count", "5"},
+			paramName: "MaxCount",
+			want:      5,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.command, func(t *testing.T) {
+			tool, ok := clicore.FindTool(clicore.LoadDefaultTools(), testCase.command)
+			if !ok {
+				t.Fatalf("%s was not found in default tools", testCase.command)
+			}
+
+			params, _, err := buildToolParams(testCase.args, tool)
+			if err != nil {
+				t.Fatalf("renamed option was rejected: %v", err)
+			}
+			if params[testCase.paramName] != testCase.want {
+				t.Fatalf("%s mismatch: %#v", testCase.paramName, params)
+			}
+		})
+	}
+}
+
+// Verifies removed option names are invalid arguments that guide callers to the replacement names.
+func TestBuildToolParamsRejectsRemovedFirstPartyToolOptionsWithReplacementSuggestions(t *testing.T) {
+	cases := []struct {
+		command string
+		args    []string
+		want    []string
+	}{
+		{
+			command: clicore.CompileCommandName,
+			args:    []string{"--compile-wait-timeout-seconds", "45"},
+			want: []string{
+				"Did you mean: uloop compile --timeout-seconds",
+				"Run `uloop compile --help` to inspect supported options.",
+			},
+		},
+		{
+			command: "find-game-objects",
+			args:    []string{"--max-results", "5"},
+			want: []string{
+				"Did you mean: uloop find-game-objects --max-count",
+				"Run `uloop find-game-objects --help` to inspect supported options.",
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.command, func(t *testing.T) {
+			tool, ok := clicore.FindTool(clicore.LoadDefaultTools(), testCase.command)
+			if !ok {
+				t.Fatalf("%s was not found in default tools", testCase.command)
+			}
+
+			_, _, err := buildToolParams(testCase.args, tool)
+			argumentError := requireArgumentError(t, err)
+			cliError := argumentError.ToCLIError(clierrors.ErrorContext{Command: testCase.command})
+			if cliError.ErrorCode != clierrors.ErrorCodeInvalidArgument {
+				t.Fatalf("error code mismatch: %#v", cliError)
+			}
+			requireNextActions(t, err, testCase.want)
+		})
+	}
+}
+
 // Verifies enable-pause-point suggests its CLI-only trigger option when a supplied flag is a close typo.
 func TestBuildToolParamsUnknownOptionSuggestsPausePointTrigger(t *testing.T) {
 	tool, ok := clicore.FindTool(clicore.LoadDefaultTools(), pausePointEnableCommandName)

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "05e6f510ba0450be9dfd9204fc2cbebb74bf7352"
+  "sharedInputsHash": "aec0be1224d2f776f2af0e3bd5582fd15cd9c229"
 }

--- a/docs/cli-option-naming.md
+++ b/docs/cli-option-naming.md
@@ -1,0 +1,26 @@
+# CLI Option Naming
+
+Rules for naming first-party tool options (schema property names and their
+kebab-case CLI flags). Apply them when adding an option or auditing an
+existing one. Renaming a published option is a breaking change — schema
+property names are JSON-RPC Params keys — and requires a protocol version
+bump; see `docs/protocol-version.md`.
+
+- Result-row caps use `Max<Noun>Count`, or plain `MaxCount` (`--max-count`)
+  when the tool has a single primary result list. A result-row cap limits how
+  many rows of that list the response returns.
+- Timeouts use `TimeoutSeconds` (`--timeout-seconds`), with the unit in the
+  name. Tool-specific prefixes (such as the former
+  `CompileWaitTimeoutSeconds`) are not used: within one tool the bare name is
+  unambiguous.
+- File targets use `OutputPath`; directory targets use `OutputDirectory`.
+  The two are distinct on purpose — do not unify them.
+- Caps that bound something other than result rows keep their domain names:
+  `MaxHistory` (retained history entries), `MaxPreviewElements` (preview
+  depth), `MaxCallerFrames` (captured frames). Renaming them to `Max*Count`
+  would erase what is being bounded.
+
+Renamed in the alignment pass, with no compatibility aliases:
+`CompileWaitTimeoutSeconds` → `TimeoutSeconds` (compile) and `MaxResults` →
+`MaxCount` (find-game-objects). The old flags fail with `INVALID_ARGUMENT`,
+and the unknown-option suggestion proposes the new name.

--- a/docs/shared-release-inputs.md
+++ b/docs/shared-release-inputs.md
@@ -16,6 +16,10 @@ trigger updates in the same PR:
   accompanied by changes under both `cli/project-runner/` and `cli/dispatcher/`.
 - Installer scripts (`scripts/install.sh`, `scripts/install.ps1`) must be accompanied by a
   change under `cli/dispatcher/`, because installers ship as dispatcher release assets.
+- The embedded tool catalog (`cli/common/tools/default-tools.json`) is the one
+  non-Go shared input: it is compiled into both binaries, so catalog changes —
+  including regenerations driven by skill parameter-table edits — need the
+  same accompanying trigger changes and stamp refresh.
 
 Run `scripts/stamp-release-inputs.sh` to refresh
 `cli/project-runner/shared-inputs-stamp.json` and

--- a/docs/soak-testing.md
+++ b/docs/soak-testing.md
@@ -68,7 +68,7 @@ PowerShell-only parameters:
 | Parameter | Default | Meaning |
 | --- | --- | --- |
 | `-CommandTimeoutSeconds` | 600 | Kill bound for one uloop call. Raise it for large projects and parallel soaks (see below) |
-| `-CompileWaitTimeoutSeconds` | 0 (runner default) | Passed to every compile as `--compile-wait-timeout-seconds` when the pinned runner accepts it |
+| `-CompileWaitTimeoutSeconds` | 0 (runner default) | Passed to every compile as `--timeout-seconds` (`--compile-wait-timeout-seconds` on pre-rename runners) when the pinned runner accepts it |
 | `-KeepCodeOptimization` | off | Leave the editor's code optimization mode alone (see below) |
 
 Environment: `ULOOP_BIN` selects the uloop binary (default: `uloop` from
@@ -85,11 +85,12 @@ took ~8 minutes on its own, and over 10 minutes with three editors compiling in
 parallel, so raise `-CommandTimeoutSeconds` for runs like that.
 
 A compile that outlives the runner's own wait returns `COMPILE_WAIT_TIMEOUT`
-while Unity keeps compiling. Runners from `--compile-wait-timeout-seconds`
-onwards let that wait be raised: pass `-CompileWaitTimeoutSeconds` and the
-harness appends the flag to every compile, lifting its kill watchdog above the
-new wait so a timeout can still be reported rather than killed. Against an
-older pinned runner the request is logged and ignored. Values above 1200 exceed
+while Unity keeps compiling. Runners with a configurable wait let that wait be raised: pass
+`-CompileWaitTimeoutSeconds` and the harness appends the flag the pinned
+runner accepts (`--timeout-seconds`, or `--compile-wait-timeout-seconds`
+before the rename) to every compile, lifting its kill watchdog above the new
+wait so a timeout can still be reported rather than killed. Against an older
+pinned runner the request is logged and ignored. Values above 1200 exceed
 Unity's 20-minute result retention, which weakens the post-timeout recovery.
 
 uloop is single-flight, so a command issued while Unity still runs an earlier

--- a/scripts/run-windows-e2e.ps1
+++ b/scripts/run-windows-e2e.ps1
@@ -364,7 +364,7 @@ function Invoke-CliRecoveryReadinessSmoke {
 function Invoke-DiscoverySmoke {
     Open-Scene -ScenePath $DiscoveryScenePath
     Start-PlayMode
-    Invoke-UloopJsonChecked -CommandArguments @("find-game-objects", "--search-mode", "Contains", "--name-pattern", "Canvas", "--max-results", "10") | Out-Null
+    Invoke-UloopJsonChecked -CommandArguments @("find-game-objects", "--search-mode", "Contains", "--name-pattern", "Canvas", "--max-count", "10") | Out-Null
     Invoke-UloopJsonChecked -CommandArguments @("get-hierarchy", "--max-depth", "3") | Out-Null
     Invoke-UloopJsonChecked -CommandArguments @("screenshot", "--capture-mode", "rendering", "--annotate-elements", "--elements-only") | Out-Null
     Stop-PlayMode

--- a/scripts/soak-loop.ps1
+++ b/scripts/soak-loop.ps1
@@ -61,10 +61,10 @@ param(
     # especially for parallel soaks: a full recompile of one large project took
     # over 10 minutes with three editors compiling at once.
     [int]$CommandTimeoutSeconds = 600,
-    # Passed to every compile as --compile-wait-timeout-seconds when the pinned
-    # runner accepts it (0 = leave the runner's own default alone). Raise it on
-    # a project whose forced recompile outlives the runner's 10-minute wait;
-    # above 1200 the runner warns that Unity may drop the retained result.
+    # Passed to every compile as --timeout-seconds, or --compile-wait-timeout-seconds
+    # when the pinned runner predates the rename (0 = leave the runner's own default
+    # alone). Raise it on a project whose forced recompile outlives the runner's
+    # 10-minute wait; above 1200 the runner warns that Unity may drop the retained result.
     [int]$CompileWaitTimeoutSeconds = 0,
     # Pause between iterations.
     [int]$SleepSeconds = 0,
@@ -953,14 +953,20 @@ try {
     }
 
     # Runners predating the configurable wait reject the flag outright, and the
-    # soak has to keep working against whichever runner the project pins.
+    # soak has to keep working against whichever runner the project pins. The
+    # flag name also changed across runner generations, so probe help for the
+    # current name first and fall back to the pre-rename one.
     if ($CompileWaitTimeoutSeconds -gt 0) {
-        if ($compileHelp -match '(?m)^\s*--compile-wait-timeout-seconds') {
+        if ($compileHelp -match '(?m)^\s*--timeout-seconds') {
+            $CompileWaitArguments += @("--timeout-seconds", "$CompileWaitTimeoutSeconds")
+            Write-SoakLog -Message "compile wait timeout: ${CompileWaitTimeoutSeconds}s (watchdog ${CommandTimeoutSeconds}s)"
+        }
+        elseif ($compileHelp -match '(?m)^\s*--compile-wait-timeout-seconds') {
             $CompileWaitArguments += @("--compile-wait-timeout-seconds", "$CompileWaitTimeoutSeconds")
             Write-SoakLog -Message "compile wait timeout: ${CompileWaitTimeoutSeconds}s (watchdog ${CommandTimeoutSeconds}s)"
         }
         else {
-            Write-SoakLog -Message "compile wait timeout: ignored - the pinned runner has no --compile-wait-timeout-seconds"
+            Write-SoakLog -Message "compile wait timeout: ignored - the pinned runner has no configurable compile wait flag"
         }
     }
 


### PR DESCRIPTION
## Summary

- Use consistent `--timeout-seconds` and `--max-count` options for compile waits and GameObject result limits.
- Reject the removed option names with direct suggestions, so callers can correct commands without guessing.

## User Impact

The two tools now use the same naming patterns as the rest of the CLI. Older invocations fail clearly instead of silently accepting compatibility aliases.

## Changes

- Rename the matching CLI flags and JSON-RPC parameter keys, then update the embedded catalog and generated skills.
- Raise the protocol version in both contract declarations because renamed parameter keys are incompatible across generations.
- Add the option-naming reference and refresh shared-release stamps.

## Release Sequencing

Publish a matching project-runner release before a package that requires protocol version 5. Release automation updates the package pin; no release or pin versions are edited manually here.

## Verification

- `scripts/check-go-cli.sh`
- Focused `FindGameObjectsToolTests.ExecuteAsync_WithMaxCount_LimitsReturnedObjects`
- Full EditMode suite: 3622 tests, exit 0, `Status: Passed`, `Success: true`
- Development-binary checks for both new flags, removed-flag replacement suggestions, and Unity catalog property-set parity


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

