### PR TITLE
fix: package install now finds the Unity project from the repository root

### DIFF
--- a/cli/common/errors/project_errors.go
+++ b/cli/common/errors/project_errors.go
@@ -14,6 +14,20 @@ func (err ProjectNotFoundError) ToCLIError(context ErrorContext) CLIError {
 	return projectResolveCLIError(err.Error(), context)
 }
 
+type MultipleProjectsFoundError struct {
+	SearchRoot string
+}
+
+func (err MultipleProjectsFoundError) Error() string {
+	return fmt.Sprintf(
+		"multiple Unity projects found under %s; use --project-path to choose one",
+		err.SearchRoot)
+}
+
+func (err MultipleProjectsFoundError) ToCLIError(context ErrorContext) CLIError {
+	return projectResolveCLIError(err.Error(), context)
+}
+
 type NotUnityProjectError struct {
 	ProjectRoot string
 	Suggestion  string

--- a/cli/common/project/project.go
+++ b/cli/common/project/project.go
@@ -125,10 +125,35 @@ func FindUnityProjectRootWithin(startPath string, maxDepth int) (string, error) 
 		return childProjects[0], nil
 	}
 	if len(childProjects) > 1 {
-		return "", fmt.Errorf("multiple Unity projects found under %s; use --project-path to choose one", currentPath)
+		return "", clierrors.MultipleProjectsFoundError{SearchRoot: currentPath}
 	}
 
 	return findUnityProjectRootInParents(currentPath)
+}
+
+// FindUnityProjectRootPreferringParents resolves the enclosing Unity project first and only
+// falls back to a child-directory search when no ancestor is one. Commands that edit an
+// existing project (package, skills) must not let a nested Unity-shaped folder (for example a
+// CI fixture) shadow the project the user is standing in.
+func FindUnityProjectRootPreferringParents(startPath string, maxDepth int) (string, error) {
+	currentPath, err := filepath.Abs(startPath)
+	if err != nil {
+		return "", err
+	}
+
+	projectRoot, parentErr := findUnityProjectRootInParents(currentPath)
+	if parentErr == nil {
+		return projectRoot, nil
+	}
+
+	childProjects := findUnityProjectsInChildren(currentPath, maxDepth)
+	if len(childProjects) == 1 {
+		return childProjects[0], nil
+	}
+	if len(childProjects) > 1 {
+		return "", clierrors.MultipleProjectsFoundError{SearchRoot: currentPath}
+	}
+	return "", parentErr
 }
 
 func findUnityProjectRootInParents(currentPath string) (string, error) {

--- a/cli/common/project/project_test.go
+++ b/cli/common/project/project_test.go
@@ -91,6 +91,51 @@ func TestFindUnityProjectRootWithinRejectsAmbiguousNestedProjects(t *testing.T) 
 	}
 }
 
+// Verifies parents-first resolution prefers the enclosing Unity project over a nested
+// Unity-shaped child folder (for example a CI fixture) when starting from a subdirectory.
+func TestFindUnityProjectRootPreferringParentsPrefersEnclosingProject(t *testing.T) {
+	projectRoot := t.TempDir()
+	createUnityProject(t, projectRoot)
+	createUnityProject(t, filepath.Join(projectRoot, "ci", "fixtures", "NestedApp"))
+
+	resolved, err := FindUnityProjectRootPreferringParents(filepath.Join(projectRoot, "ci"), 3)
+	if err != nil {
+		t.Fatalf("FindUnityProjectRootPreferringParents failed: %v", err)
+	}
+	if resolved != projectRoot {
+		t.Fatalf("must resolve enclosing project, got: %s", resolved)
+	}
+}
+
+// Verifies parents-first resolution falls back to the child search when no ancestor is a Unity project.
+func TestFindUnityProjectRootPreferringParentsFallsBackToChildSearch(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	projectRoot := filepath.Join(workspaceRoot, "nested", "Game")
+	createUnityProject(t, projectRoot)
+
+	resolved, err := FindUnityProjectRootPreferringParents(workspaceRoot, 3)
+	if err != nil {
+		t.Fatalf("FindUnityProjectRootPreferringParents failed: %v", err)
+	}
+	if resolved != projectRoot {
+		t.Fatalf("project root mismatch: %s", resolved)
+	}
+}
+
+// Verifies the ambiguous child fallback classifies as MultipleProjectsFoundError instead of an internal error.
+func TestFindUnityProjectRootPreferringParentsRejectsAmbiguousChildren(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	createUnityProject(t, filepath.Join(workspaceRoot, "first", "Game"))
+	createUnityProject(t, filepath.Join(workspaceRoot, "second", "Game"))
+
+	_, err := FindUnityProjectRootPreferringParents(workspaceRoot, 3)
+
+	var multipleErr clierrors.MultipleProjectsFoundError
+	if !stderrors.As(err, &multipleErr) {
+		t.Fatalf("expected MultipleProjectsFoundError, got %T: %v", err, err)
+	}
+}
+
 func TestFindUnityProjectRootWithinHonorsMaxDepth(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	projectRoot := filepath.Join(workspaceRoot, "nested", "Game")

--- a/cli/dispatcher/internal/dispatcher/launch.go
+++ b/cli/dispatcher/internal/dispatcher/launch.go
@@ -80,7 +80,7 @@ func tryHandleLaunchRequestWithDeps(
 func parseLaunchOptions(args []string, globalProjectPath string) (launchOptions, error) {
 	options := launchOptions{
 		projectPath: globalProjectPath,
-		maxDepth:    3,
+		maxDepth:    defaultProjectSearchDepth,
 	}
 
 	for index := 0; index < len(args); index++ {

--- a/cli/dispatcher/internal/dispatcher/package.go
+++ b/cli/dispatcher/internal/dispatcher/package.go
@@ -126,15 +126,15 @@ func parsePackageStatusOptions(args []string) error {
 	return nil
 }
 
-// packageProjectSearchDepth matches the child-directory search depth used by `uloop launch`,
-// so both setup-time commands resolve the same project from a repository root.
-const packageProjectSearchDepth = 3
+// defaultProjectSearchDepth is the child-directory search depth shared by every setup-time
+// command (launch, package, skills), so they all resolve the same project from a repository root.
+const defaultProjectSearchDepth = 3
 
 func resolvePackageProjectRoot(startPath string, explicitProjectPath string) (string, error) {
 	if explicitProjectPath != "" {
 		return project.ResolveExplicitProjectRoot(explicitProjectPath)
 	}
-	return project.FindUnityProjectRootWithin(startPath, packageProjectSearchDepth)
+	return project.FindUnityProjectRootPreferringParents(startPath, defaultProjectSearchDepth)
 }
 
 func runPackageInstall(

--- a/cli/dispatcher/internal/dispatcher/package.go
+++ b/cli/dispatcher/internal/dispatcher/package.go
@@ -126,11 +126,15 @@ func parsePackageStatusOptions(args []string) error {
 	return nil
 }
 
+// packageProjectSearchDepth matches the child-directory search depth used by `uloop launch`,
+// so both setup-time commands resolve the same project from a repository root.
+const packageProjectSearchDepth = 3
+
 func resolvePackageProjectRoot(startPath string, explicitProjectPath string) (string, error) {
 	if explicitProjectPath != "" {
 		return project.ResolveExplicitProjectRoot(explicitProjectPath)
 	}
-	return project.FindUnityProjectRoot(startPath)
+	return project.FindUnityProjectRootWithin(startPath, packageProjectSearchDepth)
 }
 
 func runPackageInstall(

--- a/cli/dispatcher/internal/dispatcher/package_test.go
+++ b/cli/dispatcher/internal/dispatcher/package_test.go
@@ -490,3 +490,87 @@ func stubOpenUPMRegistry(t *testing.T, body string) func() {
 		packageRegistryHTTPClient = previousClient
 	}
 }
+
+// Verifies install resolves a Unity project in a child directory when run from a repository root.
+func TestPackageInstallFindsProjectInChildDirectory(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("failed to create .git: %v", err)
+	}
+	projectRoot := filepath.Join(repoRoot, "client", "UnityApp")
+	createPackageProjectAt(t, projectRoot, barePackageManifest())
+	t.Chdir(repoRoot)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunDispatcher(
+		context.Background(),
+		[]string{"package", "install", "--version", "9.9.9"},
+		&stdout,
+		&stderr,
+	)
+	if code != 0 {
+		t.Fatalf("package install failed: code=%d stderr=%s", code, stderr.String())
+	}
+
+	content := readPackageManifest(t, projectRoot)
+	if !strings.Contains(content, `"`+dispatcherUnityPackageName+`": "9.9.9"`) {
+		t.Fatalf("dependency missing from manifest:\n%s", content)
+	}
+}
+
+// Verifies install fails with guidance when multiple Unity projects exist under the start directory.
+func TestPackageInstallFailsWithMultipleChildProjects(t *testing.T) {
+	repoRoot := t.TempDir()
+	createPackageProjectAt(t, filepath.Join(repoRoot, "AppA"), barePackageManifest())
+	createPackageProjectAt(t, filepath.Join(repoRoot, "AppB"), barePackageManifest())
+	t.Chdir(repoRoot)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunDispatcher(
+		context.Background(),
+		[]string{"package", "install", "--version", "9.9.9"},
+		&stdout,
+		&stderr,
+	)
+	if code == 0 {
+		t.Fatalf("package install must fail with multiple candidate projects: stdout=%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "--project-path") {
+		t.Fatalf("error must guide toward --project-path:\n%s", stderr.String())
+	}
+}
+
+// Verifies status resolves a Unity project in a child directory when run from a repository root.
+func TestPackageStatusFindsProjectInChildDirectory(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("failed to create .git: %v", err)
+	}
+	createPackageProjectAt(t, filepath.Join(repoRoot, "UnityApp"), barePackageManifest())
+	t.Chdir(repoRoot)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunDispatcher(context.Background(), []string{"package", "status"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("package status failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Dependency: not installed") {
+		t.Fatalf("status output unexpected:\n%s", stdout.String())
+	}
+}
+
+func createPackageProjectAt(t *testing.T, projectRoot string, manifest string) {
+	t.Helper()
+	for _, directory := range []string{"Assets", "ProjectSettings", "Packages"} {
+		if err := os.MkdirAll(filepath.Join(projectRoot, directory), 0o755); err != nil {
+			t.Fatalf("failed to create %s: %v", directory, err)
+		}
+	}
+	manifestPath := filepath.Join(projectRoot, "Packages", "manifest.json")
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/package_test.go
+++ b/cli/dispatcher/internal/dispatcher/package_test.go
@@ -422,15 +422,7 @@ func TestPackageUnknownSubcommandFails(t *testing.T) {
 func createPackageTestProject(t *testing.T, manifest string) string {
 	t.Helper()
 	projectRoot := t.TempDir()
-	for _, directory := range []string{"Assets", "ProjectSettings", "Packages"} {
-		if err := os.MkdirAll(filepath.Join(projectRoot, directory), 0o755); err != nil {
-			t.Fatalf("failed to create %s: %v", directory, err)
-		}
-	}
-	manifestPath := filepath.Join(projectRoot, "Packages", "manifest.json")
-	if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
-		t.Fatalf("failed to write manifest: %v", err)
-	}
+	createPackageProjectAt(t, projectRoot, manifest)
 	return projectRoot
 }
 
@@ -540,6 +532,37 @@ func TestPackageInstallFailsWithMultipleChildProjects(t *testing.T) {
 	if !strings.Contains(stderr.String(), "--project-path") {
 		t.Fatalf("error must guide toward --project-path:\n%s", stderr.String())
 	}
+	if !strings.Contains(stderr.String(), `"ErrorCode": "PROJECT_NOT_FOUND"`) {
+		t.Fatalf("ambiguous resolution must classify as PROJECT_NOT_FOUND, not an internal error:\n%s", stderr.String())
+	}
+}
+
+// Verifies install prefers the enclosing Unity project over a nested Unity-shaped child folder
+// when run from a subdirectory of a Unity project.
+func TestPackageInstallPrefersEnclosingProjectOverNestedChild(t *testing.T) {
+	projectRoot := createPackageTestProject(t, barePackageManifest())
+	nestedFixture := filepath.Join(projectRoot, "ci", "fixtures", "NestedApp")
+	createPackageProjectAt(t, nestedFixture, barePackageManifest())
+	t.Chdir(filepath.Join(projectRoot, "ci"))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunDispatcher(
+		context.Background(),
+		[]string{"package", "install", "--version", "9.9.9"},
+		&stdout,
+		&stderr,
+	)
+	if code != 0 {
+		t.Fatalf("package install failed: code=%d stderr=%s", code, stderr.String())
+	}
+
+	if !strings.Contains(readPackageManifest(t, projectRoot), `"`+dispatcherUnityPackageName+`": "9.9.9"`) {
+		t.Fatalf("enclosing project manifest must be updated")
+	}
+	if strings.Contains(readPackageManifest(t, nestedFixture), dispatcherUnityPackageName) {
+		t.Fatalf("nested fixture manifest must stay untouched")
+	}
 }
 
 // Verifies status resolves a Unity project in a child directory when run from a repository root.
@@ -572,5 +595,23 @@ func createPackageProjectAt(t *testing.T, projectRoot string, manifest string) {
 	manifestPath := filepath.Join(projectRoot, "Packages", "manifest.json")
 	if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
 		t.Fatalf("failed to write manifest: %v", err)
+	}
+}
+
+// Verifies skills install resolves a Unity project in a child directory the same way package install does.
+func TestResolveSkillsProjectRootFindsProjectInChildDirectory(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("failed to create .git: %v", err)
+	}
+	projectRoot := filepath.Join(repoRoot, "UnityApp")
+	createPackageProjectAt(t, projectRoot, barePackageManifest())
+
+	resolved, err := resolveSkillsProjectRoot(repoRoot, "", false)
+	if err != nil {
+		t.Fatalf("resolveSkillsProjectRoot failed: %v", err)
+	}
+	if resolved != projectRoot {
+		t.Fatalf("project root mismatch: %s", resolved)
 	}
 }

--- a/cli/dispatcher/internal/dispatcher/skills.go
+++ b/cli/dispatcher/internal/dispatcher/skills.go
@@ -204,13 +204,13 @@ func resolveSkillsProjectRoot(startPath string, explicitProjectPath string, glob
 		return project.ResolveExplicitProjectRoot(explicitProjectPath)
 	}
 	if global {
-		projectRoot, err := project.FindUnityProjectRoot(startPath)
+		projectRoot, err := project.FindUnityProjectRootPreferringParents(startPath, defaultProjectSearchDepth)
 		if err == nil {
 			return projectRoot, nil
 		}
 		return "", nil
 	}
-	return project.FindUnityProjectRoot(startPath)
+	return project.FindUnityProjectRootPreferringParents(startPath, defaultProjectSearchDepth)
 }
 
 func runSkillsList(projectRoot string, skills []skillDefinition, options skillCommandOptions, stdout io.Writer, stderr io.Writer) int {

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "f0fb6f2600ccebf576875a3557572a8b9cd2dfb8"
+  "sharedInputsHash": "d7e313193da18cb7add3137769076e839f4cf2e6"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "427d82de89d4599057bafefd808f403bc547f44c"
+  "sharedInputsHash": "ac7f51a4ae8bee4efbaeb2056a1b382de235ed48"
 }


### PR DESCRIPTION
## Summary
- `uloop package install`, `uloop package status`, and `uloop skills` now find the Unity project automatically when run from a repository root whose Unity project lives in a subdirectory, without requiring `--project-path`.
- The enclosing Unity project always wins over nested Unity-shaped folders (such as CI fixtures), so running from a subdirectory of a project never silently targets the wrong manifest.

## User Impact
- Before: running `uloop package install` from the repository root failed with `PROJECT_NOT_FOUND` unless the current directory was inside the Unity project, because the search only walked upward and stopped at the `.git` directory. `uloop skills` had the same limitation.
- After: these commands resolve the enclosing project first and, when no ancestor is a Unity project, search child directories the same way `uloop launch` does (up to depth 3). The common "repo root with the Unity project one level below" layout works out of the box.
- When multiple child Unity projects are found, the command fails with `PROJECT_NOT_FOUND` and guidance to pass `--project-path` (previously this ambiguity surfaced as `INTERNAL_ERROR`).

## Changes
- New `FindUnityProjectRootPreferringParents` resolver: parents first, child-directory search (shared depth 3 constant with `launch`) only as fallback, so nested Unity-shaped folders cannot shadow the project the user is standing in.
- `package install`/`status` and `skills` project resolution switched to the new resolver; `--project-path` still overrides auto-detection unchanged.
- Ambiguous child matches now return a typed `MultipleProjectsFoundError` classified as `PROJECT_NOT_FOUND` with proper next actions.
- Shared release input stamps regenerated for the `cli/common` change.

## Verification
- Added tests: install/status/skills resolve a child project from a repo root with `.git`; install prefers the enclosing project over a nested fixture; ambiguous children fail with `PROJECT_NOT_FOUND` and `--project-path` guidance (TDD: each confirmed red first).
- `scripts/check-go-cli.sh` (format, vet, lint, all Go tests, binary rebuild) passes.

https://claude.ai/code/session_01XbhSMKK4LFud57iAmowDz7
