### PR TITLE
chore: Installer error hints now point to SECURITY.md for the archive manifest override

### DIFF
--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "d7e313193da18cb7add3137769076e839f4cf2e6"
+  "sharedInputsHash": "27374e725e567225ab18cb408fd26d4f8868e41f"
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -160,7 +160,7 @@ function Resolve-UloopManifestFromPin {
     try {
         $PinJsonText = Get-UloopPinJson
     } catch {
-        throw "Could not fetch project-runner pin from $PinUrl. Set ULOOP_ARCHIVE_MANIFEST from a verified attestation (see README), or fix ULOOP_REF."
+        throw "Could not fetch project-runner pin from $PinUrl. Set ULOOP_ARCHIVE_MANIFEST from a verified attestation (see SECURITY.md), or fix ULOOP_REF."
     }
 
     $PinDocument = ConvertFrom-UloopPinDocument -JsonText $PinJsonText
@@ -180,7 +180,7 @@ function Resolve-UloopManifestFromPin {
         $script:Version = $PinTag
         Write-Host "Using dispatcher release $($script:Version) pinned at $PinRef"
     } elseif ($Version -ne $PinTag) {
-        throw "ULOOP_VERSION ($Version) does not match the pin dispatcherReleaseTag ($PinTag) at $PinRef. Unset ULOOP_VERSION, or supply ULOOP_ARCHIVE_MANIFEST from a verified attestation (see README)."
+        throw "ULOOP_VERSION ($Version) does not match the pin dispatcherReleaseTag ($PinTag) at $PinRef. Unset ULOOP_VERSION, or supply ULOOP_ARCHIVE_MANIFEST from a verified attestation (see SECURITY.md)."
     }
 
     $script:ResolvedArchiveManifest = $PinManifest

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -441,7 +441,7 @@ resolve_manifest_from_pin_if_needed() {
 
   pin_json=$(fetch_pin_json) || {
     echo "Could not fetch project-runner pin from https://raw.githubusercontent.com/$REPOSITORY/$PIN_REF/Packages/src/project-runner-pin.json" >&2
-    echo "Set ULOOP_ARCHIVE_MANIFEST from a verified attestation (see README), or fix ULOOP_REF." >&2
+    echo "Set ULOOP_ARCHIVE_MANIFEST from a verified attestation (see SECURITY.md), or fix ULOOP_REF." >&2
     exit 1
   }
 
@@ -470,7 +470,7 @@ resolve_manifest_from_pin_if_needed() {
     :
   else
     echo "ULOOP_VERSION ($VERSION) does not match the pin dispatcherReleaseTag ($pin_tag) at $PIN_REF." >&2
-    echo "Unset ULOOP_VERSION, or supply ULOOP_ARCHIVE_MANIFEST from a verified attestation (see README)." >&2
+    echo "Unset ULOOP_VERSION, or supply ULOOP_ARCHIVE_MANIFEST from a verified attestation (see SECURITY.md)." >&2
     exit 1
   fi
 


### PR DESCRIPTION
## Summary
- The CLI installers now point at `SECURITY.md` instead of the README when they tell you how to supply `ULOOP_ARCHIVE_MANIFEST`

## User Impact
- Before: when the installer could not fetch the project-runner pin, or when `ULOOP_VERSION` did not match the pinned release tag, the error said "Set ULOOP_ARCHIVE_MANIFEST from a verified attestation (see README)". Since #2470 the README no longer documents that override, so the hint led nowhere
- After: the same errors say "(see SECURITY.md)", which is where the `ULOOP_ARCHIVE_MANIFEST` override and its relationship to the repository pin are described

## Changes
- `scripts/install.sh` / `scripts/install.ps1`: four error messages reference `SECURITY.md` instead of the README; no behavior change
- `cli/dispatcher/shared-inputs-stamp.json`: refreshed with `scripts/stamp-release-inputs.sh`, since installer scripts are shared release inputs shipped as dispatcher release assets

## Verification
- `sh -n scripts/install.sh`
- `go run ./cmd/check-release-triggers --base origin/main --head HEAD` in `cli/release-automation`: "Release trigger guard passed."
- `grep -rn "see README"` across the repository returns nothing

https://claude.ai/code/session_01XbhSMKK4LFud57iAmowDz7


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

