### PR TITLE
feat: run-tests can now keep, fail on, or discard unsaved editor changes

### DIFF
--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -10,7 +10,7 @@ Execute Unity Test Runner. When tests fail, NUnit XML results with error message
 
 `uloop run-tests` automatically compiles pending script changes before running tests. Pass `--skip-compile` only while validating active hot-reload patches, because the compile clears those patches; otherwise let the default compile surface errors and run against current scripts.
 
-Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
+Before executing tests, `uloop run-tests` handles unsaved loaded Scene and Prefab Stage changes according to `--unsaved-changes` (default `save`): `save` writes them first, `fail` stops if any remain, and `discard` reloads disk state so tests run against saved files. Untitled scenes cannot be discarded and fail. If the chosen mode cannot proceed, it returns `Success: false`, keeps `TestCount` at `0`, lists the items in `Message`, and does not start the Unity Test Runner.
 
 Active pause points are automatically cleared (the underlying code patches are removed as well) before test execution begins. Cleared IDs are reported in the response's `ClearedPausePointIds` field.
 
@@ -31,7 +31,7 @@ uloop run-tests [options]
 | `--test-mode` | string | `EditMode` | Test mode: `EditMode`, `PlayMode` |
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
-| `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
+| `--unsaved-changes` | string | `save` | `save` writes unsaved Scene/Prefab Stage changes; `fail` stops if any remain; `discard` reloads disk state (Untitled scenes fail) |
 | `--skip-compile` | flag | - | Skip the automatic compile before running tests; use only while validating active hot-reload patches. |
 | `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
 

--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -10,7 +10,7 @@ Execute Unity Test Runner. When tests fail, NUnit XML results with error message
 
 `uloop run-tests` automatically compiles pending script changes before running tests. Pass `--skip-compile` only while validating active hot-reload patches, because the compile clears those patches; otherwise let the default compile surface errors and run against current scripts.
 
-Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
+Before executing tests, `uloop run-tests` handles unsaved loaded Scene and Prefab Stage changes according to `--unsaved-changes` (default `save`): `save` writes them first, `fail` stops if any remain, and `discard` reloads disk state so tests run against saved files. Untitled scenes cannot be discarded and fail. If the chosen mode cannot proceed, it returns `Success: false`, keeps `TestCount` at `0`, lists the items in `Message`, and does not start the Unity Test Runner.
 
 Active pause points are automatically cleared (the underlying code patches are removed as well) before test execution begins. Cleared IDs are reported in the response's `ClearedPausePointIds` field.
 
@@ -31,7 +31,7 @@ uloop run-tests [options]
 | `--test-mode` | string | `EditMode` | Test mode: `EditMode`, `PlayMode` |
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
-| `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
+| `--unsaved-changes` | string | `save` | `save` writes unsaved Scene/Prefab Stage changes; `fail` stops if any remain; `discard` reloads disk state (Untitled scenes fail) |
 | `--skip-compile` | flag | - | Skip the automatic compile before running tests; use only while validating active hot-reload patches. |
 | `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
 

--- a/Assets/Tests/Editor/EditorUnsavedChangesDiscarderTests.cs
+++ b/Assets/Tests/Editor/EditorUnsavedChangesDiscarderTests.cs
@@ -67,6 +67,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(failures, Is.Empty);
             Assert.That(reloaded.IsValid(), Is.True);
             Assert.That(reloaded.isDirty, Is.False);
+            Assert.That(GameObject.Find("DiscarderProbe"), Is.Null);
             Assert.That(File.GetLastWriteTimeUtc(TempScenePath), Is.EqualTo(mtimeBefore));
         }
 
@@ -88,6 +89,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(current.scene.isDirty, Is.False);
             Assert.That(File.GetLastWriteTimeUtc(TempPrefabPath), Is.EqualTo(mtimeBefore));
             Assert.That(stage, Is.Not.EqualTo(current));
+        }
+
+        /// <summary>
+        /// Verifies discard restores both a dirty Prefab Stage and a dirty saved Scene without writing either file.
+        /// </summary>
+        [Test]
+        public void DiscardUnsavedEditorChanges_WithDirtyPrefabStageAndDirtySavedScene_RestoresBothWithoutWritingFiles()
+        {
+            Scene scene = CreateSavedActiveScene();
+            MakeSceneDirty(scene);
+            OpenDirtyPrefabStage();
+            DateTime sceneMtimeBefore = File.GetLastWriteTimeUtc(TempScenePath);
+            DateTime prefabMtimeBefore = File.GetLastWriteTimeUtc(TempPrefabPath);
+
+            string[] failures = _discarder.DiscardUnsavedEditorChanges();
+
+            PrefabStage current = PrefabStageUtility.GetCurrentPrefabStage();
+            Scene reloaded = SceneManager.GetSceneByPath(TempScenePath);
+            Assert.That(failures, Is.Empty);
+            Assert.That(current, Is.Not.Null);
+            Assert.That(current.assetPath, Is.EqualTo(TempPrefabPath));
+            Assert.That(current.scene.isDirty, Is.False);
+            Assert.That(reloaded.IsValid(), Is.True);
+            Assert.That(reloaded.isLoaded, Is.True);
+            Assert.That(reloaded.isDirty, Is.False);
+            Assert.That(GameObject.Find("DiscarderProbe"), Is.Null);
+            Assert.That(File.GetLastWriteTimeUtc(TempScenePath), Is.EqualTo(sceneMtimeBefore));
+            Assert.That(File.GetLastWriteTimeUtc(TempPrefabPath), Is.EqualTo(prefabMtimeBefore));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/EditorUnsavedChangesDiscarderTests.cs
+++ b/Assets/Tests/Editor/EditorUnsavedChangesDiscarderTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Drives EditorUnsavedChangesDiscarder against real Scenes and Prefab Stages so discard
+    /// restores disk contents without writing files or prompting.
+    /// </summary>
+    public sealed class EditorUnsavedChangesDiscarderTests
+    {
+        private const string TempFolder = "Assets/UloopUnsavedChangesDiscarderTemp";
+        private const string TempScenePath = TempFolder + "/DiscarderScene.unity";
+        private const string TempPrefabPath = TempFolder + "/DiscarderPrefab.prefab";
+
+        private readonly EditorUnsavedChangesDiscarder _discarder = new EditorUnsavedChangesDiscarder();
+
+        [SetUp]
+        public void SetUp()
+        {
+            if (!AssetDatabase.IsValidFolder(TempFolder))
+            {
+                AssetDatabase.CreateFolder("Assets", "UloopUnsavedChangesDiscarderTemp");
+            }
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (PrefabStageUtility.GetCurrentPrefabStage() != null)
+            {
+                PrefabStageUtility.GetCurrentPrefabStage().ClearDirtiness();
+                StageUtility.GoBackToPreviousStage();
+            }
+
+            Scene tempScene = SceneManager.GetSceneByPath(TempScenePath);
+            if (tempScene.IsValid() && tempScene.isLoaded)
+            {
+                // Why NewScene: the temp scene is the active (and only) scene, and Unity cannot
+                // close the last loaded scene; replacing it releases the asset for deletion.
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            }
+
+            AssetDatabase.DeleteAsset(TempFolder);
+        }
+
+        /// <summary>
+        /// Verifies a dirty saved Scene is reloaded from disk without writing the file.
+        /// </summary>
+        [Test]
+        public void DiscardUnsavedEditorChanges_WithDirtySavedScene_ReloadsWithoutWritingFile()
+        {
+            Scene scene = CreateSavedActiveScene();
+            MakeSceneDirty(scene);
+            DateTime mtimeBefore = File.GetLastWriteTimeUtc(TempScenePath);
+
+            string[] failures = _discarder.DiscardUnsavedEditorChanges();
+
+            Scene reloaded = SceneManager.GetSceneByPath(TempScenePath);
+            Assert.That(failures, Is.Empty);
+            Assert.That(reloaded.IsValid(), Is.True);
+            Assert.That(reloaded.isDirty, Is.False);
+            Assert.That(File.GetLastWriteTimeUtc(TempScenePath), Is.EqualTo(mtimeBefore));
+        }
+
+        /// <summary>
+        /// Verifies a dirty Prefab Stage is reopened from disk without writing the prefab file.
+        /// </summary>
+        [Test]
+        public void DiscardUnsavedEditorChanges_WithDirtyPrefabStage_ReopensWithoutWritingFile()
+        {
+            PrefabStage stage = OpenDirtyPrefabStage();
+            DateTime mtimeBefore = File.GetLastWriteTimeUtc(TempPrefabPath);
+
+            string[] failures = _discarder.DiscardUnsavedEditorChanges();
+
+            PrefabStage current = PrefabStageUtility.GetCurrentPrefabStage();
+            Assert.That(failures, Is.Empty);
+            Assert.That(current, Is.Not.Null);
+            Assert.That(current.assetPath, Is.EqualTo(TempPrefabPath));
+            Assert.That(current.scene.isDirty, Is.False);
+            Assert.That(File.GetLastWriteTimeUtc(TempPrefabPath), Is.EqualTo(mtimeBefore));
+            Assert.That(stage, Is.Not.EqualTo(current));
+        }
+
+        /// <summary>
+        /// Verifies an untitled dirty Scene is reported and left untouched because it has no disk path.
+        /// </summary>
+        [Test]
+        public void DiscardUnsavedEditorChanges_WithUntitledDirtyScene_ReturnsFailureAndLeavesSceneUntouched()
+        {
+            Scene scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            MakeSceneDirty(scene);
+
+            string[] failures = _discarder.DiscardUnsavedEditorChanges();
+
+            Assert.That(failures, Has.Some.Contains("Scene:"));
+            Assert.That(scene.IsValid(), Is.True);
+            Assert.That(scene.isDirty, Is.True);
+            Assert.That(string.IsNullOrEmpty(scene.path), Is.True);
+        }
+
+        private static Scene CreateSavedActiveScene()
+        {
+            // Why Single: the test runner can hold an untitled unsaved scene, and Unity refuses to
+            // create an additive scene next to one. Replacing the active scene avoids that restriction.
+            Scene scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            bool saved = EditorSceneManager.SaveScene(scene, TempScenePath);
+            Assert.That(saved, Is.True, "temp scene must save so discard can reload it from disk");
+            return scene;
+        }
+
+        private static void MakeSceneDirty(Scene scene)
+        {
+            GameObject probe = new GameObject("DiscarderProbe");
+            SceneManager.MoveGameObjectToScene(probe, scene);
+            EditorSceneManager.MarkSceneDirty(scene);
+            Assert.That(scene.isDirty, Is.True, "scene must be dirty before discard runs");
+        }
+
+        private static PrefabStage OpenDirtyPrefabStage()
+        {
+            GameObject root = new GameObject("DiscarderPrefabRoot");
+            bool created;
+            PrefabUtility.SaveAsPrefabAsset(root, TempPrefabPath, out created);
+            UnityEngine.Object.DestroyImmediate(root);
+            Assert.That(created, Is.True, "temp prefab must save before it can be opened in a stage");
+
+            PrefabStage stage = PrefabStageUtility.OpenPrefab(TempPrefabPath);
+            Assert.That(stage, Is.Not.Null, "temp prefab stage must open");
+            GameObject probe = new GameObject("DiscarderProbe");
+            probe.transform.SetParent(stage.prefabContentsRoot.transform);
+            EditorSceneManager.MarkSceneDirty(stage.scene);
+            Assert.That(stage.scene.isDirty, Is.True, "prefab stage must be dirty before discard runs");
+            return stage;
+        }
+    }
+}

--- a/Assets/Tests/Editor/EditorUnsavedChangesDiscarderTests.cs.meta
+++ b/Assets/Tests/Editor/EditorUnsavedChangesDiscarderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e1f8ac13ecd0042499a7a8f4e2fdc7de
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/RunTestsToolTests.cs
+++ b/Assets/Tests/Editor/RunTestsToolTests.cs
@@ -35,7 +35,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         /// Default value test with default schema.
         /// </summary>
         [Test]
-        public void ParseParameters_WithNullParams_ShouldSaveBeforeRunByDefault()
+        public void ParseParameters_WithNullParams_ShouldUseSaveUnsavedChangesModeByDefault()
         {
             // Verifies that run-tests saves unsaved editor changes unless callers opt into a custom schema.
             
@@ -44,7 +44,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(schema.TestMode, Is.EqualTo(UnityCliLoopTestMode.EditMode));
             Assert.That(schema.FilterType, Is.EqualTo(TestFilterType.all));
             Assert.That(schema.FilterValue ?? string.Empty, Is.EqualTo(string.Empty));
-            Assert.That(schema.SaveBeforeRun, Is.True);
+            Assert.That(schema.UnsavedChanges, Is.EqualTo(RunTestsUnsavedChangesMode.save));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -30,7 +30,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             RunTestsSchema parameters = new()
             {
                 TestMode = UnityCliLoopTestMode.EditMode,
-                SaveBeforeRun = true
+                UnsavedChanges = RunTestsUnsavedChangesMode.save
             };
 
             RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
@@ -47,7 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.FailedCount, Is.EqualTo(0));
             Assert.That(response.SkippedCount, Is.EqualTo(0));
             Assert.That(executionService.WasCalled, Is.False);
-            Assert.That(validationService.SaveBeforeRun, Is.True);
+            Assert.That(validationService.UnsavedChanges, Is.EqualTo(RunTestsUnsavedChangesMode.save));
         }
 
         [Test]
@@ -128,7 +128,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public async Task ExecuteAsync_WithDefaultRequest_ShouldSaveBeforeRun()
+        public async Task ExecuteAsync_WithDefaultRequest_ShouldUseSaveUnsavedChangesMode()
         {
             // Verifies default use-case requests preserve the run-tests auto-save behavior.
             StubTestExecutionService executionService = new();
@@ -144,7 +144,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             await useCase.ExecuteAsync(parameters, CancellationToken.None);
 
             Assert.That(validationService.WasCalled, Is.True);
-            Assert.That(validationService.SaveBeforeRun, Is.True);
+            Assert.That(validationService.UnsavedChanges, Is.EqualTo(RunTestsUnsavedChangesMode.save));
             Assert.That(executionService.WasCalled, Is.True);
         }
 
@@ -166,7 +166,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             RunTestsSchema parameters = new()
             {
                 TestMode = UnityCliLoopTestMode.PlayMode,
-                SaveBeforeRun = true
+                UnsavedChanges = RunTestsUnsavedChangesMode.save
             };
 
             RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
@@ -1096,7 +1096,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             private readonly ValidationResult _result;
 
-            public bool SaveBeforeRun { get; private set; }
+            public RunTestsUnsavedChangesMode UnsavedChanges { get; private set; }
             public bool WasCalled { get; private set; }
 
             public StubTestExecutionStateValidationService(ValidationResult result)
@@ -1104,10 +1104,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 _result = result;
             }
 
-            public override ValidationResult Validate(UnityCliLoopTestMode testMode, bool saveBeforeRun)
+            public override ValidationResult Validate(UnityCliLoopTestMode testMode, RunTestsUnsavedChangesMode unsavedChanges)
             {
                 WasCalled = true;
-                SaveBeforeRun = saveBeforeRun;
+                UnsavedChanges = unsavedChanges;
                 return _result;
             }
         }

--- a/Assets/Tests/Editor/SkillParameterTableCoverageTests.cs
+++ b/Assets/Tests/Editor/SkillParameterTableCoverageTests.cs
@@ -186,11 +186,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 return kebabName;
             }
 
-            // These two flags read as an action rather than as the negation of a property name.
-            if (toolName == "run-tests" && propertyName == "SaveBeforeRun")
-            {
-                return "fail-on-unsaved-changes";
-            }
+            // This flag reads as an action rather than as the negation of a property name.
             if (toolName == "compile" && propertyName == "ReloadExternalSceneChanges")
             {
                 return "stop-on-external-scene-changes";

--- a/Assets/Tests/Editor/TestExecutionStateValidationServiceTests.cs
+++ b/Assets/Tests/Editor/TestExecutionStateValidationServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
@@ -10,39 +11,51 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     /// </summary>
     public class TestExecutionStateValidationServiceTests
     {
+        /// <summary>
+        /// Verifies EditMode tests are rejected while Play Mode is active.
+        /// </summary>
         [Test]
         public void Validate_WithEditModeWhilePlaying_ShouldReturnFailure()
         {
             TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(true);
 
-            ValidationResult result = service.Validate(UnityCliLoopTestMode.EditMode, saveBeforeRun: false);
+            ValidationResult result = service.Validate(UnityCliLoopTestMode.EditMode, RunTestsUnsavedChangesMode.fail);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Is.EqualTo("EditMode tests cannot run during play mode. Use control-play-mode --action Stop to exit play mode, then rerun the tests."));
         }
 
+        /// <summary>
+        /// Verifies EditMode tests pass validation when the editor is not playing.
+        /// </summary>
         [Test]
         public void Validate_WithEditModeWhileNotPlaying_ShouldReturnSuccess()
         {
             TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(false);
 
-            ValidationResult result = service.Validate(UnityCliLoopTestMode.EditMode, saveBeforeRun: false);
+            ValidationResult result = service.Validate(UnityCliLoopTestMode.EditMode, RunTestsUnsavedChangesMode.fail);
 
             Assert.That(result.IsValid, Is.True);
             Assert.That(result.ErrorMessage, Is.Null);
         }
 
+        /// <summary>
+        /// Verifies PlayMode tests pass validation while Play Mode is active and not paused.
+        /// </summary>
         [Test]
         public void Validate_WithPlayModeWhilePlaying_ShouldReturnSuccess()
         {
             TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(true);
 
-            ValidationResult result = service.Validate(UnityCliLoopTestMode.PlayMode, saveBeforeRun: false);
+            ValidationResult result = service.Validate(UnityCliLoopTestMode.PlayMode, RunTestsUnsavedChangesMode.fail);
 
             Assert.That(result.IsValid, Is.True);
             Assert.That(result.ErrorMessage, Is.Null);
         }
 
+        /// <summary>
+        /// Verifies tests are rejected while compilation is in progress.
+        /// </summary>
         [Test]
         public void Validate_WhenCompilationIsInProgress_ShouldReturnFailure()
         {
@@ -50,12 +63,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 isPlaying: false,
                 isCompiling: true);
 
-            ValidationResult result = service.Validate(UnityCliLoopTestMode.EditMode, saveBeforeRun: false);
+            ValidationResult result = service.Validate(UnityCliLoopTestMode.EditMode, RunTestsUnsavedChangesMode.fail);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Is.EqualTo("Tests cannot run while compilation is in progress"));
         }
 
+        /// <summary>
+        /// Verifies tests are rejected while the editor is updating.
+        /// </summary>
         [Test]
         public void Validate_WhenEditorIsUpdating_ShouldReturnFailure()
         {
@@ -63,21 +79,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 isPlaying: false,
                 isUpdating: true);
 
-            ValidationResult result = service.Validate(UnityCliLoopTestMode.EditMode, saveBeforeRun: false);
+            ValidationResult result = service.Validate(UnityCliLoopTestMode.EditMode, RunTestsUnsavedChangesMode.fail);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Is.EqualTo("Tests cannot run while the editor is updating"));
         }
 
+        /// <summary>
+        /// Verifies PlayMode tests are rejected when Play Mode is paused.
+        /// </summary>
         [Test]
         public void Validate_WithPlayModeWhilePaused_ShouldReturnFailure()
         {
-            // Verifies that PlayMode tests are rejected when Play Mode is paused.
             TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(
                 isPlaying: true,
                 isPaused: true);
 
-            ValidationResult result = service.Validate(UnityCliLoopTestMode.PlayMode, saveBeforeRun: false);
+            ValidationResult result = service.Validate(UnityCliLoopTestMode.PlayMode, RunTestsUnsavedChangesMode.fail);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Does.Contain("paused"));
@@ -85,90 +103,199 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result.ErrorMessage, Does.Contain("clear-pause-point"));
         }
 
+        /// <summary>
+        /// Verifies the existing "cannot run during play mode" check takes precedence over the paused check for EditMode.
+        /// </summary>
         [Test]
         public void Validate_WithEditModeWhilePaused_ShouldReturnPlayModeFailureNotPausedFailure()
         {
-            // Verifies that the existing "cannot run during play mode" check takes precedence over the paused check for EditMode.
             TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(
                 isPlaying: true,
                 isPaused: true);
 
-            ValidationResult result = service.Validate(UnityCliLoopTestMode.EditMode, saveBeforeRun: false);
+            ValidationResult result = service.Validate(UnityCliLoopTestMode.EditMode, RunTestsUnsavedChangesMode.fail);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Is.EqualTo("EditMode tests cannot run during play mode. Use control-play-mode --action Stop to exit play mode, then rerun the tests."));
         }
 
+        /// <summary>
+        /// Verifies PlayMode tests pass validation when playing but not paused.
+        /// </summary>
         [Test]
         public void Validate_WithPlayModeWhilePlayingNotPaused_ShouldReturnSuccess()
         {
-            // Verifies that PlayMode tests pass validation when playing but not paused.
             TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(
                 isPlaying: true,
                 isPaused: false);
 
-            ValidationResult result = service.Validate(UnityCliLoopTestMode.PlayMode, saveBeforeRun: false);
+            ValidationResult result = service.Validate(UnityCliLoopTestMode.PlayMode, RunTestsUnsavedChangesMode.fail);
 
             Assert.That(result.IsValid, Is.True);
         }
 
+        /// <summary>
+        /// Verifies save mode persists dirty editor changes and then succeeds.
+        /// </summary>
         [Test]
-        public void Validate_WhenEditorHasUnsavedChangesAndSaveBeforeRunIsFalse_ShouldReturnFailure()
+        public void Validate_WithSaveModeWhenSaveSucceeds_ShouldReturnSuccess()
+        {
+            string[] unsavedEditorChanges =
+            {
+                "Scene: Assets/Scenes/Minecraft.unity"
+            };
+            FakeEditorUnsavedChangesQuietSaver saver = new FakeEditorUnsavedChangesQuietSaver(
+                unsavedEditorChanges,
+                Array.Empty<string>());
+            FakeEditorUnsavedChangesDiscarder discarder = new FakeEditorUnsavedChangesDiscarder(Array.Empty<string>());
+            StubTestExecutionStateValidationService service = new StubTestExecutionStateValidationService(
+                isPlaying: false,
+                saver: saver,
+                discarder: discarder);
+
+            ValidationResult result = service.Validate(UnityCliLoopTestMode.PlayMode, RunTestsUnsavedChangesMode.save);
+
+            Assert.That(result.IsValid, Is.True);
+            Assert.That(result.ErrorMessage, Is.Null);
+            Assert.That(saver.SaveCallCount, Is.EqualTo(1));
+            Assert.That(discarder.DiscardCallCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies save mode returns the save-failure message and the failed change list.
+        /// </summary>
+        [Test]
+        public void Validate_WithSaveModeWhenSaveFails_ShouldReturnFailureWithFailedChanges()
+        {
+            string[] unsavedEditorChanges =
+            {
+                "Prefab Stage: Assets/Scenes/Crosshair.prefab"
+            };
+            FakeEditorUnsavedChangesQuietSaver saver = new FakeEditorUnsavedChangesQuietSaver(
+                unsavedEditorChanges,
+                unsavedEditorChanges);
+            FakeEditorUnsavedChangesDiscarder discarder = new FakeEditorUnsavedChangesDiscarder(Array.Empty<string>());
+            TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(
+                isPlaying: false,
+                saver: saver,
+                discarder: discarder);
+
+            ValidationResult result = service.Validate(UnityCliLoopTestMode.PlayMode, RunTestsUnsavedChangesMode.save);
+
+            Assert.That(result.IsValid, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("Tests cannot save unsaved scene or prefab changes before running tests"));
+            Assert.That(result.ErrorMessage, Does.Contain("Prefab Stage: Assets/Scenes/Crosshair.prefab"));
+            Assert.That(saver.SaveCallCount, Is.EqualTo(1));
+            Assert.That(discarder.DiscardCallCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies fail mode leaves dirty editor changes untouched and rejects the run.
+        /// </summary>
+        [Test]
+        public void Validate_WithFailModeWhenEditorIsDirty_ShouldReturnFailureWithoutSavingOrDiscarding()
         {
             string[] unsavedEditorChanges =
             {
                 "Scene: Assets/Scenes/Minecraft.unity",
                 "Prefab Stage: Assets/Scenes/GameCanvas.prefab"
             };
+            FakeEditorUnsavedChangesQuietSaver saver = new FakeEditorUnsavedChangesQuietSaver(
+                unsavedEditorChanges,
+                Array.Empty<string>());
+            FakeEditorUnsavedChangesDiscarder discarder = new FakeEditorUnsavedChangesDiscarder(Array.Empty<string>());
             TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(
                 isPlaying: false,
-                unsavedEditorChanges: unsavedEditorChanges);
+                saver: saver,
+                discarder: discarder);
 
-            ValidationResult result = service.Validate(UnityCliLoopTestMode.PlayMode, saveBeforeRun: false);
+            ValidationResult result = service.Validate(UnityCliLoopTestMode.PlayMode, RunTestsUnsavedChangesMode.fail);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Does.Contain("Tests cannot run while the editor has unsaved scene or prefab changes"));
             Assert.That(result.ErrorMessage, Does.Contain("Scene: Assets/Scenes/Minecraft.unity"));
             Assert.That(result.ErrorMessage, Does.Contain("Prefab Stage: Assets/Scenes/GameCanvas.prefab"));
+            Assert.That(saver.SaveCallCount, Is.EqualTo(0));
+            Assert.That(discarder.DiscardCallCount, Is.EqualTo(0));
         }
 
+        /// <summary>
+        /// Verifies fail mode succeeds when the editor has no unsaved changes.
+        /// </summary>
         [Test]
-        public void Validate_WhenEditorHasUnsavedChangesAndSaveBeforeRunIsTrue_ShouldSaveAndReturnSuccess()
+        public void Validate_WithFailModeWhenEditorIsClean_ShouldReturnSuccess()
+        {
+            FakeEditorUnsavedChangesQuietSaver saver = new FakeEditorUnsavedChangesQuietSaver(
+                Array.Empty<string>(),
+                Array.Empty<string>());
+            FakeEditorUnsavedChangesDiscarder discarder = new FakeEditorUnsavedChangesDiscarder(Array.Empty<string>());
+            TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(
+                isPlaying: false,
+                saver: saver,
+                discarder: discarder);
+
+            ValidationResult result = service.Validate(UnityCliLoopTestMode.PlayMode, RunTestsUnsavedChangesMode.fail);
+
+            Assert.That(result.IsValid, Is.True);
+            Assert.That(result.ErrorMessage, Is.Null);
+            Assert.That(saver.SaveCallCount, Is.EqualTo(0));
+            Assert.That(discarder.DiscardCallCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies discard mode drops dirty editor changes and then succeeds.
+        /// </summary>
+        [Test]
+        public void Validate_WithDiscardModeWhenDiscardSucceeds_ShouldReturnSuccess()
         {
             string[] unsavedEditorChanges =
             {
                 "Scene: Assets/Scenes/Minecraft.unity"
             };
-            StubTestExecutionStateValidationService service = new(
+            FakeEditorUnsavedChangesQuietSaver saver = new FakeEditorUnsavedChangesQuietSaver(
+                unsavedEditorChanges,
+                Array.Empty<string>());
+            FakeEditorUnsavedChangesDiscarder discarder = new FakeEditorUnsavedChangesDiscarder(Array.Empty<string>());
+            discarder.BindSaver(saver);
+            TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(
                 isPlaying: false,
-                unsavedEditorChanges: unsavedEditorChanges,
-                saveResult: ValidationResult.Success(),
-                clearUnsavedChangesAfterSave: true);
+                saver: saver,
+                discarder: discarder);
 
-            ValidationResult result = service.Validate(UnityCliLoopTestMode.PlayMode, saveBeforeRun: true);
+            ValidationResult result = service.Validate(UnityCliLoopTestMode.PlayMode, RunTestsUnsavedChangesMode.discard);
 
             Assert.That(result.IsValid, Is.True);
             Assert.That(result.ErrorMessage, Is.Null);
-            Assert.That(service.SaveWasCalled, Is.True);
+            Assert.That(saver.SaveCallCount, Is.EqualTo(0));
+            Assert.That(discarder.DiscardCallCount, Is.EqualTo(1));
         }
 
+        /// <summary>
+        /// Verifies discard mode returns the discard-failure message and the failed change list.
+        /// </summary>
         [Test]
-        public void Validate_WhenSaveBeforeRunFails_ShouldReturnFailure()
+        public void Validate_WithDiscardModeWhenDiscardFails_ShouldReturnFailureWithFailedChanges()
         {
             string[] unsavedEditorChanges =
             {
-                "Prefab Stage: Assets/Scenes/Crosshair.prefab"
+                "Scene: Untitled scene"
             };
+            FakeEditorUnsavedChangesQuietSaver saver = new FakeEditorUnsavedChangesQuietSaver(
+                unsavedEditorChanges,
+                Array.Empty<string>());
+            FakeEditorUnsavedChangesDiscarder discarder = new FakeEditorUnsavedChangesDiscarder(unsavedEditorChanges);
             TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(
                 isPlaying: false,
-                unsavedEditorChanges: unsavedEditorChanges,
-                saveResult: ValidationResult.Failure("Tests cannot save unsaved scene or prefab changes before running tests. Unsaved changes that failed to save: Prefab Stage: Assets/Scenes/Crosshair.prefab"));
+                saver: saver,
+                discarder: discarder);
 
-            ValidationResult result = service.Validate(UnityCliLoopTestMode.PlayMode, saveBeforeRun: true);
+            ValidationResult result = service.Validate(UnityCliLoopTestMode.PlayMode, RunTestsUnsavedChangesMode.discard);
 
             Assert.That(result.IsValid, Is.False);
-            Assert.That(result.ErrorMessage, Does.Contain("Tests cannot save unsaved scene or prefab changes before running tests"));
-            Assert.That(result.ErrorMessage, Does.Contain("Prefab Stage: Assets/Scenes/Crosshair.prefab"));
+            Assert.That(result.ErrorMessage, Does.Contain("Tests cannot discard unsaved scene or prefab changes before running tests."));
+            Assert.That(result.ErrorMessage, Does.Contain("Scene: Untitled scene"));
+            Assert.That(saver.SaveCallCount, Is.EqualTo(0));
+            Assert.That(discarder.DiscardCallCount, Is.EqualTo(1));
         }
 
         /// <summary>
@@ -180,48 +307,97 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             private readonly bool _isPaused;
             private readonly bool _isCompiling;
             private readonly bool _isUpdating;
-            private readonly ValidationResult _saveResult;
-            private readonly bool _clearUnsavedChangesAfterSave;
-            private string[] _unsavedEditorChanges;
-
-            public bool SaveWasCalled { get; private set; }
 
             public StubTestExecutionStateValidationService(
                 bool isPlaying,
                 bool isPaused = false,
                 bool isCompiling = false,
                 bool isUpdating = false,
-                string[] unsavedEditorChanges = null,
-                ValidationResult saveResult = null,
-                bool clearUnsavedChangesAfterSave = false)
+                FakeEditorUnsavedChangesQuietSaver saver = null,
+                FakeEditorUnsavedChangesDiscarder discarder = null)
+                : base(
+                    saver ?? new FakeEditorUnsavedChangesQuietSaver(Array.Empty<string>(), Array.Empty<string>()),
+                    discarder ?? new FakeEditorUnsavedChangesDiscarder(Array.Empty<string>()))
             {
                 _isPlaying = isPlaying;
                 _isPaused = isPaused;
                 _isCompiling = isCompiling;
                 _isUpdating = isUpdating;
-                _unsavedEditorChanges = unsavedEditorChanges ?? new string[0];
-                _saveResult = saveResult ?? ValidationResult.Success();
-                _clearUnsavedChangesAfterSave = clearUnsavedChangesAfterSave;
             }
 
             protected override bool IsPlaying => _isPlaying;
             protected override bool IsPaused => _isPaused;
             protected override bool IsCompiling => _isCompiling;
             protected override bool IsUpdating => _isUpdating;
-            protected override string[] DetectUnsavedEditorChanges()
+        }
+
+        /// <summary>
+        /// Fake saver that records save calls and optionally clears detected dirty items after a successful save.
+        /// </summary>
+        private sealed class FakeEditorUnsavedChangesQuietSaver : IEditorUnsavedChangesQuietSaver
+        {
+            private string[] _detectedChanges;
+            private readonly string[] _saveFailures;
+
+            public int SaveCallCount { get; private set; }
+
+            public FakeEditorUnsavedChangesQuietSaver(string[] detectedChanges, string[] saveFailures)
             {
-                return _unsavedEditorChanges;
+                _detectedChanges = detectedChanges;
+                _saveFailures = saveFailures;
             }
 
-            protected override ValidationResult SaveUnsavedEditorChanges()
+            public void ClearDetectedChanges()
             {
-                SaveWasCalled = true;
-                if (_clearUnsavedChangesAfterSave)
+                _detectedChanges = Array.Empty<string>();
+            }
+
+            public string[] DetectUnsavedEditorChanges()
+            {
+                return _detectedChanges;
+            }
+
+            public string[] SaveUnsavedEditorChanges()
+            {
+                SaveCallCount++;
+                if (_saveFailures.Length == 0)
                 {
-                    _unsavedEditorChanges = new string[0];
+                    ClearDetectedChanges();
                 }
 
-                return _saveResult;
+                return _saveFailures;
+            }
+        }
+
+        /// <summary>
+        /// Fake discarder that records discard calls and optionally clears the bound saver's dirty items.
+        /// </summary>
+        private sealed class FakeEditorUnsavedChangesDiscarder : IEditorUnsavedChangesDiscarder
+        {
+            private readonly string[] _discardFailures;
+            private FakeEditorUnsavedChangesQuietSaver _saver;
+
+            public int DiscardCallCount { get; private set; }
+
+            public FakeEditorUnsavedChangesDiscarder(string[] discardFailures)
+            {
+                _discardFailures = discardFailures;
+            }
+
+            public void BindSaver(FakeEditorUnsavedChangesQuietSaver saver)
+            {
+                _saver = saver;
+            }
+
+            public string[] DiscardUnsavedEditorChanges()
+            {
+                DiscardCallCount++;
+                if (_discardFailures.Length == 0 && _saver != null)
+                {
+                    _saver.ClearDetectedChanges();
+                }
+
+                return _discardFailures;
             }
         }
     }

--- a/Packages/src/Documentation~/migration-v2-to-v3.md
+++ b/Packages/src/Documentation~/migration-v2-to-v3.md
@@ -125,7 +125,7 @@ For any boolean not listed below, run `uloop <command> --help`: every V3 flag pr
 | `uloop compile` | `--reload-external-scene-changes true` | remove |
 | `uloop compile` | `--reload-external-scene-changes false` | `--stop-on-external-scene-changes` |
 | `uloop run-tests` | `--save-before-run true` or bare | remove |
-| `uloop run-tests` | `--save-before-run false` | `--fail-on-unsaved-changes` |
+| `uloop run-tests` | `--save-before-run false` | `--unsaved-changes fail` |
 | `uloop replay-input` | `--show-overlay true` | remove |
 | `uloop replay-input` | `--show-overlay false` | `--no-show-overlay` |
 | `uloop get-hierarchy` | `--include-components true` | remove |

--- a/Packages/src/Documentation~/migration-v2-to-v3_ja.md
+++ b/Packages/src/Documentation~/migration-v2-to-v3_ja.md
@@ -125,7 +125,7 @@ V3のbooleanオプションは値を取りません。V2の呼び出しをどう
 | `uloop compile` | `--reload-external-scene-changes true` | 削除 |
 | `uloop compile` | `--reload-external-scene-changes false` | `--stop-on-external-scene-changes` |
 | `uloop run-tests` | `--save-before-run true` またはフラグのみ | 削除 |
-| `uloop run-tests` | `--save-before-run false` | `--fail-on-unsaved-changes` |
+| `uloop run-tests` | `--save-before-run false` | `--unsaved-changes fail` |
 | `uloop replay-input` | `--show-overlay true` | 削除 |
 | `uloop replay-input` | `--show-overlay false` | `--no-show-overlay` |
 | `uloop get-hierarchy` | `--include-components true` | 削除 |

--- a/Packages/src/Documentation~/tools.md
+++ b/Packages/src/Documentation~/tools.md
@@ -34,12 +34,12 @@ This allows you to retrieve logs while keeping the context small.
 Executes Unity Test Runner and retrieves test results. You can set conditions with FilterType and FilterValue.
 - FilterType: all (all tests), exact (individual test method name), regex (class name or namespace), assembly (assembly name)
 - FilterValue: Value according to filter type (class name, namespace, etc.)
-- SaveBeforeRun: Saves unsaved loaded Scene changes and current Prefab Stage changes before running tests by default. When disabled, unsaved editor changes stop test execution instead of being discarded.
+- UnsavedChanges: How to handle unsaved loaded Scene and Prefab Stage changes before tests. `save` (default) writes them, `fail` stops if any remain, `discard` reloads disk state (Untitled scenes fail).
 Test results can be output as xml. The output path is returned so AI can read it.
 This is also a strategy to avoid consuming context.
 ```text
 → run-tests (FilterType: exact, FilterValue: "PlayerControllerTests.TestJump")
-→ run-tests (SaveBeforeRun: false, fail if editor changes are unsaved)
+→ run-tests (--unsaved-changes fail, stop if editor changes are unsaved)
 → Check failed tests, fix implementation to pass tests
 ```
 > [!WARNING]

--- a/Packages/src/Documentation~/tools_ja.md
+++ b/Packages/src/Documentation~/tools_ja.md
@@ -34,12 +34,12 @@ LogTypeや検索対象の文字列で絞り込む事ができます。また、s
 Unity Test Runnerを実行し、テスト結果を取得します。FilterTypeとFilterValueで条件を設定できます。
 - FilterType: all（全テスト）、exact（個別テストメソッド名）、regex（クラス名や名前空間）、assembly（アセンブリ名）
 - FilterValue: フィルタータイプに応じた値（クラス名、名前空間など）
-- SaveBeforeRun: デフォルトで未保存のロード済みScene変更と現在のPrefab Stage変更を保存してからテストを実行。無効にした場合、未保存のエディタ変更は破棄されず、テスト実行前に停止します。
+- UnsavedChanges: テスト前の未保存 Scene / Prefab Stage 変更の扱い。`save`（デフォルト）は保存、`fail` は残っていれば停止、`discard` はディスク状態へ戻す（Untitled シーンは破棄できず失敗）。
 テスト結果をxmlで出力する事が可能です。出力pathを返すので、それをAIに読み取ってもらう事ができます。
 これもコンテキストを圧迫しないための工夫です。
 ```text
 → run-tests (FilterType: exact, FilterValue: "PlayerControllerTests.TestJump")
-→ run-tests (SaveBeforeRun: false、未保存のエディタ変更があれば停止)
+→ run-tests (--unsaved-changes fail、未保存のエディタ変更があれば停止)
 → 失敗したテストを確認、実装を修正してテストをパス
 ```
 > [!WARNING]

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnsavedChangesDiscarder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnsavedChangesDiscarder.cs
@@ -20,8 +20,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return failures.ToArray();
             }
 
-            DiscardDirtyPrefabStage(failures);
+            // OpenScene leaves Prefab Stage: Unity's StageNavigationManager.OnSceneOpened
+            // returns to MainStage for every OpenSceneMode. Close the dirty stage first,
+            // reload scenes, then reopen the prefab last.
+            string prefabAssetPath = CloseDirtyPrefabStage(failures);
             ReloadDirtySavedScenes();
+            ReopenPrefabStage(prefabAssetPath, failures);
             return failures.ToArray();
         }
 
@@ -46,14 +50,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        private static void DiscardDirtyPrefabStage(List<string> failures)
+        private static string CloseDirtyPrefabStage(List<string> failures)
         {
             Debug.Assert(failures != null, "failures must not be null");
 
             PrefabStage prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
             if (prefabStage == null || !prefabStage.scene.IsValid() || !prefabStage.scene.isDirty)
             {
-                return;
+                return null;
             }
 
             string assetPath = prefabStage.assetPath;
@@ -61,11 +65,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 // OpenPrefab requires a disk path; leaving the stage alone avoids a prompt-less dead end.
                 failures.Add("Prefab Stage: " + GetPrefabStageDisplayPath(prefabStage));
-                return;
+                return null;
             }
 
             prefabStage.ClearDirtiness();
             StageUtility.GoBackToPreviousStage();
+            return assetPath;
+        }
+
+        private static void ReopenPrefabStage(string assetPath, List<string> failures)
+        {
+            Debug.Assert(failures != null, "failures must not be null");
+            if (string.IsNullOrEmpty(assetPath))
+            {
+                return;
+            }
+
             PrefabStage reopened = PrefabStageUtility.OpenPrefab(assetPath);
             if (reopened == null)
             {
@@ -81,12 +96,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             List<LoadedSceneSnapshot> snapshots = SnapshotLoadedScenes();
-            Debug.Assert(snapshots.Count > 0, "dirty saved scenes must produce at least one path snapshot");
+            int firstLoadedIndex = IndexOfFirstLoadedSnapshot(snapshots);
+            Debug.Assert(firstLoadedIndex >= 0, "dirty saved scenes must include a loaded path snapshot");
 
             string activePath = SceneManager.GetActiveScene().path;
-            EditorSceneManager.OpenScene(snapshots[0].Path, OpenSceneMode.Single);
-            for (int i = 1; i < snapshots.Count; i++)
+            EditorSceneManager.OpenScene(snapshots[firstLoadedIndex].Path, OpenSceneMode.Single);
+            for (int i = 0; i < snapshots.Count; i++)
             {
+                if (i == firstLoadedIndex)
+                {
+                    continue;
+                }
+
                 OpenSceneMode mode = snapshots[i].IsLoaded
                     ? OpenSceneMode.Additive
                     : OpenSceneMode.AdditiveWithoutLoading;
@@ -108,6 +129,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return false;
+        }
+
+        private static int IndexOfFirstLoadedSnapshot(List<LoadedSceneSnapshot> snapshots)
+        {
+            Debug.Assert(snapshots != null, "snapshots must not be null");
+
+            for (int i = 0; i < snapshots.Count; i++)
+            {
+                if (snapshots[i].IsLoaded)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
         }
 
         private static List<LoadedSceneSnapshot> SnapshotLoadedScenes()

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnsavedChangesDiscarder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnsavedChangesDiscarder.cs
@@ -1,0 +1,185 @@
+using System.Collections.Generic;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Discards dirty loaded Scenes and the current Prefab Stage without prompting the user.
+    /// Untitled dirty scenes cannot be reloaded from disk, so those are reported and left untouched.
+    /// </summary>
+    public sealed class EditorUnsavedChangesDiscarder : IEditorUnsavedChangesDiscarder
+    {
+        public string[] DiscardUnsavedEditorChanges()
+        {
+            List<string> failures = new();
+            CollectUndiscardableDirtyScenes(failures);
+            if (failures.Count > 0)
+            {
+                return failures.ToArray();
+            }
+
+            DiscardDirtyPrefabStage(failures);
+            ReloadDirtySavedScenes();
+            return failures.ToArray();
+        }
+
+        private static void CollectUndiscardableDirtyScenes(List<string> failures)
+        {
+            Debug.Assert(failures != null, "failures must not be null");
+
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                Scene scene = SceneManager.GetSceneAt(i);
+                if (!scene.IsValid() || !scene.isLoaded || !scene.isDirty)
+                {
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(scene.path))
+                {
+                    continue;
+                }
+
+                failures.Add("Scene: " + GetSceneDisplayPath(scene));
+            }
+        }
+
+        private static void DiscardDirtyPrefabStage(List<string> failures)
+        {
+            Debug.Assert(failures != null, "failures must not be null");
+
+            PrefabStage prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+            if (prefabStage == null || !prefabStage.scene.IsValid() || !prefabStage.scene.isDirty)
+            {
+                return;
+            }
+
+            string assetPath = prefabStage.assetPath;
+            if (string.IsNullOrEmpty(assetPath))
+            {
+                // OpenPrefab requires a disk path; leaving the stage alone avoids a prompt-less dead end.
+                failures.Add("Prefab Stage: " + GetPrefabStageDisplayPath(prefabStage));
+                return;
+            }
+
+            prefabStage.ClearDirtiness();
+            StageUtility.GoBackToPreviousStage();
+            PrefabStage reopened = PrefabStageUtility.OpenPrefab(assetPath);
+            if (reopened == null)
+            {
+                failures.Add("Prefab Stage: " + assetPath);
+            }
+        }
+
+        private static void ReloadDirtySavedScenes()
+        {
+            if (!HasDirtyLoadedSceneWithPath())
+            {
+                return;
+            }
+
+            List<LoadedSceneSnapshot> snapshots = SnapshotLoadedScenes();
+            Debug.Assert(snapshots.Count > 0, "dirty saved scenes must produce at least one path snapshot");
+
+            string activePath = SceneManager.GetActiveScene().path;
+            EditorSceneManager.OpenScene(snapshots[0].Path, OpenSceneMode.Single);
+            for (int i = 1; i < snapshots.Count; i++)
+            {
+                OpenSceneMode mode = snapshots[i].IsLoaded
+                    ? OpenSceneMode.Additive
+                    : OpenSceneMode.AdditiveWithoutLoading;
+                EditorSceneManager.OpenScene(snapshots[i].Path, mode);
+            }
+
+            RestoreActiveScene(activePath);
+        }
+
+        private static bool HasDirtyLoadedSceneWithPath()
+        {
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                Scene scene = SceneManager.GetSceneAt(i);
+                if (scene.IsValid() && scene.isLoaded && scene.isDirty && !string.IsNullOrEmpty(scene.path))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static List<LoadedSceneSnapshot> SnapshotLoadedScenes()
+        {
+            List<LoadedSceneSnapshot> snapshots = new();
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                Scene scene = SceneManager.GetSceneAt(i);
+                if (!scene.IsValid() || string.IsNullOrEmpty(scene.path))
+                {
+                    continue;
+                }
+
+                snapshots.Add(new LoadedSceneSnapshot(scene.path, scene.isLoaded));
+            }
+
+            return snapshots;
+        }
+
+        private static void RestoreActiveScene(string activePath)
+        {
+            if (string.IsNullOrEmpty(activePath))
+            {
+                return;
+            }
+
+            Scene activeScene = SceneManager.GetSceneByPath(activePath);
+            if (!activeScene.IsValid() || !activeScene.isLoaded)
+            {
+                return;
+            }
+
+            SceneManager.SetActiveScene(activeScene);
+        }
+
+        private static string GetSceneDisplayPath(Scene scene)
+        {
+            if (!string.IsNullOrEmpty(scene.path))
+            {
+                return scene.path;
+            }
+
+            if (!string.IsNullOrEmpty(scene.name))
+            {
+                return scene.name;
+            }
+
+            return "Untitled scene";
+        }
+
+        private static string GetPrefabStageDisplayPath(PrefabStage prefabStage)
+        {
+            Debug.Assert(prefabStage != null, "prefabStage must not be null");
+
+            if (!string.IsNullOrEmpty(prefabStage.assetPath))
+            {
+                return prefabStage.assetPath;
+            }
+
+            return GetSceneDisplayPath(prefabStage.scene);
+        }
+
+        private readonly struct LoadedSceneSnapshot
+        {
+            public readonly string Path;
+            public readonly bool IsLoaded;
+
+            public LoadedSceneSnapshot(string path, bool isLoaded)
+            {
+                Path = path;
+                IsLoaded = isLoaded;
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnsavedChangesDiscarder.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnsavedChangesDiscarder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5cb8de6308282473cbf3e4f6a7a3b73d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/IEditorUnsavedChangesDiscarder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/IEditorUnsavedChangesDiscarder.cs
@@ -1,0 +1,14 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Discards dirty Editor Scene / Prefab Stage state without user prompts, restoring disk contents.
+    /// </summary>
+    public interface IEditorUnsavedChangesDiscarder
+    {
+        /// <summary>
+        /// Discards dirty loaded Scenes and the current Prefab Stage.
+        /// Returns display names that could not be discarded; empty when every dirty item was discarded.
+        /// </summary>
+        string[] DiscardUnsavedEditorChanges();
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/IEditorUnsavedChangesDiscarder.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/IEditorUnsavedChangesDiscarder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db8059ba5c9ce4723a46a3fbda1d9b50
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsSchema.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsSchema.cs
@@ -25,7 +25,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// • assembly: Assembly name (e.g.: UnityCliLoop.Tests.Editor)
         /// </summary>
         public string FilterValue { get; set; } = "";
-        public bool SaveBeforeRun { get; set; } = true;
+
+        /// <summary>
+        /// How to handle unsaved Scene and Prefab Stage changes before running tests.
+        /// </summary>
+        public RunTestsUnsavedChangesMode UnsavedChanges { get; set; } = RunTestsUnsavedChangesMode.save;
 
         /// <summary>
         /// Maximum seconds to wait for Unity Test Runner RunFinished before canceling the await.

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -87,7 +87,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return CreateFailureResponse(timeoutError);
             }
 
-            ValidationResult validation = _validationService.Validate(parameters.TestMode, parameters.SaveBeforeRun);
+            ValidationResult validation = _validationService.Validate(parameters.TestMode, parameters.UnsavedChanges);
             if (!validation.IsValid)
             {
                 return CreateFailureResponse(validation.ErrorMessage);

--- a/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
@@ -10,7 +10,7 @@ Execute Unity Test Runner. When tests fail, NUnit XML results with error message
 
 `uloop run-tests` automatically compiles pending script changes before running tests. Pass `--skip-compile` only while validating active hot-reload patches, because the compile clears those patches; otherwise let the default compile surface errors and run against current scripts.
 
-Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
+Before executing tests, `uloop run-tests` handles unsaved loaded Scene and Prefab Stage changes according to `--unsaved-changes` (default `save`): `save` writes them first, `fail` stops if any remain, and `discard` reloads disk state so tests run against saved files. Untitled scenes cannot be discarded and fail. If the chosen mode cannot proceed, it returns `Success: false`, keeps `TestCount` at `0`, lists the items in `Message`, and does not start the Unity Test Runner.
 
 Active pause points are automatically cleared (the underlying code patches are removed as well) before test execution begins. Cleared IDs are reported in the response's `ClearedPausePointIds` field.
 
@@ -31,7 +31,7 @@ uloop run-tests [options]
 | `--test-mode` | string | `EditMode` | Test mode: `EditMode`, `PlayMode` |
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
-| `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
+| `--unsaved-changes` | string | `save` | `save` writes unsaved Scene/Prefab Stage changes; `fail` stops if any remain; `discard` reloads disk state (Untitled scenes fail) |
 | `--skip-compile` | flag | - | Skip the automatic compile before running tests; use only while validating active hot-reload patches. |
 | `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionStateValidationService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionStateValidationService.cs
@@ -23,18 +23,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             "Tests cannot run while the editor has unsaved scene or prefab changes. Save or discard these changes before running tests.";
         private const string UnsavedEditorChangesSaveFailureMessage =
             "Tests cannot save unsaved scene or prefab changes before running tests.";
+        private const string UnsavedEditorChangesDiscardFailureMessage =
+            "Tests cannot discard unsaved scene or prefab changes before running tests.";
 
         private readonly IEditorUnsavedChangesQuietSaver _unsavedChangesQuietSaver;
+        private readonly IEditorUnsavedChangesDiscarder _unsavedChangesDiscarder;
 
         public TestExecutionStateValidationService()
-            : this(new EditorUnsavedChangesQuietSaver())
+            : this(new EditorUnsavedChangesQuietSaver(), new EditorUnsavedChangesDiscarder())
         {
         }
 
-        public TestExecutionStateValidationService(IEditorUnsavedChangesQuietSaver unsavedChangesQuietSaver)
+        public TestExecutionStateValidationService(
+            IEditorUnsavedChangesQuietSaver unsavedChangesQuietSaver,
+            IEditorUnsavedChangesDiscarder unsavedChangesDiscarder)
         {
             Debug.Assert(unsavedChangesQuietSaver != null, "unsavedChangesQuietSaver must not be null");
+            Debug.Assert(unsavedChangesDiscarder != null, "unsavedChangesDiscarder must not be null");
             _unsavedChangesQuietSaver = unsavedChangesQuietSaver;
+            _unsavedChangesDiscarder = unsavedChangesDiscarder;
         }
 
         protected virtual bool IsPlaying => EditorApplication.isPlaying;
@@ -57,7 +64,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return ValidationResult.Success();
         }
 
-        public virtual ValidationResult Validate(UnityCliLoopTestMode testMode, bool saveBeforeRun)
+        protected virtual ValidationResult DiscardUnsavedEditorChanges()
+        {
+            string[] failedChanges = _unsavedChangesDiscarder.DiscardUnsavedEditorChanges();
+            Debug.Assert(failedChanges != null, "Unsaved editor change discard must return an array");
+            if (failedChanges.Length > 0)
+            {
+                return ValidationResult.Failure(CreateUnsavedEditorChangesDiscardFailureMessage(failedChanges));
+            }
+
+            return ValidationResult.Success();
+        }
+
+        public virtual ValidationResult Validate(UnityCliLoopTestMode testMode, RunTestsUnsavedChangesMode unsavedChanges)
         {
             if (IsCompiling)
             {
@@ -79,13 +98,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return ValidationResult.Failure(PlayModePausedMessage);
             }
 
-            if (saveBeforeRun)
+            ValidationResult applyResult = ApplyUnsavedChangesMode(unsavedChanges);
+            if (!applyResult.IsValid)
             {
-                ValidationResult saveResult = SaveUnsavedEditorChanges();
-                if (!saveResult.IsValid)
-                {
-                    return saveResult;
-                }
+                return applyResult;
             }
 
             string[] unsavedEditorChanges = DetectUnsavedEditorChanges();
@@ -95,6 +111,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return ValidationResult.Failure(CreateUnsavedEditorChangesFailureMessage(unsavedEditorChanges));
             }
 
+            return ValidationResult.Success();
+        }
+
+        private ValidationResult ApplyUnsavedChangesMode(RunTestsUnsavedChangesMode unsavedChanges)
+        {
+            if (unsavedChanges == RunTestsUnsavedChangesMode.save)
+            {
+                return SaveUnsavedEditorChanges();
+            }
+
+            if (unsavedChanges == RunTestsUnsavedChangesMode.discard)
+            {
+                return DiscardUnsavedEditorChanges();
+            }
+
+            Debug.Assert(
+                unsavedChanges == RunTestsUnsavedChangesMode.fail,
+                "unsavedChanges must be save, fail, or discard");
             return ValidationResult.Success();
         }
 
@@ -112,6 +146,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(failedChanges.Length > 0, "failedChanges must not be empty");
 
             return UnsavedEditorChangesSaveFailureMessage + " Unsaved changes that failed to save: " + string.Join(", ", failedChanges);
+        }
+
+        private static string CreateUnsavedEditorChangesDiscardFailureMessage(string[] failedChanges)
+        {
+            Debug.Assert(failedChanges != null, "failedChanges must not be null");
+            Debug.Assert(failedChanges.Length > 0, "failedChanges must not be empty");
+
+            return UnsavedEditorChangesDiscardFailureMessage + " Unsaved changes that failed to discard: " + string.Join(", ", failedChanges);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/UnityCliLoopTestExecutionTypes.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/UnityCliLoopTestExecutionTypes.cs
@@ -21,6 +21,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     }
 
     /// <summary>
+    /// How run-tests handles unsaved Scene and Prefab Stage changes before execution.
+    /// </summary>
+    public enum RunTestsUnsavedChangesMode
+    {
+        save = 0,
+        fail = 1,
+        discard = 2
+    }
+
+    /// <summary>
     /// Defines machine-readable run-tests result states returned to CLI callers.
     /// </summary>
     internal static class RunTestsExecutionStatus

--- a/Packages/src/TemporarySkills~/v3-cli-invocation-migration/Skill/references/first-party-v2-to-v3.md
+++ b/Packages/src/TemporarySkills~/v3-cli-invocation-migration/Skill/references/first-party-v2-to-v3.md
@@ -61,7 +61,7 @@ For third-party tools, inspect the current tool schema or docs before choosing t
 | `uloop compile` | `--reload-external-scene-changes true` | remove |
 | `uloop compile` | `--reload-external-scene-changes false` | `--stop-on-external-scene-changes` |
 | `uloop run-tests` | `--save-before-run true` or bare `--save-before-run` | remove |
-| `uloop run-tests` | `--save-before-run false` | `--fail-on-unsaved-changes` |
+| `uloop run-tests` | `--save-before-run false` | `--unsaved-changes fail` |
 | `uloop replay-input` | `--show-overlay true` | remove |
 | `uloop replay-input` | `--show-overlay false` | `--no-show-overlay` |
 | `uloop get-hierarchy` | `--include-components true` | remove |

--- a/cli/common/clicore/tool_catalog_test.go
+++ b/cli/common/clicore/tool_catalog_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/hatayama/unity-cli-loop/common/tooldocs"
 )
 
-// Tests that run-tests-specific help text does not leak into unrelated tool schemas.
-func TestVisibleOptionHelpEntriesKeepsGenericSaveBeforeRunHelpForOtherTools(t *testing.T) {
+// Tests that negated-boolean help stays generic for tools that are not run-tests.
+func TestVisibleOptionHelpEntriesKeepsGenericNegatedBooleanHelpForOtherTools(t *testing.T) {
 	tool := ToolDefinition{
 		Name: "sample-tool",
 		InputSchema: InputSchema{
 			Properties: map[string]ToolProperty{
-				"SaveBeforeRun": {Type: "boolean", Default: true},
+				"AutoSaveDrafts": {Type: "boolean", Default: true},
 			},
 		},
 	}
@@ -27,10 +27,10 @@ func TestVisibleOptionHelpEntriesKeepsGenericSaveBeforeRunHelpForOtherTools(t *t
 	if len(entries) != 1 {
 		t.Fatalf("entry count mismatch: %#v", entries)
 	}
-	if entries[0].Name != "--no-save-before-run" {
+	if entries[0].Name != "--no-auto-save-drafts" {
 		t.Fatalf("option name mismatch: %#v", entries[0].Name)
 	}
-	if entries[0].Description != "Disable save before run; default: enabled" {
+	if entries[0].Description != "Disable auto save drafts; default: enabled" {
 		t.Fatalf("description mismatch: %#v", entries[0].Description)
 	}
 }

--- a/cli/common/tooldocs/tool_option_help.go
+++ b/cli/common/tooldocs/tool_option_help.go
@@ -91,9 +91,6 @@ func optionValueName(property tools.ToolProperty) string {
 }
 
 func optionDescription(toolName string, propertyName string, property tools.ToolProperty) string {
-	if isRunTestsSaveBeforeRunOption(toolName, propertyName, property) {
-		return OptionSummary(toolName, propertyName, property) + "; default: auto-save enabled"
-	}
 	if isCompileReloadExternalSceneChangesOption(toolName, propertyName, property) {
 		return OptionSummary(toolName, propertyName, property) + "; default: auto-reload enabled"
 	}

--- a/cli/common/tooldocs/tool_options.go
+++ b/cli/common/tooldocs/tool_options.go
@@ -25,21 +25,12 @@ func FindProperty(tool tools.ToolDefinition, kebabName string) (string, tools.To
 func OptionNameForProperty(toolName string, propertyName string, property tools.ToolProperty) string {
 	kebabName := pascalToKebab(propertyName)
 	if IsNegatedBooleanProperty(property) {
-		if isRunTestsSaveBeforeRunOption(toolName, propertyName, property) {
-			return "fail-on-unsaved-changes"
-		}
 		if isCompileReloadExternalSceneChangesOption(toolName, propertyName, property) {
 			return "stop-on-external-scene-changes"
 		}
 		return "no-" + kebabName
 	}
 	return kebabName
-}
-
-func isRunTestsSaveBeforeRunOption(toolName string, propertyName string, property tools.ToolProperty) bool {
-	return toolName == runTestsCommandName &&
-		propertyName == "SaveBeforeRun" &&
-		IsNegatedBooleanProperty(property)
 }
 
 func isCompileReloadExternalSceneChangesOption(toolName string, propertyName string, property tools.ToolProperty) bool {

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -100,10 +100,15 @@
             "type": "string",
             "description": "Filter value (test name, pattern, or assembly)"
           },
-          "SaveBeforeRun": {
-            "type": "boolean",
-            "description": "Fail before test execution if unsaved editor changes remain instead of auto-saving them",
-            "default": true
+          "UnsavedChanges": {
+            "type": "string",
+            "description": "save writes unsaved Scene/Prefab Stage changes; fail stops if any remain; discard reloads disk state (Untitled scenes fail)",
+            "enum": [
+              "save",
+              "fail",
+              "discard"
+            ],
+            "default": "save"
           },
           "TimeoutSeconds": {
             "type": "integer",

--- a/cli/dispatcher/internal/dispatcher/help_test.go
+++ b/cli/dispatcher/internal/dispatcher/help_test.go
@@ -482,9 +482,9 @@ func TestRunDispatcherRunTestsHelpDoesNotRequireUnityProject(t *testing.T) {
 		"--test-mode",
 		"--filter-type",
 		"--filter-value",
-		"--fail-on-unsaved-changes",
-		"Fail before test execution if unsaved editor changes remain instead of auto-saving them",
-		"default: auto-save enabled",
+		"--unsaved-changes",
+		"default: save",
+		"values: save|fail|discard",
 	} {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("run-tests help missing %q:\n%s", expected, output)

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "27374e725e567225ab18cb408fd26d4f8868e41f"
+  "sharedInputsHash": "1f278505a06225a5e851d19c261e886638ffd9be"
 }

--- a/cli/project-runner/internal/projectrunner/list_output_test.go
+++ b/cli/project-runner/internal/projectrunner/list_output_test.go
@@ -61,7 +61,11 @@ func TestNewListCatalogUsesSpecialOptionAliases(t *testing.T) {
 				Name: clicore.RunTestsCommandName,
 				InputSchema: clicore.InputSchema{
 					Properties: map[string]clicore.ToolProperty{
-						"SaveBeforeRun": {Type: "boolean", Default: true},
+						"UnsavedChanges": {
+							Type:    "string",
+							Default: "save",
+							Enum:    []string{"save", "fail", "discard"},
+						},
 					},
 				},
 			},
@@ -79,11 +83,16 @@ func TestNewListCatalogUsesSpecialOptionAliases(t *testing.T) {
 	catalog := newListCatalog(cache)
 
 	runTestsTool := findListTool(t, catalog, clicore.RunTestsCommandName)
-	failOnUnsavedChanges := findListOption(t, runTestsTool, "--fail-on-unsaved-changes")
-	if failOnUnsavedChanges.Default != false {
-		t.Fatalf("fail-on-unsaved-changes default mismatch: %#v", failOnUnsavedChanges)
+	unsavedChanges := findListOption(t, runTestsTool, "--unsaved-changes")
+	if unsavedChanges.Default != "save" {
+		t.Fatalf("unsaved-changes default mismatch: %#v", unsavedChanges)
 	}
-	assertListOptionMissing(t, runTestsTool, "--no-save-before-run")
+	if len(unsavedChanges.Values) != 3 ||
+		unsavedChanges.Values[0] != "save" ||
+		unsavedChanges.Values[1] != "fail" ||
+		unsavedChanges.Values[2] != "discard" {
+		t.Fatalf("unsaved-changes values mismatch: %#v", unsavedChanges)
+	}
 	skipCompile := findListOption(t, runTestsTool, tooldocs.RunTestsSkipCompileOptionName)
 	if skipCompile.Type != "boolean" {
 		t.Fatalf("skip-compile type mismatch: %#v", skipCompile)

--- a/cli/project-runner/internal/projectrunner/tools_test.go
+++ b/cli/project-runner/internal/projectrunner/tools_test.go
@@ -131,20 +131,20 @@ func TestBuildToolParamsPreservesExecuteDynamicCodeMultilineCode(t *testing.T) {
 	}
 }
 
-// Tests that run-tests accepts --fail-on-unsaved-changes from embedded tools.
-func TestBuildToolParamsConvertsRunTestsFailOnUnsavedChangesFlag(t *testing.T) {
+// Tests that run-tests accepts --unsaved-changes from embedded tools.
+func TestBuildToolParamsConvertsRunTestsUnsavedChangesFlag(t *testing.T) {
 	tool, ok := clicore.FindTool(clicore.LoadDefaultTools(), clicore.RunTestsCommandName)
 	if !ok {
 		t.Fatal("run-tests was not found in default tools")
 	}
 
-	params, _, err := buildToolParams([]string{"--fail-on-unsaved-changes"}, tool)
+	params, _, err := buildToolParams([]string{"--unsaved-changes", "fail"}, tool)
 	if err != nil {
 		t.Fatalf("buildToolParams failed: %v", err)
 	}
 
-	if params["SaveBeforeRun"] != false {
-		t.Fatalf("SaveBeforeRun mismatch: %#v", params["SaveBeforeRun"])
+	if params["UnsavedChanges"] != "fail" {
+		t.Fatalf("UnsavedChanges mismatch: %#v", params["UnsavedChanges"])
 	}
 }
 
@@ -165,28 +165,28 @@ func TestBuildToolParamsConvertsCompileStopOnExternalSceneChangesFlag(t *testing
 	}
 }
 
-// Tests that run-tests-specific aliases do not leak into unrelated tool schemas.
-func TestBuildToolParamsKeepsGenericSaveBeforeRunFlagForOtherTools(t *testing.T) {
+// Tests that run-tests-specific options do not leak into unrelated tool schemas.
+func TestBuildToolParamsKeepsGenericNegatedBooleanFlagForOtherTools(t *testing.T) {
 	tool := clicore.ToolDefinition{
 		Name: "sample-tool",
 		InputSchema: clicore.InputSchema{
 			Properties: map[string]clicore.ToolProperty{
-				"SaveBeforeRun": {Type: "boolean", Default: true},
+				"AutoSaveDrafts": {Type: "boolean", Default: true},
 			},
 		},
 	}
 
-	params, _, err := buildToolParams([]string{"--no-save-before-run"}, tool)
+	params, _, err := buildToolParams([]string{"--no-auto-save-drafts"}, tool)
 	if err != nil {
 		t.Fatalf("buildToolParams failed: %v", err)
 	}
-	if params["SaveBeforeRun"] != false {
-		t.Fatalf("SaveBeforeRun mismatch: %#v", params["SaveBeforeRun"])
+	if params["AutoSaveDrafts"] != false {
+		t.Fatalf("AutoSaveDrafts mismatch: %#v", params["AutoSaveDrafts"])
 	}
 
-	_, _, err = buildToolParams([]string{"--fail-on-unsaved-changes"}, tool)
+	_, _, err = buildToolParams([]string{"--unsaved-changes", "fail"}, tool)
 	if err == nil {
-		t.Fatal("expected run-tests-specific flag to be rejected")
+		t.Fatal("expected run-tests option to be rejected")
 	}
 }
 

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "ac7f51a4ae8bee4efbaeb2056a1b382de235ed48"
+  "sharedInputsHash": "becc3ce134d4d07205e895e93ecac0a79bc8cf0f"
 }

--- a/docs/focus-return-asset-handling.md
+++ b/docs/focus-return-asset-handling.md
@@ -38,7 +38,7 @@ Through package 3.0.0 the preflight saved every dirty Scene and the dirty Prefab
 return, regardless of whether anything changed on disk. Because an agent-driven workflow
 switches focus between the terminal and Unity constantly, that silently committed in-progress
 editor work to disk within seconds of making it — the user saw a Scene they had not saved
-become saved, and `run-tests --fail-on-unsaved-changes` had nothing left to detect. Saving is
+become saved, and `run-tests --unsaved-changes fail` had nothing left to detect. Saving is
 now gated on an actual external change, which is the only case the dialog-avoidance rationale
 covers.
 


### PR DESCRIPTION
## Summary
- `uloop run-tests` now takes `--unsaved-changes save|fail|discard` (default `save`) so a test run can write dirty editor work, refuse it, or reload disk state.
- The old `--fail-on-unsaved-changes` flag is gone. Use `--unsaved-changes fail` for that behavior.

## User Impact
- Before: unsaved Scene / Prefab Stage changes were either auto-saved or blocked the run. There was no way to throw those edits away and test the files on disk.
- After: `save` keeps the previous default, `fail` stops with the unsaved-item list, and `discard` reloads saved Scenes and the Prefab Stage without writing them. Untitled scenes still fail because they have no disk path.

## Changes
- Replaced the `SaveBeforeRun` boolean with `RunTestsUnsavedChangesMode`.
- Added a quiet discarder that fail-fasts on untitled dirty scenes, reopens a dirty Prefab Stage from disk, and reloads dirty saved scenes.
- Removed the CLI special-case that rewrote `SaveBeforeRun` as `--fail-on-unsaved-changes`. Help and the generated catalog now show the enum.

## Verification
- `scripts/check-go-cli.sh`: fmt / vet / lint / test / rebuild all passed.
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`: 0 errors / 0 warnings.
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value TestExecutionStateValidationServiceTests`: 14 passed.
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value EditorUnsavedChangesDiscarderTests`: 3 passed.
- Full EditMode suite: 3632 passed, 8 skipped, 15 failed. Those 15 are pre-existing VibeLog assertions (`GetLogsForAi` returned `[]`) caused by the local uncommitted removal of `ULOOP_DEBUG` from `ProjectSettings/ProjectSettings.asset`. They are unrelated to this PR and pass with the committed define. That settings file was not staged.
- E2E on `Assets/Scenes/SampleScene.unity` (mtime before: `1788192943`):
  - `--unsaved-changes fail`: `Success: false`, `Status: ExecutionFailed`, `TestCount: 0`, Message listed `Scene: Assets/Scenes/SampleScene.unity`. mtime unchanged. `isDirty == true`.
  - `--unsaved-changes discard` (filter `TestExecutionStateValidationServiceTests`): 14 passed. mtime unchanged. `isDirty == false`.
  - default (no flag = save), same filter: 14 passed. mtime updated to `1788195741`. `isDirty == false`. Restored the scene with `git checkout -- Assets/Scenes/SampleScene.unity`.
- `dist/darwin-arm64/uloop run-tests --help` lists `--unsaved-changes <value>` with `default: save; values: save|fail|discard` and does not list `--fail-on-unsaved-changes`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

