### PR TITLE
chore: EditMode suite passes on headless CI renderers and Unity 6.5+ Roslyn formatting

### DIFF
--- a/Assets/Tests/Editor/EditorWindowCaptureUtilityTests.cs
+++ b/Assets/Tests/Editor/EditorWindowCaptureUtilityTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 
@@ -53,6 +54,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void ReadPlayModeViewTexture_WithSrgbSourceInLinearColorSpace_PreservesBrightnessAndFlips()
         {
+            IgnoreWhenGpuBlitIsUnavailable();
             Assert.That(QualitySettings.activeColorSpace, Is.EqualTo(ColorSpace.Linear));
 
             const int SIZE = 4;
@@ -100,6 +102,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void ReadPlayModeViewTexture_WithResolutionScaleInLinearColorSpace_PreservesBrightness()
         {
+            IgnoreWhenGpuBlitIsUnavailable();
             Assert.That(QualitySettings.activeColorSpace, Is.EqualTo(ColorSpace.Linear));
 
             const int SOURCE_SIZE = 8;
@@ -136,6 +139,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 {
                     UnityEngine.Object.DestroyImmediate(result);
                 }
+            }
+        }
+
+        // Null (-nographics) does not run Blit, and CI llvmpipe (OpenGLCore) does not
+        // match real-GPU sRGB write encoding, so pixel-value checks cannot hold there.
+        private static void IgnoreWhenGpuBlitIsUnavailable()
+        {
+            GraphicsDeviceType deviceType = SystemInfo.graphicsDeviceType;
+            if (deviceType == GraphicsDeviceType.Null || deviceType == GraphicsDeviceType.OpenGLCore)
+            {
+                Assert.Ignore($"sRGB RenderTexture blits need a real GPU; skipped on {deviceType}.");
             }
         }
 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -921,9 +922,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(result.Output.hasAccessorDelegates, Is.True);
+            // Unity 6.5+ bundled Roslyn formats `[] { typeof(`; drop whitespace so we only
+            // assert that delegateArgs is an explicit Type[] rather than a trailing null.
+            string normalizedShimSource = Regex.Replace(result.Output.shimSource, @"\s+", string.Empty);
             Assert.That(
-                result.Output.shimSource,
-                Does.Contain(", false, new global::System.Type[]{typeof("),
+                normalizedShimSource,
+                Does.Contain(",false,newglobal::System.Type[]{typeof("),
                 "Instance MethodDelegate bind must pass explicit delegateArgs, not null.\n"
                 + result.Output.shimSource);
         }


### PR DESCRIPTION
## Summary
- Scheduled EditMode no longer fails on headless CI renderers or Unity 6.5+ Roslyn formatting.
- Product code is unchanged; only two EditMode tests were adjusted.

## User Impact
- Before: the periodic EditMode suite went false-red on CI editors without a real GPU, and on Unity 6.5+ when bundled Roslyn inserted whitespace in a generated Type[] initializer.
- After: those three tests stay green on CI (color tests skip on Null/OpenGLCore; the shim assertion ignores whitespace). Product and CLI runtime behavior is unchanged.

## Changes
- Normalize generated shim source before asserting that MethodDelegate bind emit includes explicit delegateArgs.
- Skip the two sRGB Play Mode view color tests on Null (`-nographics`) and OpenGLCore (CI llvmpipe).

## Verification
- Pre-fix pixel reads: Metal passed; Null returned 205; CI llvmpipe returned 102.
- Local Unity 6 (Metal): exact filter on the delegateArgs test -> Success true, PassedCount 1.
- Local Unity 6 (Metal): regex filter on EditorWindowCaptureUtilityTests -> Success true, PassedCount 5, SkippedCount 0.
- Unity 2022.3.62f3 `-batchmode -nographics`: total=5 passed=3 failed=0 skipped=2.
- Unity 2022.3.62f3 `-batchmode` (Metal): total=5 passed=5 failed=0 skipped=0.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

