### PR TITLE
feat: PlayMode run-tests can recover after Domain Reload with --respect-enter-play-mode-settings

### DIFF
--- a/Packages/src/Documentation~/tools.md
+++ b/Packages/src/Documentation~/tools.md
@@ -45,6 +45,7 @@ This is also a strategy to avoid consuming context.
 > [!WARNING]
 > During PlayMode test execution, Domain Reload is forcibly turned OFF. (Settings are restored after test completion)
 > Note that static variables will not be reset during this period.
+> Pass `--respect-enter-play-mode-settings` to keep the project's Enter Play Mode settings instead of forcing Domain Reload off.
 
 ### 4. hot-reload - Apply Method-Body Changes Instantly Without Recompiling
 Applies the method bodies of edited `.cs` files directly to the running Editor (EditMode / PlayMode) without a recompile or a Domain Reload in between. No attributes or source markers are required, and access to private / internal members, static methods, async methods, and iterators all work. You can fix game logic without leaving PlayMode and see the new behavior on the spot.

--- a/cli/project-runner/internal/projectrunner/run.go
+++ b/cli/project-runner/internal/projectrunner/run.go
@@ -76,11 +76,24 @@ func runTool(ctx context.Context, connection unityipc.Connection, command string
 		return runControlPlayModeWithStateWait(ctx, connection, params, stdout, stderr)
 	}
 
-	result := runPlainTool(ctx, connection, command, params, stderr)
+	result := runToolExecution(ctx, connection, command, params, stderr)
 	if len(result.result) > 0 {
 		clicore.WriteJSON(stdout, result.result)
 	}
 	return result.exitCode
+}
+
+func runToolExecution(
+	ctx context.Context,
+	connection unityipc.Connection,
+	command string,
+	params map[string]any,
+	stderr io.Writer,
+) toolExecutionResult {
+	if command == clicore.RunTestsCommandName && shouldWaitForRunTestsDomainReload(params) {
+		return runRunTestsWithDomainReloadWait(ctx, connection, params, stderr)
+	}
+	return runPlainTool(ctx, connection, command, params, stderr)
 }
 
 type toolExecutionResult struct {

--- a/cli/project-runner/internal/projectrunner/run_tests_domain_reload_wait.go
+++ b/cli/project-runner/internal/projectrunner/run_tests_domain_reload_wait.go
@@ -1,0 +1,273 @@
+package projectrunner
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+	"github.com/hatayama/unity-cli-loop/common/ui"
+
+	"github.com/hatayama/unity-cli-loop/common/clicontract"
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+)
+
+const (
+	runTestsStatusCommandName                 = "get-run-tests-status"
+	runTestsRequestIDParam                    = "RequestId"
+	runTestsRespectEnterPlayModeSettingsParam = "RespectEnterPlayModeSettings"
+	runTestsTestModeParam                     = "TestMode"
+	runTestsTimeoutParam                      = "TimeoutSeconds"
+	runTestsWaitTimeoutMargin                 = 60 * time.Second
+	runTestsWaitDefaultTimeoutSeconds         = 600
+	runTestsStatusProbeTimeout                = clicore.ToolReadinessProbeTimeout
+	runTestsWaitPollInterval                  = clicore.ToolReadinessPoll
+	runTestsWaitTimeoutErrorCode              = "RUN_TESTS_WAIT_TIMEOUT"
+	runTestsDomainReloadWaitSpinnerMessage    = "Domain Reload interrupted the connection. Waiting for the PlayMode test run to finish..."
+)
+
+type runTestsStatusResponse struct {
+	Success                  bool            `json:"Success"`
+	Ready                    bool            `json:"Ready"`
+	HasResult                bool            `json:"HasResult"`
+	IsCompiling              bool            `json:"IsCompiling"`
+	IsUpdating               bool            `json:"IsUpdating"`
+	IsDomainReloadInProgress bool            `json:"IsDomainReloadInProgress"`
+	Result                   json.RawMessage `json:"Result"`
+	Message                  string          `json:"Message"`
+}
+
+type runTestsStatusQueryFunc func(context.Context, unityipc.Connection, string) (runTestsStatusResponse, error)
+
+// shouldWaitForRunTestsDomainReload is true only for PlayMode runs that keep the
+// project's Enter Play Mode settings. EditMode and the default force-off path
+// still use the in-memory response and must not poll get-run-tests-status.
+func shouldWaitForRunTestsDomainReload(params map[string]any) bool {
+	respect, ok := params[runTestsRespectEnterPlayModeSettingsParam].(bool)
+	if !ok || !respect {
+		return false
+	}
+	testMode, ok := params[runTestsTestModeParam].(string)
+	if !ok {
+		return false
+	}
+	return strings.EqualFold(testMode, "PlayMode")
+}
+
+func prepareRunTestsWaitParams(params map[string]any) (string, error) {
+	if value, ok := params[runTestsRequestIDParam].(string); ok && value != "" && isSafeCompileRequestID(value) {
+		return value, nil
+	}
+
+	requestID, err := createRunTestsRequestID()
+	if err != nil {
+		return "", err
+	}
+	params[runTestsRequestIDParam] = requestID
+	return requestID, nil
+}
+
+func createRunTestsRequestID() (string, error) {
+	token := [4]byte{}
+	if _, err := rand.Read(token[:]); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("run_tests_%d_%s", time.Now().UnixMilli(), hex.EncodeToString(token[:])), nil
+}
+
+func runTestsWaitTimeoutFromParams(params map[string]any) time.Duration {
+	seconds := runTestsWaitDefaultTimeoutSeconds
+	value, exists := params[runTestsTimeoutParam]
+	if exists && value != nil {
+		if parsed, ok := positiveInt64FromAny(value); ok {
+			seconds = int(parsed)
+		}
+	}
+	return time.Duration(seconds)*time.Second + runTestsWaitTimeoutMargin
+}
+
+func queryRunTestsStatusFromUnity(ctx context.Context, connection unityipc.Connection, requestID string) (runTestsStatusResponse, error) {
+	probeContext, cancel := context.WithTimeout(ctx, runTestsStatusProbeTimeout)
+	defer cancel()
+
+	response, err := unityipc.NewClient(connection, clicontract.ProjectRunnerVersion()).Send(
+		probeContext,
+		runTestsStatusCommandName,
+		map[string]any{runTestsRequestIDParam: requestID},
+	)
+	if err != nil {
+		return runTestsStatusResponse{}, err
+	}
+
+	status := runTestsStatusResponse{}
+	if err := json.Unmarshal(response, &status); err != nil {
+		return runTestsStatusResponse{}, err
+	}
+	return status, nil
+}
+
+// waitForRunTestsResult polls get-run-tests-status until that request id has a
+// stored result. Ready is ignored: it is editor-wide, not request-specific.
+func waitForRunTestsResult(
+	ctx context.Context,
+	connection unityipc.Connection,
+	requestID string,
+	timeout time.Duration,
+	pollInterval time.Duration,
+	query runTestsStatusQueryFunc,
+) (json.RawMessage, bool, error) {
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		if !time.Now().Before(deadline) {
+			return nil, false, nil
+		}
+
+		status, err := query(ctx, connection, requestID)
+		if err == nil && status.HasResult && len(status.Result) > 0 {
+			return status.Result, true, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, false, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func runRunTestsWithDomainReloadWait(
+	ctx context.Context,
+	connection unityipc.Connection,
+	params map[string]any,
+	stderr io.Writer,
+) toolExecutionResult {
+	return runRunTestsWithDomainReloadWaitWithQuery(ctx, connection, params, stderr, queryRunTestsStatusFromUnity)
+}
+
+func runRunTestsWithDomainReloadWaitWithQuery(
+	ctx context.Context,
+	connection unityipc.Connection,
+	params map[string]any,
+	stderr io.Writer,
+	query runTestsStatusQueryFunc,
+) toolExecutionResult {
+	requestID, err := prepareRunTestsWaitParams(params)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
+			ProjectRoot: connection.ProjectRoot,
+			Command:     clicore.RunTestsCommandName,
+		})
+		return toolExecutionResult{exitCode: 1}
+	}
+
+	applyDebugTimingParams(clicore.RunTestsCommandName, params)
+	startedAt := time.Now()
+	spinner := clicore.NewToolSpinner(stderr, clicore.RunTestsCommandName)
+	outcome, err := sendWithTransientConnectionRetry(
+		ctx,
+		connection,
+		clicore.RunTestsCommandName,
+		params,
+		ui.NewSpinnerProgressFunc(spinner, "Executing run-tests..."),
+	)
+	if err == nil {
+		return finishRunTestsSendSuccess(stderr, spinner, startedAt, outcome)
+	}
+	if !shouldWaitForCompileStatus(err, outcome) {
+		spinner.Stop()
+		writeDebugTiming(stderr, clicore.RunTestsCommandName, time.Since(startedAt), outcome)
+		clierrors.WriteToolFailure(stderr, err, outcome, clierrors.ErrorContext{
+			ProjectRoot: connection.ProjectRoot,
+			Command:     clicore.RunTestsCommandName,
+		})
+		return toolExecutionResult{exitCode: 1}
+	}
+
+	spinner.Update(runTestsDomainReloadWaitSpinnerMessage)
+	return finishRunTestsRecoveredResult(
+		ctx,
+		connection,
+		requestID,
+		runTestsWaitTimeoutFromParams(params),
+		stderr,
+		spinner,
+		startedAt,
+		outcome,
+		query,
+	)
+}
+
+func finishRunTestsSendSuccess(
+	stderr io.Writer,
+	spinner *ui.TerminalSpinner,
+	startedAt time.Time,
+	outcome unityipc.UnitySendOutcome,
+) toolExecutionResult {
+	spinner.Stop()
+	result := stripDebugTimingResult(clicore.RunTestsCommandName, outcome.Result)
+	writeDebugTiming(stderr, clicore.RunTestsCommandName, time.Since(startedAt), outcome)
+	return toolExecutionResult{result: result, exitCode: toolEnvelopeExitCode(result)}
+}
+
+func finishRunTestsRecoveredResult(
+	ctx context.Context,
+	connection unityipc.Connection,
+	requestID string,
+	timeout time.Duration,
+	stderr io.Writer,
+	spinner *ui.TerminalSpinner,
+	startedAt time.Time,
+	outcome unityipc.UnitySendOutcome,
+	query runTestsStatusQueryFunc,
+) toolExecutionResult {
+	result, completed, waitErr := waitForRunTestsResult(
+		ctx,
+		connection,
+		requestID,
+		timeout,
+		runTestsWaitPollInterval,
+		query,
+	)
+	spinner.Stop()
+	writeDebugTiming(stderr, clicore.RunTestsCommandName, time.Since(startedAt), outcome)
+	if waitErr != nil {
+		clierrors.WriteClassifiedError(stderr, waitErr, clierrors.ErrorContext{
+			ProjectRoot: connection.ProjectRoot,
+			Command:     clicore.RunTestsCommandName,
+		})
+		return toolExecutionResult{exitCode: 1}
+	}
+	if !completed {
+		clierrors.WriteErrorEnvelope(stderr, runTestsWaitTimeoutError(connection.ProjectRoot, timeout))
+		return toolExecutionResult{exitCode: 1}
+	}
+	result = stripDebugTimingResult(clicore.RunTestsCommandName, result)
+	return toolExecutionResult{result: result, exitCode: toolEnvelopeExitCode(result)}
+}
+
+func runTestsWaitTimeoutError(projectRoot string, timeout time.Duration) clierrors.CLIError {
+	return clierrors.CLIError{
+		ErrorCode: runTestsWaitTimeoutErrorCode,
+		Phase:     clierrors.ErrorPhaseResponseWaiting,
+		Message: fmt.Sprintf(
+			"run-tests status wait timed out after %dms. This does not mean the Unity Editor is frozen; the PlayMode test run may still be finishing after Domain Reload.",
+			timeout.Milliseconds()),
+		Retryable:   true,
+		SafeToRetry: true,
+		ProjectRoot: projectRoot,
+		Command:     clicore.RunTestsCommandName,
+		NextActions: []string{
+			"Increase --timeout-seconds for long PlayMode suites and rerun with --respect-enter-play-mode-settings.",
+			"Run a light command such as `uloop get-logs --max-count 1` to check whether Unity is responsive before treating this as a freeze.",
+			"Only if Unity does not respond to any command, restart it with `uloop launch -r`.",
+		},
+	}
+}

--- a/cli/project-runner/internal/projectrunner/run_tests_domain_reload_wait.go
+++ b/cli/project-runner/internal/projectrunner/run_tests_domain_reload_wait.go
@@ -45,6 +45,26 @@ type runTestsStatusResponse struct {
 
 type runTestsStatusQueryFunc func(context.Context, unityipc.Connection, string) (runTestsStatusResponse, error)
 
+type runTestsSendFunc func(
+	ctx context.Context,
+	connection unityipc.Connection,
+	method string,
+	params map[string]any,
+	progress unityipc.ProgressFunc,
+) (unityipc.UnitySendOutcome, error)
+
+type runTestsWaitDeps struct {
+	send  runTestsSendFunc
+	query runTestsStatusQueryFunc
+}
+
+func defaultRunTestsWaitDeps() runTestsWaitDeps {
+	return runTestsWaitDeps{
+		send:  sendWithTransientConnectionRetry,
+		query: queryRunTestsStatusFromUnity,
+	}
+}
+
 // shouldWaitForRunTestsDomainReload is true only for PlayMode runs that keep the
 // project's Enter Play Mode settings. EditMode and the default force-off path
 // still use the in-memory response and must not poll get-run-tests-status.
@@ -149,15 +169,15 @@ func runRunTestsWithDomainReloadWait(
 	params map[string]any,
 	stderr io.Writer,
 ) toolExecutionResult {
-	return runRunTestsWithDomainReloadWaitWithQuery(ctx, connection, params, stderr, queryRunTestsStatusFromUnity)
+	return runRunTestsWithDomainReloadWaitWithDeps(ctx, connection, params, stderr, defaultRunTestsWaitDeps())
 }
 
-func runRunTestsWithDomainReloadWaitWithQuery(
+func runRunTestsWithDomainReloadWaitWithDeps(
 	ctx context.Context,
 	connection unityipc.Connection,
 	params map[string]any,
 	stderr io.Writer,
-	query runTestsStatusQueryFunc,
+	deps runTestsWaitDeps,
 ) toolExecutionResult {
 	requestID, err := prepareRunTestsWaitParams(params)
 	if err != nil {
@@ -171,7 +191,7 @@ func runRunTestsWithDomainReloadWaitWithQuery(
 	applyDebugTimingParams(clicore.RunTestsCommandName, params)
 	startedAt := time.Now()
 	spinner := clicore.NewToolSpinner(stderr, clicore.RunTestsCommandName)
-	outcome, err := sendWithTransientConnectionRetry(
+	outcome, err := deps.send(
 		ctx,
 		connection,
 		clicore.RunTestsCommandName,
@@ -201,7 +221,7 @@ func runRunTestsWithDomainReloadWaitWithQuery(
 		spinner,
 		startedAt,
 		outcome,
-		query,
+		deps.query,
 	)
 }
 

--- a/cli/project-runner/internal/projectrunner/run_tests_domain_reload_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/run_tests_domain_reload_wait_test.go
@@ -1,0 +1,193 @@
+package projectrunner
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+)
+
+// Verifies respect+PlayMode waits, while EditMode, respect-off, and unset stay on the fast path.
+func TestShouldWaitForRunTestsDomainReload(t *testing.T) {
+	cases := []struct {
+		name   string
+		params map[string]any
+		want   bool
+	}{
+		{
+			name: "respect and PlayMode",
+			params: map[string]any{
+				runTestsRespectEnterPlayModeSettingsParam: true,
+				runTestsTestModeParam:                     "PlayMode",
+			},
+			want: true,
+		},
+		{
+			name: "respect and EditMode",
+			params: map[string]any{
+				runTestsRespectEnterPlayModeSettingsParam: true,
+				runTestsTestModeParam:                     "EditMode",
+			},
+			want: false,
+		},
+		{
+			name: "respect off and PlayMode",
+			params: map[string]any{
+				runTestsRespectEnterPlayModeSettingsParam: false,
+				runTestsTestModeParam:                     "PlayMode",
+			},
+			want: false,
+		},
+		{
+			name:   "unset",
+			params: map[string]any{},
+			want:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldWaitForRunTestsDomainReload(tc.params)
+			if got != tc.want {
+				t.Fatalf("shouldWaitForRunTestsDomainReload mismatch: got %v want %v params=%#v", got, tc.want, tc.params)
+			}
+		})
+	}
+}
+
+// Verifies an existing safe request id is kept and a missing id is generated as run_tests_*.
+func TestPrepareRunTestsWaitParams(t *testing.T) {
+	existing := map[string]any{runTestsRequestIDParam: "run_tests_existing-1"}
+	kept, err := prepareRunTestsWaitParams(existing)
+	if err != nil {
+		t.Fatalf("prepareRunTestsWaitParams failed: %v", err)
+	}
+	if kept != "run_tests_existing-1" {
+		t.Fatalf("existing request id was not kept: %s", kept)
+	}
+	if existing[runTestsRequestIDParam] != "run_tests_existing-1" {
+		t.Fatalf("params request id mismatch: %#v", existing[runTestsRequestIDParam])
+	}
+
+	generatedParams := map[string]any{}
+	generated, err := prepareRunTestsWaitParams(generatedParams)
+	if err != nil {
+		t.Fatalf("prepareRunTestsWaitParams failed: %v", err)
+	}
+	if !strings.HasPrefix(generated, "run_tests_") {
+		t.Fatalf("generated request id prefix mismatch: %s", generated)
+	}
+	if !isSafeCompileRequestID(generated) {
+		t.Fatalf("generated request id is unsafe: %s", generated)
+	}
+	if generatedParams[runTestsRequestIDParam] != generated {
+		t.Fatalf("generated request id was not written to params: %#v", generatedParams[runTestsRequestIDParam])
+	}
+}
+
+// Verifies the wait deadline is TimeoutSeconds (default 600) plus the 60s margin.
+func TestRunTestsWaitTimeoutFromParams(t *testing.T) {
+	defaultTimeout := runTestsWaitTimeoutFromParams(map[string]any{})
+	if defaultTimeout != (runTestsWaitDefaultTimeoutSeconds*time.Second)+runTestsWaitTimeoutMargin {
+		t.Fatalf("default timeout mismatch: %s", defaultTimeout)
+	}
+
+	configured := runTestsWaitTimeoutFromParams(map[string]any{runTestsTimeoutParam: 30})
+	if configured != 90*time.Second {
+		t.Fatalf("configured timeout mismatch: %s", configured)
+	}
+}
+
+// Verifies polling returns the stored result on the third HasResult response.
+func TestWaitForRunTestsResultReturnsStoredResult(t *testing.T) {
+	connection := compileWaitTestConnection(t)
+	callCount := 0
+	query := func(context.Context, unityipc.Connection, string) (runTestsStatusResponse, error) {
+		callCount++
+		if callCount < 3 {
+			return runTestsStatusResponse{Ready: true, HasResult: false}, nil
+		}
+		return runTestsStatusResponse{
+			HasResult: true,
+			Result:    json.RawMessage(`{"Success":true,"TestCount":1}`),
+		}, nil
+	}
+
+	result, completed, err := waitForRunTestsResult(
+		context.Background(),
+		connection,
+		"run_tests_poll",
+		time.Second,
+		5*time.Millisecond,
+		query,
+	)
+	if err != nil {
+		t.Fatalf("waitForRunTestsResult failed: %v", err)
+	}
+	if !completed {
+		t.Fatal("waitForRunTestsResult did not complete")
+	}
+	if string(result) != `{"Success":true,"TestCount":1}` {
+		t.Fatalf("result mismatch: %s", result)
+	}
+	if callCount != 3 {
+		t.Fatalf("query call count mismatch: got %d want 3", callCount)
+	}
+}
+
+// Verifies a wait with no stored result times out as (nil, false, nil).
+func TestWaitForRunTestsResultTimesOutWithoutResult(t *testing.T) {
+	connection := compileWaitTestConnection(t)
+	query := func(context.Context, unityipc.Connection, string) (runTestsStatusResponse, error) {
+		return runTestsStatusResponse{Ready: true, HasResult: false}, nil
+	}
+
+	result, completed, err := waitForRunTestsResult(
+		context.Background(),
+		connection,
+		"run_tests_timeout",
+		20*time.Millisecond,
+		5*time.Millisecond,
+		query,
+	)
+	if err != nil {
+		t.Fatalf("waitForRunTestsResult failed: %v", err)
+	}
+	if completed {
+		t.Fatal("waitForRunTestsResult should time out without a stored result")
+	}
+	if result != nil {
+		t.Fatalf("timed-out result should be nil: %s", result)
+	}
+}
+
+// Verifies cancellation returns the context error instead of a timeout triple.
+func TestWaitForRunTestsResultReturnsContextError(t *testing.T) {
+	connection := compileWaitTestConnection(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	query := func(context.Context, unityipc.Connection, string) (runTestsStatusResponse, error) {
+		cancel()
+		return runTestsStatusResponse{HasResult: false}, nil
+	}
+
+	result, completed, err := waitForRunTestsResult(
+		ctx,
+		connection,
+		"run_tests_cancel",
+		time.Second,
+		time.Second,
+		query,
+	)
+	if err == nil {
+		t.Fatal("waitForRunTestsResult should return the cancellation error")
+	}
+	if completed {
+		t.Fatal("cancelled wait should not complete")
+	}
+	if result != nil {
+		t.Fatalf("cancelled result should be nil: %s", result)
+	}
+}

--- a/cli/project-runner/internal/projectrunner/run_tests_domain_reload_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/run_tests_domain_reload_wait_test.go
@@ -1,8 +1,10 @@
 package projectrunner
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -189,5 +191,131 @@ func TestWaitForRunTestsResultReturnsContextError(t *testing.T) {
 	}
 	if result != nil {
 		t.Fatalf("cancelled result should be nil: %s", result)
+	}
+}
+
+// Verifies accepted-after-send disconnect polls get-run-tests-status and returns the stored JSON.
+func TestRunRunTestsWithDomainReloadWaitRecoversStoredResultAfterAcceptedDisconnect(t *testing.T) {
+	connection := compileWaitTestConnection(t)
+	params := map[string]any{
+		runTestsRespectEnterPlayModeSettingsParam: true,
+		runTestsTestModeParam:                     "PlayMode",
+	}
+	queryCalls := 0
+	stderr := bytes.Buffer{}
+	execution := runRunTestsWithDomainReloadWaitWithDeps(
+		context.Background(),
+		connection,
+		params,
+		&stderr,
+		runTestsWaitDeps{
+			send:  runTestsAcceptedDisconnectSend,
+			query: runTestsStatusResultOnSecondQuery(&queryCalls, `{"Success":true,"TestCount":1}`),
+		},
+	)
+	if execution.exitCode != 0 {
+		t.Fatalf("exit code mismatch: got %d want 0 stderr=%s", execution.exitCode, stderr.String())
+	}
+	if string(execution.result) != `{"Success":true,"TestCount":1}` {
+		t.Fatalf("recovered result mismatch: %s", execution.result)
+	}
+	if queryCalls != 2 {
+		t.Fatalf("query call count mismatch: got %d want 2", queryCalls)
+	}
+	requestID, ok := params[runTestsRequestIDParam].(string)
+	if !ok || !strings.HasPrefix(requestID, "run_tests_") {
+		t.Fatalf("generated request id mismatch: %#v", params[runTestsRequestIDParam])
+	}
+}
+
+// Verifies a send error that is not waitable fails immediately without polling.
+func TestRunRunTestsWithDomainReloadWaitDoesNotPollWhenSendIsNotWaitable(t *testing.T) {
+	connection := compileWaitTestConnection(t)
+	params := map[string]any{
+		runTestsRespectEnterPlayModeSettingsParam: true,
+		runTestsTestModeParam:                     "PlayMode",
+	}
+	queryCalls := 0
+	stderr := bytes.Buffer{}
+	execution := runRunTestsWithDomainReloadWaitWithDeps(
+		context.Background(),
+		connection,
+		params,
+		&stderr,
+		runTestsWaitDeps{
+			send: func(
+				context.Context,
+				unityipc.Connection,
+				string,
+				map[string]any,
+				unityipc.ProgressFunc,
+			) (unityipc.UnitySendOutcome, error) {
+				return unityipc.UnitySendOutcome{}, fmt.Errorf("missing")
+			},
+			query: func(context.Context, unityipc.Connection, string) (runTestsStatusResponse, error) {
+				queryCalls++
+				return runTestsStatusResponse{}, nil
+			},
+		},
+	)
+	if execution.exitCode != 1 {
+		t.Fatalf("exit code mismatch: got %d want 1", execution.exitCode)
+	}
+	if queryCalls != 0 {
+		t.Fatalf("query must not run for a non-waitable send error: calls=%d", queryCalls)
+	}
+}
+
+// Verifies toolEnvelopeExitCode is applied to a recovered unsuccessful result.
+func TestRunRunTestsWithDomainReloadWaitUsesRecoveredResultExitCode(t *testing.T) {
+	connection := compileWaitTestConnection(t)
+	params := map[string]any{
+		runTestsRespectEnterPlayModeSettingsParam: true,
+		runTestsTestModeParam:                     "PlayMode",
+	}
+	queryCalls := 0
+	stderr := bytes.Buffer{}
+	execution := runRunTestsWithDomainReloadWaitWithDeps(
+		context.Background(),
+		connection,
+		params,
+		&stderr,
+		runTestsWaitDeps{
+			send:  runTestsAcceptedDisconnectSend,
+			query: runTestsStatusResultOnSecondQuery(&queryCalls, `{"Success":false}`),
+		},
+	)
+	if execution.exitCode != 1 {
+		t.Fatalf("exit code mismatch: got %d want 1 stderr=%s", execution.exitCode, stderr.String())
+	}
+	if string(execution.result) != `{"Success":false}` {
+		t.Fatalf("recovered result mismatch: %s", execution.result)
+	}
+}
+
+func runTestsAcceptedDisconnectSend(
+	context.Context,
+	unityipc.Connection,
+	string,
+	map[string]any,
+	unityipc.ProgressFunc,
+) (unityipc.UnitySendOutcome, error) {
+	return unityipc.UnitySendOutcome{RequestDispatched: true, RequestAccepted: true},
+		fmt.Errorf("read tcp 127.0.0.1:1: i/o timeout")
+}
+
+func runTestsStatusResultOnSecondQuery(
+	queryCalls *int,
+	resultJSON string,
+) runTestsStatusQueryFunc {
+	return func(context.Context, unityipc.Connection, string) (runTestsStatusResponse, error) {
+		*queryCalls++
+		if *queryCalls < 2 {
+			return runTestsStatusResponse{HasResult: false}, nil
+		}
+		return runTestsStatusResponse{
+			HasResult: true,
+			Result:    json.RawMessage(resultJSON),
+		}, nil
 	}
 }

--- a/cli/project-runner/internal/projectrunner/runner_commands.go
+++ b/cli/project-runner/internal/projectrunner/runner_commands.go
@@ -108,7 +108,7 @@ func runDynamicProjectToolWithCompileNote(
 		return runTool(ctx, connection, command, params, stdout, stderr)
 	}
 
-	result := runPlainTool(ctx, connection, command, params, stderr)
+	result := runToolExecution(ctx, connection, command, params, stderr)
 	if len(result.result) == 0 {
 		return result.exitCode
 	}


### PR DESCRIPTION
## Summary
- `uloop run-tests --test-mode PlayMode --respect-enter-play-mode-settings` now returns a normal run-tests JSON after a Domain Reload, instead of `UNITY_DISCONNECTED_AFTER_ACCEPT`.
- The default PlayMode path is unchanged: Domain Reload stays forced off unless the flag is passed.

## User Impact
- Before: keeping the project's Enter Play Mode settings let Unity reload on Play entry. The CLI connection dropped and the in-memory test result was gone, so the command failed even when Unity finished the suite.
- After: the CLI assigns a hidden request id, and if the connection drops after the request was accepted it polls `get-run-tests-status` until the stored result is available. Agents see the usual run-tests payload, plus a warning that the result was recovered after reload.

## Changes
- Add Domain Reload wait/polling for respect-path PlayMode `run-tests` (`get-run-tests-status`, request id, TimeoutSeconds + 60s deadline).
- Route both `runTool` and the implicit-compile path through that wait when the flag is set and TestMode is PlayMode.
- Document the opt-out on the PlayMode Domain Reload warning in `tools.md`.

## Verification
`scripts/check-go-cli.sh` passed. `uloop run-tests --help` shows `--respect-enter-play-mode-settings` and does not show `--request-id`.

### To-Do 17 (dev PlayMode assembly, Domain Reload enabled)

Saved settings: `enterPlayModeOptionsEnabled = True`, `enterPlayModeOptions = DisableDomainReload`. Enabled Domain Reload with `enterPlayModeOptionsEnabled = false`, then restored those saved values.

With `--respect-enter-play-mode-settings`:

```text
uloop run-tests --project-path <PROJECT_ROOT> --test-mode PlayMode --filter-type assembly --filter-value UnityCLILoop.Tests.PlayMode --respect-enter-play-mode-settings
```

- Normal run-tests JSON. `UNITY_DISCONNECTED_AFTER_ACCEPT` did not appear.
- `TestCount`: 126, `PassedCount`: 122, `FailedCount`: 4, `Success`: false
- `Warning`: `The run entered Play Mode with a Domain Reload, so the result was recovered from SessionState after the reload. Pause-point and hot-reload notes were not evaluated for this run.`
- Editor.log:
  - `Reloading assemblies for play mode.`
  - `Reloading assemblies after forced synchronous recompile.`
  - `Begin MonoManager ReloadAssembly`

Without the flag (same filter): same counts (`126` / `122` / `4`), no recovery `Warning`.

### To-Do 17b (DOTween 1.3.030 minimal test)

A temporary PlayMode test started `transform.DOMoveX` and `DOVirtual.DelayedCall`. Before (flag off) and After (flag on) both completed with `Success` true. Neither run produced `Resolve of invalid GC handle. The handle is from a previous domain.` The Issue symptom did not reproduce on this minimal setup; only the recovery path was confirmed (After included the DomainReloadRecoveredWarning). All DOTween files and the temporary test were deleted; `git status --porcelain` was empty afterward.

### Out of scope

The 4 PlayMode failures (`MouseInputSimulationResponseFactoryTests` / `SimulateMouseInputTests`) are the same with and without the flag and are outside this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

