### PR TITLE
feat: graduate v3 to the stable release channel

### DIFF
--- a/.github/workflows/dispatcher-publish.yml
+++ b/.github/workflows/dispatcher-publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v3-beta
   workflow_dispatch:
     inputs:
       dry-run:
@@ -19,7 +18,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v3-beta'
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: read
       actions: write
@@ -185,7 +184,7 @@ jobs:
             echo "Build SHA and release target must match the approved event commit." >&2
             exit 1
           fi
-          if [ "${event_ref}" != "refs/heads/main" ] && [ "${event_ref}" != "refs/heads/v3-beta" ]; then
+          if [ "${event_ref}" != "refs/heads/main" ]; then
             echo "Unsupported release ref ${event_ref}." >&2
             exit 1
           fi

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v3-beta
   workflow_dispatch:
     inputs:
       dry-run:
@@ -15,7 +14,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v3-beta'
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: read
       actions: write
@@ -197,7 +196,7 @@ jobs:
             exit 1
           fi
           release_sha="${GITHUB_SHA}"
-          if [ "${event_ref}" != "refs/heads/main" ] && [ "${event_ref}" != "refs/heads/v3-beta" ]; then
+          if [ "${event_ref}" != "refs/heads/main" ]; then
             echo "Unsupported release ref ${event_ref}." >&2
             exit 1
           fi

--- a/.github/workflows/release-approval-pending-notify.yml
+++ b/.github/workflows/release-approval-pending-notify.yml
@@ -25,13 +25,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # schedule/workflow_run only fire from workflow files on the default branch (main), which
-      # has no cli/ directory; the reconcile implementation lives on v3-beta, so this checkout
-      # must pin ref explicitly instead of using the triggering event's ref.
+      # schedule/workflow_run can fire with a non-branch or stale ref, so this checkout pins
+      # the branch that carries the release automation (cli/) explicitly: main, where the V3
+      # tree lives after the stable merge.
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: v3-beta
+          ref: main
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v3-beta
   # Enable manual execution via "Run workflow" button in browser
   workflow_dispatch:
     inputs:
@@ -105,14 +104,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Go for release PR automation
-        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false' && steps.release.outputs.prs_created == 'true'
+        if: steps.target.outputs.branch == 'main' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false' && steps.release.outputs.prs_created == 'true'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: cli/.go-version
           cache-dependency-path: '**/go.sum'
 
       - name: Dispatch release PR checks
-        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false' && steps.release.outputs.prs_created == 'true'
+        if: steps.target.outputs.branch == 'main' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false' && steps.release.outputs.prs_created == 'true'
         working-directory: cli/release-automation
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,9 +4,7 @@
     "Packages/src": {
       "component": "unity-package",
       "release-type": "go",
-      "versioning": "prerelease",
-      "prerelease": true,
-      "prerelease-type": "beta",
+      "release-as": "3.0.0",
       "include-v-in-tag": true,
       "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md",
@@ -21,9 +19,7 @@
     "cli/dispatcher": {
       "component": "dispatcher",
       "release-type": "go",
-      "versioning": "prerelease",
-      "prerelease": true,
-      "prerelease-type": "beta",
+      "release-as": "3.0.0",
       "include-v-in-tag": true,
       "include-component-in-tag": true,
       "changelog-path": "CHANGELOG.md",
@@ -38,9 +34,7 @@
     "cli/project-runner": {
       "component": "uloop-project-runner",
       "release-type": "go",
-      "versioning": "prerelease",
-      "prerelease": true,
-      "prerelease-type": "beta",
+      "release-as": "3.0.0",
       "include-v-in-tag": true,
       "include-component-in-tag": true,
       "changelog-path": "CHANGELOG.md",

--- a/scripts/test-dispatcher-publish-workflow.sh
+++ b/scripts/test-dispatcher-publish-workflow.sh
@@ -98,6 +98,7 @@ test_unprivileged_build_uses_only_the_approved_event_commit() {
   assert_contains '          ref: ${{ github.sha }}'
   assert_count 2 "          persist-credentials: false"
   assert_contains "if: github.ref == 'refs/heads/main'"
+  assert_not_contains "github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v3-beta'"
 }
 
 test_publish_validates_metadata_without_checking_out_source() {

--- a/scripts/test-dispatcher-publish-workflow.sh
+++ b/scripts/test-dispatcher-publish-workflow.sh
@@ -97,7 +97,7 @@ test_unprivileged_build_uses_only_the_approved_event_commit() {
   assert_not_contains "INPUT_REF"
   assert_contains '          ref: ${{ github.sha }}'
   assert_count 2 "          persist-credentials: false"
-  assert_contains "github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v3-beta'"
+  assert_contains "if: github.ref == 'refs/heads/main'"
 }
 
 test_publish_validates_metadata_without_checking_out_source() {

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -107,6 +107,7 @@ test_unprivileged_build_uses_only_the_approved_event_commit() {
   assert_contains '          ref: ${{ github.sha }}'
   assert_count 2 "          persist-credentials: false"
   assert_contains "if: github.ref == 'refs/heads/main'"
+  assert_not_contains "github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v3-beta'"
 }
 
 test_publish_validates_metadata_without_checking_out_source() {

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -106,7 +106,7 @@ test_unprivileged_build_uses_only_the_approved_event_commit() {
   assert_not_contains "INPUT_REF"
   assert_contains '          ref: ${{ github.sha }}'
   assert_count 2 "          persist-credentials: false"
-  assert_contains "github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v3-beta'"
+  assert_contains "if: github.ref == 'refs/heads/main'"
 }
 
 test_publish_validates_metadata_without_checking_out_source() {

--- a/scripts/test-release-please-config.sh
+++ b/scripts/test-release-please-config.sh
@@ -152,8 +152,10 @@ assert_json_value '.packages["cli/project-runner"]["extra-files"][2].jsonpath' '
 assert_json_value '.packages["cli/dispatcher"].component' 'dispatcher'
 assert_json_value '.packages["cli/dispatcher"].["include-component-in-tag"]' 'true'
 assert_json_value '.packages["cli/dispatcher"].["include-v-in-tag"]' 'true'
-assert_json_value '.packages["cli/dispatcher"].["versioning"]' 'prerelease'
-assert_json_value '.packages["cli/dispatcher"].["prerelease-type"]' 'beta'
+assert_json_value '.packages["cli/dispatcher"] | has("versioning")' 'false'
+assert_json_value '.packages["cli/dispatcher"] | has("prerelease")' 'false'
+assert_json_value '.packages["cli/dispatcher"] | has("prerelease-type")' 'false'
+assert_json_value '.packages["cli/dispatcher"].["release-as"]' '3.0.0'
 assert_json_value '.packages["cli/dispatcher"].["changelog-path"]' 'CHANGELOG.md'
 assert_json_value '.packages["cli/dispatcher"] | has("exclude-paths")' 'false'
 assert_json_value '.packages["cli/dispatcher"]["extra-files"] | length' '1'
@@ -169,8 +171,8 @@ assert_file_contains "$RELEASE_WORKFLOW" '      - name: Setup Go for release PR 
 assert_file_contains "$RELEASE_WORKFLOW" '      - name: Dispatch release PR checks'
 assert_file_contains "$RELEASE_WORKFLOW" '        working-directory: cli/release-automation'
 assert_file_contains "$RELEASE_WORKFLOW" '        run: go run ./cmd/dispatch-release-please-pr-checks'
-assert_step_contains "$RELEASE_WORKFLOW" '      - name: Setup Go for release PR automation' "        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false' && steps.release.outputs.prs_created == 'true'"
-assert_step_contains "$RELEASE_WORKFLOW" '      - name: Dispatch release PR checks' "        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false' && steps.release.outputs.prs_created == 'true'"
+assert_step_contains "$RELEASE_WORKFLOW" '      - name: Setup Go for release PR automation' "        if: steps.target.outputs.branch == 'main' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false' && steps.release.outputs.prs_created == 'true'"
+assert_step_contains "$RELEASE_WORKFLOW" '      - name: Dispatch release PR checks' "        if: steps.target.outputs.branch == 'main' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false' && steps.release.outputs.prs_created == 'true'"
 assert_file_order "$RELEASE_WORKFLOW" '      - name: Setup Go for package release sync' 'Sync release-please package releases'
 assert_file_order "$RELEASE_WORKFLOW" '      - name: Setup Go for release PR automation' '      - name: Dispatch release PR checks'
 


### PR DESCRIPTION
## Summary
- Graduates the release pipeline from the beta channel to the stable channel, so the upcoming v3-beta -> main merge releases all three components as 3.0.0.

## User Impact
- Before: every release from this branch was a `3.0.0-beta.N` prerelease, and release automation only ran on pushes to `v3-beta`.
- After: the next release cut from `main` is the stable `3.0.0` for the Unity package, the dispatcher, and the project runner, and release automation runs on `main` only.

## Changes
- `release-please-config.json`: replace the prerelease (beta) versioning of all three packages with `release-as: "3.0.0"` so the first stable version is deterministic.
- `release-please.yml`, `dispatcher-publish.yml`, `native-cli-publish.yml`: drop the `v3-beta` push trigger and gate every branch condition on `main` only.
- `release-approval-pending-notify.yml`: check out `main` instead of the pinned `v3-beta` ref, since the release automation sources live on `main` after the merge.
- Test scripts (`test-release-please-config.sh`, `test-native-cli-publish-workflow.sh`, `test-dispatcher-publish-workflow.sh`): update the asserts to the new stable expectations (prerelease keys absent, `release-as` 3.0.0, main-only refs).

## Notes
- `release-as` is a one-shot pin: a follow-up PR removes it right after the 3.0.0 release so future releases version normally.
- The `main|v3-beta` case in the `workflow_dispatch` branch validation of `release-please.yml` is intentionally kept for manual runs during the transition.

## Verification
- `sh scripts/test-release-please-config.sh` → exit 0
- `sh scripts/test-native-cli-publish-workflow.sh` → exit 0
- `sh scripts/test-dispatcher-publish-workflow.sh` → exit 0

https://claude.ai/code/session_01XbhSMKK4LFud57iAmowDz7


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

