### PR TITLE
fix(release-automation): add schema header to winget manifests

### DIFF
--- a/cli/release-automation/internal/automation/winget_manifest_update.go
+++ b/cli/release-automation/internal/automation/winget_manifest_update.go
@@ -23,14 +23,19 @@ const (
 	wingetLocaleManifestFilename    = "hatayama.uloop.locale.en-US.yaml"
 )
 
-const wingetVersionManifestTemplate = `PackageIdentifier: hatayama.uloop
+// winget-pkgs validation rejects manifests at ManifestVersion 1.7.0 or later
+// with SchemaHeaderNotFound when the yaml-language-server schema header is
+// missing, so every generated manifest must start with it.
+const wingetVersionManifestTemplate = `# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.` + wingetManifestSchemaVersion + `.schema.json
+PackageIdentifier: hatayama.uloop
 PackageVersion: {{.Version}}
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: ` + wingetManifestSchemaVersion + `
 `
 
-const wingetInstallerManifestTemplate = `PackageIdentifier: hatayama.uloop
+const wingetInstallerManifestTemplate = `# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.` + wingetManifestSchemaVersion + `.schema.json
+PackageIdentifier: hatayama.uloop
 PackageVersion: {{.Version}}
 InstallerType: zip
 NestedInstallerType: portable
@@ -48,7 +53,8 @@ ManifestType: installer
 ManifestVersion: ` + wingetManifestSchemaVersion + `
 `
 
-const wingetLocaleManifestTemplate = `PackageIdentifier: hatayama.uloop
+const wingetLocaleManifestTemplate = `# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.` + wingetManifestSchemaVersion + `.schema.json
+PackageIdentifier: hatayama.uloop
 PackageVersion: {{.Version}}
 PackageLocale: en-US
 Publisher: hatayama

--- a/cli/release-automation/internal/automation/winget_manifest_update_test.go
+++ b/cli/release-automation/internal/automation/winget_manifest_update_test.go
@@ -96,13 +96,15 @@ func TestRenderWingetManifests(t *testing.T) {
 	}
 
 	expected := map[string]string{
-		"hatayama.uloop.yaml": `PackageIdentifier: hatayama.uloop
+		"hatayama.uloop.yaml": `# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: hatayama.uloop
 PackageVersion: 3.1.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.10.0
 `,
-		"hatayama.uloop.installer.yaml": `PackageIdentifier: hatayama.uloop
+		"hatayama.uloop.installer.yaml": `# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: hatayama.uloop
 PackageVersion: 3.1.0
 InstallerType: zip
 NestedInstallerType: portable
@@ -119,7 +121,8 @@ Installers:
 ManifestType: installer
 ManifestVersion: 1.10.0
 `,
-		"hatayama.uloop.locale.en-US.yaml": `PackageIdentifier: hatayama.uloop
+		"hatayama.uloop.locale.en-US.yaml": `# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: hatayama.uloop
 PackageVersion: 3.1.0
 PackageLocale: en-US
 Publisher: hatayama
@@ -151,6 +154,58 @@ ManifestVersion: 1.10.0
 	}
 	if wingetManifestSchemaVersion != "1.10.0" {
 		t.Fatalf("manifest schema version = %q, want 1.10.0", wingetManifestSchemaVersion)
+	}
+}
+
+// TestRenderWingetManifestsIncludesSchemaHeader verifies every rendered manifest starts
+// with the yaml-language-server schema header winget-pkgs validation requires (missing
+// headers fail SchemaHeaderNotFound for ManifestVersion 1.7.0+), and that the header's
+// manifest type and version match the ManifestType/ManifestVersion fields in the same file.
+func TestRenderWingetManifestsIncludesSchemaHeader(t *testing.T) {
+	manifests, err := renderWingetManifests(wingetManifestData{
+		Version:     "3.1.0",
+		Repository:  "hatayama/unity-cli-loop",
+		SHA256Upper: strings.ToUpper(testWingetSHA256),
+		ReleaseDate: "2026-08-31",
+	})
+	if err != nil {
+		t.Fatalf("renderWingetManifests failed: %v", err)
+	}
+
+	wantHeaderByFilename := map[string]string{
+		"hatayama.uloop.yaml":              "# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json",
+		"hatayama.uloop.installer.yaml":    "# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json",
+		"hatayama.uloop.locale.en-US.yaml": "# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json",
+	}
+	wantManifestTypeByFilename := map[string]string{
+		"hatayama.uloop.yaml":              "version",
+		"hatayama.uloop.installer.yaml":    "installer",
+		"hatayama.uloop.locale.en-US.yaml": "defaultLocale",
+	}
+
+	for filename, content := range manifests {
+		lines := strings.SplitN(content, "\n", 2)
+		firstLine := lines[0]
+
+		if !strings.HasPrefix(firstLine, "# yaml-language-server: $schema=https://aka.ms/winget-manifest.") {
+			t.Fatalf("manifest %s first line = %q, want yaml-language-server schema header", filename, firstLine)
+		}
+
+		wantHeader := wantHeaderByFilename[filename]
+		if firstLine != wantHeader {
+			t.Fatalf("manifest %s header = %q, want %q", filename, firstLine, wantHeader)
+		}
+
+		wantManifestType := wantManifestTypeByFilename[filename]
+		if !strings.Contains(content, "ManifestType: "+wantManifestType+"\n") {
+			t.Fatalf("manifest %s missing ManifestType: %s matching its header", filename, wantManifestType)
+		}
+		if !strings.Contains(content, "ManifestVersion: "+wingetManifestSchemaVersion+"\n") {
+			t.Fatalf("manifest %s missing ManifestVersion: %s matching its header", filename, wingetManifestSchemaVersion)
+		}
+		if !strings.HasSuffix(firstLine, wingetManifestSchemaVersion+".schema.json") {
+			t.Fatalf("manifest %s header %q does not end with schema version %s", filename, firstLine, wingetManifestSchemaVersion)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- The initial `hatayama.uloop` submission (microsoft/winget-pkgs#427857) failed with `Manifest-Validation-Error`.
- Root cause: for `ManifestVersion` 1.7.0+, winget-cli's `ValidateYamlManifestsSchemaHeader` reports `SchemaHeaderNotFound` as an error, and WinGetUtil (used by the winget-pkgs pipeline) does not downgrade it to a warning. Our generated manifests had no `# yaml-language-server: $schema=` header.
- Emit the header as the first line of the version, installer, and defaultLocale manifests, and cover it with a test.

## Verification
- `scripts/check-go-cli.sh` passes.

https://claude.ai/code/session_01XbhSMKK4LFud57iAmowDz7


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

