### PR TITLE
chore: Quick start verifies the CLI install before the Unity package steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ irm https://raw.githubusercontent.com/hatayama/unity-cli-loop/main/scripts/insta
 brew install hatayama/tap/uloop
 ```
 
+Check that the install worked:
+
+```bash
+uloop -v
+```
+
+The install succeeded when the first line shows the CLI version (for example `3.0.1`).
+
 ### Step 2: Install the Unity package
 
 Run this in the root of your Unity project:
@@ -108,23 +116,6 @@ uloop skills install --claude --global
 # Sync into any directory (e.g. an external skill-package store)
 uloop skills install --output-dir path/to/skills
 ```
-
-### Step 4: Verify the setup
-
-With the project open in Unity, run this in the project root:
-
-```bash
-uloop -v
-```
-
-You are done when the CLI version is followed by the project runner version this project uses:
-
-```text
-3.0.1
-This Unity project pins uloop project runner 3.0.0.
-```
-
-When the output is captured instead of shown in a terminal — for example when an AI agent runs the command — only the version line is printed. That is also success.
 
 ## Install from the Unity UI
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -73,6 +73,14 @@ irm https://raw.githubusercontent.com/hatayama/unity-cli-loop/main/scripts/insta
 brew install hatayama/tap/uloop
 ```
 
+インストールできたか確認します：
+
+```bash
+uloop -v
+```
+
+最初の行に CLI のバージョン（例: `3.0.1`）が表示されれば成功です。
+
 ### ステップ 2：Unity パッケージをインストールする
 
 Unity プロジェクトのルートで実行します：
@@ -108,23 +116,6 @@ uloop skills install --claude --global
 # 任意のディレクトリ（外部のスキルパッケージストアなど）へ
 uloop skills install --output-dir path/to/skills
 ```
-
-### ステップ 4：動作を確認する
-
-Unity でプロジェクトを開いた状態で、プロジェクトのルートで実行します：
-
-```bash
-uloop -v
-```
-
-CLI のバージョンに続いて、このプロジェクトが使う project runner のバージョンが表示されれば完了です：
-
-```text
-3.0.1
-This Unity project pins uloop project runner 3.0.0.
-```
-
-ターミナルに表示せず出力を受け取る場合（AI エージェントがコマンドを実行する場合など）はバージョンの行だけが表示されます。これも成功です。
 
 ## Unity の UI から入れる場合
 


### PR DESCRIPTION
## Summary
- In the terminal quick start, readers now confirm the CLI installed (`uloop -v`) at the end of Step 1, before any later step depends on it

## User Impact
- Before: the `uloop -v` check sat at the end as Step 4, after the reader had already run `uloop package install`, `uloop launch`, and `uloop skills install`. A failed CLI install only surfaced as a failing Step 2
- After: Step 1 ends with `uloop -v` and "the first line shows the CLI version" as the success signal; the trailing Step 4 is gone. Steps 2 and 3 are unchanged

## Changes
- `README_ja.md` / `README.md`: move the version check into Step 1, remove Step 4, drop the project-runner pin sample output and the non-terminal clause that only mattered when the check ran inside an opened project

## Verification
- `uloop -v` on dispatcher 3.0.1 prints the version on the first line both inside and outside a Unity project
- No remaining references to "Step 4" / "ステップ 4" in either README

https://claude.ai/code/session_01XbhSMKK4LFud57iAmowDz7


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

