### PR TITLE
fix: Unsaved Scene and Prefab Stage edits are no longer saved automatically when Unity regains focus

### DIFF
--- a/Assets/Tests/Editor/ExternalAssetFocusReturnSavePolicyTests.cs
+++ b/Assets/Tests/Editor/ExternalAssetFocusReturnSavePolicyTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests which dirty assets focus return is allowed to save, without touching Unity Scene APIs.
+    /// </summary>
+    public sealed class ExternalAssetFocusReturnSavePolicyTests
+    {
+        private const string ScenePath = "Assets/Scenes/SampleScene.unity";
+        private const string OtherScenePath = "Assets/Scenes/AdditiveScene.unity";
+        private static readonly DateTime SavedTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly DateTime ChangedTime = new DateTime(2026, 1, 1, 0, 1, 0, DateTimeKind.Utc);
+        private static readonly (bool Exists, DateTime LastWriteTimeUtc, long Length) SavedFingerprint =
+            (true, SavedTime, 10);
+        private static readonly (bool Exists, DateTime LastWriteTimeUtc, long Length) ChangedFingerprint =
+            (true, ChangedTime, 20);
+        private static readonly (bool Exists, DateTime LastWriteTimeUtc, long Length) MissingFingerprint =
+            (false, DateTime.MinValue, 0);
+
+        [Test]
+        public void SelectDirtyAssetsToSave_WhenDirtyAssetFileIsUnchanged_DoesNotSelectIt()
+        {
+            // Verifies plain unsaved editor work survives focus return when nothing changed on disk.
+            string[] selected = ExternalAssetFocusReturnSavePolicy.SelectDirtyAssetsToSave(
+                new[] { (AssetPath: ScenePath, IsDirty: true) },
+                CreateSnapshots(),
+                _ => SavedFingerprint);
+
+            Assert.That(selected, Is.Empty);
+        }
+
+        [Test]
+        public void SelectDirtyAssetsToSave_WhenDirtyAssetFileChangedOnDisk_SelectsIt()
+        {
+            // Verifies the in-memory state wins only when the file was replaced while unfocused.
+            string[] selected = ExternalAssetFocusReturnSavePolicy.SelectDirtyAssetsToSave(
+                new[] { (AssetPath: ScenePath, IsDirty: true) },
+                CreateSnapshots(),
+                _ => ChangedFingerprint);
+
+            Assert.That(selected, Is.EqualTo(new[] { ScenePath }));
+        }
+
+        [Test]
+        public void SelectDirtyAssetsToSave_WhenDirtyAssetFileIsMissing_SelectsIt()
+        {
+            // Verifies a dirty asset whose file disappeared on disk is written back from memory.
+            string[] selected = ExternalAssetFocusReturnSavePolicy.SelectDirtyAssetsToSave(
+                new[] { (AssetPath: ScenePath, IsDirty: true) },
+                CreateSnapshots(),
+                _ => MissingFingerprint);
+
+            Assert.That(selected, Is.EqualTo(new[] { ScenePath }));
+        }
+
+        [Test]
+        public void SelectDirtyAssetsToSave_WhenCleanAssetFileChangedOnDisk_DoesNotSelectIt()
+        {
+            // Verifies clean assets are left to the reload path instead of being saved.
+            string[] selected = ExternalAssetFocusReturnSavePolicy.SelectDirtyAssetsToSave(
+                new[] { (AssetPath: ScenePath, IsDirty: false) },
+                CreateSnapshots(),
+                _ => ChangedFingerprint);
+
+            Assert.That(selected, Is.Empty);
+        }
+
+        [Test]
+        public void SelectDirtyAssetsToSave_WhenDirtyAssetHasNoSnapshot_DoesNotSelectIt()
+        {
+            // Verifies an untracked asset is never saved because no external change can be proven for it.
+            string[] selected = ExternalAssetFocusReturnSavePolicy.SelectDirtyAssetsToSave(
+                new[] { (AssetPath: ScenePath, IsDirty: true) },
+                new Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)>(StringComparer.Ordinal),
+                _ => ChangedFingerprint);
+
+            Assert.That(selected, Is.Empty);
+        }
+
+        [Test]
+        public void SelectDirtyAssetsToSave_WithMixedAssets_SelectsOnlyDirtyChangedOnesInOrder()
+        {
+            // Verifies a dirty unchanged Scene stays unsaved even when a sibling dirty Scene changed on disk.
+            Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots = CreateSnapshots();
+            snapshots[OtherScenePath] = SavedFingerprint;
+
+            string[] selected = ExternalAssetFocusReturnSavePolicy.SelectDirtyAssetsToSave(
+                new[]
+                {
+                    (AssetPath: ScenePath, IsDirty: true),
+                    (AssetPath: OtherScenePath, IsDirty: true)
+                },
+                snapshots,
+                assetPath => assetPath == OtherScenePath ? ChangedFingerprint : SavedFingerprint);
+
+            Assert.That(selected, Is.EqualTo(new[] { OtherScenePath }));
+        }
+
+        private static Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> CreateSnapshots()
+        {
+            return new Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)>(StringComparer.Ordinal)
+            {
+                [ScenePath] = SavedFingerprint
+            };
+        }
+    }
+}

--- a/Assets/Tests/Editor/ExternalAssetFocusReturnSavePolicyTests.cs.meta
+++ b/Assets/Tests/Editor/ExternalAssetFocusReturnSavePolicyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2387c5550f0143529b706ab1eeadc60
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/ExternalFocusReturnTrackerWiringTests.cs
+++ b/Assets/Tests/Editor/ExternalFocusReturnTrackerWiringTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Drives the focus-return save and reload paths through the real trackers with real assets,
+    /// so a broken wiring between the save policy and the trackers fails these tests.
+    /// </summary>
+    public sealed class ExternalFocusReturnTrackerWiringTests
+    {
+        private const string TempFolder = "Assets/UloopFocusReturnWiringTemp";
+        private const string TempScenePath = TempFolder + "/WiringScene.unity";
+        private const string TempPrefabPath = TempFolder + "/WiringPrefab.prefab";
+
+        [SetUp]
+        public void SetUp()
+        {
+            ExternalSceneChangeTracker.Initialize();
+            if (!AssetDatabase.IsValidFolder(TempFolder))
+            {
+                AssetDatabase.CreateFolder("Assets", "UloopFocusReturnWiringTemp");
+            }
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (PrefabStageUtility.GetCurrentPrefabStage() != null)
+            {
+                PrefabStageUtility.GetCurrentPrefabStage().ClearDirtiness();
+                StageUtility.GoBackToPreviousStage();
+            }
+
+            Scene tempScene = SceneManager.GetSceneByPath(TempScenePath);
+            if (tempScene.IsValid() && tempScene.isLoaded)
+            {
+                // Why NewScene: the temp scene is the active (and only) scene, and Unity cannot
+                // close the last loaded scene; replacing it releases the asset for deletion.
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            }
+
+            AssetDatabase.DeleteAsset(TempFolder);
+        }
+
+        [Test]
+        public void SaveDirtyOpenScenesChangedExternally_WithUnchangedFile_LeavesSceneDirtyAndFileUntouched()
+        {
+            // Verifies the focus-return wiring does not save a dirty Scene whose file never changed on disk.
+            Scene scene = CreateSavedActiveScene();
+            MakeSceneDirty(scene);
+            DateTime mtimeBefore = File.GetLastWriteTimeUtc(TempScenePath);
+
+            string[] failures = ExternalSceneChangeTracker.SaveDirtyOpenScenesChangedExternally();
+
+            Assert.That(failures, Is.Empty);
+            Assert.That(scene.isDirty, Is.True);
+            Assert.That(File.GetLastWriteTimeUtc(TempScenePath), Is.EqualTo(mtimeBefore));
+        }
+
+        [Test]
+        public void SaveDirtyOpenScenesChangedExternally_WithExternallyTouchedFile_SavesTheScene()
+        {
+            // Verifies the focus-return wiring still writes the in-memory state over an externally changed file.
+            Scene scene = CreateSavedActiveScene();
+            MakeSceneDirty(scene);
+            File.SetLastWriteTimeUtc(TempScenePath, DateTime.UtcNow.AddMinutes(1));
+
+            string[] failures = ExternalSceneChangeTracker.SaveDirtyOpenScenesChangedExternally();
+
+            Assert.That(failures, Is.Empty);
+            Assert.That(scene.isDirty, Is.False);
+        }
+
+        [Test]
+        public void SaveDirtyIfChangedExternally_WithUnchangedFile_LeavesPrefabStageDirtyAndFileUntouched()
+        {
+            // Verifies the focus-return wiring does not save a dirty Prefab Stage whose file never changed on disk.
+            PrefabStage stage = OpenDirtyPrefabStage();
+            DateTime mtimeBefore = File.GetLastWriteTimeUtc(TempPrefabPath);
+
+            string[] failures = ExternalPrefabStageChangeTracker.SaveDirtyIfChangedExternally();
+
+            Assert.That(failures, Is.Empty);
+            Assert.That(stage.scene.isDirty, Is.True);
+            Assert.That(File.GetLastWriteTimeUtc(TempPrefabPath), Is.EqualTo(mtimeBefore));
+        }
+
+        [Test]
+        public void SaveDirtyIfChangedExternally_WithExternallyTouchedFile_SavesThePrefabStage()
+        {
+            // Verifies the focus-return wiring still writes a dirty Prefab Stage over an externally changed file.
+            PrefabStage stage = OpenDirtyPrefabStage();
+            File.SetLastWriteTimeUtc(TempPrefabPath, DateTime.UtcNow.AddMinutes(1));
+
+            string[] failures = ExternalPrefabStageChangeTracker.SaveDirtyIfChangedExternally();
+
+            Assert.That(failures, Is.Empty);
+            Assert.That(stage.scene.isDirty, Is.False);
+        }
+
+        [Test]
+        public void ResolveExternalChangeForFocusReturn_WithDirtyStageAndChangedFile_KeepsUnsavedEditsInsteadOfReloading()
+        {
+            // Verifies a Prefab Stage left dirty when its file changed after the save check is not reloaded over.
+            PrefabStage stage = OpenDirtyPrefabStage();
+            File.SetLastWriteTimeUtc(TempPrefabPath, DateTime.UtcNow.AddMinutes(1));
+
+            ExternalPrefabStageChangeTracker.ResolveExternalChangeForFocusReturn();
+
+            PrefabStage current = PrefabStageUtility.GetCurrentPrefabStage();
+            Assert.That(current, Is.SameAs(stage));
+            Assert.That(current.scene.isDirty, Is.True);
+            Assert.That(current.prefabContentsRoot.transform.Find("WiringProbe"), Is.Not.Null);
+        }
+
+        private static Scene CreateSavedActiveScene()
+        {
+            // Why Single: the test runner can hold an untitled unsaved scene, and Unity refuses to
+            // create an additive scene next to one. Replacing the active scene avoids that restriction.
+            Scene scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            bool saved = EditorSceneManager.SaveScene(scene, TempScenePath);
+            Assert.That(saved, Is.True, "temp scene must save so a snapshot fingerprint exists");
+            return scene;
+        }
+
+        private static void MakeSceneDirty(Scene scene)
+        {
+            GameObject probe = new GameObject("WiringProbe");
+            SceneManager.MoveGameObjectToScene(probe, scene);
+            EditorSceneManager.MarkSceneDirty(scene);
+            Assert.That(scene.isDirty, Is.True, "scene must be dirty before the save decision runs");
+        }
+
+        private static PrefabStage OpenDirtyPrefabStage()
+        {
+            GameObject root = new GameObject("WiringPrefabRoot");
+            bool created;
+            PrefabUtility.SaveAsPrefabAsset(root, TempPrefabPath, out created);
+            UnityEngine.Object.DestroyImmediate(root);
+            Assert.That(created, Is.True, "temp prefab must save before it can be opened in a stage");
+
+            PrefabStage stage = PrefabStageUtility.OpenPrefab(TempPrefabPath);
+            ExternalPrefabStageChangeTracker.RecordCurrent();
+            GameObject probe = new GameObject("WiringProbe");
+            probe.transform.SetParent(stage.prefabContentsRoot.transform);
+            EditorSceneManager.MarkSceneDirty(stage.scene);
+            Assert.That(stage.scene.isDirty, Is.True, "prefab stage must be dirty before the save decision runs");
+            return stage;
+        }
+    }
+}

--- a/Assets/Tests/Editor/ExternalFocusReturnTrackerWiringTests.cs.meta
+++ b/Assets/Tests/Editor/ExternalFocusReturnTrackerWiringTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d716f2255530d43769d09007eae31704
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalAssetFocusReturnSavePolicy.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalAssetFocusReturnSavePolicy.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Decides which dirty open assets focus return may save before Unity refreshes the asset database.
+    /// </summary>
+    internal static class ExternalAssetFocusReturnSavePolicy
+    {
+        /// <summary>
+        /// Selects the dirty assets whose file changed or disappeared on disk while the Editor was unfocused.
+        /// Only those would otherwise raise Unity's external-change dialog, so only those trade the disk
+        /// state for the in-memory state; every other dirty asset keeps its unsaved edits untouched.
+        /// An asset without a snapshot is skipped because no external change can be proven for it.
+        /// </summary>
+        internal static string[] SelectDirtyAssetsToSave(
+            (string AssetPath, bool IsDirty)[] openAssets,
+            Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots,
+            Func<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> readFingerprint)
+        {
+            Debug.Assert(openAssets != null, "openAssets must not be null");
+            Debug.Assert(snapshots != null, "snapshots must not be null");
+            Debug.Assert(readFingerprint != null, "readFingerprint must not be null");
+
+            List<string> selected = new List<string>();
+            for (int i = 0; i < openAssets.Length; i++)
+            {
+                (string AssetPath, bool IsDirty) asset = openAssets[i];
+                if (!asset.IsDirty)
+                {
+                    continue;
+                }
+
+                if (!snapshots.TryGetValue(
+                        asset.AssetPath,
+                        out (bool Exists, DateTime LastWriteTimeUtc, long Length) snapshot))
+                {
+                    continue;
+                }
+
+                if (ExternalAssetFileStateComparer.HasSameFileState(snapshot, readFingerprint(asset.AssetPath)))
+                {
+                    continue;
+                }
+
+                selected.Add(asset.AssetPath);
+            }
+
+            return selected.ToArray();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalAssetFocusReturnSavePolicy.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalAssetFocusReturnSavePolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63545c92980f84a4584a23257a078601
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalPrefabStageChangeTracker.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalPrefabStageChangeTracker.cs
@@ -115,6 +115,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return;
             }
 
+            // The save step has already reconciled dirty stages whose file changed; a stage that is
+            // still dirty here changed on disk after that check (or its save failed), and reloading
+            // would silently drop the unsaved edits. Keep them and report the conflict instead.
+            if (prefabStage.scene.isDirty)
+            {
+                Debug.LogWarning(
+                    "Unity CLI Loop skipped Prefab Stage external-change reload because the current Prefab Stage has unsaved changes.");
+                return;
+            }
+
             AssetDatabase.ImportAsset(assetPath);
             UnityEngine.Object prefabAsset = AssetDatabase.LoadMainAssetAtPath(assetPath);
             if (prefabAsset == null)

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalPrefabStageChangeTracker.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalPrefabStageChangeTracker.cs
@@ -161,10 +161,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return (null, PrefabStage.Mode.InIsolation);
         }
 
-        internal static string[] SaveDirty()
+        /// <summary>
+        /// Saves the current dirty Prefab Stage only when its asset file changed or disappeared on disk.
+        /// </summary>
+        internal static string[] SaveDirtyIfChangedExternally()
         {
             PrefabStage prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
             if (!IsTrackable(prefabStage) || !prefabStage.scene.isDirty)
+            {
+                return Array.Empty<string>();
+            }
+
+            string assetPath = ExternalSceneChangeTracker.NormalizeAssetPath(prefabStage.assetPath);
+            string[] assetPathsToSave = ExternalAssetFocusReturnSavePolicy.SelectDirtyAssetsToSave(
+                new[] { (AssetPath: assetPath, IsDirty: true) },
+                PrefabStageSnapshots,
+                ExternalSceneChangeTracker.ReadAssetFileFingerprint);
+            if (assetPathsToSave.Length == 0)
             {
                 return Array.Empty<string>();
             }
@@ -199,12 +212,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return new[] { GetDisplayPath(prefabStage) };
-        }
-
-        internal static bool IsCurrentDirty()
-        {
-            PrefabStage prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
-            return IsTrackable(prefabStage) && prefabStage.scene.isDirty;
         }
 
         private static bool TrySave(PrefabStage prefabStage)

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeTracker.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeTracker.cs
@@ -338,7 +338,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                              result.Message);
         }
 
-        private static string[] SaveDirtyOpenScenesChangedExternally()
+        internal static string[] SaveDirtyOpenScenesChangedExternally()
         {
             string[] scenePathsToSave = ExternalAssetFocusReturnSavePolicy.SelectDirtyAssetsToSave(
                 GetOpenSceneStates(), SceneSnapshots, ReadAssetFileFingerprint);

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeTracker.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeTracker.cs
@@ -138,8 +138,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static void ResolveForFocusReturn()
         {
-            // Focus return treats Unity's in-memory editor state as authoritative because source-control
-            // operations can replace files while Unity is unfocused and would otherwise trigger reload dialogs.
+            // Focus return treats Unity's in-memory editor state as authoritative for assets whose file
+            // was replaced while Unity was unfocused (source-control operations), because Unity would
+            // otherwise raise a reload dialog for them. Dirty assets whose file is unchanged are left
+            // unsaved: saving them would silently commit the user's in-progress edits on every focus switch.
             (string AssetPath, bool IsDirty)[] openScenesBefore = GetOpenSceneStates();
             object[] fingerprintDiffsBefore =
                 BuildFingerprintDiffContexts(openScenesBefore, SceneSnapshots, ReadAssetFileFingerprint);
@@ -155,28 +157,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 },
                 includeStackTrace: false);
 
-            string[] dirtySceneSaveFailures = SaveDirtyOpenScenesBeforeReload();
-            LogFocusReturnFailures("save dirty Scene files", dirtySceneSaveFailures);
+            string[] dirtySceneSaveFailures = SaveDirtyOpenScenesChangedExternally();
+            LogFocusReturnFailures("save dirty Scene files that changed on disk", dirtySceneSaveFailures);
 
             string[] missingSceneSaveFailures = SaveMissingOpenScenesFromUnity();
             LogFocusReturnFailures("restore missing Scene files from the Unity state", missingSceneSaveFailures);
 
-            string[] dirtyPrefabSaveFailures = ExternalPrefabStageChangeTracker.SaveDirty();
-            LogFocusReturnFailures("save the dirty Prefab Stage", dirtyPrefabSaveFailures);
+            string[] dirtyPrefabSaveFailures = ExternalPrefabStageChangeTracker.SaveDirtyIfChangedExternally();
+            LogFocusReturnFailures("save the dirty Prefab Stage that changed on disk", dirtyPrefabSaveFailures);
 
             string[] missingPrefabSaveFailures = ExternalPrefabStageChangeTracker.SaveMissingAsset();
             LogFocusReturnFailures("restore the missing Prefab asset from the Unity state", missingPrefabSaveFailures);
 
             ResolveSceneExternalChangesForFocusReturn();
-            if (dirtyPrefabSaveFailures.Length > 0 ||
-                missingPrefabSaveFailures.Length > 0 ||
-                ExternalPrefabStageChangeTracker.IsCurrentDirty())
+            // A dirty Prefab Stage that survived the save step is unchanged on disk, so the reload below
+            // is a no-op for it; only a failed save leaves a real conflict that reload must not overwrite.
+            if (dirtyPrefabSaveFailures.Length > 0 || missingPrefabSaveFailures.Length > 0)
             {
                 Debug.LogWarning(
-                    "Unity CLI Loop skipped Prefab Stage external-change reload because the current Prefab Stage is still dirty or could not be saved.");
+                    "Unity CLI Loop skipped Prefab Stage external-change reload because the current Prefab Stage could not be saved.");
                 VibeLogger.LogInfo(
                     "external_scene_resolve_focus_return",
-                    "ResolveForFocusReturn finished early (Prefab Stage still dirty or unsaved)",
+                    "ResolveForFocusReturn finished early (Prefab Stage could not be saved)",
                     new
                     {
                         phase = "end",
@@ -334,6 +336,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             Debug.LogWarning("Unity CLI Loop could not resolve external Scene changes on focus return. " +
                              result.Message);
+        }
+
+        private static string[] SaveDirtyOpenScenesChangedExternally()
+        {
+            string[] scenePathsToSave = ExternalAssetFocusReturnSavePolicy.SelectDirtyAssetsToSave(
+                GetOpenSceneStates(), SceneSnapshots, ReadAssetFileFingerprint);
+            List<string> failedScenePaths = new List<string>();
+            bool hasRecordedSceneSnapshot = false;
+            for (int i = 0; i < scenePathsToSave.Length; i++)
+            {
+                Scene scene = SceneManager.GetSceneByPath(scenePathsToSave[i]);
+                if (!EditorSceneManager.SaveScene(scene))
+                {
+                    failedScenePaths.Add(scenePathsToSave[i]);
+                    continue;
+                }
+
+                hasRecordedSceneSnapshot = RecordSceneSnapshotIfTrackable(scene) || hasRecordedSceneSnapshot;
+            }
+
+            if (hasRecordedSceneSnapshot)
+            {
+                SaveSceneSnapshotsToSessionState();
+            }
+
+            return failedScenePaths.ToArray();
         }
 
         private static string[] SaveDirtyOpenScenesBeforeReload()

--- a/docs/focus-return-asset-handling.md
+++ b/docs/focus-return-asset-handling.md
@@ -23,7 +23,11 @@ return each asset falls into exactly one of these cases:
 | any | no fingerprint recorded | record one, nothing else |
 
 The `dirty + changed` row is the only place where the package writes a user's unsaved edits
-to disk on its own. It does so because the alternative is a modal conflict dialog, and the
+to disk on its own, with one multi-Scene exception: when a *clean* open Scene changed on disk,
+the reload goes through `EditorSceneManager.RestoreSceneManagerSetup`, which reloads every
+open Scene, so the resolver saves all dirty Scenes first rather than lose their edits. That
+still requires an external change to some open Scene; with nothing changed on disk, nothing
+is saved. It does so because the alternative is a modal conflict dialog, and the
 in-memory state is treated as authoritative there. The decision is isolated in
 `ExternalAssetFocusReturnSavePolicy` so it can be unit-tested without Unity Scene APIs
 (`Assets/Tests/Editor/ExternalAssetFocusReturnSavePolicyTests.cs`).

--- a/docs/focus-return-asset-handling.md
+++ b/docs/focus-return-asset-handling.md
@@ -1,0 +1,49 @@
+# Focus-return handling of open Scenes and the Prefab Stage
+
+The Unity package holds Unity's Auto Refresh (`AssetDatabase.DisallowAutoRefresh`) while the
+Editor is unfocused and releases it only after a preflight runs on focus return. The preflight
+exists so that files replaced outside Unity while it was unfocused — a `git checkout`, a
+revert, an agent editing a Scene file — do not surface as native "changed on disk" dialogs
+that block `uloop` commands. Implementation: `ExternalSceneChangeTracker.ResolveForFocusReturn`
+and `ExternalPrefabStageChangeTracker` under `Packages/src/Editor/FirstPartyTools/Compile/`.
+
+## What the preflight does, per open asset
+
+The package keeps a file fingerprint (`Exists`, `LastWriteTimeUtc`, `Length`) for every open
+Scene and for the current Prefab Stage, recorded when the asset is opened or saved. On focus
+return each asset falls into exactly one of these cases:
+
+| In-memory state | File on disk vs. fingerprint | Action |
+|---|---|---|
+| clean | unchanged | nothing |
+| clean | changed | reload the Scene setup / reopen the Prefab Stage from disk |
+| clean | missing | write the asset back from memory |
+| dirty | unchanged | **nothing — unsaved edits stay unsaved** |
+| dirty | changed or missing | save the in-memory state over the file, then continue |
+| any | no fingerprint recorded | record one, nothing else |
+
+The `dirty + changed` row is the only place where the package writes a user's unsaved edits
+to disk on its own. It does so because the alternative is a modal conflict dialog, and the
+in-memory state is treated as authoritative there. The decision is isolated in
+`ExternalAssetFocusReturnSavePolicy` so it can be unit-tested without Unity Scene APIs
+(`Assets/Tests/Editor/ExternalAssetFocusReturnSavePolicyTests.cs`).
+
+## Why dirty-but-unchanged assets are never saved
+
+Through package 3.0.0 the preflight saved every dirty Scene and the dirty Prefab Stage on every focus
+return, regardless of whether anything changed on disk. Because an agent-driven workflow
+switches focus between the terminal and Unity constantly, that silently committed in-progress
+editor work to disk within seconds of making it — the user saw a Scene they had not saved
+become saved, and `run-tests --fail-on-unsaved-changes` had nothing left to detect. Saving is
+now gated on an actual external change, which is the only case the dialog-avoidance rationale
+covers.
+
+## Related but separate paths
+
+- `uloop compile` runs the same fingerprint comparison before compiling (`ExternalSceneChangeResolver`).
+  There, a dirty Scene that changed externally is reported and never overwritten; clean changed
+  Scenes are reloaded, and dirty Scenes are saved first only when a reload of the whole Scene
+  setup is required. `--stop-on-external-scene-changes` turns the reload into a hard stop.
+- `uloop run-tests` and `uloop control-play-mode` save unsaved Scene and Prefab Stage changes
+  before starting by default; that is an explicit, documented step in those tools, not part of
+  focus return.


### PR DESCRIPTION
## Summary
- Unsaved Scene and Prefab Stage edits now survive switching focus away from Unity and back.
- Focus return still writes the in-memory state over a file only when that file was replaced or removed on disk while Unity was unfocused — the one case that would otherwise raise Unity's external-change dialog.

## User Impact
- Before: every time Unity regained focus, the package saved every dirty open Scene and the dirty Prefab Stage, regardless of whether anything had changed on disk. In an agent workflow that switches between the terminal and Unity constantly, an edit made in the Inspector became a saved file within seconds without the user ever pressing save, and `run-tests --fail-on-unsaved-changes` had nothing left to detect.
- After: a dirty Scene or Prefab Stage whose file is unchanged on disk stays dirty across focus changes. Dirty assets whose file changed or disappeared while unfocused are still saved from memory, so no reload dialog appears and `uloop` commands are not blocked.

## Changes
- `ExternalAssetFocusReturnSavePolicy` (new): pure decision that selects dirty assets to save as those whose fingerprint differs from the recorded snapshot; assets without a snapshot are never saved.
- `ExternalSceneChangeTracker.ResolveForFocusReturn` saves only the scenes the policy selects; `ExternalPrefabStageChangeTracker.SaveDirtyIfChangedExternally` applies the same rule to the Prefab Stage.
- The "skip Prefab Stage reload while it is dirty" branch is reduced to the failed-save case, because a dirty stage that survived the save step is by construction unchanged on disk; `IsCurrentDirty` had no remaining callers and is removed.
- `docs/focus-return-asset-handling.md` documents the focus-return matrix and the related compile / run-tests paths.
- `uloop compile` preflight (`ExternalSceneChangeResolver`) is unchanged.

## Verification
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value "ExternalAssetFocusReturnSavePolicyTests|ExternalSceneChangeResolverTests"` → 32 passed (6 new).
- `uloop compile` → 0 errors.
- `scripts/check-file-length.sh` → no files exceed the limit.
- Manual, Unity 2022.3.62f3, driving the focus handler in the Editor:
  - dirty Scene, file unchanged → focus cycle → still dirty, file mtime unchanged
  - dirty Scene, file touched externally → focus cycle → saved from memory, no dialog
  - dirty Prefab Stage, unchanged → still dirty; touched externally → saved, stage kept open
  - real focus switch (activate another app, `uloop focus-window`) → dirty Scene still dirty

https://claude.ai/code/session_01XbhSMKK4LFud57iAmowDz7


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

