### PR TITLE
feat: run-tests proposes a ready-to-write test asmdef when no test assembly exists

### DIFF
--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -16,7 +16,7 @@ Active pause points are automatically cleared (the underlying code patches are r
 
 A test run can end by discarding active hot-reload changes: script edits imported during the run are compiled when the test runner releases its assembly-reload lock, and that deferred domain reload wipes the patches even though the tests themselves ran patched. The response's Warning field reports this; re-apply 'uloop hot-reload' or bake the edits in with 'uloop compile' before the next Play or test run.
 
-`NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints.
+`NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints. When the project has no test assembly for the TestMode, `ProposedTestAsmdef` carries a ready-to-write `.asmdef`: save `Content` at `AssetPath`, move the test scripts under that folder, then compile and rerun.
 
 ## Usage
 
@@ -56,6 +56,7 @@ Returns JSON with:
 - `ClearedPausePointIds` (string[], optional): IDs of pause points that were cleared before test execution. Omitted from JSON when no pause points were active.
 - `FailedTests` (array, optional): Up to 10 failed leaf tests with `FullName`, `Message`, and when the stack trace contains a path:line location, `File` and `Line`. Omitted when no tests failed. When `FailedCount` is greater than 10, `Message` ends with `first 10 of N failures listed; see XmlPath for full results.`
 - `SkippedTests` (string[], optional): Up to 10 full names of skipped leaf tests. Omitted when no tests were skipped. When `SkippedCount` is greater than 10, only the first 10 names are listed.
+- `ProposedTestAsmdef` (object, optional): `AssetPath` and `Content` of a ready-to-write test `.asmdef` (test-assembly wiring plus references to the project's assemblies under test). Present only when an unfiltered run found no tests and no test assembly exists for the TestMode.
 - `CompileNote` (string, optional): States that the automatic compile ran and succeeded before the tests and names `--skip-compile` as the opt-out. Omitted when `--skip-compile` was passed; a failed compile returns the compile error response instead.
 
 ### XML Result File

--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -16,7 +16,7 @@ Active pause points are automatically cleared (the underlying code patches are r
 
 A test run can end by discarding active hot-reload changes: script edits imported during the run are compiled when the test runner releases its assembly-reload lock, and that deferred domain reload wipes the patches even though the tests themselves ran patched. The response's Warning field reports this; re-apply 'uloop hot-reload' or bake the edits in with 'uloop compile' before the next Play or test run.
 
-`NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints. When the project has no test assembly for the TestMode, `ProposedTestAsmdef` carries a ready-to-write `.asmdef`: save `Content` at `AssetPath`, move the test scripts under that folder, then compile and rerun.
+`NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints. When an unfiltered run finds no tests and the project has no test assembly for the TestMode, `ProposedTestAsmdef` carries a ready-to-write `.asmdef`: save `Content` at `AssetPath`, move the test scripts under that folder, then compile and rerun.
 
 ## Usage
 

--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -16,7 +16,7 @@ Active pause points are automatically cleared (the underlying code patches are r
 
 A test run can end by discarding active hot-reload changes: script edits imported during the run are compiled when the test runner releases its assembly-reload lock, and that deferred domain reload wipes the patches even though the tests themselves ran patched. The response's Warning field reports this; re-apply 'uloop hot-reload' or bake the edits in with 'uloop compile' before the next Play or test run.
 
-`NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints.
+`NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints. When the project has no test assembly for the TestMode, `ProposedTestAsmdef` carries a ready-to-write `.asmdef`: save `Content` at `AssetPath`, move the test scripts under that folder, then compile and rerun.
 
 ## Usage
 
@@ -56,6 +56,7 @@ Returns JSON with:
 - `ClearedPausePointIds` (string[], optional): IDs of pause points that were cleared before test execution. Omitted from JSON when no pause points were active.
 - `FailedTests` (array, optional): Up to 10 failed leaf tests with `FullName`, `Message`, and when the stack trace contains a path:line location, `File` and `Line`. Omitted when no tests failed. When `FailedCount` is greater than 10, `Message` ends with `first 10 of N failures listed; see XmlPath for full results.`
 - `SkippedTests` (string[], optional): Up to 10 full names of skipped leaf tests. Omitted when no tests were skipped. When `SkippedCount` is greater than 10, only the first 10 names are listed.
+- `ProposedTestAsmdef` (object, optional): `AssetPath` and `Content` of a ready-to-write test `.asmdef` (test-assembly wiring plus references to the project's assemblies under test). Present only when an unfiltered run found no tests and no test assembly exists for the TestMode.
 - `CompileNote` (string, optional): States that the automatic compile ran and succeeded before the tests and names `--skip-compile` as the opt-out. Omitted when `--skip-compile` was passed; a failed compile returns the compile error response instead.
 
 ### XML Result File

--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -16,7 +16,7 @@ Active pause points are automatically cleared (the underlying code patches are r
 
 A test run can end by discarding active hot-reload changes: script edits imported during the run are compiled when the test runner releases its assembly-reload lock, and that deferred domain reload wipes the patches even though the tests themselves ran patched. The response's Warning field reports this; re-apply 'uloop hot-reload' or bake the edits in with 'uloop compile' before the next Play or test run.
 
-`NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints. When the project has no test assembly for the TestMode, `ProposedTestAsmdef` carries a ready-to-write `.asmdef`: save `Content` at `AssetPath`, move the test scripts under that folder, then compile and rerun.
+`NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints. When an unfiltered run finds no tests and the project has no test assembly for the TestMode, `ProposedTestAsmdef` carries a ready-to-write `.asmdef`: save `Content` at `AssetPath`, move the test scripts under that folder, then compile and rerun.
 
 ## Usage
 

--- a/Assets/Tests/Editor/RunTestsTestAsmdefProposalBuilderTests.cs
+++ b/Assets/Tests/Editor/RunTestsTestAsmdefProposalBuilderTests.cs
@@ -13,6 +13,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     public sealed class RunTestsTestAsmdefProposalBuilderTests
     {
         private const string ProductName = "My Game";
+        private static readonly string[] NoExistingAssemblies = Array.Empty<string>();
 
         [Test]
         public void Build_WhenAnEditorTestAsmdefExists_ReturnsNullForEditMode()
@@ -24,7 +25,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 TestAsmdef("Assets/Tests/Editor/Game.Tests.Editor.asmdef", "Game.Tests.Editor", editorOnly: true)
             };
 
-            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName);
+            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName, NoExistingAssemblies);
 
             Assert.That(proposal, Is.Null);
         }
@@ -39,8 +40,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 TestAsmdef("Assets/Tests/PlayMode/Game.Tests.PlayMode.asmdef", "Game.Tests.PlayMode", editorOnly: false)
             };
 
-            RunTestsTestAsmdefProposal editMode = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName);
-            RunTestsTestAsmdefProposal playMode = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.PlayMode, ProductName);
+            RunTestsTestAsmdefProposal editMode = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName, NoExistingAssemblies);
+            RunTestsTestAsmdefProposal playMode = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.PlayMode, ProductName, NoExistingAssemblies);
 
             Assert.That(editMode, Is.Not.Null);
             Assert.That(playMode, Is.Null);
@@ -53,7 +54,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Assets/Tests/Editor, marked as a test assembly, Editor-only, and referencing that assembly.
             RunTestsAsmdefInfo[] asmdefs = { Runtime("Assets/Scripts/Game.asmdef", "Game") };
 
-            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName);
+            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName, NoExistingAssemblies);
             JObject content = JObject.Parse(proposal.Content);
 
             Assert.That(proposal.AssetPath, Is.EqualTo("Assets/Tests/Editor/Game.Tests.Editor.asmdef"));
@@ -76,7 +77,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 EditorAsmdef("Assets/Editor/Game.Editor.asmdef", "Game.Editor")
             };
 
-            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.PlayMode, ProductName);
+            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.PlayMode, ProductName, NoExistingAssemblies);
             JObject content = JObject.Parse(proposal.Content);
 
             Assert.That(proposal.AssetPath, Is.EqualTo("Assets/Tests/PlayMode/Game.Tests.PlayMode.asmdef"));
@@ -95,7 +96,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Runtime("Assets/Scripts/Game.UI.asmdef", "Game.UI")
             };
 
-            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName);
+            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName, NoExistingAssemblies);
             JObject content = JObject.Parse(proposal.Content);
 
             Assert.That(content["name"].Value<string>(), Is.EqualTo("MyGame.Tests.Editor"));
@@ -106,7 +107,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void Build_WithNoAsmdefsAndUnusableProductName_FallsBackToAGenericName()
         {
             // Verifies a project with no asmdefs and a product name made of symbols still gets a valid proposal.
-            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(Array.Empty<RunTestsAsmdefInfo>(), UnityCliLoopTestMode.EditMode, "!!!");
+            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(Array.Empty<RunTestsAsmdefInfo>(), UnityCliLoopTestMode.EditMode, "!!!", NoExistingAssemblies);
             JObject content = JObject.Parse(proposal.Content);
 
             Assert.That(content["name"].Value<string>(), Is.EqualTo("Project.Tests.Editor"));
@@ -118,17 +119,33 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Verifies the proposal never tells the caller to overwrite an existing asmdef or reuse its
             // assembly name, which Unity rejects as a duplicate.
+            // Why a PlayMode test asmdef: it keeps "Game" the sole assembly under test (so the
+            // preferred name is Game.Tests.Editor) without satisfying the EditMode check.
             RunTestsAsmdefInfo[] asmdefs =
             {
                 Runtime("Assets/Scripts/Game.asmdef", "Game"),
-                Runtime("Assets/Tests/Editor/Game.Tests.Editor.asmdef", "Game.Tests.Editor")
+                TestAsmdef("Assets/Tests/Editor/Game.Tests.Editor.asmdef", "Game.Tests.Editor", editorOnly: false)
             };
 
-            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName);
+            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName, NoExistingAssemblies);
             JObject content = JObject.Parse(proposal.Content);
 
-            Assert.That(proposal.AssetPath, Is.EqualTo("Assets/Tests/Editor/MyGame.Tests.Editor.asmdef"));
-            Assert.That(content["name"].Value<string>(), Is.EqualTo("MyGame.Tests.Editor"));
+            Assert.That(proposal.AssetPath, Is.EqualTo("Assets/Tests/Editor/Game.Tests.Editor2.asmdef"));
+            Assert.That(content["name"].Value<string>(), Is.EqualTo("Game.Tests.Editor2"));
+        }
+
+        [Test]
+        public void Build_WhenACompiledAssemblyOutsideAssetsOwnsThePreferredName_ChoosesAnUnusedName()
+        {
+            // Verifies package and predefined assemblies, which are not loaded as project asmdefs, still
+            // reserve their names, because Unity rejects duplicate assembly names project-wide.
+            RunTestsAsmdefInfo[] asmdefs = { Runtime("Assets/Scripts/Game.asmdef", "Game") };
+            string[] existingAssemblyNames = { "Game.Tests.Editor", "Game.Tests.Editor2" };
+
+            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName, existingAssemblyNames);
+            JObject content = JObject.Parse(proposal.Content);
+
+            Assert.That(content["name"].Value<string>(), Is.EqualTo("Game.Tests.Editor3"));
         }
 
         [Test]
@@ -142,8 +159,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new RunTestsAsmdefInfo("Assets/Tests/Game.Tests.asmdef", "guid-Tests", "Game.Tests", new[] { "UnityEngine.TestRunner" }, Array.Empty<string>(), new[] { "Editor", "Android" }, testAssemblies: false)
             };
 
-            RunTestsTestAsmdefProposal playMode = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.PlayMode, ProductName);
-            RunTestsTestAsmdefProposal editMode = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName);
+            RunTestsTestAsmdefProposal playMode = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.PlayMode, ProductName, NoExistingAssemblies);
+            RunTestsTestAsmdefProposal editMode = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName, NoExistingAssemblies);
             JObject content = JObject.Parse(editMode.Content);
 
             Assert.That(playMode, Is.Null);
@@ -154,7 +171,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void AppendNotice_AddsAPeriodBeforeTheNoticeWhenTheMessageHasNone()
         {
             // Verifies the notice names the proposed path and joins the existing message with a sentence break.
-            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(Array.Empty<RunTestsAsmdefInfo>(), UnityCliLoopTestMode.EditMode, ProductName);
+            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(Array.Empty<RunTestsAsmdefInfo>(), UnityCliLoopTestMode.EditMode, ProductName, NoExistingAssemblies);
 
             string message = RunTestsTestAsmdefProposal.AppendNotice(RunTestsResponse.NoTestsFoundMessage, proposal);
 

--- a/Assets/Tests/Editor/RunTestsTestAsmdefProposalBuilderTests.cs
+++ b/Assets/Tests/Editor/RunTestsTestAsmdefProposalBuilderTests.cs
@@ -114,6 +114,43 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void Build_WhenAnUnmarkedAsmdefOwnsThePreferredName_ChoosesAnUnusedName()
+        {
+            // Verifies the proposal never tells the caller to overwrite an existing asmdef or reuse its
+            // assembly name, which Unity rejects as a duplicate.
+            RunTestsAsmdefInfo[] asmdefs =
+            {
+                Runtime("Assets/Scripts/Game.asmdef", "Game"),
+                Runtime("Assets/Tests/Editor/Game.Tests.Editor.asmdef", "Game.Tests.Editor")
+            };
+
+            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName);
+            JObject content = JObject.Parse(proposal.Content);
+
+            Assert.That(proposal.AssetPath, Is.EqualTo("Assets/Tests/Editor/MyGame.Tests.Editor.asmdef"));
+            Assert.That(content["name"].Value<string>(), Is.EqualTo("MyGame.Tests.Editor"));
+        }
+
+        [Test]
+        public void Build_WhenATestAsmdefTargetsEditorAndAPlayerPlatform_TreatsItAsARuntimeTestAssembly()
+        {
+            // Verifies only a sole Editor platform makes an assembly EditMode: Editor plus a player
+            // platform is a runtime assembly, so it satisfies PlayMode and is referenced by EditMode proposals.
+            RunTestsAsmdefInfo[] asmdefs =
+            {
+                new RunTestsAsmdefInfo("Assets/Scripts/Game.asmdef", "guid-Game", "Game", Array.Empty<string>(), Array.Empty<string>(), new[] { "Editor", "Android" }, testAssemblies: false),
+                new RunTestsAsmdefInfo("Assets/Tests/Game.Tests.asmdef", "guid-Tests", "Game.Tests", new[] { "UnityEngine.TestRunner" }, Array.Empty<string>(), new[] { "Editor", "Android" }, testAssemblies: false)
+            };
+
+            RunTestsTestAsmdefProposal playMode = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.PlayMode, ProductName);
+            RunTestsTestAsmdefProposal editMode = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName);
+            JObject content = JObject.Parse(editMode.Content);
+
+            Assert.That(playMode, Is.Null);
+            Assert.That(content["references"].Values<string>(), Is.EqualTo(new[] { "UnityEngine.TestRunner", "UnityEditor.TestRunner", "Game" }));
+        }
+
+        [Test]
         public void AppendNotice_AddsAPeriodBeforeTheNoticeWhenTheMessageHasNone()
         {
             // Verifies the notice names the proposed path and joins the existing message with a sentence break.

--- a/Assets/Tests/Editor/RunTestsTestAsmdefProposalBuilderTests.cs
+++ b/Assets/Tests/Editor/RunTestsTestAsmdefProposalBuilderTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies the ready-to-write test .asmdef proposal built on zero discovery.
+    /// </summary>
+    public sealed class RunTestsTestAsmdefProposalBuilderTests
+    {
+        private const string ProductName = "My Game";
+
+        [Test]
+        public void Build_WhenAnEditorTestAsmdefExists_ReturnsNullForEditMode()
+        {
+            // Verifies no proposal is made when the project already has a test assembly for the requested mode.
+            RunTestsAsmdefInfo[] asmdefs =
+            {
+                Runtime("Assets/Scripts/Game.asmdef", "Game"),
+                TestAsmdef("Assets/Tests/Editor/Game.Tests.Editor.asmdef", "Game.Tests.Editor", editorOnly: true)
+            };
+
+            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName);
+
+            Assert.That(proposal, Is.Null);
+        }
+
+        [Test]
+        public void Build_WhenOnlyAPlayModeTestAsmdefExists_StillProposesAnEditModeOne()
+        {
+            // Verifies mode relevance is decided by the Editor platform: a runtime test assembly cannot host EditMode tests.
+            RunTestsAsmdefInfo[] asmdefs =
+            {
+                Runtime("Assets/Scripts/Game.asmdef", "Game"),
+                TestAsmdef("Assets/Tests/PlayMode/Game.Tests.PlayMode.asmdef", "Game.Tests.PlayMode", editorOnly: false)
+            };
+
+            RunTestsTestAsmdefProposal editMode = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName);
+            RunTestsTestAsmdefProposal playMode = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.PlayMode, ProductName);
+
+            Assert.That(editMode, Is.Not.Null);
+            Assert.That(playMode, Is.Null);
+        }
+
+        [Test]
+        public void Build_WithSingleRuntimeAsmdef_NamesTheProposalAfterItAndReferencesIt()
+        {
+            // Verifies the proposal is concrete: named after the one assembly under test, saved under
+            // Assets/Tests/Editor, marked as a test assembly, Editor-only, and referencing that assembly.
+            RunTestsAsmdefInfo[] asmdefs = { Runtime("Assets/Scripts/Game.asmdef", "Game") };
+
+            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName);
+            JObject content = JObject.Parse(proposal.Content);
+
+            Assert.That(proposal.AssetPath, Is.EqualTo("Assets/Tests/Editor/Game.Tests.Editor.asmdef"));
+            Assert.That(content["name"].Value<string>(), Is.EqualTo("Game.Tests.Editor"));
+            Assert.That(content["references"].Values<string>(), Is.EqualTo(new[] { "UnityEngine.TestRunner", "UnityEditor.TestRunner", "Game" }));
+            Assert.That(content["includePlatforms"].Values<string>(), Is.EqualTo(new[] { "Editor" }));
+            Assert.That(content["overrideReferences"].Value<bool>(), Is.True);
+            Assert.That(content["precompiledReferences"].Values<string>(), Is.EqualTo(new[] { "nunit.framework.dll" }));
+            Assert.That(content["defineConstraints"].Values<string>(), Is.EqualTo(new[] { "UNITY_INCLUDE_TESTS" }));
+        }
+
+        [Test]
+        public void Build_ForPlayMode_TargetsAllPlatformsAndSkipsEditorOnlyAsmdefs()
+        {
+            // Verifies a PlayMode proposal is not Editor-only and does not reference editor assemblies,
+            // which a runtime test assembly cannot compile against.
+            RunTestsAsmdefInfo[] asmdefs =
+            {
+                Runtime("Assets/Scripts/Game.asmdef", "Game"),
+                EditorAsmdef("Assets/Editor/Game.Editor.asmdef", "Game.Editor")
+            };
+
+            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.PlayMode, ProductName);
+            JObject content = JObject.Parse(proposal.Content);
+
+            Assert.That(proposal.AssetPath, Is.EqualTo("Assets/Tests/PlayMode/Game.Tests.PlayMode.asmdef"));
+            Assert.That(content["includePlatforms"].Values<string>(), Is.Empty);
+            Assert.That(content["references"].Values<string>(), Is.EqualTo(new[] { "UnityEngine.TestRunner", "UnityEditor.TestRunner", "Game" }));
+        }
+
+        [Test]
+        public void Build_WithMultipleRuntimeAsmdefs_UsesSanitizedProductNameAndReferencesAll()
+        {
+            // Verifies the product name (with non-identifier characters removed) names the proposal when no
+            // single assembly under test stands out, and every assembly under test is referenced.
+            RunTestsAsmdefInfo[] asmdefs =
+            {
+                Runtime("Assets/Scripts/Game.Core.asmdef", "Game.Core"),
+                Runtime("Assets/Scripts/Game.UI.asmdef", "Game.UI")
+            };
+
+            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(asmdefs, UnityCliLoopTestMode.EditMode, ProductName);
+            JObject content = JObject.Parse(proposal.Content);
+
+            Assert.That(content["name"].Value<string>(), Is.EqualTo("MyGame.Tests.Editor"));
+            Assert.That(content["references"].Values<string>().Skip(2), Is.EqualTo(new[] { "Game.Core", "Game.UI" }));
+        }
+
+        [Test]
+        public void Build_WithNoAsmdefsAndUnusableProductName_FallsBackToAGenericName()
+        {
+            // Verifies a project with no asmdefs and a product name made of symbols still gets a valid proposal.
+            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(Array.Empty<RunTestsAsmdefInfo>(), UnityCliLoopTestMode.EditMode, "!!!");
+            JObject content = JObject.Parse(proposal.Content);
+
+            Assert.That(content["name"].Value<string>(), Is.EqualTo("Project.Tests.Editor"));
+            Assert.That(content["references"].Values<string>(), Is.EqualTo(new[] { "UnityEngine.TestRunner", "UnityEditor.TestRunner" }));
+        }
+
+        [Test]
+        public void AppendNotice_AddsAPeriodBeforeTheNoticeWhenTheMessageHasNone()
+        {
+            // Verifies the notice names the proposed path and joins the existing message with a sentence break.
+            RunTestsTestAsmdefProposal proposal = RunTestsTestAsmdefProposalBuilder.Build(Array.Empty<RunTestsAsmdefInfo>(), UnityCliLoopTestMode.EditMode, ProductName);
+
+            string message = RunTestsTestAsmdefProposal.AppendNotice(RunTestsResponse.NoTestsFoundMessage, proposal);
+
+            Assert.That(message, Does.StartWith(RunTestsResponse.NoTestsFoundMessage + ". "));
+            Assert.That(message, Does.Contain("ProposedTestAsmdef"));
+            Assert.That(message, Does.Contain("Assets/Tests/Editor/MyGame.Tests.Editor.asmdef"));
+        }
+
+        private static RunTestsAsmdefInfo Runtime(string assetPath, string name)
+        {
+            return new RunTestsAsmdefInfo(assetPath, "guid-" + name, name, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), testAssemblies: false);
+        }
+
+        private static RunTestsAsmdefInfo EditorAsmdef(string assetPath, string name)
+        {
+            return new RunTestsAsmdefInfo(assetPath, "guid-" + name, name, Array.Empty<string>(), Array.Empty<string>(), new[] { "Editor" }, testAssemblies: false);
+        }
+
+        private static RunTestsAsmdefInfo TestAsmdef(string assetPath, string name, bool editorOnly)
+        {
+            string[] includePlatforms = editorOnly ? new[] { "Editor" } : Array.Empty<string>();
+            return new RunTestsAsmdefInfo(assetPath, "guid-" + name, name, new[] { "UnityEngine.TestRunner" }, Array.Empty<string>(), includePlatforms, testAssemblies: false);
+        }
+    }
+}

--- a/Assets/Tests/Editor/RunTestsTestAsmdefProposalBuilderTests.cs
+++ b/Assets/Tests/Editor/RunTestsTestAsmdefProposalBuilderTests.cs
@@ -115,7 +115,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void Build_WhenAnUnmarkedAsmdefOwnsThePreferredName_ChoosesAnUnusedName()
+        public void Build_WhenAPlayModeTestAsmdefOwnsThePreferredName_ChoosesAnUnusedName()
         {
             // Verifies the proposal never tells the caller to overwrite an existing asmdef or reuse its
             // assembly name, which Unity rejects as a duplicate.

--- a/Assets/Tests/Editor/RunTestsTestAsmdefProposalBuilderTests.cs.meta
+++ b/Assets/Tests/Editor/RunTestsTestAsmdefProposalBuilderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb1cb6296608a435492ed25ca8573aad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -949,6 +949,74 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: filter-all NoTestsFound attaches the proposed test .asmdef to the response and names it in Message.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenFilterAllNoTestsFoundWithoutTestAsmdef_AttachesProposedTestAsmdef()
+        {
+            RunTestsTestAsmdefProposal proposal = new RunTestsTestAsmdefProposal("Assets/Tests/Editor/Game.Tests.Editor.asmdef", "{}");
+            StubTestExecutionService executionService = new StubTestExecutionService
+            {
+                NextResult = CreateNoTestsFoundResult()
+            };
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                new StubTestExecutionStateValidationService(ValidationResult.Success()),
+                waitForTestRunnerCleanupAsync: NoCleanupWait,
+                appendNoTestsDiagnostics: PassThroughNoTestsDiagnostics,
+                proposeTestAsmdef: _ => proposal);
+            RunTestsSchema parameters = new RunTestsSchema
+            {
+                TestMode = UnityCliLoopTestMode.EditMode,
+                FilterType = TestFilterType.all
+            };
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.ProposedTestAsmdef, Is.SameAs(proposal));
+            Assert.That(response.ShouldSerializeProposedTestAsmdef(), Is.True);
+            Assert.That(response.Message, Does.StartWith(RunTestsResponse.NoTestsFoundMessage + ". "));
+            Assert.That(response.Message, Does.Contain("Assets/Tests/Editor/Game.Tests.Editor.asmdef"));
+        }
+
+        /// <summary>
+        /// What: a filtered NoTestsFound run never asks for a test .asmdef proposal, because the filter is the likelier cause.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenFilteredNoTestsFound_DoesNotProposeTestAsmdef()
+        {
+            bool proposalRequested = false;
+            StubTestExecutionService executionService = new StubTestExecutionService
+            {
+                NextResult = CreateNoTestsFoundResult(),
+                UnfilteredTestListResult = RunTestsUnfilteredTestListResult.Success(new[] { "Example.Tests.Alpha" })
+            };
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                new StubTestExecutionStateValidationService(ValidationResult.Success()),
+                waitForTestRunnerCleanupAsync: NoCleanupWait,
+                proposeTestAsmdef: _ =>
+                {
+                    proposalRequested = true;
+                    return null;
+                });
+            RunTestsSchema parameters = new RunTestsSchema
+            {
+                TestMode = UnityCliLoopTestMode.EditMode,
+                FilterType = TestFilterType.exact,
+                FilterValue = "Missing.Test"
+            };
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(proposalRequested, Is.False);
+            Assert.That(response.ProposedTestAsmdef, Is.Null);
+            Assert.That(response.ShouldSerializeProposedTestAsmdef(), Is.False);
+        }
+
+        /// <summary>
         /// What: filter-all NoTestsFound appends the predefined-assembly notice after the original message when findings exist.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -981,6 +981,36 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: an unfiltered NoTestsFound run whose project already has a test assembly leaves the response untouched.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenFilterAllNoTestsFoundWithTestAsmdef_LeavesResponseWithoutProposal()
+        {
+            StubTestExecutionService executionService = new StubTestExecutionService
+            {
+                NextResult = CreateNoTestsFoundResult()
+            };
+            RunTestsUseCase useCase = new RunTestsUseCase(
+                new TestFilterCreationService(),
+                executionService,
+                new StubTestExecutionStateValidationService(ValidationResult.Success()),
+                waitForTestRunnerCleanupAsync: NoCleanupWait,
+                appendNoTestsDiagnostics: PassThroughNoTestsDiagnostics,
+                proposeTestAsmdef: _ => null);
+            RunTestsSchema parameters = new RunTestsSchema
+            {
+                TestMode = UnityCliLoopTestMode.EditMode,
+                FilterType = TestFilterType.all
+            };
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.ProposedTestAsmdef, Is.Null);
+            Assert.That(response.ShouldSerializeProposedTestAsmdef(), Is.False);
+            Assert.That(response.Message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
+        }
+
+        /// <summary>
         /// What: a filtered NoTestsFound run never asks for a test .asmdef proposal, because the filter is the likelier cause.
         /// </summary>
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs
@@ -30,6 +30,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal const string PredefinedAssemblyTestNoticeFormat =
             " Additionally, {0} NUnit test method(s) are compiled into predefined assemblies rather than any test assembly, so this run could not discover them: {1}. Move these scripts into a folder whose .asmdef has Test Assemblies enabled (EditMode tests target the Editor platform only), reference the assemblies under test, then run 'uloop compile' and rerun the tests.";
 
+        // Format: proposed asset path. Appended after the asmdef hints and the predefined-assembly
+        // notice, so it inherits their leading-space convention.
+        internal const string TestAsmdefProposalNoticeFormat =
+            " No test assembly exists for this TestMode, so no test script can be discovered until one is added. ProposedTestAsmdef holds a ready-to-write .asmdef for {0}: save it there, move the test scripts under that folder, then run 'uloop compile' and rerun the tests.";
+
         // Why a listing timeout instead of --timeout-seconds: RetrieveTestList is a catalog
         // callback, not a test run. Waiting the full run timeout would stall a no-tests
         // response for minutes when the callback never arrives.

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsNoTestsDiagnosticService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsNoTestsDiagnosticService.cs
@@ -15,11 +15,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal sealed class RunTestsNoTestsDiagnosticService
     {
         private const string HintPrefix = " Possible asmdef issues:";
-        private const string TestAssembliesReference = "TestAssemblies";
-        private const string UnityEngineTestRunnerReference = "UnityEngine.TestRunner";
-        private const string UnityEditorTestRunnerReference = "UnityEditor.TestRunner";
-        private const string UnityEngineTestRunnerGuidReference = "GUID:27619889b8ba8c24980f49ee34dbb44a";
-        private const string UnityEditorTestRunnerGuidReference = "GUID:0acc523941302664db1f4e527237feb3";
         private const int MaxFindings = 4;
 
         public string AppendDiagnosticsIfNeeded(
@@ -44,16 +39,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal static string AppendDiagnosticsOrOriginalMessage(string message, Func<string> appendDiagnostics)
         {
-            Debug.Assert(appendDiagnostics != null, "appendDiagnostics must not be null");
+            return InspectAsmdefsOrFallback(message, appendDiagnostics);
+        }
+
+        /// <summary>
+        /// Runs an asmdef inspection and returns the fallback when the project files cannot be
+        /// read, so optional no-tests guidance never replaces the run-tests result with an I/O failure.
+        /// </summary>
+        internal static T InspectAsmdefsOrFallback<T>(T fallback, Func<T> inspect)
+        {
+            Debug.Assert(inspect != null, "inspect must not be null");
 
             try
             {
-                return appendDiagnostics();
+                return inspect();
             }
             catch (Exception exception) when (IsRecoverableAsmdefInspectionException(exception))
             {
                 Debug.LogWarning($"Failed to build no-tests diagnostics: {exception}");
-                return message;
+                return fallback;
             }
         }
 
@@ -156,7 +160,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return filterType == TestFilterType.all && noTestsFound;
         }
 
-        private static RunTestsAsmdefInfo[] LoadProjectAsmdefs()
+        internal static RunTestsAsmdefInfo[] LoadProjectAsmdefs()
         {
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             string[] asmdefGuids = AssetDatabase.FindAssets("t:AssemblyDefinitionAsset");
@@ -285,32 +289,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(asmdef != null, "asmdef must not be null");
 
-            return asmdef.TestAssemblies
-                   || asmdef.OptionalUnityReferences.Contains(TestAssembliesReference);
-        }
-
-        private static bool HasNamedDirectTestRunnerReference(RunTestsAsmdefInfo asmdef)
-        {
-            Debug.Assert(asmdef != null, "asmdef must not be null");
-
-            return asmdef.References.Contains(UnityEngineTestRunnerReference)
-                   || asmdef.References.Contains(UnityEditorTestRunnerReference);
+            return asmdef.HasTestAssemblyMarker();
         }
 
         private static bool HasAnyDirectTestRunnerReference(RunTestsAsmdefInfo asmdef)
         {
             Debug.Assert(asmdef != null, "asmdef must not be null");
 
-            return HasNamedDirectTestRunnerReference(asmdef)
-                   || asmdef.References.Contains(UnityEngineTestRunnerGuidReference)
-                   || asmdef.References.Contains(UnityEditorTestRunnerGuidReference);
+            return asmdef.HasDirectTestRunnerReference();
         }
 
         private static bool IncludesEditorPlatform(RunTestsAsmdefInfo asmdef)
         {
             Debug.Assert(asmdef != null, "asmdef must not be null");
 
-            return asmdef.IncludePlatforms.Contains("Editor");
+            return asmdef.IncludesEditorPlatform();
         }
 
         private static bool LooksLikeEditModeAsmdef(RunTestsAsmdefInfo asmdef)
@@ -399,6 +392,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             TestAssemblies = testAssemblies;
         }
 
+        private const string TestAssembliesReference = "TestAssemblies";
+        private const string UnityEngineTestRunnerReference = "UnityEngine.TestRunner";
+        private const string UnityEditorTestRunnerReference = "UnityEditor.TestRunner";
+        private const string UnityEngineTestRunnerGuidReference = "GUID:27619889b8ba8c24980f49ee34dbb44a";
+        private const string UnityEditorTestRunnerGuidReference = "GUID:0acc523941302664db1f4e527237feb3";
+
         public string AssetPath { get; }
         public string Guid { get; }
         public string Name { get; }
@@ -406,6 +405,31 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string[] OptionalUnityReferences { get; }
         public string[] IncludePlatforms { get; }
         public bool TestAssemblies { get; }
+
+        public bool HasTestAssemblyMarker()
+        {
+            return TestAssemblies || OptionalUnityReferences.Contains(TestAssembliesReference);
+        }
+
+        // Why GUIDs as well as names: the Inspector writes TestRunner references as GUIDs, so a
+        // name-only check would miss every asmdef created through the UI.
+        public bool HasDirectTestRunnerReference()
+        {
+            return References.Contains(UnityEngineTestRunnerReference)
+                   || References.Contains(UnityEditorTestRunnerReference)
+                   || References.Contains(UnityEngineTestRunnerGuidReference)
+                   || References.Contains(UnityEditorTestRunnerGuidReference);
+        }
+
+        public bool IsTestAssembly()
+        {
+            return HasTestAssemblyMarker() || HasDirectTestRunnerReference();
+        }
+
+        public bool IncludesEditorPlatform()
+        {
+            return IncludePlatforms.Contains("Editor");
+        }
     }
 
     /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsNoTestsDiagnosticService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsNoTestsDiagnosticService.cs
@@ -430,6 +430,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             return IncludePlatforms.Contains("Editor");
         }
+
+        // Why "sole platform": an asmdef that lists Editor next to a player platform is a runtime
+        // assembly that also compiles in the Editor, so it hosts PlayMode tests, not EditMode ones.
+        public bool IsEditorOnly()
+        {
+            return IncludePlatforms.Length == 1 && IncludePlatforms[0] == "Editor";
+        }
     }
 
     /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
@@ -120,6 +120,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         public int UnfilteredTestCount { get; set; }
 
+        /// <summary>
+        /// Ready-to-write test .asmdef when an unfiltered run found no tests and the project has
+        /// no test assembly for the TestMode. Null otherwise; omitted from JSON.
+        /// </summary>
+        public RunTestsTestAsmdefProposal ProposedTestAsmdef { get; set; }
+
+        public bool ShouldSerializeProposedTestAsmdef()
+        {
+            return ProposedTestAsmdef != null;
+        }
+
         // Why omit empty: a clean run with no live patches must not grow a Warning field.
         public bool ShouldSerializeWarning()
         {

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTestAsmdefProposal.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTestAsmdefProposal.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Globalization;
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// A ready-to-write test .asmdef offered when a run discovers no tests and the project has no
+    /// test assembly for the requested TestMode.
+    /// </summary>
+    public sealed class RunTestsTestAsmdefProposal
+    {
+        public RunTestsTestAsmdefProposal(string assetPath, string content)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assetPath), "assetPath must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(content), "content must not be null or empty");
+
+            AssetPath = assetPath;
+            Content = content;
+        }
+
+        /// <summary>
+        /// Project-relative path to save the file at. Test scripts belong under its folder.
+        /// </summary>
+        public string AssetPath { get; }
+
+        /// <summary>
+        /// Complete .asmdef JSON to write verbatim.
+        /// </summary>
+        public string Content { get; }
+
+        /// <summary>
+        /// Appends the sentence that points at ProposedTestAsmdef to a no-tests message.
+        /// </summary>
+        internal static string AppendNotice(string message, RunTestsTestAsmdefProposal proposal)
+        {
+            Debug.Assert(message != null, "message must not be null");
+            Debug.Assert(proposal != null, "proposal must not be null");
+
+            // Why a conditional period: the base NoTestsFound message has no terminator, while the
+            // asmdef hints and the predefined-assembly notice that may precede this one end with one.
+            string terminator = message.EndsWith(".", StringComparison.Ordinal) ? string.Empty : ".";
+            return message
+                   + terminator
+                   + string.Format(
+                       CultureInfo.InvariantCulture,
+                       RunTestsConstants.TestAsmdefProposalNoticeFormat,
+                       proposal.AssetPath);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTestAsmdefProposal.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTestAsmdefProposal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bfab3fa1e18e64edd976ecee9ab0301e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTestAsmdefProposalBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTestAsmdefProposalBuilder.cs
@@ -47,7 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Editor-only assemblies and PlayMode tests only from the others, so a project with a
             // PlayMode test assembly still has nowhere to put an EditMode test.
             bool hasTestAssemblyForMode = asmdefs.Any(asmdef =>
-                asmdef.IsTestAssembly() && asmdef.IncludesEditorPlatform() == editMode);
+                asmdef.IsTestAssembly() && asmdef.IsEditorOnly() == editMode);
             if (hasTestAssemblyForMode)
             {
                 return null;
@@ -57,12 +57,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // compile against them, so the proposal would fail on its first compile.
             string[] assembliesUnderTest = asmdefs
                 .Where(asmdef => !asmdef.IsTestAssembly())
-                .Where(asmdef => editMode || !asmdef.IncludesEditorPlatform())
+                .Where(asmdef => editMode || !asmdef.IsEditorOnly())
                 .Select(asmdef => asmdef.Name)
                 .OrderBy(name => name, StringComparer.Ordinal)
                 .ToArray();
-            string name = ChooseBaseName(assembliesUnderTest, productName) + (editMode ? ".Tests.Editor" : ".Tests.PlayMode");
+            string preferredName = ChooseBaseName(assembliesUnderTest, productName) + (editMode ? ".Tests.Editor" : ".Tests.PlayMode");
             string folder = editMode ? "Assets/Tests/Editor/" : "Assets/Tests/PlayMode/";
+            string name = ChooseUnusedName(preferredName, folder, asmdefs);
 
             AsmdefTemplate template = new AsmdefTemplate
             {
@@ -74,6 +75,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
             string content = JsonConvert.SerializeObject(template, Formatting.Indented);
             return new RunTestsTestAsmdefProposal(folder + name + ".asmdef", content);
+        }
+
+        // Why a suffix instead of reusing the name: an unmarked asmdef may already own the
+        // preferred name or path, and Unity rejects duplicate assembly names, so the proposal
+        // must never tell the caller to overwrite an existing file.
+        private static string ChooseUnusedName(string preferredName, string folder, IReadOnlyList<RunTestsAsmdefInfo> asmdefs)
+        {
+            string candidate = preferredName;
+            for (int suffix = 2; IsNameOrPathTaken(candidate, folder, asmdefs); suffix++)
+            {
+                candidate = preferredName + suffix.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            }
+
+            return candidate;
+        }
+
+        private static bool IsNameOrPathTaken(string name, string folder, IReadOnlyList<RunTestsAsmdefInfo> asmdefs)
+        {
+            string assetPath = folder + name + ".asmdef";
+            return asmdefs.Any(asmdef =>
+                string.Equals(asmdef.Name, name, StringComparison.Ordinal)
+                || string.Equals(asmdef.AssetPath, assetPath, StringComparison.Ordinal));
         }
 
         // Why a single assembly wins: "Game" -> "Game.Tests.Editor" reads as the natural sibling.

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTestAsmdefProposalBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTestAsmdefProposalBuilder.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using UnityEditor;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Synthesizes a concrete test .asmdef (name, path, test-assembly wiring, references to the
+    /// assemblies under test) for a project that has no test assembly for the requested TestMode.
+    /// </summary>
+    internal static class RunTestsTestAsmdefProposalBuilder
+    {
+        private const string FallbackBaseName = "Project";
+        private const string EditorSuffix = ".Editor";
+        private const string UnityEngineTestRunnerReference = "UnityEngine.TestRunner";
+        private const string UnityEditorTestRunnerReference = "UnityEditor.TestRunner";
+
+        /// <summary>
+        /// Loads the project's asmdefs and product name, then builds the proposal. Null when a
+        /// test assembly for the mode already exists.
+        /// </summary>
+        internal static RunTestsTestAsmdefProposal Propose(UnityCliLoopTestMode testMode)
+        {
+            Debug.Assert(
+                MainThreadSwitcher.IsMainThread,
+                "Test asmdef proposals must run on the main thread because AssetDatabase and PlayerSettings are Unity APIs.");
+
+            RunTestsAsmdefInfo[] asmdefs = RunTestsNoTestsDiagnosticService.LoadProjectAsmdefs();
+            return Build(asmdefs, testMode, PlayerSettings.productName);
+        }
+
+        internal static RunTestsTestAsmdefProposal Build(
+            IReadOnlyList<RunTestsAsmdefInfo> asmdefs,
+            UnityCliLoopTestMode testMode,
+            string productName)
+        {
+            Debug.Assert(asmdefs != null, "asmdefs must not be null");
+            Debug.Assert(productName != null, "productName must not be null");
+
+            bool editMode = testMode == UnityCliLoopTestMode.EditMode;
+            // Why the Editor platform decides relevance: EditMode tests are discovered only from
+            // Editor-only assemblies and PlayMode tests only from the others, so a project with a
+            // PlayMode test assembly still has nowhere to put an EditMode test.
+            bool hasTestAssemblyForMode = asmdefs.Any(asmdef =>
+                asmdef.IsTestAssembly() && asmdef.IncludesEditorPlatform() == editMode);
+            if (hasTestAssemblyForMode)
+            {
+                return null;
+            }
+
+            // Why editor-only assemblies are dropped for PlayMode: a runtime test assembly cannot
+            // compile against them, so the proposal would fail on its first compile.
+            string[] assembliesUnderTest = asmdefs
+                .Where(asmdef => !asmdef.IsTestAssembly())
+                .Where(asmdef => editMode || !asmdef.IncludesEditorPlatform())
+                .Select(asmdef => asmdef.Name)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+            string name = ChooseBaseName(assembliesUnderTest, productName) + (editMode ? ".Tests.Editor" : ".Tests.PlayMode");
+            string folder = editMode ? "Assets/Tests/Editor/" : "Assets/Tests/PlayMode/";
+
+            AsmdefTemplate template = new AsmdefTemplate
+            {
+                name = name,
+                references = new[] { UnityEngineTestRunnerReference, UnityEditorTestRunnerReference }
+                    .Concat(assembliesUnderTest)
+                    .ToArray(),
+                includePlatforms = editMode ? new[] { "Editor" } : Array.Empty<string>()
+            };
+            string content = JsonConvert.SerializeObject(template, Formatting.Indented);
+            return new RunTestsTestAsmdefProposal(folder + name + ".asmdef", content);
+        }
+
+        // Why a single assembly wins: "Game" -> "Game.Tests.Editor" reads as the natural sibling.
+        // With several assemblies no single one is the subject, so the product name stands in.
+        private static string ChooseBaseName(IReadOnlyList<string> assembliesUnderTest, string productName)
+        {
+            if (assembliesUnderTest.Count == 1)
+            {
+                return TrimEditorSuffix(assembliesUnderTest[0]);
+            }
+
+            string sanitized = new string(productName.Where(IsAssemblyNameCharacter).ToArray());
+            return sanitized.Length == 0 ? FallbackBaseName : sanitized;
+        }
+
+        private static string TrimEditorSuffix(string assemblyName)
+        {
+            if (assemblyName.EndsWith(EditorSuffix, StringComparison.Ordinal) && assemblyName.Length > EditorSuffix.Length)
+            {
+                return assemblyName.Substring(0, assemblyName.Length - EditorSuffix.Length);
+            }
+
+            return assemblyName;
+        }
+
+        private static bool IsAssemblyNameCharacter(char character)
+        {
+            return char.IsLetterOrDigit(character) || character == '.' || character == '_';
+        }
+
+        // Why this shape: it is what the Inspector's "Test Assemblies" toggle writes on current
+        // Unity versions. Newtonsoft keeps the declaration order, so the output reads like a
+        // hand-written asmdef.
+        private sealed class AsmdefTemplate
+        {
+            public string name = string.Empty;
+            public string rootNamespace = string.Empty;
+            public string[] references = Array.Empty<string>();
+            public string[] includePlatforms = Array.Empty<string>();
+            public string[] excludePlatforms = Array.Empty<string>();
+            public bool allowUnsafeCode = false;
+            public bool overrideReferences = true;
+            public string[] precompiledReferences = { "nunit.framework.dll" };
+            public bool autoReferenced = false;
+            public string[] defineConstraints = { "UNITY_INCLUDE_TESTS" };
+            public string[] versionDefines = Array.Empty<string>();
+            public bool noEngineReferences = false;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTestAsmdefProposalBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTestAsmdefProposalBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using UnityEditor;
+using UnityEditor.Compilation;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -31,16 +32,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 "Test asmdef proposals must run on the main thread because AssetDatabase and PlayerSettings are Unity APIs.");
 
             RunTestsAsmdefInfo[] asmdefs = RunTestsNoTestsDiagnosticService.LoadProjectAsmdefs();
-            return Build(asmdefs, testMode, PlayerSettings.productName);
+            // Why the compilation pipeline: the loaded asmdefs cover Assets/ only, while a
+            // package or predefined assembly may already own the proposed name, and Unity rejects
+            // duplicate assembly names project-wide.
+            string[] compiledAssemblyNames = CompilationPipeline.GetAssemblies()
+                .Select(assembly => assembly.name)
+                .ToArray();
+            return Build(asmdefs, testMode, PlayerSettings.productName, compiledAssemblyNames);
         }
 
         internal static RunTestsTestAsmdefProposal Build(
             IReadOnlyList<RunTestsAsmdefInfo> asmdefs,
             UnityCliLoopTestMode testMode,
-            string productName)
+            string productName,
+            IReadOnlyList<string> existingAssemblyNames)
         {
             Debug.Assert(asmdefs != null, "asmdefs must not be null");
             Debug.Assert(productName != null, "productName must not be null");
+            Debug.Assert(existingAssemblyNames != null, "existingAssemblyNames must not be null");
 
             bool editMode = testMode == UnityCliLoopTestMode.EditMode;
             // Why the Editor platform decides relevance: EditMode tests are discovered only from
@@ -63,7 +72,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 .ToArray();
             string preferredName = ChooseBaseName(assembliesUnderTest, productName) + (editMode ? ".Tests.Editor" : ".Tests.PlayMode");
             string folder = editMode ? "Assets/Tests/Editor/" : "Assets/Tests/PlayMode/";
-            string name = ChooseUnusedName(preferredName, folder, asmdefs);
+            string name = ChooseUnusedName(preferredName, folder, asmdefs, existingAssemblyNames);
 
             AsmdefTemplate template = new AsmdefTemplate
             {
@@ -80,10 +89,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Why a suffix instead of reusing the name: an unmarked asmdef may already own the
         // preferred name or path, and Unity rejects duplicate assembly names, so the proposal
         // must never tell the caller to overwrite an existing file.
-        private static string ChooseUnusedName(string preferredName, string folder, IReadOnlyList<RunTestsAsmdefInfo> asmdefs)
+        private static string ChooseUnusedName(
+            string preferredName,
+            string folder,
+            IReadOnlyList<RunTestsAsmdefInfo> asmdefs,
+            IReadOnlyList<string> existingAssemblyNames)
         {
             string candidate = preferredName;
-            for (int suffix = 2; IsNameOrPathTaken(candidate, folder, asmdefs); suffix++)
+            for (int suffix = 2; IsNameOrPathTaken(candidate, folder, asmdefs, existingAssemblyNames); suffix++)
             {
                 candidate = preferredName + suffix.ToString(System.Globalization.CultureInfo.InvariantCulture);
             }
@@ -91,12 +104,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return candidate;
         }
 
-        private static bool IsNameOrPathTaken(string name, string folder, IReadOnlyList<RunTestsAsmdefInfo> asmdefs)
+        private static bool IsNameOrPathTaken(
+            string name,
+            string folder,
+            IReadOnlyList<RunTestsAsmdefInfo> asmdefs,
+            IReadOnlyList<string> existingAssemblyNames)
         {
             string assetPath = folder + name + ".asmdef";
-            return asmdefs.Any(asmdef =>
-                string.Equals(asmdef.Name, name, StringComparison.Ordinal)
-                || string.Equals(asmdef.AssetPath, assetPath, StringComparison.Ordinal));
+            return existingAssemblyNames.Contains(name, StringComparer.Ordinal)
+                   || asmdefs.Any(asmdef =>
+                       string.Equals(asmdef.Name, name, StringComparison.Ordinal)
+                       || string.Equals(asmdef.AssetPath, assetPath, StringComparison.Ordinal));
         }
 
         // Why a single assembly wins: "Game" -> "Game.Tests.Editor" reads as the natural sibling.

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTestAsmdefProposalBuilder.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTestAsmdefProposalBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a3a933d83fa0e4a4eb29677494bbf727
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -23,6 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly Func<string[]> _clearActivePausePoints;
         private readonly Func<CancellationToken, Task> _waitForTestRunnerCleanupAsync;
         private readonly Func<int> _getActiveHotReloadChangeCount;
+        private readonly Func<UnityCliLoopTestMode, RunTestsTestAsmdefProposal> _proposeTestAsmdef;
         private const int TestRunnerCleanupFallbackDelayMilliseconds = 3000;
 
         public RunTestsUseCase()
@@ -40,7 +41,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Func<string[]> clearActivePausePoints = null,
             Func<CancellationToken, Task> waitForTestRunnerCleanupAsync = null,
             Func<string, bool, UnityCliLoopTestMode, TestFilterType, string> appendNoTestsDiagnostics = null,
-            Func<int> getActiveHotReloadChangeCount = null)
+            Func<int> getActiveHotReloadChangeCount = null,
+            Func<UnityCliLoopTestMode, RunTestsTestAsmdefProposal> proposeTestAsmdef = null)
         {
             Debug.Assert(filterService != null, "filterService must not be null");
             Debug.Assert(executionService != null, "executionService must not be null");
@@ -55,6 +57,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _clearActivePausePoints = clearActivePausePoints ?? ClearActivePausePointsDefault;
             _waitForTestRunnerCleanupAsync = waitForTestRunnerCleanupAsync ?? WaitForTestRunnerCleanupAsync;
             _getActiveHotReloadChangeCount = getActiveHotReloadChangeCount ?? ReadActiveHotReloadChangeCount;
+            _proposeTestAsmdef = proposeTestAsmdef ?? RunTestsTestAsmdefProposalBuilder.Propose;
         }
 
         /// <summary>
@@ -198,6 +201,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     parameters.TestMode,
                     parameters.FilterType));
             AppendPredefinedAssemblyTestNoticeIfNeeded(response, parameters);
+            AttachTestAsmdefProposalIfNeeded(response, parameters);
             await ApplyUnfilteredFilterEchoIfNeededAsync(response, parameters, ct)
                 .ConfigureAwait(false);
             return response;
@@ -234,6 +238,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             response.Message = RunTestsPredefinedAssemblyTestNoticeFormatter.AppendIfNeeded(
                 response.Message,
                 findings);
+        }
+
+        // Why after the predefined-assembly notice: that notice names the stranded test methods,
+        // and this one tells the caller where to put them.
+        private void AttachTestAsmdefProposalIfNeeded(RunTestsResponse response, RunTestsSchema parameters)
+        {
+            Debug.Assert(response != null, "response must not be null");
+            Debug.Assert(parameters != null, "parameters must not be null");
+
+            if (!RunTestsNoTestsDiagnosticService.ShouldAppendDiagnostics(
+                    response.NoTestsFound,
+                    parameters.FilterType))
+            {
+                return;
+            }
+
+            RunTestsTestAsmdefProposal proposal = RunTestsNoTestsDiagnosticService.InspectAsmdefsOrFallback<RunTestsTestAsmdefProposal>(
+                null,
+                () => _proposeTestAsmdef(parameters.TestMode));
+            if (proposal == null)
+            {
+                return;
+            }
+
+            response.ProposedTestAsmdef = proposal;
+            response.Message = RunTestsTestAsmdefProposal.AppendNotice(response.Message, proposal);
         }
 
         private async Task ApplyUnfilteredFilterEchoIfNeededAsync(

--- a/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
@@ -16,7 +16,7 @@ Active pause points are automatically cleared (the underlying code patches are r
 
 A test run can end by discarding active hot-reload changes: script edits imported during the run are compiled when the test runner releases its assembly-reload lock, and that deferred domain reload wipes the patches even though the tests themselves ran patched. The response's Warning field reports this; re-apply 'uloop hot-reload' or bake the edits in with 'uloop compile' before the next Play or test run.
 
-`NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints.
+`NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints. When the project has no test assembly for the TestMode, `ProposedTestAsmdef` carries a ready-to-write `.asmdef`: save `Content` at `AssetPath`, move the test scripts under that folder, then compile and rerun.
 
 ## Usage
 
@@ -56,6 +56,7 @@ Returns JSON with:
 - `ClearedPausePointIds` (string[], optional): IDs of pause points that were cleared before test execution. Omitted from JSON when no pause points were active.
 - `FailedTests` (array, optional): Up to 10 failed leaf tests with `FullName`, `Message`, and when the stack trace contains a path:line location, `File` and `Line`. Omitted when no tests failed. When `FailedCount` is greater than 10, `Message` ends with `first 10 of N failures listed; see XmlPath for full results.`
 - `SkippedTests` (string[], optional): Up to 10 full names of skipped leaf tests. Omitted when no tests were skipped. When `SkippedCount` is greater than 10, only the first 10 names are listed.
+- `ProposedTestAsmdef` (object, optional): `AssetPath` and `Content` of a ready-to-write test `.asmdef` (test-assembly wiring plus references to the project's assemblies under test). Present only when an unfiltered run found no tests and no test assembly exists for the TestMode.
 - `CompileNote` (string, optional): States that the automatic compile ran and succeeded before the tests and names `--skip-compile` as the opt-out. Omitted when `--skip-compile` was passed; a failed compile returns the compile error response instead.
 
 ### XML Result File

--- a/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
@@ -16,7 +16,7 @@ Active pause points are automatically cleared (the underlying code patches are r
 
 A test run can end by discarding active hot-reload changes: script edits imported during the run are compiled when the test runner releases its assembly-reload lock, and that deferred domain reload wipes the patches even though the tests themselves ran patched. The response's Warning field reports this; re-apply 'uloop hot-reload' or bake the edits in with 'uloop compile' before the next Play or test run.
 
-`NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints. When the project has no test assembly for the TestMode, `ProposedTestAsmdef` carries a ready-to-write `.asmdef`: save `Content` at `AssetPath`, move the test scripts under that folder, then compile and rerun.
+`NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints. When an unfiltered run finds no tests and the project has no test assembly for the TestMode, `ProposedTestAsmdef` carries a ready-to-write `.asmdef`: save `Content` at `AssetPath`, move the test scripts under that folder, then compile and rerun.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

When an unfiltered `uloop run-tests` run discovers no tests and the project has no test assembly for the requested TestMode, the response now carries `ProposedTestAsmdef`: a ready-to-write `.asmdef` (path + complete JSON) wired as a test assembly and referencing the project's assemblies under test. This removes the one remaining round-trip in a fresh project's first TDD loop.

## User Impact

- `NoTestsFound` responses gain `ProposedTestAsmdef { AssetPath, Content }` when no test assembly exists for the mode, and `Message` ends with a sentence pointing at it: save `Content` at `AssetPath`, move the test scripts under that folder, compile, rerun.
- The proposal is concrete: named `<Assembly>.Tests.Editor` / `.Tests.PlayMode` after the single assembly under test (or after the sanitized product name, or `Project` as a last resort), saved under `Assets/Tests/Editor/` or `Assets/Tests/PlayMode/`, with `UnityEngine.TestRunner` / `UnityEditor.TestRunner` references, `nunit.framework.dll`, `UNITY_INCLUDE_TESTS`, and every non-test project asmdef as a reference. EditMode proposals are Editor-only; PlayMode proposals skip editor-only assemblies, which a runtime test assembly cannot compile against.
- Filtered runs and projects that already have a test assembly for the mode are unchanged. A PlayMode-only test assembly still yields an EditMode proposal, because EditMode tests are discovered only from Editor-only assemblies.
- The skill documents the new field.

## Changes

- New `RunTestsTestAsmdefProposal` (response DTO + message notice) and `RunTestsTestAsmdefProposalBuilder` (pure `Build` over the loaded asmdefs, `Propose` that gathers project inputs on the main thread).
- `RunTestsUseCase` attaches the proposal after the predefined-assembly notice, through the existing asmdef-inspection I/O fallback (now generic `InspectAsmdefsOrFallback<T>`), and takes an optional `proposeTestAsmdef` delegate for tests.
- Asmdef predicates (`HasTestAssemblyMarker`, `HasDirectTestRunnerReference`, `IsTestAssembly`, `IncludesEditorPlatform`) moved onto `RunTestsAsmdefInfo` so the diagnostic service and the builder share one definition; `LoadProjectAsmdefs` is now internal.
- `RunTestsResponse.ProposedTestAsmdef` with `ShouldSerialize` omission; new message constant.
- Skill text and regenerated `.claude/` / `.agents/` copies.
- Tests: new `RunTestsTestAsmdefProposalBuilderTests` (mode relevance, naming, references, platform handling, fallback name, notice format) and two `RunTestsUseCaseTests` cases (attached on unfiltered NoTestsFound; never requested on filtered runs).

Out of scope: the compile-time detection half folded in from #2324 (warning at `uloop compile` when NUnit-attributed sources land in a non-test assembly). This PR covers the remedy half; the existing predefined-assembly notice still names the stranded methods at run time.

## Verification

- `uloop compile`: 0 errors.
- `uloop run-tests --filter-type regex --filter-value "RunTestsTestAsmdefProposalBuilderTests|RunTestsUseCaseTests|RunTestsNoTestsDiagnosticServiceTests|RunTestsToolTests"`: 72 passed, 0 failed.
- `scripts/sync-tool-docs.sh --check` clean; `check-skill-size` clean (5,406 bytes).

Closes #2362

https://claude.ai/code/session_01R3jkx6NbNYKPdy5q1NSWYo


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

