### PR TITLE
fix: enumerate Go packages with ./... in check-go-cli-source.sh

### DIFF
--- a/scripts/check-go-cli-source.sh
+++ b/scripts/check-go-cli-source.sh
@@ -18,20 +18,10 @@ run_module_checks() {
 
   (
     cd "$module_dir"
-    module_root=$(pwd)
-    packages=$(go list -f '{{.Dir}}' ./... | grep -v '/node_modules/' | awk -v root="$module_root" '
-      $0 == root {
-        print "."
-        next
-      }
-      index($0, root "/") == 1 {
-        print "./" substr($0, length(root) + 2)
-      }
-    ')
     golangci-lint fmt --config "$ROOT_DIR/cli/.golangci.yml" --diff
-    go vet $packages
-    golangci-lint run --config "$ROOT_DIR/cli/.golangci.yml" $packages
-    go test $packages
+    go vet ./...
+    golangci-lint run --config "$ROOT_DIR/cli/.golangci.yml" ./...
+    go test ./...
   )
 }
 


### PR DESCRIPTION
## Summary

`scripts/check-go-cli-source.sh` now passes `./...` to `go vet`, `golangci-lint run`, and `go test` instead of rewriting `go list` paths.

## User Impact

Windows developers can run `scripts/check-go-cli.sh` locally. The previous package rewrite produced an empty list when `pwd` and `go list` used different path formats, so those commands fell back to `.` and failed.

## Changes

- Remove the `go list` / `awk` rewrite and the unused `node_modules` filter from `run_module_checks`.
- Keep `golangci-lint fmt --diff` as it was.

## Verification

- `scripts/check-go-cli.sh` on Windows Git Bash → exit 0

Closes #2511


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

