### PR TITLE
chore: complete stub .cs.meta files with Unity-generated importer settings

### DIFF
--- a/Assets/Tests/Editor/HotReload/PublicizerTestSearchDirectories.cs.meta
+++ b/Assets/Tests/Editor/HotReload/PublicizerTestSearchDirectories.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 8fd745ff1a126407bbb939b686472dc3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/PlayModeStartDomainReloadDropWarningBuilderTests.cs.meta
+++ b/Assets/Tests/Editor/PlayModeStartDomainReloadDropWarningBuilderTests.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: a236192f056f24326b8655771e42c776
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeDomainReloadDropStateService.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeDomainReloadDropStateService.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: c3fc15b6008734865803768f542c8af7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/PlayModeStartDomainReloadDropWarningBuilder.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/PlayModeStartDomainReloadDropWarningBuilder.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: a58118277c36a487aa9f5a9d350a599a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

Four `.cs.meta` files were committed as guid-only stubs without a trailing newline. Unity's asset importer regenerates them with the full `MonoImporter` block on every import, which leaves the working tree permanently dirty for anyone with these files checked out. This PR commits the Unity-regenerated form so the working tree stays clean going forward.

## Changes

- `Assets/Tests/Editor/HotReload/PublicizerTestSearchDirectories.cs.meta`
- `Assets/Tests/Editor/PlayModeStartDomainReloadDropWarningBuilderTests.cs.meta`
- `Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeDomainReloadDropStateService.cs.meta`
- `Packages/src/Editor/FirstPartyTools/ControlPlayMode/PlayModeStartDomainReloadDropWarningBuilder.cs.meta`

Each file gains the standard `MonoImporter` block (`externalObjects`, `serializedVersion`, `defaultReferences`, `executionOrder`, `icon`, `userData`, `assetBundleName`, `assetBundleVariant`). GUIDs are unchanged for all four files.

## Verification

- `git diff --cached` before committing confirmed the diff touches only these four files, and that each file's `-guid:` and `+guid:` lines carry the same value.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

