### PR TITLE
fix: hot reload no longer fails when an inactive #if region precedes the edited method

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadDisabledTextFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadDisabledTextFixture.cs
@@ -1,0 +1,24 @@
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Provides an inactive conditional region immediately before a hot-reloadable method.
+    /// </summary>
+    public sealed class HotReloadDisabledTextFixture
+    {
+        private bool _plainField;
+#if ULOOP_TEST_NEVER_DEFINED_SYMBOL
+        private bool _uloopDisabledGuardedField;
+
+        private void UloopDisabledGuardedMethod()
+        {
+            _uloopDisabledGuardedField = true;
+        }
+#endif
+
+        public bool GuardedNeighborMethod()
+        {
+            bool guardedNeighbor = _plainField;
+            return guardedNeighbor;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadDisabledTextFixture.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadDisabledTextFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 859ce2bc1410c46e7bb969830d7dcb8e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerDisabledTextTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerDisabledTextTests.cs
@@ -29,8 +29,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task Emit_InactiveIfRegionBeforeMethod_DisabledTextDoesNotLeakIntoShim()
         {
-            string source = ReadFixtureSource();
-            TransformWorkerClientResult result = await RunWorkerOnFixtureAsync(source);
+            TransformWorkerClientResult result = await RunWorkerOnFixtureAsync();
             string shimSource = result.Output.shimSource;
 
             Assert.That(shimSource, Does.Not.Contain("_uloopDisabledGuardedField"));
@@ -38,7 +37,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(shimSource, Does.Contain("GuardedNeighborMethod__shim"));
         }
 
-        private static async Task<TransformWorkerClientResult> RunWorkerOnFixtureAsync(string source)
+        private static async Task<TransformWorkerClientResult> RunWorkerOnFixtureAsync()
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string sourcePath = Path.Combine(projectRoot, ProjectRelativePath.Replace('/', Path.DirectorySeparatorChar));
@@ -49,13 +48,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(result.Output.shimSource, Is.Not.Null.And.Not.Empty);
             return result;
-        }
-
-        private static string ReadFixtureSource()
-        {
-            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
-            string sourcePath = Path.Combine(projectRoot, ProjectRelativePath.Replace('/', Path.DirectorySeparatorChar));
-            return File.ReadAllText(sourcePath);
         }
 
         private static async Task<TransformWorkerClientResult> RunWorkerOnSourceAsync(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerDisabledTextTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerDisabledTextTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Verifies inactive conditional regions do not leak into emitted shim source.
+    /// </summary>
+    public sealed class TransformWorkerDisabledTextTests
+    {
+        private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+        private const string ProjectRelativePath =
+            "Assets/Tests/Editor/HotReload/HotReloadDisabledTextFixture.cs";
+
+        /// <summary>
+        /// What: disabled text before a method is omitted while the neighboring shim is emitted.
+        /// </summary>
+        [Test]
+        public async Task Emit_InactiveIfRegionBeforeMethod_DisabledTextDoesNotLeakIntoShim()
+        {
+            string source = ReadFixtureSource();
+            TransformWorkerClientResult result = await RunWorkerOnFixtureAsync(source);
+            string shimSource = result.Output.shimSource;
+
+            Assert.That(shimSource, Does.Not.Contain("_uloopDisabledGuardedField"));
+            Assert.That(shimSource, Does.Not.Contain("UloopDisabledGuardedMethod"));
+            Assert.That(shimSource, Does.Contain("GuardedNeighborMethod__shim"));
+        }
+
+        private static async Task<TransformWorkerClientResult> RunWorkerOnFixtureAsync(string source)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string sourcePath = Path.Combine(projectRoot, ProjectRelativePath.Replace('/', Path.DirectorySeparatorChar));
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                ProjectRelativePath,
+                snapshotSource: null);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.shimSource, Is.Not.Null.And.Not.Empty);
+            return result;
+        }
+
+        private static string ReadFixtureSource()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string sourcePath = Path.Combine(projectRoot, ProjectRelativePath.Replace('/', Path.DirectorySeparatorChar));
+            return File.ReadAllText(sourcePath);
+        }
+
+        private static async Task<TransformWorkerClientResult> RunWorkerOnSourceAsync(
+            string sourcePath,
+            string projectRelativePath,
+            string snapshotSource)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string targetDllPath = Path.Combine(
+                projectRoot,
+                "Library",
+                "ScriptAssemblies",
+                TestAssemblyName + ".dll");
+            Assert.That(File.Exists(targetDllPath), Is.True, "Test assembly dll missing: " + targetDllPath);
+
+            UnityEditor.Compilation.Assembly compilationAssembly = null;
+            foreach (UnityEditor.Compilation.Assembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name == TestAssemblyName)
+                {
+                    compilationAssembly = assembly;
+                    break;
+                }
+            }
+
+            Assert.That(compilationAssembly, Is.Not.Null, "CompilationPipeline assembly not found.");
+
+            List<string> referencePaths = new List<string>();
+            if (compilationAssembly.allReferences != null)
+            {
+                foreach (string reference in compilationAssembly.allReferences)
+                {
+                    if (!string.IsNullOrEmpty(reference) && File.Exists(reference))
+                    {
+                        referencePaths.Add(Path.GetFullPath(reference));
+                    }
+                }
+            }
+
+            string fullTarget = Path.GetFullPath(targetDllPath);
+            if (!referencePaths.Contains(fullTarget))
+            {
+                referencePaths.Add(fullTarget);
+            }
+
+            List<string> assemblySourcePaths = new List<string>();
+            if (compilationAssembly.sourceFiles != null)
+            {
+                foreach (string sourceFile in compilationAssembly.sourceFiles)
+                {
+                    assemblySourcePaths.Add(Path.GetFullPath(sourceFile));
+                }
+            }
+
+            TransformWorkerInputDto input = new TransformWorkerInputDto
+            {
+                sourcePath = sourcePath,
+                defines = compilationAssembly.defines ?? Array.Empty<string>(),
+                referencePaths = referencePaths.ToArray(),
+                targetTypesAssemblyPath = targetDllPath,
+                snapshotSource = snapshotSource,
+                projectRelativePath = projectRelativePath,
+                assemblySourcePaths = assemblySourcePaths.ToArray()
+            };
+
+            return await TransformWorkerClient.RunAsync(input, CancellationToken.None);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerDisabledTextTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerDisabledTextTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6124168625de46b0bdcef0f609d583c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimMethodFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimMethodFactory.cs
@@ -52,16 +52,20 @@ internal static class ShimMethodFactory
 
     // Why strip directives: #if sits on the method's leading trivia while its matching #endif
     // belongs to the next token, so copied directives are unbalanced in the shim; #line mapping
-    // is injected later from annotations and needs no user directives.
+    // is injected later from annotations and needs no user directives. Disabled text from an
+    // inactive #if region would otherwise lose its guarding directives and become live code
+    // inside the static shim class, causing CS0708 for instance fields.
     private static SyntaxTriviaList StripDirectiveTrivia(SyntaxTriviaList trivia)
     {
         List<SyntaxTrivia> kept = new List<SyntaxTrivia>();
         foreach (SyntaxTrivia item in trivia)
         {
-            if (!item.IsDirective)
+            if (item.IsDirective || item.IsKind(SyntaxKind.DisabledTextTrivia))
             {
-                kept.Add(item);
+                continue;
             }
+
+            kept.Add(item);
         }
 
         return SyntaxFactory.TriviaList(kept);


### PR DESCRIPTION
## Summary
- Hot reload no longer fails when an edited method follows an inactive conditional region.
- Guarded fields and methods stay excluded from generated shim source.

## User Impact
- Previously, disabled code immediately before an edited method could become live inside a generated static shim and cause compilation errors such as CS0708.
- Hot reload now keeps inactive conditional members out of the shim while still emitting the edited method.

## Changes
- Remove disabled conditional text together with copied directives from shim method trivia.
- Add a regression fixture covering both a guarded instance field and a guarded method.
- Verify that the neighboring method shim remains generated.

## Verification
- Red: `TransformWorkerDisabledTextTests` ran 1 test and failed on the expected leaked-field assertion before the fix.
- Green: `TransformWorkerDisabledTextTests` ran 1 test with 1 pass and 0 failures after the fix.
- Regression: the `TransformWorker` regex suite ran 164 tests with 164 passes and 0 failures.
- Compile: `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` completed with 0 errors and 0 warnings.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

