### PR TITLE
chore: Dispatcher pin freshness gate now runs on pushes to main and on a daily schedule

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -93,16 +93,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: go run ./cmd/check-dispatcher-pin --network
 
-      # Not on pull_request: while the automated pin-stamp pull request is open, the pin on every
-      # other branch legitimately lags the newest stable dispatcher release, and failing there would
-      # turn all open pull requests red for a state only main can fix. Failing on main is the point.
-      - name: Check dispatcher pin freshness
-        if: github.event_name != 'pull_request'
-        working-directory: cli/release-automation
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: go run ./cmd/check-dispatcher-pin-freshness
-
       - name: Check release triggers
         if: github.event_name == 'pull_request'
         working-directory: cli/release-automation

--- a/.github/workflows/dispatcher-pin-freshness.yml
+++ b/.github/workflows/dispatcher-pin-freshness.yml
@@ -1,0 +1,41 @@
+name: Dispatcher Pin Freshness
+
+# Fails while Packages/src/project-runner-pin.json records an older dispatcher
+# release than the newest published stable one, so a skipped pin stamp is
+# visible on main instead of silently sending fresh installs to a stale release.
+#
+# Not on pull_request: while the automated pin-stamp pull request is open, the
+# pin on every other branch legitimately lags, and failing there would turn all
+# open pull requests red for a state only main can fix. The schedule covers the
+# case where a release is published and nothing is pushed to main afterwards.
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: cli/.go-version
+          cache: false
+
+      - name: Check dispatcher pin freshness
+        working-directory: cli/release-automation
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: go run ./cmd/check-dispatcher-pin-freshness

--- a/docs/dispatcher-pin-release-order.md
+++ b/docs/dispatcher-pin-release-order.md
@@ -17,13 +17,15 @@ installation. Package release preparation must follow this order:
 3. Verify the resulting pin with `check-dispatcher-pin` and publish the Unity
    package.
 
-`build-and-test.yml` runs `check-dispatcher-pin-freshness` on everything except
-pull requests, so `main` fails while the pin still records an older release than
-the newest published stable `dispatcher-v*` one. The failure clears by merging
-the automated pin-stamp pull request, or by stamping by hand with
-`stamp-dispatcher-pin --tag <tag>`. The gate deliberately skips `pull_request`
-runs: until that pull request merges, every other branch carries the same lagging
-pin, and failing there would only hide the state that `main` alone can fix.
+`dispatcher-pin-freshness.yml` runs `check-dispatcher-pin-freshness` on every
+push to `main`, once a day on a schedule, and on manual dispatch, so `main` fails
+while the pin still records an older release than the newest published stable
+`dispatcher-v*` one. The failure clears by merging the automated pin-stamp pull
+request, or by stamping by hand with `stamp-dispatcher-pin --tag <tag>`. The
+gate deliberately does not run on `pull_request`: until that pull request
+merges, every other branch carries the same lagging pin, and failing there would
+only hide the state that `main` alone can fix. The schedule exists because a
+dispatcher release can be published without any later push to `main`.
 
 A pull request created with `GITHUB_TOKEN` does not trigger `pull_request`
 workflows, so `open-dispatcher-pin-pr` dispatches the required check workflows


### PR DESCRIPTION
Follow-up to #2474 (issue #2463).

## Summary
- The dispatcher pin freshness gate now actually runs on `main`: it moves from `build-and-test.yml`, which never runs on branch pushes, into its own workflow triggered by pushes to `main`, a daily schedule, and manual dispatch

## User Impact
- Before: #2474 placed the step in `build-and-test.yml` under `if: github.event_name != 'pull_request'`, but that workflow's `push` trigger is tag-only (`v*`, `uloop-project-runner-v*`, `dispatcher-v*`), so the gate would only ever have run on a manual dispatch. A lagging pin would still have gone unnoticed on `main` — the exact gap #2463 set out to close
- After: `Dispatcher Pin Freshness` runs on every push to `main`, once a day (so a release published without a later push is still caught), and on demand. It fails with the same message as before while `dispatcherReleaseTag` lags the newest stable release

## Changes
- `.github/workflows/dispatcher-pin-freshness.yml` (new): checkout + `setup-go` (`cache: false`) + `go run ./cmd/check-dispatcher-pin-freshness`; `contents: read` only; action SHAs reused from existing workflows
- `.github/workflows/build-and-test.yml`: the misplaced step removed
- `docs/dispatcher-pin-release-order.md`: names the new workflow and why it also runs on a schedule

## Verification
- `actionlint` on both workflows: clean
- `go run ./cmd/check-dispatcher-pin-freshness` from `cli/release-automation` against the live repository still passes for the current pin (`dispatcher-v3.0.1`)
- The first automatic run happens on the merge commit of this PR; I will confirm it in the Actions tab

https://claude.ai/code/session_01XbhSMKK4LFud57iAmowDz7


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

