### PR TITLE
chore: Restore the file-length check on v3-beta so pull requests can merge again

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
@@ -16,7 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal sealed class PausePointUseCase
     {
         // Tracks which currently-armed source pause point ids carry a physics-callback warning,
-        // and their declaring type, so a later expiry (LogExpired) can attribute the same
+        // and their declaring type, so a later expiry (PausePointUseCaseLogger.LogExpired) can attribute the same
         // diagnostics snapshot to a miss that was never hit. Volatile by design: a domain reload
         // clears the Harmony patches this tracks anyway, so this dictionary does not need to
         // survive one, and entries are removed as soon as their pause point is cleared.
@@ -42,7 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             if (hitCount == 0 && PhysicsFlaggedDeclaringTypesById.TryGetValue(id, out Type declaringType))
             {
-                LogPhysicsDispatchDiagnostics("pause_point_cleared_without_hit_physics", id, declaringType, statusBeforeClear);
+                PausePointUseCaseLogger.LogPhysicsDispatchDiagnostics("pause_point_cleared_without_hit_physics", id, declaringType, statusBeforeClear);
             }
             PhysicsFlaggedDeclaringTypesById.Remove(id);
         }
@@ -112,7 +112,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             PausePointEnableWarningList.Assign(response, warningEntries);
             response.RecommendedNextAction = PausePointEnableWarnings
                 .ResolveSuccessEnableRecommendedNextAction(response.RecommendedNextAction, response.Id);
-            LogEnable(response.Id, resolvedMethod: string.Empty, fileLine: string.Empty, response.Mode, response.Warning);
+            PausePointUseCaseLogger.LogEnable(response.Id, resolvedMethod: string.Empty, fileLine: string.Empty, response.Mode, response.Warning);
             return response;
         }
 
@@ -139,7 +139,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     UloopPausePointSnapshot trackedSnapshot = UloopPausePointRegistry.GetStatus(tracked.Key);
                     if (trackedSnapshot.HitCount == 0)
                     {
-                        LogPhysicsDispatchDiagnostics(
+                        PausePointUseCaseLogger.LogPhysicsDispatchDiagnostics(
                             "pause_point_cleared_without_hit_physics", tracked.Key, tracked.Value, trackedSnapshot.Status);
                     }
                 }
@@ -148,7 +148,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // SourcePausePointPatcher wires into it; this use case never references the
                 // Patcher directly.
                 UloopPausePointClearAllResult clearAllResult = UloopPausePointRegistry.ClearAll();
-                LogCleared("all", string.Empty);
+                PausePointUseCaseLogger.LogCleared("all", string.Empty);
                 PhysicsFlaggedDeclaringTypesById.Clear();
                 return PausePointResponse.FromClearAll(clearAllResult);
             }
@@ -164,10 +164,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             (UloopPausePointSnapshot snapshot, bool resumedFromPause, int clearedCount) =
                 UloopPausePointRegistry.Clear(parameters.Id);
-            LogCleared(snapshot.Id, snapshot.StatusBeforeClear);
+            PausePointUseCaseLogger.LogCleared(snapshot.Id, snapshot.StatusBeforeClear);
             if (snapshot.StatusBeforeClear == UloopPausePointStatus.Expired)
             {
-                LogExpired(snapshot.Id, snapshot.ElapsedSinceEnabledMilliseconds);
+                PausePointUseCaseLogger.LogExpired(snapshot.Id, snapshot.ElapsedSinceEnabledMilliseconds);
             }
 
             // The zero-hit physics diagnostic (for any StatusBeforeClear, not just Expired - the
@@ -188,28 +188,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return response;
-        }
-
-        // Why: PausePointStatusBridgeCommand duplicates this instead of sharing it, since that
-        // bridge must not reference this Editor-only tool assembly. Keep both in sync if the
-        // log shape or wording changes.
-        private static void LogCleared(string target, string statusBeforeClear)
-        {
-            VibeLogger.LogInfo(
-                "pause_point_cleared",
-                $"Pause point cleared: {target}",
-                new { Target = target, StatusBeforeClear = statusBeforeClear });
-        }
-
-        // Why: PausePointStatusBridgeCommand duplicates this instead of sharing it, since that
-        // bridge must not reference this Editor-only tool assembly. Keep both in sync if the
-        // log shape or wording changes.
-        private static void LogExpired(string id, long elapsedSinceEnabledMilliseconds)
-        {
-            VibeLogger.LogInfo(
-                "pause_point_expired",
-                $"Pause point expired before being cleared: {id}",
-                new { Id = id, ElapsedSinceEnabledMilliseconds = elapsedSinceEnabledMilliseconds });
         }
 
         // Resolves File:Line to a patch location via the Resolver, patches it via Harmony, then
@@ -547,65 +525,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             PausePointEnableWarningList.Assign(response, warningEntries);
             response.RecommendedNextAction = PausePointEnableWarnings
                 .ResolveSuccessEnableRecommendedNextAction(response.RecommendedNextAction, id);
-            LogEnable(response.Id, response.ResolvedMethod, $"{parameters.File}:{response.ResolvedLine}", response.Mode, response.Warning);
+            PausePointUseCaseLogger.LogEnable(response.Id, response.ResolvedMethod, $"{parameters.File}:{response.ResolvedLine}", response.Mode, response.Warning);
 
             if (patchResult.HasPhysicsCallbackWarning)
             {
                 PhysicsFlaggedDeclaringTypesById[id] = patchResult.DeclaringType;
-                LogPhysicsDispatchDiagnostics(
+                PausePointUseCaseLogger.LogPhysicsDispatchDiagnostics(
                     "pause_point_physics_dispatch_diagnostics", id, patchResult.DeclaringType, statusBeforeClear: string.Empty);
             }
 
             return response;
-        }
-
-        private static void LogEnable(string id, string resolvedMethod, string fileLine, string mode, string warning)
-        {
-            VibeLogger.LogInfo(
-                "pause_point_enable",
-                $"Pause point enabled: {id}",
-                new { Id = id, ResolvedMethod = resolvedMethod, FileLine = fileLine, Mode = mode, HasWarning = !string.IsNullOrEmpty(warning) });
-        }
-
-        // Captures the state needed to diagnose a physics-callback dispatch miss if one recurs:
-        // whether Play Mode is running, how long the current domain has been alive without a
-        // reload (a suspected factor -- see docs/regression-harness.md), the declaring type, and
-        // (for MonoBehaviour-derived types only) how many instances currently exist in the loaded
-        // scenes. statusBeforeClear is empty at enable time (no clear has happened yet) and
-        // Enabled/Expired at clear time.
-        private static void LogPhysicsDispatchDiagnostics(string operation, string id, Type declaringType, string statusBeforeClear)
-        {
-            // Only reachable via PhysicsFlaggedDeclaringTypesById, which is populated solely from
-            // a successful patch's method.DeclaringType -- a C#-sourced method always has one.
-            Debug.Assert(declaringType != null, "declaringType must not be null");
-
-            bool isMonoBehaviourDerived = typeof(MonoBehaviour).IsAssignableFrom(declaringType);
-            // -1 signals "not applicable": counting instances only means something when the
-            // declaring type is a MonoBehaviour (the physics dispatch miss this diagnostic exists
-            // for is scoped to MonoBehaviour physics message methods).
-#if UNITY_6000_4_OR_NEWER
-            int instanceCount = isMonoBehaviourDerived
-                ? UnityEngine.Object.FindObjectsByType(declaringType, FindObjectsInactive.Include).Length
-                : -1;
-#else
-            int instanceCount = isMonoBehaviourDerived
-                ? UnityEngine.Object.FindObjectsByType(declaringType, FindObjectsInactive.Include, FindObjectsSortMode.None).Length
-                : -1;
-#endif
-
-            VibeLogger.LogInfo(
-                operation,
-                $"Physics-callback pause point dispatch diagnostics: {id}",
-                new
-                {
-                    Id = id,
-                    IsPlaying = EditorApplication.isPlaying,
-                    IsPaused = EditorApplication.isPaused,
-                    SecondsSinceLastDomainReload = PausePointDomainReloadTracker.SecondsSinceLoad(),
-                    DeclaringType = declaringType.FullName,
-                    InstanceCount = instanceCount,
-                    StatusBeforeClear = statusBeforeClear
-                });
         }
 
         // The derived id must use the originally requested file/line (not the resolved/rounded

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCaseLogger.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCaseLogger.cs
@@ -1,0 +1,87 @@
+using System;
+
+using UnityEditor;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Emits the structured log entries for pause point enable, clear, and expiry events.
+    /// </summary>
+    internal static class PausePointUseCaseLogger
+    {
+        // Why: PausePointStatusBridgeCommand duplicates this instead of sharing it, since that
+        // bridge must not reference this Editor-only tool assembly. Keep both in sync if the
+        // log shape or wording changes.
+        internal static void LogCleared(string target, string statusBeforeClear)
+        {
+            VibeLogger.LogInfo(
+                "pause_point_cleared",
+                $"Pause point cleared: {target}",
+                new { Target = target, StatusBeforeClear = statusBeforeClear });
+        }
+
+        // Why: PausePointStatusBridgeCommand duplicates this instead of sharing it, since that
+        // bridge must not reference this Editor-only tool assembly. Keep both in sync if the
+        // log shape or wording changes.
+        internal static void LogExpired(string id, long elapsedSinceEnabledMilliseconds)
+        {
+            VibeLogger.LogInfo(
+                "pause_point_expired",
+                $"Pause point expired before being cleared: {id}",
+                new { Id = id, ElapsedSinceEnabledMilliseconds = elapsedSinceEnabledMilliseconds });
+        }
+
+        internal static void LogEnable(string id, string resolvedMethod, string fileLine, string mode, string warning)
+        {
+            VibeLogger.LogInfo(
+                "pause_point_enable",
+                $"Pause point enabled: {id}",
+                new { Id = id, ResolvedMethod = resolvedMethod, FileLine = fileLine, Mode = mode, HasWarning = !string.IsNullOrEmpty(warning) });
+        }
+
+        // Captures the state needed to diagnose a physics-callback dispatch miss if one recurs:
+        // whether Play Mode is running, how long the current domain has been alive without a
+        // reload (a suspected factor -- see docs/regression-harness.md), the declaring type, and
+        // (for MonoBehaviour-derived types only) how many instances currently exist in the loaded
+        // scenes. statusBeforeClear is empty at enable time (no clear has happened yet) and
+        // Enabled/Expired at clear time.
+        internal static void LogPhysicsDispatchDiagnostics(string operation, string id, Type declaringType, string statusBeforeClear)
+        {
+            // Only reachable via PausePointUseCase.PhysicsFlaggedDeclaringTypesById, which is populated solely from
+            // a successful patch's method.DeclaringType -- a C#-sourced method always has one.
+            Debug.Assert(declaringType != null, "declaringType must not be null");
+
+            bool isMonoBehaviourDerived = typeof(MonoBehaviour).IsAssignableFrom(declaringType);
+            // -1 signals "not applicable": counting instances only means something when the
+            // declaring type is a MonoBehaviour (the physics dispatch miss this diagnostic exists
+            // for is scoped to MonoBehaviour physics message methods).
+#if UNITY_6000_4_OR_NEWER
+            int instanceCount = isMonoBehaviourDerived
+                ? UnityEngine.Object.FindObjectsByType(declaringType, FindObjectsInactive.Include).Length
+                : -1;
+#else
+            int instanceCount = isMonoBehaviourDerived
+                ? UnityEngine.Object.FindObjectsByType(declaringType, FindObjectsInactive.Include, FindObjectsSortMode.None).Length
+                : -1;
+#endif
+
+            VibeLogger.LogInfo(
+                operation,
+                $"Physics-callback pause point dispatch diagnostics: {id}",
+                new
+                {
+                    Id = id,
+                    IsPlaying = EditorApplication.isPlaying,
+                    IsPaused = EditorApplication.isPaused,
+                    SecondsSinceLastDomainReload = PausePointDomainReloadTracker.SecondsSinceLoad(),
+                    DeclaringType = declaringType.FullName,
+                    InstanceCount = instanceCount,
+                    StatusBeforeClear = statusBeforeClear
+                });
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCaseLogger.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCaseLogger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cd83616b6707243a7a46736fddb6b69e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Restores a green `File Length Report` job on v3-beta so pull requests can merge again.

## User Impact
- Before: after #2519 and #2521 both landed, `PausePointUseCase.cs` sits at 508 SLOC, and every new pull request against v3-beta fails the `File Length Report` check even when it does not touch pause points (first seen on #2522).
- After: the file is back under the 500 SLOC limit. No CLI or Unity runtime behavior changes.

## Changes
- Moved the four structured-log helpers (enable, cleared, expired, physics dispatch diagnostics) from `PausePointUseCase` into a new `PausePointUseCaseLogger` class, unchanged.

## Verification
- `go run ./cmd/check-file-length --root ../.. --max-length 500` in `cli/release-automation`: no files exceeded.
- `uloop compile` (dev binary): success, 0 errors.
- `uloop run-tests --filter-type regex --filter-value PausePoint`: 624 passed, 0 failed.

https://claude.ai/code/session_01R3jkx6NbNYKPdy5q1NSWYo


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

