### PR TITLE
feat(dispatcher): refuse self-update for winget-managed installs

### DIFF
--- a/cli/dispatcher/internal/dispatcher/dispatcher_freshness.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_freshness.go
@@ -35,19 +35,18 @@ type dispatcherFreshnessInputs struct {
 	SelfUpdateDisabled bool
 	HasSiblingRealCLI  bool
 	UpdateDue          bool
-	HomebrewManaged    bool
+	ManagedInstall     sharedupdate.ManagedInstall
 }
 
 type dispatcherFreshnessPlan struct {
 	Action         dispatcherFreshnessAction
 	MinimumVersion string
 	Reason         string
+	NextAction     string
 }
 
 const (
 	dispatcherFreshnessReasonSelfUpdateDisabled = "Automatic update is disabled."
-	// Why: Homebrew installs must not run the curl installer; brew upgrade is the only safe path.
-	dispatcherFreshnessReasonHomebrewManaged = "This uloop install is managed by Homebrew. Run `brew upgrade uloop` to update."
 )
 
 func enforceDispatcherFreshnessWithDeps(ctx context.Context, pin dispatcherPin, stderr io.Writer, deps dispatcherRunDeps) (bool, int) {
@@ -70,20 +69,20 @@ func enforceDispatcherFreshnessWithDeps(ctx context.Context, pin dispatcherPin, 
 		SelfUpdateDisabled: selfUpdateDisabled,
 		HasSiblingRealCLI:  hasSiblingRealCLI,
 		UpdateDue:          updateDue,
-		HomebrewManaged:    isHomebrewManagedDispatcherInstall(),
+		ManagedInstall:     detectManagedDispatcherInstall(),
 	})
 	return executeDispatcherFreshnessPlan(ctx, plan, stderr, deps)
 }
 
-// isHomebrewManagedDispatcherInstall reports whether this dispatcher binary lives under Homebrew.
+// detectManagedDispatcherInstall reports whether a package manager owns this dispatcher binary.
 // Why: freshness is best-effort background work — path resolution failures stay false here so
 // ordinary commands keep running; explicit `uloop update` is what surfaces resolution errors.
-func isHomebrewManagedDispatcherInstall() bool {
+func detectManagedDispatcherInstall() sharedupdate.ManagedInstall {
 	executablePath, err := resolveUpdateExecutablePathFunc()
 	if err != nil {
-		return false
+		return sharedupdate.ManagedInstall{}
 	}
-	return sharedupdate.IsHomebrewManagedPath(executablePath)
+	return sharedupdate.DetectManagedInstall(executablePath)
 }
 
 func decideDispatcherFreshness(inputs dispatcherFreshnessInputs) dispatcherFreshnessPlan {
@@ -92,11 +91,12 @@ func decideDispatcherFreshness(inputs dispatcherFreshnessInputs) dispatcherFresh
 		return dispatcherFreshnessPlan{Action: dispatcherFreshnessNoop}
 	}
 	updateRequired := sharedversion.IsLessThan(inputs.CurrentVersion, minimumVersion)
-	if updateRequired && inputs.HomebrewManaged {
+	if updateRequired && inputs.ManagedInstall.IsManaged() {
 		return dispatcherFreshnessPlan{
 			Action:         dispatcherFreshnessManualUpdateRequired,
 			MinimumVersion: minimumVersion,
-			Reason:         dispatcherFreshnessReasonHomebrewManaged,
+			Reason:         managedInstallFreshnessReason(inputs.ManagedInstall),
+			NextAction:     "Run `" + inputs.ManagedInstall.UpgradeCommand + "` and retry the command.",
 		}
 	}
 	if updateRequired && inputs.SelfUpdateDisabled {
@@ -104,15 +104,20 @@ func decideDispatcherFreshness(inputs dispatcherFreshnessInputs) dispatcherFresh
 			Action:         dispatcherFreshnessManualUpdateRequired,
 			MinimumVersion: minimumVersion,
 			Reason:         dispatcherFreshnessReasonSelfUpdateDisabled,
+			NextAction:     "Run `uloop update` and retry the command.",
 		}
 	}
 	if updateRequired {
 		return dispatcherFreshnessPlan{Action: dispatcherFreshnessRunRequiredUpdate, MinimumVersion: minimumVersion}
 	}
-	if inputs.HomebrewManaged || inputs.HasSiblingRealCLI || !inputs.UpdateDue {
+	if inputs.ManagedInstall.IsManaged() || inputs.HasSiblingRealCLI || !inputs.UpdateDue {
 		return dispatcherFreshnessPlan{Action: dispatcherFreshnessNoop, MinimumVersion: minimumVersion}
 	}
 	return dispatcherFreshnessPlan{Action: dispatcherFreshnessRunOptionalUpdate, MinimumVersion: minimumVersion}
+}
+
+func managedInstallFreshnessReason(managedInstall sharedupdate.ManagedInstall) string {
+	return "This uloop install is managed by " + managedInstall.DisplayName + ". Run `" + managedInstall.UpgradeCommand + "` to update."
 }
 
 func executeDispatcherFreshnessPlan(ctx context.Context, plan dispatcherFreshnessPlan, stderr io.Writer, deps dispatcherRunDeps) (bool, int) {
@@ -120,7 +125,7 @@ func executeDispatcherFreshnessPlan(ctx context.Context, plan dispatcherFreshnes
 	case dispatcherFreshnessNoop:
 		return false, 0
 	case dispatcherFreshnessManualUpdateRequired:
-		writeDispatcherManualUpdateRequiredError(stderr, plan.MinimumVersion, plan.Reason)
+		writeDispatcherManualUpdateRequiredError(stderr, plan)
 		return true, 1
 	case dispatcherFreshnessRunRequiredUpdate, dispatcherFreshnessRunOptionalUpdate:
 		return runDispatcherFreshnessUpdate(ctx, plan, stderr, deps)
@@ -151,8 +156,10 @@ func runDispatcherFreshnessUpdate(ctx context.Context, plan dispatcherFreshnessP
 	}
 
 	if plan.Action == dispatcherFreshnessRunRequiredUpdate {
-		writeDispatcherManualUpdateRequiredError(stderr, plan.MinimumVersion, "Automatic update failed: "+err.Error())
-		return true, 1
+		plan.Action = dispatcherFreshnessManualUpdateRequired
+		plan.Reason = "Automatic update failed: " + err.Error()
+		plan.NextAction = "Run `uloop update` and retry the command."
+		return executeDispatcherFreshnessPlan(ctx, plan, stderr, deps)
 	}
 
 	// Why: optional update failures should not retry and redraw installer progress on every command.
@@ -184,22 +191,17 @@ func writeDispatcherSelfUpdateRequiredError(stderr io.Writer, updatedVersion str
 	})
 }
 
-func writeDispatcherManualUpdateRequiredError(stderr io.Writer, minimumVersion string, reason string) {
-	nextActions := []string{"Run `uloop update` and retry the command."}
-	if reason == dispatcherFreshnessReasonHomebrewManaged {
-		// Why: uloop update refuses Homebrew installs; brew upgrade is the only safe next step.
-		nextActions = []string{"Run `brew upgrade uloop` and retry the command."}
-	}
+func writeDispatcherManualUpdateRequiredError(stderr io.Writer, plan dispatcherFreshnessPlan) {
 	clierrors.WriteErrorEnvelope(stderr, clierrors.CLIError{
 		ErrorCode:   clierrors.ErrorCodeCLIUpdateRequired,
 		Phase:       clierrors.ErrorPhaseExecution,
-		Message:     "This project requires uloop dispatcher >= " + minimumVersion + ". " + reason,
+		Message:     "This project requires uloop dispatcher >= " + plan.MinimumVersion + ". " + plan.Reason,
 		Retryable:   true,
 		SafeToRetry: true,
-		NextActions: nextActions,
+		NextActions: []string{plan.NextAction},
 		Details: map[string]any{
 			"CurrentDispatcherVersion": dispatcherVersion,
-			"MinimumDispatcherVersion": minimumVersion,
+			"MinimumDispatcherVersion": plan.MinimumVersion,
 		},
 	})
 }

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -419,6 +419,9 @@ func TestEnforceDispatcherFreshnessRequiresManualUpdateWhenSelfUpdateDisabled(t 
 	if !bytes.Contains(stderr.Bytes(), []byte(clierrors.ErrorCodeCLIUpdateRequired)) {
 		t.Fatalf("freshness output mismatch: %s", stderr.String())
 	}
+	if !strings.Contains(stderr.String(), "Run `uloop update` and retry the command.") {
+		t.Fatalf("expected self-update NextActions guidance in stderr, got: %s", stderr.String())
+	}
 }
 
 func TestEnforceDispatcherFreshnessRequiresBrewUpgradeWhenHomebrewManagedAndUpdateRequired(t *testing.T) {
@@ -452,6 +455,67 @@ func TestEnforceDispatcherFreshnessRequiresBrewUpgradeWhenHomebrewManagedAndUpda
 	}
 	if !bytes.Contains(stderr.Bytes(), []byte(clierrors.ErrorCodeCLIUpdateRequired)) {
 		t.Fatalf("freshness output mismatch: %s", stderr.String())
+	}
+}
+
+func TestEnforceDispatcherFreshnessRequiresWingetUpgradeWhenWingetManagedAndUpdateRequired(t *testing.T) {
+	// Verifies winget-managed installs return their reason and package-manager retry action for required updates.
+	previousResolver := resolveUpdateExecutablePathFunc
+	defer func() {
+		resolveUpdateExecutablePathFunc = previousResolver
+	}()
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return `C:\Program Files\WinGet\Links\uloop.exe`, nil
+	}
+	deps := defaultDispatcherRunDeps()
+	deps.runUpdate = func(context.Context) (bool, error) {
+		t.Fatal("runUpdate must not run for winget-managed required freshness")
+		return false, nil
+	}
+
+	var stderr bytes.Buffer
+	handled, code := enforceDispatcherFreshnessWithDeps(
+		context.Background(),
+		dispatcherPin{MinimumDispatcherVersion: "999.0.0"},
+		&stderr,
+		deps)
+
+	if !handled || code != 1 {
+		t.Fatalf("freshness result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "This uloop install is managed by winget. Run `winget upgrade --id hatayama.uloop` to update.") {
+		t.Fatalf("expected winget-managed reason in stderr, got: %s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Run `winget upgrade --id hatayama.uloop` and retry the command.") {
+		t.Fatalf("expected winget NextActions guidance in stderr, got: %s", stderr.String())
+	}
+}
+
+func TestEnforceDispatcherFreshnessSkipsOptionalUpdateWhenWingetManaged(t *testing.T) {
+	// Verifies winget-managed installs skip optional auto-update without running the installer.
+	t.Setenv(nativepath.CacheDirEnvName, t.TempDir())
+	previousResolver := resolveUpdateExecutablePathFunc
+	defer func() {
+		resolveUpdateExecutablePathFunc = previousResolver
+	}()
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return `C:\Program Files\WinGet\Links\uloop.exe`, nil
+	}
+	deps := defaultDispatcherRunDeps()
+	deps.runUpdate = func(context.Context) (bool, error) {
+		t.Fatal("runUpdate must not run for winget-managed optional freshness")
+		return false, nil
+	}
+
+	var stderr bytes.Buffer
+	handled, code := enforceDispatcherFreshnessWithDeps(
+		context.Background(),
+		dispatcherPin{MinimumDispatcherVersion: dispatcherVersion},
+		&stderr,
+		deps)
+
+	if handled || code != 0 || stderr.Len() != 0 {
+		t.Fatalf("freshness result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
 	}
 }
 
@@ -778,9 +842,10 @@ func TestDecideDispatcherFreshnessPlansUpdatePaths(t *testing.T) {
 		selfUpdateDisabled bool
 		hasSiblingRealCLI  bool
 		updateDue          bool
-		homebrewManaged    bool
+		managedInstall     update.ManagedInstall
 		expectedAction     dispatcherFreshnessAction
 		expectedReason     string
+		expectedNextAction string
 	}{
 		{
 			name:           "no minimum",
@@ -795,15 +860,27 @@ func TestDecideDispatcherFreshnessPlansUpdatePaths(t *testing.T) {
 			updateDue:          true,
 			expectedAction:     dispatcherFreshnessManualUpdateRequired,
 			expectedReason:     dispatcherFreshnessReasonSelfUpdateDisabled,
+			expectedNextAction: "Run `uloop update` and retry the command.",
 		},
 		{
-			name:            "required update homebrew managed",
-			minimumVersion:  "999.0.0",
-			currentVersion:  dispatcherVersion,
-			homebrewManaged: true,
-			updateDue:       true,
-			expectedAction:  dispatcherFreshnessManualUpdateRequired,
-			expectedReason:  dispatcherFreshnessReasonHomebrewManaged,
+			name:               "required update homebrew managed",
+			minimumVersion:     "999.0.0",
+			currentVersion:     dispatcherVersion,
+			managedInstall:     update.DetectManagedInstall("/opt/homebrew/Cellar/uloop/3.1.0/bin/uloop"),
+			updateDue:          true,
+			expectedAction:     dispatcherFreshnessManualUpdateRequired,
+			expectedReason:     "This uloop install is managed by Homebrew. Run `brew upgrade uloop` to update.",
+			expectedNextAction: "Run `brew upgrade uloop` and retry the command.",
+		},
+		{
+			name:               "required update winget managed",
+			minimumVersion:     "999.0.0",
+			currentVersion:     dispatcherVersion,
+			managedInstall:     update.DetectManagedInstall(`C:\Program Files\WinGet\Links\uloop.exe`),
+			updateDue:          true,
+			expectedAction:     dispatcherFreshnessManualUpdateRequired,
+			expectedReason:     "This uloop install is managed by winget. Run `winget upgrade --id hatayama.uloop` to update.",
+			expectedNextAction: "Run `winget upgrade --id hatayama.uloop` and retry the command.",
 		},
 		{
 			name:           "required update runs immediately",
@@ -820,12 +897,12 @@ func TestDecideDispatcherFreshnessPlansUpdatePaths(t *testing.T) {
 			expectedAction:    dispatcherFreshnessNoop,
 		},
 		{
-			name:            "optional homebrew skip",
-			minimumVersion:  dispatcherVersion,
-			currentVersion:  dispatcherVersion,
-			homebrewManaged: true,
-			updateDue:       true,
-			expectedAction:  dispatcherFreshnessNoop,
+			name:           "optional homebrew skip",
+			minimumVersion: dispatcherVersion,
+			currentVersion: dispatcherVersion,
+			managedInstall: update.DetectManagedInstall("/opt/homebrew/Cellar/uloop/3.1.0/bin/uloop"),
+			updateDue:      true,
+			expectedAction: dispatcherFreshnessNoop,
 		},
 		{
 			name:           "optional due",
@@ -850,7 +927,7 @@ func TestDecideDispatcherFreshnessPlansUpdatePaths(t *testing.T) {
 				SelfUpdateDisabled: tt.selfUpdateDisabled,
 				HasSiblingRealCLI:  tt.hasSiblingRealCLI,
 				UpdateDue:          tt.updateDue,
-				HomebrewManaged:    tt.homebrewManaged,
+				ManagedInstall:     tt.managedInstall,
 			})
 
 			if plan.Action != tt.expectedAction {
@@ -861,6 +938,9 @@ func TestDecideDispatcherFreshnessPlansUpdatePaths(t *testing.T) {
 			}
 			if plan.Reason != tt.expectedReason {
 				t.Fatalf("reason mismatch: %q", plan.Reason)
+			}
+			if plan.NextAction != tt.expectedNextAction {
+				t.Fatalf("next action mismatch: %q", plan.NextAction)
 			}
 		})
 	}

--- a/cli/dispatcher/internal/dispatcher/update.go
+++ b/cli/dispatcher/internal/dispatcher/update.go
@@ -41,11 +41,12 @@ func tryHandleUpdateRequest(ctx context.Context, args []string, stdout io.Writer
 		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{Command: clicore.UpdateCommandName})
 		return true, 1
 	}
-	if update.IsHomebrewManagedPath(executablePath) {
+	managedInstall := update.DetectManagedInstall(executablePath)
+	if managedInstall.IsManaged() {
 		clierrors.WriteErrorEnvelope(stderr, invalidArgumentExecutionError(
-			"uloop is managed by Homebrew ("+executablePath+"); self-update would create a second install in ~/.local/bin",
+			"uloop is managed by "+managedInstall.DisplayName+" ("+executablePath+"); self-update would create a second install outside the package manager",
 			clierrors.ErrorContext{Command: clicore.UpdateCommandName},
-			[]string{"Run `brew upgrade uloop` to update."},
+			[]string{"Run `" + managedInstall.UpgradeCommand + "` to update."},
 		))
 		return true, 1
 	}
@@ -177,8 +178,8 @@ func printUpdateHelp(stdout io.Writer) {
 }
 
 // resolveUpdateExecutablePath returns the on-disk path of this dispatcher binary.
-// Why: Homebrew installs link <prefix>/bin/uloop to Cellar; EvalSymlinks is required
-// so IsHomebrewManagedPath sees the Cellar segment instead of the shim path.
+// Why: package managers may link the invoked binary to their managed install directory;
+// EvalSymlinks ensures managed-install detection sees the owning path instead of a shim.
 func resolveUpdateExecutablePath() (string, error) {
 	executablePath, err := os.Executable()
 	if err != nil {

--- a/cli/dispatcher/internal/dispatcher/update_test.go
+++ b/cli/dispatcher/internal/dispatcher/update_test.go
@@ -548,6 +548,34 @@ func TestUpdateRefusesHomebrewManagedExecutable(t *testing.T) {
 	}
 }
 
+func TestUpdateRefusesWingetManagedExecutable(t *testing.T) {
+	// Verifies winget-managed installs refuse self-update and point users at winget upgrade.
+	previousResolver := resolveUpdateExecutablePathFunc
+	previousRunner := updateRunCommand
+	defer func() {
+		resolveUpdateExecutablePathFunc = previousResolver
+		updateRunCommand = previousRunner
+	}()
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return `C:\Program Files\WinGet\Links\uloop.exe`, nil
+	}
+	updateRunCommand = func(context.Context, update.Command, io.Writer, io.Writer) error {
+		t.Fatal("updateRunCommand must not run for winget-managed installs")
+		return nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	handled, code := tryHandleUpdateRequest(context.Background(), []string{clicore.UpdateCommandName}, &stdout, &stderr)
+
+	if !handled || code != 1 {
+		t.Fatalf("update result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "winget upgrade --id hatayama.uloop") {
+		t.Fatalf("expected winget upgrade guidance in stderr, got: %s", stderr.String())
+	}
+}
+
 func TestUpdateRefusesCurrentTargetForHomebrewManagedExecutable(t *testing.T) {
 	// Verifies the Homebrew guard keeps brew guidance ahead of current-target resolution.
 	previousExecutablePath := resolveUpdateExecutablePathFunc

--- a/cli/dispatcher/internal/update/managed_install.go
+++ b/cli/dispatcher/internal/update/managed_install.go
@@ -1,0 +1,59 @@
+package update
+
+import "strings"
+
+// ManagedInstallKind identifies the package manager that owns a dispatcher install.
+type ManagedInstallKind string
+
+const (
+	ManagedInstallNone     ManagedInstallKind = ""
+	ManagedInstallHomebrew ManagedInstallKind = "homebrew"
+	ManagedInstallWinget   ManagedInstallKind = "winget"
+)
+
+// ManagedInstall describes how a package-manager-owned dispatcher must be updated.
+type ManagedInstall struct {
+	Kind           ManagedInstallKind
+	DisplayName    string
+	UpgradeCommand string
+}
+
+// IsManaged reports whether a package manager owns the dispatcher install.
+func (managedInstall ManagedInstall) IsManaged() bool {
+	return managedInstall.Kind != ManagedInstallNone
+}
+
+// DetectManagedInstall resolves the package-manager update policy for an executable path.
+func DetectManagedInstall(executablePath string) ManagedInstall {
+	if IsHomebrewManagedPath(executablePath) {
+		return ManagedInstall{
+			Kind:           ManagedInstallHomebrew,
+			DisplayName:    "Homebrew",
+			UpgradeCommand: "brew upgrade uloop",
+		}
+	}
+	if IsWingetManagedPath(executablePath) {
+		return ManagedInstall{
+			Kind:           ManagedInstallWinget,
+			DisplayName:    "winget",
+			UpgradeCommand: "winget upgrade --id hatayama.uloop",
+		}
+	}
+	return ManagedInstall{}
+}
+
+// IsWingetManagedPath reports whether executablePath is under a WinGet Packages or Links directory.
+func IsWingetManagedPath(executablePath string) bool {
+	normalizedPath := strings.ReplaceAll(executablePath, "\\", "/")
+	segments := strings.Split(normalizedPath, "/")
+	for index := 0; index+1 < len(segments); index++ {
+		if !strings.EqualFold(segments[index], "WinGet") {
+			continue
+		}
+		managedDirectory := segments[index+1]
+		if strings.EqualFold(managedDirectory, "Packages") || strings.EqualFold(managedDirectory, "Links") {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/dispatcher/internal/update/managed_install.go
+++ b/cli/dispatcher/internal/update/managed_install.go
@@ -43,6 +43,8 @@ func DetectManagedInstall(executablePath string) ManagedInstall {
 }
 
 // IsWingetManagedPath reports whether executablePath is under a WinGet Packages or Links directory.
+// Why: WinGet supports custom portable package roots, so ownership must key on
+// its Packages or Links path segments instead of fixed AppData or Program Files roots.
 func IsWingetManagedPath(executablePath string) bool {
 	normalizedPath := strings.ReplaceAll(executablePath, "\\", "/")
 	segments := strings.Split(normalizedPath, "/")

--- a/cli/dispatcher/internal/update/managed_install_test.go
+++ b/cli/dispatcher/internal/update/managed_install_test.go
@@ -18,6 +18,7 @@ func TestIsWingetManagedPath(t *testing.T) {
 		{name: "curl install", path: `C:\Users\<USER_NAME>\AppData\Local\Programs\uloop\bin\uloop.exe`, want: false},
 		{name: "homebrew install", path: `/opt/homebrew/Cellar/uloop/3.1.0/bin/uloop`, want: false},
 		{name: "winget without managed directory", path: `C:\Tools\WinGet\uloop.exe`, want: false},
+		{name: "managed directory is not adjacent", path: `C:\Tools\WinGet\Other\Packages\uloop.exe`, want: false},
 		{name: "reversed segments", path: `D:\Packages\WinGet\uloop.exe`, want: false},
 	}
 
@@ -42,6 +43,7 @@ func TestDetectManagedInstall(t *testing.T) {
 	}{
 		{name: "homebrew", path: "/opt/homebrew/Cellar/uloop/3.1.0/bin/uloop", expectedKind: ManagedInstallHomebrew, expectedName: "Homebrew", expectedUpgrade: "brew upgrade uloop"},
 		{name: "winget", path: `C:\Program Files\WinGet\Links\uloop.exe`, expectedKind: ManagedInstallWinget, expectedName: "winget", expectedUpgrade: "winget upgrade --id hatayama.uloop"},
+		{name: "homebrew precedence", path: "/opt/homebrew/Cellar/uloop/3.1.0/WinGet/Links/uloop", expectedKind: ManagedInstallHomebrew, expectedName: "Homebrew", expectedUpgrade: "brew upgrade uloop"},
 		{name: "unmanaged", path: "/home/<USER_NAME>/.local/bin/uloop", expectedKind: ManagedInstallNone},
 	}
 

--- a/cli/dispatcher/internal/update/managed_install_test.go
+++ b/cli/dispatcher/internal/update/managed_install_test.go
@@ -1,0 +1,59 @@
+package update
+
+import "testing"
+
+// TestIsWingetManagedPath verifies WinGet Packages and Links path detection across separators and casing.
+func TestIsWingetManagedPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "user package", path: `C:\Users\<USER_NAME>\AppData\Local\Microsoft\WinGet\Packages\hatayama.uloop_Microsoft.Winget.Source_8wekyb3d8bbwe\uloop.exe`, want: true},
+		{name: "user link", path: `C:\Users\<USER_NAME>\AppData\Local\Microsoft\WinGet\Links\uloop.exe`, want: true},
+		{name: "machine package", path: `C:\Program Files\WinGet\Packages\hatayama.uloop_Microsoft.Winget.Source_8wekyb3d8bbwe\uloop.exe`, want: true},
+		{name: "machine link", path: `C:\Program Files\WinGet\Links\uloop.exe`, want: true},
+		{name: "forward slashes", path: `C:/Users/<USER_NAME>/AppData/Local/Microsoft/WinGet/Packages/hatayama.uloop_Microsoft.Winget.Source_8wekyb3d8bbwe/uloop.exe`, want: true},
+		{name: "case insensitive", path: `C:\Users\<USER_NAME>\AppData\Local\Microsoft\winget\packages\hatayama.uloop\uloop.exe`, want: true},
+		{name: "curl install", path: `C:\Users\<USER_NAME>\AppData\Local\Programs\uloop\bin\uloop.exe`, want: false},
+		{name: "homebrew install", path: `/opt/homebrew/Cellar/uloop/3.1.0/bin/uloop`, want: false},
+		{name: "winget without managed directory", path: `C:\Tools\WinGet\uloop.exe`, want: false},
+		{name: "reversed segments", path: `D:\Packages\WinGet\uloop.exe`, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := IsWingetManagedPath(test.path)
+			if actual != test.want {
+				t.Fatalf("IsWingetManagedPath(%q) = %v, want %v", test.path, actual, test.want)
+			}
+		})
+	}
+}
+
+// TestDetectManagedInstall verifies Homebrew, winget, and unmanaged paths map to their update policies.
+func TestDetectManagedInstall(t *testing.T) {
+	tests := []struct {
+		name            string
+		path            string
+		expectedKind    ManagedInstallKind
+		expectedName    string
+		expectedUpgrade string
+	}{
+		{name: "homebrew", path: "/opt/homebrew/Cellar/uloop/3.1.0/bin/uloop", expectedKind: ManagedInstallHomebrew, expectedName: "Homebrew", expectedUpgrade: "brew upgrade uloop"},
+		{name: "winget", path: `C:\Program Files\WinGet\Links\uloop.exe`, expectedKind: ManagedInstallWinget, expectedName: "winget", expectedUpgrade: "winget upgrade --id hatayama.uloop"},
+		{name: "unmanaged", path: "/home/<USER_NAME>/.local/bin/uloop", expectedKind: ManagedInstallNone},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			managedInstall := DetectManagedInstall(test.path)
+			if managedInstall.Kind != test.expectedKind || managedInstall.DisplayName != test.expectedName || managedInstall.UpgradeCommand != test.expectedUpgrade {
+				t.Fatalf("DetectManagedInstall(%q) = %#v", test.path, managedInstall)
+			}
+			if managedInstall.IsManaged() != (test.expectedKind != ManagedInstallNone) {
+				t.Fatalf("IsManaged() mismatch for %#v", managedInstall)
+			}
+		})
+	}
+}

--- a/docs/package-manager-distribution.md
+++ b/docs/package-manager-distribution.md
@@ -35,7 +35,7 @@ winget receives stable dispatcher releases only. Prereleases are not submitted.
 - `uloop update` refuses Homebrew-managed installs and directs users to
   `brew upgrade uloop`. The dispatcher freshness path does the same for required
   updates and skips optional auto-updates.
-- `uloop update` will also refuse winget-managed installs and direct users to
+- `uloop update` also refuses winget-managed installs and directs users to
   `winget upgrade --id hatayama.uloop`.
 - The Unity Settings window and the Setup Wizard offer no CLI action for a
   Homebrew-managed install: the primary button is disabled and reads


### PR DESCRIPTION
## Summary

- detect Homebrew and winget-managed dispatcher installations through one shared policy
- refuse direct winget self-updates and provide the package-manager upgrade command
- route required freshness failures through plan-owned next actions and skip optional managed updates
- describe the now-implemented dispatcher behavior in the distribution documentation

## Testing

- `scripts/check-go-cli.sh`
- `cd cli/dispatcher && go test ./... 2>&1 | tail -5`
- TDD red confirmed before implementation: winget path APIs were undefined, required and optional freshness invoked the installer, and `uloop update` returned success


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

