### PR TITLE
feat: add set-code-optimization command and recommend permanent Debug for pause-point

### DIFF
--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -5,11 +5,9 @@ description: "Pauses Unity playback at any source file:line without editing code
 
 # uloop await-pause-point
 
-A pause point is the standard frame proof for verifying simulated input, physics, or UI transitions; sleeps and after-the-fact reads are not substitutes. Skip it only for persistent-state checks that do not validate input delivery, event ordering, or transition-frame fidelity. It is patched into the already-compiled code — no source edit — and captures locals and branch reasons `execute-dynamic-code` cannot reach.
+A pause point captures locals and branch reasons at an exact frame without a source edit. Use it instead of sleeps or after-the-fact reads when input delivery, event ordering, or transition-frame fidelity matters.
 
 ## Quick Check
-
-The standard loop for one representative frame:
 
 1. Enter PlayMode. If the game progresses on its own, pause it with `control-play-mode --action Pause`, arrange the scenario while paused, and add `--resume-play` in step 2.
 2. Arm the marker, fire the input, and wait for the hit in one foreground command:
@@ -85,11 +83,15 @@ Clear one or all registered C# watch expressions
 
 `uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` takes the same two forms but always requires a target.
 
-On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint` first, then follow `RecommendedNextAction`; `MethodEntryCount` interpretation is in `references/troubleshooting.md`. After a hot reload of the target file, pass `--method <Type.Method>` so `--line` stays inside the intended method.
+On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `RecommendedNextAction`; see `references/troubleshooting.md` for diagnosis. After hot reload, use `--method <Type.Method>` to constrain `--line`.
 
 ## Requirements & Safety
 
-- Release Code Optimization is switched to Debug (with a recompile) before arming; the switch reverts on the next Editor restart.
+- When an enable response carries the automatic Debug-switch warning, tell the user that the Debug setting reverts on every Editor restart and each re-switch costs a full script recompile, and propose making Debug the startup default. Run `uloop set-code-optimization debug --startup` only after the user approves - it changes a machine-wide preference that affects every Unity project on this machine. Reassure the user that only the project's C# script execution slows down (mainly during Play Mode); the Unity Editor itself is not slowed.
+
+`uloop set-code-optimization debug` switches only the current session (it reverts on restart);
+with `--startup` it also makes Debug the machine-wide startup default.
+
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.
 - An `--id` marker waits on a hand-written `UloopPausePoint.Pause(id)` call; its hits record no `CapturedVariables`.
@@ -100,11 +102,11 @@ On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint` first, the
 
 All live in `references/` beside this skill; read the one whose trigger matches:
 
-- `references/quick-check-template.md` — full loop: `--trigger`/`--await`/`--resume-play`, split steps, timeouts, hit fields.
-- `references/captured-variables.md` — `CapturedVariables`, previews/truncation, name filters, `--expect` value forms, caller frames, raw capture API.
-- `references/capture-modes-and-history.md` — mode details, history, `--max-history`, `--hit-when`.
-- `references/line-placement.md` — choosing the line to arm, every-frame lines, held input, input+N frames.
-- `references/watch-expressions.md` — watch evaluation rules.
-- `references/condition-triggered-pause.md` — pausing on a runtime condition (id-only marker + watcher).
-- `references/fast-progressing-games.md` — freezing self-progressing games, `--resume-play`, `ResumePlayResult`.
-- `references/troubleshooting.md` — timeouts, `HitCount` 0, physics misses, hot-reload line resolution, failure codes.
+- `references/quick-check-template.md` — complete trigger/await loop and response fields.
+- `references/captured-variables.md` — captures, filters, expectations, caller frames, raw values.
+- `references/capture-modes-and-history.md` — modes, history, and hit conditions.
+- `references/line-placement.md` — choosing reliable lines.
+- `references/watch-expressions.md` — watch rules.
+- `references/condition-triggered-pause.md` — runtime-condition pauses.
+- `references/fast-progressing-games.md` — paused setup and resume.
+- `references/troubleshooting.md` — timeouts, missed hits, hot reload, failure codes.

--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -87,10 +87,7 @@ On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `Rec
 
 ## Requirements & Safety
 
-- When an enable response carries the automatic Debug-switch warning, tell the user that the Debug setting reverts on every Editor restart and each re-switch costs a full script recompile, and propose making Debug the startup default. Run `uloop set-code-optimization debug --startup` only after the user approves - it changes a machine-wide preference that affects every Unity project on this machine. Reassure the user that only the project's C# script execution slows down (mainly during Play Mode); the Unity Editor itself is not slowed.
-
-`uloop set-code-optimization debug` switches only the current session (it reverts on restart);
-with `--startup` it also makes Debug the machine-wide startup default.
+- On the automatic Debug-switch warning: the setting reverts on every Editor restart and each re-switch costs a full script recompile. Propose making Debug the startup default; only after the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It changes a machine-wide preference affecting every Unity project on this machine; only the project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed.
 
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.
@@ -102,11 +99,11 @@ with `--startup` it also makes Debug the machine-wide startup default.
 
 All live in `references/` beside this skill; read the one whose trigger matches:
 
-- `references/quick-check-template.md` — complete trigger/await loop and response fields.
-- `references/captured-variables.md` — captures, filters, expectations, caller frames, raw values.
-- `references/capture-modes-and-history.md` — modes, history, and hit conditions.
-- `references/line-placement.md` — choosing reliable lines.
+- `references/quick-check-template.md` — full `--trigger`/`--await`/`--resume-play` loop, timeouts, hit fields.
+- `references/captured-variables.md` — captures, name filters, `--expect` value forms, caller frames, raw values.
+- `references/capture-modes-and-history.md` — modes, history, `--max-history`, `--hit-when`.
+- `references/line-placement.md` — choosing the line: every-frame lines, held input, input+N frames.
 - `references/watch-expressions.md` — watch rules.
 - `references/condition-triggered-pause.md` — runtime-condition pauses.
-- `references/fast-progressing-games.md` — paused setup and resume.
+- `references/fast-progressing-games.md` — freezing self-progressing games, `--resume-play`.
 - `references/troubleshooting.md` — timeouts, missed hits, hot reload, failure codes.

--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -87,7 +87,7 @@ On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `Rec
 
 ## Requirements & Safety
 
-- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask the user mid-flow. The setting reverts on every Editor restart and each re-switch costs a full script recompile, so after finishing the task, propose making Debug the startup default; only if the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It changes a machine-wide preference affecting every Unity project on this machine; only the project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed.
+- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask the user mid-flow. The setting reverts on every Editor restart and each re-switch costs a full script recompile, so at the next natural stopping point, propose making Debug the startup default; only if the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It changes a machine-wide preference affecting every Unity project on this machine; only the project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed.
 
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.

--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -87,7 +87,7 @@ On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `Rec
 
 ## Requirements & Safety
 
-- On the automatic Debug-switch warning: the setting reverts on every Editor restart and each re-switch costs a full script recompile. Propose making Debug the startup default; only after the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It changes a machine-wide preference affecting every Unity project on this machine; only the project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed.
+- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask the user mid-flow. The setting reverts on every Editor restart and each re-switch costs a full script recompile, so after finishing the task, propose making Debug the startup default; only if the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It changes a machine-wide preference affecting every Unity project on this machine; only the project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed.
 
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -5,11 +5,9 @@ description: "Pauses Unity playback at any source file:line without editing code
 
 # uloop await-pause-point
 
-A pause point is the standard frame proof for verifying simulated input, physics, or UI transitions; sleeps and after-the-fact reads are not substitutes. Skip it only for persistent-state checks that do not validate input delivery, event ordering, or transition-frame fidelity. It is patched into the already-compiled code — no source edit — and captures locals and branch reasons `execute-dynamic-code` cannot reach.
+A pause point captures locals and branch reasons at an exact frame without a source edit. Use it instead of sleeps or after-the-fact reads when input delivery, event ordering, or transition-frame fidelity matters.
 
 ## Quick Check
-
-The standard loop for one representative frame:
 
 1. Enter PlayMode. If the game progresses on its own, pause it with `control-play-mode --action Pause`, arrange the scenario while paused, and add `--resume-play` in step 2.
 2. Arm the marker, fire the input, and wait for the hit in one foreground command:
@@ -85,11 +83,15 @@ Clear one or all registered C# watch expressions
 
 `uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` takes the same two forms but always requires a target.
 
-On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint` first, then follow `RecommendedNextAction`; `MethodEntryCount` interpretation is in `references/troubleshooting.md`. After a hot reload of the target file, pass `--method <Type.Method>` so `--line` stays inside the intended method.
+On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `RecommendedNextAction`; see `references/troubleshooting.md` for diagnosis. After hot reload, use `--method <Type.Method>` to constrain `--line`.
 
 ## Requirements & Safety
 
-- Release Code Optimization is switched to Debug (with a recompile) before arming; the switch reverts on the next Editor restart.
+- When an enable response carries the automatic Debug-switch warning, tell the user that the Debug setting reverts on every Editor restart and each re-switch costs a full script recompile, and propose making Debug the startup default. Run `uloop set-code-optimization debug --startup` only after the user approves - it changes a machine-wide preference that affects every Unity project on this machine. Reassure the user that only the project's C# script execution slows down (mainly during Play Mode); the Unity Editor itself is not slowed.
+
+`uloop set-code-optimization debug` switches only the current session (it reverts on restart);
+with `--startup` it also makes Debug the machine-wide startup default.
+
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.
 - An `--id` marker waits on a hand-written `UloopPausePoint.Pause(id)` call; its hits record no `CapturedVariables`.
@@ -100,11 +102,11 @@ On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint` first, the
 
 All live in `references/` beside this skill; read the one whose trigger matches:
 
-- `references/quick-check-template.md` — full loop: `--trigger`/`--await`/`--resume-play`, split steps, timeouts, hit fields.
-- `references/captured-variables.md` — `CapturedVariables`, previews/truncation, name filters, `--expect` value forms, caller frames, raw capture API.
-- `references/capture-modes-and-history.md` — mode details, history, `--max-history`, `--hit-when`.
-- `references/line-placement.md` — choosing the line to arm, every-frame lines, held input, input+N frames.
-- `references/watch-expressions.md` — watch evaluation rules.
-- `references/condition-triggered-pause.md` — pausing on a runtime condition (id-only marker + watcher).
-- `references/fast-progressing-games.md` — freezing self-progressing games, `--resume-play`, `ResumePlayResult`.
-- `references/troubleshooting.md` — timeouts, `HitCount` 0, physics misses, hot-reload line resolution, failure codes.
+- `references/quick-check-template.md` — complete trigger/await loop and response fields.
+- `references/captured-variables.md` — captures, filters, expectations, caller frames, raw values.
+- `references/capture-modes-and-history.md` — modes, history, and hit conditions.
+- `references/line-placement.md` — choosing reliable lines.
+- `references/watch-expressions.md` — watch rules.
+- `references/condition-triggered-pause.md` — runtime-condition pauses.
+- `references/fast-progressing-games.md` — paused setup and resume.
+- `references/troubleshooting.md` — timeouts, missed hits, hot reload, failure codes.

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -87,10 +87,7 @@ On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `Rec
 
 ## Requirements & Safety
 
-- When an enable response carries the automatic Debug-switch warning, tell the user that the Debug setting reverts on every Editor restart and each re-switch costs a full script recompile, and propose making Debug the startup default. Run `uloop set-code-optimization debug --startup` only after the user approves - it changes a machine-wide preference that affects every Unity project on this machine. Reassure the user that only the project's C# script execution slows down (mainly during Play Mode); the Unity Editor itself is not slowed.
-
-`uloop set-code-optimization debug` switches only the current session (it reverts on restart);
-with `--startup` it also makes Debug the machine-wide startup default.
+- On the automatic Debug-switch warning: the setting reverts on every Editor restart and each re-switch costs a full script recompile. Propose making Debug the startup default; only after the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It changes a machine-wide preference affecting every Unity project on this machine; only the project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed.
 
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.
@@ -102,11 +99,11 @@ with `--startup` it also makes Debug the machine-wide startup default.
 
 All live in `references/` beside this skill; read the one whose trigger matches:
 
-- `references/quick-check-template.md` — complete trigger/await loop and response fields.
-- `references/captured-variables.md` — captures, filters, expectations, caller frames, raw values.
-- `references/capture-modes-and-history.md` — modes, history, and hit conditions.
-- `references/line-placement.md` — choosing reliable lines.
+- `references/quick-check-template.md` — full `--trigger`/`--await`/`--resume-play` loop, timeouts, hit fields.
+- `references/captured-variables.md` — captures, name filters, `--expect` value forms, caller frames, raw values.
+- `references/capture-modes-and-history.md` — modes, history, `--max-history`, `--hit-when`.
+- `references/line-placement.md` — choosing the line: every-frame lines, held input, input+N frames.
 - `references/watch-expressions.md` — watch rules.
 - `references/condition-triggered-pause.md` — runtime-condition pauses.
-- `references/fast-progressing-games.md` — paused setup and resume.
+- `references/fast-progressing-games.md` — freezing self-progressing games, `--resume-play`.
 - `references/troubleshooting.md` — timeouts, missed hits, hot reload, failure codes.

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -87,7 +87,7 @@ On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `Rec
 
 ## Requirements & Safety
 
-- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask the user mid-flow. The setting reverts on every Editor restart and each re-switch costs a full script recompile, so after finishing the task, propose making Debug the startup default; only if the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It changes a machine-wide preference affecting every Unity project on this machine; only the project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed.
+- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask the user mid-flow. The setting reverts on every Editor restart and each re-switch costs a full script recompile, so at the next natural stopping point, propose making Debug the startup default; only if the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It changes a machine-wide preference affecting every Unity project on this machine; only the project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed.
 
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -87,7 +87,7 @@ On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `Rec
 
 ## Requirements & Safety
 
-- On the automatic Debug-switch warning: the setting reverts on every Editor restart and each re-switch costs a full script recompile. Propose making Debug the startup default; only after the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It changes a machine-wide preference affecting every Unity project on this machine; only the project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed.
+- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask the user mid-flow. The setting reverts on every Editor restart and each re-switch costs a full script recompile, so after finishing the task, propose making Debug the startup default; only if the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It changes a machine-wide preference affecting every Unity project on this machine; only the project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed.
 
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.

--- a/Assets/Tests/Editor/SetCodeOptimizationBridgeCommandTests.cs
+++ b/Assets/Tests/Editor/SetCodeOptimizationBridgeCommandTests.cs
@@ -1,0 +1,43 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests the persistent Code Optimization bridge contract without changing Editor preferences.
+    /// </summary>
+    [TestFixture]
+    public sealed class SetCodeOptimizationBridgeCommandTests
+    {
+        /// <summary>
+        /// Verifies the startup bridge command is registered as an internal command.
+        /// </summary>
+        [Test]
+        public void InternalBridgeCommandRouter_StartupCodeOptimizationCommand_IsInternal()
+        {
+            bool isInternal = InternalBridgeCommandRouter.IsInternalCommand(
+                UnityCliLoopConstants.COMMAND_NAME_SET_CODE_OPTIMIZATION_DEBUG_STARTUP);
+
+            Assert.That(isInternal, Is.True);
+        }
+
+        /// <summary>
+        /// Verifies the Release recovery action ends with the exact approved persistence guidance.
+        /// </summary>
+        [Test]
+        public void ReleaseCodeOptimizationRecommendedNextAction_EndsWithApprovedPersistenceGuidance()
+        {
+            const string expectedSuffix =
+                "To make Unity start in Debug permanently, run: uloop set-code-optimization debug --startup "
+                + "(machine-wide: applies to every Unity project on this machine; only your project's C# script "
+                + "execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed).";
+
+            Assert.That(
+                SourcePausePointConstants.ReleaseCodeOptimizationRecommendedNextAction,
+                Does.EndWith(expectedSuffix));
+        }
+    }
+}

--- a/Assets/Tests/Editor/SetCodeOptimizationBridgeCommandTests.cs
+++ b/Assets/Tests/Editor/SetCodeOptimizationBridgeCommandTests.cs
@@ -1,3 +1,5 @@
+using UnityEditor;
+
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
@@ -7,7 +9,7 @@ using io.github.hatayama.UnityCliLoop.ToolContracts;
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
     /// <summary>
-    /// Tests the persistent Code Optimization bridge contract without changing Editor preferences.
+    /// Tests the persistent Code Optimization bridge contract while restoring Editor preferences.
     /// </summary>
     [TestFixture]
     public sealed class SetCodeOptimizationBridgeCommandTests
@@ -22,6 +24,41 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 UnityCliLoopConstants.COMMAND_NAME_SET_CODE_OPTIMIZATION_DEBUG_STARTUP);
 
             Assert.That(isInternal, Is.True);
+        }
+
+        /// <summary>
+        /// Verifies startup Debug persistence reports the previous value and confirms its readback.
+        /// </summary>
+        [Test]
+        public void PersistStartupDebugPreference_PersistsAndReportsVerifiedDebug()
+        {
+            const string editorPrefsKey = "ScriptDebugInfoEnabled";
+            bool hadOriginalValue = EditorPrefs.HasKey(editorPrefsKey);
+            bool originalValue = EditorPrefs.GetBool(editorPrefsKey, false);
+
+            try
+            {
+                EditorPrefs.SetBool(editorPrefsKey, false);
+
+                StartupDebugPreferenceResult result =
+                    SetCodeOptimizationDebugStartupBridgeCommand.PersistStartupDebugPreference();
+
+                Assert.That(result.Previous, Is.False);
+                Assert.That(result.Current, Is.True);
+                Assert.That(result.Verified, Is.True);
+                Assert.That(EditorPrefs.GetBool(editorPrefsKey, false), Is.True);
+            }
+            finally
+            {
+                if (hadOriginalValue)
+                {
+                    EditorPrefs.SetBool(editorPrefsKey, originalValue);
+                }
+                else
+                {
+                    EditorPrefs.DeleteKey(editorPrefsKey);
+                }
+            }
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/SetCodeOptimizationBridgeCommandTests.cs.meta
+++ b/Assets/Tests/Editor/SetCodeOptimizationBridgeCommandTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b31ff403e4624bfbbec07714e1645b3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -5,11 +5,9 @@ description: "Pauses Unity playback at any source file:line without editing code
 
 # uloop await-pause-point
 
-A pause point is the standard frame proof for verifying simulated input, physics, or UI transitions; sleeps and after-the-fact reads are not substitutes. Skip it only for persistent-state checks that do not validate input delivery, event ordering, or transition-frame fidelity. It is patched into the already-compiled code — no source edit — and captures locals and branch reasons `execute-dynamic-code` cannot reach.
+A pause point captures locals and branch reasons at an exact frame without a source edit. Use it instead of sleeps or after-the-fact reads when input delivery, event ordering, or transition-frame fidelity matters.
 
 ## Quick Check
-
-The standard loop for one representative frame:
 
 1. Enter PlayMode. If the game progresses on its own, pause it with `control-play-mode --action Pause`, arrange the scenario while paused, and add `--resume-play` in step 2.
 2. Arm the marker, fire the input, and wait for the hit in one foreground command:
@@ -85,11 +83,15 @@ Clear one or all registered C# watch expressions
 
 `uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` takes the same two forms but always requires a target.
 
-On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint` first, then follow `RecommendedNextAction`; `MethodEntryCount` interpretation is in `references/troubleshooting.md`. After a hot reload of the target file, pass `--method <Type.Method>` so `--line` stays inside the intended method.
+On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `RecommendedNextAction`; see `references/troubleshooting.md` for diagnosis. After hot reload, use `--method <Type.Method>` to constrain `--line`.
 
 ## Requirements & Safety
 
-- Release Code Optimization is switched to Debug (with a recompile) before arming; the switch reverts on the next Editor restart.
+- When an enable response carries the automatic Debug-switch warning, tell the user that the Debug setting reverts on every Editor restart and each re-switch costs a full script recompile, and propose making Debug the startup default. Run `uloop set-code-optimization debug --startup` only after the user approves - it changes a machine-wide preference that affects every Unity project on this machine. Reassure the user that only the project's C# script execution slows down (mainly during Play Mode); the Unity Editor itself is not slowed.
+
+`uloop set-code-optimization debug` switches only the current session (it reverts on restart);
+with `--startup` it also makes Debug the machine-wide startup default.
+
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.
 - An `--id` marker waits on a hand-written `UloopPausePoint.Pause(id)` call; its hits record no `CapturedVariables`.
@@ -100,11 +102,11 @@ On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint` first, the
 
 All live in `references/` beside this skill; read the one whose trigger matches:
 
-- `references/quick-check-template.md` — full loop: `--trigger`/`--await`/`--resume-play`, split steps, timeouts, hit fields.
-- `references/captured-variables.md` — `CapturedVariables`, previews/truncation, name filters, `--expect` value forms, caller frames, raw capture API.
-- `references/capture-modes-and-history.md` — mode details, history, `--max-history`, `--hit-when`.
-- `references/line-placement.md` — choosing the line to arm, every-frame lines, held input, input+N frames.
-- `references/watch-expressions.md` — watch evaluation rules.
-- `references/condition-triggered-pause.md` — pausing on a runtime condition (id-only marker + watcher).
-- `references/fast-progressing-games.md` — freezing self-progressing games, `--resume-play`, `ResumePlayResult`.
-- `references/troubleshooting.md` — timeouts, `HitCount` 0, physics misses, hot-reload line resolution, failure codes.
+- `references/quick-check-template.md` — complete trigger/await loop and response fields.
+- `references/captured-variables.md` — captures, filters, expectations, caller frames, raw values.
+- `references/capture-modes-and-history.md` — modes, history, and hit conditions.
+- `references/line-placement.md` — choosing reliable lines.
+- `references/watch-expressions.md` — watch rules.
+- `references/condition-triggered-pause.md` — runtime-condition pauses.
+- `references/fast-progressing-games.md` — paused setup and resume.
+- `references/troubleshooting.md` — timeouts, missed hits, hot reload, failure codes.

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -87,10 +87,7 @@ On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `Rec
 
 ## Requirements & Safety
 
-- When an enable response carries the automatic Debug-switch warning, tell the user that the Debug setting reverts on every Editor restart and each re-switch costs a full script recompile, and propose making Debug the startup default. Run `uloop set-code-optimization debug --startup` only after the user approves - it changes a machine-wide preference that affects every Unity project on this machine. Reassure the user that only the project's C# script execution slows down (mainly during Play Mode); the Unity Editor itself is not slowed.
-
-`uloop set-code-optimization debug` switches only the current session (it reverts on restart);
-with `--startup` it also makes Debug the machine-wide startup default.
+- On the automatic Debug-switch warning: the setting reverts on every Editor restart and each re-switch costs a full script recompile. Propose making Debug the startup default; only after the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It changes a machine-wide preference affecting every Unity project on this machine; only the project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed.
 
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.
@@ -102,11 +99,11 @@ with `--startup` it also makes Debug the machine-wide startup default.
 
 All live in `references/` beside this skill; read the one whose trigger matches:
 
-- `references/quick-check-template.md` — complete trigger/await loop and response fields.
-- `references/captured-variables.md` — captures, filters, expectations, caller frames, raw values.
-- `references/capture-modes-and-history.md` — modes, history, and hit conditions.
-- `references/line-placement.md` — choosing reliable lines.
+- `references/quick-check-template.md` — full `--trigger`/`--await`/`--resume-play` loop, timeouts, hit fields.
+- `references/captured-variables.md` — captures, name filters, `--expect` value forms, caller frames, raw values.
+- `references/capture-modes-and-history.md` — modes, history, `--max-history`, `--hit-when`.
+- `references/line-placement.md` — choosing the line: every-frame lines, held input, input+N frames.
 - `references/watch-expressions.md` — watch rules.
 - `references/condition-triggered-pause.md` — runtime-condition pauses.
-- `references/fast-progressing-games.md` — paused setup and resume.
+- `references/fast-progressing-games.md` — freezing self-progressing games, `--resume-play`.
 - `references/troubleshooting.md` — timeouts, missed hits, hot reload, failure codes.

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -87,7 +87,7 @@ On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `Rec
 
 ## Requirements & Safety
 
-- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask the user mid-flow. The setting reverts on every Editor restart and each re-switch costs a full script recompile, so after finishing the task, propose making Debug the startup default; only if the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It changes a machine-wide preference affecting every Unity project on this machine; only the project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed.
+- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask the user mid-flow. The setting reverts on every Editor restart and each re-switch costs a full script recompile, so at the next natural stopping point, propose making Debug the startup default; only if the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It changes a machine-wide preference affecting every Unity project on this machine; only the project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed.
 
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -87,7 +87,7 @@ On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `Rec
 
 ## Requirements & Safety
 
-- On the automatic Debug-switch warning: the setting reverts on every Editor restart and each re-switch costs a full script recompile. Propose making Debug the startup default; only after the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It changes a machine-wide preference affecting every Unity project on this machine; only the project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed.
+- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask the user mid-flow. The setting reverts on every Editor restart and each re-switch costs a full script recompile, so after finishing the task, propose making Debug the startup default; only if the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It changes a machine-wide preference affecting every Unity project on this machine; only the project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed.
 
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -205,7 +205,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             "Automatic Debug switch and recompile did not succeed. Confirm Code Optimization is Debug "
             + "(the bug icon in the main toolbar), run uloop compile, then retry enable-pause-point. "
             + "Note: the Debug setting reverts to the 'Code Optimization On Startup' preference "
-            + "whenever the Editor restarts, including uloop launch -r.";
+            + "whenever the Editor restarts, including uloop launch -r. "
+            + "To make Unity start in Debug permanently, run: uloop set-code-optimization debug --startup "
+            + "(machine-wide: applies to every Unity project on this machine; only your project's C# script "
+            + "execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed).";
 
         // Why fill when empty: some Expired snapshots reach the response with no next
         // action, and agents then have no recovery for a timeout that fired during setup.

--- a/Packages/src/Editor/Infrastructure/Api/InternalBridgeCommandRouter.cs
+++ b/Packages/src/Editor/Infrastructure/Api/InternalBridgeCommandRouter.cs
@@ -20,6 +20,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                    methodName == UnityCliLoopConstants.COMMAND_NAME_CLEAR_PAUSE_POINT_STATUS ||
                    methodName == UnityCliLoopConstants.COMMAND_NAME_EXTEND_PAUSE_POINT_STATUS ||
                    methodName == UnityCliLoopConstants.COMMAND_NAME_SET_CODE_OPTIMIZATION_DEBUG ||
+                   methodName == UnityCliLoopConstants.COMMAND_NAME_SET_CODE_OPTIMIZATION_DEBUG_STARTUP ||
                    methodName == UnityCliLoopConstants.COMMAND_NAME_GET_TOOL_DETAILS;
         }
 
@@ -69,6 +70,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             if (methodName == UnityCliLoopConstants.COMMAND_NAME_SET_CODE_OPTIMIZATION_DEBUG)
             {
                 return SetCodeOptimizationDebugBridgeCommand.Execute();
+            }
+
+            if (methodName == UnityCliLoopConstants.COMMAND_NAME_SET_CODE_OPTIMIZATION_DEBUG_STARTUP)
+            {
+                return SetCodeOptimizationDebugStartupBridgeCommand.Execute();
             }
 
             throw new ArgumentException($"Unknown internal bridge command: {methodName}", nameof(methodName));

--- a/Packages/src/Editor/Infrastructure/Api/SetCodeOptimizationDebugStartupBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/SetCodeOptimizationDebugStartupBridgeCommand.cs
@@ -1,0 +1,58 @@
+using UnityEditor;
+using UnityEditor.Compilation;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Reports the session and startup Code Optimization values around a persistent Debug switch.
+    /// </summary>
+    public class SetCodeOptimizationDebugStartupResponse : UnityCliLoopToolResponse
+    {
+        public string Previous { get; set; } = string.Empty;
+
+        public string Current { get; set; } = string.Empty;
+
+        public bool StartupPrevious { get; set; }
+
+        public bool StartupCurrent { get; set; }
+
+        public bool StartupVerified { get; set; }
+    }
+
+    /// <summary>
+    /// Switches the current session and Unity's machine-wide startup preference to Debug.
+    /// </summary>
+    internal static class SetCodeOptimizationDebugStartupBridgeCommand
+    {
+        private const string ScriptDebugInfoEnabledEditorPrefsKey = "ScriptDebugInfoEnabled";
+
+        public static SetCodeOptimizationDebugStartupResponse Execute()
+        {
+            CodeOptimization previous = CompilationPipeline.codeOptimization;
+            bool startupPrevious = EditorPrefs.GetBool(ScriptDebugInfoEnabledEditorPrefsKey, false);
+
+            CompilationPipeline.codeOptimization = CodeOptimization.Debug;
+            Debug.Assert(
+                CompilationPipeline.codeOptimization == CodeOptimization.Debug,
+                "Code Optimization must be Debug after the switch.");
+
+            EditorPrefs.SetBool(ScriptDebugInfoEnabledEditorPrefsKey, true);
+            bool startupCurrent = EditorPrefs.GetBool(ScriptDebugInfoEnabledEditorPrefsKey, false);
+            bool startupVerified = startupCurrent;
+            Debug.Assert(startupVerified, "The startup Code Optimization preference must read back as Debug.");
+
+            return new SetCodeOptimizationDebugStartupResponse
+            {
+                Success = startupVerified,
+                Previous = previous.ToString(),
+                Current = CompilationPipeline.codeOptimization.ToString(),
+                StartupPrevious = startupPrevious,
+                StartupCurrent = startupCurrent,
+                StartupVerified = startupVerified
+            };
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Api/SetCodeOptimizationDebugStartupBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/SetCodeOptimizationDebugStartupBridgeCommand.cs
@@ -7,6 +7,25 @@ using io.github.hatayama.UnityCliLoop.ToolContracts;
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
 {
     /// <summary>
+    /// Carries startup Debug preference values before and after persistence.
+    /// </summary>
+    internal readonly struct StartupDebugPreferenceResult
+    {
+        public bool Previous { get; }
+
+        public bool Current { get; }
+
+        public bool Verified { get; }
+
+        public StartupDebugPreferenceResult(bool previous, bool current, bool verified)
+        {
+            Previous = previous;
+            Current = current;
+            Verified = verified;
+        }
+    }
+
+    /// <summary>
     /// Reports the session and startup Code Optimization values around a persistent Debug switch.
     /// </summary>
     public class SetCodeOptimizationDebugStartupResponse : UnityCliLoopToolResponse
@@ -32,27 +51,40 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public static SetCodeOptimizationDebugStartupResponse Execute()
         {
             CodeOptimization previous = CompilationPipeline.codeOptimization;
-            bool startupPrevious = EditorPrefs.GetBool(ScriptDebugInfoEnabledEditorPrefsKey, false);
 
             CompilationPipeline.codeOptimization = CodeOptimization.Debug;
             Debug.Assert(
                 CompilationPipeline.codeOptimization == CodeOptimization.Debug,
                 "Code Optimization must be Debug after the switch.");
 
+            StartupDebugPreferenceResult startupPreference = PersistStartupDebugPreference();
+
+            return new SetCodeOptimizationDebugStartupResponse
+            {
+                Success = startupPreference.Verified,
+                Previous = previous.ToString(),
+                Current = CompilationPipeline.codeOptimization.ToString(),
+                StartupPrevious = startupPreference.Previous,
+                StartupCurrent = startupPreference.Current,
+                StartupVerified = startupPreference.Verified
+            };
+        }
+
+        /// <summary>
+        /// Persists Debug as the machine-wide startup preference and verifies its readback.
+        /// </summary>
+        internal static StartupDebugPreferenceResult PersistStartupDebugPreference()
+        {
+            bool startupPrevious = EditorPrefs.GetBool(ScriptDebugInfoEnabledEditorPrefsKey, false);
             EditorPrefs.SetBool(ScriptDebugInfoEnabledEditorPrefsKey, true);
             bool startupCurrent = EditorPrefs.GetBool(ScriptDebugInfoEnabledEditorPrefsKey, false);
             bool startupVerified = startupCurrent;
             Debug.Assert(startupVerified, "The startup Code Optimization preference must read back as Debug.");
 
-            return new SetCodeOptimizationDebugStartupResponse
-            {
-                Success = startupVerified,
-                Previous = previous.ToString(),
-                Current = CompilationPipeline.codeOptimization.ToString(),
-                StartupPrevious = startupPrevious,
-                StartupCurrent = startupCurrent,
-                StartupVerified = startupVerified
-            };
+            return new StartupDebugPreferenceResult(
+                startupPrevious,
+                startupCurrent,
+                startupVerified);
         }
     }
 }

--- a/Packages/src/Editor/Infrastructure/Api/SetCodeOptimizationDebugStartupBridgeCommand.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Api/SetCodeOptimizationDebugStartupBridgeCommand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6d75697b3ecb41ae907a632202ccf4f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -83,6 +83,8 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public const string COMMAND_NAME_CLEAR_PAUSE_POINT_STATUS = "clear-pause-point-status";
         public const string COMMAND_NAME_EXTEND_PAUSE_POINT_STATUS = "extend-pause-point-status";
         public const string COMMAND_NAME_SET_CODE_OPTIMIZATION_DEBUG = "set-code-optimization-debug";
+        public const string COMMAND_NAME_SET_CODE_OPTIMIZATION_DEBUG_STARTUP =
+            "set-code-optimization-debug-startup";
 
         // Optional package names
         public const string PACKAGE_NAME_TEST_FRAMEWORK = "com.unity.test-framework";

--- a/cli/common/clicore/command_errors_test.go
+++ b/cli/common/clicore/command_errors_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestAvailableCommandNamesIncludesBuiltIns(t *testing.T) {
 	// Verifies unknown-command suggestions include built-in CLI commands before cached tools.
 	names := availableCommandNames(ToolsCache{})
-	expectedBuiltIns := []string{"launch", "list", "sync", "focus-window", "await-pause-point", "pause-point-status", "skills", "package", "install", "update", "uninstall"}
+	expectedBuiltIns := []string{"launch", "list", "sync", "focus-window", "await-pause-point", "pause-point-status", "set-code-optimization", "skills", "package", "install", "update", "uninstall"}
 	for index, expected := range expectedBuiltIns {
 		if names[index] != expected {
 			t.Fatalf("built-in command mismatch: %#v", names)

--- a/cli/common/clicore/command_registry.go
+++ b/cli/common/clicore/command_registry.go
@@ -12,6 +12,7 @@ const (
 	ExecuteDynamicCodeCommandName   = "execute-dynamic-code"
 	PausePointAwaitCommandName      = "await-pause-point"
 	PausePointStatusUserCommandName = "pause-point-status"
+	SetCodeOptimizationCommandName  = "set-code-optimization"
 	RunTestsCommandName             = "run-tests"
 )
 
@@ -35,6 +36,7 @@ var NativeCommands = []NativeCommandEntry{
 	{Name: "focus-window", Description: "Bring the Unity Editor window to the foreground", Owner: RunnerOwned},
 	{Name: PausePointAwaitCommandName, Description: "Wait until a named UloopPausePoint.Pause marker pauses Unity", Owner: RunnerOwned},
 	{Name: PausePointStatusUserCommandName, Description: "Show one pause point marker's state, or list all registered markers when no target is given", Owner: RunnerOwned},
+	{Name: SetCodeOptimizationCommandName, Description: "Switch Unity's Code Optimization to Debug for this session or, with approval, as the machine-wide startup default", Owner: RunnerOwned},
 	{Name: SkillsCommandName, Description: "List, install, or uninstall agent skills", Owner: DispatcherOwned},
 	{Name: PackageCommandName, Description: "Install or inspect the Unity CLI Loop package in a project", Owner: DispatcherOwned},
 	{Name: InstallCommandName, Description: "Configure the global uloop dispatcher binary", Owner: DispatcherOwned},

--- a/cli/common/clicore/command_registry_test.go
+++ b/cli/common/clicore/command_registry_test.go
@@ -17,6 +17,7 @@ func TestNativeCommandEntriesDeclareOwners(t *testing.T) {
 		"focus-window":                  RunnerOwned,
 		PausePointAwaitCommandName:      RunnerOwned,
 		PausePointStatusUserCommandName: RunnerOwned,
+		SetCodeOptimizationCommandName:  RunnerOwned,
 	}
 	if len(NativeCommands) != len(expectedOwners) {
 		t.Fatalf("native command owner fixture is stale: %#v", NativeCommands)
@@ -69,6 +70,7 @@ func TestIsRunnerOwnedCommandName(t *testing.T) {
 		"focus-window",
 		PausePointAwaitCommandName,
 		PausePointStatusUserCommandName,
+		SetCodeOptimizationCommandName,
 	} {
 		if !IsRunnerOwnedCommandName(command) {
 			t.Fatalf("%s must be runner-owned", command)

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "afdbca03e473053a7d7a86913d9af28c4b1eedca"
+  "sharedInputsHash": "f0fb6f2600ccebf576875a3557572a8b9cd2dfb8"
 }

--- a/cli/project-runner/internal/projectrunner/list_names_test.go
+++ b/cli/project-runner/internal/projectrunner/list_names_test.go
@@ -44,7 +44,7 @@ func TestRunResolvedProjectCommandListNamesWritesNativeAndLiveToolNames(t *testi
 		t.Fatalf("list --names failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 
-	const expected = "launch\nlist\nsync\nfocus-window\nawait-pause-point\npause-point-status\nskills\npackage\ninstall\nupdate\nuninstall\nversion\nenable-watch\nclear-watch\nget-watch-values\n"
+	const expected = "launch\nlist\nsync\nfocus-window\nawait-pause-point\npause-point-status\nset-code-optimization\nskills\npackage\ninstall\nupdate\nuninstall\nversion\nenable-watch\nclear-watch\nget-watch-values\n"
 	if stdout.String() != expected {
 		t.Fatalf("list --names output mismatch:\n got:\n%s\nwant:\n%s", stdout.String(), expected)
 	}
@@ -58,7 +58,7 @@ func TestRunResolvedProjectCommandListNamesWritesNativeAndLiveToolNames(t *testi
 // Verifies list accepts repeated names selectors but rejects value assignment and positional
 // arguments with the complete stable INVALID_ARGUMENT envelope.
 func TestRunListOptionBoundaries(t *testing.T) {
-	const namesOutput = "launch\nlist\nsync\nfocus-window\nawait-pause-point\npause-point-status\nskills\npackage\ninstall\nupdate\nuninstall\nversion\n"
+	const namesOutput = "launch\nlist\nsync\nfocus-window\nawait-pause-point\npause-point-status\nset-code-optimization\nskills\npackage\ninstall\nupdate\nuninstall\nversion\n"
 	const namesAssignmentError = "{\n" +
 		"  \"Success\": false,\n" +
 		"  \"Error\": {\n" +

--- a/cli/project-runner/internal/projectrunner/native_command_help.go
+++ b/cli/project-runner/internal/projectrunner/native_command_help.go
@@ -31,6 +31,14 @@ func runnerNativeCLIOnlyOptions(command string) []tooldocs.PausePointCLIOnlyOpti
 		return tooldocs.PausePointAwaitCLIOnlyOptions()
 	case clicore.PausePointStatusUserCommandName:
 		return tooldocs.PausePointStatusCLIOnlyOptions()
+	case clicore.SetCodeOptimizationCommandName:
+		return []tooldocs.PausePointCLIOnlyOption{
+			{
+				FlagName:    "startup",
+				Type:        "boolean",
+				Description: "Also set the machine-wide startup preference to Debug",
+			},
+		}
 	default:
 		return nil
 	}
@@ -56,7 +64,7 @@ func printNativeCommandHelp(command string, stdout io.Writer) {
 
 	clicore.WriteLine(stdout, "Usage:")
 	if len(helpEntries) > 0 {
-		clicore.WriteFormat(stdout, "  uloop %s [options]\n", command)
+		clicore.WriteFormat(stdout, "  %s\n", nativeCommandUsage(command, true))
 		clicore.WriteLine(stdout, "")
 		clicore.WriteLine(stdout, entry.Description)
 		clicore.WriteLine(stdout, "")
@@ -67,7 +75,7 @@ func printNativeCommandHelp(command string, stdout io.Writer) {
 			clicore.WriteFormat(stdout, "  %-34s %s\n", helpEntry.Usage, helpEntry.Description)
 		}
 	} else {
-		clicore.WriteFormat(stdout, "  uloop %s\n", command)
+		clicore.WriteFormat(stdout, "  %s\n", nativeCommandUsage(command, false))
 		clicore.WriteLine(stdout, "")
 		clicore.WriteLine(stdout, entry.Description)
 	}
@@ -82,6 +90,16 @@ func printNativeCommandHelp(command string, stdout io.Writer) {
 		clicore.WriteLine(stdout, "")
 		clicore.WriteLine(stdout, guidance)
 	}
+}
+
+func nativeCommandUsage(command string, hasOptions bool) string {
+	if command == clicore.SetCodeOptimizationCommandName {
+		return "uloop set-code-optimization debug [options]"
+	}
+	if hasOptions {
+		return "uloop " + command + " [options]"
+	}
+	return "uloop " + command
 }
 
 func sortedNativeCommandHelpEntries(entries []tooldocs.OptionHelpEntry) []tooldocs.OptionHelpEntry {

--- a/cli/project-runner/internal/projectrunner/native_command_help_test.go
+++ b/cli/project-runner/internal/projectrunner/native_command_help_test.go
@@ -84,6 +84,36 @@ func TestRunProjectLocalPausePointStatusHelpOptionsSection(t *testing.T) {
 	assertNativeCommandHelpOptionsSection(t, "pause-point-status", expectedOptions)
 }
 
+// Verifies set-code-optimization help exposes its required debug mode and optional startup flag.
+func TestRunProjectLocalSetCodeOptimizationHelpOutput(t *testing.T) {
+	t.Chdir(t.TempDir())
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := RunProjectLocal(
+		context.Background(),
+		[]string{"set-code-optimization", "--help"},
+		&stdout,
+		&stderr)
+
+	if code != 0 {
+		t.Fatalf("set-code-optimization --help failed: code=%d stderr=%s", code, stderr.String())
+	}
+	const expected = "Usage:\n" +
+		"  uloop set-code-optimization debug [options]\n" +
+		"\n" +
+		"Switch Unity's Code Optimization to Debug for this session or, with approval, as the machine-wide startup default\n" +
+		"\n" +
+		"Options:\n" +
+		"  --startup                          Also set the machine-wide startup preference to Debug\n" +
+		"\n" +
+		"Global options:\n" +
+		"  --project-path <path>   Run against a Unity project outside the current directory\n"
+	if stdout.String() != expected {
+		t.Fatalf("set-code-optimization --help output mismatch:\n got:\n%s\nwant:\n%s", stdout.String(), expected)
+	}
+}
+
 // Verifies list --help prints the complete names-only option contract, including the usage and
 // global options sections that callers need after the unknown-option recovery guidance.
 func TestRunProjectLocalListHelpOutput(t *testing.T) {

--- a/cli/project-runner/internal/projectrunner/pause_point_release_recovery.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_release_recovery.go
@@ -16,7 +16,7 @@ import (
 
 const pausePointReleaseCodeOptimizationErrorCode = "PAUSE_POINT_RELEASE_CODE_OPTIMIZATION"
 
-const pausePointAutoDebugSwitchWarning = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. After the current task is done, suggest making Debug permanent: with the user's approval, run uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
+const pausePointAutoDebugSwitchWarning = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. Once the current task reaches a natural stopping point, suggest making Debug permanent: with the user's approval, run uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
 
 const pausePointRecoveryCompileBusyRetryInterval = 2 * time.Second
 

--- a/cli/project-runner/internal/projectrunner/pause_point_release_recovery.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_release_recovery.go
@@ -16,7 +16,7 @@ import (
 
 const pausePointReleaseCodeOptimizationErrorCode = "PAUSE_POINT_RELEASE_CODE_OPTIMIZATION"
 
-const pausePointAutoDebugSwitchWarning = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. Do not interrupt the current task for this. After the task is done, suggest making Debug permanent: with the user's approval, run uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
+const pausePointAutoDebugSwitchWarning = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. After the current task is done (do not interrupt it for this), suggest making Debug permanent: with the user's approval, run uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
 
 const pausePointRecoveryCompileBusyRetryInterval = 2 * time.Second
 

--- a/cli/project-runner/internal/projectrunner/pause_point_release_recovery.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_release_recovery.go
@@ -16,7 +16,7 @@ import (
 
 const pausePointReleaseCodeOptimizationErrorCode = "PAUSE_POINT_RELEASE_CODE_OPTIMIZATION"
 
-const pausePointAutoDebugSwitchWarning = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. To make Unity start in Debug permanently, run: uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
+const pausePointAutoDebugSwitchWarning = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. Do not interrupt the current task for this. After the task is done, suggest making Debug permanent: with the user's approval, run uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
 
 const pausePointRecoveryCompileBusyRetryInterval = 2 * time.Second
 

--- a/cli/project-runner/internal/projectrunner/pause_point_release_recovery.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_release_recovery.go
@@ -16,7 +16,7 @@ import (
 
 const pausePointReleaseCodeOptimizationErrorCode = "PAUSE_POINT_RELEASE_CODE_OPTIMIZATION"
 
-const pausePointAutoDebugSwitchWarning = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. Note: this setting reverts on editor restart."
+const pausePointAutoDebugSwitchWarning = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. To make Unity start in Debug permanently, run: uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
 
 const pausePointRecoveryCompileBusyRetryInterval = 2 * time.Second
 

--- a/cli/project-runner/internal/projectrunner/pause_point_release_recovery.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_release_recovery.go
@@ -16,7 +16,7 @@ import (
 
 const pausePointReleaseCodeOptimizationErrorCode = "PAUSE_POINT_RELEASE_CODE_OPTIMIZATION"
 
-const pausePointAutoDebugSwitchWarning = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. After the current task is done (do not interrupt it for this), suggest making Debug permanent: with the user's approval, run uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
+const pausePointAutoDebugSwitchWarning = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. After the current task is done, suggest making Debug permanent: with the user's approval, run uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
 
 const pausePointRecoveryCompileBusyRetryInterval = 2 * time.Second
 

--- a/cli/project-runner/internal/projectrunner/pause_point_release_recovery_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_release_recovery_test.go
@@ -14,7 +14,7 @@ import (
 
 // Verifies the automatic Debug-switch warning gives the exact approved persistence guidance.
 func TestPausePointAutoDebugSwitchWarningRecommendsApprovedStartupCommand(t *testing.T) {
-	const expected = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. After the current task is done, suggest making Debug permanent: with the user's approval, run uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
+	const expected = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. Once the current task reaches a natural stopping point, suggest making Debug permanent: with the user's approval, run uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
 	if pausePointAutoDebugSwitchWarning != expected {
 		t.Fatalf("warning = %q, want %q", pausePointAutoDebugSwitchWarning, expected)
 	}

--- a/cli/project-runner/internal/projectrunner/pause_point_release_recovery_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_release_recovery_test.go
@@ -14,7 +14,7 @@ import (
 
 // Verifies the automatic Debug-switch warning gives the exact approved persistence guidance.
 func TestPausePointAutoDebugSwitchWarningRecommendsApprovedStartupCommand(t *testing.T) {
-	const expected = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. After the current task is done (do not interrupt it for this), suggest making Debug permanent: with the user's approval, run uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
+	const expected = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. After the current task is done, suggest making Debug permanent: with the user's approval, run uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
 	if pausePointAutoDebugSwitchWarning != expected {
 		t.Fatalf("warning = %q, want %q", pausePointAutoDebugSwitchWarning, expected)
 	}

--- a/cli/project-runner/internal/projectrunner/pause_point_release_recovery_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_release_recovery_test.go
@@ -14,7 +14,7 @@ import (
 
 // Verifies the automatic Debug-switch warning gives the exact approved persistence guidance.
 func TestPausePointAutoDebugSwitchWarningRecommendsApprovedStartupCommand(t *testing.T) {
-	const expected = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. Do not interrupt the current task for this. After the task is done, suggest making Debug permanent: with the user's approval, run uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
+	const expected = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. After the current task is done (do not interrupt it for this), suggest making Debug permanent: with the user's approval, run uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
 	if pausePointAutoDebugSwitchWarning != expected {
 		t.Fatalf("warning = %q, want %q", pausePointAutoDebugSwitchWarning, expected)
 	}

--- a/cli/project-runner/internal/projectrunner/pause_point_release_recovery_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_release_recovery_test.go
@@ -12,6 +12,14 @@ import (
 	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
 
+// Verifies the automatic Debug-switch warning gives the exact approved persistence guidance.
+func TestPausePointAutoDebugSwitchWarningRecommendsApprovedStartupCommand(t *testing.T) {
+	const expected = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. To make Unity start in Debug permanently, run: uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
+	if pausePointAutoDebugSwitchWarning != expected {
+		t.Fatalf("warning = %q, want %q", pausePointAutoDebugSwitchWarning, expected)
+	}
+}
+
 const releaseCodeOptimizationEnableFailureJSON = `{"Success":false,"ErrorCode":"PAUSE_POINT_RELEASE_CODE_OPTIMIZATION","Message":"Release code optimization"}`
 
 const unrelatedEnableFailureJSON = `{"Success":false,"ErrorCode":"PAUSE_POINT_RESOLVE_FAILED","Message":"No sequence point found"}`

--- a/cli/project-runner/internal/projectrunner/pause_point_release_recovery_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_release_recovery_test.go
@@ -14,7 +14,7 @@ import (
 
 // Verifies the automatic Debug-switch warning gives the exact approved persistence guidance.
 func TestPausePointAutoDebugSwitchWarningRecommendsApprovedStartupCommand(t *testing.T) {
-	const expected = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. To make Unity start in Debug permanently, run: uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
+	const expected = "Code Optimization was Release; switched to Debug and recompiled before arming the pause point. This setting reverts on every Editor restart, and each re-switch costs a full script recompile. Do not interrupt the current task for this. After the task is done, suggest making Debug permanent: with the user's approval, run uloop set-code-optimization debug --startup (machine-wide: applies to every Unity project on this machine; only your project's C# script execution slows down, mainly during Play Mode - the Unity Editor itself is not slowed)."
 	if pausePointAutoDebugSwitchWarning != expected {
 		t.Fatalf("warning = %q, want %q", pausePointAutoDebugSwitchWarning, expected)
 	}

--- a/cli/project-runner/internal/projectrunner/runner_commands.go
+++ b/cli/project-runner/internal/projectrunner/runner_commands.go
@@ -36,6 +36,8 @@ func runResolvedProjectCommand(
 		return runWaitForPausePointCommand(ctx, connection, commandArgs, startPath, stdout, stderr)
 	case clicore.PausePointStatusUserCommandName:
 		return runPausePointStatusCommand(ctx, connection, commandArgs, stdout, stderr)
+	case clicore.SetCodeOptimizationCommandName:
+		return runSetCodeOptimizationCommand(ctx, connection, commandArgs, stdout, stderr)
 	case pausePointEnableCommandName:
 		return runEnablePausePointCommand(ctx, connection, commandArgs, startPath, stdout, stderr)
 	default:

--- a/cli/project-runner/internal/projectrunner/set_code_optimization.go
+++ b/cli/project-runner/internal/projectrunner/set_code_optimization.go
@@ -1,0 +1,135 @@
+package projectrunner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+
+	"github.com/hatayama/unity-cli-loop/common/clicontract"
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+)
+
+const (
+	setCodeOptimizationDebugStartupCommandName = "set-code-optimization-debug-startup"
+	setCodeOptimizationStartupFlag             = "--startup"
+)
+
+type setCodeOptimizationArguments struct {
+	startup bool
+}
+
+type setCodeOptimizationCommandDependencies struct {
+	send func(context.Context, unityipc.Connection, string) (json.RawMessage, error)
+}
+
+func parseSetCodeOptimizationArguments(args []string) (setCodeOptimizationArguments, error) {
+	if len(args) == 0 {
+		return setCodeOptimizationArguments{}, setCodeOptimizationModeError("")
+	}
+	if args[0] != "debug" {
+		return setCodeOptimizationArguments{}, setCodeOptimizationModeError(args[0])
+	}
+
+	arguments := setCodeOptimizationArguments{}
+	for _, argument := range args[1:] {
+		if !strings.HasPrefix(argument, "--") {
+			return setCodeOptimizationArguments{}, setCodeOptimizationModeError(argument)
+		}
+		if argument != setCodeOptimizationStartupFlag || arguments.startup {
+			return setCodeOptimizationArguments{}, &clierrors.ArgumentError{
+				Message: fmt.Sprintf("Unknown option for %s: %s", clicore.SetCodeOptimizationCommandName, argument),
+				Option:  argument,
+				Command: clicore.SetCodeOptimizationCommandName,
+				NextActions: []string{
+					"Run `uloop set-code-optimization --help` to inspect supported arguments.",
+				},
+			}
+		}
+		arguments.startup = true
+	}
+	return arguments, nil
+}
+
+func setCodeOptimizationModeError(mode string) *clierrors.ArgumentError {
+	message := "set-code-optimization requires the mode argument: debug."
+	if mode != "" {
+		message = fmt.Sprintf("Unsupported Code Optimization mode %q; only debug is supported.", mode)
+	}
+	return &clierrors.ArgumentError{
+		Message: message,
+		Option:  mode,
+		Command: clicore.SetCodeOptimizationCommandName,
+		NextActions: []string{
+			"Run `uloop set-code-optimization debug` for this Editor session.",
+			"Run `uloop set-code-optimization debug --startup` to also persist the machine-wide startup preference after user approval.",
+		},
+	}
+}
+
+func runSetCodeOptimizationCommand(
+	ctx context.Context,
+	connection unityipc.Connection,
+	args []string,
+	stdout io.Writer,
+	stderr io.Writer,
+) int {
+	dependencies := setCodeOptimizationCommandDependencies{send: sendSetCodeOptimizationBridgeCommand}
+	return runSetCodeOptimizationCommandWithDependencies(
+		ctx,
+		connection,
+		args,
+		stdout,
+		stderr,
+		dependencies)
+}
+
+func runSetCodeOptimizationCommandWithDependencies(
+	ctx context.Context,
+	connection unityipc.Connection,
+	args []string,
+	stdout io.Writer,
+	stderr io.Writer,
+	dependencies setCodeOptimizationCommandDependencies,
+) int {
+	arguments, err := parseSetCodeOptimizationArguments(args)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
+			ProjectRoot: connection.ProjectRoot,
+			Command:     clicore.SetCodeOptimizationCommandName,
+		})
+		return 1
+	}
+
+	bridgeCommand := setCodeOptimizationDebugCommandName
+	if arguments.startup {
+		bridgeCommand = setCodeOptimizationDebugStartupCommandName
+	}
+	result, err := dependencies.send(ctx, connection, bridgeCommand)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
+			ProjectRoot: connection.ProjectRoot,
+			Command:     clicore.SetCodeOptimizationCommandName,
+		})
+		return 1
+	}
+
+	clicore.WriteJSON(stdout, result)
+	return toolEnvelopeExitCode(result)
+}
+
+func sendSetCodeOptimizationBridgeCommand(
+	ctx context.Context,
+	connection unityipc.Connection,
+	bridgeCommand string,
+) (json.RawMessage, error) {
+	result, err := unityipc.NewClient(connection, clicontract.ProjectRunnerVersion()).Send(
+		ctx,
+		bridgeCommand,
+		map[string]any{})
+	return result, err
+}

--- a/cli/project-runner/internal/projectrunner/set_code_optimization_test.go
+++ b/cli/project-runner/internal/projectrunner/set_code_optimization_test.go
@@ -1,0 +1,126 @@
+package projectrunner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+)
+
+// Verifies set-code-optimization rejects every mode except the required debug positional argument.
+func TestParseSetCodeOptimizationArgumentsRejectsUnsupportedModes(t *testing.T) {
+	for _, args := range [][]string{
+		{},
+		{"release"},
+		{"Debug"},
+		{"debug", "release"},
+	} {
+		_, err := parseSetCodeOptimizationArguments(args)
+		if err == nil {
+			t.Fatalf("args %v must be rejected", args)
+		}
+		if !strings.Contains(err.Error(), "debug") {
+			t.Fatalf("args %v error must name the supported mode: %v", args, err)
+		}
+	}
+}
+
+// Verifies set-code-optimization rejects flags outside its single documented startup flag.
+func TestParseSetCodeOptimizationArgumentsRejectsUnknownFlags(t *testing.T) {
+	for _, args := range [][]string{
+		{"debug", "--release"},
+		{"debug", "--startup=true"},
+		{"debug", "--startup", "--startup"},
+	} {
+		_, err := parseSetCodeOptimizationArguments(args)
+		if err == nil {
+			t.Fatalf("args %v must be rejected", args)
+		}
+	}
+}
+
+// Verifies the project-runner native command switch routes set-code-optimization before dynamic tool lookup.
+func TestRunResolvedProjectCommandRoutesSetCodeOptimization(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runResolvedProjectCommand(
+		context.Background(),
+		unityipc.Connection{},
+		"set-code-optimization",
+		[]string{"release"},
+		"",
+		&stdout,
+		&stderr)
+
+	if exitCode != 1 {
+		t.Fatalf("unsupported mode exit code = %d, want 1", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "only debug is supported") {
+		t.Fatalf("native route did not return set-code-optimization validation: %s", stderr.String())
+	}
+}
+
+// Verifies the session-only command selects the existing Debug bridge and preserves its response.
+func TestRunSetCodeOptimizationCommandWithoutStartupUsesSessionBridge(t *testing.T) {
+	assertSetCodeOptimizationBridgeSelection(
+		t,
+		[]string{"debug"},
+		setCodeOptimizationDebugCommandName,
+		`{"Success":true,"Previous":"Release","Current":"Debug"}`,
+		"{\n  \"Success\": true,\n  \"Previous\": \"Release\",\n  \"Current\": \"Debug\"\n}\n")
+}
+
+// Verifies --startup selects the persistent Debug bridge and preserves its verification fields.
+func TestRunSetCodeOptimizationCommandWithStartupUsesPersistentBridge(t *testing.T) {
+	assertSetCodeOptimizationBridgeSelection(
+		t,
+		[]string{"debug", "--startup"},
+		setCodeOptimizationDebugStartupCommandName,
+		`{"Success":true,"Previous":"Release","Current":"Debug","StartupPrevious":false,"StartupCurrent":true,"StartupVerified":true}`,
+		"{\n  \"Success\": true,\n  \"Previous\": \"Release\",\n  \"Current\": \"Debug\",\n  \"StartupPrevious\": false,\n  \"StartupCurrent\": true,\n  \"StartupVerified\": true\n}\n")
+}
+
+func assertSetCodeOptimizationBridgeSelection(
+	t *testing.T,
+	args []string,
+	expectedBridgeCommand string,
+	response string,
+	expectedOutput string,
+) {
+	t.Helper()
+	calledBridgeCommand := ""
+	dependencies := setCodeOptimizationCommandDependencies{
+		send: func(
+			_ context.Context,
+			_ unityipc.Connection,
+			bridgeCommand string,
+		) (json.RawMessage, error) {
+			calledBridgeCommand = bridgeCommand
+			return json.RawMessage(response), nil
+		},
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runSetCodeOptimizationCommandWithDependencies(
+		context.Background(),
+		unityipc.Connection{},
+		args,
+		&stdout,
+		&stderr,
+		dependencies)
+
+	if exitCode != 0 {
+		t.Fatalf("command failed: code=%d stderr=%s", exitCode, stderr.String())
+	}
+	if calledBridgeCommand != expectedBridgeCommand {
+		t.Fatalf("bridge command = %q, want %q", calledBridgeCommand, expectedBridgeCommand)
+	}
+	if stdout.String() != expectedOutput {
+		t.Fatalf("stdout mismatch:\n got:\n%s\nwant:\n%s", stdout.String(), expectedOutput)
+	}
+}

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "a36e87dc511638b4d1233ae6589d001806860fbe"
+  "sharedInputsHash": "427d82de89d4599057bafefd808f403bc547f44c"
 }


### PR DESCRIPTION
## Summary
- Add `uloop set-code-optimization debug` for an explicit session-only Debug switch.
- Add `--startup` for an approved machine-wide Debug startup default, with preference readback verification.
- Teach pause-point warnings and guidance to recommend the persistent setting while stating its exact performance scope.

## User Impact
- Pause-point can still recover from Release mode automatically, but users no longer need to pay for the same full script recompile after every Editor restart when they choose the persistent option.
- The machine-wide preference is changed only by the explicit `--startup` command after user approval.
- Guidance clarifies that Debug slows project C# script execution, mainly during Play Mode, and does not slow the Unity Editor itself.

## Changes
- Register `set-code-optimization` as a runner-owned native command with dedicated argument parsing and help.
- Route session-only and startup persistence through separate internal bridge commands without changing the protocol version.
- Set `ScriptDebugInfoEnabled`, read it back, and report `StartupPrevious`, `StartupCurrent`, and `StartupVerified` alongside the session values.
- Refresh both shared release input stamps because the common native command registry changed.
- Keep the workflow in the existing pause-point skill rather than adding a standalone skill for this utility command.

## EditorPrefs Compatibility Note
- The key is undocumented. The reference evidence was checked against the UnityCsReference `6000.3` snapshot for Unity 6000.3.18f1 (commit `5867118dd68a64e13136caf51dc0a791bd8baff8`): `PreferencesSettingsProviders.cs` writes `ScriptDebugInfoEnabled` at line 1231 and reads it at line 1328; `ManagedDebuggerWindow.cs` writes it at line 135.
- That source confirmation covers the 6000.3 snapshot only. For Unity 2022.3, the command's immediate `EditorPrefs.GetBool` readback and `StartupVerified` result are the compatibility fallback rather than a source-level guarantee.

## Verification
- `scripts/check-go-cli.sh`
- `go run ./cmd/check-release-triggers --base origin/v3-beta --head HEAD`
- `go run ./cmd/check-skill-size --root <REPOSITORY_ROOT>`
- `go run ./cmd/sync-tool-docs --check --repository-root <REPOSITORY_ROOT>`
- `dist/darwin-arm64/uloop compile --project-path <REPOSITORY_ROOT>`: success, 0 errors, 0 warnings
- Focused EditMode tests for the bridge contract: 2 passed, 0 failed
- Native help, list discovery, argument rejection, bridge selection, and response formatting tests
- Unity 2022.3.62f3 runtime check from Release: response reported `Previous: Release`, `Current: Debug`, `StartupPrevious: true`, `StartupCurrent: true`, `StartupVerified: true`, and `Success: true`
- Independent post-reload readback reported session `Debug` and `ScriptDebugInfoEnabled: true`; the first probe was disposed during domain reload and the documented retry succeeded


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

