### PR TITLE
feat(release-automation): add update-winget-manifest command

### DIFF
--- a/cli/release-automation/cmd/update-winget-manifest/main.go
+++ b/cli/release-automation/cmd/update-winget-manifest/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/hatayama/unity-cli-loop/tools/release-automation/internal/automation"
+)
+
+func main() {
+	os.Exit(automation.RunUpdateWingetManifest(context.Background(), os.Stdout, os.Stderr, os.Args[1:]))
+}

--- a/cli/release-automation/internal/automation/winget_manifest_github.go
+++ b/cli/release-automation/internal/automation/winget_manifest_github.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 )
 
@@ -155,7 +156,7 @@ func wingetForkContentSHA(
 		wingetTokenEnvironment(token),
 		"gh",
 		"api",
-		"repos/"+forkRepo+"/contents/"+path+"?ref="+branch,
+		"repos/"+forkRepo+"/contents/"+path+"?ref="+url.QueryEscape(branch),
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP 404") {
@@ -182,7 +183,7 @@ func wingetPullRequestOpen(
 		wingetTokenEnvironment(token),
 		"gh",
 		"api",
-		"repos/"+wingetUpstreamRepo+"/pulls?head="+forkOwner+":"+branch+"&state=open",
+		"repos/"+wingetUpstreamRepo+"/pulls?head="+url.QueryEscape(forkOwner+":"+branch)+"&state=open",
 	)
 	if err != nil {
 		return false, err

--- a/cli/release-automation/internal/automation/winget_manifest_github.go
+++ b/cli/release-automation/internal/automation/winget_manifest_github.go
@@ -1,0 +1,238 @@
+package automation
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type wingetContentResponse struct {
+	SHA string `json:"sha"`
+}
+
+type wingetPullRequestResponse struct {
+	HTMLURL string `json:"html_url"`
+}
+
+func wingetUpstreamPathExists(
+	ctx context.Context,
+	deps wingetManifestUpdateDeps,
+	token string,
+	path string,
+) (bool, error) {
+	_, err := deps.runOutput(
+		ctx,
+		wingetTokenEnvironment(token),
+		"gh",
+		"api",
+		"repos/"+wingetUpstreamRepo+"/contents/"+path+"?ref="+wingetUpstreamBranch,
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "HTTP 404") {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func syncWingetFork(
+	ctx context.Context,
+	deps wingetManifestUpdateDeps,
+	token string,
+	forkRepo string,
+) error {
+	_, err := deps.runOutput(
+		ctx,
+		wingetTokenEnvironment(token),
+		"gh",
+		"api",
+		"-X",
+		"POST",
+		"repos/"+forkRepo+"/merge-upstream",
+		"-f",
+		"branch="+wingetUpstreamBranch,
+	)
+	return err
+}
+
+func wingetUpstreamMasterSHA(
+	ctx context.Context,
+	deps wingetManifestUpdateDeps,
+	token string,
+) (string, error) {
+	output, err := deps.runOutput(
+		ctx,
+		wingetTokenEnvironment(token),
+		"gh",
+		"api",
+		"repos/"+wingetUpstreamRepo+"/git/ref/heads/"+wingetUpstreamBranch,
+		"--jq",
+		".object.sha",
+	)
+	if err != nil {
+		return "", err
+	}
+	sha := strings.TrimSpace(output)
+	if sha == "" {
+		return "", fmt.Errorf("winget upstream %s SHA is empty", wingetUpstreamBranch)
+	}
+	return sha, nil
+}
+
+func ensureWingetBranch(
+	ctx context.Context,
+	deps wingetManifestUpdateDeps,
+	token string,
+	forkRepo string,
+	branch string,
+	sha string,
+) error {
+	_, err := deps.runOutput(
+		ctx,
+		wingetTokenEnvironment(token),
+		"gh",
+		"api",
+		"-X",
+		"POST",
+		"repos/"+forkRepo+"/git/refs",
+		"-f",
+		"ref=refs/heads/"+branch,
+		"-f",
+		"sha="+sha,
+	)
+	if err != nil && strings.Contains(err.Error(), "HTTP 422") && strings.Contains(err.Error(), "Reference already exists") {
+		return nil
+	}
+	return err
+}
+
+func putWingetManifestFile(
+	ctx context.Context,
+	deps wingetManifestUpdateDeps,
+	token string,
+	forkRepo string,
+	branch string,
+	path string,
+	version string,
+	content string,
+) error {
+	existingSHA, err := wingetForkContentSHA(ctx, deps, token, forkRepo, branch, path)
+	if err != nil {
+		return err
+	}
+	args := []string{
+		"api",
+		"-X",
+		"PUT",
+		"repos/" + forkRepo + "/contents/" + path,
+		"-f",
+		"message=New version: " + wingetPackageIdentifier + " version " + version,
+		"-f",
+		"content=" + base64.StdEncoding.EncodeToString([]byte(content)),
+		"-f",
+		"branch=" + branch,
+	}
+	if existingSHA != "" {
+		args = append(args, "-f", "sha="+existingSHA)
+	}
+	_, err = deps.runOutput(ctx, wingetTokenEnvironment(token), "gh", args...)
+	return err
+}
+
+func wingetForkContentSHA(
+	ctx context.Context,
+	deps wingetManifestUpdateDeps,
+	token string,
+	forkRepo string,
+	branch string,
+	path string,
+) (string, error) {
+	output, err := deps.runOutput(
+		ctx,
+		wingetTokenEnvironment(token),
+		"gh",
+		"api",
+		"repos/"+forkRepo+"/contents/"+path+"?ref="+branch,
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "HTTP 404") {
+			return "", nil
+		}
+		return "", err
+	}
+	response := wingetContentResponse{}
+	if err = json.Unmarshal([]byte(output), &response); err != nil {
+		return "", fmt.Errorf("failed to parse winget fork content response: %w", err)
+	}
+	return response.SHA, nil
+}
+
+func wingetPullRequestOpen(
+	ctx context.Context,
+	deps wingetManifestUpdateDeps,
+	token string,
+	forkOwner string,
+	branch string,
+) (bool, error) {
+	output, err := deps.runOutput(
+		ctx,
+		wingetTokenEnvironment(token),
+		"gh",
+		"api",
+		"repos/"+wingetUpstreamRepo+"/pulls?head="+forkOwner+":"+branch+"&state=open",
+	)
+	if err != nil {
+		return false, err
+	}
+	pullRequests := []wingetPullRequestResponse{}
+	if err = json.Unmarshal([]byte(output), &pullRequests); err != nil {
+		return false, fmt.Errorf("failed to parse winget pull request list: %w", err)
+	}
+	return len(pullRequests) > 0, nil
+}
+
+func openWingetPullRequest(
+	ctx context.Context,
+	deps wingetManifestUpdateDeps,
+	token string,
+	forkOwner string,
+	branch string,
+	title string,
+	body string,
+) (string, error) {
+	output, err := deps.runOutput(
+		ctx,
+		wingetTokenEnvironment(token),
+		"gh",
+		"api",
+		"-X",
+		"POST",
+		"repos/"+wingetUpstreamRepo+"/pulls",
+		"-f",
+		"title="+title,
+		"-f",
+		"head="+forkOwner+":"+branch,
+		"-f",
+		"base="+wingetUpstreamBranch,
+		"-f",
+		"body="+body,
+	)
+	if err != nil {
+		return "", err
+	}
+	response := wingetPullRequestResponse{}
+	if err = json.Unmarshal([]byte(output), &response); err != nil {
+		return "", fmt.Errorf("failed to parse created winget pull request: %w", err)
+	}
+	if response.HTMLURL == "" {
+		return "", fmt.Errorf("created winget pull request URL is empty")
+	}
+	return response.HTMLURL, nil
+}
+
+func wingetTokenEnvironment(token string) []string {
+	return []string{"GH_TOKEN=" + token}
+}

--- a/cli/release-automation/internal/automation/winget_manifest_update.go
+++ b/cli/release-automation/internal/automation/winget_manifest_update.go
@@ -1,0 +1,354 @@
+package automation
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/template"
+)
+
+const (
+	wingetPkgsTokenEnvName          = "WINGET_PKGS_TOKEN"
+	wingetPackageIdentifier         = "hatayama.uloop"
+	wingetWindowsAmd64AssetName     = "uloop-dispatcher-windows-amd64.zip"
+	wingetUpstreamRepo              = "microsoft/winget-pkgs"
+	wingetUpstreamBranch            = "master"
+	wingetManifestSchemaVersion     = "1.10.0"
+	wingetVersionManifestFilename   = "hatayama.uloop.yaml"
+	wingetInstallerManifestFilename = "hatayama.uloop.installer.yaml"
+	wingetLocaleManifestFilename    = "hatayama.uloop.locale.en-US.yaml"
+)
+
+const wingetVersionManifestTemplate = `PackageIdentifier: hatayama.uloop
+PackageVersion: {{.Version}}
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: ` + wingetManifestSchemaVersion + `
+`
+
+const wingetInstallerManifestTemplate = `PackageIdentifier: hatayama.uloop
+PackageVersion: {{.Version}}
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: uloop.exe
+    PortableCommandAlias: uloop
+Commands:
+  - uloop
+ReleaseDate: {{.ReleaseDate}}
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/{{.Repository}}/releases/download/dispatcher-v{{.Version}}/uloop-dispatcher-windows-amd64.zip
+    InstallerSha256: {{.SHA256Upper}}
+ManifestType: installer
+ManifestVersion: ` + wingetManifestSchemaVersion + `
+`
+
+const wingetLocaleManifestTemplate = `PackageIdentifier: hatayama.uloop
+PackageVersion: {{.Version}}
+PackageLocale: en-US
+Publisher: hatayama
+PublisherUrl: https://github.com/hatayama
+PublisherSupportUrl: https://github.com/hatayama/unity-cli-loop/issues
+PackageName: Unity CLI Loop
+PackageUrl: https://github.com/hatayama/unity-cli-loop
+License: MIT
+LicenseUrl: https://github.com/hatayama/unity-cli-loop/blob/main/LICENSE
+ShortDescription: Let AI drive Unity, from Editor to Play Mode
+Moniker: uloop
+Tags:
+  - unity
+  - cli
+  - ai
+ReleaseNotesUrl: https://github.com/{{.Repository}}/releases/tag/dispatcher-v{{.Version}}
+ManifestType: defaultLocale
+ManifestVersion: ` + wingetManifestSchemaVersion + `
+`
+
+type wingetManifestUpdateConfig struct {
+	repository string
+	tag        string
+	forkRepo   string
+}
+
+type wingetManifestUpdateDeps struct {
+	runOutput func(ctx context.Context, extraEnv []string, name string, args ...string) (string, error)
+}
+
+type wingetManifestData struct {
+	Version     string
+	Repository  string
+	SHA256Upper string
+	ReleaseDate string
+}
+
+// RunUpdateWingetManifest opens a winget-pkgs pull request for a stable dispatcher release.
+func RunUpdateWingetManifest(ctx context.Context, stdout io.Writer, stderr io.Writer, args []string) int {
+	config, err := parseWingetManifestUpdateFlags(args)
+	if err != nil {
+		writeWingetManifestUpdateLine(stderr, "update-winget-manifest:", err)
+		return 1
+	}
+	return runUpdateWingetManifestWithDeps(ctx, stdout, stderr, config, defaultWingetManifestUpdateDeps())
+}
+
+func defaultWingetManifestUpdateDeps() wingetManifestUpdateDeps {
+	return wingetManifestUpdateDeps{runOutput: runHomebrewFormulaUpdateCommandOutput}
+}
+
+func parseWingetManifestUpdateFlags(args []string) (wingetManifestUpdateConfig, error) {
+	flagSet := flag.NewFlagSet("update-winget-manifest", flag.ContinueOnError)
+	repository := flagSet.String("repo", "", "GitHub repository that owns the dispatcher release")
+	tag := flagSet.String("tag", "", "dispatcher release tag such as dispatcher-v3.1.0")
+	forkRepo := flagSet.String("fork-repo", "", "winget-pkgs fork repository in owner/name form")
+	err := flagSet.Parse(args)
+	if err != nil {
+		return wingetManifestUpdateConfig{}, err
+	}
+	if *repository == "" {
+		return wingetManifestUpdateConfig{}, fmt.Errorf("--repo is required")
+	}
+	if *tag == "" {
+		return wingetManifestUpdateConfig{}, fmt.Errorf("--tag is required")
+	}
+	if *forkRepo == "" {
+		return wingetManifestUpdateConfig{}, fmt.Errorf("--fork-repo is required")
+	}
+	return wingetManifestUpdateConfig{repository: *repository, tag: *tag, forkRepo: *forkRepo}, nil
+}
+
+func runUpdateWingetManifestWithDeps(
+	ctx context.Context,
+	stdout io.Writer,
+	stderr io.Writer,
+	config wingetManifestUpdateConfig,
+	deps wingetManifestUpdateDeps,
+) int {
+	// Releases must stay green until the winget-pkgs PAT is configured.
+	token := strings.TrimSpace(os.Getenv(wingetPkgsTokenEnvName))
+	if token == "" {
+		writeWingetManifestUpdateLine(stdout, "WINGET_PKGS_TOKEN is not configured; skipping winget manifest update.")
+		return 0
+	}
+
+	version, err := dispatcherVersionFromReleaseTag(config.tag)
+	if err != nil {
+		return writeWingetManifestUpdateError(stderr, err)
+	}
+	if strings.Contains(version, "-") {
+		writeWingetManifestUpdateLine(stdout, fmt.Sprintf("dispatcher %s is a pre-release; winget receives stable releases only. Skipping.", version))
+		return 0
+	}
+
+	data, err := loadWingetManifestData(ctx, deps, config, version)
+	if err != nil {
+		return writeWingetManifestUpdateError(stderr, err)
+	}
+	versionPath := wingetPackageManifestPath() + "/" + version
+	versionExists, err := wingetUpstreamPathExists(ctx, deps, token, versionPath)
+	if err != nil {
+		return writeWingetManifestUpdateError(stderr, err)
+	}
+	if versionExists {
+		writeWingetManifestUpdateLine(stdout, fmt.Sprintf("winget manifest for %s already exists upstream; skipping.", version))
+		return 0
+	}
+
+	packageExists, err := wingetUpstreamPathExists(ctx, deps, token, wingetPackageManifestPath())
+	if err != nil {
+		return writeWingetManifestUpdateError(stderr, err)
+	}
+	manifests, err := renderWingetManifests(data)
+	if err != nil {
+		return writeWingetManifestUpdateError(stderr, err)
+	}
+	branch := "hatayama-uloop-" + version
+	if err = publishWingetManifestBranch(ctx, deps, token, config.forkRepo, branch, versionPath, version, manifests); err != nil {
+		return writeWingetManifestUpdateError(stderr, err)
+	}
+
+	forkOwner := strings.SplitN(config.forkRepo, "/", 2)[0]
+	pullRequestOpen, err := wingetPullRequestOpen(ctx, deps, token, forkOwner, branch)
+	if err != nil {
+		return writeWingetManifestUpdateError(stderr, err)
+	}
+	if pullRequestOpen {
+		writeWingetManifestUpdateLine(stdout, "winget-pkgs pull request is already open; skipping.")
+		return 0
+	}
+
+	title := wingetPullRequestTitle(packageExists, version)
+	body := "Automated submission from https://github.com/" + config.repository + "/releases/tag/" + config.tag
+	pullRequestURL, err := openWingetPullRequest(ctx, deps, token, forkOwner, branch, title, body)
+	if err != nil {
+		return writeWingetManifestUpdateError(stderr, err)
+	}
+	writeWingetManifestUpdateLine(stdout, pullRequestURL)
+	return 0
+}
+
+func loadWingetManifestData(
+	ctx context.Context,
+	deps wingetManifestUpdateDeps,
+	config wingetManifestUpdateConfig,
+	version string,
+) (wingetManifestData, error) {
+	sha256, err := downloadWingetAssetSHA256(ctx, deps, config.repository, config.tag)
+	if err != nil {
+		return wingetManifestData{}, err
+	}
+	releaseDate, err := downloadWingetReleaseDate(ctx, deps, config.repository, config.tag)
+	if err != nil {
+		return wingetManifestData{}, err
+	}
+	return wingetManifestData{
+		Version:     version,
+		Repository:  config.repository,
+		SHA256Upper: strings.ToUpper(sha256),
+		ReleaseDate: releaseDate,
+	}, nil
+}
+
+func downloadWingetAssetSHA256(
+	ctx context.Context,
+	deps wingetManifestUpdateDeps,
+	repository string,
+	tag string,
+) (string, error) {
+	output, err := deps.runOutput(
+		ctx,
+		nil,
+		"gh",
+		"release",
+		"download",
+		tag,
+		"--repo",
+		repository,
+		"--pattern",
+		wingetWindowsAmd64AssetName+".sha256",
+		"--output",
+		"-",
+	)
+	if err != nil {
+		return "", err
+	}
+	return parseSha256Asset(output, wingetWindowsAmd64AssetName)
+}
+
+func downloadWingetReleaseDate(
+	ctx context.Context,
+	deps wingetManifestUpdateDeps,
+	repository string,
+	tag string,
+) (string, error) {
+	output, err := deps.runOutput(
+		ctx,
+		nil,
+		"gh",
+		"release",
+		"view",
+		tag,
+		"--repo",
+		repository,
+		"--json",
+		"publishedAt",
+		"--jq",
+		".publishedAt",
+	)
+	if err != nil {
+		return "", err
+	}
+	publishedAt := strings.TrimSpace(output)
+	if len(publishedAt) < len("2006-01-02") {
+		return "", fmt.Errorf("release %s has an invalid publishedAt value %q", tag, publishedAt)
+	}
+	return publishedAt[:len("2006-01-02")], nil
+}
+
+func renderWingetManifests(data wingetManifestData) (map[string]string, error) {
+	templates := map[string]string{
+		wingetVersionManifestFilename:   wingetVersionManifestTemplate,
+		wingetInstallerManifestFilename: wingetInstallerManifestTemplate,
+		wingetLocaleManifestFilename:    wingetLocaleManifestTemplate,
+	}
+	manifests := make(map[string]string, len(templates))
+	for filename, source := range templates {
+		content, err := renderWingetManifest(filename, source, data)
+		if err != nil {
+			return nil, err
+		}
+		manifests[filename] = content
+	}
+	return manifests, nil
+}
+
+func renderWingetManifest(name string, source string, data wingetManifestData) (string, error) {
+	parsed, err := template.New(name).Parse(source)
+	if err != nil {
+		return "", err
+	}
+	builder := strings.Builder{}
+	if err = parsed.Execute(&builder, data); err != nil {
+		return "", err
+	}
+	return builder.String(), nil
+}
+
+func publishWingetManifestBranch(
+	ctx context.Context,
+	deps wingetManifestUpdateDeps,
+	token string,
+	forkRepo string,
+	branch string,
+	versionPath string,
+	version string,
+	manifests map[string]string,
+) error {
+	if err := syncWingetFork(ctx, deps, token, forkRepo); err != nil {
+		return err
+	}
+	masterSHA, err := wingetUpstreamMasterSHA(ctx, deps, token)
+	if err != nil {
+		return err
+	}
+	if err = ensureWingetBranch(ctx, deps, token, forkRepo, branch, masterSHA); err != nil {
+		return err
+	}
+	filenames := []string{
+		wingetVersionManifestFilename,
+		wingetInstallerManifestFilename,
+		wingetLocaleManifestFilename,
+	}
+	for _, filename := range filenames {
+		path := versionPath + "/" + filename
+		if err = putWingetManifestFile(ctx, deps, token, forkRepo, branch, path, version, manifests[filename]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func wingetPullRequestTitle(packageExists bool, version string) string {
+	prefix := "New package:"
+	if packageExists {
+		prefix = "New version:"
+	}
+	return fmt.Sprintf("%s %s version %s", prefix, wingetPackageIdentifier, version)
+}
+
+func wingetPackageManifestPath() string {
+	return "manifests/h/hatayama/uloop"
+}
+
+func writeWingetManifestUpdateError(stderr io.Writer, err error) int {
+	writeWingetManifestUpdateLine(stderr, "update-winget-manifest:", err)
+	return 1
+}
+
+func writeWingetManifestUpdateLine(writer io.Writer, values ...any) {
+	// CI status output failures cannot be recovered after the command outcome is known.
+	_, _ = fmt.Fprintln(writer, values...)
+}

--- a/cli/release-automation/internal/automation/winget_manifest_update.go
+++ b/cli/release-automation/internal/automation/winget_manifest_update.go
@@ -2,6 +2,7 @@ package automation
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -85,6 +86,11 @@ type wingetManifestData struct {
 	ReleaseDate string
 }
 
+type wingetReleaseMetadata struct {
+	PublishedAt  string `json:"publishedAt"`
+	IsPrerelease bool   `json:"isPrerelease"`
+}
+
 // RunUpdateWingetManifest opens a winget-pkgs pull request for a stable dispatcher release.
 func RunUpdateWingetManifest(ctx context.Context, stdout io.Writer, stderr io.Writer, args []string) int {
 	config, err := parseWingetManifestUpdateFlags(args)
@@ -143,10 +149,6 @@ func runUpdateWingetManifestWithDeps(
 		return 0
 	}
 
-	data, err := loadWingetManifestData(ctx, deps, config, version)
-	if err != nil {
-		return writeWingetManifestUpdateError(stderr, err)
-	}
 	versionPath := wingetPackageManifestPath() + "/" + version
 	versionExists, err := wingetUpstreamPathExists(ctx, deps, token, versionPath)
 	if err != nil {
@@ -155,6 +157,18 @@ func runUpdateWingetManifestWithDeps(
 	if versionExists {
 		writeWingetManifestUpdateLine(stdout, fmt.Sprintf("winget manifest for %s already exists upstream; skipping.", version))
 		return 0
+	}
+	metadata, err := downloadWingetReleaseMetadata(ctx, deps, config.repository, config.tag)
+	if err != nil {
+		return writeWingetManifestUpdateError(stderr, err)
+	}
+	if metadata.IsPrerelease {
+		writeWingetManifestUpdateLine(stdout, fmt.Sprintf("GitHub release %s is marked as a pre-release; winget receives stable releases only. Skipping.", config.tag))
+		return 0
+	}
+	data, err := loadWingetManifestData(ctx, deps, config, version, metadata.PublishedAt)
+	if err != nil {
+		return writeWingetManifestUpdateError(stderr, err)
 	}
 
 	packageExists, err := wingetUpstreamPathExists(ctx, deps, token, wingetPackageManifestPath())
@@ -195,12 +209,9 @@ func loadWingetManifestData(
 	deps wingetManifestUpdateDeps,
 	config wingetManifestUpdateConfig,
 	version string,
+	releaseDate string,
 ) (wingetManifestData, error) {
 	sha256, err := downloadWingetAssetSHA256(ctx, deps, config.repository, config.tag)
-	if err != nil {
-		return wingetManifestData{}, err
-	}
-	releaseDate, err := downloadWingetReleaseDate(ctx, deps, config.repository, config.tag)
 	if err != nil {
 		return wingetManifestData{}, err
 	}
@@ -238,12 +249,12 @@ func downloadWingetAssetSHA256(
 	return parseSha256Asset(output, wingetWindowsAmd64AssetName)
 }
 
-func downloadWingetReleaseDate(
+func downloadWingetReleaseMetadata(
 	ctx context.Context,
 	deps wingetManifestUpdateDeps,
 	repository string,
 	tag string,
-) (string, error) {
+) (wingetReleaseMetadata, error) {
 	output, err := deps.runOutput(
 		ctx,
 		nil,
@@ -254,18 +265,20 @@ func downloadWingetReleaseDate(
 		"--repo",
 		repository,
 		"--json",
-		"publishedAt",
-		"--jq",
-		".publishedAt",
+		"publishedAt,isPrerelease",
 	)
 	if err != nil {
-		return "", err
+		return wingetReleaseMetadata{}, err
 	}
-	publishedAt := strings.TrimSpace(output)
-	if len(publishedAt) < len("2006-01-02") {
-		return "", fmt.Errorf("release %s has an invalid publishedAt value %q", tag, publishedAt)
+	metadata := wingetReleaseMetadata{}
+	if err = json.Unmarshal([]byte(output), &metadata); err != nil {
+		return wingetReleaseMetadata{}, fmt.Errorf("failed to parse release metadata for %s: %w", tag, err)
 	}
-	return publishedAt[:len("2006-01-02")], nil
+	if len(metadata.PublishedAt) < len("2006-01-02") {
+		return wingetReleaseMetadata{}, fmt.Errorf("release %s has an invalid publishedAt value %q", tag, metadata.PublishedAt)
+	}
+	metadata.PublishedAt = metadata.PublishedAt[:len("2006-01-02")]
+	return metadata, nil
 }
 
 func renderWingetManifests(data wingetManifestData) (map[string]string, error) {

--- a/cli/release-automation/internal/automation/winget_manifest_update_test.go
+++ b/cli/release-automation/internal/automation/winget_manifest_update_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -60,6 +62,23 @@ func TestUpdateWingetManifestSkipsPrerelease(t *testing.T) {
 	}
 	if calls != 0 {
 		t.Fatalf("runOutput called %d times", calls)
+	}
+}
+
+// TestUpdateWingetManifestSkipsGitHubPrerelease verifies release metadata prevents stable-looking prereleases from publishing.
+func TestUpdateWingetManifestSkipsGitHubPrerelease(t *testing.T) {
+	scenario := newWingetTestScenario()
+	scenario.releasePrerelease = true
+	stdout, code := runWingetTestScenarioWithTag(t, scenario, "dispatcher-v3.2.0")
+
+	if code != 0 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if !strings.Contains(stdout, "GitHub release dispatcher-v3.2.0 is marked as a pre-release; winget receives stable releases only. Skipping.") {
+		t.Fatalf("unexpected stdout: %s", stdout)
+	}
+	if scenario.putCalls != 0 || scenario.pullRequestCreateCalls != 0 {
+		t.Fatalf("PUT calls = %d, PR creation calls = %d", scenario.putCalls, scenario.pullRequestCreateCalls)
 	}
 }
 
@@ -149,6 +168,9 @@ func TestUpdateWingetManifestSkipsExistingVersion(t *testing.T) {
 	if scenario.putCalls != 0 || scenario.pullRequestCreateCalls != 0 {
 		t.Fatalf("PUT calls = %d, PR creation calls = %d", scenario.putCalls, scenario.pullRequestCreateCalls)
 	}
+	if scenario.releaseDownloadCalls != 0 || scenario.releaseViewCalls != 0 {
+		t.Fatalf("release download calls = %d, release view calls = %d", scenario.releaseDownloadCalls, scenario.releaseViewCalls)
+	}
 }
 
 // TestUpdateWingetManifestUsesNewPackageTitle verifies a missing upstream package uses the initial-submission PR title.
@@ -210,11 +232,48 @@ func TestUpdateWingetManifestSkipsOpenPullRequest(t *testing.T) {
 	}
 }
 
+// TestWingetQueriesEncodeBuildMetadata verifies branch names with SemVer build metadata are URL encoded in query values.
+func TestWingetQueriesEncodeBuildMetadata(t *testing.T) {
+	endpoints := []string{}
+	deps := wingetManifestUpdateDeps{
+		runOutput: func(_ context.Context, _ []string, _ string, args ...string) (string, error) {
+			endpoint := args[len(args)-1]
+			endpoints = append(endpoints, endpoint)
+			if strings.Contains(endpoint, "/contents/") {
+				return "", errors.New("gh api failed: HTTP 404 Not Found")
+			}
+			return `[]`, nil
+		},
+	}
+	branch := "hatayama-uloop-3.1.0+build"
+
+	_, err := wingetForkContentSHA(context.Background(), deps, "token", "hatayama/winget-pkgs", branch, "manifest.yaml")
+	if err != nil {
+		t.Fatalf("wingetForkContentSHA failed: %v", err)
+	}
+	_, err = wingetPullRequestOpen(context.Background(), deps, "token", "hatayama", branch)
+	if err != nil {
+		t.Fatalf("wingetPullRequestOpen failed: %v", err)
+	}
+
+	joined := strings.Join(endpoints, "\n")
+	if !strings.Contains(joined, "?ref=hatayama-uloop-3.1.0%2Bbuild") {
+		t.Fatalf("encoded ref query missing from endpoints: %s", joined)
+	}
+	if !strings.Contains(joined, "?head=hatayama%3Ahatayama-uloop-3.1.0%2Bbuild&state=open") {
+		t.Fatalf("encoded head query missing from endpoints: %s", joined)
+	}
+}
+
 type wingetTestScenario struct {
+	version                string
 	versionExists          bool
 	packageExists          bool
 	branchExists           bool
 	pullRequestOpen        bool
+	releasePrerelease      bool
+	releaseDownloadCalls   int
+	releaseViewCalls       int
 	putCalls               int
 	pullRequestCreateCalls int
 	pullRequestTitle       string
@@ -234,14 +293,20 @@ func testWingetConfig(tag string) wingetManifestUpdateConfig {
 
 func runWingetTestScenario(t *testing.T, scenario *wingetTestScenario) (string, int) {
 	t.Helper()
+	return runWingetTestScenarioWithTag(t, scenario, "dispatcher-v3.1.0")
+}
+
+func runWingetTestScenarioWithTag(t *testing.T, scenario *wingetTestScenario, tag string) (string, int) {
+	t.Helper()
 	t.Setenv(wingetPkgsTokenEnvName, "winget-token")
+	scenario.version = strings.TrimPrefix(tag, "dispatcher-v")
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 	code := runUpdateWingetManifestWithDeps(
 		context.Background(),
 		&stdout,
 		&stderr,
-		testWingetConfig("dispatcher-v3.1.0"),
+		testWingetConfig(tag),
 		wingetManifestUpdateDeps{runOutput: scenario.runOutput},
 	)
 	if code != 0 && stderr.Len() > 0 {
@@ -270,16 +335,19 @@ func (s *wingetTestScenario) runOutput(_ context.Context, extraEnv []string, nam
 
 func (s *wingetTestScenario) releaseOutput(_ []string, joined string) (string, bool, error) {
 	if strings.Contains(joined, "release download") {
+		s.releaseDownloadCalls++
 		return testWingetSHA256 + "  " + wingetWindowsAmd64AssetName + "\n", true, nil
 	}
 	if strings.Contains(joined, "release view") {
-		return "2026-08-31T12:34:56Z\n", true, nil
+		s.releaseViewCalls++
+		return fmt.Sprintf(`{"publishedAt":"2026-08-31T12:34:56Z","isPrerelease":%t}`, s.releasePrerelease), true, nil
 	}
 	return "", false, nil
 }
 
 func (s *wingetTestScenario) upstreamOutput(_ []string, joined string) (string, bool, error) {
-	if strings.Contains(joined, "repos/microsoft/winget-pkgs/contents/manifests/h/hatayama/uloop/3.1.0?ref=master") {
+	versionPath := "repos/microsoft/winget-pkgs/contents/manifests/h/hatayama/uloop/" + s.version + "?ref=master"
+	if strings.Contains(joined, versionPath) {
 		if s.versionExists {
 			return `{}`, true, nil
 		}
@@ -311,7 +379,8 @@ func (s *wingetTestScenario) branchOutput(_ []string, joined string) (string, bo
 }
 
 func (s *wingetTestScenario) manifestFileOutput(args []string, joined string) (string, bool, error) {
-	if strings.Contains(joined, "repos/hatayama/winget-pkgs/contents/manifests/h/hatayama/uloop/3.1.0/") {
+	versionPath := "repos/hatayama/winget-pkgs/contents/manifests/h/hatayama/uloop/" + s.version + "/"
+	if strings.Contains(joined, versionPath) {
 		if strings.Contains(joined, "-X PUT") {
 			s.putCalls++
 			encodedContent := flagValue(args, "content")
@@ -330,7 +399,8 @@ func (s *wingetTestScenario) manifestFileOutput(args []string, joined string) (s
 }
 
 func (s *wingetTestScenario) pullRequestOutput(args []string, joined string) (string, bool, error) {
-	if strings.Contains(joined, "repos/microsoft/winget-pkgs/pulls?head=hatayama:hatayama-uloop-3.1.0&state=open") {
+	headQuery := "repos/microsoft/winget-pkgs/pulls?head=" + url.QueryEscape("hatayama:hatayama-uloop-"+s.version) + "&state=open"
+	if strings.Contains(joined, headQuery) {
 		if s.pullRequestOpen {
 			return `[{"html_url":"https://example.invalid/existing"}]`, true, nil
 		}

--- a/cli/release-automation/internal/automation/winget_manifest_update_test.go
+++ b/cli/release-automation/internal/automation/winget_manifest_update_test.go
@@ -80,6 +80,7 @@ func TestUpdateWingetManifestSkipsGitHubPrerelease(t *testing.T) {
 	if scenario.putCalls != 0 || scenario.pullRequestCreateCalls != 0 {
 		t.Fatalf("PUT calls = %d, PR creation calls = %d", scenario.putCalls, scenario.pullRequestCreateCalls)
 	}
+	assertWingetPublishSetupNotCalled(t, scenario)
 }
 
 // TestRenderWingetManifests verifies all three winget manifests render the exact release metadata.
@@ -171,6 +172,7 @@ func TestUpdateWingetManifestSkipsExistingVersion(t *testing.T) {
 	if scenario.releaseDownloadCalls != 0 || scenario.releaseViewCalls != 0 {
 		t.Fatalf("release download calls = %d, release view calls = %d", scenario.releaseDownloadCalls, scenario.releaseViewCalls)
 	}
+	assertWingetPublishSetupNotCalled(t, scenario)
 }
 
 // TestUpdateWingetManifestUsesNewPackageTitle verifies a missing upstream package uses the initial-submission PR title.
@@ -274,6 +276,9 @@ type wingetTestScenario struct {
 	releasePrerelease      bool
 	releaseDownloadCalls   int
 	releaseViewCalls       int
+	mergeUpstreamCalls     int
+	upstreamRefCalls       int
+	branchCreationCalls    int
 	putCalls               int
 	pullRequestCreateCalls int
 	pullRequestTitle       string
@@ -317,6 +322,9 @@ func runWingetTestScenarioWithTag(t *testing.T, scenario *wingetTestScenario, ta
 
 func (s *wingetTestScenario) runOutput(_ context.Context, extraEnv []string, name string, args ...string) (string, error) {
 	joined := strings.Join(args, " ")
+	if err := validateWingetTestEnvironment(extraEnv, joined); err != nil {
+		return "", err
+	}
 	handlers := []func([]string, string) (string, bool, error){
 		s.releaseOutput,
 		s.upstreamOutput,
@@ -360,16 +368,22 @@ func (s *wingetTestScenario) upstreamOutput(_ []string, joined string) (string, 
 		return "", true, errors.New("gh api failed: HTTP 404 Not Found")
 	}
 	if strings.Contains(joined, "repos/hatayama/winget-pkgs/merge-upstream") {
+		s.mergeUpstreamCalls++
 		return `{}`, true, nil
 	}
 	if strings.Contains(joined, "repos/microsoft/winget-pkgs/git/ref/heads/master") {
+		s.upstreamRefCalls++
 		return "upstream-master-sha\n", true, nil
 	}
 	return "", false, nil
 }
 
-func (s *wingetTestScenario) branchOutput(_ []string, joined string) (string, bool, error) {
+func (s *wingetTestScenario) branchOutput(args []string, joined string) (string, bool, error) {
 	if strings.Contains(joined, "repos/hatayama/winget-pkgs/git/refs") {
+		s.branchCreationCalls++
+		if err := validateWingetBranchCreationArgs(args, s.version); err != nil {
+			return "", true, err
+		}
 		if s.branchExists {
 			return "", true, errors.New("gh api failed: HTTP 422 Reference already exists")
 		}
@@ -383,8 +397,7 @@ func (s *wingetTestScenario) manifestFileOutput(args []string, joined string) (s
 	if strings.Contains(joined, versionPath) {
 		if strings.Contains(joined, "-X PUT") {
 			s.putCalls++
-			encodedContent := flagValue(args, "content")
-			decodedContent, err := base64.StdEncoding.DecodeString(encodedContent)
+			decodedContent, err := validateWingetManifestPutArgs(args, s.version)
 			if err != nil {
 				return "", true, err
 			}
@@ -408,10 +421,90 @@ func (s *wingetTestScenario) pullRequestOutput(args []string, joined string) (st
 	}
 	if strings.Contains(joined, "repos/microsoft/winget-pkgs/pulls") && strings.Contains(joined, "-X POST") {
 		s.pullRequestCreateCalls++
+		if err := validateWingetPullRequestArgs(args, s.version); err != nil {
+			return "", true, err
+		}
 		s.pullRequestTitle = flagValue(args, "title")
 		return `{"html_url":"https://example.invalid/new"}`, true, nil
 	}
 	return "", false, nil
+}
+
+func validateWingetTestEnvironment(extraEnv []string, joined string) error {
+	if strings.Contains(joined, "release download") || strings.Contains(joined, "release view") {
+		if len(extraEnv) != 0 {
+			return fmt.Errorf("gh release call has unexpected environment: %v", extraEnv)
+		}
+		return nil
+	}
+	if len(extraEnv) != 1 || extraEnv[0] != "GH_TOKEN=winget-token" {
+		return fmt.Errorf("gh api call environment = %v, want GH_TOKEN=winget-token", extraEnv)
+	}
+	return nil
+}
+
+func validateWingetBranchCreationArgs(args []string, version string) error {
+	expectedRef := "refs/heads/hatayama-uloop-" + version
+	if flagValue(args, "ref") != expectedRef {
+		return fmt.Errorf("branch ref = %q, want %q", flagValue(args, "ref"), expectedRef)
+	}
+	if flagValue(args, "sha") != "upstream-master-sha" {
+		return fmt.Errorf("branch sha = %q, want upstream-master-sha", flagValue(args, "sha"))
+	}
+	return nil
+}
+
+func validateWingetManifestPutArgs(args []string, version string) ([]byte, error) {
+	if flagValue(args, "message") == "" {
+		return nil, errors.New("manifest PUT message is empty")
+	}
+	encodedContent := flagValue(args, "content")
+	if encodedContent == "" {
+		return nil, errors.New("manifest PUT content is empty")
+	}
+	decodedContent, err := base64.StdEncoding.DecodeString(encodedContent)
+	if err != nil {
+		return nil, fmt.Errorf("manifest PUT content is not valid base64: %w", err)
+	}
+	if len(decodedContent) == 0 {
+		return nil, errors.New("manifest PUT decoded content is empty")
+	}
+	expectedBranch := "hatayama-uloop-" + version
+	if flagValue(args, "branch") != expectedBranch {
+		return nil, fmt.Errorf("manifest PUT branch = %q, want %q", flagValue(args, "branch"), expectedBranch)
+	}
+	if containsFlagName(args, "sha") {
+		return nil, errors.New("manifest PUT unexpectedly includes sha after a 404 response")
+	}
+	return decodedContent, nil
+}
+
+func validateWingetPullRequestArgs(args []string, version string) error {
+	expectedHead := "hatayama:hatayama-uloop-" + version
+	if flagValue(args, "head") != expectedHead {
+		return fmt.Errorf("pull request head = %q, want %q", flagValue(args, "head"), expectedHead)
+	}
+	if flagValue(args, "base") != "master" {
+		return fmt.Errorf("pull request base = %q, want master", flagValue(args, "base"))
+	}
+	body := flagValue(args, "body")
+	expectedReleaseURL := "https://github.com/hatayama/unity-cli-loop/releases/tag/dispatcher-v" + version
+	if body == "" || !strings.Contains(body, expectedReleaseURL) {
+		return fmt.Errorf("pull request body = %q, want release URL %q", body, expectedReleaseURL)
+	}
+	return nil
+}
+
+func assertWingetPublishSetupNotCalled(t *testing.T, scenario *wingetTestScenario) {
+	t.Helper()
+	if scenario.mergeUpstreamCalls != 0 || scenario.upstreamRefCalls != 0 || scenario.branchCreationCalls != 0 {
+		t.Fatalf(
+			"merge-upstream calls = %d, upstream ref calls = %d, branch creation calls = %d",
+			scenario.mergeUpstreamCalls,
+			scenario.upstreamRefCalls,
+			scenario.branchCreationCalls,
+		)
+	}
 }
 
 func flagValue(args []string, name string) string {

--- a/cli/release-automation/internal/automation/winget_manifest_update_test.go
+++ b/cli/release-automation/internal/automation/winget_manifest_update_test.go
@@ -1,0 +1,322 @@
+package automation
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+)
+
+const testWingetSHA256 = "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+
+// TestUpdateWingetManifestSkipsWithoutToken verifies an unset winget token exits successfully without invoking gh.
+func TestUpdateWingetManifestSkipsWithoutToken(t *testing.T) {
+	t.Setenv(wingetPkgsTokenEnvName, "")
+	calls := 0
+	deps := wingetManifestUpdateDeps{
+		runOutput: func(context.Context, []string, string, ...string) (string, error) {
+			calls++
+			return "", errors.New("runOutput must not be called when the winget token is unset")
+		},
+	}
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	code := runUpdateWingetManifestWithDeps(context.Background(), &stdout, &stderr, testWingetConfig("dispatcher-v3.1.0"), deps)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "WINGET_PKGS_TOKEN is not configured; skipping winget manifest update.") {
+		t.Fatalf("unexpected stdout: %s", stdout.String())
+	}
+	if calls != 0 {
+		t.Fatalf("runOutput called %d times", calls)
+	}
+}
+
+// TestUpdateWingetManifestSkipsPrerelease verifies prerelease tags skip before release assets are downloaded.
+func TestUpdateWingetManifestSkipsPrerelease(t *testing.T) {
+	t.Setenv(wingetPkgsTokenEnvName, "winget-token")
+	calls := 0
+	deps := wingetManifestUpdateDeps{
+		runOutput: func(context.Context, []string, string, ...string) (string, error) {
+			calls++
+			return "", errors.New("runOutput must not be called for a prerelease")
+		},
+	}
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	code := runUpdateWingetManifestWithDeps(context.Background(), &stdout, &stderr, testWingetConfig("dispatcher-v3.2.0-beta.1"), deps)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "dispatcher 3.2.0-beta.1 is a pre-release; winget receives stable releases only. Skipping.") {
+		t.Fatalf("unexpected stdout: %s", stdout.String())
+	}
+	if calls != 0 {
+		t.Fatalf("runOutput called %d times", calls)
+	}
+}
+
+// TestRenderWingetManifests verifies all three winget manifests render the exact release metadata.
+func TestRenderWingetManifests(t *testing.T) {
+	manifests, err := renderWingetManifests(wingetManifestData{
+		Version:     "3.1.0",
+		Repository:  "hatayama/unity-cli-loop",
+		SHA256Upper: strings.ToUpper(testWingetSHA256),
+		ReleaseDate: "2026-08-31",
+	})
+	if err != nil {
+		t.Fatalf("renderWingetManifests failed: %v", err)
+	}
+
+	expected := map[string]string{
+		"hatayama.uloop.yaml": `PackageIdentifier: hatayama.uloop
+PackageVersion: 3.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0
+`,
+		"hatayama.uloop.installer.yaml": `PackageIdentifier: hatayama.uloop
+PackageVersion: 3.1.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: uloop.exe
+    PortableCommandAlias: uloop
+Commands:
+  - uloop
+ReleaseDate: 2026-08-31
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/hatayama/unity-cli-loop/releases/download/dispatcher-v3.1.0/uloop-dispatcher-windows-amd64.zip
+    InstallerSha256: ABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD
+ManifestType: installer
+ManifestVersion: 1.10.0
+`,
+		"hatayama.uloop.locale.en-US.yaml": `PackageIdentifier: hatayama.uloop
+PackageVersion: 3.1.0
+PackageLocale: en-US
+Publisher: hatayama
+PublisherUrl: https://github.com/hatayama
+PublisherSupportUrl: https://github.com/hatayama/unity-cli-loop/issues
+PackageName: Unity CLI Loop
+PackageUrl: https://github.com/hatayama/unity-cli-loop
+License: MIT
+LicenseUrl: https://github.com/hatayama/unity-cli-loop/blob/main/LICENSE
+ShortDescription: Let AI drive Unity, from Editor to Play Mode
+Moniker: uloop
+Tags:
+  - unity
+  - cli
+  - ai
+ReleaseNotesUrl: https://github.com/hatayama/unity-cli-loop/releases/tag/dispatcher-v3.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0
+`,
+	}
+
+	if len(manifests) != len(expected) {
+		t.Fatalf("manifest count = %d, want %d", len(manifests), len(expected))
+	}
+	for filename, expectedContent := range expected {
+		if manifests[filename] != expectedContent {
+			t.Fatalf("manifest %s mismatch:\n got:\n%s\nwant:\n%s", filename, manifests[filename], expectedContent)
+		}
+	}
+	if wingetManifestSchemaVersion != "1.10.0" {
+		t.Fatalf("manifest schema version = %q, want 1.10.0", wingetManifestSchemaVersion)
+	}
+}
+
+// TestUpdateWingetManifestSkipsExistingVersion verifies an upstream version prevents manifest PUTs and PR creation.
+func TestUpdateWingetManifestSkipsExistingVersion(t *testing.T) {
+	scenario := newWingetTestScenario()
+	scenario.versionExists = true
+	stdout, code := runWingetTestScenario(t, scenario)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if !strings.Contains(stdout, "winget manifest for 3.1.0 already exists upstream; skipping.") {
+		t.Fatalf("unexpected stdout: %s", stdout)
+	}
+	if scenario.putCalls != 0 || scenario.pullRequestCreateCalls != 0 {
+		t.Fatalf("PUT calls = %d, PR creation calls = %d", scenario.putCalls, scenario.pullRequestCreateCalls)
+	}
+}
+
+// TestUpdateWingetManifestUsesNewPackageTitle verifies a missing upstream package uses the initial-submission PR title.
+func TestUpdateWingetManifestUsesNewPackageTitle(t *testing.T) {
+	scenario := newWingetTestScenario()
+	scenario.packageExists = false
+	_, code := runWingetTestScenario(t, scenario)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if scenario.pullRequestTitle != "New package: hatayama.uloop version 3.1.0" {
+		t.Fatalf("PR title = %q", scenario.pullRequestTitle)
+	}
+}
+
+// TestUpdateWingetManifestUsesNewVersionTitle verifies an existing upstream package uses the update PR title.
+func TestUpdateWingetManifestUsesNewVersionTitle(t *testing.T) {
+	scenario := newWingetTestScenario()
+	scenario.packageExists = true
+	_, code := runWingetTestScenario(t, scenario)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if scenario.pullRequestTitle != "New version: hatayama.uloop version 3.1.0" {
+		t.Fatalf("PR title = %q", scenario.pullRequestTitle)
+	}
+}
+
+// TestUpdateWingetManifestContinuesWhenBranchExists verifies a retry reaches all manifest PUTs after the branch already exists.
+func TestUpdateWingetManifestContinuesWhenBranchExists(t *testing.T) {
+	scenario := newWingetTestScenario()
+	scenario.branchExists = true
+	_, code := runWingetTestScenario(t, scenario)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if scenario.putCalls != 3 {
+		t.Fatalf("PUT calls = %d, want 3", scenario.putCalls)
+	}
+}
+
+// TestUpdateWingetManifestSkipsOpenPullRequest verifies an existing open PR prevents duplicate PR creation.
+func TestUpdateWingetManifestSkipsOpenPullRequest(t *testing.T) {
+	scenario := newWingetTestScenario()
+	scenario.pullRequestOpen = true
+	stdout, code := runWingetTestScenario(t, scenario)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if !strings.Contains(stdout, "winget-pkgs pull request is already open; skipping.") {
+		t.Fatalf("unexpected stdout: %s", stdout)
+	}
+	if scenario.pullRequestCreateCalls != 0 {
+		t.Fatalf("PR creation calls = %d", scenario.pullRequestCreateCalls)
+	}
+}
+
+type wingetTestScenario struct {
+	versionExists          bool
+	packageExists          bool
+	branchExists           bool
+	pullRequestOpen        bool
+	putCalls               int
+	pullRequestCreateCalls int
+	pullRequestTitle       string
+}
+
+func newWingetTestScenario() *wingetTestScenario {
+	return &wingetTestScenario{packageExists: true}
+}
+
+func testWingetConfig(tag string) wingetManifestUpdateConfig {
+	return wingetManifestUpdateConfig{
+		repository: "hatayama/unity-cli-loop",
+		tag:        tag,
+		forkRepo:   "hatayama/winget-pkgs",
+	}
+}
+
+func runWingetTestScenario(t *testing.T, scenario *wingetTestScenario) (string, int) {
+	t.Helper()
+	t.Setenv(wingetPkgsTokenEnvName, "winget-token")
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	code := runUpdateWingetManifestWithDeps(
+		context.Background(),
+		&stdout,
+		&stderr,
+		testWingetConfig("dispatcher-v3.1.0"),
+		wingetManifestUpdateDeps{runOutput: scenario.runOutput},
+	)
+	if code != 0 && stderr.Len() > 0 {
+		t.Logf("stderr: %s", stderr.String())
+	}
+	return stdout.String(), code
+}
+
+func (s *wingetTestScenario) runOutput(_ context.Context, extraEnv []string, name string, args ...string) (string, error) {
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "release download") {
+		return testWingetSHA256 + "  " + wingetWindowsAmd64AssetName + "\n", nil
+	}
+	if strings.Contains(joined, "release view") {
+		return "2026-08-31T12:34:56Z\n", nil
+	}
+	if strings.Contains(joined, "repos/microsoft/winget-pkgs/contents/manifests/h/hatayama/uloop/3.1.0?ref=master") {
+		if s.versionExists {
+			return `{}`, nil
+		}
+		return "", errors.New("gh api failed: HTTP 404 Not Found")
+	}
+	if strings.Contains(joined, "repos/microsoft/winget-pkgs/contents/manifests/h/hatayama/uloop?ref=master") {
+		if s.packageExists {
+			return `{}`, nil
+		}
+		return "", errors.New("gh api failed: HTTP 404 Not Found")
+	}
+	if strings.Contains(joined, "repos/hatayama/winget-pkgs/merge-upstream") {
+		return `{}`, nil
+	}
+	if strings.Contains(joined, "repos/microsoft/winget-pkgs/git/ref/heads/master") {
+		return "upstream-master-sha\n", nil
+	}
+	if strings.Contains(joined, "repos/hatayama/winget-pkgs/git/refs") {
+		if s.branchExists {
+			return "", errors.New("gh api failed: HTTP 422 Reference already exists")
+		}
+		return `{}`, nil
+	}
+	if strings.Contains(joined, "repos/hatayama/winget-pkgs/contents/manifests/h/hatayama/uloop/3.1.0/") {
+		if strings.Contains(joined, "-X PUT") {
+			s.putCalls++
+			encodedContent := flagValue(args, "content")
+			decodedContent, err := base64.StdEncoding.DecodeString(encodedContent)
+			if err != nil {
+				return "", err
+			}
+			if strings.Contains(string(decodedContent), "InstallerSha256:") && !strings.Contains(string(decodedContent), strings.ToUpper(testWingetSHA256)) {
+				return "", errors.New("installer sha256 was not uppercased")
+			}
+			return `{}`, nil
+		}
+		return "", errors.New("gh api failed: HTTP 404 Not Found")
+	}
+	if strings.Contains(joined, "repos/microsoft/winget-pkgs/pulls?head=hatayama:hatayama-uloop-3.1.0&state=open") {
+		if s.pullRequestOpen {
+			return `[{"html_url":"https://example.invalid/existing"}]`, nil
+		}
+		return `[]`, nil
+	}
+	if strings.Contains(joined, "repos/microsoft/winget-pkgs/pulls") && strings.Contains(joined, "-X POST") {
+		s.pullRequestCreateCalls++
+		s.pullRequestTitle = flagValue(args, "title")
+		return `{"html_url":"https://example.invalid/new"}`, nil
+	}
+	return "", errors.New("unexpected command: " + name + " " + joined + " env=" + strings.Join(extraEnv, ","))
+}
+
+func flagValue(args []string, name string) string {
+	prefix := name + "="
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] == "-f" && strings.HasPrefix(args[index+1], prefix) {
+			return strings.TrimPrefix(args[index+1], prefix)
+		}
+	}
+	return ""
+}

--- a/cli/release-automation/internal/automation/winget_manifest_update_test.go
+++ b/cli/release-automation/internal/automation/winget_manifest_update_test.go
@@ -252,63 +252,96 @@ func runWingetTestScenario(t *testing.T, scenario *wingetTestScenario) (string, 
 
 func (s *wingetTestScenario) runOutput(_ context.Context, extraEnv []string, name string, args ...string) (string, error) {
 	joined := strings.Join(args, " ")
+	handlers := []func([]string, string) (string, bool, error){
+		s.releaseOutput,
+		s.upstreamOutput,
+		s.branchOutput,
+		s.manifestFileOutput,
+		s.pullRequestOutput,
+	}
+	for _, handler := range handlers {
+		output, handled, err := handler(args, joined)
+		if handled {
+			return output, err
+		}
+	}
+	return "", errors.New("unexpected command: " + name + " " + joined + " env=" + strings.Join(extraEnv, ","))
+}
+
+func (s *wingetTestScenario) releaseOutput(_ []string, joined string) (string, bool, error) {
 	if strings.Contains(joined, "release download") {
-		return testWingetSHA256 + "  " + wingetWindowsAmd64AssetName + "\n", nil
+		return testWingetSHA256 + "  " + wingetWindowsAmd64AssetName + "\n", true, nil
 	}
 	if strings.Contains(joined, "release view") {
-		return "2026-08-31T12:34:56Z\n", nil
+		return "2026-08-31T12:34:56Z\n", true, nil
 	}
+	return "", false, nil
+}
+
+func (s *wingetTestScenario) upstreamOutput(_ []string, joined string) (string, bool, error) {
 	if strings.Contains(joined, "repos/microsoft/winget-pkgs/contents/manifests/h/hatayama/uloop/3.1.0?ref=master") {
 		if s.versionExists {
-			return `{}`, nil
+			return `{}`, true, nil
 		}
-		return "", errors.New("gh api failed: HTTP 404 Not Found")
+		return "", true, errors.New("gh api failed: HTTP 404 Not Found")
 	}
 	if strings.Contains(joined, "repos/microsoft/winget-pkgs/contents/manifests/h/hatayama/uloop?ref=master") {
 		if s.packageExists {
-			return `{}`, nil
+			return `{}`, true, nil
 		}
-		return "", errors.New("gh api failed: HTTP 404 Not Found")
+		return "", true, errors.New("gh api failed: HTTP 404 Not Found")
 	}
 	if strings.Contains(joined, "repos/hatayama/winget-pkgs/merge-upstream") {
-		return `{}`, nil
+		return `{}`, true, nil
 	}
 	if strings.Contains(joined, "repos/microsoft/winget-pkgs/git/ref/heads/master") {
-		return "upstream-master-sha\n", nil
+		return "upstream-master-sha\n", true, nil
 	}
+	return "", false, nil
+}
+
+func (s *wingetTestScenario) branchOutput(_ []string, joined string) (string, bool, error) {
 	if strings.Contains(joined, "repos/hatayama/winget-pkgs/git/refs") {
 		if s.branchExists {
-			return "", errors.New("gh api failed: HTTP 422 Reference already exists")
+			return "", true, errors.New("gh api failed: HTTP 422 Reference already exists")
 		}
-		return `{}`, nil
+		return `{}`, true, nil
 	}
+	return "", false, nil
+}
+
+func (s *wingetTestScenario) manifestFileOutput(args []string, joined string) (string, bool, error) {
 	if strings.Contains(joined, "repos/hatayama/winget-pkgs/contents/manifests/h/hatayama/uloop/3.1.0/") {
 		if strings.Contains(joined, "-X PUT") {
 			s.putCalls++
 			encodedContent := flagValue(args, "content")
 			decodedContent, err := base64.StdEncoding.DecodeString(encodedContent)
 			if err != nil {
-				return "", err
+				return "", true, err
 			}
 			if strings.Contains(string(decodedContent), "InstallerSha256:") && !strings.Contains(string(decodedContent), strings.ToUpper(testWingetSHA256)) {
-				return "", errors.New("installer sha256 was not uppercased")
+				return "", true, errors.New("installer sha256 was not uppercased")
 			}
-			return `{}`, nil
+			return `{}`, true, nil
 		}
-		return "", errors.New("gh api failed: HTTP 404 Not Found")
+		return "", true, errors.New("gh api failed: HTTP 404 Not Found")
 	}
+	return "", false, nil
+}
+
+func (s *wingetTestScenario) pullRequestOutput(args []string, joined string) (string, bool, error) {
 	if strings.Contains(joined, "repos/microsoft/winget-pkgs/pulls?head=hatayama:hatayama-uloop-3.1.0&state=open") {
 		if s.pullRequestOpen {
-			return `[{"html_url":"https://example.invalid/existing"}]`, nil
+			return `[{"html_url":"https://example.invalid/existing"}]`, true, nil
 		}
-		return `[]`, nil
+		return `[]`, true, nil
 	}
 	if strings.Contains(joined, "repos/microsoft/winget-pkgs/pulls") && strings.Contains(joined, "-X POST") {
 		s.pullRequestCreateCalls++
 		s.pullRequestTitle = flagValue(args, "title")
-		return `{"html_url":"https://example.invalid/new"}`, nil
+		return `{"html_url":"https://example.invalid/new"}`, true, nil
 	}
-	return "", errors.New("unexpected command: " + name + " " + joined + " env=" + strings.Join(extraEnv, ","))
+	return "", false, nil
 }
 
 func flagValue(args []string, name string) string {


### PR DESCRIPTION
## Summary

- Add a release automation command that opens winget-pkgs submissions for stable dispatcher releases.
- Generate the version, installer, and locale manifests from existing release metadata and assets.

## User Impact

- Stable Windows releases can be submitted to winget through a repeatable automation path.
- Missing credentials, prereleases, existing upstream versions, existing branches, and open pull requests are handled safely for release retries.

## Changes

- Render the three manifests required for `hatayama.uloop` using schema version `1.10.0`.
- Sync the configured fork, create or reuse a release branch, update manifest files, and open the upstream pull request through GitHub CLI APIs.
- Add focused tests for rendering, skip paths, initial and update titles, branch retries, and duplicate pull requests.

## Verification

- `go test ./internal/automation/ -run Winget -v`
- `scripts/check-go-cli.sh`
- `env -u WINGET_PKGS_TOKEN go run ./cmd/update-winget-manifest --repo hatayama/unity-cli-loop --tag dispatcher-v3.1.0 --fork-repo hatayama/winget-pkgs`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

