### PR TITLE
fix: Hot reload names an unresolved added-field type instead of blaming shim visibility

### DIFF
--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -761,6 +761,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: an added field whose type cannot be resolved (missing using or typo) is skipped with a reason that names the type and points at the declaration, not at shim visibility.
+        /// </summary>
+        [Test]
+        public async Task Skip_UnresolvedAddedFieldType_ReportsTypeNameAndUsingHint()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public NoSuchAddedFieldType Added;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return Added == null ? value : value + 1;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldUnresolvedType.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "NoSuchAddedFieldType");
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "missing using directive");
+
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                if (skipped.method != null
+                    && skipped.method.Contains(nameof(HotReloadAddedMemberHost.ExistingCaller)))
+                {
+                    Assert.That(
+                        skipped.reason,
+                        Does.Not.Contain("not visible to the shim assembly"));
+                }
+            }
+        }
+
+        /// <summary>
         /// What: an added const on a struct host still folds to a literal because const folding
         /// does not use the instance store.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -795,6 +795,56 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: an added field whose generic argument cannot be resolved is skipped with a
+        /// reason that names the inner type, not shim visibility.
+        /// </summary>
+        [Test]
+        public async Task Skip_UnresolvedAddedFieldTypeInGenericList_ReportsInnerTypeNameAndUsingHint()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public System.Collections.Generic.List<NoSuchAddedFieldType> Added;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return Added == null ? value : value + 1;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldUnresolvedTypeInList.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "NoSuchAddedFieldType");
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "missing using directive");
+        }
+
+        /// <summary>
+        /// What: an added field whose array element type cannot be resolved is skipped with a
+        /// reason that names the element type, not shim visibility.
+        /// </summary>
+        [Test]
+        public async Task Skip_UnresolvedAddedFieldTypeInArray_ReportsTypeNameAndUsingHint()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public NoSuchAddedFieldType[] Added;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return Added == null ? value : value + 1;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldUnresolvedTypeInArray.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "NoSuchAddedFieldType");
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "missing using directive");
+        }
+
+        /// <summary>
         /// What: an added const on a struct host still folds to a literal because const folding
         /// does not use the instance store.
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
@@ -186,7 +186,7 @@ internal static class AddedFieldClassifier
         return null;
     }
 
-    // Why recurse the same shapes as IsExternallyVisibleType: List<Missing> and Missing[]
+    // Why recurse array elements and type arguments: List<Missing> and Missing[]
     // would otherwise keep the shim-visibility reason even though the inner type is unresolved.
     private static bool TryFindUnresolvedType(ITypeSymbol typeSymbol, out ITypeSymbol unresolvedType)
     {
@@ -210,11 +210,6 @@ internal static class AddedFieldClassifier
         if (typeSymbol is IArrayTypeSymbol arrayType)
         {
             return TryFindUnresolvedType(arrayType.ElementType, out unresolvedType);
-        }
-
-        if (typeSymbol is IPointerTypeSymbol pointerType)
-        {
-            return TryFindUnresolvedType(pointerType.PointedAtType, out unresolvedType);
         }
 
         if (typeSymbol is INamedTypeSymbol namedType)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
@@ -158,6 +158,16 @@ internal static class AddedFieldClassifier
             return AddedFieldSkipReasons.StructHost;
         }
 
+        // Why unresolved types before visibility: TypeKind.Error is not externally
+        // visible, so the shim-visibility reason would hide a missing using or typo.
+        if (fieldSymbol.Type.TypeKind == TypeKind.Error)
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                AddedFieldSkipReasons.FieldTypeUnresolvedFormat,
+                fieldSymbol.Type.ToDisplayString());
+        }
+
         if (!AccessibilityRules.IsExternallyVisibleType(fieldSymbol.Type))
         {
             return AddedFieldSkipReasons.FieldTypeNotExternallyVisible;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
@@ -160,12 +160,12 @@ internal static class AddedFieldClassifier
 
         // Why unresolved types before visibility: TypeKind.Error is not externally
         // visible, so the shim-visibility reason would hide a missing using or typo.
-        if (fieldSymbol.Type.TypeKind == TypeKind.Error)
+        if (TryFindUnresolvedType(fieldSymbol.Type, out ITypeSymbol unresolvedType))
         {
             return string.Format(
                 CultureInfo.InvariantCulture,
                 AddedFieldSkipReasons.FieldTypeUnresolvedFormat,
-                fieldSymbol.Type.ToDisplayString());
+                unresolvedType.ToDisplayString());
         }
 
         if (!AccessibilityRules.IsExternallyVisibleType(fieldSymbol.Type))
@@ -184,6 +184,51 @@ internal static class AddedFieldClassifier
         }
 
         return null;
+    }
+
+    // Why recurse the same shapes as IsExternallyVisibleType: List<Missing> and Missing[]
+    // would otherwise keep the shim-visibility reason even though the inner type is unresolved.
+    private static bool TryFindUnresolvedType(ITypeSymbol typeSymbol, out ITypeSymbol unresolvedType)
+    {
+        unresolvedType = null;
+        if (typeSymbol == null)
+        {
+            return false;
+        }
+
+        if (typeSymbol.TypeKind == TypeKind.Error)
+        {
+            unresolvedType = typeSymbol;
+            return true;
+        }
+
+        if (typeSymbol is ITypeParameterSymbol)
+        {
+            return false;
+        }
+
+        if (typeSymbol is IArrayTypeSymbol arrayType)
+        {
+            return TryFindUnresolvedType(arrayType.ElementType, out unresolvedType);
+        }
+
+        if (typeSymbol is IPointerTypeSymbol pointerType)
+        {
+            return TryFindUnresolvedType(pointerType.PointedAtType, out unresolvedType);
+        }
+
+        if (typeSymbol is INamedTypeSymbol namedType)
+        {
+            foreach (ITypeSymbol typeArgument in namedType.TypeArguments)
+            {
+                if (TryFindUnresolvedType(typeArgument, out unresolvedType))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     internal static string EvaluateAddedFieldSkipReason(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldSkipReasons.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldSkipReasons.cs
@@ -33,6 +33,9 @@ internal static class AddedFieldSkipReasons
     public const string FieldTypeNotExternallyVisible =
         "Added field type is not visible to the shim assembly. Run 'uloop compile'.";
 
+    public const string FieldTypeUnresolvedFormat =
+        "Added field type '{0}' could not be resolved; check for a missing using directive or a typo, fix the declaration, and rerun. Run 'uloop compile' if the type is new.";
+
     public const string IncrementNotNumeric =
         "Increment or decrement of an added field is skipped unless the type is a numeric "
         + "primitive or enum. Run 'uloop compile'.";


### PR DESCRIPTION
## Summary
- When hot reload skips a method because an added field's type cannot be resolved, the skip reason now names that type and points at a missing using or typo.
- The previous wording blamed shim-assembly visibility and sent agents to `uloop compile`, which only reproduced the compile error.

## User Impact
- Before: adding a field such as `Image` without `using UnityEngine.UI` produced `Added field type is not visible to the shim assembly. Run 'uloop compile'.`
- After: the same case reports `Added field type 'Image' could not be resolved` and tells the user to fix the declaration first. The same wording is used when the unresolved type is nested in `List<T>` or an array.

## Changes
- Classify unresolved added-field types (`TypeKind.Error`) before the external-visibility check, including array elements and generic type arguments.
- Keep `Skipped` with `Success: true`; do not turn this case into `Failed`.
- Add EditMode worker tests that name the unresolved type and assert the old visibility wording is not used. Private nested types still use the existing visibility reason unless one of their type arguments is unresolved.

## Verification
- Red before the classifier change:
  `uloop run-tests --test-mode EditMode --filter-type class --filter-value TransformWorkerAddedFieldTests`
  → `FailedCount: 1`, `PassedCount: 56`. The new test failed with `Added field type is not visible to the shim assembly. Run 'uloop compile'.`
- Green after the top-level classifier change (same command):
  → `FailedCount: 0`, `PassedCount: 57`, `Success: true`.
- Red before nested-type recursion:
  → `FailedCount: 2`, `PassedCount: 57`. `List<NoSuchAddedFieldType>` and `NoSuchAddedFieldType[]` still reported shim visibility.
- Green after nested-type recursion (same command):
  → `FailedCount: 0`, `PassedCount: 59`, `Success: true`.
- After dropping the untested pointer walk (same command):
  → `FailedCount: 0`, `PassedCount: 59`, `Success: true`.
- Manual PlayMode reproduction on the spinning-image harness was not run: that scene is not in this checkout.
