### PR TITLE
fix: simulate-mouse-input reports whether an interrupted press reached the game instead of "may have registered"

### DIFF
--- a/.agents/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.agents/skills/uloop-simulate-mouse-input/SKILL.md
@@ -59,7 +59,7 @@ uloop simulate-mouse-input --dry-run --x <x> --y <y> [--layer-mask <mask>] [--ma
 
 ### Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this input drives a state transition, follow the `uloop-pause-point` skill — it covers line placement and interruption semantics. Tool-specific note: if `InterruptedByPausePoint: true`, Unity is paused and input bookkeeping was safely released. Clear inspection-only pause points (`uloop clear-pause-point --all`) before final validation.
+For standard frame proof when this input drives a state transition, follow the `uloop-pause-point` skill — it covers line placement and interruption semantics. Tool-specific note: if `InterruptedByPausePoint: true`, Unity is paused; read `PressDeliveredToGame` before retrying. Clear inspection-only pause points (`uloop clear-pause-point --all`) before final validation.
 
 ## When to use this vs simulate-mouse-ui
 

--- a/.agents/skills/uloop-simulate-mouse-input/references/output-and-coordinates.md
+++ b/.agents/skills/uloop-simulate-mouse-input/references/output-and-coordinates.md
@@ -21,6 +21,7 @@ Returns JSON with:
 - `InjectedUnityPositionX` / `InjectedUnityPositionY`: Coordinates injected into `Mouse.current.position` (or used for dry-run ScreenPointToRay)
 - `CoordinateConversionFormula`: Conversion formula used by the tool
 - `InterruptedByPausePoint` / `PausePointId` / `PausePointHitCount` / `PausePointHits`: Pause-point interruption info (all nullable except the boolean). `PausePointHits` lists every marker hit during this input in hit order; `PausePointId` only names the latest one. See the Pause Point Inspection section in SKILL.md
+- `PressDeliveredToGame` (boolean, nullable): Set only when a `Click` / `LongPress` was interrupted by a pause point. `true`: the Input System processed the press edge in a gameplay update before the pause, so game code polling that frame observed it and the world state may already have changed (for example a block was mined). Do not retry; re-check the affected state and `pause-point-status`. `false`: the queued edge was discarded before any gameplay update, the game never observed a press, and a retry after resume is safe. `null` for other actions and uninterrupted responses
 
 Verify visual outcome with a follow-up screenshot.
 

--- a/.claude/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-input/SKILL.md
@@ -59,7 +59,7 @@ uloop simulate-mouse-input --dry-run --x <x> --y <y> [--layer-mask <mask>] [--ma
 
 ### Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this input drives a state transition, follow the `uloop-pause-point` skill — it covers line placement and interruption semantics. Tool-specific note: if `InterruptedByPausePoint: true`, Unity is paused and input bookkeeping was safely released. Clear inspection-only pause points (`uloop clear-pause-point --all`) before final validation.
+For standard frame proof when this input drives a state transition, follow the `uloop-pause-point` skill — it covers line placement and interruption semantics. Tool-specific note: if `InterruptedByPausePoint: true`, Unity is paused; read `PressDeliveredToGame` before retrying. Clear inspection-only pause points (`uloop clear-pause-point --all`) before final validation.
 
 ## When to use this vs simulate-mouse-ui
 

--- a/.claude/skills/uloop-simulate-mouse-input/references/output-and-coordinates.md
+++ b/.claude/skills/uloop-simulate-mouse-input/references/output-and-coordinates.md
@@ -21,6 +21,7 @@ Returns JSON with:
 - `InjectedUnityPositionX` / `InjectedUnityPositionY`: Coordinates injected into `Mouse.current.position` (or used for dry-run ScreenPointToRay)
 - `CoordinateConversionFormula`: Conversion formula used by the tool
 - `InterruptedByPausePoint` / `PausePointId` / `PausePointHitCount` / `PausePointHits`: Pause-point interruption info (all nullable except the boolean). `PausePointHits` lists every marker hit during this input in hit order; `PausePointId` only names the latest one. See the Pause Point Inspection section in SKILL.md
+- `PressDeliveredToGame` (boolean, nullable): Set only when a `Click` / `LongPress` was interrupted by a pause point. `true`: the Input System processed the press edge in a gameplay update before the pause, so game code polling that frame observed it and the world state may already have changed (for example a block was mined). Do not retry; re-check the affected state and `pause-point-status`. `false`: the queued edge was discarded before any gameplay update, the game never observed a press, and a retry after resume is safe. `null` for other actions and uninterrupted responses
 
 Verify visual outcome with a follow-up screenshot.
 

--- a/Assets/Tests/Editor/MouseInputSimulationResponseFactoryTests.cs
+++ b/Assets/Tests/Editor/MouseInputSimulationResponseFactoryTests.cs
@@ -1,0 +1,68 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+#nullable enable
+using NUnit.Framework;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Pins the pause-point interruption verdicts of simulate-mouse-input button responses.
+    /// </summary>
+    [TestFixture]
+    public sealed class MouseInputSimulationResponseFactoryTests
+    {
+        /// <summary>
+        /// Verifies a press applied before the pause reports a definite delivered verdict and re-check guidance instead of "may have".
+        /// </summary>
+        [Test]
+        public void InterruptedButtonResult_WhenPressWasApplied_ReportsPressDeliveredToGame()
+        {
+            SimulateMouseInputResponse response = MouseInputSimulationResponseFactory.InterruptedButtonResult(
+                UnityCliLoopMouseInputAction.Click,
+                "Left",
+                new Vector2(10f, 20f),
+                pressWasApplied: true);
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(response.InterruptedByPausePoint, Is.True);
+            Assert.That(response.PressDeliveredToGame, Is.True);
+            Assert.That(response.Message, Does.Contain("was delivered to the game before the pause"));
+            Assert.That(response.Message, Does.Contain("world state may already have changed"));
+            Assert.That(response.Message, Does.Not.Contain("may have registered"));
+        }
+
+        /// <summary>
+        /// Verifies a press discarded before apply reports a definite not-delivered verdict and says a retry is safe.
+        /// </summary>
+        [Test]
+        public void InterruptedButtonResult_WhenPressWasDiscarded_ReportsPressNotDeliveredToGame()
+        {
+            SimulateMouseInputResponse response = MouseInputSimulationResponseFactory.InterruptedButtonResult(
+                UnityCliLoopMouseInputAction.LongPress,
+                "Right",
+                new Vector2(1f, 2f),
+                pressWasApplied: false);
+
+            Assert.That(response.PressDeliveredToGame, Is.False);
+            Assert.That(response.Message, Does.Contain("never observed"));
+            Assert.That(response.Message, Does.Contain("safe to retry"));
+        }
+
+        /// <summary>
+        /// Verifies non-button interruptions leave the press verdict absent because no press edge was involved.
+        /// </summary>
+        [Test]
+        public void InterruptedActionResult_LeavesPressDeliveredToGameNull()
+        {
+            SimulateMouseInputResponse response = MouseInputSimulationResponseFactory.InterruptedActionResult(
+                UnityCliLoopMouseInputAction.MoveDelta);
+
+            Assert.That(response.InterruptedByPausePoint, Is.True);
+            Assert.That(response.PressDeliveredToGame, Is.Null);
+        }
+    }
+}
+#endif

--- a/Assets/Tests/Editor/MouseInputSimulationResponseFactoryTests.cs.meta
+++ b/Assets/Tests/Editor/MouseInputSimulationResponseFactoryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c7498af9981849b688bead4adb13f63
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputSimulationResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputSimulationResponseFactory.cs
@@ -47,6 +47,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // (b) WaitForPressLifetime after a successful apply leaves pressWasApplied=true — the press
         // already landed (including when that press itself fired the pause point). Claiming
         // "discarded" in (b) inverts the diagnosis this message exists to prevent.
+        // The verdict is definite: apply only completes inside an Input System update of the
+        // configured gameplay type, so the game's polling in that frame observed the press. A
+        // hedged "may have registered" left callers re-deriving this from world state.
         internal static SimulateMouseInputResponse InterruptedButtonResult(
             UnityCliLoopMouseInputAction action,
             string buttonName,
@@ -54,8 +57,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool pressWasApplied)
         {
             string message = pressWasApplied
-                ? $"Mouse input stopped because Unity paused during Pause Point inspection. Button '{buttonName}' press was already delivered to the game before the pause; Unity CLI Loop released it from bookkeeping, so the game may have registered the press."
-                : $"Mouse input stopped because Unity paused during Pause Point inspection. Button '{buttonName}' was released from Unity CLI Loop bookkeeping; the queued input edge was discarded.";
+                ? $"Mouse input stopped because Unity paused during Pause Point inspection. Button '{buttonName}' press was delivered to the game before the pause: the Input System processed the press edge in a gameplay update, so game code polling that frame observed it and the world state may already have changed. Do not retry the press; re-check the affected state (and pause-point-status) before deciding the next step."
+                : $"Mouse input stopped because Unity paused during Pause Point inspection. Button '{buttonName}' was released from Unity CLI Loop bookkeeping; the queued input edge was discarded before any gameplay update processed it, so the game never observed a press and it is safe to retry after resume.";
             SimulateMouseInputResponse result = new()
             {
                 Success = true,
@@ -64,7 +67,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Button = buttonName,
                 PositionX = inputPos.x,
                 PositionY = inputPos.y,
-                InterruptedByPausePoint = true
+                InterruptedByPausePoint = true,
+                PressDeliveredToGame = pressWasApplied
             };
             AttachPausePointHit(result);
             return result;

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputResponse.cs
@@ -41,6 +41,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string CoordinateConversionFormula { get; set; } = "";
         public bool InterruptedByPausePoint { get; set; }
         /// <summary>
+        /// Set only on pause-point-interrupted Click/LongPress. True when the Input System processed
+        /// the press edge in a gameplay update before the pause (game code polling that frame
+        /// observed it, so the world state may already have changed); false when the queued edge
+        /// was discarded before any gameplay update, so the game never observed a press. Null for
+        /// non-button actions and for uninterrupted responses.
+        /// </summary>
+        public bool? PressDeliveredToGame { get; set; }
+        /// <summary>
         /// Id of the pause point that refused this call before it ran anything, null otherwise.
         /// Distinct from PausePointId, which reports a marker hit *during* the call: a refusal means
         /// no input was injected at all, so a caller reading only Success would miss that the action

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/SKILL.md
@@ -59,7 +59,7 @@ uloop simulate-mouse-input --dry-run --x <x> --y <y> [--layer-mask <mask>] [--ma
 
 ### Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this input drives a state transition, follow the `uloop-pause-point` skill — it covers line placement and interruption semantics. Tool-specific note: if `InterruptedByPausePoint: true`, Unity is paused and input bookkeeping was safely released. Clear inspection-only pause points (`uloop clear-pause-point --all`) before final validation.
+For standard frame proof when this input drives a state transition, follow the `uloop-pause-point` skill — it covers line placement and interruption semantics. Tool-specific note: if `InterruptedByPausePoint: true`, Unity is paused; read `PressDeliveredToGame` before retrying. Clear inspection-only pause points (`uloop clear-pause-point --all`) before final validation.
 
 ## When to use this vs simulate-mouse-ui
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/references/output-and-coordinates.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/references/output-and-coordinates.md
@@ -21,6 +21,7 @@ Returns JSON with:
 - `InjectedUnityPositionX` / `InjectedUnityPositionY`: Coordinates injected into `Mouse.current.position` (or used for dry-run ScreenPointToRay)
 - `CoordinateConversionFormula`: Conversion formula used by the tool
 - `InterruptedByPausePoint` / `PausePointId` / `PausePointHitCount` / `PausePointHits`: Pause-point interruption info (all nullable except the boolean). `PausePointHits` lists every marker hit during this input in hit order; `PausePointId` only names the latest one. See the Pause Point Inspection section in SKILL.md
+- `PressDeliveredToGame` (boolean, nullable): Set only when a `Click` / `LongPress` was interrupted by a pause point. `true`: the Input System processed the press edge in a gameplay update before the pause, so game code polling that frame observed it and the world state may already have changed (for example a block was mined). Do not retry; re-check the affected state and `pause-point-status`. `false`: the queued edge was discarded before any gameplay update, the game never observed a press, and a retry after resume is safe. `null` for other actions and uninterrupted responses
 
 Verify visual outcome with a follow-up screenshot.
 


### PR DESCRIPTION
## Summary
- When a `simulate-mouse-input` Click or LongPress is interrupted by a pause-point hit, the response now gives a definite `PressDeliveredToGame: true/false` verdict instead of "the game may have registered the press".

## User Impact
- Before: a click landing on the same frame as a pause-point hit returned `...so the game may have registered the press.` The world-state change was left indeterminate. In the reported session the click had mined a block and the tester only found out three commands later by back-tracking an unexpected coordinate.
- After: the response says whether the press reached the game before the pause and what to do about it.
  - `PressDeliveredToGame: true` — the Input System processed the press edge in a gameplay update before the pause, so game code polling that frame observed it and the world state may already have changed. The message says not to retry and to re-check the affected state and `pause-point-status`.
  - `PressDeliveredToGame: false` — the queued edge was discarded before any gameplay update ran, the game never observed a press, and a retry after resume is safe.
  - `null` for non-button actions and for uninterrupted responses.
- Why the verdict is definite: the press is applied only inside an Input System update of the configured gameplay type, so "applied" is exactly "the game's polling in that frame could see it". Whether game code reacted is still up to the caller to check, which the message now says explicitly.

## Changes
- `SimulateMouseInputResponse.PressDeliveredToGame` (nullable bool), set on interrupted Click/LongPress from the existing `pressWasApplied` flag.
- Both interruption messages reworded around the definite outcome and next step.
- Skill reference `output-and-coordinates.md` documents the field; the SKILL.md interruption note points at it (generated `.claude/` and `.agents/` copies regenerated; SKILL.md stays under the size cap).
- New `MouseInputSimulationResponseFactoryTests` covering delivered, discarded, and non-button outcomes.

## Verification
- `uloop run-tests --filter-type regex --filter-value "MouseInputSimulationResponseFactoryTests|SimulateMouseInputDryRunTests"`: the 3 new factory tests pass. Two pre-existing `SimulateMouseInputDryRunTests` cases fail in this Editor environment (`Hit: false`; the test reads a 640x480 Game View size while the actual Game View is 1728x1028). That path does not touch the interruption response, so it is unrelated to this change.
- `check-skill-size`: no SKILL.md over the limit.

Closes #2382

https://claude.ai/code/session_01R3jkx6NbNYKPdy5q1NSWYo


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

