### PR TITLE
feat: run-tests can filter by test class name

### DIFF
--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -29,13 +29,13 @@ uloop run-tests [options]
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--test-mode` | string | `EditMode` | Test mode: `EditMode`, `PlayMode` |
-| `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
-| `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
+| `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly`, `class` |
+| `--filter-value` | string | - | Filter value (test name, pattern, assembly, or class name) |
 | `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
 | `--skip-compile` | flag | - | Skip the automatic compile before running tests; use only while validating active hot-reload patches. |
 | `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
 
-exact matches the full test name (Namespace.Class.Method); use regex to run a whole test class, e.g. --filter-type regex --filter 'MyGame\.Tests\.PlayerTests\.'
+exact matches the full test name (Namespace.Class.Method). class runs every test of one class by bare or namespace-qualified name, e.g. --filter-type class --filter-value PlayerTests; the name is matched literally and whole, so PlayerTests does not run EnemyPlayerTests. regex matches a .NET regex against full test names, e.g. --filter-type regex --filter-value '^MyGame\.Tests\.'
 
 ## Output
 

--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -29,13 +29,13 @@ uloop run-tests [options]
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--test-mode` | string | `EditMode` | Test mode: `EditMode`, `PlayMode` |
-| `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
-| `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
+| `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly`, `class` |
+| `--filter-value` | string | - | Filter value (test name, pattern, assembly, or class name) |
 | `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
 | `--skip-compile` | flag | - | Skip the automatic compile before running tests; use only while validating active hot-reload patches. |
 | `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
 
-exact matches the full test name (Namespace.Class.Method); use regex to run a whole test class, e.g. --filter-type regex --filter 'MyGame\.Tests\.PlayerTests\.'
+exact matches the full test name (Namespace.Class.Method). class runs every test of one class by bare or namespace-qualified name, e.g. --filter-type class --filter-value PlayerTests; the name is matched literally and whole, so PlayerTests does not run EnemyPlayerTests. regex matches a .NET regex against full test names, e.g. --filter-type regex --filter-value '^MyGame\.Tests\.'
 
 ## Output
 

--- a/Assets/Tests/Editor/RunTestsClassFilterTests.cs
+++ b/Assets/Tests/Editor/RunTestsClassFilterTests.cs
@@ -1,0 +1,89 @@
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies the run-tests class filter type.
+    /// </summary>
+    public sealed class RunTestsClassFilterTests
+    {
+        private TestFilterCreationService filterService;
+
+        [SetUp]
+        public void Setup()
+        {
+            filterService = new TestFilterCreationService();
+        }
+
+        [Test]
+        public void TryCreateFilter_WithClassType_ShouldReturnRegexFilterScopedToTheClass()
+        {
+            // Verifies the class filter type is delivered to Unity as a group-name regex, because
+            // Unity's Filter has no dedicated class field.
+            (TestExecutionFilter result, string errorMessage) = filterService.TryCreateFilter(TestFilterType.@class, "PlayerTests");
+
+            Assert.That(errorMessage, Is.Null);
+            Assert.That(result.FilterType, Is.EqualTo(TestExecutionFilterType.Regex));
+            Assert.That(result.FilterValue, Is.EqualTo(TestExecutionFilter.ByTestClass("PlayerTests").FilterValue));
+        }
+
+        [Test]
+        public void TryCreateFilter_WithClassTypeAndEmptyValue_ShouldReturnErrorMessage()
+        {
+            // Verifies an empty class name is rejected up front instead of producing a pattern that
+            // silently matches nothing.
+            (TestExecutionFilter result, string errorMessage) = filterService.TryCreateFilter(TestFilterType.@class, " ");
+
+            Assert.That(result, Is.Null);
+            Assert.That(errorMessage, Does.Contain("class"));
+        }
+
+        [TestCase("MyGame.Tests.PlayerTests.Jump_AddsVelocity")]
+        [TestCase("MyGame.Tests.PlayerTests.Jump_AddsVelocity(1.5,\"a.b\")")]
+        [TestCase("PlayerTests.Jump_AddsVelocity")]
+        public void ByTestClass_WithBareClassName_MatchesEveryTestOfThatClass(string fullName)
+        {
+            // Verifies a bare class name matches the class regardless of namespace and of parameterized test names.
+            Regex pattern = new Regex(TestExecutionFilter.ByTestClass("PlayerTests").FilterValue);
+
+            Assert.That(pattern.IsMatch(fullName), Is.True);
+        }
+
+        [TestCase("MyGame.Tests.PlayerTestsExtra.Jump_AddsVelocity")]
+        [TestCase("MyGame.Tests.EnemyPlayerTests.Jump_AddsVelocity")]
+        [TestCase("MyGame.PlayerTests.Nested.Jump_AddsVelocity")]
+        [TestCase("MyGame.Tests.PlayerTests")]
+        public void ByTestClass_WithBareClassName_DoesNotMatchOtherClassesOrNamespaces(string fullName)
+        {
+            // Verifies the class name is anchored on both sides so prefixes, suffixes, namespaces of the
+            // same name, and the fixture node itself do not match.
+            Regex pattern = new Regex(TestExecutionFilter.ByTestClass("PlayerTests").FilterValue);
+
+            Assert.That(pattern.IsMatch(fullName), Is.False);
+        }
+
+        [Test]
+        public void ByTestClass_WithQualifiedClassName_MatchesOnlyThatNamespace()
+        {
+            // Verifies a namespace-qualified class name restricts the match to that namespace and that
+            // regex metacharacters in the name are treated literally.
+            Regex pattern = new Regex(TestExecutionFilter.ByTestClass("MyGame.Tests.PlayerTests").FilterValue);
+
+            Assert.That(pattern.IsMatch("MyGame.Tests.PlayerTests.Jump_AddsVelocity"), Is.True);
+            Assert.That(pattern.IsMatch("MyGameXTests.PlayerTests.Jump_AddsVelocity"), Is.False);
+            Assert.That(pattern.IsMatch("Other.Tests.PlayerTests.Jump_AddsVelocity"), Is.False);
+        }
+
+        [Test]
+        public void ByTestClass_WithNestedClassName_MatchesNestedFixtureTests()
+        {
+            // Verifies nested fixtures, which NUnit names with a '+', match by their inner class name.
+            Regex pattern = new Regex(TestExecutionFilter.ByTestClass("Inner").FilterValue);
+
+            Assert.That(pattern.IsMatch("MyGame.Tests.Outer+Inner.Jump_AddsVelocity"), Is.True);
+        }
+    }
+}

--- a/Assets/Tests/Editor/RunTestsClassFilterTests.cs
+++ b/Assets/Tests/Editor/RunTestsClassFilterTests.cs
@@ -27,15 +27,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(errorMessage, Is.Null);
             Assert.That(result.FilterType, Is.EqualTo(TestExecutionFilterType.Regex));
-            Assert.That(result.FilterValue, Is.EqualTo(TestExecutionFilter.ByTestClass("PlayerTests").FilterValue));
+            Assert.That(result.FilterValue, Is.EqualTo(@"(^|[.+])PlayerTests\.[^.(]+(\(.*\))?$"));
         }
 
-        [Test]
-        public void TryCreateFilter_WithClassTypeAndEmptyValue_ShouldReturnErrorMessage()
+        [TestCase("")]
+        [TestCase(" ")]
+        public void TryCreateFilter_WithClassTypeAndBlankValue_ShouldReturnErrorMessage(string filterValue)
         {
-            // Verifies an empty class name is rejected up front instead of producing a pattern that
-            // silently matches nothing.
-            (TestExecutionFilter result, string errorMessage) = filterService.TryCreateFilter(TestFilterType.@class, " ");
+            // Verifies an empty or whitespace class name is rejected up front instead of producing a
+            // pattern that silently matches nothing.
+            (TestExecutionFilter result, string errorMessage) = filterService.TryCreateFilter(TestFilterType.@class, filterValue);
 
             Assert.That(result, Is.Null);
             Assert.That(errorMessage, Does.Contain("class"));
@@ -75,6 +76,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(pattern.IsMatch("MyGame.Tests.PlayerTests.Jump_AddsVelocity"), Is.True);
             Assert.That(pattern.IsMatch("MyGameXTests.PlayerTests.Jump_AddsVelocity"), Is.False);
             Assert.That(pattern.IsMatch("Other.Tests.PlayerTests.Jump_AddsVelocity"), Is.False);
+        }
+
+        [Test]
+        public void ByTestClass_WithPartiallyQualifiedClassName_DoesNotMatchInsideALongerNamespace()
+        {
+            // Verifies a qualified name is anchored at the start of the full name, so a namespace suffix
+            // cannot select the same class under a longer, unintended namespace.
+            Regex pattern = new Regex(TestExecutionFilter.ByTestClass("Tests.PlayerTests").FilterValue);
+
+            Assert.That(pattern.IsMatch("Tests.PlayerTests.Jump_AddsVelocity"), Is.True);
+            Assert.That(pattern.IsMatch("MyGame.Tests.PlayerTests.Jump_AddsVelocity"), Is.False);
         }
 
         [Test]

--- a/Assets/Tests/Editor/RunTestsClassFilterTests.cs.meta
+++ b/Assets/Tests/Editor/RunTestsClassFilterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d79c0ec218514be6b4405d2b73e7d0a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Documentation~/tools.md
+++ b/Packages/src/Documentation~/tools.md
@@ -32,7 +32,7 @@ This allows you to retrieve logs while keeping the context small.
 
 ### 3. run-tests - Execute TestRunner (PlayMode, EditMode supported)
 Executes Unity Test Runner and retrieves test results. You can set conditions with FilterType and FilterValue.
-- FilterType: all (all tests), exact (individual test method name), regex (class name or namespace), assembly (assembly name)
+- FilterType: all (all tests), exact (individual test method name), regex (regex over full test names), assembly (assembly name), class (test class name, bare or namespace-qualified)
 - FilterValue: Value according to filter type (class name, namespace, etc.)
 - SaveBeforeRun: Saves unsaved loaded Scene changes and current Prefab Stage changes before running tests by default. When disabled, unsaved editor changes stop test execution instead of being discarded.
 Test results can be output as xml. The output path is returned so AI can read it.

--- a/Packages/src/Documentation~/tools_ja.md
+++ b/Packages/src/Documentation~/tools_ja.md
@@ -32,7 +32,7 @@ LogTypeや検索対象の文字列で絞り込む事ができます。また、s
 
 ### 3. run-tests - TestRunnerの実行 (PlayMode, EditMode対応)
 Unity Test Runnerを実行し、テスト結果を取得します。FilterTypeとFilterValueで条件を設定できます。
-- FilterType: all（全テスト）、exact（個別テストメソッド名）、regex（クラス名や名前空間）、assembly（アセンブリ名）
+- FilterType: all（全テスト）、exact（個別テストメソッド名）、regex（テストのフルネームに対する正規表現）、assembly（アセンブリ名）、class（テストクラス名。名前空間付きでも可）
 - FilterValue: フィルタータイプに応じた値（クラス名、名前空間など）
 - SaveBeforeRun: デフォルトで未保存のロード済みScene変更と現在のPrefab Stage変更を保存してからテストを実行。無効にした場合、未保存のエディタ変更は破棄されず、テスト実行前に停止します。
 テスト結果をxmlで出力する事が可能です。出力pathを返すので、それをAIに読み取ってもらう事ができます。

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsSchema.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsSchema.cs
@@ -14,7 +14,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public UnityCliLoopTestMode TestMode { get; set; } = UnityCliLoopTestMode.EditMode;
 
         /// <summary>
-        /// Type of test filter - all(0), exact(1), regex(2), assembly(3)
+        /// Type of test filter - all(0), exact(1), regex(2), assembly(3), class(4)
         /// </summary>
         public TestFilterType FilterType { get; set; } = TestFilterType.all;
 
@@ -23,6 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// • exact: Individual test method name (e.g.: io.github.hatayama.UnityCliLoop.ConsoleLogRetrieverTests.GetAllLogs_WithMaskAllOff_StillReturnsAllLogs)
         /// • regex: Class name or namespace (e.g.: io.github.hatayama.UnityCliLoop.ConsoleLogRetrieverTests, io.github.hatayama.UnityCliLoop)
         /// • assembly: Assembly name (e.g.: UnityCliLoop.Tests.Editor)
+        /// • class: Test class name, bare or namespace-qualified (e.g.: ConsoleLogRetrieverTests)
         /// </summary>
         public string FilterValue { get; set; } = "";
         public bool SaveBeforeRun { get; set; } = true;

--- a/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
@@ -29,13 +29,13 @@ uloop run-tests [options]
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--test-mode` | string | `EditMode` | Test mode: `EditMode`, `PlayMode` |
-| `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
-| `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
+| `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly`, `class` |
+| `--filter-value` | string | - | Filter value (test name, pattern, assembly, or class name) |
 | `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
 | `--skip-compile` | flag | - | Skip the automatic compile before running tests; use only while validating active hot-reload patches. |
 | `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
 
-exact matches the full test name (Namespace.Class.Method); use regex to run a whole test class, e.g. --filter-type regex --filter 'MyGame\.Tests\.PlayerTests\.'
+exact matches the full test name (Namespace.Class.Method). class runs every test of one class by bare or namespace-qualified name, e.g. --filter-type class --filter-value PlayerTests; the name is matched literally and whole, so PlayerTests does not run EnemyPlayerTests. regex matches a .NET regex against full test names, e.g. --filter-type regex --filter-value '^MyGame\.Tests\.'
 
 ## Output
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFilterCreationService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFilterCreationService.cs
@@ -19,7 +19,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         /// <param name="filterType">Filter type</param>
         /// <param name="filterValue">Filter value</param>
-        /// <returns>Test execution filter or an error message describing an invalid filter type</returns>
+        /// <returns>Test execution filter, or an error message for an unsupported filter type or a blank class filter value</returns>
         public (TestExecutionFilter filter, string errorMessage) TryCreateFilter(TestFilterType filterType, string filterValue)
         {
             switch (filterType)

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFilterCreationService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFilterCreationService.cs
@@ -7,9 +7,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class TestFilterCreationService
     {
+        // Why a dedicated message: an empty class name would otherwise become a pattern that
+        // matches nothing, and the resulting NoTestsFound would point at the wrong cause.
+        internal const string ClassFilterRequiresValueMessage =
+            "FilterType 'class' requires FilterValue to name a test class (e.g. PlayerTests or MyGame.Tests.PlayerTests)";
+
         /// <summary>
         /// Create test execution filter. Returns (filter, errorMessage); errorMessage is non-null
-        /// only when the caller supplied an out-of-range enum value cast from an integer.
+        /// only when the caller supplied an out-of-range enum value cast from an integer or a
+        /// class filter without a class name.
         /// </summary>
         /// <param name="filterType">Filter type</param>
         /// <param name="filterValue">Filter value</param>
@@ -26,6 +32,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return (TestExecutionFilter.ByClassName(filterValue), null);
                 case TestFilterType.assembly:
                     return (TestExecutionFilter.ByAssemblyName(filterValue), null);
+                case TestFilterType.@class:
+                    if (string.IsNullOrWhiteSpace(filterValue))
+                    {
+                        return (null, ClassFilterRequiresValueMessage);
+                    }
+                    return (TestExecutionFilter.ByTestClass(filterValue), null);
                 default:
                     return (null, $"Unsupported filter type: {filterType}");
             }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestRunner/TestExecutionFilter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestRunner/TestExecutionFilter.cs
@@ -84,11 +84,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(!string.IsNullOrWhiteSpace(className), "className must not be null or whitespace");
 
             // Why this shape: NUnit leaf full names are "Namespace.Class.Method" or
-            // "Namespace.Class.Method(args)", and nested fixtures are "Outer+Inner". The left
-            // anchor stops "EnemyPlayerTests" matching "PlayerTests"; the right anchor requires
-            // exactly one method segment, so a namespace segment of the same name and the
+            // "Namespace.Class.Method(args)", and nested fixtures are "Outer+Inner". A qualified
+            // name is anchored at the start so "Tests.PlayerTests" cannot match inside
+            // "Other.Tests.PlayerTests"; a bare name is anchored on the namespace or nested-fixture
+            // boundary so "EnemyPlayerTests" does not match "PlayerTests". The right anchor
+            // requires exactly one method segment, so a namespace segment of the same name and the
             // fixture node itself do not match. Args may contain dots, hence the paren branch.
-            string pattern = "(^|[.+])" + Regex.Escape(className) + @"\.[^.(]+(\(.*\))?$";
+            string leftAnchor = className.Contains(".") ? "^" : "(^|[.+])";
+            string pattern = leftAnchor + Regex.Escape(className) + @"\.[^.(]+(\(.*\))?$";
             return new TestExecutionFilter(TestExecutionFilterType.Regex, pattern);
         }
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestRunner/TestExecutionFilter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestRunner/TestExecutionFilter.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+using UnityEngine;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
@@ -72,6 +74,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return new TestExecutionFilter(TestExecutionFilterType.Regex, className);
         }
         
+        /// <summary>
+        /// Creates a filter that runs every test of one class, given either a bare class name
+        /// or a namespace-qualified one. Delivered as a regex because Unity's Filter has no
+        /// class field.
+        /// </summary>
+        public static TestExecutionFilter ByTestClass(string className)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(className), "className must not be null or whitespace");
+
+            // Why this shape: NUnit leaf full names are "Namespace.Class.Method" or
+            // "Namespace.Class.Method(args)", and nested fixtures are "Outer+Inner". The left
+            // anchor stops "EnemyPlayerTests" matching "PlayerTests"; the right anchor requires
+            // exactly one method segment, so a namespace segment of the same name and the
+            // fixture node itself do not match. Args may contain dots, hence the paren branch.
+            string pattern = "(^|[.+])" + Regex.Escape(className) + @"\.[^.(]+(\(.*\))?$";
+            return new TestExecutionFilter(TestExecutionFilterType.Regex, pattern);
+        }
+
         /// <summary>
         /// Creates a filter by assembly name.
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/RunTests/UnityCliLoopTestExecutionTypes.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/UnityCliLoopTestExecutionTypes.cs
@@ -17,7 +17,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         all = 0,
         exact = 1,
         regex = 2,
-        assembly = 3
+        assembly = 3,
+        // Why the verbatim identifier: the CLI spells the option value "class", and the schema
+        // generator emits enum member names verbatim, so the C# keyword has to be escaped here.
+        @class = 4
     }
 
     /// <summary>

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -87,18 +87,19 @@
           },
           "FilterType": {
             "type": "string",
-            "description": "Filter type: all, exact, regex, assembly",
+            "description": "Filter type: all, exact, regex, assembly, class",
             "enum": [
               "all",
               "exact",
               "regex",
-              "assembly"
+              "assembly",
+              "class"
             ],
             "default": "all"
           },
           "FilterValue": {
             "type": "string",
-            "description": "Filter value (test name, pattern, or assembly)"
+            "description": "Filter value (test name, pattern, assembly, or class name)"
           },
           "SaveBeforeRun": {
             "type": "boolean",

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "d7e313193da18cb7add3137769076e839f4cf2e6"
+  "sharedInputsHash": "48912728f1a11a42ac376bb325f00c89509d381f"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "ac7f51a4ae8bee4efbaeb2056a1b382de235ed48"
+  "sharedInputsHash": "4970ec7f2f710219506168577e0669b10f73fc3f"
 }


### PR DESCRIPTION
## Summary

`uloop run-tests` gains `--filter-type class`, which runs every test of one NUnit test class by its bare or namespace-qualified name. Until now this needed a hand-written, escaped regex, and an unanchored pattern such as `PlayerTests` also ran `EnemyPlayerTests`.

## User Impact

- `uloop run-tests --filter-type class --filter-value PlayerTests` runs all tests in `PlayerTests` (any namespace); `--filter-value MyGame.Tests.PlayerTests` restricts it to that namespace.
- The class name is matched literally and whole: prefixes/suffixes, a namespace of the same name, and the fixture node itself do not match. Nested fixtures (`Outer+Inner`) match by inner name; parameterized test names with dots in their arguments still match.
- An empty class name fails fast with a message naming the fix instead of a misleading `NoTestsFound`.
- The skill note now explains `exact`, `class`, and `regex` semantics side by side; `--help` / `uloop list` list the new value.

## Changes

- `TestFilterType.@class` and `TestExecutionFilter.ByTestClass`, which builds an anchored group-name regex because Unity's `Filter` has no class field.
- `TestFilterCreationService` maps the new type and rejects a blank class name.
- Skill table and note, regenerated `.claude/` and `.agents/` copies, `Documentation~/tools*.md`.
- Embedded catalog enum + regenerated descriptions (`scripts/sync-tool-docs.sh`), and the shared-inputs stamps for the structural catalog change.
- New `RunTestsClassFilterTests` covering mapping, empty-value rejection, and the pattern's positive/negative matches.

## Verification

- `uloop compile`: 0 errors.
- `uloop run-tests --filter-type regex --filter-value "RunTestsClassFilterTests|RunTestsToolTests|DefaultToolsCatalogDriftTests|SkillParameterTableCoverageTests"`: 21 passed, 0 failed.
- End to end: `--filter-type class --filter-value RunTestsClassFilterTests` ran 11 tests; the namespace-qualified `RunTestsToolTests` ran 7; `--filter-value " "` returned `ExecutionFailed` with the new message.
- `scripts/check-go-cli.sh` exit 0; `scripts/sync-tool-docs.sh --check` clean; `check-skill-size` clean; `scripts/stamp-release-inputs.sh` run.

Closes #2339

https://claude.ai/code/session_01R3jkx6NbNYKPdy5q1NSWYo


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

