### PR TITLE
feat: run-tests can keep Enter Play Mode settings and recover after Domain Reload

### DIFF
--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -34,6 +34,9 @@ uloop run-tests [options]
 | `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
 | `--skip-compile` | flag | - | Skip the automatic compile before running tests; use only while validating active hot-reload patches. |
 | `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
+| `--respect-enter-play-mode-settings` | flag | - | PlayMode only: keep the project's Enter Play Mode settings instead of forcing Domain Reload off. A Domain Reload during the run is survived; the result is recovered after the reload. Use for projects whose libraries require a Domain Reload on Play entry. |
+
+By default PlayMode still forces Domain Reload off. With `--respect-enter-play-mode-settings`, a Domain Reload may run and the command takes longer; pause-point and hot-reload notes are omitted from a result recovered after reload. Canceling the CLI (Ctrl-C) does not stop the Unity-side run on this path.
 
 exact matches the full test name (Namespace.Class.Method). class runs every test of one class by bare or namespace-qualified name, e.g. --filter-type class --filter-value PlayerTests; the name is matched literally and whole, so PlayerTests does not run EnemyPlayerTests. regex matches a .NET regex against full test names, e.g. --filter-type regex --filter-value '^MyGame\.Tests\.'
 

--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -34,6 +34,9 @@ uloop run-tests [options]
 | `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
 | `--skip-compile` | flag | - | Skip the automatic compile before running tests; use only while validating active hot-reload patches. |
 | `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
+| `--respect-enter-play-mode-settings` | flag | - | PlayMode only: keep the project's Enter Play Mode settings instead of forcing Domain Reload off. A Domain Reload during the run is survived; the result is recovered after the reload. Use for projects whose libraries require a Domain Reload on Play entry. |
+
+By default PlayMode still forces Domain Reload off. With `--respect-enter-play-mode-settings`, a Domain Reload may run and the command takes longer; pause-point and hot-reload notes are omitted from a result recovered after reload. Canceling the CLI (Ctrl-C) does not stop the Unity-side run on this path.
 
 exact matches the full test name (Namespace.Class.Method). class runs every test of one class by bare or namespace-qualified name, e.g. --filter-type class --filter-value PlayerTests; the name is matched literally and whole, so PlayerTests does not run EnemyPlayerTests. regex matches a .NET regex against full test names, e.g. --filter-type regex --filter-value '^MyGame\.Tests\.'
 

--- a/Assets/Editor/TestRunnerMenu.cs
+++ b/Assets/Editor/TestRunnerMenu.cs
@@ -28,7 +28,10 @@ namespace io.github.hatayama.UnityCliLoop.Dev
         {
             Debug.Log("Running PlayMode tests!");
 
-            SerializableTestResult result = await PlayModeTestExecuter.ExecutePlayModeTest(null, CancellationToken.None);
+            SerializableTestResult result = await PlayModeTestExecuter.ExecutePlayModeTest(
+                null,
+                CancellationToken.None,
+                RunTestsPlayModeRunOptions.WithoutRespect());
 
             LogTestResult(result);
         }

--- a/Assets/Tests/Editor/JsonRpcAcceptedRequestCancellationPolicyTests.cs
+++ b/Assets/Tests/Editor/JsonRpcAcceptedRequestCancellationPolicyTests.cs
@@ -16,7 +16,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies non-compile accepted work is tied to the CLI connection lifetime.
             bool shouldCancel = JsonRpcAcceptedRequestCancellationPolicy.ShouldCancelOnClientDisconnect(
                 UnityCliLoopConstants.TOOL_NAME_GET_LOGS,
-                true);
+                true,
+                false);
 
             Assert.That(shouldCancel, Is.True);
         }
@@ -27,7 +28,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies long compile requests can persist after the CLI connection closes.
             bool shouldCancel = JsonRpcAcceptedRequestCancellationPolicy.ShouldCancelOnClientDisconnect(
                 UnityCliLoopConstants.TOOL_NAME_COMPILE,
-                true);
+                true,
+                false);
 
             Assert.That(shouldCancel, Is.False);
         }
@@ -38,6 +40,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies fire-and-forget compile requests keep the usual disconnect cancellation behavior.
             bool shouldCancel = JsonRpcAcceptedRequestCancellationPolicy.ShouldCancelOnClientDisconnect(
                 UnityCliLoopConstants.TOOL_NAME_COMPILE,
+                false,
                 false);
 
             Assert.That(shouldCancel, Is.True);
@@ -49,9 +52,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies missing, null, or non-boolean transport values preserve the compile default wait contract.
             bool shouldCancel = JsonRpcAcceptedRequestCancellationPolicy.ShouldCancelOnClientDisconnect(
                 UnityCliLoopConstants.TOOL_NAME_COMPILE,
-                null);
+                null,
+                false);
 
             Assert.That(shouldCancel, Is.False);
+        }
+
+        /// <summary>
+        /// Verifies respect-path PlayMode run-tests keeps running after the CLI disconnects.
+        /// </summary>
+        [Test]
+        public void ShouldCancelOnClientDisconnect_WhenRunTestsRespectsEnterPlayModeSettings_ReturnsFalse()
+        {
+            bool shouldCancel = JsonRpcAcceptedRequestCancellationPolicy.ShouldCancelOnClientDisconnect(
+                UnityCliLoopConstants.TOOL_NAME_RUN_TESTS,
+                null,
+                true);
+
+            Assert.That(shouldCancel, Is.False);
+        }
+
+        /// <summary>
+        /// Verifies default run-tests requests still cancel when the CLI disconnects.
+        /// </summary>
+        [Test]
+        public void ShouldCancelOnClientDisconnect_WhenRunTestsDoesNotRespectEnterPlayModeSettings_ReturnsTrue()
+        {
+            bool shouldCancel = JsonRpcAcceptedRequestCancellationPolicy.ShouldCancelOnClientDisconnect(
+                UnityCliLoopConstants.TOOL_NAME_RUN_TESTS,
+                null,
+                false);
+
+            Assert.That(shouldCancel, Is.True);
         }
     }
 }

--- a/Assets/Tests/Editor/JsonRpcRunTestsRequestMetadataReaderTests.cs
+++ b/Assets/Tests/Editor/JsonRpcRunTestsRequestMetadataReaderTests.cs
@@ -1,0 +1,65 @@
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests run-tests JSON-RPC metadata used to keep respect-path runs alive after disconnect.
+    /// </summary>
+    public sealed class JsonRpcRunTestsRequestMetadataReaderTests
+    {
+        /// <summary>
+        /// Verifies PlayMode plus the respect flag is treated as a surviving run.
+        /// </summary>
+        [Test]
+        public void ReadRespectsEnterPlayModeSettings_WhenPlayModeAndTrue_ReturnsTrue()
+        {
+            JObject paramsObject = JObject.Parse(
+                "{\"RespectEnterPlayModeSettings\":true,\"TestMode\":\"PlayMode\"}");
+
+            bool respects = JsonRpcRunTestsRequestMetadataReader.ReadRespectsEnterPlayModeSettings(paramsObject);
+
+            Assert.That(respects, Is.True);
+        }
+
+        /// <summary>
+        /// Verifies EditMode ignores the respect flag for disconnect cancellation.
+        /// </summary>
+        [Test]
+        public void ReadRespectsEnterPlayModeSettings_WhenEditModeAndTrue_ReturnsFalse()
+        {
+            JObject paramsObject = JObject.Parse(
+                "{\"RespectEnterPlayModeSettings\":true,\"TestMode\":\"EditMode\"}");
+
+            bool respects = JsonRpcRunTestsRequestMetadataReader.ReadRespectsEnterPlayModeSettings(paramsObject);
+
+            Assert.That(respects, Is.False);
+        }
+
+        /// <summary>
+        /// Verifies a missing respect flag does not keep the run after disconnect.
+        /// </summary>
+        [Test]
+        public void ReadRespectsEnterPlayModeSettings_WhenFlagIsMissing_ReturnsFalse()
+        {
+            JObject paramsObject = JObject.Parse("{\"TestMode\":\"PlayMode\"}");
+
+            bool respects = JsonRpcRunTestsRequestMetadataReader.ReadRespectsEnterPlayModeSettings(paramsObject);
+
+            Assert.That(respects, Is.False);
+        }
+
+        /// <summary>
+        /// Verifies non-object params are treated as not respecting Enter Play Mode settings.
+        /// </summary>
+        [Test]
+        public void ReadRespectsEnterPlayModeSettings_WhenParamsAreNotObject_ReturnsFalse()
+        {
+            bool respects = JsonRpcRunTestsRequestMetadataReader.ReadRespectsEnterPlayModeSettings(new JArray());
+
+            Assert.That(respects, Is.False);
+        }
+    }
+}

--- a/Assets/Tests/Editor/JsonRpcRunTestsRequestMetadataReaderTests.cs.meta
+++ b/Assets/Tests/Editor/JsonRpcRunTestsRequestMetadataReaderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b14b8bd92373e4de4b7901e076665acf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/PlayModeTestExecuterTests.cs
+++ b/Assets/Tests/Editor/PlayModeTestExecuterTests.cs
@@ -12,6 +12,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     public class PlayModeTestExecuterTests
     {
         /// <summary>
+        /// Verifies Domain Reload is forced off when respect is false.
+        /// </summary>
+        [Test]
+        public void ShouldDisableDomainReload_WhenRespectIsFalse_ReturnsTrue()
+        {
+            Assert.That(RunTestsPlayModeRunOptions.ShouldDisableDomainReload(false), Is.True);
+        }
+
+        /// <summary>
+        /// Verifies Domain Reload is left to the project settings when respect is true.
+        /// </summary>
+        [Test]
+        public void ShouldDisableDomainReload_WhenRespectIsTrue_ReturnsFalse()
+        {
+            Assert.That(RunTestsPlayModeRunOptions.ShouldDisableDomainReload(true), Is.False);
+        }
+
+        /// <summary>
         /// Test that when filter is null, a filter for all tests is generated
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/RunTestsStatusBridgeCommandTests.cs
+++ b/Assets/Tests/Editor/RunTestsStatusBridgeCommandTests.cs
@@ -1,0 +1,109 @@
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests run-tests status bridge responses without starting Unity Test Runner.
+    /// </summary>
+    [TestFixture]
+    public sealed class RunTestsStatusBridgeCommandTests
+    {
+        private UnityCliLoopRunTestsSessionRepository _repository;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _repository = new UnityCliLoopRunTestsSessionRepository();
+            _repository.ClearAll();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _repository.ClearAll();
+        }
+
+        /// <summary>
+        /// Verifies a stored result is returned as HasResult with parsed JSON.
+        /// </summary>
+        [Test]
+        public void BuildResponse_WhenResultExists_ReturnsHasResultAndJson()
+        {
+            _repository.StoreRunResult(
+                "run_tests_status_one",
+                "{\"Success\":true}",
+                System.DateTime.UtcNow);
+
+            GetRunTestsStatusResponse response = RunTestsStatusBridgeCommand.BuildResponse(
+                "run_tests_status_one",
+                isCompiling: false,
+                isUpdating: false,
+                isDomainReloadInProgress: false,
+                _repository);
+
+            Assert.That(response.HasResult, Is.True);
+            Assert.That(response.Result, Is.Not.Null);
+            Assert.That(response.Result["Success"]?.Value<bool>(), Is.True);
+        }
+
+        /// <summary>
+        /// Verifies a busy editor without a stored result is not Ready.
+        /// </summary>
+        [Test]
+        public void BuildResponse_WhenBusyAndNoResult_ReturnsNotReady()
+        {
+            GetRunTestsStatusResponse response = RunTestsStatusBridgeCommand.BuildResponse(
+                "run_tests_status_busy",
+                isCompiling: true,
+                isUpdating: false,
+                isDomainReloadInProgress: false,
+                _repository);
+
+            Assert.That(response.Ready, Is.False);
+            Assert.That(response.HasResult, Is.False);
+        }
+
+        /// <summary>
+        /// Verifies an idle editor without a stored result is Ready with HasResult false.
+        /// </summary>
+        [Test]
+        public void BuildResponse_WhenIdleAndNoResult_ReturnsReadyWithoutResult()
+        {
+            GetRunTestsStatusResponse response = RunTestsStatusBridgeCommand.BuildResponse(
+                "run_tests_status_idle",
+                isCompiling: false,
+                isUpdating: false,
+                isDomainReloadInProgress: false,
+                _repository);
+
+            Assert.That(response.Ready, Is.True);
+            Assert.That(response.HasResult, Is.False);
+            Assert.That(response.Result, Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies an empty request id never returns a stored result.
+        /// </summary>
+        [Test]
+        public void BuildResponse_WhenRequestIdIsEmpty_ReturnsNoResult()
+        {
+            _repository.StoreRunResult(
+                "run_tests_status_other",
+                "{\"Success\":true}",
+                System.DateTime.UtcNow);
+
+            GetRunTestsStatusResponse response = RunTestsStatusBridgeCommand.BuildResponse(
+                "",
+                isCompiling: false,
+                isUpdating: false,
+                isDomainReloadInProgress: false,
+                _repository);
+
+            Assert.That(response.HasResult, Is.False);
+            Assert.That(response.Result, Is.Null);
+        }
+    }
+}

--- a/Assets/Tests/Editor/RunTestsStatusBridgeCommandTests.cs.meta
+++ b/Assets/Tests/Editor/RunTestsStatusBridgeCommandTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 120a3f437a4fa4c5486f721b6a7ad31a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -1293,7 +1293,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             public RunTestsPredefinedAssemblyTestFindings PredefinedAssemblyTestFindings { get; set; } =
                 RunTestsPredefinedAssemblyTestFindings.None();
 
-            internal override Task<SerializableTestResult> ExecutePlayModeTestAsync(
+            public override Task<SerializableTestResult> ExecutePlayModeTestAsync(
                 TestExecutionFilter filter,
                 CancellationToken ct,
                 RunTestsPlayModeRunOptions options)

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -127,6 +127,62 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(validationService.WasCalled, Is.False);
         }
 
+        /// <summary>
+        /// Verifies PlayMode respect options and request id are forwarded to the execution stub.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenPlayModeRespectsEnterPlayModeSettings_ForwardsOptionsToStub()
+        {
+            StubTestExecutionService executionService = new();
+            StubTestExecutionStateValidationService validationService = new(ValidationResult.Success());
+            RunTestsUseCase useCase = new(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                waitForTestRunnerCleanupAsync: NoCleanupWait
+            );
+            RunTestsSchema parameters = new()
+            {
+                TestMode = UnityCliLoopTestMode.PlayMode,
+                RespectEnterPlayModeSettings = true,
+                RequestId = "run_tests_x"
+            };
+
+            await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(executionService.PlayModeWasCalled, Is.True);
+            Assert.That(executionService.LastRespectEnterPlayModeSettings, Is.True);
+            Assert.That(executionService.LastRequestId, Is.EqualTo("run_tests_x"));
+        }
+
+        /// <summary>
+        /// Verifies EditMode ignores respect settings and does not call the PlayMode stub.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenEditModeRespectsEnterPlayModeSettings_DoesNotCallPlayModeStub()
+        {
+            StubTestExecutionService executionService = new();
+            StubTestExecutionStateValidationService validationService = new(ValidationResult.Success());
+            RunTestsUseCase useCase = new(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                waitForTestRunnerCleanupAsync: NoCleanupWait
+            );
+            RunTestsSchema parameters = new()
+            {
+                TestMode = UnityCliLoopTestMode.EditMode,
+                RespectEnterPlayModeSettings = true,
+                RequestId = "run_tests_x"
+            };
+
+            await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(executionService.PlayModeWasCalled, Is.False);
+            Assert.That(executionService.WasCalled, Is.True);
+            Assert.That(executionService.LastRequestId, Is.Null);
+        }
+
         [Test]
         public async Task ExecuteAsync_WithDefaultRequest_ShouldSaveBeforeRun()
         {
@@ -1217,6 +1273,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             public bool TestFrameworkAvailable { get; set; } = true;
             public bool WasCalled { get; private set; }
+            public bool PlayModeWasCalled { get; private set; }
+            public bool LastRespectEnterPlayModeSettings { get; private set; }
+            public string LastRequestId { get; private set; }
             // Default stub result satisfies RunTestsResponse preconditions (non-null status
             // and noTestsFoundExplanation); individual tests override NextResult when they
             // need a specific execution status.
@@ -1234,10 +1293,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             public RunTestsPredefinedAssemblyTestFindings PredefinedAssemblyTestFindings { get; set; } =
                 RunTestsPredefinedAssemblyTestFindings.None();
 
-            public override Task<SerializableTestResult> ExecutePlayModeTestAsync(TestExecutionFilter filter, CancellationToken ct)
+            internal override Task<SerializableTestResult> ExecutePlayModeTestAsync(
+                TestExecutionFilter filter,
+                CancellationToken ct,
+                RunTestsPlayModeRunOptions options)
             {
                 ct.ThrowIfCancellationRequested();
                 WasCalled = true;
+                PlayModeWasCalled = true;
+                LastRespectEnterPlayModeSettings = options.RespectEnterPlayModeSettings;
+                LastRequestId = options.RequestId;
                 return Task.FromResult(NextResult);
             }
 

--- a/Assets/Tests/Editor/UnityCliLoopRunTestsSessionRepositoryTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopRunTestsSessionRepositoryTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests SessionState persistence for pending run-tests recovery across Domain Reload.
+    /// </summary>
+    [TestFixture]
+    public sealed class UnityCliLoopRunTestsSessionRepositoryTests
+    {
+        private UnityCliLoopRunTestsSessionRepository _repository;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _repository = new UnityCliLoopRunTestsSessionRepository();
+            _repository.ClearAll();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _repository.ClearAll();
+        }
+
+        /// <summary>
+        /// Verifies a stored pending run is visible through HasPendingRun and the pending id list.
+        /// </summary>
+        [Test]
+        public void StorePendingRun_WhenSaved_IsVisibleInPendingQueries()
+        {
+            DateTime expiresAtUtc = DateTime.UtcNow.AddMinutes(10);
+
+            _repository.StorePendingRun("run_tests_pending_one", expiresAtUtc);
+
+            IReadOnlyList<string> pendingIds = _repository.GetPendingRunRequestIds();
+            Assert.That(_repository.HasPendingRun("run_tests_pending_one"), Is.True);
+            Assert.That(_repository.HasAnyPendingRun(), Is.True);
+            Assert.That(pendingIds, Does.Contain("run_tests_pending_one"));
+        }
+
+        /// <summary>
+        /// Verifies storing a result clears that pending run and returns HasResult with the JSON.
+        /// </summary>
+        [Test]
+        public void StoreRunResult_WhenPendingExists_ClearsPendingAndExposesResult()
+        {
+            _repository.StorePendingRun("run_tests_result_one", DateTime.UtcNow.AddMinutes(10));
+
+            _repository.StoreRunResult(
+                "run_tests_result_one",
+                "{\"Success\":true}",
+                DateTime.UtcNow);
+
+            UnityCliLoopStoredRunTestsResult storedResult = _repository.GetRunResult("run_tests_result_one");
+            Assert.That(_repository.HasPendingRun("run_tests_result_one"), Is.False);
+            Assert.That(storedResult.HasResult, Is.True);
+            Assert.That(storedResult.ResultJson, Is.EqualTo("{\"Success\":true}"));
+        }
+
+        /// <summary>
+        /// Verifies ClearExpired drops an expired pending run and a result older than the result lifetime.
+        /// </summary>
+        [Test]
+        public void ClearExpired_WhenPendingAndResultArePastLifetime_RemovesBoth()
+        {
+            DateTime utcNow = DateTime.UtcNow;
+            _repository.StorePendingRun("run_tests_expired_pending", utcNow.AddMinutes(-1));
+            _repository.StoreRunResult(
+                "run_tests_expired_result",
+                "{\"Success\":false}",
+                utcNow - UnityCliLoopRunTestsSessionRepository.RunTestsResultLifetime - TimeSpan.FromMinutes(1));
+
+            _repository.ClearExpired(utcNow);
+
+            Assert.That(_repository.HasPendingRun("run_tests_expired_pending"), Is.False);
+            Assert.That(_repository.GetRunResult("run_tests_expired_result").HasResult, Is.False);
+        }
+
+        /// <summary>
+        /// Verifies an unknown request id yields a None result instead of leftover SessionState data.
+        /// </summary>
+        [Test]
+        public void GetRunResult_WhenRequestIdIsUnknown_ReturnsNone()
+        {
+            UnityCliLoopStoredRunTestsResult storedResult = _repository.GetRunResult("run_tests_unknown");
+
+            Assert.That(storedResult.HasResult, Is.False);
+            Assert.That(storedResult.ResultJson, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// Verifies two stored pending runs are both enumerated.
+        /// </summary>
+        [Test]
+        public void GetPendingRunRequestIds_WhenTwoPendingRunsExist_ReturnsBothIds()
+        {
+            DateTime expiresAtUtc = DateTime.UtcNow.AddMinutes(10);
+            _repository.StorePendingRun("run_tests_pending_a", expiresAtUtc);
+            _repository.StorePendingRun("run_tests_pending_b", expiresAtUtc);
+
+            IReadOnlyList<string> pendingIds = _repository.GetPendingRunRequestIds();
+            Assert.That(pendingIds, Does.Contain("run_tests_pending_a"));
+            Assert.That(pendingIds, Does.Contain("run_tests_pending_b"));
+            Assert.That(pendingIds.Count, Is.EqualTo(2));
+        }
+    }
+}

--- a/Assets/Tests/Editor/UnityCliLoopRunTestsSessionRepositoryTests.cs.meta
+++ b/Assets/Tests/Editor/UnityCliLoopRunTestsSessionRepositoryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 405d15ead46b04fb7a445c04f51ecf38
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
@@ -28,6 +28,8 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
                 new UnityCliLoopCompileResultSessionRepository();
             IPendingCompileSessionRepository pendingCompileSessionRepository =
                 new UnityCliLoopPendingCompileSessionRepository();
+            IRunTestsSessionRepository runTestsSessionRepository =
+                new UnityCliLoopRunTestsSessionRepository();
             UnityCliLoopCompileSessionLifecycleService compileSessionLifecycleService = new(
                 sessionFlagsRepository,
                 compileResultSessionRepository,
@@ -35,6 +37,7 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
             UnityCliLoopSessionFlagsFacade.RegisterRepository(sessionFlagsRepository);
             UnityCliLoopCompileResultSessionRepositoryFacade.RegisterRepository(compileResultSessionRepository);
             UnityCliLoopPendingCompileSessionRepositoryFacade.RegisterRepository(pendingCompileSessionRepository);
+            UnityCliLoopRunTestsSessionRepositoryFacade.RegisterRepository(runTestsSessionRepository);
             UnityCliLoopCompileSessionLifecycleFacade.RegisterService(compileSessionLifecycleService);
             UnityCliLoopFirstPartyServerLifecycleBinding firstPartyServerLifecycle = new(new ProjectIpcWarmupClient());
             DomainReloadDetectionFileService domainReloadDetectionService = new(

--- a/Packages/src/Editor/Domain/IRunTestsSessionRepository.cs
+++ b/Packages/src/Editor/Domain/IRunTestsSessionRepository.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Persists pending run-tests recovery records and stored results across Domain Reload.
+    /// </summary>
+    public interface IRunTestsSessionRepository
+    {
+        void StorePendingRun(string requestId, DateTime expiresAtUtc);
+        bool HasPendingRun(string requestId);
+        IReadOnlyList<string> GetPendingRunRequestIds();
+        bool HasAnyPendingRun();
+        void ClearPendingRun(string requestId);
+        void StoreRunResult(string requestId, string resultJson, DateTime completedAtUtc);
+        UnityCliLoopStoredRunTestsResult GetRunResult(string requestId);
+        void ClearExpired(DateTime utcNow);
+    }
+}

--- a/Packages/src/Editor/Domain/IRunTestsSessionRepository.cs.meta
+++ b/Packages/src/Editor/Domain/IRunTestsSessionRepository.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cfaa7480b3e9944b5a35cf8f2e459521
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Domain/JsonRpcAcceptedRequestCancellationPolicy.cs
+++ b/Packages/src/Editor/Domain/JsonRpcAcceptedRequestCancellationPolicy.cs
@@ -9,8 +9,14 @@ namespace io.github.hatayama.UnityCliLoop.Domain
     {
         public static bool ShouldCancelOnClientDisconnect(
             string methodName,
-            bool? compileWaitsForDomainReload)
+            bool? compileWaitsForDomainReload,
+            bool runTestsRespectsEnterPlayModeSettings)
         {
+            if (methodName == UnityCliLoopConstants.TOOL_NAME_RUN_TESTS && runTestsRespectsEnterPlayModeSettings)
+            {
+                return false;
+            }
+
             if (methodName != UnityCliLoopConstants.TOOL_NAME_COMPILE)
             {
                 return true;

--- a/Packages/src/Editor/Domain/UnityCliLoopRunTestsSessionRepositoryFacade.cs
+++ b/Packages/src/Editor/Domain/UnityCliLoopRunTestsSessionRepositoryFacade.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Exposes the CompositionRoot-owned run-tests session repository to static call sites.
+    /// Why: Activator-created tools and static bridge handlers need the shared repository without
+    /// reconstructing infrastructure outside the CompositionRoot.
+    /// </summary>
+    public static class UnityCliLoopRunTestsSessionRepositoryFacade
+    {
+        private static IRunTestsSessionRepository RepositoryValue;
+
+        internal static void RegisterRepository(IRunTestsSessionRepository repository)
+        {
+            Debug.Assert(repository != null, "repository must not be null");
+
+            RepositoryValue = repository ?? throw new ArgumentNullException(nameof(repository));
+        }
+
+        public static IRunTestsSessionRepository Repository
+        {
+            get
+            {
+                if (RepositoryValue == null)
+                {
+                    throw new InvalidOperationException(
+                        "Unity CLI Loop run-tests session repository is not registered.");
+                }
+
+                return RepositoryValue;
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/Domain/UnityCliLoopRunTestsSessionRepositoryFacade.cs.meta
+++ b/Packages/src/Editor/Domain/UnityCliLoopRunTestsSessionRepositoryFacade.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98b0a444593ae4b3d96e1925b28d219f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Domain/UnityCliLoopStoredRunTestsResult.cs
+++ b/Packages/src/Editor/Domain/UnityCliLoopStoredRunTestsResult.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Records the run-tests result that the CLI reads after Unity finishes Domain Reload.
+    /// </summary>
+    public sealed class UnityCliLoopStoredRunTestsResult
+    {
+        private UnityCliLoopStoredRunTestsResult(
+            bool hasResult,
+            string requestId,
+            string resultJson,
+            long completedAtUtcTicks)
+        {
+            HasResult = hasResult;
+            RequestId = requestId;
+            ResultJson = resultJson;
+            CompletedAtUtcTicks = completedAtUtcTicks;
+        }
+
+        public bool HasResult { get; }
+        public string RequestId { get; }
+        public string ResultJson { get; }
+        public long CompletedAtUtcTicks { get; }
+
+        public static UnityCliLoopStoredRunTestsResult None()
+        {
+            return new UnityCliLoopStoredRunTestsResult(false, "", "", 0);
+        }
+
+        public static UnityCliLoopStoredRunTestsResult Create(
+            string requestId,
+            string resultJson,
+            long completedAtUtcTicks)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+            Debug.Assert(!string.IsNullOrWhiteSpace(resultJson), "resultJson must not be null or whitespace");
+            Debug.Assert(completedAtUtcTicks > 0, "completedAtUtcTicks must be positive");
+
+            if (string.IsNullOrWhiteSpace(requestId))
+            {
+                throw new ArgumentException("requestId must not be null or whitespace.", nameof(requestId));
+            }
+
+            if (string.IsNullOrWhiteSpace(resultJson))
+            {
+                throw new ArgumentException("resultJson must not be null or whitespace.", nameof(resultJson));
+            }
+
+            return new UnityCliLoopStoredRunTestsResult(
+                true,
+                requestId,
+                resultJson,
+                completedAtUtcTicks);
+        }
+
+        public bool IsExpiredAt(DateTime utcNow, TimeSpan lifetime)
+        {
+            Debug.Assert(utcNow.Kind == DateTimeKind.Utc, "utcNow must be UTC");
+            Debug.Assert(lifetime > TimeSpan.Zero, "lifetime must be positive");
+            return HasResult && CompletedAtUtcTicks <= (utcNow - lifetime).Ticks;
+        }
+    }
+}

--- a/Packages/src/Editor/Domain/UnityCliLoopStoredRunTestsResult.cs.meta
+++ b/Packages/src/Editor/Domain/UnityCliLoopStoredRunTestsResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 81cda48591f1f43aead08188cbf8fb5b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/AssemblyInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/AssemblyInfo.cs
@@ -5,4 +5,3 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.PlayMode")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Demo.Editor")]
-[assembly: InternalsVisibleTo("UnityCLILoop.Dev")]

--- a/Packages/src/Editor/FirstPartyTools/RunTests/AssemblyInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/AssemblyInfo.cs
@@ -5,3 +5,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.PlayMode")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Demo.Editor")]
+[assembly: InternalsVisibleTo("UnityCLILoop.Dev")]

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsConstants.cs
@@ -7,6 +7,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public const int FailedTestDetailsLimit = 10;
 
+        public const string DomainReloadRecoveredWarning =
+            "The run entered Play Mode with a Domain Reload, so the result was recovered from SessionState after the reload. Pause-point and hot-reload notes were not evaluated for this run.";
+
         public const int UnfilteredTestNamesLimit = 20;
 
         public const int PredefinedAssemblyTestSampleLimit = 5;

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsPlayModeRunOptions.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsPlayModeRunOptions.cs
@@ -6,9 +6,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// <summary>
     /// PlayMode execution options for Domain Reload respect and pending-run recovery.
     /// </summary>
-    internal sealed class RunTestsPlayModeRunOptions
+    public sealed class RunTestsPlayModeRunOptions
     {
-        internal RunTestsPlayModeRunOptions(
+        public RunTestsPlayModeRunOptions(
             bool respectEnterPlayModeSettings,
             string requestId,
             DateTime pendingRunExpiresAtUtc)
@@ -20,16 +20,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             PendingRunExpiresAtUtc = pendingRunExpiresAtUtc;
         }
 
-        internal bool RespectEnterPlayModeSettings { get; }
-        internal string RequestId { get; }
-        internal DateTime PendingRunExpiresAtUtc { get; }
+        public bool RespectEnterPlayModeSettings { get; }
+        public string RequestId { get; }
+        public DateTime PendingRunExpiresAtUtc { get; }
 
-        internal static RunTestsPlayModeRunOptions WithoutRespect()
+        public static RunTestsPlayModeRunOptions WithoutRespect()
         {
             return new RunTestsPlayModeRunOptions(false, "", DateTime.MinValue);
         }
 
-        internal static bool ShouldDisableDomainReload(bool respectEnterPlayModeSettings)
+        public static bool ShouldDisableDomainReload(bool respectEnterPlayModeSettings)
         {
             return !respectEnterPlayModeSettings;
         }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsPlayModeRunOptions.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsPlayModeRunOptions.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// PlayMode execution options for Domain Reload respect and pending-run recovery.
+    /// </summary>
+    internal sealed class RunTestsPlayModeRunOptions
+    {
+        internal RunTestsPlayModeRunOptions(
+            bool respectEnterPlayModeSettings,
+            string requestId,
+            DateTime pendingRunExpiresAtUtc)
+        {
+            Debug.Assert(requestId != null, "requestId must not be null");
+
+            RespectEnterPlayModeSettings = respectEnterPlayModeSettings;
+            RequestId = requestId;
+            PendingRunExpiresAtUtc = pendingRunExpiresAtUtc;
+        }
+
+        internal bool RespectEnterPlayModeSettings { get; }
+        internal string RequestId { get; }
+        internal DateTime PendingRunExpiresAtUtc { get; }
+
+        internal static RunTestsPlayModeRunOptions WithoutRespect()
+        {
+            return new RunTestsPlayModeRunOptions(false, "", DateTime.MinValue);
+        }
+
+        internal static bool ShouldDisableDomainReload(bool respectEnterPlayModeSettings)
+        {
+            return !respectEnterPlayModeSettings;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsPlayModeRunOptions.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsPlayModeRunOptions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3222f2b89b6534fcab77e5efc45aab59
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponseFactory.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics;
+using System.Globalization;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Builds the pure run-tests response fields from a SerializableTestResult.
+    /// </summary>
+    internal static class RunTestsResponseFactory
+    {
+        internal static RunTestsResponse FromResult(SerializableTestResult result)
+        {
+            Debug.Assert(result != null, "result must not be null");
+
+            RunTestsResponse response = new(
+                success: result.success,
+                message: result.message,
+                completedAt: result.completedAt,
+                testCount: result.testCount,
+                passedCount: result.passedCount,
+                failedCount: result.failedCount,
+                skippedCount: result.skippedCount,
+                xmlPath: result.xmlPath,
+                status: result.status,
+                hasFailures: result.hasFailures,
+                noTestsFound: result.noTestsFound,
+                noTestsFoundExplanation: result.noTestsFoundExplanation);
+            CopyTestDetails(result, response);
+            if (result.failedCount > RunTestsConstants.FailedTestDetailsLimit)
+            {
+                response.Message = response.Message
+                    + " "
+                    + string.Format(
+                        CultureInfo.InvariantCulture,
+                        RunTestsConstants.FailedTestDetailsTruncatedMessageFormat,
+                        RunTestsConstants.FailedTestDetailsLimit,
+                        result.failedCount);
+            }
+
+            return response;
+        }
+
+        private static void CopyTestDetails(SerializableTestResult result, RunTestsResponse response)
+        {
+            if (result.failedTests != null && result.failedTests.Length > 0)
+            {
+                response.FailedTests = result.failedTests;
+            }
+
+            if (result.skippedTests != null && result.skippedTests.Length > 0)
+            {
+                response.SkippedTests = result.skippedTests;
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponseFactory.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponseFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 18293cbf0ae914f129174679991d23bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsSchema.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsSchema.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -33,5 +35,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Kept below the CLI absolute response timeout so hung runs free the single-flight slot first.
         /// </summary>
         public int TimeoutSeconds { get; set; } = RunTestsExecutionTimeout.DefaultTimeoutSeconds;
+
+        /// <summary>
+        /// When true and TestMode is PlayMode, keeps the project's Enter Play Mode settings instead of forcing Domain Reload off; a Domain Reload during the run is survived by storing the result in SessionState for CLI polling. Ignored for EditMode.
+        /// </summary>
+        public bool RespectEnterPlayModeSettings { get; set; } = false;
+
+        /// <summary>
+        /// Internal request identifier used for delayed result recovery across domain reload.
+        /// </summary>
+        [Browsable(false)]
+        public string RequestId { get; set; } = "";
     }
 } 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -124,7 +124,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 if (parameters.TestMode == UnityCliLoopTestMode.PlayMode)
                 {
-                    result = await _executionService.ExecutePlayModeTestAsync(filter, executionCt).ConfigureAwait(false);
+                    result = await _executionService.ExecutePlayModeTestAsync(
+                        filter,
+                        executionCt,
+                        CreatePlayModeRunOptions(parameters)).ConfigureAwait(false);
                 }
                 else
                 {
@@ -245,6 +248,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameters.FilterType,
                 parameters.FilterValue,
                 unfiltered);
+        }
+
+        private static RunTestsPlayModeRunOptions CreatePlayModeRunOptions(RunTestsSchema parameters)
+        {
+            Debug.Assert(parameters != null, "parameters must not be null");
+
+            if (!parameters.RespectEnterPlayModeSettings)
+            {
+                return RunTestsPlayModeRunOptions.WithoutRespect();
+            }
+
+            return new RunTestsPlayModeRunOptions(
+                true,
+                parameters.RequestId,
+                DateTime.UtcNow.AddSeconds(parameters.TimeoutSeconds + 120));
         }
 
         private static bool IsSupportedTestMode(UnityCliLoopTestMode testMode)

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Globalization;
 using System.Threading.Tasks;
 using System.Threading;
 using UnityEngine;
@@ -156,38 +155,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             // 3. Response creation.
-            RunTestsResponse response = new(
-                success: result.success,
-                message: result.message,
-                completedAt: result.completedAt,
-                testCount: result.testCount,
-                passedCount: result.passedCount,
-                failedCount: result.failedCount,
-                skippedCount: result.skippedCount,
-                xmlPath: result.xmlPath,
-                status: result.status,
-                hasFailures: result.hasFailures,
-                noTestsFound: result.noTestsFound,
-                noTestsFoundExplanation: result.noTestsFoundExplanation);
+            RunTestsResponse response = RunTestsResponseFactory.FromResult(result);
             if (clearedPausePointIds != null && clearedPausePointIds.Length > 0)
             {
                 response.ClearedPausePointIds = clearedPausePointIds;
             }
 
-            CopyTestDetails(result, response);
-
             response.Warning = RunTestsHotReloadDiscardWarningBuilder.Build(activeHotReloadChangeCountAtStart);
-
-            if (result.failedCount > RunTestsConstants.FailedTestDetailsLimit)
-            {
-                response.Message = response.Message
-                    + " "
-                    + string.Format(
-                        CultureInfo.InvariantCulture,
-                        RunTestsConstants.FailedTestDetailsTruncatedMessageFormat,
-                        RunTestsConstants.FailedTestDetailsLimit,
-                        result.failedCount);
-            }
 
             // Why switch here: cleanup waits with ConfigureAwait(false), so this resume is
             // off-thread. No-tests diagnostics call AssetDatabase.FindAssets, and the
@@ -205,19 +179,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             await ApplyUnfilteredFilterEchoIfNeededAsync(response, parameters, ct)
                 .ConfigureAwait(false);
             return response;
-        }
-
-        private void CopyTestDetails(SerializableTestResult result, RunTestsResponse response)
-        {
-            if (result.failedTests != null && result.failedTests.Length > 0)
-            {
-                response.FailedTests = result.failedTests;
-            }
-
-            if (result.skippedTests != null && result.skippedTests.Length > 0)
-            {
-                response.SkippedTests = result.skippedTests;
-            }
         }
 
         private void AppendPredefinedAssemblyTestNoticeIfNeeded(

--- a/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
@@ -34,6 +34,9 @@ uloop run-tests [options]
 | `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
 | `--skip-compile` | flag | - | Skip the automatic compile before running tests; use only while validating active hot-reload patches. |
 | `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
+| `--respect-enter-play-mode-settings` | flag | - | PlayMode only: keep the project's Enter Play Mode settings instead of forcing Domain Reload off. A Domain Reload during the run is survived; the result is recovered after the reload. Use for projects whose libraries require a Domain Reload on Play entry. |
+
+By default PlayMode still forces Domain Reload off. With `--respect-enter-play-mode-settings`, a Domain Reload may run and the command takes longer; pause-point and hot-reload notes are omitted from a result recovered after reload. Canceling the CLI (Ctrl-C) does not stop the Unity-side run on this path.
 
 exact matches the full test name (Namespace.Class.Method). class runs every test of one class by bare or namespace-qualified name, e.g. --filter-type class --filter-value PlayerTests; the name is matched literally and whole, so PlayerTests does not run EnemyPlayerTests. regex matches a .NET regex against full test names, e.g. --filter-type regex --filter-value '^MyGame\.Tests\.'
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionService.cs
@@ -18,7 +18,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         /// <param name="filter">Test execution filter</param>
         /// <returns>Test execution result</returns>
-        internal virtual Task<SerializableTestResult> ExecutePlayModeTestAsync(
+        public virtual Task<SerializableTestResult> ExecutePlayModeTestAsync(
             TestExecutionFilter filter,
             CancellationToken ct,
             RunTestsPlayModeRunOptions options)

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionService.cs
@@ -18,10 +18,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         /// <param name="filter">Test execution filter</param>
         /// <returns>Test execution result</returns>
-        public virtual Task<SerializableTestResult> ExecutePlayModeTestAsync(TestExecutionFilter filter, CancellationToken ct)
+        internal virtual Task<SerializableTestResult> ExecutePlayModeTestAsync(
+            TestExecutionFilter filter,
+            CancellationToken ct,
+            RunTestsPlayModeRunOptions options)
         {
             ct.ThrowIfCancellationRequested();
-            return UnityTestFrameworkExecutionServiceRegistry.Current.ExecutePlayModeTestAsync(filter, ct);
+            return UnityTestFrameworkExecutionServiceRegistry.Current.ExecutePlayModeTestAsync(filter, ct, options);
         }
 
         /// <summary>
@@ -57,7 +60,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
     internal interface IUnityTestFrameworkExecutionService
     {
-        Task<SerializableTestResult> ExecutePlayModeTestAsync(TestExecutionFilter filter, CancellationToken ct);
+        Task<SerializableTestResult> ExecutePlayModeTestAsync(
+            TestExecutionFilter filter,
+            CancellationToken ct,
+            RunTestsPlayModeRunOptions options);
         Task<SerializableTestResult> ExecuteEditModeTestAsync(TestExecutionFilter filter, CancellationToken ct);
         Task<RunTestsUnfilteredTestListResult> RetrieveUnfilteredTestNamesAsync(
             UnityCliLoopTestMode testMode,
@@ -84,7 +90,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
     internal sealed class TestFrameworkUnavailableExecutionService : IUnityTestFrameworkExecutionService
     {
-        public Task<SerializableTestResult> ExecutePlayModeTestAsync(TestExecutionFilter filter, CancellationToken ct)
+        public Task<SerializableTestResult> ExecutePlayModeTestAsync(
+            TestExecutionFilter filter,
+            CancellationToken ct,
+            RunTestsPlayModeRunOptions options)
         {
             ct.ThrowIfCancellationRequested();
             return Task.FromResult(SerializableTestResult.CreateTestFrameworkUnavailable());

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Editor")]
+[assembly: InternalsVisibleTo("UnityCLILoop.Dev")]
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
@@ -25,9 +26,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
     internal sealed class UnityTestFrameworkExecutionService : IUnityTestFrameworkExecutionService
     {
-        public Task<SerializableTestResult> ExecutePlayModeTestAsync(TestExecutionFilter filter, CancellationToken ct)
+        public Task<SerializableTestResult> ExecutePlayModeTestAsync(
+            TestExecutionFilter filter,
+            CancellationToken ct,
+            RunTestsPlayModeRunOptions options)
         {
-            return PlayModeTestExecuter.ExecutePlayModeTest(filter, ct);
+            return PlayModeTestExecuter.ExecutePlayModeTest(filter, ct, options);
         }
 
         public Task<SerializableTestResult> ExecuteEditModeTestAsync(TestExecutionFilter filter, CancellationToken ct)
@@ -50,26 +54,60 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
     public static class PlayModeTestExecuter
     {
-        public static async Task<SerializableTestResult> ExecutePlayModeTest(
+        internal static async Task<SerializableTestResult> ExecutePlayModeTest(
             TestExecutionFilter filter,
-            CancellationToken ct)
+            CancellationToken ct,
+            RunTestsPlayModeRunOptions options)
         {
+            Debug.Assert(options != null, "options must not be null");
             ct.ThrowIfCancellationRequested();
             DomainReloadDisableScope.RecoverAbandonedScopeBeforeNewRun();
+            bool respectEnterPlayModeSettings = options.RespectEnterPlayModeSettings;
+            if (respectEnterPlayModeSettings)
+            {
+                Debug.Assert(
+                    !string.IsNullOrEmpty(options.RequestId),
+                    "requestId must not be empty on the respect path; the CLI always supplies it");
+            }
+
             // Why not `using`: Dispose must run only after cancel-time stop/restore finishes.
             // Disposing earlier re-enables domain reload while Test Runner / Play Mode may still be active.
-            DomainReloadDisableScope scope = new DomainReloadDisableScope();
+            DomainReloadDisableScope scope = RunTestsPlayModeRunOptions.ShouldDisableDomainReload(
+                respectEnterPlayModeSettings)
+                ? new DomainReloadDisableScope()
+                : null;
+            RunTestsPendingRunScope pendingScope = respectEnterPlayModeSettings
+                ? new RunTestsPendingRunScope(options.RequestId, options.PendingRunExpiresAtUtc)
+                : null;
+            pendingScope?.Begin();
             string runGuid = null;
             try
             {
-                return await ExecuteTestWithEventNotification(
+                SerializableTestResult result = await ExecuteTestWithEventNotification(
                     TestMode.PlayMode,
                     filter,
                     ct,
                     startedRunGuid => runGuid = startedRunGuid).ConfigureAwait(false);
+                pendingScope?.ClearPending();
+                return result;
             }
             catch (OperationCanceledException originalException)
             {
+                if (respectEnterPlayModeSettings && pendingScope != null && pendingScope.ReloadObserved)
+                {
+                    // Why not stop/restore: RunTestsCancelStopRestore also calls TryCancelTestRun,
+                    // which would tear down the Test Runner that must finish in the next domain.
+                    // The server's beforeAssemblyReload handler cancels the in-flight request, but
+                    // TaskCompletionSource uses RunContinuationsAsynchronously so this catch does
+                    // not run synchronously; the same event delivery sets ReloadObserved first.
+                    throw;
+                }
+
+                if (respectEnterPlayModeSettings)
+                {
+                    pendingScope?.ClearPending();
+                }
+
                 // Why switch first: ExecuteTestWithEventNotification may resume off-thread via
                 // ConfigureAwait(false), but stop/restore hooks call Unity Play Mode APIs.
                 await MainThreadSwitcher.SwitchToMainThread(CancellationToken.None);
@@ -82,7 +120,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             finally
             {
                 await MainThreadSwitcher.SwitchToMainThread(CancellationToken.None);
-                scope.Dispose();
+                pendingScope?.End();
+                scope?.Dispose();
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
@@ -9,7 +9,6 @@ using UnityEngine;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Editor")]
-[assembly: InternalsVisibleTo("UnityCLILoop.Dev")]
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
@@ -54,7 +53,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
     public static class PlayModeTestExecuter
     {
-        internal static async Task<SerializableTestResult> ExecutePlayModeTest(
+        public static async Task<SerializableTestResult> ExecutePlayModeTest(
             TestExecutionFilter filter,
             CancellationToken ct,
             RunTestsPlayModeRunOptions options)
@@ -83,13 +82,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string runGuid = null;
             try
             {
-                SerializableTestResult result = await ExecuteTestWithEventNotification(
+                return await ExecuteTestWithEventNotification(
                     TestMode.PlayMode,
                     filter,
                     ct,
                     startedRunGuid => runGuid = startedRunGuid).ConfigureAwait(false);
-                pendingScope?.ClearPending();
-                return result;
             }
             catch (OperationCanceledException originalException)
             {
@@ -101,11 +98,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     // TaskCompletionSource uses RunContinuationsAsynchronously so this catch does
                     // not run synchronously; the same event delivery sets ReloadObserved first.
                     throw;
-                }
-
-                if (respectEnterPlayModeSettings)
-                {
-                    pendingScope?.ClearPending();
                 }
 
                 // Why switch first: ExecuteTestWithEventNotification may resume off-thread via
@@ -120,6 +112,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             finally
             {
                 await MainThreadSwitcher.SwitchToMainThread(CancellationToken.None);
+                // Why not only on success/cancel: any other failure would leave a pending id,
+                // and a later unrelated RunFinished would store against it after reload.
+                if (pendingScope != null && !pendingScope.ReloadObserved)
+                {
+                    pendingScope.ClearPending();
+                }
+
                 pendingScope?.End();
                 scope?.Dispose();
             }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPendingRunCallback.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPendingRunCallback.cs
@@ -1,0 +1,62 @@
+#if ULOOP_HAS_TEST_FRAMEWORK
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using UnityEditor.TestTools.TestRunner.Api;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Records the post-reload RunFinished result against every pending run-tests request id.
+    /// </summary>
+    internal sealed class RunTestsPendingRunCallback : ICallbacks
+    {
+        private readonly TestRunnerApi _testRunnerApi;
+
+        internal RunTestsPendingRunCallback(TestRunnerApi testRunnerApi)
+        {
+            _testRunnerApi = testRunnerApi;
+        }
+
+        public void RunStarted(ITestAdaptor tests)
+        {
+        }
+
+        public void RunFinished(ITestResultAdaptor result)
+        {
+            SerializableTestResult serializableResult = SerializableTestResultConverter.FromTestResult(result);
+            if (serializableResult.failedCount > 0)
+            {
+                serializableResult.xmlPath = PlayModeTestExecuter.TrySaveFailureXml(result);
+            }
+
+            RunTestsResponse response = RunTestsResponseFactory.FromResult(serializableResult);
+            response.Warning = RunTestsConstants.DomainReloadRecoveredWarning;
+            string resultJson = JsonConvert.SerializeObject(
+                response,
+                Formatting.None,
+                UnityCliLoopJsonResponseSerializerSettings.Settings);
+            IRunTestsSessionRepository repository = UnityCliLoopRunTestsSessionRepositoryFacade.Repository;
+            IReadOnlyList<string> requestIds = repository.GetPendingRunRequestIds();
+            DateTime completedAtUtc = DateTime.UtcNow;
+            foreach (string requestId in requestIds)
+            {
+                repository.StoreRunResult(requestId, resultJson, completedAtUtc);
+            }
+
+            _testRunnerApi.UnregisterCallbacks(this);
+        }
+
+        public void TestStarted(ITestAdaptor test)
+        {
+        }
+
+        public void TestFinished(ITestResultAdaptor result)
+        {
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPendingRunCallback.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPendingRunCallback.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6a56dfa436f44379984761bbe5fe3b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPendingRunCallbackRegistrar.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPendingRunCallbackRegistrar.cs
@@ -1,0 +1,41 @@
+#if ULOOP_HAS_TEST_FRAMEWORK
+using UnityEditor;
+using UnityEditor.TestTools.TestRunner.Api;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Re-registers RunFinished after Domain Reload when a pending respect-path run exists.
+    /// First-domain loads see no pending record yet because StorePendingRun happens just before
+    /// Execute, so only UnifiedTestCallback runs there. After reload, SessionState still has the
+    /// pending id and this registrar attaches again, including after Play Mode exit reload.
+    /// </summary>
+    internal static class RunTestsPendingRunCallbackRegistrar
+    {
+        [InitializeOnLoadMethod]
+        private static void ScheduleRegisterIfPending()
+        {
+            // Why delayCall: Facade registration comes from UnityCliLoopEditorBootstrap's
+            // [InitializeOnLoadMethod]. Unity runs [InitializeOnLoad] static constructors first
+            // and does not order [InitializeOnLoadMethod] peers, so reading Repository here can
+            // throw before CompositionRoot has registered it.
+            EditorApplication.delayCall += RegisterIfPending;
+        }
+
+        private static void RegisterIfPending()
+        {
+            IRunTestsSessionRepository repository = UnityCliLoopRunTestsSessionRepositoryFacade.Repository;
+            if (!repository.HasAnyPendingRun())
+            {
+                return;
+            }
+
+            TestRunnerApi testRunnerApi = ScriptableObject.CreateInstance<TestRunnerApi>();
+            testRunnerApi.RegisterCallbacks(new RunTestsPendingRunCallback(testRunnerApi));
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPendingRunCallbackRegistrar.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPendingRunCallbackRegistrar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b256c8b776a6542c2a12c9f6b0a9522c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPendingRunScope.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPendingRunScope.cs
@@ -1,0 +1,52 @@
+#if ULOOP_HAS_TEST_FRAMEWORK
+using System;
+using System.Diagnostics;
+using UnityEditor;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Writes the pending run record and observes Domain Reload on the respect path.
+    /// </summary>
+    internal sealed class RunTestsPendingRunScope
+    {
+        private readonly string _requestId;
+        private readonly DateTime _expiresAtUtc;
+        private bool _reloadObserved;
+
+        internal RunTestsPendingRunScope(string requestId, DateTime expiresAtUtc)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(requestId), "requestId must not be empty on the respect path");
+            Debug.Assert(expiresAtUtc.Kind == DateTimeKind.Utc, "expiresAtUtc must be UTC");
+
+            _requestId = requestId;
+            _expiresAtUtc = expiresAtUtc;
+        }
+
+        internal bool ReloadObserved => _reloadObserved;
+
+        internal void Begin()
+        {
+            UnityCliLoopRunTestsSessionRepositoryFacade.Repository.StorePendingRun(_requestId, _expiresAtUtc);
+            AssemblyReloadEvents.beforeAssemblyReload += OnBeforeAssemblyReload;
+        }
+
+        internal void ClearPending()
+        {
+            UnityCliLoopRunTestsSessionRepositoryFacade.Repository.ClearPendingRun(_requestId);
+        }
+
+        internal void End()
+        {
+            AssemblyReloadEvents.beforeAssemblyReload -= OnBeforeAssemblyReload;
+        }
+
+        private void OnBeforeAssemblyReload()
+        {
+            _reloadObserved = true;
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPendingRunScope.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsPendingRunScope.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66addfede44304c45b501a4d7ee2dbe1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/UnityCLILoop.FirstPartyTools.RunTests.TestFramework.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/UnityCLILoop.FirstPartyTools.RunTests.TestFramework.Editor.asmdef
@@ -7,6 +7,7 @@
         "UnityCLILoop.FirstPartyTools.Common.EditorUtility.Editor",
         "UnityCLILoop.FirstPartyTools.Common.OutputRetention.Editor",
         "UnityCLILoop.ToolContracts",
+        "UnityCLILoop.Domain",
         "UnityEditor.TestRunner",
         "UnityEngine.TestRunner"
     ],

--- a/Packages/src/Editor/Infrastructure/Api/GetRunTestsStatusResponse.cs
+++ b/Packages/src/Editor/Infrastructure/Api/GetRunTestsStatusResponse.cs
@@ -1,0 +1,20 @@
+using Newtonsoft.Json.Linq;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Run-tests status payload returned by the internal CLI polling bridge command.
+    /// </summary>
+    public class GetRunTestsStatusResponse : UnityCliLoopToolResponse
+    {
+        public bool Ready { get; set; }
+        public bool HasResult { get; set; }
+        public bool IsCompiling { get; set; }
+        public bool IsUpdating { get; set; }
+        public bool IsDomainReloadInProgress { get; set; }
+        public JToken Result { get; set; }
+        public string Message { get; set; }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Api/GetRunTestsStatusResponse.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Api/GetRunTestsStatusResponse.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 627b5306c6b8e4d9eae315db8caa28ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/Api/InternalBridgeCommandRouter.cs
+++ b/Packages/src/Editor/Infrastructure/Api/InternalBridgeCommandRouter.cs
@@ -16,6 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             return methodName == UnityCliLoopConstants.COMMAND_NAME_GET_VERSION ||
                    methodName == UnityCliLoopConstants.COMMAND_NAME_GET_COMPILE_STATUS ||
+                   methodName == UnityCliLoopConstants.COMMAND_NAME_GET_RUN_TESTS_STATUS ||
                    methodName == UnityCliLoopConstants.COMMAND_NAME_GET_PAUSE_POINT_STATUS ||
                    methodName == UnityCliLoopConstants.COMMAND_NAME_CLEAR_PAUSE_POINT_STATUS ||
                    methodName == UnityCliLoopConstants.COMMAND_NAME_EXTEND_PAUSE_POINT_STATUS ||
@@ -45,6 +46,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             if (methodName == UnityCliLoopConstants.COMMAND_NAME_GET_COMPILE_STATUS)
             {
                 return CompileStatusBridgeCommand.Execute(paramsToken);
+            }
+
+            if (methodName == UnityCliLoopConstants.COMMAND_NAME_GET_RUN_TESTS_STATUS)
+            {
+                return RunTestsStatusBridgeCommand.Execute(paramsToken);
             }
 
             if (methodName == UnityCliLoopConstants.COMMAND_NAME_GET_PAUSE_POINT_STATUS)

--- a/Packages/src/Editor/Infrastructure/Api/JsonRpcRequestProcessor.cs
+++ b/Packages/src/Editor/Infrastructure/Api/JsonRpcRequestProcessor.cs
@@ -208,9 +208,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             bool? compileWaitsForDomainReload =
                 JsonRpcCompileRequestMetadataReader.ReadWaitsForDomainReload(request.Params);
+            bool runTestsRespectsEnterPlayModeSettings =
+                JsonRpcRunTestsRequestMetadataReader.ReadRespectsEnterPlayModeSettings(request.Params);
             return JsonRpcAcceptedRequestCancellationPolicy.ShouldCancelOnClientDisconnect(
                 request.Method,
-                compileWaitsForDomainReload);
+                compileWaitsForDomainReload,
+                runTestsRespectsEnterPlayModeSettings);
         }
 
         private static bool IsCliProtocolMismatch(int? currentProtocolVersion)

--- a/Packages/src/Editor/Infrastructure/Api/JsonRpcRunTestsRequestMetadataReader.cs
+++ b/Packages/src/Editor/Infrastructure/Api/JsonRpcRunTestsRequestMetadataReader.cs
@@ -1,0 +1,36 @@
+using System;
+using Newtonsoft.Json.Linq;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Reads run-tests JSON-RPC request metadata used before tool dispatch.
+    /// </summary>
+    internal static class JsonRpcRunTestsRequestMetadataReader
+    {
+        private const string RespectEnterPlayModeSettingsParamName = "RespectEnterPlayModeSettings";
+        private const string TestModeParamName = "TestMode";
+        private const string PlayModeValue = "PlayMode";
+
+        internal static bool ReadRespectsEnterPlayModeSettings(JToken paramsToken)
+        {
+            if (paramsToken is not JObject paramsObject)
+            {
+                return false;
+            }
+
+            bool? respectEnterPlayModeSettings = StrictJsonBooleanMetadataReader.ReadOptionalBoolean(
+                paramsObject,
+                RespectEnterPlayModeSettingsParamName,
+                StringComparison.OrdinalIgnoreCase);
+            if (respectEnterPlayModeSettings != true)
+            {
+                return false;
+            }
+
+            JToken testModeToken = paramsObject.GetValue(TestModeParamName, StringComparison.OrdinalIgnoreCase);
+            string testMode = testModeToken?.ToString() ?? "";
+            return string.Equals(testMode, PlayModeValue, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Api/JsonRpcRunTestsRequestMetadataReader.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Api/JsonRpcRunTestsRequestMetadataReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6fe39de4dcf5a406a8529ac9e7cd9856
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/Api/RunTestsStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/RunTestsStatusBridgeCommand.cs
@@ -1,0 +1,89 @@
+using System;
+using Newtonsoft.Json.Linq;
+using UnityEditor;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Reports run-tests completion state for the CLI without entering the normal tool execution slot.
+    /// </summary>
+    internal static class RunTestsStatusBridgeCommand
+    {
+        private const string RequestIdParamName = "RequestId";
+
+        public static GetRunTestsStatusResponse Execute(JToken paramsToken)
+        {
+            string requestId = ReadRequestId(paramsToken);
+            IRunTestsSessionRepository repository = UnityCliLoopRunTestsSessionRepositoryFacade.Repository;
+            repository.ClearExpired(DateTime.UtcNow);
+            ISessionFlagsRepository sessionFlagsRepository = UnityCliLoopSessionFlagsFacade.Repository;
+            bool isCompiling = EditorApplication.isCompiling;
+            bool isUpdating = EditorApplication.isUpdating;
+            bool isDomainReloadInProgress =
+                sessionFlagsRepository.GetIsDomainReloadInProgress() ||
+                DomainReloadStateRegistry.IsDomainReloadInProgress();
+            return BuildResponse(
+                requestId,
+                isCompiling,
+                isUpdating,
+                isDomainReloadInProgress,
+                repository);
+        }
+
+        internal static GetRunTestsStatusResponse BuildResponse(
+            string requestId,
+            bool isCompiling,
+            bool isUpdating,
+            bool isDomainReloadInProgress,
+            IRunTestsSessionRepository repository)
+        {
+            Debug.Assert(repository != null, "repository must not be null");
+
+            bool ready = !isCompiling && !isUpdating && !isDomainReloadInProgress;
+            UnityCliLoopStoredRunTestsResult storedResult = string.IsNullOrWhiteSpace(requestId)
+                ? UnityCliLoopStoredRunTestsResult.None()
+                : repository.GetRunResult(requestId);
+            JToken result = storedResult.HasResult ? JToken.Parse(storedResult.ResultJson) : null;
+            return new GetRunTestsStatusResponse
+            {
+                Ready = ready,
+                HasResult = storedResult.HasResult,
+                IsCompiling = isCompiling,
+                IsUpdating = isUpdating,
+                IsDomainReloadInProgress = isDomainReloadInProgress,
+                Result = result,
+                Message = CreateMessage(ready, storedResult.HasResult)
+            };
+        }
+
+        private static string ReadRequestId(JToken paramsToken)
+        {
+            if (paramsToken is not JObject paramsObject)
+            {
+                return "";
+            }
+
+            JToken requestIdToken = paramsObject.GetValue(RequestIdParamName, StringComparison.OrdinalIgnoreCase);
+            return requestIdToken?.ToString() ?? "";
+        }
+
+        private static string CreateMessage(bool ready, bool hasResult)
+        {
+            if (!ready)
+            {
+                return "Unity is still compiling, updating assets, or reloading scripts.";
+            }
+
+            if (!hasResult)
+            {
+                return "Run-tests result is not available for this request. Unity may have restarted or the request may not have completed.";
+            }
+
+            return "Run-tests result is available.";
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Api/RunTestsStatusBridgeCommand.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Api/RunTestsStatusBridgeCommand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75fc3f06d72274ad6a7fe65a46289525
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopRunTestsSessionRepository.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopRunTestsSessionRepository.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Stores pending run-tests recovery records and results in Unity SessionState.
+    /// </summary>
+    public sealed class UnityCliLoopRunTestsSessionRepository : IRunTestsSessionRepository
+    {
+        internal static readonly TimeSpan RunTestsResultLifetime = TimeSpan.FromMinutes(20);
+
+        private const string PendingRequestIdsKey =
+            UnityCliLoopEditorSessionStateStorage.KeyPrefix + "runTestsPendingRequestIds";
+        private const string ResultRequestIdsKey =
+            UnityCliLoopEditorSessionStateStorage.KeyPrefix + "runTestsResultRequestIds";
+        private const string RunTestsKeyPrefix =
+            UnityCliLoopEditorSessionStateStorage.KeyPrefix + "runTests.";
+        private const string PendingExpiresAtUtcTicksKeySuffix = ".expiresAtUtcTicks";
+        private const string ResultJsonKeySuffix = ".json";
+        private const string ResultCompletedAtUtcTicksKeySuffix = ".completedAtUtcTicks";
+
+        public void StorePendingRun(string requestId, DateTime expiresAtUtc)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+            Debug.Assert(expiresAtUtc.Kind == DateTimeKind.Utc, "expiresAtUtc must be UTC");
+            Debug.Assert(expiresAtUtc.Ticks > 0, "expiresAtUtc ticks must be positive");
+
+            SetPendingRequestIds(
+                UnityCliLoopEditorSessionStateStorage.AddRequestIdToIndex(GetPendingRequestIds(), requestId));
+            SetPendingExpiresAtUtcTicks(requestId, expiresAtUtc.Ticks.ToString());
+        }
+
+        public bool HasPendingRun(string requestId)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+
+            IReadOnlyList<string> pendingIds = GetPendingRunRequestIds();
+            for (int i = 0; i < pendingIds.Count; i++)
+            {
+                if (pendingIds[i] == requestId)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public IReadOnlyList<string> GetPendingRunRequestIds()
+        {
+            string[] requestIds =
+                UnityCliLoopEditorSessionStateStorage.ParseRequestIdIndex(GetPendingRequestIds());
+            List<string> pendingIds = new List<string>();
+            foreach (string requestId in requestIds)
+            {
+                if (!HasValidPendingExpiresAt(requestId))
+                {
+                    ClearPendingRunValues(requestId);
+                    continue;
+                }
+
+                pendingIds.Add(requestId);
+            }
+
+            if (pendingIds.Count != requestIds.Length)
+            {
+                string rebuiltIndex = "";
+                foreach (string pendingId in pendingIds)
+                {
+                    rebuiltIndex = UnityCliLoopEditorSessionStateStorage.AddRequestIdToIndex(rebuiltIndex, pendingId);
+                }
+
+                SetPendingRequestIds(rebuiltIndex);
+            }
+
+            return pendingIds;
+        }
+
+        public bool HasAnyPendingRun()
+        {
+            return GetPendingRunRequestIds().Count > 0;
+        }
+
+        public void ClearPendingRun(string requestId)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+
+            ClearPendingRunValues(requestId);
+            SetPendingRequestIds(
+                UnityCliLoopEditorSessionStateStorage.RemoveRequestIdFromIndex(GetPendingRequestIds(), requestId));
+        }
+
+        public void StoreRunResult(string requestId, string resultJson, DateTime completedAtUtc)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+            Debug.Assert(!string.IsNullOrWhiteSpace(resultJson), "resultJson must not be null or whitespace");
+            Debug.Assert(completedAtUtc.Kind == DateTimeKind.Utc, "completedAtUtc must be UTC");
+
+            SetResultRequestIds(
+                UnityCliLoopEditorSessionStateStorage.AddRequestIdToIndex(GetResultRequestIds(), requestId));
+            SetResultJson(requestId, resultJson);
+            SetResultCompletedAtUtcTicks(requestId, completedAtUtc.Ticks.ToString());
+            ClearPendingRun(requestId);
+        }
+
+        public UnityCliLoopStoredRunTestsResult GetRunResult(string requestId)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+
+            string resultJson = GetResultJson(requestId);
+            if (string.IsNullOrWhiteSpace(resultJson))
+            {
+                ClearRunResult(requestId);
+                return UnityCliLoopStoredRunTestsResult.None();
+            }
+
+            string completedAtUtcTicksText = GetResultCompletedAtUtcTicks(requestId);
+            (bool isValid, long completedAtUtcTicks) =
+                UnityCliLoopEditorSessionStateStorage.ParseUtcTicks(completedAtUtcTicksText);
+            if (!isValid || completedAtUtcTicks <= 0)
+            {
+                ClearRunResult(requestId);
+                return UnityCliLoopStoredRunTestsResult.None();
+            }
+
+            return UnityCliLoopStoredRunTestsResult.Create(requestId, resultJson, completedAtUtcTicks);
+        }
+
+        public void ClearExpired(DateTime utcNow)
+        {
+            Debug.Assert(utcNow.Kind == DateTimeKind.Utc, "utcNow must be UTC");
+
+            IReadOnlyList<string> pendingIds = GetPendingRunRequestIds();
+            foreach (string requestId in pendingIds)
+            {
+                if (!IsPendingExpired(requestId, utcNow))
+                {
+                    continue;
+                }
+
+                ClearPendingRun(requestId);
+            }
+
+            string[] resultIds =
+                UnityCliLoopEditorSessionStateStorage.ParseRequestIdIndex(GetResultRequestIds());
+            foreach (string requestId in resultIds)
+            {
+                UnityCliLoopStoredRunTestsResult storedResult = GetRunResult(requestId);
+                if (!storedResult.IsExpiredAt(utcNow, RunTestsResultLifetime))
+                {
+                    continue;
+                }
+
+                ClearRunResult(requestId);
+            }
+        }
+
+        internal void ClearAll()
+        {
+            foreach (string requestId in UnityCliLoopEditorSessionStateStorage.ParseRequestIdIndex(
+                GetPendingRequestIds()))
+            {
+                ClearPendingRunValues(requestId);
+            }
+
+            SetPendingRequestIds("");
+
+            foreach (string requestId in UnityCliLoopEditorSessionStateStorage.ParseRequestIdIndex(
+                GetResultRequestIds()))
+            {
+                ClearRunResultValues(requestId);
+            }
+
+            SetResultRequestIds("");
+        }
+
+        private static bool HasValidPendingExpiresAt(string requestId)
+        {
+            (bool isValid, long expiresAtUtcTicks) =
+                UnityCliLoopEditorSessionStateStorage.ParseUtcTicks(GetPendingExpiresAtUtcTicks(requestId));
+            return isValid && expiresAtUtcTicks > 0;
+        }
+
+        private static bool IsPendingExpired(string requestId, DateTime utcNow)
+        {
+            (bool isValid, long expiresAtUtcTicks) =
+                UnityCliLoopEditorSessionStateStorage.ParseUtcTicks(GetPendingExpiresAtUtcTicks(requestId));
+            return isValid && expiresAtUtcTicks > 0 && expiresAtUtcTicks <= utcNow.Ticks;
+        }
+
+        private void ClearRunResult(string requestId)
+        {
+            ClearRunResultValues(requestId);
+            SetResultRequestIds(
+                UnityCliLoopEditorSessionStateStorage.RemoveRequestIdFromIndex(GetResultRequestIds(), requestId));
+        }
+
+        private static void ClearPendingRunValues(string requestId)
+        {
+            SetPendingExpiresAtUtcTicks(requestId, "");
+        }
+
+        private static void ClearRunResultValues(string requestId)
+        {
+            SetResultJson(requestId, "");
+            SetResultCompletedAtUtcTicks(requestId, "");
+        }
+
+        private static string GetPendingRequestIds()
+        {
+            return UnityCliLoopEditorSessionStateStorage.GetString(PendingRequestIdsKey);
+        }
+
+        private static void SetPendingRequestIds(string pendingRequestIds)
+        {
+            UnityCliLoopEditorSessionStateStorage.SetString(PendingRequestIdsKey, pendingRequestIds);
+        }
+
+        private static string GetResultRequestIds()
+        {
+            return UnityCliLoopEditorSessionStateStorage.GetString(ResultRequestIdsKey);
+        }
+
+        private static void SetResultRequestIds(string resultRequestIds)
+        {
+            UnityCliLoopEditorSessionStateStorage.SetString(ResultRequestIdsKey, resultRequestIds);
+        }
+
+        private static string GetPendingExpiresAtUtcTicks(string requestId)
+        {
+            return UnityCliLoopEditorSessionStateStorage.GetString(
+                CreateRunTestsKey(requestId, PendingExpiresAtUtcTicksKeySuffix));
+        }
+
+        private static void SetPendingExpiresAtUtcTicks(string requestId, string expiresAtUtcTicks)
+        {
+            UnityCliLoopEditorSessionStateStorage.SetString(
+                CreateRunTestsKey(requestId, PendingExpiresAtUtcTicksKeySuffix),
+                expiresAtUtcTicks);
+        }
+
+        private static string GetResultJson(string requestId)
+        {
+            return UnityCliLoopEditorSessionStateStorage.GetString(
+                CreateRunTestsKey(requestId, ResultJsonKeySuffix));
+        }
+
+        private static void SetResultJson(string requestId, string resultJson)
+        {
+            UnityCliLoopEditorSessionStateStorage.SetString(
+                CreateRunTestsKey(requestId, ResultJsonKeySuffix),
+                resultJson);
+        }
+
+        private static string GetResultCompletedAtUtcTicks(string requestId)
+        {
+            return UnityCliLoopEditorSessionStateStorage.GetString(
+                CreateRunTestsKey(requestId, ResultCompletedAtUtcTicksKeySuffix));
+        }
+
+        private static void SetResultCompletedAtUtcTicks(string requestId, string completedAtUtcTicks)
+        {
+            UnityCliLoopEditorSessionStateStorage.SetString(
+                CreateRunTestsKey(requestId, ResultCompletedAtUtcTicksKeySuffix),
+                completedAtUtcTicks);
+        }
+
+        private static string CreateRunTestsKey(string requestId, string suffix)
+        {
+            return UnityCliLoopEditorSessionStateStorage.CreateRequestScopedKey(
+                RunTestsKeyPrefix,
+                requestId,
+                suffix);
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopRunTestsSessionRepository.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopRunTestsSessionRepository.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6bb2abab6ba34cd1b58c2fa148c2dea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -76,6 +76,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public const string COMMAND_NAME_GET_TOOL_DETAILS = "get-tool-details";
         public const string COMMAND_NAME_GET_VERSION = "get-version";
         public const string COMMAND_NAME_GET_COMPILE_STATUS = "get-compile-status";
+        public const string COMMAND_NAME_GET_RUN_TESTS_STATUS = "get-run-tests-status";
         public const string COMMAND_NAME_AWAIT_PAUSE_POINT = "await-pause-point";
         public const string SETTINGS_TOOL_NAME_PAUSE_POINT = "pause-point";
         public const string COMMAND_NAME_PAUSE_POINT_STATUS = "pause-point-status";

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -110,6 +110,11 @@
             "type": "integer",
             "description": "Maximum seconds to wait for RunFinished before canceling the await (max 1500). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands",
             "default": 600
+          },
+          "RespectEnterPlayModeSettings": {
+            "type": "boolean",
+            "description": "PlayMode only: keep the project's Enter Play Mode settings instead of forcing Domain Reload off. A Domain Reload during the run is survived; the result is recovered after the reload. Use for projects whose libraries require a Domain Reload on Play entry.",
+            "default": false
           }
         }
       }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "5f5e7a3aa79f6ba4009d9bf3e49bc9abc997d9a4"
+  "sharedInputsHash": "e6d868dbf6dc28cd61dce631909930261a8351b2"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "d8f7d25405b3aa51d72b14fcfa62aee828d37246"
+  "sharedInputsHash": "a8ba6f27409b5e00114edb5fde069e924660daa9"
 }


### PR DESCRIPTION
## Summary
- PlayMode `run-tests` can keep the project's Enter Play Mode settings instead of always forcing Domain Reload off.
- When a Domain Reload happens, Unity stores the usual run-tests result so the CLI can recover it after the connection drops.

## User Impact
- Before this change, PlayMode runs always disabled Domain Reload. Projects whose libraries need a reload on Play entry could leave stale static state and fail later EditMode tests.
- After this change, `--respect-enter-play-mode-settings` is a PlayMode-only opt-in. Default PlayMode behavior is unchanged. Canceling the CLI on this path does not stop the Unity-side run.

## Changes
- Add schema fields, a SessionState pending/result repository, and `get-run-tests-status`.
- On the respect path, skip forcing Domain Reload off, keep the pending record across reload, and re-register `RunFinished` in the next domain.
- Do not cancel an accepted respect-path run-tests request when the CLI disconnects.
- Document the flag in the run-tests skill and embedded catalog.

## Verification
- `uloop compile` → `"Success": true`
- `uloop run-tests --filter-type regex --filter-value 'RunTests|Compile|PlayMode'` → `FailedCount: 0`, `PassedCount: 723`, `SkippedCount: 1` (unrelated Roslyn worker host skip)
- `uloop get-logs --log-type Error` after the registrar landed → `TotalCount: 0`
- `go run ./cmd/sync-tool-docs --check` and `go run ./cmd/check-skill-size` in `cli/release-automation` passed
- `uloop run-tests --help` shows `--respect-enter-play-mode-settings` and does not show `--request-id`
- This PR targets the integration branch, so repository CI that filters `pull_request.branches: [main, v3-beta]` will not run here. The same local checks above stand in; full CI is expected on the final PR to `v3-beta`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

