### PR TITLE
fix: normalize cross-platform behavior found by pre-release Windows verification

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/SourceShaperCharacterizationTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SourceShaperCharacterizationTests.cs
@@ -42,6 +42,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
+        /// Verifies CR-only line breaks are counted when padding the body to original line numbers,
+        /// so diagnostics keep pointing at the right source line for CR-only input.
+        /// </summary>
+        [Test]
+        public void Analyze_WhenCrOnlyBlankLinePrecedesStatement_ShouldPadToOriginalLine()
+        {
+            string source = "\r\rreturn 1;";
+
+            SourceShapeResult result = SourceShaper.Analyze(source);
+
+            string body = result.TopLevelBodyBuilder.ToString();
+            Assert.That(body, Does.Not.Contain("\r"));
+            Assert.That(body, Does.StartWith("\n\nreturn 1;"));
+        }
+
+        /// <summary>
         /// Pins using-directive extraction and remaining body content.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/DynamicCodeToolTests/SourceShaperCharacterizationTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SourceShaperCharacterizationTests.cs
@@ -26,6 +26,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
+        /// Verifies CRLF input to a multi-line top-level statement is emitted with LF only,
+        /// so the shaped body is identical across Windows and macOS clients.
+        /// </summary>
+        [Test]
+        public void Analyze_WhenMultiLineStatementUsesCrlf_ShouldEmitLfOnlyBody()
+        {
+            string source = "int total = 1 +\r\n    2;\r\nreturn total;";
+
+            SourceShapeResult result = SourceShaper.Analyze(source);
+
+            string body = result.TopLevelBodyBuilder.ToString();
+            Assert.That(body, Does.Not.Contain("\r"));
+            Assert.That(body, Does.Contain("int total = 1 +\n    2;"));
+        }
+
+        /// <summary>
         /// Pins using-directive extraction and remaining body content.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/HotReloadSourceSnapshotTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSourceSnapshotTests.cs
@@ -28,6 +28,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
         private const string FixtureProjectRelativePath =
             "Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs";
+        private const string PredefinedEditorAssemblyName = "Assembly-CSharp-Editor";
+        private const string PredefinedEditorFixtureProjectRelativePath =
+            "Assets/RegressionHarness/AnnotatedScreenshotMismatch/Editor/AnnotatedScreenshotMismatchSceneBuilder.cs";
 
         /// <summary>
         /// What: the portable PDB next to a script assembly carries a per-document checksum that matches the hash of the source file bytes, which the snapshot baseline validation relies on.
@@ -78,6 +81,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 FixtureProjectRelativePath,
                 dllPath);
             Assert.That(loaded, Is.Not.Null, "Verified snapshot must resolve after domain-reload capture.");
+            Assert.That(loaded, Is.EqualTo(File.ReadAllText(fixtureAbsolutePath)));
+        }
+
+        /// <summary>
+        /// What: predefined editor assemblies receive compile snapshots so bare hot reload can detect their changed sources.
+        /// </summary>
+        [Test]
+        public void LoadVerifiedSnapshotSource_ForPredefinedEditorAssembly_ReturnsOnDiskText()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string dllPath = Path.Combine(
+                projectRoot,
+                HotReloadConstants.ScriptAssembliesRelativeDirectory,
+                PredefinedEditorAssemblyName + HotReloadConstants.CompiledAssemblyExtension);
+            string fixtureAbsolutePath = Path.Combine(
+                projectRoot,
+                PredefinedEditorFixtureProjectRelativePath);
+
+            string loaded = HotReloadSourceBaseline.LoadVerifiedSnapshotSource(
+                PredefinedEditorFixtureProjectRelativePath,
+                dllPath);
+
+            Assert.That(loaded, Is.Not.Null, "Predefined editor assembly snapshot must exist after compile.");
             Assert.That(loaded, Is.EqualTo(File.ReadAllText(fixtureAbsolutePath)));
         }
 

--- a/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
+++ b/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
@@ -224,15 +224,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             string[] runtimeSourcePaths = Directory.GetFiles(runtimeSourceDirectory, "*.cs", SearchOption.AllDirectories);
             string[] assemblyDefinitionPaths = Directory.GetFiles(runtimeSourceDirectory, "*.asmdef", SearchOption.AllDirectories);
+            string normalizedRuntimeSourceDirectory = NormalizeDirectorySeparators(
+                Path.GetFullPath(runtimeSourceDirectory));
             HashSet<string> allowedNestedAssemblyDefinitionPaths =
                 GetAllowedNestedRuntimeAssemblyDefinitionPaths(projectRoot);
             HashSet<string> nestedAssemblyDirectories = new();
 
             for (int pathIndex = 0; pathIndex < assemblyDefinitionPaths.Length; pathIndex++)
             {
-                string assemblyDefinitionPath = Path.GetFullPath(assemblyDefinitionPaths[pathIndex]);
-                string assemblyDefinitionDirectory = Path.GetDirectoryName(assemblyDefinitionPaths[pathIndex]);
-                if (assemblyDefinitionDirectory == runtimeSourceDirectory)
+                string assemblyDefinitionPath = NormalizeDirectorySeparators(
+                    Path.GetFullPath(assemblyDefinitionPaths[pathIndex]));
+                string assemblyDefinitionDirectory = NormalizeDirectorySeparators(
+                    Path.GetDirectoryName(assemblyDefinitionPaths[pathIndex]));
+                if (assemblyDefinitionDirectory == normalizedRuntimeSourceDirectory)
                 {
                     continue;
                 }
@@ -267,7 +271,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 string assemblyDefinitionPath = Path.GetFullPath(
                     Path.Combine(projectRoot, PlayerVisibleNestedRuntimeAssemblyDefinitionPaths[pathIndex]));
-                allowedAssemblyDefinitionPaths.Add(assemblyDefinitionPath);
+                allowedAssemblyDefinitionPaths.Add(NormalizeDirectorySeparators(assemblyDefinitionPath));
             }
 
             return allowedAssemblyDefinitionPaths;
@@ -277,16 +281,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string sourcePath,
             HashSet<string> nestedAssemblyDirectories)
         {
+            string normalizedSourcePath = NormalizeDirectorySeparators(sourcePath);
             foreach (string nestedAssemblyDirectory in nestedAssemblyDirectories)
             {
-                string nestedAssemblyPrefix = nestedAssemblyDirectory + Path.DirectorySeparatorChar;
-                if (sourcePath.StartsWith(nestedAssemblyPrefix, System.StringComparison.Ordinal))
+                string nestedAssemblyPrefix = nestedAssemblyDirectory + "/";
+                if (normalizedSourcePath.StartsWith(nestedAssemblyPrefix, System.StringComparison.Ordinal))
                 {
                     return true;
                 }
             }
 
             return false;
+        }
+
+        private static string NormalizeDirectorySeparators(string path)
+        {
+            return path.Replace('\\', '/');
         }
 
         private static void AssertEditorOnlyTags(GameObject root, string prefabPath)

--- a/Assets/Tests/Editor/ScreenshotUseCaseCharacterizationTests.cs
+++ b/Assets/Tests/Editor/ScreenshotUseCaseCharacterizationTests.cs
@@ -214,15 +214,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
-        /// Pins file-name sanitization replacing platform-invalid path characters with underscores.
+        /// Pins file-name sanitization replacing the fixed cross-platform invalid set with underscores.
         /// </summary>
         [Test]
         public void SanitizeFileName_WhenNameContainsInvalidChars_ShouldReplaceWithUnderscore()
         {
-            // why: on this Unity/macOS runtime Path.GetInvalidFileNameChars is only NUL and '/', so ':' stays
             string sanitized = ScreenshotCaptureResults.SanitizeFileName("Game/View:Main");
 
-            Assert.That(sanitized, Is.EqualTo("Game_View:Main"));
+            Assert.That(sanitized, Is.EqualTo("Game_View_Main"));
         }
     }
 }

--- a/Assets/Tests/Editor/VibeLoggerRetentionTests.cs
+++ b/Assets/Tests/Editor/VibeLoggerRetentionTests.cs
@@ -52,5 +52,48 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Directory.Delete(temporaryDirectory, recursive: true);
             }
         }
+
+        /// <summary>
+        /// Verifies the write path itself prunes old day files when appending creates a new day file,
+        /// so retention cannot regress to running only after size rotation.
+        /// </summary>
+        [Test]
+        public void AppendLogLineWithRetention_WhenNewDayFileIsCreated_PrunesOldestFiles()
+        {
+            string temporaryDirectory = Path.Combine(
+                Path.GetTempPath(),
+                "vibe-logger-retention-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(temporaryDirectory);
+
+            try
+            {
+                int preexistingFileCount = VibeLoggerService.MAX_LOG_FILES + 2;
+                DateTime baseWriteTimeUtc = DateTime.UtcNow.AddDays(-preexistingFileCount - 1);
+                for (int index = 0; index < preexistingFileCount; index++)
+                {
+                    string filePath = Path.Combine(
+                        temporaryDirectory,
+                        "unity_vibe_202601" + index.ToString("D2") + ".json");
+                    File.WriteAllText(filePath, index.ToString());
+                    File.SetLastWriteTimeUtc(filePath, baseWriteTimeUtc.AddDays(index));
+                }
+
+                VibeLoggerService.AppendLogLineWithRetention(temporaryDirectory, "{}\n");
+
+                string todayFilePath = Path.Combine(
+                    temporaryDirectory,
+                    $"unity_vibe_{DateTime.UtcNow:yyyyMMdd}.json");
+                string[] remainingFiles = Directory.GetFiles(temporaryDirectory, "unity_vibe_*.json");
+                Assert.That(File.Exists(todayFilePath), Is.True);
+                Assert.That(remainingFiles, Has.Length.EqualTo(VibeLoggerService.MAX_LOG_FILES));
+                Assert.That(
+                    File.Exists(Path.Combine(temporaryDirectory, "unity_vibe_20260100.json")),
+                    Is.False);
+            }
+            finally
+            {
+                Directory.Delete(temporaryDirectory, recursive: true);
+            }
+        }
     }
 }

--- a/Assets/Tests/Editor/VibeLoggerRetentionTests.cs
+++ b/Assets/Tests/Editor/VibeLoggerRetentionTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests count-based retention for VibeLogger day files.
+    /// </summary>
+    public class VibeLoggerRetentionTests
+    {
+        /// <summary>
+        /// Verifies VibeLogger keeps only the newest files up to the shared output retention limit.
+        /// </summary>
+        [Test]
+        public void DeleteOldestLogFilesBeyondLimit_WhenLimitIsExceeded_KeepsNewestFiles()
+        {
+            string temporaryDirectory = Path.Combine(
+                Path.GetTempPath(),
+                "vibe-logger-retention-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(temporaryDirectory);
+
+            try
+            {
+                int totalFileCount = VibeLoggerService.MAX_LOG_FILES + 2;
+                DateTime baseWriteTimeUtc = DateTime.UtcNow.AddDays(-totalFileCount);
+                for (int index = 0; index < totalFileCount; index++)
+                {
+                    string filePath = Path.Combine(
+                        temporaryDirectory,
+                        "unity_vibe_202601" + index.ToString("D2") + ".json");
+                    File.WriteAllText(filePath, index.ToString());
+                    File.SetLastWriteTimeUtc(filePath, baseWriteTimeUtc.AddDays(index));
+                }
+
+                VibeLoggerService.DeleteOldestLogFilesBeyondLimit(temporaryDirectory);
+
+                string[] remainingFiles = Directory.GetFiles(temporaryDirectory, "unity_vibe_*.json");
+                Assert.That(remainingFiles, Has.Length.EqualTo(VibeLoggerService.MAX_LOG_FILES));
+                Assert.That(
+                    File.Exists(Path.Combine(temporaryDirectory, "unity_vibe_20260100.json")),
+                    Is.False);
+                Assert.That(
+                    File.Exists(Path.Combine(temporaryDirectory, "unity_vibe_20260101.json")),
+                    Is.False);
+            }
+            finally
+            {
+                Directory.Delete(temporaryDirectory, recursive: true);
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/VibeLoggerRetentionTests.cs.meta
+++ b/Assets/Tests/Editor/VibeLoggerRetentionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92c4e1ebc77ac714f855b679d99ff1ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Domain/CliPathSetupProfileResolver.cs
+++ b/Packages/src/Editor/Domain/CliPathSetupProfileResolver.cs
@@ -56,7 +56,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 string configurationRoot = string.IsNullOrWhiteSpace(zDotDirectory)
                     ? homeDirectory
                     : zDotDirectory;
-                string configurationPath = Path.Combine(configurationRoot, ZshProfileFileName);
+                string configurationPath = CombinePosixPath(configurationRoot, ZshProfileFileName);
                 string configurationLine = BuildPosixExportLine(profileInstallDirectory);
                 return CreateSupportedPlan(
                     CliPathSetupShellKind.Zsh,
@@ -83,11 +83,10 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             if (string.Equals(shellName, "fish", StringComparison.Ordinal))
             {
                 string configRoot = string.IsNullOrWhiteSpace(xdgConfigHome)
-                    ? Path.Combine(homeDirectory, DefaultXdgConfigDirectoryName)
+                    ? CombinePosixPath(homeDirectory, DefaultXdgConfigDirectoryName)
                     : xdgConfigHome;
-                string configurationPath = Path.Combine(
-                    configRoot,
-                    FishConfigDirectoryName,
+                string configurationPath = CombinePosixPath(
+                    CombinePosixPath(configRoot, FishConfigDirectoryName),
                     FishConfigFileName);
                 string configurationLine = $"fish_add_path --move \"{EscapeDoubleQuotedPathValue(profileInstallDirectory, false)}\"";
                 return CreateSupportedPlan(
@@ -140,20 +139,25 @@ namespace io.github.hatayama.UnityCliLoop.Domain
 
         private static string SelectBashProfilePath(string homeDirectory, Func<string, bool> fileExists)
         {
-            string bashProfilePath = Path.Combine(homeDirectory, BashProfileFileName);
+            string bashProfilePath = CombinePosixPath(homeDirectory, BashProfileFileName);
             if (fileExists(bashProfilePath))
             {
                 return bashProfilePath;
             }
 
-            string bashLoginPath = Path.Combine(homeDirectory, BashLoginFileName);
+            string bashLoginPath = CombinePosixPath(homeDirectory, BashLoginFileName);
             if (fileExists(bashLoginPath))
             {
                 return bashLoginPath;
             }
 
-            string profilePath = Path.Combine(homeDirectory, PosixProfileFileName);
+            string profilePath = CombinePosixPath(homeDirectory, PosixProfileFileName);
             return fileExists(profilePath) ? profilePath : bashProfilePath;
+        }
+
+        private static string CombinePosixPath(string root, string child)
+        {
+            return root.TrimEnd('/') + "/" + child.TrimStart('/');
         }
 
         private static string GetShellName(string shellPath)
@@ -170,13 +174,13 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 return installDirectory;
             }
 
-            string normalizedHome = homeDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            string normalizedHome = homeDirectory.TrimEnd('/');
             if (string.Equals(installDirectory, normalizedHome, StringComparison.Ordinal))
             {
                 return HomeReference;
             }
 
-            string homePrefix = normalizedHome + Path.DirectorySeparatorChar;
+            string homePrefix = normalizedHome + "/";
             return installDirectory.StartsWith(homePrefix, StringComparison.Ordinal)
                 ? HomeReference + "/" + installDirectory.Substring(homePrefix.Length)
                 : installDirectory;

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SourceShaper.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SourceShaper.cs
@@ -302,7 +302,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int stmtEnd = SourceTokenScanner.FindStatementEnd(source, pos, ref nextBraceDepth);
             int originalLineNumber1Based = GetLineNumber1Based(source, pos);
             PadTopLevelBodyBuilderToOriginalLine(result, originalLineNumber1Based);
-            string statementText = source.Substring(pos, stmtEnd - pos + 1).TrimEnd();
+            // Multi-line statements are copied verbatim, so CRLF input would leak
+            // platform line endings into the emitted body unless normalized here.
+            string statementText = source.Substring(pos, stmtEnd - pos + 1).TrimEnd()
+                .Replace("\r\n", "\n")
+                .Replace('\r', '\n');
             result.TopLevelBodyBuilder.Append(statementText);
             result.TopLevelBodyBuilder.Append('\n');
             result.NextBodyLineNumber1Based = originalLineNumber1Based + CountLinesInText(statementText);

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SourceShaper.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SourceShaper.cs
@@ -329,7 +329,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int lineNumber = 1;
             for (int position = 0; position < index && position < source.Length; position++)
             {
-                if (source[position] == '\n')
+                // A standalone CR is a line break too; CRLF must count as one break,
+                // matching the LF-normalized text the body builder emits.
+                if (source[position] == '\r')
+                {
+                    lineNumber++;
+                    if (position + 1 < index && source[position + 1] == '\n')
+                    {
+                        position++;
+                    }
+                }
+                else if (source[position] == '\n')
                 {
                     lineNumber++;
                 }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SourceShaper.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SourceShaper.cs
@@ -303,7 +303,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int originalLineNumber1Based = GetLineNumber1Based(source, pos);
             PadTopLevelBodyBuilderToOriginalLine(result, originalLineNumber1Based);
             string statementText = source.Substring(pos, stmtEnd - pos + 1).TrimEnd();
-            result.TopLevelBodyBuilder.AppendLine(statementText);
+            result.TopLevelBodyBuilder.Append(statementText);
+            result.TopLevelBodyBuilder.Append('\n');
             result.NextBodyLineNumber1Based = originalLineNumber1Based + CountLinesInText(statementText);
             return new SourceTopLevelStep(stmtEnd + 1, nextBraceDepth);
         }
@@ -314,7 +315,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             while (result.NextBodyLineNumber1Based < originalLineNumber1Based)
             {
-                result.TopLevelBodyBuilder.AppendLine();
+                result.TopLevelBodyBuilder.Append('\n');
                 result.NextBodyLineNumber1Based++;
             }
         }

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotFileWriter.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotFileWriter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -11,6 +12,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class ScreenshotFileWriter
     {
+        private const string InvalidFileNameCharacters = "<>:\"/\\|?*";
+
         internal static string EnsureOutputDirectoryExists(string outputDirectory)
         {
             string resolvedDirectory;
@@ -32,13 +35,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal static string SanitizeFileName(string name)
         {
-            char[] invalidChars = Path.GetInvalidFileNameChars();
-            string sanitized = name;
-            foreach (char c in invalidChars)
+            StringBuilder sanitized = new StringBuilder(name.Length);
+            foreach (char character in name)
             {
-                sanitized = sanitized.Replace(c, '_');
+                bool isInvalid = character < ' '
+                    || InvalidFileNameCharacters.IndexOf(character) >= 0;
+                sanitized.Append(isInvalid ? '_' : character);
             }
-            return sanitized;
+
+            return sanitized.ToString();
         }
 
         internal static void SaveTextureAsPng(Texture2D texture, string fullPath)

--- a/Packages/src/Editor/ToolContracts/VibeLogger.cs
+++ b/Packages/src/Editor/ToolContracts/VibeLogger.cs
@@ -24,7 +24,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         private const string LOG_FILE_PREFIX = "unity_vibe";
         private const int MAX_FILE_SIZE_MB = 10;
         private const int MAX_MEMORY_LOGS = 1000;
-        private const int MAX_LOG_FILES = 3;
+        internal const int MAX_LOG_FILES = 20;
         private const int UNINITIALIZED_MAIN_THREAD_ID = 0;
         private const string DOMAIN_RELOAD_STATE_IN_PROGRESS = "InProgress";
         private const string DOMAIN_RELOAD_STATE_IDLE = "Idle";
@@ -260,6 +260,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
             
             string fileName = $"{LOG_FILE_PREFIX}_{DateTime.UtcNow:yyyyMMdd}.json";
             string filePath = Path.Combine(logDirectory, fileName);
+            bool shouldPruneAfterWrite = !File.Exists(filePath);
             
             // Check file size and rotate if necessary
             if (File.Exists(filePath))
@@ -270,9 +271,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
                     string rotatedFileName = $"{LOG_FILE_PREFIX}_{DateTime.UtcNow:yyyyMMdd_HHmmss}.json";
                     string rotatedFilePath = Path.Combine(logDirectory, rotatedFileName);
                     File.Move(filePath, rotatedFilePath);
-                    
-                    // Clean up old files after rotation
-                    CleanupOldLogFiles();
+                    shouldPruneAfterWrite = true;
                 }
             }
             
@@ -291,8 +290,14 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
                     {
                         writer.Write(jsonLog);
                         writer.Flush();
-                        return; // Success - exit retry loop
                     }
+
+                    if (shouldPruneAfterWrite)
+                    {
+                        CleanupOldLogFiles();
+                    }
+
+                    return; // Success - exit retry loop
                 }
                 catch (IOException ex) when (IsFileSharingViolation(ex) && retry < maxRetries - 1)
                 {
@@ -329,32 +334,30 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
 
             try
             {
-                if (!Directory.Exists(logDirectory))
-                    return;
-                    
-                // Get all vibe log files, sorted by creation time (newest first)
-                FileInfo[] logFiles = Directory.GetFiles(logDirectory, $"{LOG_FILE_PREFIX}_*.json")
-                    .Select(file => new FileInfo(file))
-                    .OrderByDescending(file => file.CreationTime)
-                    .ToArray();
-                    
-                // Delete files beyond the limit
-                for (int i = MAX_LOG_FILES; i < logFiles.Length; i++)
-                {
-                    try
-                    {
-                        logFiles[i].Delete();
-                    }
-                    catch (Exception ex)
-                    {
-                        // Log deletion failure but don't crash
-                        UnityEngine.Debug.LogWarning($"[VibeLogger] Failed to delete old log file {logFiles[i].Name}: {ex.Message}");
-                    }
-                }
+                DeleteOldestLogFilesBeyondLimit(logDirectory);
             }
             catch (Exception ex)
             {
                 UnityEngine.Debug.LogWarning($"[VibeLogger] Failed to cleanup old log files: {ex.Message}");
+            }
+        }
+
+        internal static void DeleteOldestLogFilesBeyondLimit(string logDirectory)
+        {
+            if (!Directory.Exists(logDirectory))
+            {
+                return;
+            }
+
+            FileInfo[] logFiles = Directory.GetFiles(logDirectory, $"{LOG_FILE_PREFIX}_*.json")
+                .Select(file => new FileInfo(file))
+                .OrderByDescending(file => file.LastWriteTimeUtc)
+                .ThenByDescending(file => file.Name, StringComparer.Ordinal)
+                .ToArray();
+
+            for (int index = MAX_LOG_FILES; index < logFiles.Length; index++)
+            {
+                logFiles[index].Delete();
             }
         }
         

--- a/Packages/src/Editor/ToolContracts/VibeLogger.cs
+++ b/Packages/src/Editor/ToolContracts/VibeLogger.cs
@@ -368,7 +368,20 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
 
             for (int index = MAX_LOG_FILES; index < logFiles.Length; index++)
             {
-                logFiles[index].Delete();
+                DeleteLogFileSafely(logFiles[index]);
+            }
+        }
+
+        private static void DeleteLogFileSafely(FileInfo logFile)
+        {
+            try
+            {
+                logFile.Delete();
+            }
+            catch (Exception ex)
+            {
+                // A locked or inaccessible file must not stop pruning of the remaining files.
+                UnityEngine.Debug.LogWarning($"[VibeLogger] Failed to delete old log file {logFile.Name}: {ex.Message}");
             }
         }
         

--- a/Packages/src/Editor/ToolContracts/VibeLogger.cs
+++ b/Packages/src/Editor/ToolContracts/VibeLogger.cs
@@ -258,10 +258,20 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
                 }
             }
             
+            string jsonLog = JsonConvert.SerializeObject(logEntry) + "\n";
+            AppendLogLineWithRetention(logDirectory, jsonLog);
+        }
+
+        /// <summary>
+        /// Append one log line to the current day file, rotating oversized files and
+        /// pruning the directory to the retention limit when a new file appears.
+        /// </summary>
+        internal static void AppendLogLineWithRetention(string logDirectory, string jsonLog)
+        {
             string fileName = $"{LOG_FILE_PREFIX}_{DateTime.UtcNow:yyyyMMdd}.json";
             string filePath = Path.Combine(logDirectory, fileName);
             bool shouldPruneAfterWrite = !File.Exists(filePath);
-            
+
             // Check file size and rotate if necessary
             if (File.Exists(filePath))
             {
@@ -274,13 +284,11 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
                     shouldPruneAfterWrite = true;
                 }
             }
-            
-            string jsonLog = JsonConvert.SerializeObject(logEntry) + "\n";
-            
+
             // Use file locking with retry mechanism to handle concurrent access
             int maxRetries = 3;
             int retryDelayMs = 50;
-            
+
             for (int retry = 0; retry < maxRetries; retry++)
             {
                 try
@@ -294,7 +302,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
 
                     if (shouldPruneAfterWrite)
                     {
-                        CleanupOldLogFiles();
+                        PruneLogDirectory(logDirectory);
                     }
 
                     return; // Success - exit retry loop
@@ -330,8 +338,11 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         /// </summary>
         private void CleanupOldLogFiles()
         {
-            string logDirectory = GetLogDirectory();
+            PruneLogDirectory(GetLogDirectory());
+        }
 
+        private static void PruneLogDirectory(string logDirectory)
+        {
             try
             {
                 DeleteOldestLogFilesBeyondLimit(logDirectory);

--- a/docs/soak-testing.md
+++ b/docs/soak-testing.md
@@ -24,6 +24,10 @@ point it at a large production project for the most realistic signal.
 - The Unity Editor does not have to be running: if no editor has the target
   project open, the harness launches one via `uloop launch`; a running but
   busy editor (importing/compiling) is waited on for up to 15 minutes.
+- When the PlayMode cycle is enabled (`--pause-every` > 0 or `-PauseEvery` >
+  0), the target project must have `com.unity.inputsystem` and `com.unity.ugui`
+  installed. Active Input Handling must be set to **Input System Package
+  (New)** or **Both**.
 - macOS/Linux (`soak-loop.sh`): POSIX sh, plus `jq` when the PlayMode cycle is
   enabled (`--pause-every` > 0). Metrics are sampled with `ps`/`pgrep`/`perl`,
   so this variant is not expected to run on Windows.
@@ -208,6 +212,9 @@ editor.
 
 The harness leaves `Assets/UloopSoak/` (scratch script, ticker, button probe,
 scene) in the target project so a follow-up run can be compared against the
-same state. Delete that folder and its `.meta` manually when finished. Do not
-revert the target project's `manifest.json`/`packages-lock.json` changes if
-they came from installing the uloop package itself.
+same state. At normal completion or after an abort, the harness opens a fresh
+empty scene when the active scene is still under `Assets/UloopSoak/`; it never
+replaces an active user scene during cleanup. Delete the generated folder and
+its `.meta` manually after the reminder. Do not revert the target project's
+`manifest.json`/`packages-lock.json` changes if they came from installing the
+uloop package itself.

--- a/scripts/soak-loop.ps1
+++ b/scripts/soak-loop.ps1
@@ -32,7 +32,8 @@ All generated files live under Assets/UloopSoak/ in the target project (the
 recompile scratch script, the PlayMode ticker script, and the pause-point
 scene) and are left behind after the run - delete the folder and its .meta
 manually when done. When -PauseEvery > 0, the harness opens its generated
-scene and keeps it open, so save your own scene changes before running.
+scene during the run and releases it before the cleanup reminder, so save
+your own scene changes before running.
 #>
 
 [CmdletBinding()]
@@ -738,6 +739,8 @@ function Reset-EditorState {
         $null = Invoke-Uloop -CommandArguments @("control-play-mode", "--action", "Stop")
         # Only after PlayMode has stopped: Unity refuses to recompile while playing.
         Restore-CodeOptimization
+        [string]$releaseSoakSceneCode = 'string activeScenePath = UnityEngine.SceneManagement.SceneManager.GetActiveScene().path; if (!activeScenePath.StartsWith("Assets/UloopSoak/", System.StringComparison.Ordinal)) { return "not-soak-scene"; } UnityEditor.SceneManagement.EditorSceneManager.NewScene(UnityEditor.SceneManagement.NewSceneSetup.EmptyScene, UnityEditor.SceneManagement.NewSceneMode.Single); return "released";'
+        $null = Invoke-Uloop -CommandArguments @("execute-dynamic-code", "--code", $releaseSoakSceneCode)
     }
     catch {
         Write-SoakLog -Message "Editor state cleanup failed: $($_.Exception.Message)"
@@ -770,7 +773,7 @@ function Write-Summary {
         Add-TextLine -Path $RunLog -Line $line
     }
 
-    Write-SoakLog -Message "Reminder: delete $SoakAssetsDir (and its .meta) from the target project when finished."
+    Write-SoakLog -Message "Reminder: the harness released the soak scene if it was still active; delete $SoakAssetsDir (and its .meta) from the target project when finished."
 }
 
 # Reads the SoakButton's simulation coordinates out of an annotated screenshot

--- a/scripts/soak-loop.ps1
+++ b/scripts/soak-loop.ps1
@@ -739,7 +739,7 @@ function Reset-EditorState {
         $null = Invoke-Uloop -CommandArguments @("control-play-mode", "--action", "Stop")
         # Only after PlayMode has stopped: Unity refuses to recompile while playing.
         Restore-CodeOptimization
-        [string]$releaseSoakSceneCode = 'string activeScenePath = UnityEngine.SceneManagement.SceneManager.GetActiveScene().path; if (!activeScenePath.StartsWith("Assets/UloopSoak/", System.StringComparison.Ordinal)) { return "not-soak-scene"; } UnityEditor.SceneManagement.EditorSceneManager.NewScene(UnityEditor.SceneManagement.NewSceneSetup.EmptyScene, UnityEditor.SceneManagement.NewSceneMode.Single); return "released";'
+        [string]$releaseSoakSceneCode = 'string activeScenePath = UnityEngine.SceneManagement.SceneManager.GetActiveScene().path; if (!System.String.Equals(activeScenePath, "Assets/UloopSoak/UloopSoak.unity", System.StringComparison.Ordinal)) { return "not-soak-scene"; } UnityEditor.SceneManagement.EditorSceneManager.NewScene(UnityEditor.SceneManagement.NewSceneSetup.EmptyScene, UnityEditor.SceneManagement.NewSceneMode.Single); return "released";'
         $null = Invoke-Uloop -CommandArguments @("execute-dynamic-code", "--code", $releaseSoakSceneCode)
     }
     catch {

--- a/scripts/soak-loop.sh
+++ b/scripts/soak-loop.sh
@@ -284,7 +284,7 @@ cleanup_editor_state() {
     if [ "$PAUSE_EVERY" -gt 0 ]; then
         run_uloop clear-pause-point --all > /dev/null 2>&1 || true
         run_uloop control-play-mode --action Stop > /dev/null 2>&1 || true
-        run_uloop execute-dynamic-code --code 'string activeScenePath = UnityEngine.SceneManagement.SceneManager.GetActiveScene().path; if (!activeScenePath.StartsWith("Assets/UloopSoak/", System.StringComparison.Ordinal)) { return "not-soak-scene"; } UnityEditor.SceneManagement.EditorSceneManager.NewScene(UnityEditor.SceneManagement.NewSceneSetup.EmptyScene, UnityEditor.SceneManagement.NewSceneMode.Single); return "released";' > /dev/null 2>&1 || true
+        run_uloop execute-dynamic-code --code 'string activeScenePath = UnityEngine.SceneManagement.SceneManager.GetActiveScene().path; if (!System.String.Equals(activeScenePath, "Assets/UloopSoak/UloopSoak.unity", System.StringComparison.Ordinal)) { return "not-soak-scene"; } UnityEditor.SceneManagement.EditorSceneManager.NewScene(UnityEditor.SceneManagement.NewSceneSetup.EmptyScene, UnityEditor.SceneManagement.NewSceneMode.Single); return "released";' > /dev/null 2>&1 || true
     fi
 }
 

--- a/scripts/soak-loop.sh
+++ b/scripts/soak-loop.sh
@@ -38,7 +38,8 @@ set -u
 # recompile scratch script, the PlayMode ticker script, and the pause-point
 # scene) and are left behind after the run — delete the folder and its .meta
 # manually when done. When --pause-every > 0, the harness opens its generated
-# scene and keeps it open, so save your own scene changes before running.
+# scene during the run and releases it before the cleanup reminder, so save
+# your own scene changes before running.
 
 ULOOP_BIN="${ULOOP_BIN:-uloop}"
 
@@ -283,6 +284,7 @@ cleanup_editor_state() {
     if [ "$PAUSE_EVERY" -gt 0 ]; then
         run_uloop clear-pause-point --all > /dev/null 2>&1 || true
         run_uloop control-play-mode --action Stop > /dev/null 2>&1 || true
+        run_uloop execute-dynamic-code --code 'string activeScenePath = UnityEngine.SceneManagement.SceneManager.GetActiveScene().path; if (!activeScenePath.StartsWith("Assets/UloopSoak/", System.StringComparison.Ordinal)) { return "not-soak-scene"; } UnityEditor.SceneManagement.EditorSceneManager.NewScene(UnityEditor.SceneManagement.NewSceneSetup.EmptyScene, UnityEditor.SceneManagement.NewSceneMode.Single); return "released";' > /dev/null 2>&1 || true
     fi
 }
 
@@ -297,7 +299,7 @@ summarize() {
         for (c in total)
             printf "%-14s %8d %8d %10d\n", c, total[c], fail[c] + 0, ms[c] / total[c]
     }' "$COMMANDS_CSV" | tee -a "$RUN_LOG"
-    log "Reminder: delete $SOAK_ASSETS_DIR (and its .meta) from the target project when finished."
+    log "Reminder: the harness released the soak scene if it was still active; delete $SOAK_ASSETS_DIR (and its .meta) from the target project when finished."
 }
 trap summarize EXIT
 trap 'exit 130' INT TERM


### PR DESCRIPTION
## Summary

Pre-release Windows verification (soak 50 iterations + manual checks) surfaced five issues. This PR fixes them and adds regression coverage. Two fixes intentionally change macOS behavior to make output deterministic across platforms.

- **POSIX profile paths** (`CliPathSetupProfileResolver`): profile paths were built with `Path.Combine`, producing `\`-separated paths on Windows for POSIX shell profiles (e.g. `<HOME>\.zshrc`). Paths that are POSIX by definition are now joined with explicit `/`.
- **Cross-platform normalization**: `SourceShaper` now always emits `\n` (was `Environment.NewLine`), `SanitizeFileName` uses a fixed Windows-superset invalid character set so screenshot file names are identical on every OS (macOS behavior change: `:` etc. now become `_`), and the nested Runtime asmdef guard test normalizes directory separators before comparing.
- **VibeLogger retention**: day files were only pruned after a size rotation, so `.uloop/outputs/VibeLogs` grew without bound. Pruning now also runs when a new day file is created, and the retention limit is covered by a test.
- **Soak harness scene release**: both soak variants now open an empty scene during cleanup when the soak scene is still active, so deleting `Assets/UloopSoak/` after a run no longer breaks the next compile. User scenes are never replaced.
- **Soak docs**: documented the PlayMode-cycle prerequisites (`com.unity.inputsystem`, `com.unity.ugui`, active input handling) that made runs on bare projects abort with CS0234.
- **Hot reload coverage**: regression test pinning that predefined assemblies (`Assembly-CSharp-Editor`) receive compile snapshots, so bare `uloop hot-reload` works in asmdef-less projects.

## Verification

- Windows 11 / Unity 2022.3.62f3: full EditMode suite 2,888 tests, 0 failed (7 failed before these fixes)
- macOS / Unity 2022.3: full EditMode suite 2,888 tests, 2,880 passed / 8 skipped (Windows-only) / 0 failed, under Debug code optimization
- Windows soak: 50 iterations fails=0; 10 iterations on a path with spaces and Japanese characters fails=0


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

