### PR TITLE
fix: discover tools via TypeCache instead of scanning every loaded assembly

### DIFF
--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopToolDiscovery.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopToolDiscovery.cs
@@ -3,47 +3,24 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
+using UnityEditor;
+
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.CompositionRoot
 {
     /// <summary>
-    /// Discovers Unity CLI tool implementations decorated with UnityCliLoopToolAttribute across
-    /// loaded assemblies and instantiates them for registration.
+    /// Discovers Unity CLI tool implementations indexed by Unity's editor type cache and
+    /// instantiates them for registration.
     /// </summary>
     internal static class UnityCliLoopToolDiscovery
     {
         internal static IReadOnlyList<IUnityCliLoopTool> DiscoverTools()
         {
-            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
-            List<Type> toolTypes = new();
-
-            foreach (Assembly assembly in assemblies)
-            {
-                if (assembly.IsDynamic)
-                {
-                    continue;
-                }
-
-                Type[] loadedTypes;
-                try
-                {
-                    loadedTypes = assembly.GetTypes();
-                }
-                catch (ReflectionTypeLoadException ex)
-                {
-                    // A partially loadable assembly must not abort tool discovery for every other assembly.
-                    loadedTypes = Array.FindAll(ex.Types, static t => t != null);
-                }
-
-                Type[] types = loadedTypes
-                    .Where(type => type.GetCustomAttribute<UnityCliLoopToolAttribute>() != null)
-                    .Where(type => typeof(IUnityCliLoopTool).IsAssignableFrom(type))
-                    .Where(type => !type.IsAbstract && !type.IsInterface)
-                    .ToArray();
-
-                toolTypes.AddRange(types);
-            }
+            Type[] toolTypes = TypeCache.GetTypesWithAttribute<UnityCliLoopToolAttribute>()
+                .Where(type => typeof(IUnityCliLoopTool).IsAssignableFrom(type))
+                .Where(type => !type.IsAbstract && !type.IsInterface)
+                .ToArray();
 
             List<IUnityCliLoopTool> tools = new();
             foreach (Type type in toolTypes)


### PR DESCRIPTION
## Summary
- Reduce synchronous tool discovery during Editor startup and domain reloads from a measured 1,816 ms assembly scan to a 17 ms cached lookup.
- Keep the tool catalog published synchronously so CLI discovery does not regain a stale-cache window.

## User Impact
- Editor startup and every domain reload previously scanned 42,770 loaded types before publishing the tool catalog, taking 1,816 ms and 2,539 ms in measured runs.
- Tool discovery now uses Unity's precomputed type cache and finds the same tools in 17 ms, removing that repeated startup delay.

## Changes
- Replace loaded-assembly enumeration and `Assembly.GetTypes()` calls with the attribute-indexed `TypeCache` lookup.
- Preserve the existing tool-interface, concrete-type, constructor validation, and instantiation paths.
- Remove the obsolete partial type-load exception handling together with the assembly scan.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT> --timeout-seconds 600` (success, 0 errors; 1 unrelated existing warning)
- Discovery and registry EditMode tests: 38 passed, 0 failed
- Catalog and tool-settings EditMode tests: 11 passed, 0 failed
- `dist/darwin-arm64/uloop list --project-path <PROJECT_ROOT>` returned the same 23 live development-project tools and schemas; the normalized catalog SHA-256 matched before and after (`668bfaad48cb033773a58b58a24d8c1406d2e26c98ccab289b6ba09bdb1c1add`)
- Two consecutive domain reloads produced the same raw `tools.json` SHA-256 (`f3417c0ca653ecec3c4a4c7d0aee2a9baf5f313d4d188cafec1a88116c451d12`), confirming stable TypeCache enumeration for catalog publishing


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

