### PR TITLE
fix: Skills no longer show as Outdated when other tools add extra files at the skill root

### DIFF
--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -1232,6 +1232,70 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(detectedTargets[0].HasExistingSkills, Is.True);
         }
 
+        /// <summary>
+        /// Verifies that extra non-markdown files placed at the skill directory root by other tools
+        /// do not make the skill report as Outdated.
+        /// </summary>
+        [Test]
+        public void DetectTargets_WhenInstalledSkillRootContainsExtraNonMarkdownFile_ReportsInstalled()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(temporaryRoot, "uloop-fake-skill", "FakeTool", "reference.md", "reference");
+
+            string installedSkillDir = Path.Combine(
+                temporaryRoot,
+                ".claude",
+                SkillInstallLayout.SkillsDirName,
+                SkillInstallLayout.ManagedSkillsDirName,
+                "uloop-fake-skill");
+            WriteSkillFile(installedSkillDir, "---\nname: uloop-fake-skill\n---\n");
+            File.WriteAllText(Path.Combine(installedSkillDir, "reference.md"), "reference");
+            File.WriteAllText(Path.Combine(installedSkillDir, "extra.yml"), "name: uloop-fake-skill\n");
+
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
+                    temporaryRoot,
+                    requireSkillsDirectory: true,
+                    groupSkillsUnderUnityCliLoop: true,
+                    includeFreshnessCheck: true)
+                .ToArray();
+
+            Assert.That(detectedTargets.Length, Is.EqualTo(1));
+            Assert.That(detectedTargets[0].InstallState, Is.EqualTo(SkillInstallState.Installed));
+        }
+
+        /// <summary>
+        /// Verifies that a shipped non-markdown file inside a skill subdirectory is still compared,
+        /// so a changed script makes the skill report as Outdated.
+        /// </summary>
+        [Test]
+        public void DetectTargets_WhenShippedScriptInSubdirectoryDiffers_ReportsOutdated()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            string scriptRelativePath = Path.Combine("scripts", "run.sh");
+            CreateFakeSourceSkill(temporaryRoot, "uloop-fake-skill", "FakeTool", scriptRelativePath, "echo source");
+
+            string installedSkillDir = Path.Combine(
+                temporaryRoot,
+                ".claude",
+                SkillInstallLayout.SkillsDirName,
+                SkillInstallLayout.ManagedSkillsDirName,
+                "uloop-fake-skill");
+            WriteSkillFile(installedSkillDir, "---\nname: uloop-fake-skill\n---\n");
+            string installedScriptPath = Path.Combine(installedSkillDir, scriptRelativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(installedScriptPath));
+            File.WriteAllText(installedScriptPath, "echo installed");
+
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
+                    temporaryRoot,
+                    requireSkillsDirectory: true,
+                    groupSkillsUnderUnityCliLoop: true,
+                    includeFreshnessCheck: true)
+                .ToArray();
+
+            Assert.That(detectedTargets.Length, Is.EqualTo(1));
+            Assert.That(detectedTargets[0].InstallState, Is.EqualTo(SkillInstallState.Outdated));
+        }
+
         // Tests that CRLF-only drift from Windows checkouts does not mark installed skills stale.
         [Test]
         public void DetectTargets_WhenInstalledSkillUsesCrlfLineEndings_ReportsInstalled()
@@ -1862,7 +1926,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             File.WriteAllText(
                 Path.Combine(skillDir, SkillInstallLayout.SkillFileName),
                 $"---\nname: {skillName}\n{internalLine}---\n");
-            File.WriteAllText(Path.Combine(skillDir, additionalFileRelativePath), additionalFileContent);
+            string additionalFilePath = Path.Combine(skillDir, additionalFileRelativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(additionalFilePath));
+            File.WriteAllText(additionalFilePath, additionalFileContent);
             if (!string.IsNullOrEmpty(sourceMetaFileRelativePath))
             {
                 File.WriteAllText(Path.Combine(skillDir, sourceMetaFileRelativePath), "meta");

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallLayout.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallLayout.cs
@@ -18,6 +18,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         internal const string SkillsDirName = "skills";
         internal const string ManagedSkillsDirName = "unity-cli-loop";
         internal const string SkillFileName = "SKILL.md";
+        private const string MarkdownFileExtension = ".md";
 
         internal readonly struct SkillSourceInfo
         {
@@ -298,19 +299,25 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return Path.Combine(skillsRoot, skillName);
         }
 
+        // At the skill directory root only markdown files are compared, because other tools may
+        // place their own metadata files there and those must not make an up-to-date skill report
+        // as Outdated. Files inside subdirectories (references, scripts, and so on) are shipped
+        // by the skill itself, so they are compared regardless of extension.
         private static bool IsSkillDirectoryOutdated(
             Dictionary<string, byte[]> sourceFiles,
             string installedSkillDirectory)
         {
-            Dictionary<string, byte[]> installedFiles = CollectInstalledSkillFiles(installedSkillDirectory);
-            if (sourceFiles.Count != installedFiles.Count)
+            Dictionary<string, byte[]> comparableSourceFiles = SelectComparableSkillFiles(sourceFiles);
+            Dictionary<string, byte[]> comparableInstalledFiles = SelectComparableSkillFiles(
+                CollectInstalledSkillFiles(installedSkillDirectory));
+            if (comparableSourceFiles.Count != comparableInstalledFiles.Count)
             {
                 return true;
             }
 
-            foreach (KeyValuePair<string, byte[]> sourceFile in sourceFiles)
+            foreach (KeyValuePair<string, byte[]> sourceFile in comparableSourceFiles)
             {
-                if (!installedFiles.TryGetValue(sourceFile.Key, out byte[] installedContent))
+                if (!comparableInstalledFiles.TryGetValue(sourceFile.Key, out byte[] installedContent))
                 {
                     return true;
                 }
@@ -322,6 +329,41 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return false;
+        }
+
+        private static Dictionary<string, byte[]> SelectComparableSkillFiles(Dictionary<string, byte[]> skillFiles)
+        {
+            Debug.Assert(skillFiles != null, "skillFiles must not be null");
+
+            Dictionary<string, byte[]> comparableFiles = new(StringComparer.Ordinal);
+            foreach (KeyValuePair<string, byte[]> skillFile in skillFiles)
+            {
+                if (!IsComparableSkillFile(skillFile.Key))
+                {
+                    continue;
+                }
+
+                comparableFiles[skillFile.Key] = skillFile.Value;
+            }
+
+            return comparableFiles;
+        }
+
+        private static bool IsComparableSkillFile(string relativePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(relativePath), "relativePath must not be null or empty");
+
+            bool isInSubdirectory = relativePath.IndexOf(Path.DirectorySeparatorChar) >= 0
+                || relativePath.IndexOf(Path.AltDirectorySeparatorChar) >= 0;
+            if (isInSubdirectory)
+            {
+                return true;
+            }
+
+            return string.Equals(
+                Path.GetExtension(relativePath),
+                MarkdownFileExtension,
+                StringComparison.OrdinalIgnoreCase);
         }
 
         private static Dictionary<string, byte[]> CollectInstalledSkillFiles(string skillDirectory)

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallLayout.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallLayout.cs
@@ -308,8 +308,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string installedSkillDirectory)
         {
             Dictionary<string, byte[]> comparableSourceFiles = SelectComparableSkillFiles(sourceFiles);
-            Dictionary<string, byte[]> comparableInstalledFiles = SelectComparableSkillFiles(
-                CollectInstalledSkillFiles(installedSkillDirectory));
+            Dictionary<string, byte[]> comparableInstalledFiles = CollectSkillFiles(
+                installedSkillDirectory,
+                IsComparableSkillFile);
             if (comparableSourceFiles.Count != comparableInstalledFiles.Count)
             {
                 return true;
@@ -368,6 +369,19 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private static Dictionary<string, byte[]> CollectInstalledSkillFiles(string skillDirectory)
         {
+            return CollectSkillFiles(skillDirectory, _ => true);
+        }
+
+        // Files rejected by the filter are skipped before they are read, so a large or
+        // unreadable file placed next to the skill by another tool never slows down or breaks
+        // the freshness check.
+        private static Dictionary<string, byte[]> CollectSkillFiles(
+            string skillDirectory,
+            Func<string, bool> relativePathFilter)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(skillDirectory), "skillDirectory must not be null or empty");
+            Debug.Assert(relativePathFilter != null, "relativePathFilter must not be null");
+
             Dictionary<string, byte[]> files = new(StringComparer.Ordinal);
             foreach (string filePath in Directory.EnumerateFiles(skillDirectory, "*", SearchOption.AllDirectories))
             {
@@ -378,6 +392,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
 
                 string relativePath = Path.GetRelativePath(skillDirectory, filePath);
+                if (!relativePathFilter(relativePath))
+                {
+                    continue;
+                }
+
                 files[relativePath] = SkillFileContentNormalizer.NormalizeSkillFileContent(
                     relativePath,
                     File.ReadAllBytes(filePath));


### PR DESCRIPTION
## Summary
- Installed skills no longer show as Outdated in the Setup Wizard and Settings when other tools add their own non-markdown files at the root of the skill directory.

## User Impact
- Before: if any extra file existed inside an installed skill directory, the skill status was always Outdated, even right after installing the latest skills, because the freshness check counted every file in the directory.
- After: at the skill directory root only markdown files (such as `SKILL.md`) are compared, so metadata files dropped there by other tools are ignored and the status correctly reports Installed.
- Files inside subdirectories (`references/`, `scripts/`, and so on) are still compared regardless of extension, so a changed shipped script or reference still reports Outdated.

## Changes
- The outdated check filters both the package source side and the installed side with one rule: keep every file inside a subdirectory, and keep root-level files only when they are markdown.
- Extra or changed markdown files at the root still mark the skill as Outdated (existing behavior, covered by existing tests).

## Verification
- Added an EditMode test that places a non-markdown file at the root of an installed skill directory and expects Installed. Confirmed it fails before the change and passes after.
- Added an EditMode test that ships a script under `scripts/` and changes it in the installed copy, expecting Outdated.
- `uloop compile` succeeds.
- `uloop run-tests --filter-type regex --filter-value "ToolSkillSynchronizerTests|SkillInstallLayoutTests"`: 72 passed, 0 failed.

https://claude.ai/code/session_01PUaDr3P6JwBbHQS8dVLJBX
