### PR TITLE
feat: compile response now explains indeterminate results and hints at asmdef reference gaps

### DIFF
--- a/.agents/skills/uloop-compile/SKILL.md
+++ b/.agents/skills/uloop-compile/SKILL.md
@@ -49,6 +49,9 @@ Returns JSON:
 - `WarningCount`: number or null
 - `Message`: string
 - `ErrorCode`: string or null. `COMPILE_ALREADY_IN_PROGRESS` when Unity is already compiling, `COMPILE_EDITOR_UPDATING` when the editor is updating, `COMPILE_RESULT_UNKNOWN` after a forced recompile that did not return a definitive result.
+- `NextActions`: string array or null. Corrective steps derived from the errors, e.g. the assembly that declares an unresolved namespace (CS0234), or, for CS0246 in a script under an asmdef, a reminder to check that asmdef's references (the type may instead be a typo — decide from the error).
+
+When Unity stops compiling before the finish callback (`Success: null`, indeterminate), `Message` keeps the get-logs pointer and appends `Recent Console errors:` with the last few Console errors (typically the asmdef or compiler error that aborted the compile), so fix from that list before reaching for `uloop get-logs`.
 
 ## Troubleshooting
 

--- a/.claude/skills/uloop-compile/SKILL.md
+++ b/.claude/skills/uloop-compile/SKILL.md
@@ -49,6 +49,9 @@ Returns JSON:
 - `WarningCount`: number or null
 - `Message`: string
 - `ErrorCode`: string or null. `COMPILE_ALREADY_IN_PROGRESS` when Unity is already compiling, `COMPILE_EDITOR_UPDATING` when the editor is updating, `COMPILE_RESULT_UNKNOWN` after a forced recompile that did not return a definitive result.
+- `NextActions`: string array or null. Corrective steps derived from the errors, e.g. the assembly that declares an unresolved namespace (CS0234), or, for CS0246 in a script under an asmdef, a reminder to check that asmdef's references (the type may instead be a typo — decide from the error).
+
+When Unity stops compiling before the finish callback (`Success: null`, indeterminate), `Message` keeps the get-logs pointer and appends `Recent Console errors:` with the last few Console errors (typically the asmdef or compiler error that aborted the compile), so fix from that list before reaching for `uloop get-logs`.
 
 ## Troubleshooting
 

--- a/Assets/Tests/Editor/CompileAssemblyDefinitionReferenceHintBuilderTests.cs
+++ b/Assets/Tests/Editor/CompileAssemblyDefinitionReferenceHintBuilderTests.cs
@@ -1,0 +1,138 @@
+using System;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Pins the asmdef reference-gap hint appended for CS0246 errors raised from scripts that
+    /// belong to an Assembly Definition.
+    /// </summary>
+    [TestFixture]
+    public sealed class CompileAssemblyDefinitionReferenceHintBuilderTests
+    {
+        private const string ScriptPath = "Assets/Scripts/Gameplay/Player.cs";
+        private const string AsmdefPath = "Assets/Scripts/Gameplay/Gameplay.asmdef";
+
+        private const string Cs0246Error =
+            "error CS0246: The type or namespace name 'InputSystem' could not be found (are you missing a using directive or an assembly reference?)";
+
+        private const string PrefixlessCs0246Error =
+            "CS0246: The type or namespace name 'InputSystem' could not be found (are you missing a using directive or an assembly reference?)";
+
+        private const string Cs0246Hint =
+            "error CS0246: 'InputSystem' could not be found from a script under 'Assets/Scripts/Gameplay/Gameplay.asmdef'. If that type lives in another assembly (for example the script was recently moved under a new asmdef), add the declaring assembly to that asmdef's references and run 'uloop compile' again; if the name is a typo, fix the name instead.";
+
+        private const string Cs0234Error =
+            "error CS0234: The type or namespace name 'InputSystem' does not exist in the namespace 'UnityEngine' (are you missing an assembly reference?)";
+
+        /// <summary>
+        /// What: a CS0246 error from a script under an asmdef produces the reference-gap hint naming that asmdef.
+        /// </summary>
+        [Test]
+        public void Build_WhenCs0246FromAsmdefScript_ReturnsHintNamingAsmdef()
+        {
+            string[] hints = CompileAssemblyDefinitionReferenceHintBuilder.Build(
+                new[] { new CompileErrorOrigin(Cs0246Error, ScriptPath) },
+                file => file == ScriptPath ? AsmdefPath : null);
+
+            Assert.That(hints, Is.EqualTo(new[] { Cs0246Hint }));
+        }
+
+        /// <summary>
+        /// What: a prefix-less CS0246 message produces the same hint.
+        /// </summary>
+        [Test]
+        public void Build_WhenPrefixlessCs0246_ReturnsHint()
+        {
+            string[] hints = CompileAssemblyDefinitionReferenceHintBuilder.Build(
+                new[] { new CompileErrorOrigin(PrefixlessCs0246Error, ScriptPath) },
+                file => AsmdefPath);
+
+            Assert.That(hints, Is.EqualTo(new[] { Cs0246Hint }));
+        }
+
+        /// <summary>
+        /// What: a CS0246 error from a script outside any asmdef stays fail-open with no hint.
+        /// </summary>
+        [Test]
+        public void Build_WhenScriptHasNoAsmdef_ReturnsEmpty()
+        {
+            string[] hints = CompileAssemblyDefinitionReferenceHintBuilder.Build(
+                new[] { new CompileErrorOrigin(Cs0246Error, ScriptPath) },
+                file => null);
+
+            Assert.That(hints, Is.EqualTo(Array.Empty<string>()));
+        }
+
+        /// <summary>
+        /// What: errors other than CS0246 never trigger the hint or the asmdef lookup.
+        /// </summary>
+        [Test]
+        public void Build_WhenNotCs0246_ReturnsEmptyWithoutLookup()
+        {
+            int lookupCalls = 0;
+            string[] hints = CompileAssemblyDefinitionReferenceHintBuilder.Build(
+                new[] { new CompileErrorOrigin(Cs0234Error, ScriptPath) },
+                file =>
+                {
+                    lookupCalls++;
+                    return AsmdefPath;
+                });
+
+            Assert.That(hints, Is.EqualTo(Array.Empty<string>()));
+            Assert.That(lookupCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: a CS0246 error without a file path cannot be mapped to an asmdef and produces no hint.
+        /// </summary>
+        [Test]
+        public void Build_WhenFileIsMissing_ReturnsEmptyWithoutLookup()
+        {
+            int lookupCalls = 0;
+            string[] hints = CompileAssemblyDefinitionReferenceHintBuilder.Build(
+                new[] { new CompileErrorOrigin(Cs0246Error, string.Empty) },
+                file =>
+                {
+                    lookupCalls++;
+                    return AsmdefPath;
+                });
+
+            Assert.That(hints, Is.EqualTo(Array.Empty<string>()));
+            Assert.That(lookupCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: several CS0246 errors under the same asmdef produce one hint, for the first missing name.
+        /// </summary>
+        [Test]
+        public void Build_WhenMultipleCs0246UnderSameAsmdef_ReturnsOneHint()
+        {
+            const string secondError =
+                "error CS0246: The type or namespace name 'Keyboard' could not be found (are you missing a using directive or an assembly reference?)";
+
+            string[] hints = CompileAssemblyDefinitionReferenceHintBuilder.Build(
+                new[]
+                {
+                    new CompileErrorOrigin(Cs0246Error, ScriptPath),
+                    new CompileErrorOrigin(secondError, "Assets/Scripts/Gameplay/Enemy.cs")
+                },
+                file => AsmdefPath);
+
+            Assert.That(hints, Is.EqualTo(new[] { Cs0246Hint }));
+        }
+
+        /// <summary>
+        /// What: a null error list produces no hints.
+        /// </summary>
+        [Test]
+        public void Build_WhenErrorsNull_ReturnsEmpty()
+        {
+            string[] hints = CompileAssemblyDefinitionReferenceHintBuilder.Build(null, file => AsmdefPath);
+
+            Assert.That(hints, Is.EqualTo(Array.Empty<string>()));
+        }
+    }
+}

--- a/Assets/Tests/Editor/CompileAssemblyDefinitionReferenceHintBuilderTests.cs.meta
+++ b/Assets/Tests/Editor/CompileAssemblyDefinitionReferenceHintBuilderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3da6ebda8b3748bd9433c946680579e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/CompileErrorNextActionsComposerTests.cs
+++ b/Assets/Tests/Editor/CompileErrorNextActionsComposerTests.cs
@@ -518,6 +518,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: a CS0246 raised from a script that belongs to an asmdef appends the reference-gap hint
+        /// naming that asmdef, resolved through Unity's CompilationPipeline.
+        /// </summary>
+        [Test]
+        public void Apply_WhenCs0246FromScriptUnderAsmdef_AppendsAssemblyDefinitionReferenceHint()
+        {
+            const string scriptPath = "Assets/Tests/Editor/CompileErrorNextActionsComposerTests.cs";
+            const string expectedHint =
+                "error CS0246: 'InputSystem' could not be found from a script under 'Assets/Tests/Editor/UnityCLILoop.Tests.Editor.asmdef'. If that type lives in another assembly (for example the script was recently moved under a new asmdef), add the declaring assembly to that asmdef's references and run 'uloop compile' again; if the name is a typo, fix the name instead.";
+            CompileResponse response = CreateResponse(success: false);
+            CompilerMessage error = new CompilerMessage
+            {
+                type = CompilerMessageType.Error,
+                message = Cs0246Error,
+                file = scriptPath,
+                line = 1
+            };
+
+            CompileErrorNextActionsComposer.Apply(response, new[] { error });
+
+            Assert.That(response.NextActions, Is.EqualTo(new[] { expectedHint }));
+        }
+
+        /// <summary>
         /// What: CreateResponse appends the TypeCache CS0234 action after the API Updater action.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/CompileIndeterminateErrorSummaryBuilderTests.cs
+++ b/Assets/Tests/Editor/CompileIndeterminateErrorSummaryBuilderTests.cs
@@ -122,6 +122,58 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: entries at or before the compile-start boundary are dropped, later ones kept in order.
+        /// </summary>
+        [Test]
+        public void TakeEntriesAfter_WhenBoundaryWithinSnapshot_ReturnsEntriesAfterBoundary()
+        {
+            UnityCliLoopConsoleLogEntry[] entries =
+            {
+                new(UnityCliLoopLogType.Error, "stale", string.Empty),
+                new(UnityCliLoopLogType.Error, "fresh 1", string.Empty),
+                new(UnityCliLoopLogType.Error, "fresh 2", string.Empty)
+            };
+
+            UnityCliLoopConsoleLogEntry[] recent = CompileIndeterminateErrorSummaryBuilder.TakeEntriesAfter(entries, 1);
+
+            Assert.That(recent.Length, Is.EqualTo(2));
+            Assert.That(recent[0].Message, Is.EqualTo("fresh 1"));
+            Assert.That(recent[1].Message, Is.EqualTo("fresh 2"));
+        }
+
+        /// <summary>
+        /// What: a boundary larger than the snapshot (Console cleared mid-request) keeps every entry.
+        /// </summary>
+        [Test]
+        public void TakeEntriesAfter_WhenBoundaryExceedsSnapshot_ReturnsAllEntries()
+        {
+            UnityCliLoopConsoleLogEntry[] entries =
+            {
+                new(UnityCliLoopLogType.Error, "fresh", string.Empty)
+            };
+
+            UnityCliLoopConsoleLogEntry[] recent = CompileIndeterminateErrorSummaryBuilder.TakeEntriesAfter(entries, 5);
+
+            Assert.That(recent, Is.SameAs(entries));
+        }
+
+        /// <summary>
+        /// What: a zero boundary (nothing logged before the compile) keeps every entry.
+        /// </summary>
+        [Test]
+        public void TakeEntriesAfter_WhenBoundaryIsZero_ReturnsAllEntries()
+        {
+            UnityCliLoopConsoleLogEntry[] entries =
+            {
+                new(UnityCliLoopLogType.Error, "fresh", string.Empty)
+            };
+
+            UnityCliLoopConsoleLogEntry[] recent = CompileIndeterminateErrorSummaryBuilder.TakeEntriesAfter(entries, 0);
+
+            Assert.That(recent, Is.SameAs(entries));
+        }
+
+        /// <summary>
         /// What: blank error messages are skipped instead of producing empty bullet lines.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/CompileIndeterminateErrorSummaryBuilderTests.cs
+++ b/Assets/Tests/Editor/CompileIndeterminateErrorSummaryBuilderTests.cs
@@ -1,0 +1,141 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Pins the Console error summary appended to indeterminate compile results so agents can
+    /// self-correct without a separate get-logs round trip.
+    /// </summary>
+    [TestFixture]
+    public sealed class CompileIndeterminateErrorSummaryBuilderTests
+    {
+        private const string DuplicateReferencesError =
+            "Assembly has duplicate references: UnityEngine.TestRunner,UnityEditor.TestRunner";
+
+        /// <summary>
+        /// What: an empty Console snapshot produces no summary so the base message stays untouched.
+        /// </summary>
+        [Test]
+        public void Build_WhenNoEntries_ReturnsNull()
+        {
+            string summary = CompileIndeterminateErrorSummaryBuilder.Build(new UnityCliLoopConsoleLogEntry[0]);
+
+            Assert.That(summary, Is.Null);
+        }
+
+        /// <summary>
+        /// What: entries that are not errors never appear in the summary.
+        /// </summary>
+        [Test]
+        public void Build_WhenOnlyNonErrorEntries_ReturnsNull()
+        {
+            UnityCliLoopConsoleLogEntry[] entries =
+            {
+                new(UnityCliLoopLogType.Warning, "some warning", string.Empty),
+                new(UnityCliLoopLogType.Log, "some log", string.Empty)
+            };
+
+            string summary = CompileIndeterminateErrorSummaryBuilder.Build(entries);
+
+            Assert.That(summary, Is.Null);
+        }
+
+        /// <summary>
+        /// What: an error entry is listed under the summary header using only its first line.
+        /// </summary>
+        [Test]
+        public void Build_WhenErrorEntryExists_ListsFirstLineUnderHeader()
+        {
+            UnityCliLoopConsoleLogEntry[] entries =
+            {
+                new(UnityCliLoopLogType.Error, DuplicateReferencesError + "\nsecond line", "stack")
+            };
+
+            string summary = CompileIndeterminateErrorSummaryBuilder.Build(entries);
+
+            Assert.That(
+                summary,
+                Is.EqualTo(
+                    CompileIndeterminateErrorSummaryBuilder.Header + "\n- " + DuplicateReferencesError));
+        }
+
+        /// <summary>
+        /// What: identical error messages are listed once.
+        /// </summary>
+        [Test]
+        public void Build_WhenDuplicateErrors_ListsThemOnce()
+        {
+            UnityCliLoopConsoleLogEntry[] entries =
+            {
+                new(UnityCliLoopLogType.Error, DuplicateReferencesError, string.Empty),
+                new(UnityCliLoopLogType.Error, DuplicateReferencesError, string.Empty)
+            };
+
+            string summary = CompileIndeterminateErrorSummaryBuilder.Build(entries);
+
+            Assert.That(
+                summary,
+                Is.EqualTo(
+                    CompileIndeterminateErrorSummaryBuilder.Header + "\n- " + DuplicateReferencesError));
+        }
+
+        /// <summary>
+        /// What: only the most recent errors are kept, in Console order, when more exist than the cap.
+        /// </summary>
+        [Test]
+        public void Build_WhenMoreErrorsThanCap_KeepsMostRecentInOrder()
+        {
+            int total = CompileIndeterminateErrorSummaryBuilder.MaxEntries + 2;
+            UnityCliLoopConsoleLogEntry[] entries = new UnityCliLoopConsoleLogEntry[total];
+            for (int index = 0; index < total; index++)
+            {
+                entries[index] = new UnityCliLoopConsoleLogEntry(UnityCliLoopLogType.Error, $"error {index}", string.Empty);
+            }
+
+            string summary = CompileIndeterminateErrorSummaryBuilder.Build(entries);
+
+            string[] lines = summary.Split('\n');
+            Assert.That(lines.Length, Is.EqualTo(CompileIndeterminateErrorSummaryBuilder.MaxEntries + 1));
+            Assert.That(lines[1], Is.EqualTo("- error 2"));
+            Assert.That(lines[lines.Length - 1], Is.EqualTo($"- error {total - 1}"));
+        }
+
+        /// <summary>
+        /// What: a very long error line is truncated with an ellipsis so the response stays short.
+        /// </summary>
+        [Test]
+        public void Build_WhenErrorLineIsTooLong_TruncatesWithEllipsis()
+        {
+            string longMessage = new string('x', CompileIndeterminateErrorSummaryBuilder.MaxLineLength + 50);
+            UnityCliLoopConsoleLogEntry[] entries =
+            {
+                new(UnityCliLoopLogType.Error, longMessage, string.Empty)
+            };
+
+            string summary = CompileIndeterminateErrorSummaryBuilder.Build(entries);
+
+            string line = summary.Split('\n')[1];
+            Assert.That(line, Does.EndWith("..."));
+            Assert.That(line.Length, Is.EqualTo(CompileIndeterminateErrorSummaryBuilder.MaxLineLength + 2 + 3));
+        }
+
+        /// <summary>
+        /// What: blank error messages are skipped instead of producing empty bullet lines.
+        /// </summary>
+        [Test]
+        public void Build_WhenErrorMessageIsBlank_SkipsEntry()
+        {
+            UnityCliLoopConsoleLogEntry[] entries =
+            {
+                new(UnityCliLoopLogType.Error, "   ", string.Empty),
+                new(UnityCliLoopLogType.Error, null, string.Empty)
+            };
+
+            string summary = CompileIndeterminateErrorSummaryBuilder.Build(entries);
+
+            Assert.That(summary, Is.Null);
+        }
+    }
+}

--- a/Assets/Tests/Editor/CompileIndeterminateErrorSummaryBuilderTests.cs.meta
+++ b/Assets/Tests/Editor/CompileIndeterminateErrorSummaryBuilderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b77c8f2716a7f4f7f96e9c6f2383cb33
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/CompileLifecycleRecoveryCoordinatorTests.cs
+++ b/Assets/Tests/Editor/CompileLifecycleRecoveryCoordinatorTests.cs
@@ -140,6 +140,50 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(abortedWithResult.Errors[0].message, Is.EqualTo("CS0000: sample compile error"));
         }
 
+        [Test]
+        public void HandleCompileStoppedWithoutFinishEvent_WhenConsoleErrorsExist_AppendsSummaryToIndeterminateMessage()
+        {
+            // Verifies the indeterminate message keeps its wording and get-logs pointer while appending
+            // the recent Console errors so the cause is visible without a second round trip.
+            const string consoleError =
+                "Assembly has duplicate references: UnityEngine.TestRunner,UnityEditor.TestRunner";
+            CompileResult abortedWithResult = null;
+            CompileLifecycleRecoveryCoordinator coordinator = CreateCoordinator(
+                getConsoleErrorEntries: () => new[]
+                {
+                    new UnityCliLoopConsoleLogEntry(UnityCliLoopLogType.Error, consoleError, string.Empty)
+                },
+                abortWithResult: result => abortedWithResult = result);
+
+            coordinator.HandleCompileStoppedWithoutFinishEvent(500);
+
+            Assert.That(abortedWithResult, Is.Not.Null);
+            Assert.That(abortedWithResult.IsIndeterminate, Is.True);
+            Assert.That(
+                abortedWithResult.Message,
+                Is.EqualTo(
+                    "Unity stopped compiling before Unity CLI Loop received the compilationFinished callback. " +
+                    "The compile result is indeterminate; use get-logs to inspect the compiler output.\n" +
+                    "Recent Console errors:\n- " + consoleError));
+        }
+
+        [Test]
+        public void HandleCompileStoppedWithoutFinishEvent_WhenNoConsoleErrorsExist_KeepsIndeterminateMessageUnchanged()
+        {
+            // Verifies an empty Console leaves the indeterminate message exactly as before.
+            CompileResult abortedWithResult = null;
+            CompileLifecycleRecoveryCoordinator coordinator = CreateCoordinator(
+                abortWithResult: result => abortedWithResult = result);
+
+            coordinator.HandleCompileStoppedWithoutFinishEvent(500);
+
+            Assert.That(
+                abortedWithResult.Message,
+                Is.EqualTo(
+                    "Unity stopped compiling before Unity CLI Loop received the compilationFinished callback. " +
+                    "The compile result is indeterminate; use get-logs to inspect the compiler output."));
+        }
+
         /// <summary>
         /// Verifies an assembly-progress stall warning never aborts the compile request.
         /// </summary>
@@ -205,6 +249,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
         private static CompileLifecycleRecoveryCoordinator CreateCoordinator(
             Func<AssemblyDefinitionConsoleErrorResult> findAssemblyDefinitionErrors = null,
+            Func<UnityCliLoopConsoleLogEntry[]> getConsoleErrorEntries = null,
             Func<ValidationResult> validateNoDuplicateAsmdefNames = null,
             Func<CompilerMessage[]> getCompileMessages = null,
             Func<int> getAssemblyFinishedCount = null,
@@ -218,6 +263,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 getCurrentCompileTask: () => null,
                 findAssemblyDefinitionErrors: findAssemblyDefinitionErrors ??
                     (() => new AssemblyDefinitionConsoleErrorResult(new AssemblyDefinitionConsoleError[0])),
+                getConsoleErrorEntries: getConsoleErrorEntries ?? (() => new UnityCliLoopConsoleLogEntry[0]),
                 validateNoDuplicateAsmdefNames: validateNoDuplicateAsmdefNames ?? ValidationResult.Success,
                 getIsForceCompile: getIsForceCompile ?? (() => false),
                 getCompileMessages: getCompileMessages ?? (() => new CompilerMessage[0]),

--- a/Assets/Tests/Editor/CompileLifecycleRecoveryCoordinatorTests.cs
+++ b/Assets/Tests/Editor/CompileLifecycleRecoveryCoordinatorTests.cs
@@ -29,7 +29,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             CompileResult abortedWithResult = null;
             string abortedWithMessage = null;
             CompileLifecycleRecoveryCoordinator coordinator = CreateCoordinator(
-                findAssemblyDefinitionErrors: () => assemblyDefinitionErrors,
+                findAssemblyDefinitionErrors: _ => assemblyDefinitionErrors,
                 validateNoDuplicateAsmdefNames: ValidationResult.Success,
                 abortWithResult: result => abortedWithResult = result,
                 abort: message => abortedWithMessage = message);
@@ -51,7 +51,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             CompileResult abortedWithResult = null;
             string abortedWithMessage = null;
             CompileLifecycleRecoveryCoordinator coordinator = CreateCoordinator(
-                findAssemblyDefinitionErrors: () => new AssemblyDefinitionConsoleErrorResult(
+                findAssemblyDefinitionErrors: _ => new AssemblyDefinitionConsoleErrorResult(
                     new AssemblyDefinitionConsoleError[0]),
                 validateNoDuplicateAsmdefNames: () => ValidationResult.Failure(duplicateAsmdefMessage),
                 abortWithResult: result => abortedWithResult = result,
@@ -70,7 +70,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             CompileResult abortedWithResult = null;
             string abortedWithMessage = null;
             CompileLifecycleRecoveryCoordinator coordinator = CreateCoordinator(
-                findAssemblyDefinitionErrors: () => new AssemblyDefinitionConsoleErrorResult(
+                findAssemblyDefinitionErrors: _ => new AssemblyDefinitionConsoleErrorResult(
                     new AssemblyDefinitionConsoleError[0]),
                 validateNoDuplicateAsmdefNames: ValidationResult.Success,
                 abortWithResult: result => abortedWithResult = result,
@@ -97,7 +97,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 });
             CompileResult abortedWithResult = null;
             CompileLifecycleRecoveryCoordinator coordinator = CreateCoordinator(
-                findAssemblyDefinitionErrors: () => assemblyDefinitionErrors,
+                findAssemblyDefinitionErrors: _ => assemblyDefinitionErrors,
                 getCompileMessages: () => new CompilerMessage[0],
                 getIsForceCompile: () => false,
                 abortWithResult: result => abortedWithResult = result);
@@ -126,7 +126,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             };
             CompileResult abortedWithResult = null;
             CompileLifecycleRecoveryCoordinator coordinator = CreateCoordinator(
-                findAssemblyDefinitionErrors: () => new AssemblyDefinitionConsoleErrorResult(
+                findAssemblyDefinitionErrors: _ => new AssemblyDefinitionConsoleErrorResult(
                     new AssemblyDefinitionConsoleError[0]),
                 getCompileMessages: () => compileMessages,
                 getIsForceCompile: () => false,
@@ -165,6 +165,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     "Unity stopped compiling before Unity CLI Loop received the compilationFinished callback. " +
                     "The compile result is indeterminate; use get-logs to inspect the compiler output.\n" +
                     "Recent Console errors:\n- " + consoleError));
+        }
+
+        [Test]
+        public void HandleCompileStoppedWithoutFinishEvent_WhenConsoleErrorsPredateCompileStart_OmitsThemFromSummary()
+        {
+            // Verifies errors logged before the compile request started are not presented as its cause,
+            // while the asmdef validation still sees the full Console snapshot.
+            const string staleError = "NullReferenceException from an earlier Play session";
+            const string freshError = "Assembly has duplicate references: UnityEngine.TestRunner,UnityEditor.TestRunner";
+            UnityCliLoopConsoleLogEntry[] validatedEntries = null;
+            CompileResult abortedWithResult = null;
+            CompileLifecycleRecoveryCoordinator coordinator = CreateCoordinator(
+                findAssemblyDefinitionErrors: entries =>
+                {
+                    validatedEntries = entries;
+                    return new AssemblyDefinitionConsoleErrorResult(new AssemblyDefinitionConsoleError[0]);
+                },
+                getConsoleErrorEntries: () => new[]
+                {
+                    new UnityCliLoopConsoleLogEntry(UnityCliLoopLogType.Error, staleError, string.Empty),
+                    new UnityCliLoopConsoleLogEntry(UnityCliLoopLogType.Error, freshError, string.Empty)
+                },
+                getConsoleErrorCountAtCompileStart: () => 1,
+                abortWithResult: result => abortedWithResult = result);
+
+            coordinator.HandleCompileStoppedWithoutFinishEvent(500);
+
+            Assert.That(abortedWithResult.Message, Does.EndWith("Recent Console errors:\n- " + freshError));
+            Assert.That(abortedWithResult.Message, Does.Not.Contain(staleError));
+            Assert.That(validatedEntries, Is.Not.Null);
+            Assert.That(validatedEntries.Length, Is.EqualTo(2));
         }
 
         [Test]
@@ -248,8 +279,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         private static CompileLifecycleRecoveryCoordinator CreateCoordinator(
-            Func<AssemblyDefinitionConsoleErrorResult> findAssemblyDefinitionErrors = null,
+            Func<UnityCliLoopConsoleLogEntry[], AssemblyDefinitionConsoleErrorResult> findAssemblyDefinitionErrors = null,
             Func<UnityCliLoopConsoleLogEntry[]> getConsoleErrorEntries = null,
+            Func<int> getConsoleErrorCountAtCompileStart = null,
             Func<ValidationResult> validateNoDuplicateAsmdefNames = null,
             Func<CompilerMessage[]> getCompileMessages = null,
             Func<int> getAssemblyFinishedCount = null,
@@ -262,8 +294,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 isRequestCompleted: () => false,
                 getCurrentCompileTask: () => null,
                 findAssemblyDefinitionErrors: findAssemblyDefinitionErrors ??
-                    (() => new AssemblyDefinitionConsoleErrorResult(new AssemblyDefinitionConsoleError[0])),
+                    (_ => new AssemblyDefinitionConsoleErrorResult(new AssemblyDefinitionConsoleError[0])),
                 getConsoleErrorEntries: getConsoleErrorEntries ?? (() => new UnityCliLoopConsoleLogEntry[0]),
+                getConsoleErrorCountAtCompileStart: getConsoleErrorCountAtCompileStart ?? (() => 0),
                 validateNoDuplicateAsmdefNames: validateNoDuplicateAsmdefNames ?? ValidationResult.Success,
                 getIsForceCompile: getIsForceCompile ?? (() => false),
                 getCompileMessages: getCompileMessages ?? (() => new CompilerMessage[0]),

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileAssemblyDefinitionReferenceHintBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileAssemblyDefinitionReferenceHintBuilder.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Builds the asmdef reference-gap NextAction for CS0246 errors raised from scripts that belong to
+    /// an Assembly Definition, without depending on CompilerMessage or CompilationPipeline.
+    /// </summary>
+    internal static class CompileAssemblyDefinitionReferenceHintBuilder
+    {
+        private static readonly Regex ErrorCodeRegex = new Regex(
+            CompileErrorNextActionsConstants.ErrorCodePattern,
+            RegexOptions.CultureInvariant);
+
+        private static readonly Regex MissingTypeRegex = new Regex(
+            CompileErrorNextActionsConstants.MissingTypePattern,
+            RegexOptions.CultureInvariant);
+
+        /// <summary>
+        /// Returns at most one hint per asmdef for the first ten errors.
+        /// Why CS0246 only, and only under an asmdef: the message cannot name the declaring assembly,
+        /// so the hint is worth its noise only where a missing asmdef reference is a plausible cause.
+        /// </summary>
+        internal static string[] Build(
+            CompileErrorOrigin[] errors,
+            Func<string, string> findAssemblyDefinitionPath)
+        {
+            if (errors == null || findAssemblyDefinitionPath == null)
+            {
+                return Array.Empty<string>();
+            }
+
+            List<string> hints = new List<string>();
+            HashSet<string> hintedAssemblyDefinitions = new HashSet<string>(StringComparer.Ordinal);
+            int scanCount = Math.Min(errors.Length, CompileErrorNextActionsConstants.MaxErrorsToScan);
+            for (int index = 0; index < scanCount; index++)
+            {
+                if (hints.Count >= CompileErrorNextActionsConstants.MaxNextActionsToAppend)
+                {
+                    break;
+                }
+
+                TryAppendHint(hints, hintedAssemblyDefinitions, errors[index], findAssemblyDefinitionPath);
+            }
+
+            return hints.ToArray();
+        }
+
+        private static void TryAppendHint(
+            List<string> hints,
+            HashSet<string> hintedAssemblyDefinitions,
+            CompileErrorOrigin error,
+            Func<string, string> findAssemblyDefinitionPath)
+        {
+            string missingName = TryExtractMissingTypeName(error.Message);
+            if (missingName == null || string.IsNullOrWhiteSpace(error.File))
+            {
+                return;
+            }
+
+            string assemblyDefinitionPath = findAssemblyDefinitionPath(error.File);
+            if (string.IsNullOrWhiteSpace(assemblyDefinitionPath))
+            {
+                return;
+            }
+
+            if (!hintedAssemblyDefinitions.Add(assemblyDefinitionPath))
+            {
+                return;
+            }
+
+            hints.Add(string.Format(
+                CompileErrorNextActionsConstants.AssemblyDefinitionReferenceHintFormat,
+                CompileErrorNextActionsConstants.Cs0246ErrorCode,
+                missingName,
+                assemblyDefinitionPath));
+        }
+
+        /// <summary>
+        /// Returns the unresolved name from a CS0246 message, or null for any other error.
+        /// </summary>
+        private static string TryExtractMissingTypeName(string message)
+        {
+            if (string.IsNullOrEmpty(message))
+            {
+                return null;
+            }
+
+            Match errorCodeMatch = ErrorCodeRegex.Match(message);
+            if (!errorCodeMatch.Success ||
+                errorCodeMatch.Groups[1].Value != CompileErrorNextActionsConstants.Cs0246ErrorCode)
+            {
+                return null;
+            }
+
+            Match missingTypeMatch = MissingTypeRegex.Match(message);
+            if (!missingTypeMatch.Success)
+            {
+                return null;
+            }
+
+            return missingTypeMatch.Groups["name"].Value;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileAssemblyDefinitionReferenceHintBuilder.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileAssemblyDefinitionReferenceHintBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4f27b0ffd85444009d0439f51a4281e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -46,6 +46,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 IsCompileRequestCompleted,
                 () => _currentCompileTask,
                 () => new AssemblyDefinitionConsoleErrorValidationService().FindCurrentErrors(),
+                ReadConsoleErrorEntries,
                 () => new AssemblyDefinitionDuplicationValidationService().ValidateNoDuplicateAsmdefNames(),
                 () => _isForceCompile,
                 () => _compileMessages.ToArray(),
@@ -243,6 +244,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private bool IsCompileRequestCompleted()
         {
             return _currentCompileTask == null || _currentCompileTask.Task.IsCompleted;
+        }
+
+        /// <summary>
+        /// Snapshots the current Unity Console error entries for indeterminate-result diagnosis.
+        /// </summary>
+        private static UnityCliLoopConsoleLogEntry[] ReadConsoleErrorEntries()
+        {
+            IUnityCliLoopConsoleLogService consoleLogs = new LogRetrievalService();
+            UnityCliLoopConsoleLogResult errorLogs = consoleLogs.GetLogs(UnityCliLoopLogType.Error);
+            return errorLogs.LogEntries;
         }
 
         private Dictionary<string, object> BuildCompileControllerStateContext(

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -28,6 +28,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private CompileResultRecordingContext _resultRecordingContext = CompileResultRecordingContext.Disabled();
         private DateTime _compileStartedAtUtc = DateTime.MinValue;
         private int _assemblyFinishedCount;
+        private int _consoleErrorCountAtCompileStart;
         private readonly CompileLifecycleRecoveryCoordinator _recoveryCoordinator;
 
         public CompileController(
@@ -45,8 +46,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 () => EditorApplication.isCompiling,
                 IsCompileRequestCompleted,
                 () => _currentCompileTask,
-                () => new AssemblyDefinitionConsoleErrorValidationService().FindCurrentErrors(),
+                entries => new AssemblyDefinitionConsoleErrorValidationService().FindErrors(entries),
                 ReadConsoleErrorEntries,
+                () => _consoleErrorCountAtCompileStart,
                 () => new AssemblyDefinitionDuplicationValidationService().ValidateNoDuplicateAsmdefNames(),
                 () => _isForceCompile,
                 () => _compileMessages.ToArray(),
@@ -179,6 +181,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             TaskCompletionSource<CompileResult> compileTask = new();
             _currentCompileTask = compileTask;
             _isForceCompile = forceRecompile;
+            // Why before Refresh: the asmdef import errors that abort a compile are logged during
+            // AssetDatabase.Refresh, so the boundary must precede it to keep them in the summary.
+            _consoleErrorCountAtCompileStart = ReadConsoleErrorEntries().Length;
             bool eventsRegistered = false;
             bool compileTaskTransferred = false;
 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileErrorNextActionsComposer.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileErrorNextActionsComposer.cs
@@ -26,24 +26,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             string[] messages = new string[errors.Length];
+            CompileErrorOrigin[] origins = new CompileErrorOrigin[errors.Length];
             for (int index = 0; index < errors.Length; index++)
             {
                 messages[index] = errors[index].message;
+                origins[index] = new CompileErrorOrigin(errors[index].message, errors[index].file);
             }
 
             string[] additions = CompileErrorNextActionsBuilder.Build(
                 messages,
                 CompileMissingReferenceAssemblyLookup.CreateLazyFinder());
-            if (additions.Length == 0)
-            {
-                return;
-            }
-
-            response.NextActions = Append(response.NextActions, additions);
+            string[] assemblyDefinitionHints = CompileAssemblyDefinitionReferenceHintBuilder.Build(
+                origins,
+                CompilationPipeline.GetAssemblyDefinitionFilePathFromScriptPath);
+            response.NextActions = Append(Append(response.NextActions, additions), assemblyDefinitionHints);
         }
 
         private static string[] Append(string[] existing, string[] additions)
         {
+            // Why: a null NextActions must stay null when nothing matched, so the JSON shape is unchanged.
+            if (additions == null || additions.Length == 0)
+            {
+                return existing;
+            }
+
             if (existing == null || existing.Length == 0)
             {
                 return additions;

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileErrorNextActionsConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileErrorNextActionsConstants.cs
@@ -21,6 +21,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public const string Cs0234ErrorCode = "CS0234";
 
+        public const string Cs0246ErrorCode = "CS0246";
+
+        public const string MissingTypePattern =
+            @"The type or namespace name '(?<name>[^']+)' could not be found";
+
+        public const string AssemblyDefinitionReferenceHintFormat =
+            "error {0}: '{1}' could not be found from a script under '{2}'. If that type lives in another assembly (for example the script was recently moved under a new asmdef), add the declaring assembly to that asmdef's references and run 'uloop compile' again; if the name is a typo, fix the name instead.";
+
         public const string SingleDeclaringAssemblyFormat = "assembly '{0}'";
 
         public const string MultipleDeclaringAssembliesFormat = "assemblies '{0}'";

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileErrorOrigin.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileErrorOrigin.cs
@@ -1,0 +1,17 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Compiler error text paired with the script path it was reported from, without depending on CompilerMessage.
+    /// </summary>
+    internal sealed class CompileErrorOrigin
+    {
+        internal string Message { get; }
+        internal string File { get; }
+
+        internal CompileErrorOrigin(string message, string file)
+        {
+            Message = message ?? string.Empty;
+            File = file ?? string.Empty;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileErrorOrigin.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileErrorOrigin.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d4966bb2c6514b74b65fa8341c0547d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileIndeterminateErrorSummaryBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileIndeterminateErrorSummaryBuilder.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Summarizes the most recent Unity Console errors for indeterminate compile results so the
+    /// likely cause is visible in the compile response itself.
+    /// </summary>
+    internal static class CompileIndeterminateErrorSummaryBuilder
+    {
+        internal const string Header = "Recent Console errors:";
+        internal const int MaxEntries = 5;
+        internal const int MaxLineLength = 300;
+        private const string LinePrefix = "- ";
+        private const string Ellipsis = "...";
+
+        /// <summary>
+        /// Returns the summary block, or null when the Console holds no usable error entries.
+        /// Why only the most recent entries: an aborted compile leaves its cause at the tail of the
+        /// Console, and older unrelated errors would bury it.
+        /// </summary>
+        internal static string Build(UnityCliLoopConsoleLogEntry[] consoleEntries)
+        {
+            Debug.Assert(consoleEntries != null, "consoleEntries must not be null");
+
+            List<string> lines = new List<string>();
+            HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
+            for (int index = consoleEntries.Length - 1; index >= 0; index--)
+            {
+                if (lines.Count >= MaxEntries)
+                {
+                    break;
+                }
+
+                string line = ToSummaryLine(consoleEntries[index]);
+                if (line == null || !seen.Add(line))
+                {
+                    continue;
+                }
+
+                lines.Add(line);
+            }
+
+            if (lines.Count == 0)
+            {
+                return null;
+            }
+
+            // Why reverse: entries were collected newest-first, but Console order reads naturally.
+            lines.Reverse();
+            return Header + "\n" + string.Join("\n", lines);
+        }
+
+        private static string ToSummaryLine(UnityCliLoopConsoleLogEntry entry)
+        {
+            if (entry == null ||
+                !string.Equals(entry.Type, UnityCliLoopLogType.Error, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            string firstLine = ExtractFirstLine(entry.Message);
+            if (firstLine.Length == 0)
+            {
+                return null;
+            }
+
+            if (firstLine.Length > MaxLineLength)
+            {
+                firstLine = firstLine.Substring(0, MaxLineLength) + Ellipsis;
+            }
+
+            return LinePrefix + firstLine;
+        }
+
+        private static string ExtractFirstLine(string message)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                return string.Empty;
+            }
+
+            int newlineIndex = message.IndexOfAny(new[] { '\r', '\n' });
+            string firstLine = newlineIndex < 0 ? message : message.Substring(0, newlineIndex);
+            return firstLine.Trim();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileIndeterminateErrorSummaryBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileIndeterminateErrorSummaryBuilder.cs
@@ -53,6 +53,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return Header + "\n" + string.Join("\n", lines);
         }
 
+        /// <summary>
+        /// Returns the entries logged after the compile request started.
+        /// Why fall back to every entry: a Console cleared during the request shrinks below the
+        /// boundary, and dropping everything would hide the error that aborted the compile.
+        /// </summary>
+        internal static UnityCliLoopConsoleLogEntry[] TakeEntriesAfter(
+            UnityCliLoopConsoleLogEntry[] consoleEntries,
+            int boundaryCount)
+        {
+            Debug.Assert(consoleEntries != null, "consoleEntries must not be null");
+            Debug.Assert(boundaryCount >= 0, "boundaryCount must not be negative");
+
+            if (boundaryCount <= 0 || boundaryCount > consoleEntries.Length)
+            {
+                return consoleEntries;
+            }
+
+            UnityCliLoopConsoleLogEntry[] recent = new UnityCliLoopConsoleLogEntry[consoleEntries.Length - boundaryCount];
+            Array.Copy(consoleEntries, boundaryCount, recent, 0, recent.Length);
+            return recent;
+        }
+
         private static string ToSummaryLine(UnityCliLoopConsoleLogEntry entry)
         {
             if (entry == null ||

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileIndeterminateErrorSummaryBuilder.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileIndeterminateErrorSummaryBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 104ca49395a5646afa83f2e40722a56c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleRecoveryCoordinator.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleRecoveryCoordinator.cs
@@ -14,14 +14,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// Decides and triggers recovery actions when CompileLifecycleWatchdog observes a stalled or
     /// faulted compile request. Assembly Definition validation, message building, and abort actions
     /// are injected so these recovery decisions can be pinned with tests without running Unity compilation.
+    /// Why one Console snapshot per recovery: asmdef validation and the indeterminate summary both read
+    /// the Console, and scanning it twice on the main thread doubles recovery work for nothing.
     /// </summary>
     internal sealed class CompileLifecycleRecoveryCoordinator
     {
         private readonly Func<bool> _isEditorCompiling;
         private readonly Func<bool> _isRequestCompleted;
         private readonly Func<TaskCompletionSource<CompileResult>> _getCurrentCompileTask;
-        private readonly Func<AssemblyDefinitionConsoleErrorResult> _findAssemblyDefinitionErrors;
+        private readonly Func<UnityCliLoopConsoleLogEntry[], AssemblyDefinitionConsoleErrorResult> _findAssemblyDefinitionErrors;
         private readonly Func<UnityCliLoopConsoleLogEntry[]> _getConsoleErrorEntries;
+        private readonly Func<int> _getConsoleErrorCountAtCompileStart;
         private readonly Func<ValidationResult> _validateNoDuplicateAsmdefNames;
         private readonly Func<bool> _getIsForceCompile;
         private readonly Func<CompilerMessage[]> _getCompileMessages;
@@ -35,8 +38,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Func<bool> isEditorCompiling,
             Func<bool> isRequestCompleted,
             Func<TaskCompletionSource<CompileResult>> getCurrentCompileTask,
-            Func<AssemblyDefinitionConsoleErrorResult> findAssemblyDefinitionErrors,
+            Func<UnityCliLoopConsoleLogEntry[], AssemblyDefinitionConsoleErrorResult> findAssemblyDefinitionErrors,
             Func<UnityCliLoopConsoleLogEntry[]> getConsoleErrorEntries,
+            Func<int> getConsoleErrorCountAtCompileStart,
             Func<ValidationResult> validateNoDuplicateAsmdefNames,
             Func<bool> getIsForceCompile,
             Func<CompilerMessage[]> getCompileMessages,
@@ -51,6 +55,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(getCurrentCompileTask != null, "getCurrentCompileTask must not be null");
             Debug.Assert(findAssemblyDefinitionErrors != null, "findAssemblyDefinitionErrors must not be null");
             Debug.Assert(getConsoleErrorEntries != null, "getConsoleErrorEntries must not be null");
+            Debug.Assert(
+                getConsoleErrorCountAtCompileStart != null,
+                "getConsoleErrorCountAtCompileStart must not be null");
             Debug.Assert(validateNoDuplicateAsmdefNames != null, "validateNoDuplicateAsmdefNames must not be null");
             Debug.Assert(getIsForceCompile != null, "getIsForceCompile must not be null");
             Debug.Assert(getCompileMessages != null, "getCompileMessages must not be null");
@@ -67,6 +74,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 throw new ArgumentNullException(nameof(findAssemblyDefinitionErrors));
             _getConsoleErrorEntries = getConsoleErrorEntries ??
                 throw new ArgumentNullException(nameof(getConsoleErrorEntries));
+            _getConsoleErrorCountAtCompileStart = getConsoleErrorCountAtCompileStart ??
+                throw new ArgumentNullException(nameof(getConsoleErrorCountAtCompileStart));
             _validateNoDuplicateAsmdefNames = validateNoDuplicateAsmdefNames ??
                 throw new ArgumentNullException(nameof(validateNoDuplicateAsmdefNames));
             _getIsForceCompile = getIsForceCompile ?? throw new ArgumentNullException(nameof(getIsForceCompile));
@@ -187,7 +196,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         internal void HandleCompileStartTimeout(int waitedMs)
         {
-            AssemblyDefinitionConsoleErrorResult assemblyDefinitionErrors = _findAssemblyDefinitionErrors();
+            AssemblyDefinitionConsoleErrorResult assemblyDefinitionErrors =
+                _findAssemblyDefinitionErrors(_getConsoleErrorEntries());
             if (assemblyDefinitionErrors.HasErrors)
             {
                 VibeLogger.LogWarning(
@@ -237,13 +247,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 "The compile result is indeterminate; use get-logs to inspect the compiler output.";
             // Why append the Console errors: the indeterminate result otherwise costs a second
             // get-logs round trip to see the asmdef or compiler error that aborted the compile.
-            string consoleErrorSummary = CompileIndeterminateErrorSummaryBuilder.Build(_getConsoleErrorEntries());
+            // Why only entries after the compile-start boundary: older Console errors belong to
+            // earlier sessions and would be misread as this compile's cause.
+            UnityCliLoopConsoleLogEntry[] consoleErrorEntries = _getConsoleErrorEntries();
+            string consoleErrorSummary = CompileIndeterminateErrorSummaryBuilder.Build(
+                CompileIndeterminateErrorSummaryBuilder.TakeEntriesAfter(
+                    consoleErrorEntries,
+                    _getConsoleErrorCountAtCompileStart()));
             if (consoleErrorSummary != null)
             {
                 message = message + "\n" + consoleErrorSummary;
             }
 
-            AssemblyDefinitionConsoleErrorResult assemblyDefinitionErrors = _findAssemblyDefinitionErrors();
+            AssemblyDefinitionConsoleErrorResult assemblyDefinitionErrors =
+                _findAssemblyDefinitionErrors(consoleErrorEntries);
             CompilerMessage[] compileMessages = _getCompileMessages();
             bool isForceCompile = _getIsForceCompile();
             CompileResult result = CompileResultFactory.CreateStoppedWithoutFinishResult(

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleRecoveryCoordinator.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleRecoveryCoordinator.cs
@@ -21,6 +21,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly Func<bool> _isRequestCompleted;
         private readonly Func<TaskCompletionSource<CompileResult>> _getCurrentCompileTask;
         private readonly Func<AssemblyDefinitionConsoleErrorResult> _findAssemblyDefinitionErrors;
+        private readonly Func<UnityCliLoopConsoleLogEntry[]> _getConsoleErrorEntries;
         private readonly Func<ValidationResult> _validateNoDuplicateAsmdefNames;
         private readonly Func<bool> _getIsForceCompile;
         private readonly Func<CompilerMessage[]> _getCompileMessages;
@@ -35,6 +36,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Func<bool> isRequestCompleted,
             Func<TaskCompletionSource<CompileResult>> getCurrentCompileTask,
             Func<AssemblyDefinitionConsoleErrorResult> findAssemblyDefinitionErrors,
+            Func<UnityCliLoopConsoleLogEntry[]> getConsoleErrorEntries,
             Func<ValidationResult> validateNoDuplicateAsmdefNames,
             Func<bool> getIsForceCompile,
             Func<CompilerMessage[]> getCompileMessages,
@@ -48,6 +50,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(isRequestCompleted != null, "isRequestCompleted must not be null");
             Debug.Assert(getCurrentCompileTask != null, "getCurrentCompileTask must not be null");
             Debug.Assert(findAssemblyDefinitionErrors != null, "findAssemblyDefinitionErrors must not be null");
+            Debug.Assert(getConsoleErrorEntries != null, "getConsoleErrorEntries must not be null");
             Debug.Assert(validateNoDuplicateAsmdefNames != null, "validateNoDuplicateAsmdefNames must not be null");
             Debug.Assert(getIsForceCompile != null, "getIsForceCompile must not be null");
             Debug.Assert(getCompileMessages != null, "getCompileMessages must not be null");
@@ -62,6 +65,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _getCurrentCompileTask = getCurrentCompileTask ?? throw new ArgumentNullException(nameof(getCurrentCompileTask));
             _findAssemblyDefinitionErrors = findAssemblyDefinitionErrors ??
                 throw new ArgumentNullException(nameof(findAssemblyDefinitionErrors));
+            _getConsoleErrorEntries = getConsoleErrorEntries ??
+                throw new ArgumentNullException(nameof(getConsoleErrorEntries));
             _validateNoDuplicateAsmdefNames = validateNoDuplicateAsmdefNames ??
                 throw new ArgumentNullException(nameof(validateNoDuplicateAsmdefNames));
             _getIsForceCompile = getIsForceCompile ?? throw new ArgumentNullException(nameof(getIsForceCompile));
@@ -230,6 +235,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string message =
                 "Unity stopped compiling before Unity CLI Loop received the compilationFinished callback. " +
                 "The compile result is indeterminate; use get-logs to inspect the compiler output.";
+            // Why append the Console errors: the indeterminate result otherwise costs a second
+            // get-logs round trip to see the asmdef or compiler error that aborted the compile.
+            string consoleErrorSummary = CompileIndeterminateErrorSummaryBuilder.Build(_getConsoleErrorEntries());
+            if (consoleErrorSummary != null)
+            {
+                message = message + "\n" + consoleErrorSummary;
+            }
+
             AssemblyDefinitionConsoleErrorResult assemblyDefinitionErrors = _findAssemblyDefinitionErrors();
             CompilerMessage[] compileMessages = _getCompileMessages();
             bool isForceCompile = _getIsForceCompile();

--- a/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
@@ -49,6 +49,9 @@ Returns JSON:
 - `WarningCount`: number or null
 - `Message`: string
 - `ErrorCode`: string or null. `COMPILE_ALREADY_IN_PROGRESS` when Unity is already compiling, `COMPILE_EDITOR_UPDATING` when the editor is updating, `COMPILE_RESULT_UNKNOWN` after a forced recompile that did not return a definitive result.
+- `NextActions`: string array or null. Corrective steps derived from the errors, e.g. the assembly that declares an unresolved namespace (CS0234), or, for CS0246 in a script under an asmdef, a reminder to check that asmdef's references (the type may instead be a typo — decide from the error).
+
+When Unity stops compiling before the finish callback (`Success: null`, indeterminate), `Message` keeps the get-logs pointer and appends `Recent Console errors:` with the last few Console errors (typically the asmdef or compiler error that aborted the compile), so fix from that list before reaching for `uloop get-logs`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

`uloop compile` now surfaces compiler-error diagnosis directly in the response, in two places:

1. **Indeterminate result summary.** When Unity stops compiling before the `compilationFinished` callback, the `Message` keeps the existing indeterminate wording and the get-logs pointer, and appends a `Recent Console errors:` block with the last few Console errors (deduplicated, first line only, truncated).
2. **Asmdef reference-gap hint (from #2316).** When a `CS0246` error is raised from a script that belongs to an Assembly Definition, `NextActions` gains one hint per asmdef pointing at that asmdef's references, while noting that a typo is the other likely cause. Scripts outside any asmdef get no hint, which keeps typo-induced noise down.

Closes #2348

## User Impact

- An asmdef misconfiguration that aborts compilation no longer costs a second `uloop get-logs` round trip: the aborting error is visible in the compile response itself.
- Scripts recently moved under a new asmdef that fail with `CS0246` now get a pointer to the asmdef's reference list in the same response.
- Successful compiles, force compiles, and unmatched errors are unchanged; `NextActions` stays `null` when nothing matched.

## Changes

- `CompileIndeterminateErrorSummaryBuilder` (pure): builds the `Recent Console errors:` block from a Console snapshot (max 5 most recent errors, Console order, 300-char lines).
- `CompileLifecycleRecoveryCoordinator`: takes a Console error snapshot reader and appends the summary to the missed-finish-callback message; `CompileController` wires it through `LogRetrievalService`.
- `CompileAssemblyDefinitionReferenceHintBuilder` (pure) plus `CompileErrorOrigin`: the CS0246 hint, keyed on an injected script-to-asmdef resolver.
- `CompileErrorNextActionsComposer`: resolves the asmdef via `CompilationPipeline.GetAssemblyDefinitionFilePathFromScriptPath` and appends the hints after the existing language-version and CS0234 actions; appending nothing now leaves `NextActions` untouched.
- Compile skill documents `NextActions` and the indeterminate summary; generated skill copies regenerated.

## Verification

- EditMode tests (all passing, 63 tests): `CompileIndeterminateErrorSummaryBuilderTests`, `CompileAssemblyDefinitionReferenceHintBuilderTests`, `CompileLifecycleRecoveryCoordinatorTests`, `CompileErrorNextActionsComposerTests` (including a live `CompilationPipeline` resolution against the test asmdef), `CompileResponseFactoryTests`.
- Live check: a scratch script under `Assets/Tests/Editor/` referencing an unknown type produced the `CS0246` error plus the new NextAction naming `Assets/Tests/Editor/UnityCLILoop.Tests.Editor.asmdef`; scratch removed, compile clean.
- Live check: a scratch asmdef with duplicate references is still reported through the existing determinate asmdef-import path (unchanged); the indeterminate branch is pinned by the coordinator tests.
- `check-skill-size` passes (SKILL.md 4,104 bytes); `sync-tool-docs` reports the catalog up to date (no parameter table changes).

https://claude.ai/code/session_01R3jkx6NbNYKPdy5q1NSWYo


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

