### PR TITLE
feat(editor): stand down CLI install actions for winget-managed uloop

### DIFF
--- a/Assets/Tests/Editor/CliPathSetupFlowTests.cs
+++ b/Assets/Tests/Editor/CliPathSetupFlowTests.cs
@@ -174,9 +174,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 return true;
             }
 
-            public bool IsHomebrewManagedInstallPath(string cliExecutablePath)
+            public ManagedCliKind ResolveManagedCliKind(string cliExecutablePath)
             {
-                return false;
+                return ManagedCliKind.None;
             }
 
             public bool HasPackageOwnedCurrentUserInstall(RuntimePlatform platform)

--- a/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
+++ b/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
@@ -163,9 +163,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 return false;
             }
 
-            public bool IsHomebrewManagedInstallPath(string cliExecutablePath)
+            public ManagedCliKind ResolveManagedCliKind(string cliExecutablePath)
             {
-                return false;
+                return ManagedCliKind.None;
             }
 
             public bool HasPackageOwnedCurrentUserInstall(RuntimePlatform platform)

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -15,24 +15,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     /// </summary>
     public class CliSetupSectionTests
     {
-        [TestCase(false, false, false, false, false, false, false, null, "3.0.0", "Install CLI")]
-        [TestCase(false, false, false, false, false, true, false, null, "3.0.0", "Fix PATH")]
-        [TestCase(true, false, false, false, true, false, false, "3.0.0", "3.0.0", "Uninstall CLI")]
-        [TestCase(true, false, false, false, false, false, false, "3.0.0", "3.0.0", "Install CLI")]
-        [TestCase(true, false, false, false, true, true, false, "3.0.0", "3.0.0", "Fix PATH")]
-        [TestCase(true, false, false, true, true, false, false, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
-        [TestCase(true, false, false, true, true, true, false, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
-        [TestCase(true, false, false, true, true, false, false, "3.0.0", "3.0.0", "Update CLI (v3.0.0 required)")]
-        [TestCase(true, true, false, false, true, false, false, "3.0.0", "3.0.0", "Uninstalling...")]
-        [TestCase(true, true, false, false, true, true, false, "3.0.0", "3.0.0", "Fixing PATH...")]
-        [TestCase(false, true, false, false, false, false, false, null, "3.0.0", "Installing...")]
-        [TestCase(false, false, true, false, false, false, false, null, "3.0.0", "Checking...")]
-        [TestCase(true, false, false, false, false, false, true, "3.0.0", "3.0.0", "Managed by Homebrew")]
-        [TestCase(true, false, false, true, false, false, true, "2.9.0", "3.0.0", "Managed by Homebrew")]
-        [TestCase(true, false, true, false, false, false, true, "3.0.0", "3.0.0", "Checking...")]
-        [TestCase(false, false, false, false, false, false, true, null, "3.0.0", "Managed by Homebrew")]
-        [TestCase(true, false, false, false, false, true, true, "3.0.0", "3.0.0", "Fix PATH")]
-        [TestCase(true, true, false, false, false, true, true, "3.0.0", "3.0.0", "Fixing PATH...")]
+        [TestCase(false, false, false, false, false, false, ManagedCliKind.None, null, "3.0.0", "Install CLI")]
+        [TestCase(false, false, false, false, false, true, ManagedCliKind.None, null, "3.0.0", "Fix PATH")]
+        [TestCase(true, false, false, false, true, false, ManagedCliKind.None, "3.0.0", "3.0.0", "Uninstall CLI")]
+        [TestCase(true, false, false, false, false, false, ManagedCliKind.None, "3.0.0", "3.0.0", "Install CLI")]
+        [TestCase(true, false, false, false, true, true, ManagedCliKind.None, "3.0.0", "3.0.0", "Fix PATH")]
+        [TestCase(true, false, false, true, true, false, ManagedCliKind.None, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
+        [TestCase(true, false, false, true, true, true, ManagedCliKind.None, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
+        [TestCase(true, false, false, true, true, false, ManagedCliKind.None, "3.0.0", "3.0.0", "Update CLI (v3.0.0 required)")]
+        [TestCase(true, true, false, false, true, false, ManagedCliKind.None, "3.0.0", "3.0.0", "Uninstalling...")]
+        [TestCase(true, true, false, false, true, true, ManagedCliKind.None, "3.0.0", "3.0.0", "Fixing PATH...")]
+        [TestCase(false, true, false, false, false, false, ManagedCliKind.None, null, "3.0.0", "Installing...")]
+        [TestCase(false, false, true, false, false, false, ManagedCliKind.None, null, "3.0.0", "Checking...")]
+        [TestCase(true, false, false, false, false, false, ManagedCliKind.Homebrew, "3.0.0", "3.0.0", "Managed by Homebrew")]
+        [TestCase(true, false, false, true, false, false, ManagedCliKind.Homebrew, "2.9.0", "3.0.0", "Managed by Homebrew")]
+        [TestCase(true, false, true, false, false, false, ManagedCliKind.Homebrew, "3.0.0", "3.0.0", "Checking...")]
+        [TestCase(false, false, false, false, false, false, ManagedCliKind.Homebrew, null, "3.0.0", "Managed by Homebrew")]
+        [TestCase(true, false, false, false, false, false, ManagedCliKind.Winget, "3.0.0", "3.0.0", "Managed by winget")]
+        [TestCase(true, false, false, false, false, true, ManagedCliKind.Homebrew, "3.0.0", "3.0.0", "Fix PATH")]
+        [TestCase(true, true, false, false, false, true, ManagedCliKind.Homebrew, "3.0.0", "3.0.0", "Fixing PATH...")]
         public void GetInstallCliButtonText_ReturnsExpectedText(
             bool isCliInstalled,
             bool isInstallingCli,
@@ -40,7 +41,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool needsUpdate,
             bool canUninstallCli,
             bool needsCliPathSetup,
-            bool isHomebrewManagedCli,
+            ManagedCliKind managedCliKind,
             string cliVersion,
             string requiredCliVersion,
             string expectedText)
@@ -52,31 +53,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 needsUpdate,
                 canUninstallCli,
                 needsCliPathSetup,
-                isHomebrewManagedCli,
+                managedCliKind,
                 cliVersion,
                 requiredCliVersion);
 
             Assert.That(text, Is.EqualTo(expectedText));
         }
 
-        [TestCase(false, false, false, false, true)]
-        [TestCase(true, false, false, false, false)]
-        [TestCase(false, true, false, false, false)]
-        [TestCase(false, false, true, false, false)]
-        [TestCase(false, false, true, true, true)]
-        [TestCase(true, false, true, true, false)]
+        [TestCase(false, false, ManagedCliKind.None, false, true)]
+        [TestCase(true, false, ManagedCliKind.None, false, false)]
+        [TestCase(false, true, ManagedCliKind.None, false, false)]
+        [TestCase(false, false, ManagedCliKind.Homebrew, false, false)]
+        [TestCase(false, false, ManagedCliKind.Winget, true, true)]
+        [TestCase(true, false, ManagedCliKind.Winget, true, false)]
         public void IsInstallCliButtonEnabled_ReturnsExpectedValue(
             bool isInstallingCli,
             bool isChecking,
-            bool isHomebrewManagedCli,
+            ManagedCliKind managedCliKind,
             bool needsCliPathSetup,
             bool expectedEnabled)
         {
-            // Verifies a Homebrew-managed CLI leaves only PATH repair, which writes no binary, enabled.
+            // Verifies a managed CLI leaves only PATH repair, which writes no binary, enabled.
             bool enabled = CliSetupSection.IsInstallCliButtonEnabled(
                 isInstallingCli,
                 isChecking,
-                isHomebrewManagedCli,
+                managedCliKind,
                 needsCliPathSetup);
 
             Assert.That(enabled, Is.EqualTo(expectedEnabled));
@@ -110,7 +111,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 isCliInstalled: true,
                 isChecking: false,
                 selectedTargetInstallState: SkillInstallState.Installed,
-                isHomebrewManagedCli: true);
+                managedCliKind: ManagedCliKind.Homebrew);
 
             section.Update(data);
 
@@ -129,7 +130,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 isCliInstalled: true,
                 isChecking: false,
                 selectedTargetInstallState: SkillInstallState.Installed,
-                isHomebrewManagedCli: true,
+                managedCliKind: ManagedCliKind.Homebrew,
                 cliVersion: null,
                 needsCliPathSetup: true);
 
@@ -150,7 +151,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 isCliInstalled: false,
                 isChecking: false,
                 selectedTargetInstallState: SkillInstallState.Installed,
-                isHomebrewManagedCli: true,
+                managedCliKind: ManagedCliKind.Homebrew,
                 cliVersion: null);
 
             section.Update(data);
@@ -176,7 +177,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 isCliInstalled: true,
                 isChecking: false,
                 selectedTargetInstallState: SkillInstallState.Installed,
-                isHomebrewManagedCli: true,
+                managedCliKind: ManagedCliKind.Homebrew,
                 needsUpdate: true,
                 cliVersion: "2.9.0");
 
@@ -192,6 +193,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(warningLabel.ClassListContains("unity-cli-loop-warning-message--visible"), Is.True);
         }
 
+        /// <summary>
+        /// Verifies the winget upgrade command is shown when a winget-managed CLI is below the minimum version.
+        /// </summary>
+        [Test]
+        public void Update_WhenWingetManagedCliNeedsUpdate_ShowsUpgradeWarning()
+        {
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            CliSetupData data = CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Installed,
+                managedCliKind: ManagedCliKind.Winget,
+                needsUpdate: true,
+                cliVersion: "2.9.0");
+
+            section.Update(data);
+
+            Button installCliButton = root.Q<Button>("install-cli-button");
+            Label warningLabel = root.Q<Label>("cli-homebrew-upgrade-message");
+            Assert.That(installCliButton.text, Is.EqualTo("Managed by winget"));
+            Assert.That(installCliButton.enabledSelf, Is.False);
+            Assert.That(
+                warningLabel.text,
+                Is.EqualTo("winget-managed CLI v2.9.0 does not meet the required v3.0.0.\n"
+                    + "Run this command in your terminal:\nwinget upgrade --id hatayama.uloop"));
+            Assert.That(warningLabel.ClassListContains("unity-cli-loop-warning-message--visible"), Is.True);
+        }
+
         [Test]
         public void Update_WhenHomebrewCliMeetsVersionButNeedsUpdate_ShowsReinstallGuidance()
         {
@@ -203,7 +233,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 isCliInstalled: true,
                 isChecking: false,
                 selectedTargetInstallState: SkillInstallState.Installed,
-                isHomebrewManagedCli: true,
+                managedCliKind: ManagedCliKind.Homebrew,
                 needsUpdate: true,
                 cliVersion: "3.0.0");
 
@@ -227,7 +257,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 isCliInstalled: true,
                 isChecking: false,
                 selectedTargetInstallState: SkillInstallState.Installed,
-                isHomebrewManagedCli: true);
+                managedCliKind: ManagedCliKind.Homebrew);
 
             section.Update(data);
 
@@ -563,7 +593,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             SkillInstallState selectedTargetInstallState,
             IReadOnlyList<SkillSetupTargetInfo> installableSkillTargets = null,
             bool? isSkillStateChecking = null,
-            bool isHomebrewManagedCli = false,
+            ManagedCliKind managedCliKind = ManagedCliKind.None,
             bool needsUpdate = false,
             string cliVersion = "3.0.0",
             bool needsCliPathSetup = false)
@@ -575,7 +605,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 needsUpdate,
                 canUninstallCli: true,
                 needsCliPathSetup,
-                isHomebrewManagedCli,
+                managedCliKind,
                 isInstallingCli: false,
                 isChecking,
                 isSkillStateChecking: isSkillStateChecking ?? isChecking,

--- a/Assets/Tests/Editor/HomebrewManagedCliPolicyTests.cs
+++ b/Assets/Tests/Editor/HomebrewManagedCliPolicyTests.cs
@@ -130,21 +130,5 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result, Is.False);
         }
 
-        /// <summary>
-        /// Verifies brew guidance is shown for every Homebrew path that does not yield a usable CLI.
-        /// </summary>
-        [TestCase(true, false, true)]
-        [TestCase(true, true, false)]
-        [TestCase(false, false, false)]
-        [TestCase(false, true, false)]
-        public void ShouldShowUpgradeGuidance_ReturnsExpectedValue(
-            bool isHomebrewManagedPath,
-            bool isCliUsable,
-            bool expected)
-        {
-            bool result = HomebrewManagedCliPolicy.ShouldShowUpgradeGuidance(isHomebrewManagedPath, isCliUsable);
-
-            Assert.That(result, Is.EqualTo(expected));
-        }
     }
 }

--- a/Assets/Tests/Editor/ManagedCliPolicyTests.cs
+++ b/Assets/Tests/Editor/ManagedCliPolicyTests.cs
@@ -1,0 +1,43 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies managed CLI policy resolution and guidance visibility.
+    /// </summary>
+    public class ManagedCliPolicyTests
+    {
+        /// <summary>
+        /// Verifies that executable paths resolve to Homebrew, winget, or no package manager.
+        /// </summary>
+        [TestCase("/opt/homebrew/Cellar/uloop/3.1.0/bin/uloop", ManagedCliKind.Homebrew)]
+        [TestCase(@"C:\Program Files\WinGet\Links\uloop.exe", ManagedCliKind.Winget)]
+        [TestCase(@"C:\Users\<USER_NAME>\AppData\Local\Programs\uloop\bin\uloop.exe", ManagedCliKind.None)]
+        [TestCase("/opt/homebrew/Cellar/uloop/3.1.0/WinGet/Links/uloop", ManagedCliKind.Homebrew)]
+        public void Resolve_ReturnsExpectedKind(string executablePath, ManagedCliKind expectedKind)
+        {
+            ManagedCliKind result = ManagedCliPolicy.Resolve(executablePath, directoryPath => false);
+
+            Assert.That(result, Is.EqualTo(expectedKind));
+        }
+
+        /// <summary>
+        /// Verifies that guidance is shown only for an unusable package-manager-owned CLI.
+        /// </summary>
+        [TestCase(ManagedCliKind.Homebrew, false, true)]
+        [TestCase(ManagedCliKind.Winget, false, true)]
+        [TestCase(ManagedCliKind.Homebrew, true, false)]
+        [TestCase(ManagedCliKind.None, false, false)]
+        public void ShouldShowUpgradeGuidance_ReturnsExpectedValue(
+            ManagedCliKind kind,
+            bool isCliUsable,
+            bool expected)
+        {
+            bool result = ManagedCliPolicy.ShouldShowUpgradeGuidance(kind, isCliUsable);
+
+            Assert.That(result, Is.EqualTo(expected));
+        }
+    }
+}

--- a/Assets/Tests/Editor/ManagedCliPolicyTests.cs.meta
+++ b/Assets/Tests/Editor/ManagedCliPolicyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b1677c70ed1d41d2a17516eafd87a8b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/NativeCliInstallPathResolverTests.cs
+++ b/Assets/Tests/Editor/NativeCliInstallPathResolverTests.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies package-manager ownership through the native CLI path resolver.
+    /// </summary>
+    public class NativeCliInstallPathResolverTests
+    {
+        /// <summary>
+        /// Verifies the real resolver wiring returns winget, Homebrew, and unmanaged kinds.
+        /// </summary>
+        [TestCase(
+            @"C:\Users\<USER_NAME>\AppData\Local\Microsoft\WinGet\Links\uloop.exe",
+            ManagedCliKind.Winget)]
+        [TestCase("/opt/homebrew/Cellar/uloop/3.1.0/bin/uloop", ManagedCliKind.Homebrew)]
+        [TestCase(@"C:\Tools\uloop.exe", ManagedCliKind.None)]
+        public void ResolveManagedCliKind_ReturnsExpectedKind(string executablePath, ManagedCliKind expectedKind)
+        {
+            ManagedCliKind result = NativeCliInstallPathResolver.ResolveManagedCliKind(executablePath);
+
+            Assert.That(result, Is.EqualTo(expectedKind));
+        }
+    }
+}

--- a/Assets/Tests/Editor/NativeCliInstallPathResolverTests.cs.meta
+++ b/Assets/Tests/Editor/NativeCliInstallPathResolverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f662bc8e649f484b9e29abe07baa70c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -563,6 +563,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(ManagedCliKind.Winget, "2.9.0", true, true,
             "winget-managed CLI v2.9.0 does not meet the required v3.0.0.\n"
             + "Run this command in your terminal:\nwinget upgrade --id hatayama.uloop")]
+        [TestCase(ManagedCliKind.Winget, null, true, true,
+            "winget-managed CLI did not report a version.\n"
+            + "Run these commands in your terminal:\n"
+            + "winget uninstall --id hatayama.uloop\n"
+            + "winget install --id hatayama.uloop")]
+        [TestCase(ManagedCliKind.Winget, "3.0.0", false, true,
+            "winget-managed CLI v3.0.0 did not answer as the required uloop CLI.\n"
+            + "Run these commands in your terminal:\n"
+            + "winget uninstall --id hatayama.uloop\n"
+            + "winget install --id hatayama.uloop")]
         [TestCase(ManagedCliKind.Homebrew, "3.0.0", true, false, "")]
         [TestCase(ManagedCliKind.None, "2.9.0", true, false, "")]
         [TestCase(ManagedCliKind.None, null, true, false, "")]

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -478,28 +478,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(canManageSkills, Is.True);
         }
 
-        [TestCase(false, false, false, false, false, false, null, "3.0.0", "Install CLI")]
-        [TestCase(false, false, false, false, true, false, null, "3.0.0", "Fix PATH")]
-        [TestCase(true, false, false, false, false, false, "3.0.0", "3.0.0", "Installed")]
-        [TestCase(true, false, false, false, true, false, "3.0.0", "3.0.0", "Fix PATH")]
-        [TestCase(true, false, false, true, false, false, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
-        [TestCase(true, false, false, true, true, false, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
-        [TestCase(true, false, false, true, false, false, "3.0.0", "3.0.0", "Update CLI (v3.0.0 required)")]
-        [TestCase(true, true, false, false, false, false, "3.0.0", "3.0.0", "Installing...")]
-        [TestCase(true, true, false, false, true, false, "3.0.0", "3.0.0", "Fixing PATH...")]
-        [TestCase(false, false, true, false, false, false, null, "3.0.0", "Checking...")]
-        [TestCase(true, false, false, false, false, true, "3.0.0", "3.0.0", "Managed by Homebrew")]
-        [TestCase(true, false, false, true, false, true, "2.9.0", "3.0.0", "Managed by Homebrew")]
-        [TestCase(false, false, false, false, false, true, null, "3.0.0", "Managed by Homebrew")]
-        [TestCase(true, false, false, false, true, true, "3.0.0", "3.0.0", "Fix PATH")]
-        [TestCase(true, true, false, false, true, true, "3.0.0", "3.0.0", "Fixing PATH...")]
+        [TestCase(false, false, false, false, false, ManagedCliKind.None, null, "3.0.0", "Install CLI")]
+        [TestCase(false, false, false, false, true, ManagedCliKind.None, null, "3.0.0", "Fix PATH")]
+        [TestCase(true, false, false, false, false, ManagedCliKind.None, "3.0.0", "3.0.0", "Installed")]
+        [TestCase(true, false, false, false, true, ManagedCliKind.None, "3.0.0", "3.0.0", "Fix PATH")]
+        [TestCase(true, false, false, true, false, ManagedCliKind.None, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
+        [TestCase(true, false, false, true, true, ManagedCliKind.None, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
+        [TestCase(true, false, false, true, false, ManagedCliKind.None, "3.0.0", "3.0.0", "Update CLI (v3.0.0 required)")]
+        [TestCase(true, true, false, false, false, ManagedCliKind.None, "3.0.0", "3.0.0", "Installing...")]
+        [TestCase(true, true, false, false, true, ManagedCliKind.None, "3.0.0", "3.0.0", "Fixing PATH...")]
+        [TestCase(false, false, true, false, false, ManagedCliKind.None, null, "3.0.0", "Checking...")]
+        [TestCase(true, false, false, false, false, ManagedCliKind.Homebrew, "3.0.0", "3.0.0", "Managed by Homebrew")]
+        [TestCase(true, false, false, true, false, ManagedCliKind.Homebrew, "2.9.0", "3.0.0", "Managed by Homebrew")]
+        [TestCase(false, false, false, false, false, ManagedCliKind.Homebrew, null, "3.0.0", "Managed by Homebrew")]
+        [TestCase(true, false, false, false, false, ManagedCliKind.Winget, "3.0.0", "3.0.0", "Managed by winget")]
+        [TestCase(true, false, false, false, true, ManagedCliKind.Homebrew, "3.0.0", "3.0.0", "Fix PATH")]
+        [TestCase(true, true, false, false, true, ManagedCliKind.Homebrew, "3.0.0", "3.0.0", "Fixing PATH...")]
         public void GetCliButtonTextForSetupWizard_ReturnsExpectedLabel(
             bool cliInstalled,
             bool isInstallingCli,
             bool isChecking,
             bool needsUpdate,
             bool needsCliPathSetup,
-            bool isHomebrewManagedCli,
+            ManagedCliKind managedCliKind,
             string cliVersion,
             string requiredCliVersion,
             string expectedLabel)
@@ -510,7 +511,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 isChecking,
                 needsUpdate,
                 needsCliPathSetup,
-                isHomebrewManagedCli,
+                managedCliKind,
                 cliVersion,
                 requiredCliVersion);
 
@@ -539,37 +540,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [TestCase(
-            true,
+            ManagedCliKind.Homebrew,
             "2.9.0",
             true,
             true,
             "Homebrew-managed CLI v2.9.0 does not meet the required v3.0.0.\n"
             + "Run this command in your terminal:\nbrew upgrade uloop")]
         [TestCase(
-            true,
+            ManagedCliKind.Homebrew,
             null,
             true,
             true,
             "Homebrew-managed CLI did not report a version.\n"
             + "Run this command in your terminal:\nbrew reinstall uloop")]
         [TestCase(
-            true,
+            ManagedCliKind.Homebrew,
             "3.0.0",
             false,
             true,
             "Homebrew-managed CLI v3.0.0 did not answer as the required uloop CLI.\n"
             + "Run this command in your terminal:\nbrew reinstall uloop")]
-        [TestCase(true, "3.0.0", true, false, "")]
-        [TestCase(false, "2.9.0", true, false, "")]
-        [TestCase(false, null, true, false, "")]
-        public void Update_TogglesHomebrewUpgradeWarning(
-            bool isHomebrewManagedCli,
+        [TestCase(ManagedCliKind.Winget, "2.9.0", true, true,
+            "winget-managed CLI v2.9.0 does not meet the required v3.0.0.\n"
+            + "Run this command in your terminal:\nwinget upgrade --id hatayama.uloop")]
+        [TestCase(ManagedCliKind.Homebrew, "3.0.0", true, false, "")]
+        [TestCase(ManagedCliKind.None, "2.9.0", true, false, "")]
+        [TestCase(ManagedCliKind.None, null, true, false, "")]
+        public void Update_TogglesManagedUpgradeWarning(
+            ManagedCliKind managedCliKind,
             string cliVersion,
             bool cliIsDispatcher,
             bool expectedVisible,
             string expectedText)
         {
-            // Verifies the wizard explains every unusable Homebrew CLI, and stays silent otherwise.
+            // Verifies the wizard explains every unusable managed CLI, and stays silent otherwise.
             VisualElement statusIcon = new();
             Label statusLabel = new();
             Label homebrewUpgradeMessage = new() { name = "cli-homebrew-upgrade-message" };
@@ -588,7 +592,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 requiredCliVersion: "3.0.0",
                 isInstallingCli: false,
                 needsCliPathSetup: false,
-                isHomebrewManagedCli);
+                managedCliKind);
 
             Assert.That(
                 homebrewUpgradeMessage.ClassListContains("setup-warning-message--visible"),
@@ -596,32 +600,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(homebrewUpgradeMessage.text, Is.EqualTo(expectedText));
         }
 
-        [TestCase(false, false, false, false, false, false, true)]
-        [TestCase(true, false, true, false, false, false, true)]
-        [TestCase(true, false, false, false, false, false, true)]
-        [TestCase(true, true, false, false, false, false, false)]
-        [TestCase(false, false, false, true, false, false, false)]
-        [TestCase(false, false, false, false, true, false, false)]
-        [TestCase(true, false, false, false, false, true, false)]
-        [TestCase(false, false, false, false, false, true, false)]
-        [TestCase(true, false, true, false, false, true, true)]
+        [TestCase(false, false, false, false, false, ManagedCliKind.None, true)]
+        [TestCase(true, false, true, false, false, ManagedCliKind.None, true)]
+        [TestCase(true, false, false, false, false, ManagedCliKind.None, true)]
+        [TestCase(true, true, false, false, false, ManagedCliKind.None, false)]
+        [TestCase(false, false, false, true, false, ManagedCliKind.None, false)]
+        [TestCase(false, false, false, false, true, ManagedCliKind.None, false)]
+        [TestCase(true, false, false, false, false, ManagedCliKind.Homebrew, false)]
+        [TestCase(false, false, false, false, false, ManagedCliKind.Winget, false)]
+        [TestCase(true, false, true, false, false, ManagedCliKind.Winget, true)]
         public void IsCliButtonEnabledForSetupWizard_ReturnsExpectedValue(
             bool cliInstalled,
             bool cliVersionMatched,
             bool needsCliPathSetup,
             bool isInstallingCli,
             bool isChecking,
-            bool isHomebrewManagedCli,
+            ManagedCliKind managedCliKind,
             bool expectedEnabled)
         {
-            // Verifies a Homebrew-managed CLI leaves only PATH repair, which writes no binary, enabled.
+            // Verifies a managed CLI leaves only PATH repair, which writes no binary, enabled.
             bool enabled = SetupWizardCliStepPresenter.IsCliButtonEnabledForSetupWizard(
                 cliInstalled,
                 cliVersionMatched,
                 needsCliPathSetup,
                 isInstallingCli,
                 isChecking,
-                isHomebrewManagedCli);
+                managedCliKind);
 
             Assert.That(enabled, Is.EqualTo(expectedEnabled));
         }

--- a/Assets/Tests/Editor/SkillsTargetSelectionResolverTests.cs
+++ b/Assets/Tests/Editor/SkillsTargetSelectionResolverTests.cs
@@ -61,7 +61,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 needsUpdate: false,
                 canUninstallCli: true,
                 needsCliPathSetup: false,
-                isHomebrewManagedCli: false,
+                managedCliKind: ManagedCliKind.None,
                 isInstallingCli: false,
                 isChecking: false,
                 isSkillStateChecking: false,

--- a/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
@@ -53,38 +53,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result, Is.EqualTo(expected));
         }
 
-        [TestCase(true, "3.0.0", true, true, false, "RepairPath")]
-        [TestCase(true, "3.0.1", true, true, false, "RepairPath")]
-        [TestCase(true, "3.0.0", false, true, false, "InstallOrUpdate")]
-        [TestCase(true, "2.9.0", true, true, false, "InstallOrUpdate")]
-        [TestCase(false, "3.0.0", true, true, false, "Uninstall")]
-        [TestCase(false, "3.0.1", true, true, false, "Uninstall")]
-        [TestCase(false, "3.0.0", false, true, false, "InstallOrUpdate")]
-        [TestCase(false, "3.0.0", true, false, false, "InstallOrUpdate")]
-        [TestCase(false, null, false, true, false, "InstallOrUpdate")]
-        [TestCase(false, "", false, true, false, "InstallOrUpdate")]
-        [TestCase(false, "3.0.0", true, false, true, "None")]
-        [TestCase(false, "2.9.0", true, false, true, "None")]
-        [TestCase(false, null, false, false, true, "None")]
-        [TestCase(true, "3.0.0", true, false, true, "RepairPath")]
-        [TestCase(true, "2.9.0", true, false, true, "RepairPath")]
+        [TestCase(true, "3.0.0", true, true, ManagedCliKind.None, "RepairPath")]
+        [TestCase(true, "3.0.1", true, true, ManagedCliKind.None, "RepairPath")]
+        [TestCase(true, "3.0.0", false, true, ManagedCliKind.None, "InstallOrUpdate")]
+        [TestCase(true, "2.9.0", true, true, ManagedCliKind.None, "InstallOrUpdate")]
+        [TestCase(false, "3.0.0", true, true, ManagedCliKind.None, "Uninstall")]
+        [TestCase(false, "3.0.1", true, true, ManagedCliKind.None, "Uninstall")]
+        [TestCase(false, "3.0.0", false, true, ManagedCliKind.None, "InstallOrUpdate")]
+        [TestCase(false, "3.0.0", true, false, ManagedCliKind.None, "InstallOrUpdate")]
+        [TestCase(false, null, false, true, ManagedCliKind.None, "InstallOrUpdate")]
+        [TestCase(false, "", false, true, ManagedCliKind.None, "InstallOrUpdate")]
+        [TestCase(false, "3.0.0", true, false, ManagedCliKind.Homebrew, "None")]
+        [TestCase(false, "2.9.0", true, false, ManagedCliKind.Homebrew, "None")]
+        [TestCase(false, null, false, false, ManagedCliKind.Homebrew, "None")]
+        [TestCase(true, "3.0.0", true, false, ManagedCliKind.Homebrew, "RepairPath")]
+        [TestCase(true, "2.9.0", true, false, ManagedCliKind.Homebrew, "RepairPath")]
+        [TestCase(false, "2.9.0", true, false, ManagedCliKind.Winget, "None")]
+        [TestCase(true, "2.9.0", true, false, ManagedCliKind.Winget, "RepairPath")]
         public void ResolveCliPrimaryButtonAction_ReturnsClickedPrimaryAction(
             bool needsCliPathSetup,
             string cliVersion,
             bool cliIsDispatcher,
             bool canUninstallCli,
-            bool isHomebrewManagedCli,
+            ManagedCliKind managedCliKind,
             string expected)
         {
             // Verifies that the Settings window chooses repair only when dispatcher replacement is unnecessary,
-            // and that a Homebrew-managed path leaves PATH repair as its only executable action.
+            // and that a managed path leaves PATH repair as its only executable action.
             CliSetupPrimaryAction result =
                 UnityCliLoopSettingsCliSetupPresenter.ResolveCliPrimaryButtonAction(
                     needsCliPathSetup,
                     cliVersion,
                     cliIsDispatcher,
                     canUninstallCli,
-                    isHomebrewManagedCli,
+                    managedCliKind,
                     TestMinimumDispatcherVersion);
 
             Assert.That(result.ToString(), Is.EqualTo(expected));

--- a/Assets/Tests/Editor/WingetManagedCliPolicyTests.cs
+++ b/Assets/Tests/Editor/WingetManagedCliPolicyTests.cs
@@ -1,0 +1,43 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies winget-managed CLI path classification.
+    /// </summary>
+    public class WingetManagedCliPolicyTests
+    {
+        /// <summary>
+        /// Verifies that WinGet Packages and Links paths are recognized across roots, separators, and casing.
+        /// </summary>
+        [TestCase(@"C:\Users\<USER_NAME>\AppData\Local\Microsoft\WinGet\Packages\hatayama.uloop_Microsoft.Winget.Source_8wekyb3d8bbwe\uloop.exe")]
+        [TestCase(@"C:\Users\<USER_NAME>\AppData\Local\Microsoft\WinGet\Links\uloop.exe")]
+        [TestCase(@"C:\Program Files\WinGet\Packages\hatayama.uloop_Microsoft.Winget.Source_8wekyb3d8bbwe\uloop.exe")]
+        [TestCase(@"C:\Program Files\WinGet\Links\uloop.exe")]
+        [TestCase("C:/Users/<USER_NAME>/AppData/Local/Microsoft/WinGet/Packages/hatayama.uloop_Microsoft.Winget.Source_8wekyb3d8bbwe/uloop.exe")]
+        [TestCase(@"C:\Users\<USER_NAME>\AppData\Local\Microsoft\winget\packages\hatayama.uloop\uloop.exe")]
+        public void IsWingetManagedPath_WithManagedDirectory_ReturnsTrue(string executablePath)
+        {
+            bool result = WingetManagedCliPolicy.IsWingetManagedPath(executablePath);
+
+            Assert.That(result, Is.True);
+        }
+
+        /// <summary>
+        /// Verifies that unrelated paths are not classified as winget-managed.
+        /// </summary>
+        [TestCase(@"C:\Users\<USER_NAME>\AppData\Local\Programs\uloop\bin\uloop.exe")]
+        [TestCase("/opt/homebrew/Cellar/uloop/3.1.0/bin/uloop")]
+        [TestCase(@"C:\Tools\WinGet\uloop.exe")]
+        [TestCase(@"C:\Tools\WinGet\Other\Packages\uloop.exe")]
+        [TestCase(@"D:\Packages\WinGet\uloop.exe")]
+        public void IsWingetManagedPath_WithoutAdjacentManagedDirectory_ReturnsFalse(string executablePath)
+        {
+            bool result = WingetManagedCliPolicy.IsWingetManagedPath(executablePath);
+
+            Assert.That(result, Is.False);
+        }
+    }
+}

--- a/Assets/Tests/Editor/WingetManagedCliPolicyTests.cs.meta
+++ b/Assets/Tests/Editor/WingetManagedCliPolicyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e949548b78c594e3c8018fbc8ea566f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Application/CliSetupApplicationService.cs
+++ b/Packages/src/Editor/Application/CliSetupApplicationService.cs
@@ -75,7 +75,7 @@ namespace io.github.hatayama.UnityCliLoop.Application
     public interface INativeCliInstaller
     {
         bool IsPackageOwnedCurrentUserInstallPath(string cliExecutablePath, RuntimePlatform platform);
-        bool IsHomebrewManagedInstallPath(string cliExecutablePath);
+        ManagedCliKind ResolveManagedCliKind(string cliExecutablePath);
         bool HasPackageOwnedCurrentUserInstall(RuntimePlatform platform);
         Task<CliInstallResult> InstallGlobalCliAsync(
             RuntimePlatform platform,
@@ -170,9 +170,9 @@ namespace io.github.hatayama.UnityCliLoop.Application
             return _nativeCliInstaller.IsPackageOwnedCurrentUserInstallPath(cliExecutablePath, platform);
         }
 
-        public bool IsHomebrewManagedInstallPath(string cliExecutablePath)
+        public ManagedCliKind ResolveManagedCliKind(string cliExecutablePath)
         {
-            return _nativeCliInstaller.IsHomebrewManagedInstallPath(cliExecutablePath);
+            return _nativeCliInstaller.ResolveManagedCliKind(cliExecutablePath);
         }
 
         public bool HasPackageOwnedCurrentUserInstall(RuntimePlatform platform)

--- a/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
+++ b/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
@@ -44,9 +44,13 @@ namespace io.github.hatayama.UnityCliLoop.Application
             string managedDescription = kind == ManagedCliKind.Homebrew
                 ? "Homebrew-managed"
                 : "winget-managed";
-            string reinstallCommand = kind == ManagedCliKind.Homebrew
-                ? CliConstants.HOMEBREW_REINSTALL_COMMAND
-                : CliConstants.WINGET_REINSTALL_COMMAND;
+            // Why two winget lines: Windows PowerShell 5.1 rejects &&, and a single install command
+            // does not reliably reinstall an existing portable package.
+            string reinstallGuidance = kind == ManagedCliKind.Homebrew
+                ? "Run this command in your terminal:\n" + CliConstants.HOMEBREW_REINSTALL_COMMAND
+                : "Run these commands in your terminal:\n"
+                    + CliConstants.WINGET_UNINSTALL_COMMAND + "\n"
+                    + CliConstants.WINGET_INSTALL_COMMAND;
             string upgradeCommand = kind == ManagedCliKind.Homebrew
                 ? CliConstants.HOMEBREW_UPGRADE_COMMAND
                 : CliConstants.WINGET_UPGRADE_COMMAND;
@@ -54,15 +58,13 @@ namespace io.github.hatayama.UnityCliLoop.Application
             if (string.IsNullOrEmpty(cliVersion))
             {
                 return managedDescription + " CLI did not report a version.\n"
-                    + "Run this command in your terminal:\n"
-                    + reinstallCommand;
+                    + reinstallGuidance;
             }
 
             if (CliVersionComparer.IsVersionGreaterThanOrEqual(cliVersion, requiredCliVersion))
             {
                 return $"{managedDescription} CLI v{cliVersion} did not answer as the required uloop CLI.\n"
-                    + "Run this command in your terminal:\n"
-                    + reinstallCommand;
+                    + reinstallGuidance;
             }
 
             return $"{managedDescription} CLI v{cliVersion} does not meet the required v{requiredCliVersion}.\n"

--- a/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
+++ b/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
@@ -10,9 +10,21 @@ namespace io.github.hatayama.UnityCliLoop.Application
         // Why: uloop installed by Homebrew must be updated and removed through brew itself,
         // so the package offers no primary action for it.
         public const string HOMEBREW_MANAGED_BUTTON_TEXT = "Managed by Homebrew";
+        public const string WINGET_MANAGED_BUTTON_TEXT = "Managed by winget";
 
         /// <summary>
-        /// Formats the warning text that tells a Homebrew user which brew command makes the CLI usable.
+        /// Returns the disabled primary-button label for a package-manager-owned CLI.
+        /// </summary>
+        public static string GetManagedButtonText(ManagedCliKind kind)
+        {
+            System.Diagnostics.Debug.Assert(kind != ManagedCliKind.None, "kind must identify a package manager");
+            return kind == ManagedCliKind.Homebrew
+                ? HOMEBREW_MANAGED_BUTTON_TEXT
+                : WINGET_MANAGED_BUTTON_TEXT;
+        }
+
+        /// <summary>
+        /// Formats the warning text that tells a package-manager user which command makes the CLI usable.
         /// </summary>
         /// <remarks>
         /// Why the line breaks: the command is not run by Unity, so the text has to say where it belongs,
@@ -23,25 +35,39 @@ namespace io.github.hatayama.UnityCliLoop.Application
         /// such a user to upgrade names a command that reports nothing to do, so those cases point at a
         /// reinstall instead and the text never claims a comparison that is not true.
         /// </remarks>
-        public static string GetHomebrewUpgradeGuidanceText(string cliVersion, string requiredCliVersion)
+        public static string GetManagedUpgradeGuidanceText(
+            ManagedCliKind kind,
+            string cliVersion,
+            string requiredCliVersion)
         {
+            System.Diagnostics.Debug.Assert(kind != ManagedCliKind.None, "kind must identify a package manager");
+            string managedDescription = kind == ManagedCliKind.Homebrew
+                ? "Homebrew-managed"
+                : "winget-managed";
+            string reinstallCommand = kind == ManagedCliKind.Homebrew
+                ? CliConstants.HOMEBREW_REINSTALL_COMMAND
+                : CliConstants.WINGET_REINSTALL_COMMAND;
+            string upgradeCommand = kind == ManagedCliKind.Homebrew
+                ? CliConstants.HOMEBREW_UPGRADE_COMMAND
+                : CliConstants.WINGET_UPGRADE_COMMAND;
+
             if (string.IsNullOrEmpty(cliVersion))
             {
-                return "Homebrew-managed CLI did not report a version.\n"
+                return managedDescription + " CLI did not report a version.\n"
                     + "Run this command in your terminal:\n"
-                    + $"{CliConstants.HOMEBREW_REINSTALL_COMMAND}";
+                    + reinstallCommand;
             }
 
             if (CliVersionComparer.IsVersionGreaterThanOrEqual(cliVersion, requiredCliVersion))
             {
-                return $"Homebrew-managed CLI v{cliVersion} did not answer as the required uloop CLI.\n"
+                return $"{managedDescription} CLI v{cliVersion} did not answer as the required uloop CLI.\n"
                     + "Run this command in your terminal:\n"
-                    + $"{CliConstants.HOMEBREW_REINSTALL_COMMAND}";
+                    + reinstallCommand;
             }
 
-            return $"Homebrew-managed CLI v{cliVersion} does not meet the required v{requiredCliVersion}.\n"
+            return $"{managedDescription} CLI v{cliVersion} does not meet the required v{requiredCliVersion}.\n"
                 + "Run this command in your terminal:\n"
-                + $"{CliConstants.HOMEBREW_UPGRADE_COMMAND}";
+                + upgradeCommand;
         }
 
         public static string GetCliReplacementButtonText(string action, string cliVersion, string requiredCliVersion)

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -42,8 +42,8 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public const string HOMEBREW_REINSTALL_COMMAND = "brew reinstall " + EXECUTABLE_NAME;
         public const string WINGET_PACKAGE_IDENTIFIER = "hatayama.uloop";
         public const string WINGET_UPGRADE_COMMAND = "winget upgrade --id " + WINGET_PACKAGE_IDENTIFIER;
-        public const string WINGET_REINSTALL_COMMAND = "winget uninstall --id " + WINGET_PACKAGE_IDENTIFIER
-            + " && winget install --id " + WINGET_PACKAGE_IDENTIFIER;
+        public const string WINGET_UNINSTALL_COMMAND = "winget uninstall --id " + WINGET_PACKAGE_IDENTIFIER;
+        public const string WINGET_INSTALL_COMMAND = "winget install --id " + WINGET_PACKAGE_IDENTIFIER;
         public const string WINGET_ROOT_DIR_NAME = "WinGet";
         public const string WINGET_PACKAGES_DIR_NAME = "Packages";
         public const string WINGET_LINKS_DIR_NAME = "Links";

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -40,6 +40,13 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public const string HOMEBREW_CELLAR_DIR_NAME = "Cellar";
         public const string HOMEBREW_UPGRADE_COMMAND = "brew upgrade " + EXECUTABLE_NAME;
         public const string HOMEBREW_REINSTALL_COMMAND = "brew reinstall " + EXECUTABLE_NAME;
+        public const string WINGET_PACKAGE_IDENTIFIER = "hatayama.uloop";
+        public const string WINGET_UPGRADE_COMMAND = "winget upgrade --id " + WINGET_PACKAGE_IDENTIFIER;
+        public const string WINGET_REINSTALL_COMMAND = "winget uninstall --id " + WINGET_PACKAGE_IDENTIFIER
+            + " && winget install --id " + WINGET_PACKAGE_IDENTIFIER;
+        public const string WINGET_ROOT_DIR_NAME = "WinGet";
+        public const string WINGET_PACKAGES_DIR_NAME = "Packages";
+        public const string WINGET_LINKS_DIR_NAME = "Links";
         public const string GLOBAL_UNIX_COMMAND_NAME = EXECUTABLE_NAME;
         public const string GLOBAL_WINDOWS_COMMAND_NAME = EXECUTABLE_NAME + ".exe";
     }

--- a/Packages/src/Editor/Domain/CliSetupPrimaryActionPolicy.cs
+++ b/Packages/src/Editor/Domain/CliSetupPrimaryActionPolicy.cs
@@ -30,9 +30,9 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         }
 
         /// <remarks>
-        /// Why the Homebrew branch lives here and not only in the button state: the primary action is
-        /// resolved again after a forced refresh, so a Homebrew install that appears between click and
-        /// action would otherwise still run an install and leave a second binary beside brew's own.
+        /// Why the managed branch lives here and not only in the button state: the primary action is
+        /// resolved again after a forced refresh, so a managed install that appears between click and
+        /// action would otherwise still run an install and leave a second binary beside its owner.
         /// Why PATH repair survives it: repair neither writes nor removes a binary, it only makes an
         /// already installed package-owned CLI reachable, so it is the one action that stays safe.
         /// </remarks>
@@ -41,9 +41,9 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             bool needsUpdate,
             bool isCliInstalled,
             bool canUninstallCli,
-            bool isHomebrewManagedCli)
+            ManagedCliKind managedCliKind)
         {
-            if (isHomebrewManagedCli)
+            if (managedCliKind != ManagedCliKind.None)
             {
                 return needsCliPathSetup ? CliSetupPrimaryAction.RepairPath : CliSetupPrimaryAction.None;
             }

--- a/Packages/src/Editor/Domain/HomebrewManagedCliPolicy.cs
+++ b/Packages/src/Editor/Domain/HomebrewManagedCliPolicy.cs
@@ -45,19 +45,6 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         }
 
         /// <summary>
-        /// Reports whether the guidance that points at a brew command must be shown.
-        /// </summary>
-        /// <remarks>
-        /// Why not gate the stand-down on this too: a Homebrew path whose binary answers no version
-        /// probe is still owned by brew, so installing over it would split ownership. Such a path
-        /// stands down like any other and is explained by this guidance instead.
-        /// </remarks>
-        public static bool ShouldShowUpgradeGuidance(bool isHomebrewManagedPath, bool isCliUsable)
-        {
-            return isHomebrewManagedPath && !isCliUsable;
-        }
-
-        /// <summary>
         /// Builds the Cellar formula directory that a prefix/bin executable would be linked from.
         /// </summary>
         /// <remarks>

--- a/Packages/src/Editor/Domain/ManagedCliKind.cs
+++ b/Packages/src/Editor/Domain/ManagedCliKind.cs
@@ -1,0 +1,12 @@
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Identifies the package manager that owns a detected CLI executable.
+    /// </summary>
+    public enum ManagedCliKind
+    {
+        None,
+        Homebrew,
+        Winget
+    }
+}

--- a/Packages/src/Editor/Domain/ManagedCliKind.cs.meta
+++ b/Packages/src/Editor/Domain/ManagedCliKind.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc002f925d17b4c56975d429144e2511
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Domain/ManagedCliPolicy.cs
+++ b/Packages/src/Editor/Domain/ManagedCliPolicy.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Resolves package-manager ownership and shared managed-install behavior.
+    /// </summary>
+    public static class ManagedCliPolicy
+    {
+        /// <summary>
+        /// Resolves the package manager that owns an executable path.
+        /// </summary>
+        public static ManagedCliKind Resolve(string executablePath, Func<string, bool> directoryExists)
+        {
+            Debug.Assert(directoryExists != null, "directoryExists must not be null");
+
+            if (HomebrewManagedCliPolicy.IsHomebrewManagedPath(executablePath, directoryExists))
+            {
+                return ManagedCliKind.Homebrew;
+            }
+
+            if (WingetManagedCliPolicy.IsWingetManagedPath(executablePath))
+            {
+                return ManagedCliKind.Winget;
+            }
+
+            return ManagedCliKind.None;
+        }
+
+        /// <summary>
+        /// Reports whether an unusable package-manager-owned CLI needs manual upgrade guidance.
+        /// </summary>
+        public static bool ShouldShowUpgradeGuidance(ManagedCliKind kind, bool isCliUsable)
+        {
+            return kind != ManagedCliKind.None && !isCliUsable;
+        }
+    }
+}

--- a/Packages/src/Editor/Domain/ManagedCliPolicy.cs.meta
+++ b/Packages/src/Editor/Domain/ManagedCliPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83a9cb41ff4fc4bfb88d317ee92ec599
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Domain/WingetManagedCliPolicy.cs
+++ b/Packages/src/Editor/Domain/WingetManagedCliPolicy.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Classifies whether a detected uloop executable is owned by winget.
+    /// </summary>
+    public static class WingetManagedCliPolicy
+    {
+        private const char PATH_SEPARATOR = '/';
+        private const char WINDOWS_PATH_SEPARATOR = '\\';
+
+        /// <summary>
+        /// Reports whether the executable path contains adjacent WinGet and managed-directory segments.
+        /// </summary>
+        public static bool IsWingetManagedPath(string executablePath)
+        {
+            if (string.IsNullOrWhiteSpace(executablePath))
+            {
+                return false;
+            }
+
+            string normalizedPath = executablePath.Replace(WINDOWS_PATH_SEPARATOR, PATH_SEPARATOR);
+            string[] segments = normalizedPath.Split(PATH_SEPARATOR);
+            for (int index = 0; index + 1 < segments.Length; index++)
+            {
+                if (!string.Equals(
+                        segments[index],
+                        CliConstants.WINGET_ROOT_DIR_NAME,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                string managedDirectory = segments[index + 1];
+                if (string.Equals(
+                        managedDirectory,
+                        CliConstants.WINGET_PACKAGES_DIR_NAME,
+                        StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(
+                        managedDirectory,
+                        CliConstants.WINGET_LINKS_DIR_NAME,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Packages/src/Editor/Domain/WingetManagedCliPolicy.cs.meta
+++ b/Packages/src/Editor/Domain/WingetManagedCliPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ccfc8b14945f440e9cea795533c9f55
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliInstallPathResolver.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliInstallPathResolver.cs
@@ -156,11 +156,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         }
 
         /// <summary>
-        /// Reports whether the detected CLI executable is owned by Homebrew.
+        /// Resolves the package manager that owns the detected CLI executable.
         /// </summary>
-        internal static bool IsHomebrewManagedInstallPath(string executablePath)
+        internal static ManagedCliKind ResolveManagedCliKind(string executablePath)
         {
-            return HomebrewManagedCliPolicy.IsHomebrewManagedPath(executablePath, Directory.Exists);
+            return ManagedCliPolicy.Resolve(executablePath, Directory.Exists);
         }
 
         internal static bool IsPackageOwnedInstallPath(

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs
@@ -181,9 +181,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return NativeCliInstallPathResolver.IsPackageOwnedCurrentUserInstallPath(cliExecutablePath, platform);
         }
 
-        public bool IsHomebrewManagedInstallPath(string cliExecutablePath)
+        public ManagedCliKind ResolveManagedCliKind(string cliExecutablePath)
         {
-            return NativeCliInstallPathResolver.IsHomebrewManagedInstallPath(cliExecutablePath);
+            return NativeCliInstallPathResolver.ResolveManagedCliKind(cliExecutablePath);
         }
 
         public bool HasPackageOwnedCurrentUserInstall(RuntimePlatform platform)

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs
@@ -13,7 +13,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     {
         private readonly VisualElement _statusIcon;
         private readonly Label _statusLabel;
-        private readonly Label _homebrewUpgradeMessage;
+        private readonly Label _managedUpgradeMessage;
         private readonly Button _installButton;
 
         internal SetupWizardCliStepPresenter(
@@ -31,12 +31,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             _statusIcon = statusIcon ?? throw new System.ArgumentNullException(nameof(statusIcon));
             _statusLabel = statusLabel ?? throw new System.ArgumentNullException(nameof(statusLabel));
-            _homebrewUpgradeMessage = homebrewUpgradeMessage
+            _managedUpgradeMessage = homebrewUpgradeMessage
                 ?? throw new System.ArgumentNullException(nameof(homebrewUpgradeMessage));
             // Why: the warning carries a command to run, so it must be copyable.
             // UI Toolkit only starts a selection on a focusable text element.
-            _homebrewUpgradeMessage.focusable = true;
-            _homebrewUpgradeMessage.selection.isSelectable = true;
+            _managedUpgradeMessage.focusable = true;
+            _managedUpgradeMessage.selection.isSelectable = true;
             _installButton = installButton ?? throw new System.ArgumentNullException(nameof(installButton));
             _installButton.clicked += onInstallClicked
                 ?? throw new System.ArgumentNullException(nameof(onInstallClicked));
@@ -116,13 +116,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string cliVersion,
             string requiredCliVersion)
         {
-            _homebrewUpgradeMessage.text = isVisible
+            _managedUpgradeMessage.text = isVisible
                 ? CliSetupLabelFormatter.GetManagedUpgradeGuidanceText(
                     managedCliKind,
                     cliVersion,
                     requiredCliVersion)
                 : string.Empty;
-            ViewDataBinder.ToggleClass(_homebrewUpgradeMessage, "setup-warning-message--visible", isVisible);
+            ViewDataBinder.ToggleClass(_managedUpgradeMessage, "setup-warning-message--visible", isVisible);
         }
 
         internal static string GetCliStatusTextForSetupWizard(

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs
@@ -47,7 +47,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             ViewDataBinder.ToggleClass(_statusIcon, "setup-status-icon--success", false);
             ViewDataBinder.ToggleClass(_statusIcon, "setup-status-icon--pending", true);
             _statusLabel.text = "Checking...";
-            UpdateHomebrewUpgradeMessage(isVisible: false, cliVersion: null, requiredCliVersion: null);
+            UpdateManagedUpgradeMessage(
+                isVisible: false,
+                managedCliKind: ManagedCliKind.None,
+                cliVersion: null,
+                requiredCliVersion: null);
             _installButton.SetEnabled(false);
             _installButton.text = "Checking...";
         }
@@ -65,7 +69,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string requiredCliVersion,
             bool isInstallingCli,
             bool needsCliPathSetup,
-            bool isHomebrewManagedCli)
+            ManagedCliKind managedCliKind)
         {
             CliSetupCompatibilityState state = CliSetupCompatibility.Evaluate(
                 cliVersion,
@@ -77,7 +81,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 false,
                 state.NeedsUpdate,
                 needsCliPathSetup,
-                isHomebrewManagedCli,
+                managedCliKind,
                 cliVersion,
                 requiredCliVersion);
             bool cliVersionMatched = state.IsCompatible && cliInstalled;
@@ -87,7 +91,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 needsCliPathSetup,
                 isInstallingCli,
                 isChecking: false,
-                isHomebrewManagedCli);
+                managedCliKind);
 
             bool cliCompatible = cliInstalled && cliVersionMatched;
             _statusLabel.text = GetCliStatusTextForSetupWizard(
@@ -95,8 +99,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 cliCompatible,
                 cliVersion,
                 requiredCliVersion);
-            UpdateHomebrewUpgradeMessage(
-                HomebrewManagedCliPolicy.ShouldShowUpgradeGuidance(isHomebrewManagedCli, cliCompatible),
+            UpdateManagedUpgradeMessage(
+                ManagedCliPolicy.ShouldShowUpgradeGuidance(managedCliKind, cliCompatible),
+                managedCliKind,
                 cliVersion,
                 requiredCliVersion);
             ViewDataBinder.ToggleClass(_statusIcon, "setup-status-icon--success", cliCompatible);
@@ -105,10 +110,17 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _installButton.text = buttonText;
         }
 
-        private void UpdateHomebrewUpgradeMessage(bool isVisible, string cliVersion, string requiredCliVersion)
+        private void UpdateManagedUpgradeMessage(
+            bool isVisible,
+            ManagedCliKind managedCliKind,
+            string cliVersion,
+            string requiredCliVersion)
         {
             _homebrewUpgradeMessage.text = isVisible
-                ? CliSetupLabelFormatter.GetHomebrewUpgradeGuidanceText(cliVersion, requiredCliVersion)
+                ? CliSetupLabelFormatter.GetManagedUpgradeGuidanceText(
+                    managedCliKind,
+                    cliVersion,
+                    requiredCliVersion)
                 : string.Empty;
             ViewDataBinder.ToggleClass(_homebrewUpgradeMessage, "setup-warning-message--visible", isVisible);
         }
@@ -143,7 +155,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool isChecking,
             bool needsUpdate,
             bool needsCliPathSetup,
-            bool isHomebrewManagedCli,
+            ManagedCliKind managedCliKind,
             string cliVersion,
             string requiredCliVersion)
         {
@@ -152,7 +164,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return "Checking...";
             }
 
-            if (isHomebrewManagedCli)
+            if (managedCliKind != ManagedCliKind.None)
             {
                 if (isInstallingCli)
                 {
@@ -161,7 +173,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
                 return needsCliPathSetup
                     ? "Fix PATH"
-                    : CliSetupLabelFormatter.HOMEBREW_MANAGED_BUTTON_TEXT;
+                    : CliSetupLabelFormatter.GetManagedButtonText(managedCliKind);
             }
 
             if (isInstallingCli)
@@ -198,14 +210,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool needsCliPathSetup,
             bool isInstallingCli,
             bool isChecking,
-            bool isHomebrewManagedCli)
+            ManagedCliKind managedCliKind)
         {
             if (isInstallingCli || isChecking)
             {
                 return false;
             }
 
-            if (isHomebrewManagedCli)
+            if (managedCliKind != ManagedCliKind.None)
             {
                 return needsCliPathSetup;
             }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs
@@ -86,12 +86,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 requiredCliVersion,
                 _isInstallingCli,
                 _needsCliPathSetup,
-                IsHomebrewManagedCli());
+                ResolveManagedCliKind());
         }
 
-        private bool IsHomebrewManagedCli()
+        private ManagedCliKind ResolveManagedCliKind()
         {
-            return _cliSetupApplicationService.IsHomebrewManagedInstallPath(
+            return _cliSetupApplicationService.ResolveManagedCliKind(
                 _cliSetupApplicationService.GetCachedCliExecutablePath());
         }
 
@@ -106,10 +106,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             string cliVersion = _cliSetupApplicationService.GetCachedCliVersion();
             bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
-            // Why here: the refresh above can reveal a Homebrew install that appeared after the click,
-            // and installing over it would leave a second binary beside the one brew owns.
+            // Why here: the refresh above can reveal a managed install that appeared after the click,
+            // and installing over it would leave a second binary beside the package manager's own.
             // PATH repair stays allowed because it writes no binary.
-            if (IsHomebrewManagedCli())
+            if (ResolveManagedCliKind() != ManagedCliKind.None)
             {
                 if (_needsCliPathSetup)
                 {
@@ -141,7 +141,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 requiredCliVersion: GetMinimumRequiredCliVersion(),
                 isInstallingCli: _isInstallingCli,
                 needsCliPathSetup: _needsCliPathSetup,
-                isHomebrewManagedCli: IsHomebrewManagedCli());
+                managedCliKind: ResolveManagedCliKind());
             _installProgressView.Show();
             Progress<string> installProgress = new(_installProgressView.SetDetailLine);
 
@@ -213,7 +213,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 requiredCliVersion: GetMinimumRequiredCliVersion(),
                 isInstallingCli: _isInstallingCli,
                 needsCliPathSetup: _needsCliPathSetup,
-                isHomebrewManagedCli: IsHomebrewManagedCli());
+                managedCliKind: ResolveManagedCliKind());
 
             try
             {

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -109,16 +109,19 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 data.IsChecking,
                 data.IsCliInstalled,
                 data.CliVersion);
-            UpdateHomebrewUpgradeMessage(data);
+            UpdateManagedUpgradeMessage(data);
         }
 
-        private void UpdateHomebrewUpgradeMessage(CliSetupData data)
+        private void UpdateManagedUpgradeMessage(CliSetupData data)
         {
             bool isCliUsable = !string.IsNullOrEmpty(data.CliVersion) && !data.NeedsUpdate;
             bool isVisible = !data.IsChecking
-                && HomebrewManagedCliPolicy.ShouldShowUpgradeGuidance(data.IsHomebrewManagedCli, isCliUsable);
+                && ManagedCliPolicy.ShouldShowUpgradeGuidance(data.ManagedCliKind, isCliUsable);
             _cliHomebrewUpgradeMessage.text = isVisible
-                ? CliSetupLabelFormatter.GetHomebrewUpgradeGuidanceText(data.CliVersion, data.RequiredCliVersion)
+                ? CliSetupLabelFormatter.GetManagedUpgradeGuidanceText(
+                    data.ManagedCliKind,
+                    data.CliVersion,
+                    data.RequiredCliVersion)
                 : string.Empty;
             ViewDataBinder.ToggleClass(
                 _cliHomebrewUpgradeMessage,
@@ -140,13 +143,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 data.NeedsUpdate,
                 data.CanUninstallCli,
                 data.NeedsCliPathSetup,
-                data.IsHomebrewManagedCli,
+                data.ManagedCliKind,
                 data.CliVersion,
                 data.RequiredCliVersion);
             bool enabled = IsInstallCliButtonEnabled(
                 data.IsInstallingCli,
                 data.IsChecking,
-                data.IsHomebrewManagedCli,
+                data.ManagedCliKind,
                 data.NeedsCliPathSetup);
             bool isUninstallStyle = !data.NeedsCliPathSetup && IsUninstallCliAction(
                 data.IsCliInstalled,
@@ -202,7 +205,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool needsUpdate,
             bool canUninstallCli,
             bool needsCliPathSetup,
-            bool isHomebrewManagedCli,
+            ManagedCliKind managedCliKind,
             string cliVersion,
             string requiredCliVersion)
         {
@@ -211,7 +214,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return "Checking...";
             }
 
-            if (isHomebrewManagedCli)
+            if (managedCliKind != ManagedCliKind.None)
             {
                 if (isInstallingCli)
                 {
@@ -220,7 +223,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
                 return needsCliPathSetup
                     ? "Fix PATH"
-                    : CliSetupLabelFormatter.HOMEBREW_MANAGED_BUTTON_TEXT;
+                    : CliSetupLabelFormatter.GetManagedButtonText(managedCliKind);
             }
 
             bool isUninstallAction = IsUninstallCliAction(isCliInstalled, needsUpdate, canUninstallCli);
@@ -255,7 +258,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal static bool IsInstallCliButtonEnabled(
             bool isInstallingCli,
             bool isChecking,
-            bool isHomebrewManagedCli,
+            ManagedCliKind managedCliKind,
             bool needsCliPathSetup)
         {
             if (isInstallingCli || isChecking)
@@ -263,7 +266,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return false;
             }
 
-            return !isHomebrewManagedCli || needsCliPathSetup;
+            return managedCliKind == ManagedCliKind.None || needsCliPathSetup;
         }
 
         internal static string GetCliStatusText(

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -16,7 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     {
         private readonly VisualElement _cliStatusIcon;
         private readonly Label _cliStatusLabel;
-        private readonly Label _cliHomebrewUpgradeMessage;
+        private readonly Label _cliManagedUpgradeMessage;
         private readonly Button _refreshCliVersionButton;
         private readonly Button _installCliButton;
         private readonly CliInstallProgressView _installProgressView;
@@ -37,11 +37,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             _cliStatusIcon = root.Q<VisualElement>("cli-status-icon");
             _cliStatusLabel = root.Q<Label>("cli-status-label");
-            _cliHomebrewUpgradeMessage = root.Q<Label>("cli-homebrew-upgrade-message");
+            _cliManagedUpgradeMessage = root.Q<Label>("cli-homebrew-upgrade-message");
             // Why: the warning carries a command to run, so it must be copyable.
             // UI Toolkit only starts a selection on a focusable text element.
-            _cliHomebrewUpgradeMessage.focusable = true;
-            _cliHomebrewUpgradeMessage.selection.isSelectable = true;
+            _cliManagedUpgradeMessage.focusable = true;
+            _cliManagedUpgradeMessage.selection.isSelectable = true;
             _refreshCliVersionButton = root.Q<Button>("refresh-cli-version-button");
             _installCliButton = root.Q<Button>("install-cli-button");
             _installProgressView = new CliInstallProgressView(
@@ -117,14 +117,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool isCliUsable = !string.IsNullOrEmpty(data.CliVersion) && !data.NeedsUpdate;
             bool isVisible = !data.IsChecking
                 && ManagedCliPolicy.ShouldShowUpgradeGuidance(data.ManagedCliKind, isCliUsable);
-            _cliHomebrewUpgradeMessage.text = isVisible
+            _cliManagedUpgradeMessage.text = isVisible
                 ? CliSetupLabelFormatter.GetManagedUpgradeGuidanceText(
                     data.ManagedCliKind,
                     data.CliVersion,
                     data.RequiredCliVersion)
                 : string.Empty;
             ViewDataBinder.ToggleClass(
-                _cliHomebrewUpgradeMessage,
+                _cliManagedUpgradeMessage,
                 "unity-cli-loop-warning-message--visible",
                 isVisible);
         }

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
@@ -116,14 +116,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool canUninstallCli = _cliSetupApplicationService.IsPackageOwnedCurrentUserInstallPath(
                 cliExecutablePath,
                 UnityEngine.Application.platform);
-            bool isHomebrewManagedCli = _cliSetupApplicationService.IsHomebrewManagedInstallPath(cliExecutablePath);
+            ManagedCliKind managedCliKind = _cliSetupApplicationService.ResolveManagedCliKind(cliExecutablePath);
             string requiredCliVersion = _cliSetupApplicationService.GetMinimumRequiredCliVersion();
             return ResolveCliPrimaryButtonAction(
                 needsCliPathSetup,
                 cliVersion,
                 cliIsDispatcher,
                 canUninstallCli,
-                isHomebrewManagedCli,
+                managedCliKind,
                 requiredCliVersion);
         }
 
@@ -146,7 +146,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string cliVersion,
             bool cliIsDispatcher,
             bool canUninstallCli,
-            bool isHomebrewManagedCli,
+            ManagedCliKind managedCliKind,
             string requiredCliVersion)
         {
             bool needsUpdate = IsCliUpdateNeeded(cliVersion, cliIsDispatcher, requiredCliVersion);
@@ -156,7 +156,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 needsUpdate,
                 isCliInstalled,
                 canUninstallCli,
-                isHomebrewManagedCli);
+                managedCliKind);
         }
 
         internal static CliSetupPrimaryAction ResolveExecutableCliPrimaryButtonAction(
@@ -446,7 +446,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool canUninstallCli = _cliSetupApplicationService.IsPackageOwnedCurrentUserInstallPath(
                 cliExecutablePath,
                 UnityEngine.Application.platform);
-            bool isHomebrewManagedCli = _cliSetupApplicationService.IsHomebrewManagedInstallPath(cliExecutablePath);
+            ManagedCliKind managedCliKind = _cliSetupApplicationService.ResolveManagedCliKind(cliExecutablePath);
             bool isChecking = !_cliSetupApplicationService.IsCliCheckCompleted()
                 || isRefreshingVersion
                 || isRefreshingCliPathSetup;
@@ -470,7 +470,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 state.NeedsUpdate,
                 canUninstallCli,
                 needsCliPathSetup,
-                isHomebrewManagedCli,
+                managedCliKind,
                 isInstallingCli,
                 isChecking,
                 isSkillStateChecking,

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowViewData.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowViewData.cs
@@ -86,7 +86,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         public readonly bool NeedsUpdate;
         public readonly bool CanUninstallCli;
         public readonly bool NeedsCliPathSetup;
-        public readonly bool IsHomebrewManagedCli;
+        public readonly ManagedCliKind ManagedCliKind;
         public readonly bool IsInstallingCli;
         public readonly bool IsChecking;
         public readonly bool IsSkillStateChecking;
@@ -107,7 +107,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool needsUpdate,
             bool canUninstallCli,
             bool needsCliPathSetup,
-            bool isHomebrewManagedCli,
+            ManagedCliKind managedCliKind,
             bool isInstallingCli,
             bool isChecking,
             bool isSkillStateChecking,
@@ -127,7 +127,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             NeedsUpdate = needsUpdate;
             CanUninstallCli = canUninstallCli;
             NeedsCliPathSetup = needsCliPathSetup;
-            IsHomebrewManagedCli = isHomebrewManagedCli;
+            ManagedCliKind = managedCliKind;
             IsInstallingCli = isInstallingCli;
             IsChecking = isChecking;
             IsSkillStateChecking = isSkillStateChecking;

--- a/docs/package-manager-distribution.md
+++ b/docs/package-manager-distribution.md
@@ -49,8 +49,8 @@ winget receives stable dispatcher releases only. Prereleases are not submitted.
   repair is the one action that survives the
   stand-down, because it writes no binary and only makes an already installed
   package-owned CLI reachable.
-- The Unity Settings window and Setup Wizard will display `Managed by winget`
-  for a winget-managed CLI and will not overwrite it.
+- The Unity Settings window and Setup Wizard display `Managed by winget` for a
+  winget-managed CLI and do not overwrite it.
 
 ## Known follow-ups
 


### PR DESCRIPTION
## Summary
- classify Homebrew- and winget-managed CLI paths through a shared managed-install kind
- stand down Unity Settings and Setup Wizard install actions while preserving PATH repair
- show package-manager-specific labels and upgrade or reinstall guidance
- document the now-active Unity winget behavior

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` (errors: 0)
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "ManagedCli|CliSetup|SetupWizard|CliPathSetup" --timeout-seconds 600` (246 passed, 0 failed)
- UnityCliLoop.DeadCodeScanner type and member scans (no new managed-CLI findings)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

