### PR TITLE
fix(release-automation): skip CLI stamps for description-only catalog changes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -106,6 +106,9 @@ jobs:
         working-directory: cli/release-automation
         run: go run ./cmd/check-skill-size --root "$GITHUB_WORKSPACE"
 
+      - name: Test shared-inputs stamp script
+        run: scripts/test-stamp-release-inputs.sh
+
       # The stamp script derives its manifest from git ls-files, so a stamp generated before a new
       # input file was git-added is silently stale; check-release-triggers only checks that the
       # stamp files were touched, not that their values are current. Regenerate and diff instead.
@@ -155,6 +158,10 @@ jobs:
       - name: Test install release filter in Git Bash
         shell: bash
         run: sh scripts/test-install-release-filter.sh
+
+      - name: Test shared-inputs stamp script in Git Bash
+        shell: bash
+        run: sh scripts/test-stamp-release-inputs.sh
 
       - name: Parse PowerShell installer in Windows PowerShell
         shell: powershell

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ All three components release through release-please; `dispatcherVersion` and com
 changelogs are stamped by release PRs — never bump them by hand (sole exception: the
 documented version-series realignment; see `docs/version-series-realignment.md`). Changes to shared release
 inputs outside the package roots (non-test `cli/common/**` sources, `scripts/install.sh`,
-`scripts/install.ps1`) need matching trigger changes and a `scripts/stamp-release-inputs.sh`
+`scripts/install.ps1`, and structural changes to the embedded tool catalog `cli/common/tools/default-tools.json` (description-only regenerations are exempt)) need matching trigger changes and a `scripts/stamp-release-inputs.sh`
 run in the same PR; CI (`check-release-triggers`) fails otherwise. Rules and rationale:
 `docs/shared-release-inputs.md`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,8 +104,8 @@ All three components release through release-please; `dispatcherVersion` and com
 changelogs are stamped by release PRs — never bump them by hand (sole exception: the
 documented version-series realignment; see `docs/version-series-realignment.md`). Changes to shared release
 inputs outside the package roots (non-test `cli/common/**` sources, `scripts/install.sh`,
-`scripts/install.ps1`, and structural changes to the embedded tool catalog `cli/common/tools/default-tools.json` (description-only regenerations are exempt)) need matching trigger changes and a `scripts/stamp-release-inputs.sh`
-run in the same PR; CI (`check-release-triggers`) fails otherwise. Rules and rationale:
+`scripts/install.ps1`, and structural changes to the embedded tool catalog `cli/common/tools/default-tools.json`) need matching trigger changes and a `scripts/stamp-release-inputs.sh`
+run in the same PR; description-only catalog regenerations are exempt. CI (`check-release-triggers`) fails otherwise. Rules and rationale:
 `docs/shared-release-inputs.md`.
 
 ## Broken CLI Releases

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "82506a84476f3193eda87bec0f8a10f9c876ffe3"
+  "sharedInputsHash": "1df37387ef2084636c7e70ad3430bdcea15175e8"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "db9ce0f0bccedf6caf6bdffbd8e339f35cac18ea"
+  "sharedInputsHash": "6f22790f116e6f082bd7c79efedad728356df11f"
 }

--- a/cli/release-automation/cmd/tool-catalog-shape-digest/main.go
+++ b/cli/release-automation/cmd/tool-catalog-shape-digest/main.go
@@ -1,0 +1,35 @@
+// tool-catalog-shape-digest prints the description-stripped SHA-256 of an
+// embedded tool catalog so stamp scripts can ignore wording-only regenerations.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/hatayama/unity-cli-loop/tools/release-automation/internal/automation"
+)
+
+func main() {
+	catalogPath := flag.String("path", "", "path to the embedded tool catalog JSON")
+	flag.Parse()
+
+	if *catalogPath == "" {
+		fmt.Fprintln(os.Stderr, "-path is required")
+		os.Exit(1)
+	}
+
+	content, err := os.ReadFile(*catalogPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read %s: %v\n", *catalogPath, err)
+		os.Exit(1)
+	}
+
+	digest, err := automation.ToolCatalogShapeDigest(content)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	fmt.Println(digest)
+}

--- a/cli/release-automation/internal/automation/git_helpers.go
+++ b/cli/release-automation/internal/automation/git_helpers.go
@@ -1,0 +1,40 @@
+package automation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// gitMergeBase returns the merge-base commit of baseRef and headRef.
+func gitMergeBase(ctx context.Context, repoRoot string, baseRef string, headRef string) (string, error) {
+	command := exec.CommandContext(ctx, "git", "-C", repoRoot, "merge-base", baseRef, headRef)
+	output, err := command.Output()
+	if err != nil {
+		return "", fmt.Errorf("git merge-base %s %s failed: %w", baseRef, headRef, err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// gitFileAtRef returns the file contents at ref. ok is false when the path is
+// absent at that commit so callers can treat a newly added catalog as a
+// structural change instead of a show error.
+func gitFileAtRef(ctx context.Context, repoRoot string, ref string, path string) ([]byte, bool, error) {
+	command := exec.CommandContext(ctx, "git", "-C", repoRoot, "show", ref+":"+path)
+	command.Dir = filepath.Clean(repoRoot)
+	output, err := command.Output()
+	if err == nil {
+		return output, true, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, false, fmt.Errorf("git show %s:%s interrupted: %w", ref, path, ctxErr)
+		}
+		return nil, false, nil
+	}
+	return nil, false, fmt.Errorf("git show %s:%s failed: %w", ref, path, err)
+}

--- a/cli/release-automation/internal/automation/release_trigger_guard.go
+++ b/cli/release-automation/internal/automation/release_trigger_guard.go
@@ -50,7 +50,8 @@ type ReleaseTriggerGuardConfig struct {
 }
 
 type ReleaseTriggerGuardResult struct {
-	Violations []ReleaseTriggerViolation
+	Violations                    []ReleaseTriggerViolation
+	DescriptionOnlyCatalogSkipped bool
 }
 
 type ReleaseTriggerViolation struct {
@@ -69,6 +70,9 @@ func RunReleaseTriggerGuard(
 	if err != nil {
 		writeReleaseTriggerLine(stderr, err)
 		return 1
+	}
+	if result.DescriptionOnlyCatalogSkipped {
+		writeReleaseTriggerLine(stdout, "catalog changed only in descriptions; not counted as a shared release input")
 	}
 	if len(result.Violations) > 0 {
 		writeReleaseTriggerLine(stderr, FormatReleaseTriggerWarning(result))
@@ -100,7 +104,78 @@ func AnalyzeReleaseTriggerGuardForRefs(
 		return ReleaseTriggerGuardResult{}, fmt.Errorf("failed to inspect changed files: %w", err)
 	}
 
-	return AnalyzeReleaseTriggerGuard(changedFiles), nil
+	filteredFiles, skipped, err := filterDescriptionOnlyCatalogChange(ctx, repoRoot, config, changedFiles)
+	if err != nil {
+		return ReleaseTriggerGuardResult{}, err
+	}
+
+	result := AnalyzeReleaseTriggerGuard(filteredFiles)
+	result.DescriptionOnlyCatalogSkipped = skipped
+	return result, nil
+}
+
+// withoutDescriptionOnlyCatalogChange drops the embedded catalog from the
+// changed-file list when the shape comparison found description-only drift.
+func withoutDescriptionOnlyCatalogChange(changedFiles []string, shapeChanged bool) []string {
+	if shapeChanged {
+		return changedFiles
+	}
+	filtered := []string{}
+	for _, changedFile := range changedFiles {
+		if normalizeChangedFilePath(changedFile) == CatalogRelativePath {
+			continue
+		}
+		filtered = append(filtered, changedFile)
+	}
+	return filtered
+}
+
+func filterDescriptionOnlyCatalogChange(
+	ctx context.Context,
+	repoRoot string,
+	config ReleaseTriggerGuardConfig,
+	changedFiles []string,
+) ([]string, bool, error) {
+	if !changedFilesIncludeCatalog(changedFiles) {
+		return changedFiles, false, nil
+	}
+
+	mergeBase, err := gitMergeBase(ctx, repoRoot, config.BaseRef, config.HeadRef)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to resolve merge-base for catalog shape: %w", err)
+	}
+
+	baseContent, baseExists, err := gitFileAtRef(ctx, repoRoot, mergeBase, CatalogRelativePath)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to read catalog at merge-base: %w", err)
+	}
+	if !baseExists {
+		return changedFiles, false, nil
+	}
+
+	headContent, headExists, err := gitFileAtRef(ctx, repoRoot, config.HeadRef, CatalogRelativePath)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to read catalog at head: %w", err)
+	}
+	if !headExists {
+		return changedFiles, false, nil
+	}
+
+	shapeChanged, err := ToolCatalogShapeChanged(baseContent, headContent)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to compare catalog shape: %w", err)
+	}
+
+	return withoutDescriptionOnlyCatalogChange(changedFiles, shapeChanged), !shapeChanged, nil
+}
+
+func changedFilesIncludeCatalog(changedFiles []string) bool {
+	for _, changedFile := range changedFiles {
+		if normalizeChangedFilePath(changedFile) == CatalogRelativePath {
+			return true
+		}
+	}
+	return false
 }
 
 func AnalyzeReleaseTriggerGuard(changedFiles []string) ReleaseTriggerGuardResult {
@@ -189,9 +264,8 @@ func isCommonGoSourceUnderPackageRoots(file string, packageRoots []string) bool 
 	}
 	// JSON files under common (contract.json) are release-please stamp targets rather than binary
 	// inputs, and test files never ship, so only code and embedded runtime scripts count as release
-	// inputs. The embedded tool catalog is the exception: it is compiled into both binaries and is
-	// generated from the skill parameter tables, so a change to a tool description that shipped no new
-	// binary would be help text nobody receives.
+	// inputs. Structural catalog changes count; description-only regenerations are filtered out
+	// before this function by the shape comparison in AnalyzeReleaseTriggerGuardForRefs.
 	if strings.HasSuffix(file, "_test.go") {
 		return false
 	}

--- a/cli/release-automation/internal/automation/release_trigger_guard_test.go
+++ b/cli/release-automation/internal/automation/release_trigger_guard_test.go
@@ -362,9 +362,11 @@ func TestWithoutDescriptionOnlyCatalogChangeLeavesNonCatalogListsAlone(t *testin
 	}
 }
 
-const mergeBaseCatalogInitial = `{"tools":[{"name":"compile","description":"a","inputSchema":{"type":"object","properties":{"X":{"type":"string","description":"d"}}}}]}`
-const mergeBaseCatalogStructural = `{"tools":[{"name":"compile","description":"a","inputSchema":{"type":"object","properties":{"X":{"type":"string","description":"d"},"Y":{"type":"boolean"}}}}]}`
-const mergeBaseCatalogDescriptionOnly = `{"tools":[{"name":"compile","description":"b","inputSchema":{"type":"object","properties":{"X":{"type":"string","description":"e"}}}}]}`
+const (
+	mergeBaseCatalogInitial         = `{"tools":[{"name":"compile","description":"a","inputSchema":{"type":"object","properties":{"X":{"type":"string","description":"d"}}}}]}`
+	mergeBaseCatalogStructural      = `{"tools":[{"name":"compile","description":"a","inputSchema":{"type":"object","properties":{"X":{"type":"string","description":"d"},"Y":{"type":"boolean"}}}}]}`
+	mergeBaseCatalogDescriptionOnly = `{"tools":[{"name":"compile","description":"b","inputSchema":{"type":"object","properties":{"X":{"type":"string","description":"e"}}}}]}`
+)
 
 // Verifies catalog comparison uses merge-base, not the base tip. Comparing against
 // main's tip would treat this description-only topic as a structural change because

--- a/cli/release-automation/internal/automation/release_trigger_guard_test.go
+++ b/cli/release-automation/internal/automation/release_trigger_guard_test.go
@@ -2,6 +2,7 @@ package automation
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -108,9 +109,9 @@ func TestReleaseTriggerGuardIgnoresNonBinaryCommonChanges(t *testing.T) {
 	}
 }
 
-// Verifies the embedded tool catalog counts as a shared release input, since it is compiled into both
-// binaries and now changes whenever a skill parameter table does - a description-only change that
-// shipped no new binary would be help text nobody receives.
+// Verifies structural catalog changes count as a shared release input. Description-only
+// regenerations are filtered out before this function by the shape comparison in
+// AnalyzeReleaseTriggerGuardForRefs.
 func TestReleaseTriggerGuardCoversTheEmbeddedToolCatalog(t *testing.T) {
 	result := AnalyzeReleaseTriggerGuard([]string{CatalogRelativePath})
 
@@ -122,8 +123,7 @@ func TestReleaseTriggerGuardCoversTheEmbeddedToolCatalog(t *testing.T) {
 	}
 }
 
-// Verifies the catalog passes once both release triggers are stamped, the sequence a skill edit and a
-// regeneration go through together.
+// Verifies a structural catalog change passes once both release triggers are stamped.
 func TestReleaseTriggerGuardAcceptsTheEmbeddedToolCatalogWithBothTriggers(t *testing.T) {
 	result := AnalyzeReleaseTriggerGuard([]string{
 		CatalogRelativePath,
@@ -328,4 +328,103 @@ func TestFormatReleaseTriggerWarningNamesStampCommand(t *testing.T) {
 			t.Fatalf("expected warning to contain %q, got:\n%s", expected, warning)
 		}
 	}
+}
+
+// Verifies a description-only catalog change is dropped from the shared-input list.
+func TestWithoutDescriptionOnlyCatalogChangeRemovesCatalogWhenShapeUnchanged(t *testing.T) {
+	filtered := withoutDescriptionOnlyCatalogChange([]string{
+		CatalogRelativePath,
+		"docs/shared-release-inputs.md",
+	}, false)
+
+	if len(filtered) != 1 || filtered[0] != "docs/shared-release-inputs.md" {
+		t.Fatalf("expected only the non-catalog file, got %v", filtered)
+	}
+}
+
+// Verifies a structural catalog change stays on the shared-input list.
+func TestWithoutDescriptionOnlyCatalogChangeKeepsCatalogWhenShapeChanged(t *testing.T) {
+	changedFiles := []string{CatalogRelativePath, "docs/shared-release-inputs.md"}
+	filtered := withoutDescriptionOnlyCatalogChange(changedFiles, true)
+
+	if len(filtered) != 2 || filtered[0] != CatalogRelativePath || filtered[1] != "docs/shared-release-inputs.md" {
+		t.Fatalf("expected the original list, got %v", filtered)
+	}
+}
+
+// Verifies a file list without the catalog is left unchanged.
+func TestWithoutDescriptionOnlyCatalogChangeLeavesNonCatalogListsAlone(t *testing.T) {
+	changedFiles := []string{"cli/common/clicore/output.go"}
+	filtered := withoutDescriptionOnlyCatalogChange(changedFiles, false)
+
+	if len(filtered) != 1 || filtered[0] != "cli/common/clicore/output.go" {
+		t.Fatalf("expected the original list, got %v", filtered)
+	}
+}
+
+const mergeBaseCatalogInitial = `{"tools":[{"name":"compile","description":"a","inputSchema":{"type":"object","properties":{"X":{"type":"string","description":"d"}}}}]}`
+const mergeBaseCatalogStructural = `{"tools":[{"name":"compile","description":"a","inputSchema":{"type":"object","properties":{"X":{"type":"string","description":"d"},"Y":{"type":"boolean"}}}}]}`
+const mergeBaseCatalogDescriptionOnly = `{"tools":[{"name":"compile","description":"b","inputSchema":{"type":"object","properties":{"X":{"type":"string","description":"e"}}}}]}`
+
+// Verifies catalog comparison uses merge-base, not the base tip. Comparing against
+// main's tip would treat this description-only topic as a structural change because
+// main later added a property.
+func TestAnalyzeReleaseTriggerGuardForRefsUsesMergeBaseForCatalogShape(t *testing.T) {
+	repoRoot := t.TempDir()
+	runGitInRepo(t, repoRoot, "init", "-b", "main")
+
+	catalogPath := filepath.Join(repoRoot, filepath.FromSlash(CatalogRelativePath))
+	if err := os.MkdirAll(filepath.Dir(catalogPath), 0o755); err != nil {
+		t.Fatalf("failed to create catalog directory: %v", err)
+	}
+	if err := os.WriteFile(catalogPath, []byte(mergeBaseCatalogInitial+"\n"), 0o644); err != nil {
+		t.Fatalf("failed to write initial catalog: %v", err)
+	}
+	runGitInRepo(t, repoRoot, "add", CatalogRelativePath)
+	runGitInRepo(t, repoRoot, "commit", "-m", "initial catalog")
+	initialCommit := strings.TrimSpace(runGitInRepoOutput(t, repoRoot, "rev-parse", "HEAD"))
+
+	if err := os.WriteFile(catalogPath, []byte(mergeBaseCatalogStructural+"\n"), 0o644); err != nil {
+		t.Fatalf("failed to write structural catalog: %v", err)
+	}
+	runGitInRepo(t, repoRoot, "add", CatalogRelativePath)
+	runGitInRepo(t, repoRoot, "commit", "-m", "structural catalog change on main")
+
+	runGitInRepo(t, repoRoot, "switch", "-c", "topic", initialCommit)
+	if err := os.WriteFile(catalogPath, []byte(mergeBaseCatalogDescriptionOnly+"\n"), 0o644); err != nil {
+		t.Fatalf("failed to write description-only catalog: %v", err)
+	}
+	runGitInRepo(t, repoRoot, "add", CatalogRelativePath)
+	runGitInRepo(t, repoRoot, "commit", "-m", "description-only catalog change")
+
+	t.Chdir(repoRoot)
+
+	result, err := AnalyzeReleaseTriggerGuardForRefs(context.Background(), ReleaseTriggerGuardConfig{
+		BaseRef: "main",
+		HeadRef: "topic",
+	})
+	if err != nil {
+		t.Fatalf("expected merge-base comparison to succeed, got %v", err)
+	}
+	if len(result.Violations) != 0 {
+		t.Fatalf("expected no violations when comparing against merge-base, got %v", result.Violations)
+	}
+	if !result.DescriptionOnlyCatalogSkipped {
+		t.Fatal("expected the description-only catalog change to be filtered out")
+	}
+}
+
+func runGitInRepo(t *testing.T, repoRoot string, args ...string) {
+	t.Helper()
+	_ = runGitInRepoOutput(t, repoRoot, args...)
+}
+
+func runGitInRepoOutput(t *testing.T, repoRoot string, args ...string) string {
+	t.Helper()
+	command := exec.Command("git", append([]string{"-C", repoRoot, "-c", "user.name=test", "-c", "user.email=test@example.com"}, args...)...)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, output)
+	}
+	return string(output)
 }

--- a/cli/release-automation/internal/automation/tool_catalog_shape.go
+++ b/cli/release-automation/internal/automation/tool_catalog_shape.go
@@ -1,0 +1,79 @@
+package automation
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+// ToolCatalogShapeDigest returns a SHA-256 hex digest of the catalog with every
+// tool-level and property-level "description" removed, so description-only
+// regenerations produce the same digest. Unknown fields stay in the map so a
+// typed unmarshal cannot hide a new structural key.
+func ToolCatalogShapeDigest(content []byte) (string, error) {
+	canonical, err := canonicalizeToolCatalogShape(content)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// ToolCatalogShapeChanged reports whether base and head differ in anything
+// other than descriptions.
+func ToolCatalogShapeChanged(base []byte, head []byte) (bool, error) {
+	baseDigest, err := ToolCatalogShapeDigest(base)
+	if err != nil {
+		return false, err
+	}
+	headDigest, err := ToolCatalogShapeDigest(head)
+	if err != nil {
+		return false, err
+	}
+	return baseDigest != headDigest, nil
+}
+
+func canonicalizeToolCatalogShape(content []byte) ([]byte, error) {
+	var root map[string]any
+	if err := json.Unmarshal(content, &root); err != nil {
+		return nil, fmt.Errorf("invalid tool catalog JSON: %w", err)
+	}
+
+	stripToolCatalogDescriptions(root)
+
+	canonical, err := json.Marshal(root)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal tool catalog shape: %w", err)
+	}
+	return canonical, nil
+}
+
+func stripToolCatalogDescriptions(root map[string]any) {
+	tools, ok := root["tools"].([]any)
+	if !ok {
+		return
+	}
+	for _, entry := range tools {
+		tool, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		delete(tool, "description")
+		schema, ok := tool["inputSchema"].(map[string]any)
+		if !ok {
+			continue
+		}
+		props, ok := schema["properties"].(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, propEntry := range props {
+			prop, ok := propEntry.(map[string]any)
+			if !ok {
+				continue
+			}
+			delete(prop, "description")
+		}
+	}
+}

--- a/cli/release-automation/internal/automation/tool_catalog_shape.go
+++ b/cli/release-automation/internal/automation/tool_catalog_shape.go
@@ -5,7 +5,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 )
 
 // ToolCatalogShapeDigest returns a SHA-256 hex digest of the catalog with every
@@ -41,6 +43,12 @@ func canonicalizeToolCatalogShape(content []byte) ([]byte, error) {
 	var root map[string]any
 	if err := decoder.Decode(&root); err != nil {
 		return nil, fmt.Errorf("invalid tool catalog JSON: %w", err)
+	}
+	// Decode stops after the first JSON value, so a catalog followed by trailing text or a second
+	// value would otherwise hash as if it were well-formed and feed release-trigger decisions.
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("invalid tool catalog JSON: trailing data after the catalog object")
 	}
 
 	stripToolCatalogDescriptions(root)

--- a/cli/release-automation/internal/automation/tool_catalog_shape.go
+++ b/cli/release-automation/internal/automation/tool_catalog_shape.go
@@ -1,6 +1,7 @@
 package automation
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -35,8 +36,10 @@ func ToolCatalogShapeChanged(base []byte, head []byte) (bool, error) {
 }
 
 func canonicalizeToolCatalogShape(content []byte) ([]byte, error) {
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.UseNumber()
 	var root map[string]any
-	if err := json.Unmarshal(content, &root); err != nil {
+	if err := decoder.Decode(&root); err != nil {
 		return nil, fmt.Errorf("invalid tool catalog JSON: %w", err)
 	}
 

--- a/cli/release-automation/internal/automation/tool_catalog_shape_test.go
+++ b/cli/release-automation/internal/automation/tool_catalog_shape_test.go
@@ -164,6 +164,22 @@ func TestToolCatalogShapeDigestRejectsInvalidJSON(t *testing.T) {
 	}
 }
 
+// Verifies trailing text after the catalog object is rejected instead of being hashed as a valid shape.
+func TestToolCatalogShapeDigestRejectsTrailingText(t *testing.T) {
+	_, err := ToolCatalogShapeDigest([]byte(`{"tools":[]} garbage`))
+	if err == nil {
+		t.Fatal("expected trailing text to return an error")
+	}
+}
+
+// Verifies a second JSON value after the catalog object is rejected instead of being silently ignored.
+func TestToolCatalogShapeDigestRejectsSecondJSONValue(t *testing.T) {
+	_, err := ToolCatalogShapeDigest([]byte(`{"tools":[]} {"tools":[{"name":"compile"}]}`))
+	if err == nil {
+		t.Fatal("expected a second JSON value to return an error")
+	}
+}
+
 // Verifies a description-only edit mixed with an added property is reported as a shape change.
 func TestToolCatalogShapeChangedDetectsMixedDescriptionAndPropertyAdd(t *testing.T) {
 	head := `{

--- a/cli/release-automation/internal/automation/tool_catalog_shape_test.go
+++ b/cli/release-automation/internal/automation/tool_catalog_shape_test.go
@@ -149,6 +149,13 @@ func TestToolCatalogShapeDigestDetectsUnknownTopLevelField(t *testing.T) {
 	assertDifferentShapeDigest(t, catalogShapeBase, changed)
 }
 
+// Verifies defaults that collapse under float64 still produce different shape digests.
+func TestToolCatalogShapeDigestPreservesIntegersBeyondFloat64ExactRange(t *testing.T) {
+	left := `{"tools":[{"name":"compile","inputSchema":{"type":"object","properties":{"X":{"type":"integer","default":9007199254740992}}}}]}`
+	right := `{"tools":[{"name":"compile","inputSchema":{"type":"object","properties":{"X":{"type":"integer","default":9007199254740993}}}}]}`
+	assertDifferentShapeDigest(t, left, right)
+}
+
 // Verifies invalid catalog JSON is an error rather than a silent shape change.
 func TestToolCatalogShapeDigestRejectsInvalidJSON(t *testing.T) {
 	_, err := ToolCatalogShapeDigest([]byte(`{"tools":[`))

--- a/cli/release-automation/internal/automation/tool_catalog_shape_test.go
+++ b/cli/release-automation/internal/automation/tool_catalog_shape_test.go
@@ -1,0 +1,220 @@
+package automation
+
+import (
+	"strings"
+	"testing"
+)
+
+const catalogShapeBase = `{
+  "tools": [
+    {
+      "name": "compile",
+      "description": "Compile the project",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "X": {
+            "type": "string",
+            "description": "file path",
+            "default": "",
+            "enum": ["a", "b"],
+            "hidden": false
+          }
+        }
+      }
+    }
+  ]
+}`
+
+// Verifies identical catalog bytes produce the same shape digest.
+func TestToolCatalogShapeDigestSameContent(t *testing.T) {
+	first, err := ToolCatalogShapeDigest([]byte(catalogShapeBase))
+	if err != nil {
+		t.Fatalf("first digest failed: %v", err)
+	}
+	second, err := ToolCatalogShapeDigest([]byte(catalogShapeBase))
+	if err != nil {
+		t.Fatalf("second digest failed: %v", err)
+	}
+	if first != second {
+		t.Fatalf("expected identical content to share a digest, got %q and %q", first, second)
+	}
+}
+
+// Verifies changing only a tool-level description keeps the shape digest.
+func TestToolCatalogShapeDigestIgnoresToolDescription(t *testing.T) {
+	assertSameShapeDigest(t, catalogShapeBase, strings.Replace(catalogShapeBase, "Compile the project", "Compile now", 1))
+}
+
+// Verifies changing only a property-level description keeps the shape digest.
+func TestToolCatalogShapeDigestIgnoresPropertyDescription(t *testing.T) {
+	assertSameShapeDigest(t, catalogShapeBase, strings.Replace(catalogShapeBase, "file path", "target path", 1))
+}
+
+// Verifies adding a property changes the shape digest.
+func TestToolCatalogShapeDigestDetectsAddedProperty(t *testing.T) {
+	changed := `{
+  "tools": [
+    {
+      "name": "compile",
+      "description": "Compile the project",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "X": {
+            "type": "string",
+            "description": "file path",
+            "default": "",
+            "enum": ["a", "b"],
+            "hidden": false
+          },
+          "Y": { "type": "boolean" }
+        }
+      }
+    }
+  ]
+}`
+	assertDifferentShapeDigest(t, catalogShapeBase, changed)
+}
+
+// Verifies changing a property type changes the shape digest.
+func TestToolCatalogShapeDigestDetectsPropertyTypeChange(t *testing.T) {
+	assertDifferentShapeDigest(t, catalogShapeBase, strings.Replace(catalogShapeBase, `"type": "string"`, `"type": "integer"`, 1))
+}
+
+// Verifies changing a property default changes the shape digest.
+func TestToolCatalogShapeDigestDetectsPropertyDefaultChange(t *testing.T) {
+	assertDifferentShapeDigest(t, catalogShapeBase, strings.Replace(catalogShapeBase, `"default": ""`, `"default": "x"`, 1))
+}
+
+// Verifies changing a property enum changes the shape digest.
+func TestToolCatalogShapeDigestDetectsPropertyEnumChange(t *testing.T) {
+	assertDifferentShapeDigest(t, catalogShapeBase, strings.Replace(catalogShapeBase, `"enum": ["a", "b"]`, `"enum": ["a", "c"]`, 1))
+}
+
+// Verifies changing a property hidden flag changes the shape digest.
+func TestToolCatalogShapeDigestDetectsPropertyHiddenChange(t *testing.T) {
+	assertDifferentShapeDigest(t, catalogShapeBase, strings.Replace(catalogShapeBase, `"hidden": false`, `"hidden": true`, 1))
+}
+
+// Verifies adding a tool changes the shape digest.
+func TestToolCatalogShapeDigestDetectsAddedTool(t *testing.T) {
+	changed := `{
+  "tools": [
+    {
+      "name": "compile",
+      "description": "Compile the project",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "X": {
+            "type": "string",
+            "description": "file path",
+            "default": "",
+            "enum": ["a", "b"],
+            "hidden": false
+          }
+        }
+      }
+    },
+    { "name": "screenshot" }
+  ]
+}`
+	assertDifferentShapeDigest(t, catalogShapeBase, changed)
+}
+
+// Verifies an unknown top-level field changes the shape digest.
+func TestToolCatalogShapeDigestDetectsUnknownTopLevelField(t *testing.T) {
+	changed := `{
+  "schemaVersion": 2,
+  "tools": [
+    {
+      "name": "compile",
+      "description": "Compile the project",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "X": {
+            "type": "string",
+            "description": "file path",
+            "default": "",
+            "enum": ["a", "b"],
+            "hidden": false
+          }
+        }
+      }
+    }
+  ]
+}`
+	assertDifferentShapeDigest(t, catalogShapeBase, changed)
+}
+
+// Verifies invalid catalog JSON is an error rather than a silent shape change.
+func TestToolCatalogShapeDigestRejectsInvalidJSON(t *testing.T) {
+	_, err := ToolCatalogShapeDigest([]byte(`{"tools":[`))
+	if err == nil {
+		t.Fatal("expected invalid JSON to return an error")
+	}
+}
+
+// Verifies a description-only edit mixed with an added property is reported as a shape change.
+func TestToolCatalogShapeChangedDetectsMixedDescriptionAndPropertyAdd(t *testing.T) {
+	head := `{
+  "tools": [
+    {
+      "name": "compile",
+      "description": "Compile now",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "X": {
+            "type": "string",
+            "description": "file path",
+            "default": "",
+            "enum": ["a", "b"],
+            "hidden": false
+          },
+          "Y": { "type": "boolean" }
+        }
+      }
+    }
+  ]
+}`
+	changed, err := ToolCatalogShapeChanged([]byte(catalogShapeBase), []byte(head))
+	if err != nil {
+		t.Fatalf("shape compare failed: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected mixed description and property add to count as a shape change")
+	}
+}
+
+func assertSameShapeDigest(t *testing.T, left string, right string) {
+	t.Helper()
+	leftDigest, err := ToolCatalogShapeDigest([]byte(left))
+	if err != nil {
+		t.Fatalf("left digest failed: %v", err)
+	}
+	rightDigest, err := ToolCatalogShapeDigest([]byte(right))
+	if err != nil {
+		t.Fatalf("right digest failed: %v", err)
+	}
+	if leftDigest != rightDigest {
+		t.Fatalf("expected the same shape digest, got %q and %q", leftDigest, rightDigest)
+	}
+}
+
+func assertDifferentShapeDigest(t *testing.T, left string, right string) {
+	t.Helper()
+	leftDigest, err := ToolCatalogShapeDigest([]byte(left))
+	if err != nil {
+		t.Fatalf("left digest failed: %v", err)
+	}
+	rightDigest, err := ToolCatalogShapeDigest([]byte(right))
+	if err != nil {
+		t.Fatalf("right digest failed: %v", err)
+	}
+	if leftDigest == rightDigest {
+		t.Fatalf("expected different shape digests, both were %q", leftDigest)
+	}
+}

--- a/docs/adr/0003-release-trigger-scoping-granularity.md
+++ b/docs/adr/0003-release-trigger-scoping-granularity.md
@@ -108,7 +108,8 @@ request for other reasons, which would make the marginal cost of the comparison 
 The embedded tool catalog is classified by a field-level JSON diff that drops
 `description` keys. This is not Go reachability analysis: the ground truth is
 the one-line question "does anything other than a description differ", which
-stays reviewable. The miss direction is stale out-of-project `--help` wording
+stays reviewable. The miss direction is stale help-text fallback wording
+(outside a project, or inside one when SKILL.md has no entry for the item)
 until the next real CLI release; it cannot produce functional version skew.
 
 Reversal condition: withdraw this exception if embedded descriptions start to

--- a/docs/adr/0003-release-trigger-scoping-granularity.md
+++ b/docs/adr/0003-release-trigger-scoping-granularity.md
@@ -102,3 +102,14 @@ files mean one platform is not representative.
 
 Reversal condition: revisit if CI ends up building the full release matrix on every pull
 request for other reasons, which would make the marginal cost of the comparison near zero.
+
+## Addendum (2026-09-02): data inputs
+
+The embedded tool catalog is classified by a field-level JSON diff that drops
+`description` keys. This is not Go reachability analysis: the ground truth is
+the one-line question "does anything other than a description differ", which
+stays reviewable. The miss direction is stale out-of-project `--help` wording
+until the next real CLI release; it cannot produce functional version skew.
+
+Reversal condition: withdraw this exception if embedded descriptions start to
+affect runtime behavior, or if the CLI stops reloading them from SKILL.md.

--- a/docs/shared-release-inputs.md
+++ b/docs/shared-release-inputs.md
@@ -19,7 +19,8 @@ trigger updates in the same PR:
 - The embedded tool catalog (`cli/common/tools/default-tools.json`) is the one
   non-Go shared input: structural changes count; description-only regenerations
   do not, because the CLI reloads descriptions from SKILL.md at run time and
-  the embedded text is only the out-of-project `--help` fallback.
+  the embedded text is only a help-text fallback: outside a project, or inside
+  one when SKILL.md has no entry for the item.
 
 Run `scripts/stamp-release-inputs.sh` to refresh
 `cli/project-runner/shared-inputs-stamp.json` and

--- a/docs/shared-release-inputs.md
+++ b/docs/shared-release-inputs.md
@@ -17,14 +17,14 @@ trigger updates in the same PR:
 - Installer scripts (`scripts/install.sh`, `scripts/install.ps1`) must be accompanied by a
   change under `cli/dispatcher/`, because installers ship as dispatcher release assets.
 - The embedded tool catalog (`cli/common/tools/default-tools.json`) is the one
-  non-Go shared input: it is compiled into both binaries, so catalog changes —
-  including regenerations driven by skill parameter-table edits — need the
-  same accompanying trigger changes and stamp refresh.
+  non-Go shared input: structural changes count; description-only regenerations
+  do not, because the CLI reloads descriptions from SKILL.md at run time and
+  the embedded text is only the out-of-project `--help` fallback.
 
 Run `scripts/stamp-release-inputs.sh` to refresh
 `cli/project-runner/shared-inputs-stamp.json` and
 `cli/dispatcher/shared-inputs-stamp.json`, and commit the stamp updates with
-the change. Pull request CI runs `check-release-triggers` (authoritative rules:
+the change. The stamp script hashes the catalog shape through `go run`. Pull request CI runs `check-release-triggers` (authoritative rules:
 `releaseTriggerRules` in
 `cli/release-automation/internal/automation/release_trigger_guard.go`) and
 fails when shared release inputs changed without the matching triggers.

--- a/scripts/stamp-release-inputs.sh
+++ b/scripts/stamp-release-inputs.sh
@@ -11,6 +11,9 @@ SCRIPT_ROOT=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
 ROOT_DIR=${ULOOP_REPO_ROOT:-$SCRIPT_ROOT}
 
 cd "$ROOT_DIR"
+# Resolve a relative ULOOP_REPO_ROOT after the cd so later `go run -path`
+# still points at the fixture when the digest command changes directory.
+ROOT_DIR=$(pwd)
 
 # Input selection mirrors the release trigger guard
 # (cli/release-automation/internal/automation/release_trigger_guard.go):

--- a/scripts/stamp-release-inputs.sh
+++ b/scripts/stamp-release-inputs.sh
@@ -5,7 +5,10 @@ set -eu
 # release-please attributes a commit to a component only when the commit
 # touches that package root, so changes to shared inputs (the common module,
 # installer assets) need these stamp updates to reach every affected release.
-ROOT_DIR=${ULOOP_REPO_ROOT:-$(CDPATH= cd "$(dirname "$0")/.." && pwd)}
+# SCRIPT_ROOT is the checkout that owns this script so `go run` can find the
+# digest command even when ULOOP_REPO_ROOT points at a fixture repository.
+SCRIPT_ROOT=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
+ROOT_DIR=${ULOOP_REPO_ROOT:-$SCRIPT_ROOT}
 
 cd "$ROOT_DIR"
 
@@ -13,9 +16,8 @@ cd "$ROOT_DIR"
 # (cli/release-automation/internal/automation/release_trigger_guard.go):
 # only package roots imported by shipped binaries count; release-please stamp
 # targets such as contract.json do not. The embedded tool catalog is the one
-# JSON that does count - it is compiled into both binaries and is generated
-# from the skill parameter tables, so a tool description change has to reach a
-# release.
+# JSON that does count, structure only; descriptions are excluded because the
+# CLI reloads them from SKILL.md at run time.
 list_shared_common_inputs() {
   git ls-files -- \
     cli/common/go.mod \
@@ -62,7 +64,11 @@ hash_input_list() {
   # plausible-looking stamp over a truncated manifest.
   input_manifest=$(LC_ALL=C sort | while IFS= read -r input_file; do
     [ -n "$input_file" ] || continue
-    object_hash=$(git hash-object "$input_file") || exit 1
+    if [ "$input_file" = "cli/common/tools/default-tools.json" ]; then
+      object_hash=$(cd "$SCRIPT_ROOT/cli/release-automation" && go run ./cmd/tool-catalog-shape-digest -path "$ROOT_DIR/$input_file") || exit 1
+    else
+      object_hash=$(git hash-object "$input_file") || exit 1
+    fi
     printf '%s %s\n' "$input_file" "$object_hash"
   done) || {
     echo "Failed to hash a shared release input." >&2

--- a/scripts/test-stamp-release-inputs.sh
+++ b/scripts/test-stamp-release-inputs.sh
@@ -30,7 +30,7 @@ create_fixture_repo() {
     printf 'package subpkg\n' > cli/common/version/subpkg/compare.go
     printf 'module example.test/common\n' > cli/common/go.mod
     printf '{"projectRunnerVersion": "1.0.0"}\n' > cli/common/contract.json
-    printf '{"tools":[]}\n' > cli/common/tools/default-tools.json
+    printf '%s\n' '{"tools":[{"name":"compile","description":"a","inputSchema":{"type":"object","properties":{"X":{"type":"string","description":"d"}}}}]}' > cli/common/tools/default-tools.json
     printf 'echo install\n' > scripts/install.sh
     printf 'Write-Host install\n' > scripts/install.ps1
     printf 'echo embedded install\n' > cli/dispatcher/internal/install/scripts/install_darwin.sh
@@ -131,20 +131,29 @@ if [ "$runner_hash_after_common" = "$runner_hash_initial" ] ||
   exit 1
 fi
 
-# Verifies a change to the embedded tool catalog moves both stamps, since it is compiled into both
-# binaries even though it is JSON.
+# Verifies a structural catalog change (an added property) moves both stamps.
 commit_fixture_change "$work_dir" "common source change"
-printf '{"tools":[{"name":"compile"}]}\n' > "$work_dir/cli/common/tools/default-tools.json"
+printf '%s\n' '{"tools":[{"name":"compile","description":"a","inputSchema":{"type":"object","properties":{"X":{"type":"string","description":"d"},"Y":{"type":"boolean"}}}}]}' > "$work_dir/cli/common/tools/default-tools.json"
 run_stamp "$work_dir"
 runner_hash_after_catalog=$(stamp_hash "$work_dir" cli/project-runner/shared-inputs-stamp.json)
 dispatcher_hash_after_catalog=$(stamp_hash "$work_dir" cli/dispatcher/shared-inputs-stamp.json)
 if [ "$runner_hash_after_catalog" = "$runner_hash_after_common" ] ||
   [ "$dispatcher_hash_after_catalog" = "$dispatcher_hash_after_common" ]; then
-  echo "Expected an embedded tool catalog change to move both stamps." >&2
+  echo "Expected a structural embedded tool catalog change to move both stamps." >&2
   exit 1
 fi
 runner_hash_after_common=$runner_hash_after_catalog
 dispatcher_hash_after_common=$dispatcher_hash_after_catalog
+
+# Verifies description-only catalog regenerations leave both stamps unchanged.
+commit_fixture_change "$work_dir" "structural catalog change"
+printf '%s\n' '{"tools":[{"name":"compile","description":"b","inputSchema":{"type":"object","properties":{"X":{"type":"string","description":"e"},"Y":{"type":"boolean"}}}}]}' > "$work_dir/cli/common/tools/default-tools.json"
+run_stamp "$work_dir"
+if [ "$(stamp_hash "$work_dir" cli/project-runner/shared-inputs-stamp.json)" != "$runner_hash_after_common" ] ||
+  [ "$(stamp_hash "$work_dir" cli/dispatcher/shared-inputs-stamp.json)" != "$dispatcher_hash_after_common" ]; then
+  echo "Expected a description-only catalog change to keep both stamps." >&2
+  exit 1
+fi
 
 # Verifies a nested shared common Go source change also moves both stamps.
 commit_fixture_change "$work_dir" "shared common change"


### PR DESCRIPTION
## Summary
- Skill wording edits that only regenerate tool-catalog descriptions no longer stamp or release the dispatcher and project runner.
- Structural catalog changes (added/removed tools or properties, or any non-description field) still require both CLI stamps, same as before.

## User Impact
- Before: changing help text in a skill parameter table regenerated `default-tools.json` and kicked off CLI releases for all three components.
- After: description-only regenerations skip the shared-input stamps. Unity package releases still happen when `Packages/src` changes. Out-of-project `--help` may keep the previous wording until the next real CLI release.

This PR itself changes how the catalog line of the stamp is computed, so both CLI stamps move once and both CLI components will release once. That is expected.

Closes #2500

## Changes
- Hash the embedded catalog after stripping known `description` fields (tool-level and property-level). Unknown fields stay so new structure cannot hide.
- `check-release-triggers` compares catalog shape at merge-base vs head and drops description-only catalog files from the shared-input list.
- Stamp script uses that shape digest for the catalog line only; other inputs still use `git hash-object`.
- Docs, ADR addendum, and CI now run the stamp self-test on Ubuntu and Windows Git Bash.

## Verification
- `cd cli/release-automation && go test ./internal/automation/ -run ToolCatalogShape` — all 12 tests pass
- `cd cli/release-automation && go test ./...` — pass, including merge-base fixture (`TestAnalyzeReleaseTriggerGuardForRefsUsesMergeBaseForCatalogShape`)
- `scripts/test-stamp-release-inputs.sh` — exit 0 (structural change moves stamps; description-only does not)
- `scripts/check-go-cli.sh` — exit 0
- `cd cli/release-automation && go run ./cmd/check-release-triggers --base origin/main --head HEAD` — pass
- E2E on a temporary branch (deleted afterward):
  - (i) description-only skill edit + sync + stamp: neither stamp appeared in `git status --porcelain`
  - (ii) commit of SKILL.md + catalog: `git show --stat HEAD` had no stamp files; `check-release-triggers --base feature/description-only-catalog-stamp --head HEAD` printed `catalog changed only in descriptions; not counted as a shared release input` and passed
  - (iii) added a property to the catalog and restamped: both stamp files appeared in `git status --porcelain` (not committed)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

