### PR TITLE
fix(release-automation): point winget LicenseUrl at LICENSE.md

### DIFF
--- a/cli/release-automation/internal/automation/winget_manifest_update.go
+++ b/cli/release-automation/internal/automation/winget_manifest_update.go
@@ -63,7 +63,7 @@ PublisherSupportUrl: https://github.com/hatayama/unity-cli-loop/issues
 PackageName: Unity CLI Loop
 PackageUrl: https://github.com/hatayama/unity-cli-loop
 License: MIT
-LicenseUrl: https://github.com/hatayama/unity-cli-loop/blob/main/LICENSE
+LicenseUrl: https://github.com/hatayama/unity-cli-loop/blob/main/LICENSE.md
 ShortDescription: Let AI drive Unity, from Editor to Play Mode
 Moniker: uloop
 Tags:

--- a/cli/release-automation/internal/automation/winget_manifest_update_test.go
+++ b/cli/release-automation/internal/automation/winget_manifest_update_test.go
@@ -131,7 +131,7 @@ PublisherSupportUrl: https://github.com/hatayama/unity-cli-loop/issues
 PackageName: Unity CLI Loop
 PackageUrl: https://github.com/hatayama/unity-cli-loop
 License: MIT
-LicenseUrl: https://github.com/hatayama/unity-cli-loop/blob/main/LICENSE
+LicenseUrl: https://github.com/hatayama/unity-cli-loop/blob/main/LICENSE.md
 ShortDescription: Let AI drive Unity, from Editor to Play Mode
 Moniker: uloop
 Tags:


### PR DESCRIPTION
## Summary
- microsoft/winget-pkgs#427968 failed with `URL-Validation-Error`: the generated `LicenseUrl` pointed at `blob/main/LICENSE`, which does not exist (the file is `LICENSE.md`).
- Use the `LICENSE.md` URL, matching `Packages/src/package.json`.

## Verification
- `scripts/check-go-cli.sh` passes.

https://claude.ai/code/session_01XbhSMKK4LFud57iAmowDz7

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

