### PR TITLE
fix: support long Windows paths in hot-reload snapshots

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadFileSystemPathTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadFileSystemPathTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for hot-reload filesystem path normalization.
+    /// </summary>
+    public class HotReloadFileSystemPathTests
+    {
+        /// <summary>
+        /// What: a short absolute Windows path remains unchanged.
+        /// </summary>
+        [Test]
+        public void GetFileSystemPath_ShortWindowsPath_ReturnsUnchangedPath()
+        {
+            if (Path.DirectorySeparatorChar != '\\')
+            {
+                Assert.Pass("Windows extended-length path handling applies only on Windows.");
+                return;
+            }
+
+            string path = Path.GetFullPath("short.cs");
+            Assert.That(path.Length, Is.LessThan(260), "Test path must remain below legacy MAX_PATH.");
+
+            Assert.That(HotReloadFileSystemPath.GetFileSystemPath(path), Is.EqualTo(path));
+        }
+
+        /// <summary>
+        /// What: a Windows path at or beyond legacy MAX_PATH receives the extended-length prefix.
+        /// </summary>
+        [Test]
+        public void GetFileSystemPath_LongWindowsPath_AddsExtendedLengthPrefix()
+        {
+            if (Path.DirectorySeparatorChar != '\\')
+            {
+                Assert.Pass("Windows extended-length path handling applies only on Windows.");
+                return;
+            }
+
+            string basePath = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "uloop-path-test"));
+            string path = basePath + Path.DirectorySeparatorChar +
+                new string('a', Math.Max(1, 260 - basePath.Length));
+            Assert.That(path.Length, Is.GreaterThanOrEqualTo(260));
+
+            Assert.That(HotReloadFileSystemPath.GetFileSystemPath(path), Is.EqualTo(@"\\?\" + path));
+        }
+
+        /// <summary>
+        /// What: a long Windows UNC path is converted to the extended-length UNC form.
+        /// </summary>
+        [Test]
+        public void GetFileSystemPath_LongWindowsUncPath_ConvertsToExtendedLengthUncPath()
+        {
+            if (Path.DirectorySeparatorChar != '\\')
+            {
+                Assert.Pass("Windows extended-length path handling applies only on Windows.");
+                return;
+            }
+
+            string path = @"\\server\share\" + new string('a', 260);
+            string expected = @"\\?\UNC\" + path.Substring(2);
+
+            Assert.That(HotReloadFileSystemPath.GetFileSystemPath(path), Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// What: an already extended-length Windows path is not prefixed a second time.
+        /// </summary>
+        [Test]
+        public void GetFileSystemPath_AlreadyExtendedWindowsPath_ReturnsUnchangedPath()
+        {
+            if (Path.DirectorySeparatorChar != '\\')
+            {
+                Assert.Pass("Windows extended-length path handling applies only on Windows.");
+                return;
+            }
+
+            string path = @"\\?\C:\" + new string('a', 260);
+
+            Assert.That(HotReloadFileSystemPath.GetFileSystemPath(path), Is.EqualTo(path));
+        }
+
+        /// <summary>
+        /// What: non-Windows paths remain unchanged regardless of length.
+        /// </summary>
+        [Test]
+        public void GetFileSystemPath_LongNonWindowsPath_ReturnsUnchangedPath()
+        {
+            if (Path.DirectorySeparatorChar == '\\')
+            {
+                Assert.Pass("Non-Windows path behavior cannot be exercised on Windows.");
+                return;
+            }
+
+            string path = "/" + new string('a', 300);
+
+            Assert.That(HotReloadFileSystemPath.GetFileSystemPath(path), Is.EqualTo(path));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSourceSnapshotTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSourceSnapshotTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
 
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -13,6 +14,7 @@ using NUnit.Framework;
 using UnityEditor.Compilation;
 
 using UnityEngine;
+using UnityEngine.TestTools;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 
@@ -231,10 +233,151 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: stale MVID snapshot directories for the same assembly name are pruned, while hyphenated sibling assembly names and non-MVID suffixes are kept.
+        /// What: on Windows, an extended-length source created beyond legacy MAX_PATH is captured byte-exactly from its unprefixed project-relative path.
         /// </summary>
         [Test]
-        public void DeleteStaleSnapshotDirectories_RemovesOnlyExactMvidSiblings()
+        public void CaptureAssemblySourcesAtomically_LongWindowsSource_CapturesByteExactSnapshot()
+        {
+            if (Path.DirectorySeparatorChar != '\\')
+            {
+                Assert.Pass("Windows extended-length path handling applies only on Windows.");
+                return;
+            }
+
+            string root = Path.Combine(
+                Path.GetTempPath(),
+                "uloop-hot-reload-long-path-" + Guid.NewGuid().ToString("N"));
+            string sourceRelativePath = Path.Combine(
+                "Sources",
+                new string('a', 80),
+                new string('b', 80),
+                new string('c', 80),
+                "LongPath.cs");
+            string absoluteSourcePath = Path.Combine(root, sourceRelativePath);
+            string fileSystemSourcePath = HotReloadFileSystemPath.GetFileSystemPath(absoluteSourcePath);
+            string snapshotDirectory = Path.Combine(root, "snapshot");
+            const string sourceText = "internal static class LongPathFixture { }\n";
+
+            try
+            {
+                Assert.That(absoluteSourcePath.Length, Is.GreaterThan(260));
+                Directory.CreateDirectory(Path.GetDirectoryName(fileSystemSourcePath));
+                File.WriteAllText(
+                    fileSystemSourcePath,
+                    sourceText,
+                    new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+                HotReloadSourceSnapshotter.CaptureAssemblySourcesAtomically(
+                    root,
+                    snapshotDirectory,
+                    new[] { sourceRelativePath },
+                    "LongPathAssembly");
+
+                string normalizedRelativePath = sourceRelativePath.Replace('\\', '/');
+                string snapshotPath = Path.Combine(
+                    snapshotDirectory,
+                    HotReloadSourceSnapshotter.HashProjectRelativePath(normalizedRelativePath) + ".cs");
+                Assert.That(File.Exists(snapshotPath), Is.True);
+                Assert.That(
+                    File.ReadAllBytes(snapshotPath).SequenceEqual(File.ReadAllBytes(fileSystemSourcePath)),
+                    Is.True);
+            }
+            finally
+            {
+                string extendedRoot = @"\\?\" + Path.GetFullPath(root);
+                if (Directory.Exists(extendedRoot))
+                {
+                    Directory.Delete(extendedRoot, recursive: true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// What: an unreadable source is skipped with one warning while readable siblings still complete the atomic snapshot.
+        /// </summary>
+        [Test]
+        public void CaptureAssemblySourcesAtomically_OneLockedSource_CompletesWithReadableSnapshots()
+        {
+            if (Path.DirectorySeparatorChar != '\\')
+            {
+                // FileShare.None enforcement is only guaranteed by the Windows IO stack; POSIX
+                // Mono may allow the second open, which would leave the expected warning unmet.
+                Assert.Pass("Sharing-violation-driven skip can only be provoked reliably on Windows.");
+                return;
+            }
+
+            string root = Path.Combine(
+                Path.GetTempPath(),
+                "uloop-hot-reload-snapshot-skip-" + Guid.NewGuid().ToString("N"));
+            string sourceDirectory = Path.Combine(root, "Sources");
+            string snapshotDirectory = Path.Combine(root, "snapshot");
+            string[] sourceRelativePaths =
+            {
+                "Sources/First.cs",
+                "Sources/Locked.cs",
+                "Sources/Last.cs"
+            };
+            UTF8Encoding encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+            Directory.CreateDirectory(sourceDirectory);
+            foreach (string sourceRelativePath in sourceRelativePaths)
+            {
+                File.WriteAllText(
+                    Path.Combine(root, sourceRelativePath.Replace('/', Path.DirectorySeparatorChar)),
+                    "internal static class Fixture { }\n",
+                    encoding);
+            }
+
+            try
+            {
+                string lockedSourcePath = Path.Combine(root, "Sources", "Locked.cs");
+                using (new FileStream(
+                           lockedSourcePath,
+                           FileMode.Open,
+                           FileAccess.Read,
+                           FileShare.None))
+                {
+                    LogAssert.Expect(
+                        LogType.Warning,
+                        "[UnityCliLoop] Skipped 1 unreadable source(s) while snapshotting " +
+                        "LockedSourceAssembly: Sources/Locked.cs");
+                    HotReloadSourceSnapshotter.CaptureAssemblySourcesAtomically(
+                        root,
+                        snapshotDirectory,
+                        sourceRelativePaths,
+                        "LockedSourceAssembly");
+                }
+
+                Assert.That(Directory.Exists(snapshotDirectory), Is.True);
+                Assert.That(
+                    File.Exists(Path.Combine(
+                        snapshotDirectory,
+                        HotReloadSourceSnapshotter.HashProjectRelativePath("Sources/First.cs") + ".cs")),
+                    Is.True);
+                Assert.That(
+                    File.Exists(Path.Combine(
+                        snapshotDirectory,
+                        HotReloadSourceSnapshotter.HashProjectRelativePath("Sources/Locked.cs") + ".cs")),
+                    Is.False);
+                Assert.That(
+                    File.Exists(Path.Combine(
+                        snapshotDirectory,
+                        HotReloadSourceSnapshotter.HashProjectRelativePath("Sources/Last.cs") + ".cs")),
+                    Is.True);
+            }
+            finally
+            {
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, recursive: true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// What: stale MVID and orphaned temporary snapshot directories are pruned, while the current snapshot, hyphenated sibling assembly, and non-MVID suffix are kept.
+        /// </summary>
+        [Test]
+        public void DeleteStaleSnapshotDirectories_StaleAndOrphanTemp_RemovesOnlyExactMvidSiblings()
         {
             string tempRoot = Path.Combine(
                 Path.GetTempPath(),
@@ -244,10 +387,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string mvidA = Guid.NewGuid().ToString("N");
             string mvidB = Guid.NewGuid().ToString("N");
             string mvidC = Guid.NewGuid().ToString("N");
-            string currentDir = Path.Combine(tempRoot, "Foo-" + mvidA);
+            string mvidD = Guid.NewGuid().ToString("N");
+            string orphanTempDir = Path.Combine(tempRoot, "Foo-" + mvidA + ".tmp");
             string staleDir = Path.Combine(tempRoot, "Foo-" + mvidB);
-            string siblingAssemblyDir = Path.Combine(tempRoot, "Foo-Bar-" + mvidC);
+            string currentDir = Path.Combine(tempRoot, "Foo-" + mvidC);
+            string siblingAssemblyDir = Path.Combine(tempRoot, "Foo-Bar-" + mvidD);
             string nonMvidDir = Path.Combine(tempRoot, "Foo-notamvid");
+            Directory.CreateDirectory(orphanTempDir);
             Directory.CreateDirectory(currentDir);
             Directory.CreateDirectory(staleDir);
             Directory.CreateDirectory(siblingAssemblyDir);
@@ -257,8 +403,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             {
                 HotReloadSourceSnapshotter.DeleteStaleSnapshotDirectories(tempRoot, "Foo", currentDir);
 
-                Assert.That(Directory.Exists(currentDir), Is.True);
+                Assert.That(Directory.Exists(orphanTempDir), Is.False);
                 Assert.That(Directory.Exists(staleDir), Is.False);
+                Assert.That(Directory.Exists(currentDir), Is.True);
                 Assert.That(Directory.Exists(siblingAssemblyDir), Is.True);
                 Assert.That(Directory.Exists(nonMvidDir), Is.True);
             }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileSystemPath.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileSystemPath.cs
@@ -1,0 +1,43 @@
+// Intentionally duplicated from
+// Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileWriter.cs.
+// The source method is private in another assembly; duplicating these few lines is less coupling
+// than adding an asmdef reference and InternalsVisibleTo. A follow-up PR can centralize the helper.
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Routes hot-reload file IO through Windows extended-length paths when needed.
+    /// </summary>
+    internal static class HotReloadFileSystemPath
+    {
+        private const int WindowsLegacyMaxPathLength = 260;
+        private const string WindowsExtendedLengthPathPrefix = @"\\?\";
+        private const string WindowsExtendedLengthUncPathPrefix = @"\\?\UNC\";
+        private const string WindowsUncPathPrefix = @"\\";
+
+        internal static string GetFileSystemPath(string path)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(path), "path must not be null or empty");
+
+            string fullPath = Path.GetFullPath(path);
+            if (Path.DirectorySeparatorChar != '\\' ||
+                fullPath.Length < WindowsLegacyMaxPathLength ||
+                fullPath.StartsWith(WindowsExtendedLengthPathPrefix, StringComparison.Ordinal))
+            {
+                return fullPath;
+            }
+
+            // Windows Mono still needs the extended-length prefix for file IO beyond legacy MAX_PATH.
+            if (fullPath.StartsWith(WindowsUncPathPrefix, StringComparison.Ordinal))
+            {
+                return WindowsExtendedLengthUncPathPrefix +
+                    fullPath.Substring(WindowsUncPathPrefix.Length);
+            }
+
+            return WindowsExtendedLengthPathPrefix + fullPath;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourceSnapshotter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourceSnapshotter.cs
@@ -37,8 +37,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             foreach (UnityCompilationAssembly assembly in CompilationPipeline.GetAssemblies())
             {
-                CaptureAssemblyIfNeeded(projectRoot, snapshotRoot, assembly);
+                try
+                {
+                    CaptureAssemblyIfNeeded(projectRoot, snapshotRoot, assembly);
+                }
+                catch (Exception ex) when (IsSkippableAssemblyCaptureException(ex))
+                {
+                    // Approved deviation from the no-try-catch rule: one assembly's transient IO
+                    // or Cecil read failure must not deprive every remaining assembly of a baseline.
+                    // Continuing preserves the fail-closed invariant because missing snapshots are
+                    // rejected by PDB checksum validation rather than used for an incorrect diff.
+                    UnityEngine.Debug.LogWarning(
+                        $"[UnityCliLoop] Snapshot capture failed for assembly {assembly.name}: {ex.Message}");
+                }
             }
+        }
+
+        private static bool IsSkippableAssemblyCaptureException(Exception ex)
+        {
+            Debug.Assert(ex != null, "ex must not be null");
+
+            return ex is IOException ||
+                   ex is UnauthorizedAccessException ||
+                   ex is BadImageFormatException;
         }
 
         private static void CaptureAssemblyIfNeeded(
@@ -84,10 +105,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string assemblySnapshotDirectory = Path.Combine(snapshotRoot, assembly.name + "-" + mvid);
             if (!Directory.Exists(assemblySnapshotDirectory))
             {
-                CaptureAssemblySourcesAtomically(projectRoot, assemblySnapshotDirectory, sourceFiles);
+                CaptureAssemblySourcesAtomically(
+                    projectRoot,
+                    assemblySnapshotDirectory,
+                    sourceFiles,
+                    assembly.name);
                 DeleteStaleSnapshotDirectories(snapshotRoot, assembly.name, assemblySnapshotDirectory);
             }
 
+            // Write the stamp even when individual sources were skipped: retrying every domain
+            // reload would only repeat IO and warning spam. The partial snapshot remains fail-closed
+            // because PDB checksum validation requires a matching baseline, and a changed DLL
+            // invalidates this stamp through its mtime or length before the next capture.
             WriteStamp(stampPath, mvid, dllMtimeTicks, dllByteLength);
         }
 
@@ -160,10 +189,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return assemblyDefinition.MainModule.Mvid.ToString("N");
         }
 
-        private static void CaptureAssemblySourcesAtomically(
+        internal static void CaptureAssemblySourcesAtomically(
             string projectRoot,
             string assemblySnapshotDirectory,
-            string[] sourceFiles)
+            string[] sourceFiles,
+            string assemblyName)
         {
             // Why temp + Move: Directory.Exists is the "complete" signal. Copying into the final
             // directory first would leave a partial tree on interrupt that later reloads treat as
@@ -176,30 +206,62 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             Directory.CreateDirectory(temporaryDirectory);
+            int skippedSourceCount = 0;
+            string firstSkippedSourcePath = null;
             foreach (string projectRelativeSourcePath in sourceFiles)
             {
-                CopySourceFileByteExact(projectRoot, temporaryDirectory, projectRelativeSourcePath);
+                if (!CopySourceFileByteExact(projectRoot, temporaryDirectory, projectRelativeSourcePath))
+                {
+                    skippedSourceCount++;
+                    firstSkippedSourcePath ??= projectRelativeSourcePath;
+                }
             }
 
             Directory.Move(temporaryDirectory, assemblySnapshotDirectory);
+            if (skippedSourceCount > 0)
+            {
+                UnityEngine.Debug.LogWarning(
+                    $"[UnityCliLoop] Skipped {skippedSourceCount} unreadable source(s) while snapshotting " +
+                    $"{assemblyName}: {firstSkippedSourcePath}");
+            }
         }
 
-        private static void CopySourceFileByteExact(
+        private static bool CopySourceFileByteExact(
             string projectRoot,
             string assemblySnapshotDirectory,
             string projectRelativeSourcePath)
         {
             string normalizedRelativePath = projectRelativeSourcePath.Replace('\\', '/');
             string absoluteSourcePath = Path.Combine(projectRoot, normalizedRelativePath.Replace('/', Path.DirectorySeparatorChar));
-            if (!File.Exists(absoluteSourcePath))
+            string fileSystemSourcePath = HotReloadFileSystemPath.GetFileSystemPath(absoluteSourcePath);
+            if (!File.Exists(fileSystemSourcePath))
             {
-                return;
+                return true;
             }
 
-            string snapshotFileName = HashProjectRelativePath(normalizedRelativePath) + ".cs";
-            string destinationPath = Path.Combine(assemblySnapshotDirectory, snapshotFileName);
-            byte[] bytes = File.ReadAllBytes(absoluteSourcePath);
-            File.WriteAllBytes(destinationPath, bytes);
+            try
+            {
+                string snapshotFileName = HashProjectRelativePath(normalizedRelativePath) + ".cs";
+                string destinationPath = Path.Combine(assemblySnapshotDirectory, snapshotFileName);
+                byte[] bytes = File.ReadAllBytes(fileSystemSourcePath);
+                File.WriteAllBytes(destinationPath, bytes);
+                return true;
+            }
+            catch (Exception ex) when (IsSkippableSourceReadException(ex))
+            {
+                // Approved deviation from the no-try-catch rule: source IO can fail independently
+                // while an assembly is being snapshotted. Skipping preserves the fail-closed
+                // invariant because PDB checksum validation rejects any missing baseline at use time.
+                return false;
+            }
+        }
+
+        private static bool IsSkippableSourceReadException(Exception ex)
+        {
+            Debug.Assert(ex != null, "ex must not be null");
+
+            return ex is IOException ||
+                   ex is UnauthorizedAccessException;
         }
 
         internal static string HashProjectRelativePath(string slashNormalizedProjectRelativePath)
@@ -253,13 +315,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 // Why: the glob is a prefix match, so hyphenated sibling assembly names also match.
-                // Only delete when the suffix after "<assemblyName>-" is exactly an Mvid in "N" format.
+                // Only delete when the suffix after "<assemblyName>-" is exactly an Mvid in "N"
+                // format, optionally followed by the capture-only .tmp suffix.
                 string mvidCandidate = directoryName.Substring(prefix.Length);
+                if (mvidCandidate.EndsWith(
+                        IncompleteSnapshotDirectorySuffix,
+                        StringComparison.Ordinal))
+                {
+                    mvidCandidate = mvidCandidate.Substring(
+                        0,
+                        mvidCandidate.Length - IncompleteSnapshotDirectorySuffix.Length);
+                }
+
                 if (!Guid.TryParseExact(mvidCandidate, "N", out Guid _))
                 {
                     continue;
                 }
 
+                // Capture and cleanup run serially on the main thread, and cleanup starts only
+                // after the current capture's Move succeeds, so no active .tmp can be removed here.
                 Directory.Delete(candidateDirectory, recursive: true);
             }
         }


### PR DESCRIPTION
## Summary
- support Windows extended-length source paths during hot-reload snapshot capture
- isolate unreadable sources and assembly capture failures with aggregated warnings
- prune orphaned temporary snapshot directories
- add EditMode coverage for path mapping, long paths, locked sources, and stale cleanup

## Testing
- Not run (per request).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

