### PR TITLE
fix: First-run runner download now explains GitHub API rate limits and how to recover

### DIFF
--- a/cli/dispatcher/attestation/fetcher.go
+++ b/cli/dispatcher/attestation/fetcher.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path"
 	"time"
+
+	"github.com/hatayama/unity-cli-loop/dispatcher/internal/githubapi"
 )
 
 // DefaultHTTPClient is the http.Client used for bundle and tag-ref fetches.
@@ -126,13 +128,22 @@ func fetchGitRef(ctx context.Context, apiURL string) (string, string, error) {
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", "", fmt.Errorf("%w: status %s from %s", ErrTagRefFetch, resp.Status, apiURL)
+		return "", "", tagRefStatusError(resp, apiURL)
 	}
 	var payload TagRefResponse
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		return "", "", fmt.Errorf("%w: decode payload: %v", ErrTagRefFetch, err)
 	}
 	return payload.Object.SHA, payload.Object.Type, nil
+}
+
+// tagRefStatusError keeps the rate-limit case recoverable through errors.As
+// so the dispatcher can tell the user about GH_TOKEN instead of a bare 403.
+func tagRefStatusError(resp *http.Response, apiURL string) error {
+	if rateLimit, ok := githubapi.DetectRateLimit(resp); ok {
+		return fmt.Errorf("%w: %w (from %s)", ErrTagRefFetch, rateLimit, apiURL)
+	}
+	return fmt.Errorf("%w: status %s from %s", ErrTagRefFetch, resp.Status, apiURL)
 }
 
 func setAuthorizationIfAvailable(req *http.Request) {

--- a/cli/dispatcher/attestation/fetcher.go
+++ b/cli/dispatcher/attestation/fetcher.go
@@ -119,7 +119,7 @@ func fetchGitRef(ctx context.Context, apiURL string) (string, string, error) {
 	}
 	req.Header.Set("Accept", acceptHeaderGitHubJSON)
 	req.Header.Set("X-GitHub-Api-Version", apiVersionHeaderValue)
-	setAuthorizationIfAvailable(req)
+	authenticated := setAuthorizationIfAvailable(req)
 	resp, err := DefaultHTTPClient.Do(req)
 	if err != nil {
 		return "", "", fmt.Errorf("%w: %v", ErrTagRefFetch, err)
@@ -128,7 +128,7 @@ func fetchGitRef(ctx context.Context, apiURL string) (string, string, error) {
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", "", tagRefStatusError(resp, apiURL)
+		return "", "", tagRefStatusError(resp, apiURL, authenticated)
 	}
 	var payload TagRefResponse
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
@@ -139,21 +139,25 @@ func fetchGitRef(ctx context.Context, apiURL string) (string, string, error) {
 
 // tagRefStatusError keeps the rate-limit case recoverable through errors.As
 // so the dispatcher can tell the user about GH_TOKEN instead of a bare 403.
-func tagRefStatusError(resp *http.Response, apiURL string) error {
-	if rateLimit, ok := githubapi.DetectRateLimit(resp); ok {
+func tagRefStatusError(resp *http.Response, apiURL string, authenticated bool) error {
+	if rateLimit, ok := githubapi.DetectRateLimit(resp, authenticated); ok {
 		return fmt.Errorf("%w: %w (from %s)", ErrTagRefFetch, rateLimit, apiURL)
 	}
 	return fmt.Errorf("%w: status %s from %s", ErrTagRefFetch, resp.Status, apiURL)
 }
 
-func setAuthorizationIfAvailable(req *http.Request) {
+// setAuthorizationIfAvailable reports whether a token was attached, so a
+// later rate-limit refusal can skip the "set a token" guidance.
+func setAuthorizationIfAvailable(req *http.Request) bool {
 	token := os.Getenv(envAuthTokenPrimary)
 	if token == "" {
 		token = os.Getenv(envAuthTokenSecondary)
 	}
-	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
+	if token == "" {
+		return false
 	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	return true
 }
 
 // AssetNameFromReleaseAsset strips any query fragments and returns the base

--- a/cli/dispatcher/attestation/verifier_test.go
+++ b/cli/dispatcher/attestation/verifier_test.go
@@ -473,6 +473,9 @@ func TestFetchTagCommitSHA_ServerError(t *testing.T) {
 // Verifies FetchTagCommitSHA surfaces an exhausted GitHub quota as a typed
 // rate-limit error while still failing closed under ErrTagRefFetch.
 func TestFetchTagCommitSHA_RateLimited(t *testing.T) {
+	// Why clear both: a token in the developer's shell would turn this into the authenticated case.
+	t.Setenv(envAuthTokenPrimary, "")
+	t.Setenv(envAuthTokenSecondary, "")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-RateLimit-Remaining", "0")
 		w.Header().Set("X-RateLimit-Reset", "1790000000")

--- a/cli/dispatcher/attestation/verifier_test.go
+++ b/cli/dispatcher/attestation/verifier_test.go
@@ -495,4 +495,31 @@ func TestFetchTagCommitSHA_RateLimited(t *testing.T) {
 	if rateLimit.ResetAt.Unix() != 1790000000 {
 		t.Fatalf("unexpected reset time: %v", rateLimit.ResetAt)
 	}
+	if rateLimit.Authenticated {
+		t.Fatalf("expected an anonymous rate limit without a token in the environment")
+	}
+}
+
+// Verifies a rate limit hit with a token in the environment is reported as authenticated
+// so the guidance does not ask for a token that is already set.
+func TestFetchTagCommitSHA_RateLimitedWithToken(t *testing.T) {
+	t.Setenv(envAuthTokenPrimary, "test-token")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		http.Error(w, `{"message":"API rate limit exceeded"}`, http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	original := githubAPIBase()
+	setGithubAPIBase(server.URL)
+	defer setGithubAPIBase(original)
+
+	_, err := FetchTagCommitSHA(context.Background(), "hatayama/unity-cli-loop", "any")
+	var rateLimit githubapi.RateLimitError
+	if !errors.As(err, &rateLimit) {
+		t.Fatalf("expected RateLimitError, got: %v", err)
+	}
+	if !rateLimit.Authenticated {
+		t.Fatalf("expected an authenticated rate limit error, got: %+v", rateLimit)
+	}
 }

--- a/cli/dispatcher/attestation/verifier_test.go
+++ b/cli/dispatcher/attestation/verifier_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/hatayama/unity-cli-loop/dispatcher/internal/githubapi"
 )
 
 // happyFixture returns fixture values pulled from a real backfilled
@@ -465,5 +467,32 @@ func TestFetchTagCommitSHA_ServerError(t *testing.T) {
 	}
 	if !errors.Is(err, ErrTagRefFetch) {
 		t.Fatalf("expected ErrTagRefFetch, got: %v", err)
+	}
+}
+
+// Verifies FetchTagCommitSHA surfaces an exhausted GitHub quota as a typed
+// rate-limit error while still failing closed under ErrTagRefFetch.
+func TestFetchTagCommitSHA_RateLimited(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", "1790000000")
+		http.Error(w, `{"message":"API rate limit exceeded"}`, http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	original := githubAPIBase()
+	setGithubAPIBase(server.URL)
+	defer setGithubAPIBase(original)
+
+	_, err := FetchTagCommitSHA(context.Background(), "hatayama/unity-cli-loop", "any")
+	if !errors.Is(err, ErrTagRefFetch) {
+		t.Fatalf("expected ErrTagRefFetch, got: %v", err)
+	}
+	var rateLimit githubapi.RateLimitError
+	if !errors.As(err, &rateLimit) {
+		t.Fatalf("expected RateLimitError, got: %v", err)
+	}
+	if rateLimit.ResetAt.Unix() != 1790000000 {
+		t.Fatalf("unexpected reset time: %v", rateLimit.ResetAt)
 	}
 }

--- a/cli/dispatcher/internal/dispatcher/attestation_release.go
+++ b/cli/dispatcher/internal/dispatcher/attestation_release.go
@@ -101,7 +101,8 @@ func fetchDispatcherReleasePage(ctx context.Context, page int) ([]githubReleaseL
 	}
 	request.Header.Set("Accept", "application/vnd.github+json")
 	request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	if token := lookupGitHubAPIToken(); token != "" {
+	token := lookupGitHubAPIToken()
+	if token != "" {
 		request.Header.Set("Authorization", "Bearer "+token)
 	}
 	response, err := dispatcherHTTPClient.Do(request)
@@ -113,7 +114,7 @@ func fetchDispatcherReleasePage(ctx context.Context, page int) ([]githubReleaseL
 		_ = response.Body.Close()
 	}()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		if rateLimit, ok := githubapi.DetectRateLimit(response); ok {
+		if rateLimit, ok := githubapi.DetectRateLimit(response, token != ""); ok {
 			return nil, fmt.Errorf("list releases: %w", rateLimit)
 		}
 		return nil, fmt.Errorf("list releases: status %s", response.Status)

--- a/cli/dispatcher/internal/dispatcher/attestation_release.go
+++ b/cli/dispatcher/internal/dispatcher/attestation_release.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/hatayama/unity-cli-loop/dispatcher/attestation"
+	"github.com/hatayama/unity-cli-loop/dispatcher/internal/githubapi"
 	sharedupdate "github.com/hatayama/unity-cli-loop/dispatcher/internal/update"
 )
 
@@ -112,6 +113,9 @@ func fetchDispatcherReleasePage(ctx context.Context, page int) ([]githubReleaseL
 		_ = response.Body.Close()
 	}()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		if rateLimit, ok := githubapi.DetectRateLimit(response); ok {
+			return nil, fmt.Errorf("list releases: %w", rateLimit)
+		}
 		return nil, fmt.Errorf("list releases: status %s", response.Status)
 	}
 	var entries []githubReleaseListEntry

--- a/cli/dispatcher/internal/dispatcher/attestation_release_test.go
+++ b/cli/dispatcher/internal/dispatcher/attestation_release_test.go
@@ -3,10 +3,13 @@ package dispatcher
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/hatayama/unity-cli-loop/dispatcher/internal/githubapi"
 	sharedupdate "github.com/hatayama/unity-cli-loop/dispatcher/internal/update"
 )
 
@@ -122,5 +125,26 @@ func installReleaseListServer(t *testing.T, entries []githubReleaseListEntry) (*
 	dispatcherAPIBaseURL = server.URL
 	return server, func() {
 		dispatcherAPIBaseURL = previousBase
+	}
+}
+
+// Verifies the release listing surfaces an exhausted GitHub quota as a typed rate-limit error.
+func TestFetchDispatcherReleasePageReportsRateLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		http.Error(w, `{"message":"API rate limit exceeded"}`, http.StatusForbidden)
+	}))
+	defer server.Close()
+	previousBase := dispatcherAPIBaseURL
+	dispatcherAPIBaseURL = server.URL
+	defer func() { dispatcherAPIBaseURL = previousBase }()
+
+	_, err := fetchDispatcherReleasePage(context.Background(), 1)
+	var rateLimit githubapi.RateLimitError
+	if !errors.As(err, &rateLimit) {
+		t.Fatalf("expected RateLimitError, got: %v", err)
+	}
+	if !strings.HasPrefix(err.Error(), "list releases: ") {
+		t.Fatalf("expected list releases prefix, got: %v", err)
 	}
 }

--- a/cli/dispatcher/internal/dispatcher/dispatcher_freshness.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_freshness.go
@@ -3,6 +3,7 @@ package dispatcher
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/hatayama/unity-cli-loop/common/clicore"
 	sharedversion "github.com/hatayama/unity-cli-loop/common/version"
+	"github.com/hatayama/unity-cli-loop/dispatcher/internal/githubapi"
 	sharedupdate "github.com/hatayama/unity-cli-loop/dispatcher/internal/update"
 )
 
@@ -158,6 +160,10 @@ func runDispatcherFreshnessUpdate(ctx context.Context, plan dispatcherFreshnessP
 	// Why: optional update failures should not retry and redraw installer progress on every command.
 	markDispatcherSelfUpdateCheckedWithDeps(deps)
 	clicore.WriteFormat(stderr, "warning: dispatcher self-update skipped: %v\n", err)
+	var rateLimit githubapi.RateLimitError
+	if errors.As(err, &rateLimit) {
+		clicore.WriteFormat(stderr, "warning: %s\n", githubapi.TokenNextAction)
+	}
 	return false, 0
 }
 

--- a/cli/dispatcher/internal/dispatcher/dispatcher_freshness.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_freshness.go
@@ -162,7 +162,9 @@ func runDispatcherFreshnessUpdate(ctx context.Context, plan dispatcherFreshnessP
 	clicore.WriteFormat(stderr, "warning: dispatcher self-update skipped: %v\n", err)
 	var rateLimit githubapi.RateLimitError
 	if errors.As(err, &rateLimit) {
-		clicore.WriteFormat(stderr, "warning: %s\n", githubapi.TokenNextAction)
+		for _, action := range rateLimit.NextActions() {
+			clicore.WriteFormat(stderr, "warning: %s\n", action)
+		}
 	}
 	return false, 0
 }

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/hatayama/unity-cli-loop/common/clicontract"
 	"github.com/hatayama/unity-cli-loop/common/clicore"
+	"github.com/hatayama/unity-cli-loop/dispatcher/internal/githubapi"
 	"github.com/hatayama/unity-cli-loop/dispatcher/internal/nativepath"
 	"github.com/hatayama/unity-cli-loop/dispatcher/internal/update"
 )
@@ -1574,5 +1575,60 @@ func assertStringSliceEqual(t *testing.T, actual []string, expected []string) {
 		if actual[index] != expectedValue {
 			t.Fatalf("value mismatch at %d: actual=%#v expected=%#v", index, actual, expected)
 		}
+	}
+}
+
+// Verifies a rate-limited runner download tells the user about GH_TOKEN and the quota reset time.
+func TestDispatcherRealCLIResolutionErrorExplainsRateLimit(t *testing.T) {
+	resetAt := time.Date(2026, 9, 2, 1, 30, 0, 0, time.UTC)
+	cause := fmt.Errorf("release tag commit SHA lookup failed: %w", githubapi.RateLimitError{ResetAt: resetAt})
+
+	cliErr := dispatcherRealCLIResolutionError("/project", dispatcherPin{ProjectRunnerVersion: "3.0.0"}, cause)
+
+	if len(cliErr.NextActions) != 3 || !strings.Contains(cliErr.NextActions[0], "GH_TOKEN") {
+		t.Fatalf("unexpected next actions: %v", cliErr.NextActions)
+	}
+	if !strings.Contains(cliErr.NextActions[1], "retry after") {
+		t.Fatalf("expected reset-time retry hint, got: %v", cliErr.NextActions)
+	}
+	if cliErr.Details["GitHubRateLimitResetAt"] != "2026-09-02T01:30:00Z" {
+		t.Fatalf("unexpected reset detail: %v", cliErr.Details["GitHubRateLimitResetAt"])
+	}
+}
+
+// Verifies a non-rate-limit download failure keeps the generic network guidance.
+func TestDispatcherRealCLIResolutionErrorKeepsGenericGuidance(t *testing.T) {
+	cliErr := dispatcherRealCLIResolutionError("/project", dispatcherPin{}, errors.New("connection refused"))
+
+	if len(cliErr.NextActions) != 2 || !strings.Contains(cliErr.NextActions[0], "network access") {
+		t.Fatalf("unexpected next actions: %v", cliErr.NextActions)
+	}
+	if _, present := cliErr.Details["GitHubRateLimitResetAt"]; present {
+		t.Fatalf("reset detail must be absent for non-rate-limit causes")
+	}
+}
+
+// Verifies a rate-limited optional self-update adds the token hint after the skip warning.
+func TestEnforceDispatcherFreshnessRateLimitedOptionalUpdateSuggestsToken(t *testing.T) {
+	cacheRoot := t.TempDir()
+	t.Setenv(nativepath.CacheDirEnvName, cacheRoot)
+
+	deps := defaultDispatcherRunDeps()
+	deps.runUpdate = func(context.Context) (bool, error) {
+		return false, fmt.Errorf("list releases: %w", githubapi.RateLimitError{})
+	}
+
+	var stderr bytes.Buffer
+	handled, code := enforceDispatcherFreshnessWithDeps(
+		context.Background(),
+		dispatcherPin{MinimumDispatcherVersion: dispatcherVersion},
+		&stderr,
+		deps)
+
+	if handled || code != 0 {
+		t.Fatalf("freshness result mismatch: handled=%t code=%d", handled, code)
+	}
+	if !strings.Contains(stderr.String(), "rate limit exhausted") || !strings.Contains(stderr.String(), "GH_TOKEN") {
+		t.Fatalf("expected rate-limit warning with token hint, got: %s", stderr.String())
 	}
 }

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -1596,6 +1596,24 @@ func TestDispatcherRealCLIResolutionErrorExplainsRateLimit(t *testing.T) {
 	}
 }
 
+// Verifies an authenticated rate limit does not ask for a token and still reports the reset time.
+func TestDispatcherRealCLIResolutionErrorAuthenticatedRateLimitSkipsTokenHint(t *testing.T) {
+	resetAt := time.Date(2026, 9, 2, 1, 30, 0, 0, time.UTC)
+	cause := fmt.Errorf("lookup failed: %w", githubapi.RateLimitError{ResetAt: resetAt, Authenticated: true})
+
+	cliErr := dispatcherRealCLIResolutionError("/project", dispatcherPin{ProjectRunnerVersion: "3.0.0"}, cause)
+
+	if len(cliErr.NextActions) != 2 || strings.Contains(cliErr.NextActions[0], "GH_TOKEN") {
+		t.Fatalf("unexpected next actions: %v", cliErr.NextActions)
+	}
+	if !strings.Contains(cliErr.NextActions[0], "Retry after") {
+		t.Fatalf("expected reset-time retry hint, got: %v", cliErr.NextActions)
+	}
+	if cliErr.Details["GitHubRateLimitResetAt"] != "2026-09-02T01:30:00Z" {
+		t.Fatalf("unexpected reset detail: %v", cliErr.Details["GitHubRateLimitResetAt"])
+	}
+}
+
 // Verifies a non-rate-limit download failure keeps the generic network guidance.
 func TestDispatcherRealCLIResolutionErrorKeepsGenericGuidance(t *testing.T) {
 	cliErr := dispatcherRealCLIResolutionError("/project", dispatcherPin{}, errors.New("connection refused"))

--- a/cli/dispatcher/internal/dispatcher/run_dispatcher.go
+++ b/cli/dispatcher/internal/dispatcher/run_dispatcher.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hatayama/unity-cli-loop/common/clicore"
 	"github.com/hatayama/unity-cli-loop/common/project"
+	"github.com/hatayama/unity-cli-loop/dispatcher/internal/githubapi"
 	"github.com/hatayama/unity-cli-loop/dispatcher/internal/nativepath"
 )
 
@@ -291,6 +292,27 @@ func dispatcherPinResolutionError(projectRoot string, cause error) clierrors.CLI
 }
 
 func dispatcherRealCLIResolutionError(projectRoot string, pin dispatcherPin, cause error) clierrors.CLIError {
+	details := map[string]any{
+		"Cause":                cause.Error(),
+		"ProjectRunnerVersion": pin.ProjectRunnerVersion,
+		"PinSource":            pin.SourcePath,
+	}
+	nextActions := []string{
+		"Check network access to GitHub releases, then retry the command.",
+	}
+	// Why: an exhausted anonymous quota looks like a generic network failure, but
+	// the fix (a token, or waiting for the reset) is specific and cheap to state.
+	var rateLimit githubapi.RateLimitError
+	if errors.As(cause, &rateLimit) {
+		nextActions = rateLimit.NextActions()
+		if !rateLimit.ResetAt.IsZero() {
+			details["GitHubRateLimitResetAt"] = rateLimit.ResetAt.UTC().Format(time.RFC3339)
+		}
+	}
+	nextActions = append(nextActions,
+		"For dogfooding checkouts with an unpublished pin, set "+
+			nativepath.ProjectRunnerPathEnvName+
+			" to a locally built uloop-project-runner binary to bypass the download.")
 	return clierrors.CLIError{
 		ErrorCode:   clierrors.ErrorCodeInternalError,
 		Phase:       clierrors.ErrorPhaseExecution,
@@ -298,16 +320,7 @@ func dispatcherRealCLIResolutionError(projectRoot string, pin dispatcherPin, cau
 		Retryable:   true,
 		SafeToRetry: true,
 		ProjectRoot: projectRoot,
-		NextActions: []string{
-			"Check network access to GitHub releases, then retry the command.",
-			"For dogfooding checkouts with an unpublished pin, set " +
-				nativepath.ProjectRunnerPathEnvName +
-				" to a locally built uloop-project-runner binary to bypass the download.",
-		},
-		Details: map[string]any{
-			"Cause":                cause.Error(),
-			"ProjectRunnerVersion": pin.ProjectRunnerVersion,
-			"PinSource":            pin.SourcePath,
-		},
+		NextActions: nextActions,
+		Details:     details,
 	}
 }

--- a/cli/dispatcher/internal/githubapi/ratelimit.go
+++ b/cli/dispatcher/internal/githubapi/ratelimit.go
@@ -1,0 +1,72 @@
+// Package githubapi holds GitHub REST API response handling shared by the
+// dispatcher's attestation and self-update paths.
+package githubapi
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	headerRateLimitRemaining = "X-RateLimit-Remaining"
+	headerRateLimitReset     = "X-RateLimit-Reset"
+	headerRetryAfter         = "Retry-After"
+	resetTimeLayout          = "15:04 MST"
+)
+
+// TokenNextAction tells the user how to move from the shared anonymous quota
+// to their own authenticated one.
+const TokenNextAction = "Set GH_TOKEN (or GITHUB_TOKEN) to a GitHub token so uloop uses your authenticated API quota, then retry."
+
+// RateLimitError reports that GitHub refused a REST API request because the
+// caller's request quota is exhausted. Anonymous quota is shared by every
+// machine behind the same public IP, so this is a first-run failure in
+// offices and on CI runners rather than a misconfiguration.
+type RateLimitError struct {
+	// ResetAt is when GitHub will accept requests again; zero when unknown.
+	ResetAt time.Time
+}
+
+func (e RateLimitError) Error() string {
+	message := "GitHub API rate limit exhausted (anonymous requests share a per-IP quota)"
+	if e.ResetAt.IsZero() {
+		return message
+	}
+	return message + "; resets at " + e.ResetAt.Local().Format(resetTimeLayout)
+}
+
+// NextActions returns user-facing recovery steps for the error envelope.
+func (e RateLimitError) NextActions() []string {
+	actions := []string{TokenNextAction}
+	if e.ResetAt.IsZero() {
+		return actions
+	}
+	return append(actions, "Or retry after "+e.ResetAt.Local().Format(resetTimeLayout)+" when the anonymous quota resets.")
+}
+
+// DetectRateLimit classifies a non-2xx response. GitHub signals an exhausted
+// primary quota with 403 plus X-RateLimit-Remaining: 0, and a secondary
+// (abuse) limit with 429 plus Retry-After; every other refusal is left to the
+// caller's generic handling so a real permission problem is not mislabeled.
+func DetectRateLimit(response *http.Response) (RateLimitError, bool) {
+	if response.StatusCode != http.StatusForbidden && response.StatusCode != http.StatusTooManyRequests {
+		return RateLimitError{}, false
+	}
+	remaining := response.Header.Get(headerRateLimitRemaining)
+	retryAfter := response.Header.Get(headerRetryAfter)
+	if remaining != "0" && retryAfter == "" {
+		return RateLimitError{}, false
+	}
+	return RateLimitError{ResetAt: resetTime(response.Header.Get(headerRateLimitReset), retryAfter)}, true
+}
+
+func resetTime(resetHeader string, retryAfterHeader string) time.Time {
+	if resetUnix, err := strconv.ParseInt(resetHeader, 10, 64); err == nil {
+		return time.Unix(resetUnix, 0)
+	}
+	if retryAfterSeconds, err := strconv.ParseInt(retryAfterHeader, 10, 64); err == nil {
+		return time.Now().Add(time.Duration(retryAfterSeconds) * time.Second).Truncate(time.Second)
+	}
+	return time.Time{}
+}

--- a/cli/dispatcher/internal/githubapi/ratelimit.go
+++ b/cli/dispatcher/internal/githubapi/ratelimit.go
@@ -59,7 +59,9 @@ func (e RateLimitError) NextActions() []string {
 	}
 	actions := []string{tokenNextAction}
 	if e.ResetAt.IsZero() {
-		return actions
+		// Why the wait hint: an unknown reset means a headerless secondary limit, which
+		// clears on its own even without a token.
+		return append(actions, "Or: "+secondaryLimitFallbackWait)
 	}
 	return append(actions, "Or retry after "+e.ResetAt.Local().Format(resetTimeLayout)+" when the anonymous quota resets.")
 }

--- a/cli/dispatcher/internal/githubapi/ratelimit.go
+++ b/cli/dispatcher/internal/githubapi/ratelimit.go
@@ -3,8 +3,10 @@
 package githubapi
 
 import (
+	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -12,12 +14,17 @@ const (
 	headerRateLimitRemaining = "X-RateLimit-Remaining"
 	headerRateLimitReset     = "X-RateLimit-Reset"
 	headerRetryAfter         = "Retry-After"
-	resetTimeLayout          = "15:04 MST"
+	// Why date included: a reset shortly after midnight would otherwise read as earlier today.
+	resetTimeLayout = "2006-01-02 15:04 MST"
+	// Why bounded: the body is only inspected for GitHub's short JSON error message.
+	maxInspectedBodyBytes = 4096
+	// Why one minute: GitHub documents it as the minimum wait for a secondary limit without Retry-After.
+	secondaryLimitFallbackWait = "Wait at least a minute, then retry; GitHub's secondary rate limit clears on its own."
 )
 
-// TokenNextAction tells the user how to move from the shared anonymous quota
+// tokenNextAction tells the user how to move from the shared anonymous quota
 // to their own authenticated one.
-const TokenNextAction = "Set GH_TOKEN (or GITHUB_TOKEN) to a GitHub token so uloop uses your authenticated API quota, then retry."
+const tokenNextAction = "Set GH_TOKEN (or GITHUB_TOKEN) to a GitHub token so uloop uses your authenticated API quota, then retry."
 
 // RateLimitError reports that GitHub refused a REST API request because the
 // caller's request quota is exhausted. Anonymous quota is shared by every
@@ -26,10 +33,16 @@ const TokenNextAction = "Set GH_TOKEN (or GITHUB_TOKEN) to a GitHub token so ulo
 type RateLimitError struct {
 	// ResetAt is when GitHub will accept requests again; zero when unknown.
 	ResetAt time.Time
+	// Authenticated is true when the refused request already carried a token,
+	// so suggesting a token would not change anything.
+	Authenticated bool
 }
 
 func (e RateLimitError) Error() string {
 	message := "GitHub API rate limit exhausted (anonymous requests share a per-IP quota)"
+	if e.Authenticated {
+		message = "GitHub API rate limit exhausted for the configured token"
+	}
 	if e.ResetAt.IsZero() {
 		return message
 	}
@@ -38,7 +51,13 @@ func (e RateLimitError) Error() string {
 
 // NextActions returns user-facing recovery steps for the error envelope.
 func (e RateLimitError) NextActions() []string {
-	actions := []string{TokenNextAction}
+	if e.Authenticated {
+		if e.ResetAt.IsZero() {
+			return []string{secondaryLimitFallbackWait}
+		}
+		return []string{"Retry after " + e.ResetAt.Local().Format(resetTimeLayout) + " when the token's quota resets."}
+	}
+	actions := []string{tokenNextAction}
 	if e.ResetAt.IsZero() {
 		return actions
 	}
@@ -46,27 +65,65 @@ func (e RateLimitError) NextActions() []string {
 }
 
 // DetectRateLimit classifies a non-2xx response. GitHub signals an exhausted
-// primary quota with 403 plus X-RateLimit-Remaining: 0, and a secondary
-// (abuse) limit with 429 plus Retry-After; every other refusal is left to the
-// caller's generic handling so a real permission problem is not mislabeled.
-func DetectRateLimit(response *http.Response) (RateLimitError, bool) {
+// primary quota with 403 plus X-RateLimit-Remaining: 0, a secondary (abuse)
+// limit with 429 plus Retry-After, and sometimes a secondary limit with only
+// its documented body message; every other refusal is left to the caller's
+// generic handling so a real permission problem is not mislabeled.
+// authenticated says whether the request carried a token, which decides the
+// recovery guidance. On a positive match the response body has been consumed.
+func DetectRateLimit(response *http.Response, authenticated bool) (RateLimitError, bool) {
 	if response.StatusCode != http.StatusForbidden && response.StatusCode != http.StatusTooManyRequests {
 		return RateLimitError{}, false
 	}
 	remaining := response.Header.Get(headerRateLimitRemaining)
 	retryAfter := response.Header.Get(headerRetryAfter)
-	if remaining != "0" && retryAfter == "" {
+	if remaining != "0" && retryAfter == "" && !bodyReportsRateLimit(response.Body) {
 		return RateLimitError{}, false
 	}
-	return RateLimitError{ResetAt: resetTime(response.Header.Get(headerRateLimitReset), retryAfter)}, true
+	resetAt := resetTime(response.StatusCode, response.Header.Get(headerRateLimitReset), retryAfter)
+	return RateLimitError{ResetAt: resetAt, Authenticated: authenticated}, true
 }
 
-func resetTime(resetHeader string, retryAfterHeader string) time.Time {
-	if resetUnix, err := strconv.ParseInt(resetHeader, 10, 64); err == nil {
-		return time.Unix(resetUnix, 0)
+// bodyReportsRateLimit recognizes GitHub's documented rate-limit messages when
+// the headers are absent, which happens for some secondary-limit responses.
+func bodyReportsRateLimit(body io.Reader) bool {
+	if body == nil {
+		return false
 	}
-	if retryAfterSeconds, err := strconv.ParseInt(retryAfterHeader, 10, 64); err == nil {
-		return time.Now().Add(time.Duration(retryAfterSeconds) * time.Second).Truncate(time.Second)
+	raw, err := io.ReadAll(io.LimitReader(body, maxInspectedBodyBytes))
+	if err != nil {
+		return false
 	}
-	return time.Time{}
+	text := strings.ToLower(string(raw))
+	return strings.Contains(text, "secondary rate limit") || strings.Contains(text, "rate limit exceeded")
+}
+
+// resetTime prefers Retry-After for a 429 because a secondary limit clears on
+// its own schedule, while a 403 primary exhaustion is timed by X-RateLimit-Reset.
+func resetTime(statusCode int, resetHeader string, retryAfterHeader string) time.Time {
+	fromReset := parseResetHeader(resetHeader)
+	fromRetryAfter := parseRetryAfterHeader(retryAfterHeader)
+	if statusCode == http.StatusTooManyRequests && !fromRetryAfter.IsZero() {
+		return fromRetryAfter
+	}
+	if !fromReset.IsZero() {
+		return fromReset
+	}
+	return fromRetryAfter
+}
+
+func parseResetHeader(resetHeader string) time.Time {
+	resetUnix, err := strconv.ParseInt(resetHeader, 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	return time.Unix(resetUnix, 0)
+}
+
+func parseRetryAfterHeader(retryAfterHeader string) time.Time {
+	retryAfterSeconds, err := strconv.ParseInt(retryAfterHeader, 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	return time.Now().Add(time.Duration(retryAfterSeconds) * time.Second).Truncate(time.Second)
 }

--- a/cli/dispatcher/internal/githubapi/ratelimit_test.go
+++ b/cli/dispatcher/internal/githubapi/ratelimit_test.go
@@ -2,6 +2,7 @@ package githubapi
 
 import (
 	"errors"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -10,7 +11,11 @@ import (
 )
 
 func responseWith(status int, headers map[string]string) *http.Response {
-	response := &http.Response{StatusCode: status, Header: http.Header{}}
+	return responseWithBody(status, headers, "")
+}
+
+func responseWithBody(status int, headers map[string]string, body string) *http.Response {
+	response := &http.Response{StatusCode: status, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(body))}
 	for key, value := range headers {
 		response.Header.Set(key, value)
 	}
@@ -25,7 +30,7 @@ func TestDetectRateLimitReportsExhaustedPrimaryQuota(t *testing.T) {
 		"X-RateLimit-Reset":     strconv.FormatInt(resetAt.Unix(), 10),
 	})
 
-	rateLimit, ok := DetectRateLimit(response)
+	rateLimit, ok := DetectRateLimit(response, false)
 	if !ok {
 		t.Fatalf("expected rate limit detection")
 	}
@@ -40,7 +45,7 @@ func TestDetectRateLimitIgnoresForbiddenWithRemainingQuota(t *testing.T) {
 		"X-RateLimit-Remaining": "12",
 	})
 
-	if _, ok := DetectRateLimit(response); ok {
+	if _, ok := DetectRateLimit(response, false); ok {
 		t.Fatalf("expected no rate limit detection for a forbidden response with quota left")
 	}
 }
@@ -52,7 +57,7 @@ func TestDetectRateLimitReportsSecondaryLimitFromRetryAfter(t *testing.T) {
 	})
 
 	before := time.Now()
-	rateLimit, ok := DetectRateLimit(response)
+	rateLimit, ok := DetectRateLimit(response, false)
 	if !ok {
 		t.Fatalf("expected rate limit detection for 429")
 	}
@@ -67,7 +72,7 @@ func TestDetectRateLimitIgnoresOtherStatuses(t *testing.T) {
 		"X-RateLimit-Remaining": "0",
 	})
 
-	if _, ok := DetectRateLimit(response); ok {
+	if _, ok := DetectRateLimit(response, false); ok {
 		t.Fatalf("expected no rate limit detection for a 500")
 	}
 }
@@ -105,5 +110,81 @@ func TestNextActionsIncludeTokenHintAndResetRetry(t *testing.T) {
 	withoutReset := RateLimitError{}.NextActions()
 	if len(withoutReset) != 1 || !strings.Contains(withoutReset[0], "GH_TOKEN") {
 		t.Fatalf("unexpected next actions without reset: %v", withoutReset)
+	}
+}
+
+// Verifies a 429 carrying both headers takes Retry-After, not the unrelated primary reset time.
+func TestDetectRateLimitPrefersRetryAfterForSecondaryLimit(t *testing.T) {
+	primaryReset := time.Now().Add(50 * time.Minute).Truncate(time.Second)
+	response := responseWith(http.StatusTooManyRequests, map[string]string{
+		"Retry-After":       "60",
+		"X-RateLimit-Reset": strconv.FormatInt(primaryReset.Unix(), 10),
+	})
+
+	rateLimit, ok := DetectRateLimit(response, false)
+	if !ok {
+		t.Fatalf("expected rate limit detection for 429")
+	}
+	if !rateLimit.ResetAt.Before(time.Now().Add(2 * time.Minute)) {
+		t.Fatalf("expected Retry-After based reset about 60s ahead, got %v", rateLimit.ResetAt)
+	}
+}
+
+// Verifies a headerless secondary-limit body is still classified for both 403 and 429.
+func TestDetectRateLimitRecognizesSecondaryLimitBody(t *testing.T) {
+	body := `{"message":"You have exceeded a secondary rate limit. Please wait a few minutes before you try again."}`
+	for _, status := range []int{http.StatusForbidden, http.StatusTooManyRequests} {
+		response := responseWithBody(status, map[string]string{"X-RateLimit-Remaining": "4990"}, body)
+
+		rateLimit, ok := DetectRateLimit(response, false)
+		if !ok {
+			t.Fatalf("expected rate limit detection from body for status %d", status)
+		}
+		if !rateLimit.ResetAt.IsZero() {
+			t.Fatalf("expected unknown reset time without headers, got %v", rateLimit.ResetAt)
+		}
+	}
+}
+
+// Verifies a 403 whose body is an ordinary permission message stays a generic refusal.
+func TestDetectRateLimitIgnoresForbiddenWithUnrelatedBody(t *testing.T) {
+	response := responseWithBody(http.StatusForbidden, map[string]string{}, `{"message":"Resource not accessible by integration"}`)
+
+	if _, ok := DetectRateLimit(response, true); ok {
+		t.Fatalf("expected no rate limit detection for an unrelated 403 body")
+	}
+}
+
+// Verifies the authenticated flag is carried into the error so callers can tailor guidance.
+func TestDetectRateLimitCarriesAuthenticationState(t *testing.T) {
+	response := responseWith(http.StatusForbidden, map[string]string{"X-RateLimit-Remaining": "0"})
+
+	rateLimit, ok := DetectRateLimit(response, true)
+	if !ok || !rateLimit.Authenticated {
+		t.Fatalf("expected an authenticated rate limit error, got ok=%t %+v", ok, rateLimit)
+	}
+}
+
+// Verifies an authenticated exhaustion never suggests setting a token and names the reset when known.
+func TestNextActionsForAuthenticatedRequestsSkipTokenHint(t *testing.T) {
+	withReset := RateLimitError{ResetAt: time.Date(2026, 9, 2, 10, 30, 0, 0, time.Local), Authenticated: true}.NextActions()
+	if len(withReset) != 1 || strings.Contains(withReset[0], "GH_TOKEN") || !strings.Contains(withReset[0], "10:30") {
+		t.Fatalf("unexpected authenticated next actions with reset: %v", withReset)
+	}
+
+	withoutReset := RateLimitError{Authenticated: true}.NextActions()
+	if len(withoutReset) != 1 || strings.Contains(withoutReset[0], "GH_TOKEN") || !strings.Contains(withoutReset[0], "minute") {
+		t.Fatalf("unexpected authenticated next actions without reset: %v", withoutReset)
+	}
+	if !strings.Contains(RateLimitError{Authenticated: true}.Error(), "configured token") {
+		t.Fatalf("authenticated message should name the token quota")
+	}
+}
+
+// Verifies the displayed reset time includes the calendar date so a reset past midnight is unambiguous.
+func TestRateLimitErrorMessageIncludesResetDate(t *testing.T) {
+	message := RateLimitError{ResetAt: time.Date(2026, 9, 3, 0, 15, 0, 0, time.Local)}.Error()
+	if !strings.Contains(message, "2026-09-03 00:15") {
+		t.Fatalf("expected dated reset time, got: %s", message)
 	}
 }

--- a/cli/dispatcher/internal/githubapi/ratelimit_test.go
+++ b/cli/dispatcher/internal/githubapi/ratelimit_test.go
@@ -1,0 +1,109 @@
+package githubapi
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func responseWith(status int, headers map[string]string) *http.Response {
+	response := &http.Response{StatusCode: status, Header: http.Header{}}
+	for key, value := range headers {
+		response.Header.Set(key, value)
+	}
+	return response
+}
+
+// Verifies a 403 with an exhausted primary quota is reported with the reset time from X-RateLimit-Reset.
+func TestDetectRateLimitReportsExhaustedPrimaryQuota(t *testing.T) {
+	resetAt := time.Now().Add(40 * time.Minute).Truncate(time.Second)
+	response := responseWith(http.StatusForbidden, map[string]string{
+		"X-RateLimit-Remaining": "0",
+		"X-RateLimit-Reset":     strconv.FormatInt(resetAt.Unix(), 10),
+	})
+
+	rateLimit, ok := DetectRateLimit(response)
+	if !ok {
+		t.Fatalf("expected rate limit detection")
+	}
+	if !rateLimit.ResetAt.Equal(resetAt) {
+		t.Fatalf("reset time mismatch: got %v want %v", rateLimit.ResetAt, resetAt)
+	}
+}
+
+// Verifies a 403 that still has quota left is not classified as a rate limit.
+func TestDetectRateLimitIgnoresForbiddenWithRemainingQuota(t *testing.T) {
+	response := responseWith(http.StatusForbidden, map[string]string{
+		"X-RateLimit-Remaining": "12",
+	})
+
+	if _, ok := DetectRateLimit(response); ok {
+		t.Fatalf("expected no rate limit detection for a forbidden response with quota left")
+	}
+}
+
+// Verifies a 429 secondary limit is detected and Retry-After seconds become the reset time.
+func TestDetectRateLimitReportsSecondaryLimitFromRetryAfter(t *testing.T) {
+	response := responseWith(http.StatusTooManyRequests, map[string]string{
+		"Retry-After": "90",
+	})
+
+	before := time.Now()
+	rateLimit, ok := DetectRateLimit(response)
+	if !ok {
+		t.Fatalf("expected rate limit detection for 429")
+	}
+	if rateLimit.ResetAt.Before(before.Add(89 * time.Second)) {
+		t.Fatalf("expected reset about 90s ahead, got %v", rateLimit.ResetAt)
+	}
+}
+
+// Verifies non-limit statuses are never classified as a rate limit even with limit headers present.
+func TestDetectRateLimitIgnoresOtherStatuses(t *testing.T) {
+	response := responseWith(http.StatusInternalServerError, map[string]string{
+		"X-RateLimit-Remaining": "0",
+	})
+
+	if _, ok := DetectRateLimit(response); ok {
+		t.Fatalf("expected no rate limit detection for a 500")
+	}
+}
+
+// Verifies the error text names the quota problem and the local reset time, and survives wrapping.
+func TestRateLimitErrorMessageAndUnwrapping(t *testing.T) {
+	resetAt := time.Date(2026, 9, 2, 10, 30, 0, 0, time.Local)
+	wrapped := errors.Join(errors.New("outer"), RateLimitError{ResetAt: resetAt})
+
+	var rateLimit RateLimitError
+	if !errors.As(wrapped, &rateLimit) {
+		t.Fatalf("expected RateLimitError to be recoverable through errors.As")
+	}
+	message := rateLimit.Error()
+	if !strings.Contains(message, "rate limit") || !strings.Contains(message, "10:30") {
+		t.Fatalf("unexpected message: %s", message)
+	}
+}
+
+// Verifies an unknown reset time produces a message without a bogus timestamp.
+func TestRateLimitErrorMessageWithoutResetTime(t *testing.T) {
+	message := RateLimitError{}.Error()
+	if strings.Contains(message, "resets at") {
+		t.Fatalf("message should not mention a reset time when unknown: %s", message)
+	}
+}
+
+// Verifies NextActions offers the token hint first and the reset-time retry only when known.
+func TestNextActionsIncludeTokenHintAndResetRetry(t *testing.T) {
+	withReset := RateLimitError{ResetAt: time.Date(2026, 9, 2, 10, 30, 0, 0, time.Local)}.NextActions()
+	if len(withReset) != 2 || !strings.Contains(withReset[0], "GH_TOKEN") || !strings.Contains(withReset[1], "10:30") {
+		t.Fatalf("unexpected next actions with reset: %v", withReset)
+	}
+
+	withoutReset := RateLimitError{}.NextActions()
+	if len(withoutReset) != 1 || !strings.Contains(withoutReset[0], "GH_TOKEN") {
+		t.Fatalf("unexpected next actions without reset: %v", withoutReset)
+	}
+}

--- a/cli/dispatcher/internal/githubapi/ratelimit_test.go
+++ b/cli/dispatcher/internal/githubapi/ratelimit_test.go
@@ -100,7 +100,7 @@ func TestRateLimitErrorMessageWithoutResetTime(t *testing.T) {
 	}
 }
 
-// Verifies NextActions offers the token hint first and the reset-time retry only when known.
+// Verifies NextActions offers the token hint first, then the reset-time retry when known or the wait hint otherwise.
 func TestNextActionsIncludeTokenHintAndResetRetry(t *testing.T) {
 	withReset := RateLimitError{ResetAt: time.Date(2026, 9, 2, 10, 30, 0, 0, time.Local)}.NextActions()
 	if len(withReset) != 2 || !strings.Contains(withReset[0], "GH_TOKEN") || !strings.Contains(withReset[1], "10:30") {
@@ -108,7 +108,7 @@ func TestNextActionsIncludeTokenHintAndResetRetry(t *testing.T) {
 	}
 
 	withoutReset := RateLimitError{}.NextActions()
-	if len(withoutReset) != 1 || !strings.Contains(withoutReset[0], "GH_TOKEN") {
+	if len(withoutReset) != 2 || !strings.Contains(withoutReset[0], "GH_TOKEN") || !strings.Contains(withoutReset[1], "minute") {
 		t.Fatalf("unexpected next actions without reset: %v", withoutReset)
 	}
 }

--- a/cli/release-automation/internal/architecture/architecture_test.go
+++ b/cli/release-automation/internal/architecture/architecture_test.go
@@ -269,7 +269,7 @@ func TestInternalBoundariesPerModule(t *testing.T) {
 		{
 			moduleDir:  filepath.Join(repositoryRoot, contract.Layout.Modules.Dispatcher),
 			modulePath: dispatcherModulePath,
-			allowed:    []string{"attestation", "dispatcher", "install", "nativepath", "uninstall", "update"},
+			allowed:    []string{"attestation", "dispatcher", "githubapi", "install", "nativepath", "uninstall", "update"},
 		},
 		{
 			moduleDir:  filepath.Join(repositoryRoot, contract.Layout.Modules.ReleaseAutomation),


### PR DESCRIPTION
## Summary
- When the first `uloop` command after install cannot download the project runner because the anonymous GitHub API quota is exhausted, the error now says so and tells the user to set `GH_TOKEN` or retry after the quota reset time.
- The optional self-update skip warning carries the same hint when it hits the quota.

## User Impact
- Before: anyone behind a busy shared IP (offices, CI runners) saw `release tag commit SHA lookup failed: status 403 Forbidden` on their very first command, with generic "check network access" guidance. Nothing indicated that a token or a short wait was the fix.
- After: the error explains that the GitHub API rate limit is exhausted, lists the local reset time, and offers `GH_TOKEN` / `GITHUB_TOKEN` as the immediate fix. `Details.GitHubRateLimitResetAt` carries the reset time in RFC3339 for agents.
- Genuine 403s that still have quota left keep the existing generic guidance, so a real permission problem is not mislabeled.

## Changes
- New `internal/githubapi` package with `RateLimitError`, detected from 403 + `X-RateLimit-Remaining: 0` or 429 + `Retry-After`, carrying the reset time.
- The tag-ref lookup in the attestation fetcher and the release listing in self-update wrap that error so callers can recognise it through `errors.As`.
- The runner-prepare error envelope swaps its generic network next actions for the token hint and reset-time retry when the cause is a rate limit.
- The optional self-update skip warning appends the token hint on rate limits.
- Architecture boundary test allows the new internal package.

Not in scope: resolving the tag → SHA without the REST API. The attestation guarantee is unchanged; a runner still only runs after its attestation verifies.

## Verification
- `scripts/check-go-cli.sh` (format, vet, lint, tests across all Go modules, dist rebuild): all green.
- New tests cover detection of primary/secondary limits, non-limit 403s, error wrapping through the fetcher and release listing, the error envelope, and the self-update warning.

Closes #2464

https://claude.ai/code/session_01R3jkx6NbNYKPdy5q1NSWYo


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

