### PR TITLE
docs(distribution): point winget submission record at 3.2.0

### DIFF
--- a/docs/package-manager-distribution.md
+++ b/docs/package-manager-distribution.md
@@ -32,8 +32,11 @@ winget receives stable dispatcher releases only. Prereleases are not submitted.
 - New winget-pkgs pull requests must pass the upstream bot validation and human
   moderation. Moderation commonly takes several days and can take up to two
   weeks.
-- Initial submission: <https://github.com/microsoft/winget-pkgs/pull/427857>
-  (`dispatcher-v3.1.0`). After it merges, verify with
+- Initial submission: <https://github.com/microsoft/winget-pkgs/pull/427976>
+  (`dispatcher-v3.2.0`, opened by the `dispatcher-publish` workflow). The
+  earlier 3.1.0 submissions were withdrawn because that dispatcher predates the
+  winget-managed self-update refusal and would have updated itself outside
+  winget's control. After it merges, verify with
   `winget install --id hatayama.uloop`.
 - `WINGET_PKGS_TOKEN` is a classic PAT because fine-grained tokens cannot open
   pull requests against repositories the token owner does not own. It is


### PR DESCRIPTION
## Summary
- Record microsoft/winget-pkgs#427976 (`dispatcher-v3.2.0`, opened automatically by `dispatcher-publish`) as the initial winget submission.
- Note why the 3.1.0 submissions were withdrawn.

Docs only.

https://claude.ai/code/session_01XbhSMKK4LFud57iAmowDz7

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

