### PR TITLE
fix(pause-point): stop advertising --trigger with a leading uloop in the arming hint

### DIFF
--- a/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
+++ b/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
@@ -714,7 +714,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     + ResolveFailureFile
                     + ":"
                     + requestedLine
-                    + "\". To arm, trigger, and collect in one call, add --await --resume-play --trigger \"<uloop command>\" next time.";
+                    + "\". To arm, trigger, and collect in one call, add --await --resume-play --trigger \"<uloop subcommand without the leading 'uloop', e.g. simulate-keyboard --action Press --key Space>\" next time.";
                 Assert.That(response.RecommendedNextAction, Is.EqualTo(expectedArming));
                 AssertLineBasis(response, "LastCompiledSource");
             }

--- a/Assets/Tests/Editor/PausePointEnableGuidanceTests.cs
+++ b/Assets/Tests/Editor/PausePointEnableGuidanceTests.cs
@@ -72,6 +72,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void ResolveSuccessEnableRecommendedNextAction_WhenExistingIsEmpty_ExplainsTriggerSubcommandFormat()
         {
+            // Keep the deprecated placeholder split so repository searches for its contiguous spelling
+            // report only real regressions in user-facing guidance.
             const string deprecatedPlaceholder = "<uloop " + "command>";
             string action = PausePointEnableWarnings.ResolveSuccessEnableRecommendedNextAction(
                 string.Empty,

--- a/Assets/Tests/Editor/PausePointEnableGuidanceTests.cs
+++ b/Assets/Tests/Editor/PausePointEnableGuidanceTests.cs
@@ -24,7 +24,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private const int FixtureClosingBraceLine = 13;
 
         private const string ExpectedArmingNextActionForJump =
-            "Run the code path so the marker can hit, then read the outcome with: uloop pause-point-status --id \"jump\". To arm, trigger, and collect in one call, add --await --resume-play --trigger \"<uloop command>\" next time.";
+            "Run the code path so the marker can hit, then read the outcome with: uloop pause-point-status --id \"jump\". To arm, trigger, and collect in one call, add --await --resume-play --trigger \"<uloop subcommand without the leading 'uloop', e.g. simulate-keyboard --action Press --key Space>\" next time.";
 
         private const string ExpectedRearmDiscardWarningGeneration1 =
             "Generation 1 of this pause point had already hit; this re-arm discarded its CapturedVariables and CapturedVariableHistory. Read results with pause-point-status before re-arming when you need them.";
@@ -64,6 +64,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 "jump");
 
             Assert.That(action, Is.EqualTo(ExpectedArmingNextActionForJump));
+        }
+
+        /// <summary>
+        /// What: arming guidance describes the trigger as a subcommand without a leading uloop command.
+        /// </summary>
+        [Test]
+        public void ResolveSuccessEnableRecommendedNextAction_WhenExistingIsEmpty_ExplainsTriggerSubcommandFormat()
+        {
+            const string deprecatedPlaceholder = "<uloop " + "command>";
+            string action = PausePointEnableWarnings.ResolveSuccessEnableRecommendedNextAction(
+                string.Empty,
+                "jump");
+
+            Assert.That(action, Does.Not.Contain(deprecatedPlaceholder));
+            Assert.That(action, Does.Contain("without"));
         }
 
         /// <summary>
@@ -129,7 +144,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 + FixtureFilePath
                 + ":"
                 + FixtureStatementLine
-                + "\". To arm, trigger, and collect in one call, add --await --resume-play --trigger \"<uloop command>\" next time.";
+                + "\". To arm, trigger, and collect in one call, add --await --resume-play --trigger \"<uloop subcommand without the leading 'uloop', e.g. simulate-keyboard --action Press --key Space>\" next time.";
             Assert.That(response.RecommendedNextAction, Is.EqualTo(expected));
             string json = JsonConvert.SerializeObject(
                 response,

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -1134,7 +1134,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 response.RecommendedNextAction,
                 Is.EqualTo(
-                    "Run the code path so the marker can hit, then read the outcome with: uloop pause-point-status --id \"jump\". To arm, trigger, and collect in one call, add --await --resume-play --trigger \"<uloop command>\" next time."));
+                    "Run the code path so the marker can hit, then read the outcome with: uloop pause-point-status --id \"jump\". To arm, trigger, and collect in one call, add --await --resume-play --trigger \"<uloop subcommand without the leading 'uloop', e.g. simulate-keyboard --action Press --key Space>\" next time."));
         }
 
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -404,7 +404,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // so agents arm a marker and then stall instead of running the path or using --await.
         // Format: marker id.
         public const string EnableSuccessArmingRecommendedNextActionFormat =
-            "Run the code path so the marker can hit, then read the outcome with: uloop pause-point-status --id \"{0}\". To arm, trigger, and collect in one call, add --await --resume-play --trigger \"<uloop command>\" next time.";
+            "Run the code path so the marker can hit, then read the outcome with: uloop pause-point-status --id \"{0}\". To arm, trigger, and collect in one call, add --await --resume-play --trigger \"<uloop subcommand without the leading 'uloop', e.g. simulate-keyboard --action Press --key Space>\" next time.";
 
         // Why warn: Registry.Enable replaces the entry and drops CapturedVariables,
         // CapturedVariableHistory, and hit snapshots. The raw capture holder is kept on purpose.


### PR DESCRIPTION
## Summary
- Pause point arming guidance now shows a valid trigger subcommand without a leading `uloop`.
- The hint includes a concrete keyboard-input example that can be copied and adapted.

## User Impact
- Previously, the recommended next action used an ambiguous `<uloop command>` placeholder even though trigger parsing rejects values beginning with `uloop`.
- Users are now explicitly told to provide a subcommand without the leading `uloop`, avoiding an immediate trigger validation error.

## Changes
- Replace the ambiguous trigger placeholder in the successful enable guidance.
- Update exact guidance assertions and add a regression test for the rejected placeholder and required wording.

## Verification
- Red: the new guidance regression test failed before the production text changed.
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value PausePointEnableGuidance --project-path <PROJECT_ROOT>` (14 passed)
- Three exact guidance assertions across the affected test classes (3 passed)
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>` (0 errors, 0 warnings)
- `rg -n '<uloop command>' Packages cli docs Assets` (0 matches)
- An additional broad pause-point run passed 186 tests and exposed 8 existing VibeLogger-memory assertions returning an empty log array.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

