### PR TITLE
chore: Stop CodeRabbit from blocking pull request merges

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,7 +6,7 @@ code_generation:
 early_access: true
 reviews:
   profile: "chill"
-  request_changes_workflow: true
+  request_changes_workflow: false
   high_level_summary: false
   poem: false
   auto_review:


### PR DESCRIPTION
## Summary
- CodeRabbit no longer blocks merging: it now posts comments only instead of requesting changes.

## User Impact
- Before: a pull request with any open CodeRabbit finding stayed at `CHANGES_REQUESTED`, and the branch ruleset then refused the merge until every bot thread was resolved and re-reviewed or the review was dismissed by hand. Findings answered as "won't fix" kept the block in place.
- After: CodeRabbit findings appear as review comments and the merge decision stays with the maintainer, who already verifies each pull request manually before merging.

## Changes
- Set `reviews.request_changes_workflow` to `false` in `.coderabbit.yaml`. Auto review, path filters, and path instructions are unchanged.

## Verification
- Confirmed the `v3-beta` ruleset has been unchanged since April and that recent blocked pull requests were held only by unresolved CodeRabbit `CHANGES_REQUESTED` reviews.

https://claude.ai/code/session_01R3jkx6NbNYKPdy5q1NSWYo


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

