### PR TITLE
fix: skip dispatcher update download when already at the target version

### DIFF
--- a/cli/dispatcher/internal/dispatcher/dispatcher_bootstrap_routing_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_bootstrap_routing_test.go
@@ -82,11 +82,11 @@ func TestRunDispatcherUpdateRunsInDispatcherProcess(t *testing.T) {
 		return nil
 	}
 	dispatcherReadInstalledVersion = func(context.Context) (string, error) {
-		return dispatcherVersion, nil
+		return "999.0.0", nil
 	}
 	resolveUpdateTargetVersionFunc = func(ctx context.Context, options update.Options) (update.Options, error) {
 		if options.TargetVersion == "" {
-			options.TargetVersion = dispatcherVersion
+			options.TargetVersion = "999.0.0"
 		}
 		return options, nil
 	}

--- a/cli/dispatcher/internal/dispatcher/dispatcher_freshness.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_freshness.go
@@ -134,14 +134,18 @@ func executeDispatcherFreshnessPlan(ctx context.Context, plan dispatcherFreshnes
 }
 
 func runDispatcherFreshnessUpdate(ctx context.Context, plan dispatcherFreshnessPlan, stderr io.Writer, deps dispatcherRunDeps) (bool, int) {
-	err := deps.runUpdate(ctx)
+	updated, err := deps.runUpdate(ctx)
 	if err == nil {
 		markDispatcherSelfUpdateCheckedWithDeps(deps)
-		updatedVersion := dispatcherInstalledVersionOrEmpty(ctx)
 		if plan.Action == dispatcherFreshnessRunRequiredUpdate {
+			updatedVersion := dispatcherInstalledVersionOrEmpty(ctx)
 			writeDispatcherSelfUpdateRequiredError(stderr, updatedVersion)
 			return true, 1
 		}
+		if !updated {
+			return false, 0
+		}
+		updatedVersion := dispatcherInstalledVersionOrEmpty(ctx)
 		writeOptionalDispatcherUpdateCompletion(stderr, dispatcherVersion, updatedVersion)
 		return false, 0
 	}
@@ -237,16 +241,23 @@ func markDispatcherSelfUpdateCheckedWithDeps(deps dispatcherRunDeps) {
 	_ = os.WriteFile(filepath.Join(cacheRoot, dispatcherUpdateStateFileName), content, 0o644)
 }
 
-func runDispatcherUpdateCommand(ctx context.Context) error {
+func runDispatcherUpdateCommand(ctx context.Context) (bool, error) {
 	resolved, err := resolveUpdateTargetVersionFunc(ctx, sharedupdate.Options{
 		CurrentVersion: dispatcherVersion,
 	})
 	if err != nil {
-		return err
+		return false, err
+	}
+	_, _, targetChanged := normalizedDispatcherUpdateVersions(dispatcherVersion, resolved.TargetVersion)
+	if !targetChanged {
+		return false, nil
 	}
 	command, err := sharedupdate.CommandForOS(runtime.GOOS, resolved)
 	if err != nil {
-		return err
+		return false, err
 	}
-	return runUpdateCommand(ctx, command, io.Discard, io.Discard)
+	if err := updateRunCommand(ctx, command, io.Discard, io.Discard); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/cli/dispatcher/internal/dispatcher/dispatcher_freshness.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_freshness.go
@@ -242,6 +242,10 @@ func markDispatcherSelfUpdateCheckedWithDeps(deps dispatcherRunDeps) {
 }
 
 func runDispatcherUpdateCommand(ctx context.Context) (bool, error) {
+	return runDispatcherUpdateCommandForOS(ctx, runtime.GOOS)
+}
+
+func runDispatcherUpdateCommandForOS(ctx context.Context, goos string) (bool, error) {
 	resolved, err := resolveUpdateTargetVersionFunc(ctx, sharedupdate.Options{
 		CurrentVersion: dispatcherVersion,
 	})
@@ -252,7 +256,7 @@ func runDispatcherUpdateCommand(ctx context.Context) (bool, error) {
 	if !targetChanged {
 		return false, nil
 	}
-	command, err := sharedupdate.CommandForOS(runtime.GOOS, resolved)
+	command, err := sharedupdate.CommandForOS(goos, resolved)
 	if err != nil {
 		return false, err
 	}

--- a/cli/dispatcher/internal/dispatcher/dispatcher_freshness.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_freshness.go
@@ -252,7 +252,10 @@ func runDispatcherUpdateCommandForOS(ctx context.Context, goos string) (bool, er
 	if err != nil {
 		return false, err
 	}
-	_, _, targetChanged := normalizedDispatcherUpdateVersions(dispatcherVersion, resolved.TargetVersion)
+	_, targetVersion, targetChanged := normalizedDispatcherUpdateVersions(dispatcherVersion, resolved.TargetVersion)
+	if err := validateDispatcherProjectRunnerVersion(targetVersion); err != nil {
+		return false, err
+	}
 	if !targetChanged {
 		return false, nil
 	}

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -657,6 +657,9 @@ func TestEnforceDispatcherFreshnessRunsInstallerWhenOptionalTargetIsNewer(t *tes
 		return "/tmp/uloop", nil
 	}
 	deps := defaultDispatcherRunDeps()
+	deps.runUpdate = func(ctx context.Context) (bool, error) {
+		return runDispatcherUpdateCommandForOS(ctx, "darwin")
+	}
 
 	var stderr bytes.Buffer
 	handled, code := enforceDispatcherFreshnessWithDeps(

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -676,6 +676,74 @@ func TestEnforceDispatcherFreshnessRunsInstallerWhenOptionalTargetIsNewer(t *tes
 	}
 }
 
+func TestRunDispatcherUpdateCommandRejectsInvalidResolvedTarget(t *testing.T) {
+	// Verifies freshness updates fail fast before installer execution when resolution returns an invalid version.
+	tests := []struct {
+		name          string
+		targetVersion string
+	}{
+		{name: "empty target"},
+		{name: "invalid semantic version", targetVersion: "not-a-version"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previousRunner := updateRunCommand
+			previousResolver := resolveUpdateTargetVersionFunc
+			defer func() {
+				updateRunCommand = previousRunner
+				resolveUpdateTargetVersionFunc = previousResolver
+			}()
+			updateRunCommand = func(context.Context, update.Command, io.Writer, io.Writer) error {
+				t.Fatal("updateRunCommand must not run for an invalid resolved target")
+				return nil
+			}
+			resolveUpdateTargetVersionFunc = func(_ context.Context, options update.Options) (update.Options, error) {
+				options.TargetVersion = tt.targetVersion
+				return options, nil
+			}
+
+			updated, err := runDispatcherUpdateCommandForOS(context.Background(), "darwin")
+
+			if err == nil || !strings.Contains(err.Error(), "expected semantic version") {
+				t.Fatalf("expected invalid resolved target error, got: %v", err)
+			}
+			if updated {
+				t.Fatal("invalid resolved target must not report installer execution")
+			}
+		})
+	}
+}
+
+func TestRequiredDispatcherFreshnessStillRequiresRetryWhenUpdateWasSkipped(t *testing.T) {
+	// Verifies required freshness keeps its retry contract even if the update dependency reports no installation.
+	previousReader := dispatcherReadInstalledVersion
+	defer func() {
+		dispatcherReadInstalledVersion = previousReader
+	}()
+	dispatcherReadInstalledVersion = func(context.Context) (string, error) {
+		return dispatcherVersion, nil
+	}
+	deps := defaultDispatcherRunDeps()
+	deps.runUpdate = func(context.Context) (bool, error) {
+		return false, nil
+	}
+
+	var stderr bytes.Buffer
+	handled, code := runDispatcherFreshnessUpdate(
+		context.Background(),
+		dispatcherFreshnessPlan{Action: dispatcherFreshnessRunRequiredUpdate, MinimumVersion: "999.0.0"},
+		&stderr,
+		deps)
+
+	if !handled || code != 1 {
+		t.Fatalf("required freshness result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Retry the same uloop command.") {
+		t.Fatalf("required freshness retry guidance missing: %s", stderr.String())
+	}
+}
+
 func TestEnforceDispatcherFreshnessReportsRequiredUpdateVersionChange(t *testing.T) {
 	// Verifies required dispatcher self-updates include the version change before asking for a retry.
 	t.Setenv(nativepath.CacheDirEnvName, t.TempDir())

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hatayama/unity-cli-loop/common/clicontract"
 	"github.com/hatayama/unity-cli-loop/common/clicore"
 	"github.com/hatayama/unity-cli-loop/dispatcher/internal/nativepath"
+	"github.com/hatayama/unity-cli-loop/dispatcher/internal/update"
 )
 
 type dispatcherArchiveTestEntry struct {
@@ -430,9 +431,9 @@ func TestEnforceDispatcherFreshnessRequiresBrewUpgradeWhenHomebrewManagedAndUpda
 		return "/opt/homebrew/Cellar/uloop/3.0.0/bin/uloop", nil
 	}
 	deps := defaultDispatcherRunDeps()
-	deps.runUpdate = func(context.Context) error {
+	deps.runUpdate = func(context.Context) (bool, error) {
 		t.Fatal("runUpdate must not run for Homebrew-managed required freshness")
-		return nil
+		return false, nil
 	}
 
 	var stderr bytes.Buffer
@@ -465,9 +466,9 @@ func TestEnforceDispatcherFreshnessSkipsOptionalUpdateWhenHomebrewManaged(t *tes
 		return "/opt/homebrew/Cellar/uloop/3.0.0/bin/uloop", nil
 	}
 	deps := defaultDispatcherRunDeps()
-	deps.runUpdate = func(context.Context) error {
+	deps.runUpdate = func(context.Context) (bool, error) {
 		t.Fatal("runUpdate must not run for Homebrew-managed optional freshness")
-		return nil
+		return false, nil
 	}
 
 	var stderr bytes.Buffer
@@ -492,9 +493,9 @@ func TestEnforceDispatcherFreshnessMarksFailedOptionalUpdateChecked(t *testing.T
 
 	deps := defaultDispatcherRunDeps()
 	runnerCalls := 0
-	deps.runUpdate = func(context.Context) error {
+	deps.runUpdate = func(context.Context) (bool, error) {
 		runnerCalls++
-		return errors.New("network unavailable")
+		return false, errors.New("network unavailable")
 	}
 
 	var stderr bytes.Buffer
@@ -573,6 +574,102 @@ func TestEnforceDispatcherFreshnessSkipsOptionalUpdateMessageWhenVersionDidNotCh
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("expected no optional update output, got: %s", stderr.String())
+	}
+}
+
+func TestEnforceDispatcherFreshnessSkipsInstallerWhenOptionalTargetIsCurrent(t *testing.T) {
+	// Verifies an optional current target skips the installer, records the check, and continues silently.
+	cacheRoot := t.TempDir()
+	t.Setenv(nativepath.CacheDirEnvName, cacheRoot)
+	previousRunner := updateRunCommand
+	previousResolver := resolveUpdateTargetVersionFunc
+	previousExecutablePath := resolveUpdateExecutablePathFunc
+	defer func() {
+		updateRunCommand = previousRunner
+		resolveUpdateTargetVersionFunc = previousResolver
+		resolveUpdateExecutablePathFunc = previousExecutablePath
+	}()
+	updateRunCommand = func(context.Context, update.Command, io.Writer, io.Writer) error {
+		t.Fatal("updateRunCommand must not run when the optional target is current")
+		return nil
+	}
+	resolveUpdateTargetVersionFunc = func(_ context.Context, options update.Options) (update.Options, error) {
+		options.TargetVersion = "v" + dispatcherVersion
+		return options, nil
+	}
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return "/tmp/uloop", nil
+	}
+	deps := defaultDispatcherRunDeps()
+	checkedAt := time.Date(2026, time.August, 27, 12, 0, 0, 0, time.UTC)
+	deps.now = func() time.Time {
+		return checkedAt
+	}
+
+	var stderr bytes.Buffer
+	handled, code := enforceDispatcherFreshnessWithDeps(
+		context.Background(),
+		dispatcherPin{MinimumDispatcherVersion: dispatcherVersion},
+		&stderr,
+		deps)
+
+	if handled || code != 0 {
+		t.Fatalf("freshness result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no optional update output, got: %s", stderr.String())
+	}
+	statePath := filepath.Join(cacheRoot, dispatcherUpdateStateFileName)
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("expected update state after current optional target: %v", err)
+	}
+	if dispatcherSelfUpdateDueWithDeps(deps) {
+		t.Fatal("expected the current optional target check to reset the update interval")
+	}
+}
+
+func TestEnforceDispatcherFreshnessRunsInstallerWhenOptionalTargetIsNewer(t *testing.T) {
+	// Verifies an optional newer target still runs the installer and continues successfully.
+	t.Setenv(nativepath.CacheDirEnvName, t.TempDir())
+	previousRunner := updateRunCommand
+	previousReader := dispatcherReadInstalledVersion
+	previousResolver := resolveUpdateTargetVersionFunc
+	previousExecutablePath := resolveUpdateExecutablePathFunc
+	defer func() {
+		updateRunCommand = previousRunner
+		dispatcherReadInstalledVersion = previousReader
+		resolveUpdateTargetVersionFunc = previousResolver
+		resolveUpdateExecutablePathFunc = previousExecutablePath
+	}()
+	installerRan := false
+	updateRunCommand = func(context.Context, update.Command, io.Writer, io.Writer) error {
+		installerRan = true
+		return nil
+	}
+	dispatcherReadInstalledVersion = func(context.Context) (string, error) {
+		return "999.0.0", nil
+	}
+	resolveUpdateTargetVersionFunc = func(_ context.Context, options update.Options) (update.Options, error) {
+		options.TargetVersion = "999.0.0"
+		return options, nil
+	}
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return "/tmp/uloop", nil
+	}
+	deps := defaultDispatcherRunDeps()
+
+	var stderr bytes.Buffer
+	handled, code := enforceDispatcherFreshnessWithDeps(
+		context.Background(),
+		dispatcherPin{MinimumDispatcherVersion: dispatcherVersion},
+		&stderr,
+		deps)
+
+	if handled || code != 0 {
+		t.Fatalf("freshness result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
+	}
+	if !installerRan {
+		t.Fatal("expected updateRunCommand to run for a newer optional target")
 	}
 }
 
@@ -703,8 +800,8 @@ func stubDispatcherUpdateHooks(t *testing.T, updatedVersion string) (dispatcherR
 	previousReader := dispatcherReadInstalledVersion
 	previousExecutablePath := resolveUpdateExecutablePathFunc
 	deps := defaultDispatcherRunDeps()
-	deps.runUpdate = func(context.Context) error {
-		return nil
+	deps.runUpdate = func(context.Context) (bool, error) {
+		return true, nil
 	}
 	dispatcherReadInstalledVersion = func(context.Context) (string, error) {
 		return updatedVersion, nil

--- a/cli/dispatcher/internal/dispatcher/run_dispatcher.go
+++ b/cli/dispatcher/internal/dispatcher/run_dispatcher.go
@@ -37,7 +37,7 @@ type dispatcherRunDeps struct {
 	now        func() time.Time
 	runRealCLI func(context.Context, string, []string, io.Writer, io.Writer) int
 	runV2CLI   func(context.Context, string, []string, io.Writer, io.Writer) (int, error)
-	runUpdate  func(context.Context) error
+	runUpdate  func(context.Context) (bool, error)
 	launch     launchDeps
 }
 

--- a/cli/dispatcher/internal/dispatcher/update.go
+++ b/cli/dispatcher/internal/dispatcher/update.go
@@ -63,6 +63,11 @@ func tryHandleUpdateRequest(ctx context.Context, args []string, stdout io.Writer
 		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{Command: clicore.UpdateCommandName})
 		return true, 1
 	}
+	_, targetVersion, targetChanged := normalizedDispatcherUpdateVersions(dispatcherVersion, resolvedOptions.TargetVersion)
+	if !targetChanged {
+		clicore.WriteLine(stdout, "uloop dispatcher is already up to date ("+targetVersion+").")
+		return true, 0
+	}
 	updateCommand, err := update.CommandForOS(runtime.GOOS, resolvedOptions)
 	if err != nil {
 		clierrors.WriteClassifiedError(stderr, wrapUnsupportedPlatformError(err), clierrors.ErrorContext{Command: clicore.UpdateCommandName})

--- a/cli/dispatcher/internal/dispatcher/update.go
+++ b/cli/dispatcher/internal/dispatcher/update.go
@@ -64,6 +64,10 @@ func tryHandleUpdateRequest(ctx context.Context, args []string, stdout io.Writer
 		return true, 1
 	}
 	_, targetVersion, targetChanged := normalizedDispatcherUpdateVersions(dispatcherVersion, resolvedOptions.TargetVersion)
+	if err := validateDispatcherProjectRunnerVersion(targetVersion); err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{Command: clicore.UpdateCommandName})
+		return true, 1
+	}
 	if !targetChanged {
 		clicore.WriteLine(stdout, "uloop dispatcher is already up to date ("+targetVersion+").")
 		return true, 0

--- a/cli/dispatcher/internal/dispatcher/update_test.go
+++ b/cli/dispatcher/internal/dispatcher/update_test.go
@@ -368,6 +368,122 @@ func TestTryHandleUpdateRequestReportsAlreadyCurrentVersion(t *testing.T) {
 	}
 }
 
+func TestTryHandleUpdateRequestSkipsInstallerWhenResolvedTargetIsCurrent(t *testing.T) {
+	// Verifies a resolved target matching the current dispatcher exits successfully without running the installer.
+	skipWhenNativeUpdateIsUnsupported(t)
+	previousRunner := updateRunCommand
+	previousResolver := resolveUpdateTargetVersionFunc
+	previousExecutablePath := resolveUpdateExecutablePathFunc
+	defer func() {
+		updateRunCommand = previousRunner
+		resolveUpdateTargetVersionFunc = previousResolver
+		resolveUpdateExecutablePathFunc = previousExecutablePath
+	}()
+	updateRunCommand = func(context.Context, update.Command, io.Writer, io.Writer) error {
+		t.Fatal("updateRunCommand must not run when the resolved target is current")
+		return nil
+	}
+	resolveUpdateTargetVersionFunc = func(_ context.Context, options update.Options) (update.Options, error) {
+		options.TargetVersion = "v" + dispatcherVersion
+		return options, nil
+	}
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return "/tmp/uloop", nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	handled, code := tryHandleUpdateRequest(context.Background(), []string{clicore.UpdateCommandName}, &stdout, &stderr)
+
+	if !handled || code != 0 {
+		t.Fatalf("update result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
+	}
+	expected := "uloop dispatcher is already up to date (" + dispatcherVersion + ")."
+	if !strings.Contains(stdout.String(), expected) {
+		t.Fatalf("update output mismatch: %s", stdout.String())
+	}
+}
+
+func TestTryHandleUpdateRequestSkipsInstallerWhenRequestedTargetIsCurrent(t *testing.T) {
+	// Verifies an explicit current --to-version target exits successfully without running the installer.
+	skipWhenNativeUpdateIsUnsupported(t)
+	previousRunner := updateRunCommand
+	previousResolver := resolveUpdateTargetVersionFunc
+	previousExecutablePath := resolveUpdateExecutablePathFunc
+	defer func() {
+		updateRunCommand = previousRunner
+		resolveUpdateTargetVersionFunc = previousResolver
+		resolveUpdateExecutablePathFunc = previousExecutablePath
+	}()
+	updateRunCommand = func(context.Context, update.Command, io.Writer, io.Writer) error {
+		t.Fatal("updateRunCommand must not run when --to-version selects the current dispatcher")
+		return nil
+	}
+	resolveUpdateTargetVersionFunc = func(_ context.Context, options update.Options) (update.Options, error) {
+		return options, nil
+	}
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return "/tmp/uloop", nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	handled, code := tryHandleUpdateRequest(
+		context.Background(),
+		[]string{clicore.UpdateCommandName, "--to-version", dispatcherVersion},
+		&stdout,
+		&stderr)
+
+	if !handled || code != 0 {
+		t.Fatalf("update result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
+	}
+	expected := "uloop dispatcher is already up to date (" + dispatcherVersion + ")."
+	if !strings.Contains(stdout.String(), expected) {
+		t.Fatalf("update output mismatch: %s", stdout.String())
+	}
+}
+
+func TestTryHandleUpdateRequestRunsInstallerWhenResolvedTargetIsNewer(t *testing.T) {
+	// Verifies a resolved target newer than the current dispatcher still runs the installer.
+	skipWhenNativeUpdateIsUnsupported(t)
+	previousRunner := updateRunCommand
+	previousReader := dispatcherReadInstalledVersion
+	previousResolver := resolveUpdateTargetVersionFunc
+	previousExecutablePath := resolveUpdateExecutablePathFunc
+	defer func() {
+		updateRunCommand = previousRunner
+		dispatcherReadInstalledVersion = previousReader
+		resolveUpdateTargetVersionFunc = previousResolver
+		resolveUpdateExecutablePathFunc = previousExecutablePath
+	}()
+	installerRan := false
+	updateRunCommand = func(context.Context, update.Command, io.Writer, io.Writer) error {
+		installerRan = true
+		return nil
+	}
+	dispatcherReadInstalledVersion = func(context.Context) (string, error) {
+		return "999.0.0", nil
+	}
+	resolveUpdateTargetVersionFunc = func(_ context.Context, options update.Options) (update.Options, error) {
+		options.TargetVersion = "999.0.0"
+		return options, nil
+	}
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return "/tmp/uloop", nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	handled, code := tryHandleUpdateRequest(context.Background(), []string{clicore.UpdateCommandName}, &stdout, &stderr)
+
+	if !handled || code != 0 {
+		t.Fatalf("update result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
+	}
+	if !installerRan {
+		t.Fatal("expected updateRunCommand to run for a newer target")
+	}
+}
+
 func TestUpdateRefusesHomebrewManagedExecutable(t *testing.T) {
 	// Verifies Homebrew-managed installs refuse self-update and point users at brew upgrade.
 	previousResolver := resolveUpdateExecutablePathFunc

--- a/cli/dispatcher/internal/dispatcher/update_test.go
+++ b/cli/dispatcher/internal/dispatcher/update_test.go
@@ -482,6 +482,43 @@ func TestTryHandleUpdateRequestRunsInstallerWhenResolvedTargetIsNewer(t *testing
 	}
 }
 
+func TestTryHandleUpdateRequestRejectsEmptyResolvedTarget(t *testing.T) {
+	// Verifies an empty resolved target fails instead of reporting a false already-current success.
+	previousRunner := updateRunCommand
+	previousResolver := resolveUpdateTargetVersionFunc
+	previousExecutablePath := resolveUpdateExecutablePathFunc
+	defer func() {
+		updateRunCommand = previousRunner
+		resolveUpdateTargetVersionFunc = previousResolver
+		resolveUpdateExecutablePathFunc = previousExecutablePath
+	}()
+	updateRunCommand = func(context.Context, update.Command, io.Writer, io.Writer) error {
+		t.Fatal("updateRunCommand must not run for an empty resolved target")
+		return nil
+	}
+	resolveUpdateTargetVersionFunc = func(_ context.Context, options update.Options) (update.Options, error) {
+		options.TargetVersion = ""
+		return options, nil
+	}
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return "/tmp/uloop", nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	handled, code := tryHandleUpdateRequest(context.Background(), []string{clicore.UpdateCommandName}, &stdout, &stderr)
+
+	if !handled || code != 1 {
+		t.Fatalf("update result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "expected semantic version") {
+		t.Fatalf("expected invalid resolved target error, got: %s", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "already up to date") {
+		t.Fatalf("empty resolved target must not report success: %s", stdout.String())
+	}
+}
+
 func TestUpdateRefusesHomebrewManagedExecutable(t *testing.T) {
 	// Verifies Homebrew-managed installs refuse self-update and point users at brew upgrade.
 	previousResolver := resolveUpdateExecutablePathFunc

--- a/cli/dispatcher/internal/dispatcher/update_test.go
+++ b/cli/dispatcher/internal/dispatcher/update_test.go
@@ -511,6 +511,47 @@ func TestUpdateRefusesHomebrewManagedExecutable(t *testing.T) {
 	}
 }
 
+func TestUpdateRefusesCurrentTargetForHomebrewManagedExecutable(t *testing.T) {
+	// Verifies the Homebrew guard keeps brew guidance ahead of current-target resolution.
+	previousExecutablePath := resolveUpdateExecutablePathFunc
+	previousResolver := resolveUpdateTargetVersionFunc
+	previousRunner := updateRunCommand
+	defer func() {
+		resolveUpdateExecutablePathFunc = previousExecutablePath
+		resolveUpdateTargetVersionFunc = previousResolver
+		updateRunCommand = previousRunner
+	}()
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return "/opt/homebrew/Cellar/uloop/3.0.0/bin/uloop", nil
+	}
+	resolveUpdateTargetVersionFunc = func(context.Context, update.Options) (update.Options, error) {
+		t.Fatal("target resolution must not run before the Homebrew guard")
+		return update.Options{}, nil
+	}
+	updateRunCommand = func(context.Context, update.Command, io.Writer, io.Writer) error {
+		t.Fatal("updateRunCommand must not run for a Homebrew-managed current target")
+		return nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	handled, code := tryHandleUpdateRequest(
+		context.Background(),
+		[]string{clicore.UpdateCommandName, "--to-version", dispatcherVersion},
+		&stdout,
+		&stderr)
+
+	if !handled || code != 1 {
+		t.Fatalf("update result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "brew upgrade uloop") {
+		t.Fatalf("expected brew upgrade guidance in stderr, got: %s", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout output, got: %s", stdout.String())
+	}
+}
+
 func TestUpdateFailsWhenExecutablePathResolutionFails(t *testing.T) {
 	// Verifies update aborts when the dispatcher executable path cannot be resolved.
 	previousResolver := resolveUpdateExecutablePathFunc

--- a/cli/dispatcher/internal/dispatcher/update_test.go
+++ b/cli/dispatcher/internal/dispatcher/update_test.go
@@ -370,7 +370,6 @@ func TestTryHandleUpdateRequestReportsAlreadyCurrentVersion(t *testing.T) {
 
 func TestTryHandleUpdateRequestSkipsInstallerWhenResolvedTargetIsCurrent(t *testing.T) {
 	// Verifies a resolved target matching the current dispatcher exits successfully without running the installer.
-	skipWhenNativeUpdateIsUnsupported(t)
 	previousRunner := updateRunCommand
 	previousResolver := resolveUpdateTargetVersionFunc
 	previousExecutablePath := resolveUpdateExecutablePathFunc
@@ -406,7 +405,6 @@ func TestTryHandleUpdateRequestSkipsInstallerWhenResolvedTargetIsCurrent(t *test
 
 func TestTryHandleUpdateRequestSkipsInstallerWhenRequestedTargetIsCurrent(t *testing.T) {
 	// Verifies an explicit current --to-version target exits successfully without running the installer.
-	skipWhenNativeUpdateIsUnsupported(t)
 	previousRunner := updateRunCommand
 	previousResolver := resolveUpdateTargetVersionFunc
 	previousExecutablePath := resolveUpdateExecutablePathFunc


### PR DESCRIPTION
## Summary
- Skip dispatcher installation when the resolved update target already matches the running dispatcher version.
- Avoid redundant installer, checksum, attestation, archive download, extraction, and overwrite work for both explicit and optional updates.

## User Impact
- Previously, `uloop update` and the 24-hour optional freshness check performed the full installation flow even when the dispatcher was already current.
- Current targets now return immediately. Explicit updates print an already-up-to-date message, while optional checks remain silent and reset the 24-hour check interval.
- Required updates keep their existing execution and retry behavior.

## Changes
- Compare normalized current and resolved target versions before constructing or running the installer command.
- Reject empty or invalid resolved target versions before treating an update as already current.
- Return whether the optional freshness update actually ran so a skipped update can continue silently after recording `LastChecked`.
- Add coverage for implicit and explicit current targets, newer targets, optional freshness state updates, and unchanged required-update behavior.

## Verification
- `go test ./internal/dispatcher -count=1`
- `scripts/check-go-cli.sh`
- `dist/darwin-arm64/uloop update`
  - Output: `uloop dispatcher is already up to date (3.0.0-beta.34).`
  - No download progress was emitted and the command exited successfully.
