### PR TITLE
feat: add a compact command-name listing to uloop list

### DIFF
--- a/cli/common/tooldocs/list_cli_options.go
+++ b/cli/common/tooldocs/list_cli_options.go
@@ -1,0 +1,15 @@
+package tooldocs
+
+const ListNamesFlagName = "names"
+
+// ListCLIOnlyOptions returns list's native-only flags from the same table its help renderer reads,
+// so the parser and its recovery guidance cannot advertise a flag that list rejects.
+func ListCLIOnlyOptions() []PausePointCLIOnlyOption {
+	return []PausePointCLIOnlyOption{
+		{
+			FlagName:    ListNamesFlagName,
+			Type:        "boolean",
+			Description: "Show command names only, one per line",
+		},
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/help_test.go
+++ b/cli/dispatcher/internal/dispatcher/help_test.go
@@ -95,6 +95,26 @@ func TestPrintProjectLocalHelpListsNativeCommandsAndLiveToolGuidance(t *testing.
 	}
 }
 
+// Verifies the names-only list guidance is a complete aligned footer line, so agents can discover
+// the compact command listing without parsing the full live tool catalog.
+func TestPrintDispatcherHelpListsNamesOnlyFooterLine(t *testing.T) {
+	var stdout bytes.Buffer
+
+	printDispatcherHelp(&stdout)
+
+	const expected = "  uloop list --names                          Show command names only, one per line"
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		if !strings.HasPrefix(line, "  uloop list --names") {
+			continue
+		}
+		if line != expected {
+			t.Fatalf("names-only footer line mismatch: got %q want %q", line, expected)
+		}
+		return
+	}
+	t.Fatalf("help output missing names-only footer line %q:\n%s", expected, stdout.String())
+}
+
 // Tests that dispatcher help with --project-path includes cached tools from that explicit project.
 func TestRunDispatcherHelpWithProjectPathShowsCachedProjectTools(t *testing.T) {
 	projectRoot := createLaunchTestProject(t)

--- a/cli/dispatcher/internal/dispatcher/run_help.go
+++ b/cli/dispatcher/internal/dispatcher/run_help.go
@@ -71,6 +71,7 @@ func printMainHelp(stdout io.Writer, displayVersion string, description string, 
 	clicore.WriteLine(stdout, "")
 	clicore.WriteLine(stdout, "More:")
 	clicore.WriteLine(stdout, "  uloop list                                  Show the live Unity tool list")
+	clicore.WriteLine(stdout, "  uloop list --names                          Show command names only, one per line")
 	clicore.WriteLine(stdout, "  uloop --project-path /path/to/project list  Show tools for another Unity project")
 	clicore.WriteLine(stdout, "  uloop <command> --help                      Show help for native and Unity tool commands")
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "cc6bf14a69cb4911c57fd7dffc9a8277ac874f1d"
+  "sharedInputsHash": "19753283826897929beda8b2055ffed6c26eb087"
 }

--- a/cli/project-runner/internal/projectrunner/list_names_test.go
+++ b/cli/project-runner/internal/projectrunner/list_names_test.go
@@ -55,27 +55,16 @@ func TestRunResolvedProjectCommandListNamesWritesNativeAndLiveToolNames(t *testi
 	assertServerDidNotFail(t, serverErr)
 }
 
-// Verifies list rejects an option other than its names-only selector before it contacts Unity and
-// gives callers the established unknown-option recovery action.
-func TestRunListRejectsUnknownOption(t *testing.T) {
-	connection := unityipc.Connection{ProjectRoot: "/project"}
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-
-	code := runList(context.Background(), connection, []string{"--unexpected"}, &stdout, &stderr)
-	if code != 1 {
-		t.Fatalf("unexpected exit code: %d", code)
-	}
-	if stdout.Len() != 0 {
-		t.Fatalf("unknown list option must not write stdout: %s", stdout.String())
-	}
-
-	const expected = "{\n" +
+// Verifies list accepts repeated names selectors but rejects value assignment and positional
+// arguments with the complete stable INVALID_ARGUMENT envelope.
+func TestRunListOptionBoundaries(t *testing.T) {
+	const namesOutput = "launch\nlist\nsync\nfocus-window\nawait-pause-point\npause-point-status\nskills\npackage\ninstall\nupdate\nuninstall\nversion\n"
+	const namesAssignmentError = "{\n" +
 		"  \"Success\": false,\n" +
 		"  \"Error\": {\n" +
 		"    \"ErrorCode\": \"INVALID_ARGUMENT\",\n" +
 		"    \"Phase\": \"argument_parsing\",\n" +
-		"    \"Message\": \"Unknown option for list: --unexpected\",\n" +
+		"    \"Message\": \"Unknown option for list: --names=true\",\n" +
 		"    \"Retryable\": false,\n" +
 		"    \"SafeToRetry\": false,\n" +
 		"    \"ProjectRoot\": \"/project\",\n" +
@@ -84,11 +73,90 @@ func TestRunListRejectsUnknownOption(t *testing.T) {
 		"      \"Run \x60uloop list --help\x60 to inspect supported options.\"\n" +
 		"    ],\n" +
 		"    \"Details\": {\n" +
-		"      \"Option\": \"--unexpected\"\n" +
+		"      \"Option\": \"--names=true\"\n" +
 		"    }\n" +
 		"  }\n" +
 		"}\n"
-	if stderr.String() != expected {
-		t.Fatalf("unknown list option error mismatch:\n got:\n%s\nwant:\n%s", stderr.String(), expected)
+	const positionalArgumentError = "{\n" +
+		"  \"Success\": false,\n" +
+		"  \"Error\": {\n" +
+		"    \"ErrorCode\": \"INVALID_ARGUMENT\",\n" +
+		"    \"Phase\": \"argument_parsing\",\n" +
+		"    \"Message\": \"Unknown option for list: marker\",\n" +
+		"    \"Retryable\": false,\n" +
+		"    \"SafeToRetry\": false,\n" +
+		"    \"ProjectRoot\": \"/project\",\n" +
+		"    \"Command\": \"list\",\n" +
+		"    \"NextActions\": [\n" +
+		"      \"Run \x60uloop list --help\x60 to inspect supported options.\"\n" +
+		"    ],\n" +
+		"    \"Details\": {\n" +
+		"      \"Option\": \"marker\"\n" +
+		"    }\n" +
+		"  }\n" +
+		"}\n"
+	tests := []struct {
+		name           string
+		args           []string
+		expectedStdout string
+		expectedStderr string
+	}{
+		{
+			name:           "names assignment",
+			args:           []string{"--names=true"},
+			expectedStderr: namesAssignmentError,
+		},
+		{
+			name:           "repeated names",
+			args:           []string{"--names", "--names"},
+			expectedStdout: namesOutput,
+		},
+		{
+			name:           "positional argument",
+			args:           []string{"marker"},
+			expectedStderr: positionalArgumentError,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			connection := unityipc.Connection{ProjectRoot: "/project"}
+			var listenerErr chan error
+			var requests chan map[string]any
+			if test.expectedStdout != "" {
+				listener := newLoopbackIpcListener(t)
+				requests = make(chan map[string]any, 1)
+				listenerErr = make(chan error, 1)
+				go serveSingleIPCResponse(listener, "get-tool-details", requests, listenerErr, "{\"tools\":[]}")
+				connection.Endpoint = unityipc.Endpoint{
+					Network: listener.Addr().Network(),
+					Address: listener.Addr().String(),
+				}
+			}
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			code := runList(context.Background(), connection, test.args, &stdout, &stderr)
+			if test.expectedStdout != "" {
+				if code != 0 {
+					t.Fatalf("list --names failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+				}
+				if stdout.String() != test.expectedStdout {
+					t.Fatalf("list --names output mismatch:\n got:\n%s\nwant:\n%s", stdout.String(), test.expectedStdout)
+				}
+				readIPCRequest(t, requests)
+				assertServerDidNotFail(t, listenerErr)
+				return
+			}
+			if code != 1 {
+				t.Fatalf("unexpected exit code: %d", code)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("unknown list option must not write stdout: %s", stdout.String())
+			}
+			if stderr.String() != test.expectedStderr {
+				t.Fatalf("unknown list option error mismatch:\n got:\n%s\nwant:\n%s", stderr.String(), test.expectedStderr)
+			}
+		})
 	}
 }

--- a/cli/project-runner/internal/projectrunner/list_names_test.go
+++ b/cli/project-runner/internal/projectrunner/list_names_test.go
@@ -1,0 +1,94 @@
+package projectrunner
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+)
+
+// Verifies list --names uses the native command registry and the live Unity catalog, while
+// excluding a Unity tool that has the same name as a native command.
+func TestRunResolvedProjectCommandListNamesWritesNativeAndLiveToolNames(t *testing.T) {
+	listener := newLoopbackIpcListener(t)
+	requests := make(chan map[string]any, 1)
+	serverErr := make(chan error, 1)
+	go serveSingleIPCResponse(
+		listener,
+		"get-tool-details",
+		requests,
+		serverErr,
+		`{"tools":[{"name":"focus-window"},{"name":"enable-watch"},{"name":"clear-watch"},{"name":"get-watch-values"}]}`,
+	)
+	connection := unityipc.Connection{
+		Endpoint: unityipc.Endpoint{
+			Network: listener.Addr().Network(),
+			Address: listener.Addr().String(),
+		},
+		ProjectRoot: t.TempDir(),
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := runResolvedProjectCommand(
+		context.Background(),
+		connection,
+		"list",
+		[]string{"--names"},
+		connection.ProjectRoot,
+		&stdout,
+		&stderr,
+	)
+	if code != 0 {
+		t.Fatalf("list --names failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	const expected = "launch\nlist\nsync\nfocus-window\nawait-pause-point\npause-point-status\nskills\npackage\ninstall\nupdate\nuninstall\nversion\nenable-watch\nclear-watch\nget-watch-values\n"
+	if stdout.String() != expected {
+		t.Fatalf("list --names output mismatch:\n got:\n%s\nwant:\n%s", stdout.String(), expected)
+	}
+	request := readIPCRequest(t, requests)
+	if len(request) != 0 {
+		t.Fatalf("get-tool-details parameters mismatch: %#v", request)
+	}
+	assertServerDidNotFail(t, serverErr)
+}
+
+// Verifies list rejects an option other than its names-only selector before it contacts Unity and
+// gives callers the established unknown-option recovery action.
+func TestRunListRejectsUnknownOption(t *testing.T) {
+	connection := unityipc.Connection{ProjectRoot: "/project"}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := runList(context.Background(), connection, []string{"--unexpected"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("unexpected exit code: %d", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("unknown list option must not write stdout: %s", stdout.String())
+	}
+
+	const expected = "{\n" +
+		"  \"Success\": false,\n" +
+		"  \"Error\": {\n" +
+		"    \"ErrorCode\": \"INVALID_ARGUMENT\",\n" +
+		"    \"Phase\": \"argument_parsing\",\n" +
+		"    \"Message\": \"Unknown option for list: --unexpected\",\n" +
+		"    \"Retryable\": false,\n" +
+		"    \"SafeToRetry\": false,\n" +
+		"    \"ProjectRoot\": \"/project\",\n" +
+		"    \"Command\": \"list\",\n" +
+		"    \"NextActions\": [\n" +
+		"      \"Run \x60uloop list --help\x60 to inspect supported options.\"\n" +
+		"    ],\n" +
+		"    \"Details\": {\n" +
+		"      \"Option\": \"--unexpected\"\n" +
+		"    }\n" +
+		"  }\n" +
+		"}\n"
+	if stderr.String() != expected {
+		t.Fatalf("unknown list option error mismatch:\n got:\n%s\nwant:\n%s", stderr.String(), expected)
+	}
+}

--- a/cli/project-runner/internal/projectrunner/list_options.go
+++ b/cli/project-runner/internal/projectrunner/list_options.go
@@ -1,0 +1,24 @@
+package projectrunner
+
+import clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+
+type listOptions struct {
+	namesOnly bool
+}
+
+func parseListOptions(args []string) (listOptions, error) {
+	options := listOptions{}
+	for _, arg := range args {
+		if arg == "--names" {
+			options.namesOnly = true
+			continue
+		}
+		return listOptions{}, &clierrors.ArgumentError{
+			Message:     "Unknown option for list: " + arg,
+			Option:      arg,
+			Command:     "list",
+			NextActions: []string{"Run `uloop list --help` to inspect supported options."},
+		}
+	}
+	return options, nil
+}

--- a/cli/project-runner/internal/projectrunner/list_options.go
+++ b/cli/project-runner/internal/projectrunner/list_options.go
@@ -1,6 +1,10 @@
 package projectrunner
 
-import clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+import (
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+
+	"github.com/hatayama/unity-cli-loop/common/tooldocs"
+)
 
 type listOptions struct {
 	namesOnly bool
@@ -9,7 +13,7 @@ type listOptions struct {
 func parseListOptions(args []string) (listOptions, error) {
 	options := listOptions{}
 	for _, arg := range args {
-		if arg == "--names" {
+		if arg == "--"+tooldocs.ListNamesFlagName {
 			options.namesOnly = true
 			continue
 		}

--- a/cli/project-runner/internal/projectrunner/list_output.go
+++ b/cli/project-runner/internal/projectrunner/list_output.go
@@ -2,6 +2,7 @@ package projectrunner
 
 import (
 	"encoding/json"
+	"io"
 	"sort"
 
 	"github.com/hatayama/unity-cli-loop/common/skilldocs"
@@ -52,6 +53,24 @@ func formatToolListResult(result json.RawMessage, projectRoot string) json.RawMe
 		panic(err)
 	}
 	return content
+}
+
+func writeToolNames(result json.RawMessage, stdout io.Writer) error {
+	var cache clicore.ToolsCache
+	if err := json.Unmarshal(result, &cache); err != nil {
+		return err
+	}
+
+	for _, command := range clicore.NativeCommands {
+		clicore.WriteLine(stdout, command.Name)
+	}
+	for _, tool := range cache.Tools {
+		if _, ok := clicore.NativeCommand(tool.Name); ok {
+			continue
+		}
+		clicore.WriteLine(stdout, tool.Name)
+	}
+	return nil
 }
 
 func newListCatalog(cache clicore.ToolsCache) listCatalog {

--- a/cli/project-runner/internal/projectrunner/native_command_help.go
+++ b/cli/project-runner/internal/projectrunner/native_command_help.go
@@ -25,6 +25,8 @@ const (
 // is advertised and recognized without a second handwritten name list.
 func runnerNativeCLIOnlyOptions(command string) []tooldocs.PausePointCLIOnlyOption {
 	switch command {
+	case "list":
+		return tooldocs.ListCLIOnlyOptions()
 	case clicore.PausePointAwaitCommandName:
 		return tooldocs.PausePointAwaitCLIOnlyOptions()
 	case clicore.PausePointStatusUserCommandName:

--- a/cli/project-runner/internal/projectrunner/native_command_help_test.go
+++ b/cli/project-runner/internal/projectrunner/native_command_help_test.go
@@ -84,6 +84,33 @@ func TestRunProjectLocalPausePointStatusHelpOptionsSection(t *testing.T) {
 	assertNativeCommandHelpOptionsSection(t, "pause-point-status", expectedOptions)
 }
 
+// Verifies list --help prints the complete names-only option contract, including the usage and
+// global options sections that callers need after the unknown-option recovery guidance.
+func TestRunProjectLocalListHelpOutput(t *testing.T) {
+	t.Chdir(t.TempDir())
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := RunProjectLocal(context.Background(), []string{"list", "--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("list --help failed: code=%d stderr=%s", code, stderr.String())
+	}
+
+	const expected = "Usage:\n" +
+		"  uloop list [options]\n" +
+		"\n" +
+		"Show Unity tools currently exposed by the Editor\n" +
+		"\n" +
+		"Options:\n" +
+		"  --names                            Show command names only, one per line\n" +
+		"\n" +
+		"Global options:\n" +
+		"  --project-path <path>   Run against a Unity project outside the current directory\n"
+	if stdout.String() != expected {
+		t.Fatalf("list --help output mismatch:\n got:\n%s\nwant:\n%s", stdout.String(), expected)
+	}
+}
+
 func assertNativeCommandHelpOptionsSection(t *testing.T, command string, expectedOptions string) {
 	t.Helper()
 	t.Chdir(t.TempDir())
@@ -143,10 +170,10 @@ func TestRunProjectLocalPausePointHelpPointsAtTheSkill(t *testing.T) {
 	}
 }
 
-// Verifies list/sync/focus-window --help print only the global --project-path
+// Verifies sync/focus-window --help print only the global --project-path
 // option, since these commands take no command-specific flags.
 func TestRunProjectLocalNoOptionCommandsHelpListsOnlyGlobalOption(t *testing.T) {
-	for _, command := range []string{"list", "sync", "focus-window"} {
+	for _, command := range []string{"sync", "focus-window"} {
 		t.Run(command, func(t *testing.T) {
 			t.Chdir(t.TempDir())
 

--- a/cli/project-runner/internal/projectrunner/run.go
+++ b/cli/project-runner/internal/projectrunner/run.go
@@ -329,7 +329,16 @@ func writePostCompileWarmupWarning(stderr io.Writer, err error) {
 	_, _ = fmt.Fprintf(stderr, "warning: post-compile warmup skipped: %v\n", err)
 }
 
-func runList(ctx context.Context, connection unityipc.Connection, stdout io.Writer, stderr io.Writer) int {
+func runList(ctx context.Context, connection unityipc.Connection, commandArgs []string, stdout io.Writer, stderr io.Writer) int {
+	options, err := parseListOptions(commandArgs)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
+			ProjectRoot: connection.ProjectRoot,
+			Command:     "list",
+		})
+		return 1
+	}
+
 	spinner := clicore.NewToolSpinner(stderr, "list")
 	outcome, err := sendWithTransientConnectionRetry(
 		ctx,
@@ -345,6 +354,16 @@ func runList(ctx context.Context, connection unityipc.Connection, stdout io.Writ
 			Command:     "list",
 		})
 		return 1
+	}
+	if options.namesOnly {
+		if err := writeToolNames(outcome.Result, stdout); err != nil {
+			clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
+				ProjectRoot: connection.ProjectRoot,
+				Command:     "list",
+			})
+			return 1
+		}
+		return 0
 	}
 	clicore.WriteJSON(stdout, formatToolListResult(outcome.Result, connection.ProjectRoot))
 	return 0

--- a/cli/project-runner/internal/projectrunner/runner_commands.go
+++ b/cli/project-runner/internal/projectrunner/runner_commands.go
@@ -27,7 +27,7 @@ func runResolvedProjectCommand(
 	}
 	switch command {
 	case "list":
-		return runList(ctx, connection, stdout, stderr)
+		return runList(ctx, connection, commandArgs, stdout, stderr)
 	case "sync":
 		return runSync(ctx, connection, stdout, stderr)
 	case "focus-window":

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "aec0be1224d2f776f2af0e3bd5582fd15cd9c229"
+  "sharedInputsHash": "d5627b710e7771df92f1a84c2199f9e56a36db61"
 }


### PR DESCRIPTION
## Summary

- Add `uloop list --names` for a compact, one-command-per-line listing.
- Keep native command names unique when the live Unity catalog contains the same name.

## User Impact

Agents can discover every available command without parsing the full live tool catalog, including the watch commands exposed by Unity.

## Changes

- Pass list arguments through native dispatch and reject unsupported options.
- Add the names-only command to the main help footer.

## Verification

- `scripts/check-go-cli.sh`
- Development binary `uloop list --names` against this Unity project


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

