### PR TITLE
docs(distribution): record initial winget-pkgs submission

### DIFF
--- a/docs/package-manager-distribution.md
+++ b/docs/package-manager-distribution.md
@@ -36,10 +36,11 @@ winget receives stable dispatcher releases only. Prereleases are not submitted.
   (`dispatcher-v3.1.0`). After it merges, verify with
   `winget install --id hatayama.uloop`.
 - `WINGET_PKGS_TOKEN` is a classic PAT because fine-grained tokens cannot open
-  pull requests against repositories the token owner does not own. It expires
-  after one year; when the `Open winget-pkgs pull request` step fails with an
-  authentication error, issue a new classic PAT with `public_repo` and replace
-  the secret with `gh secret set WINGET_PKGS_TOKEN`.
+  pull requests against repositories the token owner does not own. It is
+  configured to expire after one year; when the `Open winget-pkgs pull
+  request` step fails with an authentication error, issue a new classic PAT
+  with `public_repo` and replace the secret with
+  `gh secret set WINGET_PKGS_TOKEN --repo hatayama/unity-cli-loop`.
 - `uloop update` refuses Homebrew-managed installs and directs users to
   `brew upgrade uloop`. The dispatcher freshness path does the same for required
   updates and skips optional auto-updates.

--- a/docs/package-manager-distribution.md
+++ b/docs/package-manager-distribution.md
@@ -32,6 +32,14 @@ winget receives stable dispatcher releases only. Prereleases are not submitted.
 - New winget-pkgs pull requests must pass the upstream bot validation and human
   moderation. Moderation commonly takes several days and can take up to two
   weeks.
+- Initial submission: <https://github.com/microsoft/winget-pkgs/pull/427857>
+  (`dispatcher-v3.1.0`). After it merges, verify with
+  `winget install --id hatayama.uloop`.
+- `WINGET_PKGS_TOKEN` is a classic PAT because fine-grained tokens cannot open
+  pull requests against repositories the token owner does not own. It expires
+  after one year; when the `Open winget-pkgs pull request` step fails with an
+  authentication error, issue a new classic PAT with `public_repo` and replace
+  the secret with `gh secret set WINGET_PKGS_TOKEN`.
 - `uloop update` refuses Homebrew-managed installs and directs users to
   `brew upgrade uloop`. The dispatcher freshness path does the same for required
   updates and skips optional auto-updates.


### PR DESCRIPTION
## Summary
- Record the initial `hatayama.uloop` submission (microsoft/winget-pkgs#427857) in the distribution operations doc.
- Document why `WINGET_PKGS_TOKEN` must be a classic PAT and how to rotate it.

Docs only; no code changes.

https://claude.ai/code/session_01XbhSMKK4LFud57iAmowDz7

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

