### PR TITLE
fix: Screenshots taken while Play Mode is paused now warn that UGUI may show the previous frame

### DIFF
--- a/.agents/skills/uloop-screenshot/SKILL.md
+++ b/.agents/skills/uloop-screenshot/SKILL.md
@@ -52,7 +52,7 @@ Returns JSON with:
 
 - `ScreenshotCount`: Number of windows captured
 - `ResolvedCaptureMode`: `"window"` or `"rendering"` — the mode actually used after resolving `auto`
-- `Warning`: Appears only for window captures taken while Play Mode is running with at least one image.
+- `Warning`: Appears for window captures taken while Play Mode is running with at least one image, and for any image captured while Play Mode is paused (UGUI/canvas content may show the frame rendered before the pause; run `uloop control-play-mode --action Step` once and capture again to refresh it).
 - `Screenshots`: Array of screenshot info, each containing:
   - `ImagePath`: Absolute path to the saved PNG file. Empty (`""`) when `--elements-only` is used because no image file is written; `FileSizeBytes`, `Width`, and `Height` are then `0`, while `GameViewWidth`/`GameViewHeight` and `AnnotatedElements` still carry real values. When it is non-empty, always open the file named here — the output directory accumulates every past capture, so guessing the newest file with directory listing (`ls -t` or similar) can silently pick a stale screenshot from an earlier run.
   - `FileSizeBytes`: Size of the saved file in bytes

--- a/.claude/skills/uloop-screenshot/SKILL.md
+++ b/.claude/skills/uloop-screenshot/SKILL.md
@@ -52,7 +52,7 @@ Returns JSON with:
 
 - `ScreenshotCount`: Number of windows captured
 - `ResolvedCaptureMode`: `"window"` or `"rendering"` — the mode actually used after resolving `auto`
-- `Warning`: Appears only for window captures taken while Play Mode is running with at least one image.
+- `Warning`: Appears for window captures taken while Play Mode is running with at least one image, and for any image captured while Play Mode is paused (UGUI/canvas content may show the frame rendered before the pause; run `uloop control-play-mode --action Step` once and capture again to refresh it).
 - `Screenshots`: Array of screenshot info, each containing:
   - `ImagePath`: Absolute path to the saved PNG file. Empty (`""`) when `--elements-only` is used because no image file is written; `FileSizeBytes`, `Width`, and `Height` are then `0`, while `GameViewWidth`/`GameViewHeight` and `AnnotatedElements` still carry real values. When it is non-empty, always open the file named here — the output directory accumulates every past capture, so guessing the newest file with directory listing (`ls -t` or similar) can silently pick a stale screenshot from an earlier run.
   - `FileSizeBytes`: Size of the saved file in bytes

--- a/Assets/Tests/Editor/ScreenshotPausedPlayModeWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/ScreenshotPausedPlayModeWarningBuilderTests.cs
@@ -1,0 +1,79 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies the paused Play Mode Warning is appended only for playing + paused + an image capture.
+    /// </summary>
+    public sealed class ScreenshotPausedPlayModeWarningBuilderTests
+    {
+        /// <summary>
+        /// What: an image capture while Play Mode is paused returns the stale-UGUI warning with the Step hint.
+        /// </summary>
+        [Test]
+        public void Append_WhenPausedWithImageAndNoExistingWarning_ReturnsPausedWarning()
+        {
+            string warning = ScreenshotPausedPlayModeWarningBuilder.Append(string.Empty, true, true, false, 1);
+
+            Assert.That(warning, Is.EqualTo(ScreenshotPausedPlayModeWarningBuilder.PausedWarning));
+            Assert.That(warning, Does.Contain("control-play-mode --action Step"));
+        }
+
+        /// <summary>
+        /// What: an existing chrome warning is kept and the paused warning is appended after it.
+        /// </summary>
+        [Test]
+        public void Append_WhenPausedWithExistingWarning_AppendsAfterExistingWarning()
+        {
+            string warning = ScreenshotPausedPlayModeWarningBuilder.Append("Chrome warning.", true, true, false, 1);
+
+            Assert.That(warning, Is.EqualTo("Chrome warning. " + ScreenshotPausedPlayModeWarningBuilder.PausedWarning));
+        }
+
+        /// <summary>
+        /// What: a capture while Play Mode runs unpaused leaves the existing warning untouched.
+        /// </summary>
+        [Test]
+        public void Append_WhenPlayingButNotPaused_ReturnsExistingWarning()
+        {
+            string warning = ScreenshotPausedPlayModeWarningBuilder.Append("Chrome warning.", true, false, false, 1);
+
+            Assert.That(warning, Is.EqualTo("Chrome warning."));
+        }
+
+        /// <summary>
+        /// What: a paused flag outside Play Mode (Edit Mode capture) does not warn.
+        /// </summary>
+        [Test]
+        public void Append_WhenPausedInEditMode_ReturnsExistingWarning()
+        {
+            string warning = ScreenshotPausedPlayModeWarningBuilder.Append(string.Empty, false, true, false, 1);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: an elements-only response writes no image, so no stale-image warning is added.
+        /// </summary>
+        [Test]
+        public void Append_WhenElementsOnly_ReturnsExistingWarning()
+        {
+            string warning = ScreenshotPausedPlayModeWarningBuilder.Append(string.Empty, true, true, true, 1);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: a paused capture that saved zero images does not warn about images that do not exist.
+        /// </summary>
+        [Test]
+        public void Append_WhenPausedWithZeroImages_ReturnsExistingWarning()
+        {
+            string warning = ScreenshotPausedPlayModeWarningBuilder.Append(string.Empty, true, true, false, 0);
+
+            Assert.That(warning, Is.EqualTo(string.Empty));
+        }
+    }
+}

--- a/Assets/Tests/Editor/ScreenshotPausedPlayModeWarningBuilderTests.cs.meta
+++ b/Assets/Tests/Editor/ScreenshotPausedPlayModeWarningBuilderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d73106359aa7648d89a523d432c08b25
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/ScreenshotUseCaseTests.cs
+++ b/Assets/Tests/Editor/ScreenshotUseCaseTests.cs
@@ -184,6 +184,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
 
             public bool IsPlaying { get; }
+            public bool IsPaused => false;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotEditorStateReader.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotEditorStateReader.cs
@@ -3,11 +3,12 @@ using UnityEditor;
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// Reads Editor Play Mode for screenshot capture-mode auto resolution.
+    /// Reads Editor Play Mode state for capture-mode auto resolution and the paused-capture Warning.
     /// </summary>
     internal interface IScreenshotEditorStateReader
     {
         bool IsPlaying { get; }
+        bool IsPaused { get; }
     }
 
     /// <summary>
@@ -16,5 +17,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal sealed class ScreenshotEditorStateReader : IScreenshotEditorStateReader
     {
         public bool IsPlaying => EditorApplication.isPlaying;
+        public bool IsPaused => EditorApplication.isPaused;
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotPausedPlayModeWarningBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotPausedPlayModeWarningBuilder.cs
@@ -1,0 +1,33 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Appends the Warning for a screenshot image taken while Play Mode is paused.
+    /// </summary>
+    internal static class ScreenshotPausedPlayModeWarningBuilder
+    {
+        public const string PausedWarning =
+            "Play Mode was paused during this capture. UGUI/canvas content may reflect the frame rendered before the pause, while other observations reflect the paused state. To refresh it, run `uloop control-play-mode --action Step` once, then capture again.";
+
+        // Why playing+paused+image: isPaused stays true after Play Mode exits, an elements-only
+        // response has no image that could be stale, and zero images leave nothing to describe.
+        public static string Append(
+            string existingWarning,
+            bool isPlaying,
+            bool isPaused,
+            bool elementsOnly,
+            int capturedCount)
+        {
+            if (!isPlaying || !isPaused || elementsOnly || capturedCount == 0)
+            {
+                return existingWarning;
+            }
+
+            if (string.IsNullOrEmpty(existingWarning))
+            {
+                return PausedWarning;
+            }
+
+            return existingWarning + " " + PausedWarning;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotPausedPlayModeWarningBuilder.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotPausedPlayModeWarningBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 54e5f41b6a4e64a2dbdcc13c3f6d86e9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -36,6 +36,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 request.CaptureMode,
                 _editorStateReader.IsPlaying);
             string resolvedCaptureMode = ScreenshotCaptureModeResolver.ToWireName(request.CaptureMode);
+            // Why sample before capturing: the paused Warning describes the state the image was
+            // taken in; a resume or pause racing the capture must not flip it afterwards.
+            bool wasPlaying = _editorStateReader.IsPlaying;
+            bool wasPaused = _editorStateReader.IsPaused;
 
             string correlationId = UnityCliLoopConstants.GenerateCorrelationId();
 
@@ -61,6 +65,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             response.ResolvedCaptureMode = resolvedCaptureMode;
+            response.Warning = ScreenshotPausedPlayModeWarningBuilder.Append(
+                response.Warning,
+                wasPlaying,
+                wasPaused,
+                request.ElementsOnly,
+                response.Screenshots.Count);
             return response;
         }
 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/SKILL.md
@@ -52,7 +52,7 @@ Returns JSON with:
 
 - `ScreenshotCount`: Number of windows captured
 - `ResolvedCaptureMode`: `"window"` or `"rendering"` — the mode actually used after resolving `auto`
-- `Warning`: Appears only for window captures taken while Play Mode is running with at least one image.
+- `Warning`: Appears for window captures taken while Play Mode is running with at least one image, and for any image captured while Play Mode is paused (UGUI/canvas content may show the frame rendered before the pause; run `uloop control-play-mode --action Step` once and capture again to refresh it).
 - `Screenshots`: Array of screenshot info, each containing:
   - `ImagePath`: Absolute path to the saved PNG file. Empty (`""`) when `--elements-only` is used because no image file is written; `FileSizeBytes`, `Width`, and `Height` are then `0`, while `GameViewWidth`/`GameViewHeight` and `AnnotatedElements` still carry real values. When it is non-empty, always open the file named here — the output directory accumulates every past capture, so guessing the newest file with directory listing (`ls -t` or similar) can silently pick a stale screenshot from an earlier run.
   - `FileSizeBytes`: Size of the saved file in bytes


### PR DESCRIPTION
## Summary
- A screenshot taken while Play Mode is paused now carries a `Warning` saying that UGUI/canvas content may show the frame rendered before the pause, and that one `uloop control-play-mode --action Step` refreshes it before capturing again.

## User Impact
- Before: at a pause point, the screenshot showed canvas elements from the previous frame while `get-hierarchy`, pause-point status and other reads reflected the paused state. Nothing in the response explained the mismatch, so agents spent round trips deciding which side was stale.
- After: the response says up front that the image may lag by one frame and how to refresh it. Capture behavior is unchanged; this is guidance only.

## Changes
- Play Mode and paused state are sampled before capture and a paused-capture warning is appended to any response with at least one image, in both `window` and `rendering` modes. When the existing Play Mode window chrome warning applies, both sentences are joined in one `Warning`.
- Elements-only responses and zero-image results do not warn because no image can be stale.
- Screenshot skill `Output` section documents the new condition; generated skill copies regenerated.

## Verification
- `uloop compile`: no errors.
- `uloop run-tests --filter-type regex --filter-value Screenshot`: 62 passed, 0 failed (6 new tests for the warning builder).
- Live check on Unity 2022.3 with Play Mode paused: `rendering` and `window` captures return the new warning (window also keeps the chrome warning); `--elements-only` returns no warning.
- `check-skill-size` and `sync-tool-docs -check` pass.

Refs #2392

https://claude.ai/code/session_01R3jkx6NbNYKPdy5q1NSWYo

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

https://claude.ai/code/session_01R3jkx6NbNYKPdy5q1NSWYo



