### PR TITLE
fix(get-logs): report Debug.Assert failures as Error instead of Log

### DIFF
--- a/Assets/Tests/Editor/ConsoleLogModeClassifierTests.cs
+++ b/Assets/Tests/Editor/ConsoleLogModeClassifierTests.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies Unity Console mode flags map to the public log severity.
+    /// </summary>
+    [TestFixture]
+    public sealed class ConsoleLogModeClassifierTests
+    {
+        /// <summary>
+        /// What: known scripting and assertion mode flags map to their Unity log types.
+        /// </summary>
+        [TestCase(0x804400, LogType.Log)]
+        [TestCase(0x804200, LogType.Warning)]
+        [TestCase(0x804100, LogType.Error)]
+        [TestCase((1 << 21) | (1 << 19) | (1 << 18), LogType.Assert)]
+        [TestCase(1 << 1, LogType.Assert)]
+        public void Classify_WhenModeContainsKnownSeverity_ReturnsExpectedLogType(int mode, LogType expected)
+        {
+            ConsoleLogModeClassifier classifier = new ConsoleLogModeClassifier();
+
+            LogType actual = classifier.Classify(mode);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+    }
+}

--- a/Assets/Tests/Editor/ConsoleLogModeClassifierTests.cs.meta
+++ b/Assets/Tests/Editor/ConsoleLogModeClassifierTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 49aa7e09ecf0044cfac0b10eb23b776f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/ConsoleLogRetrieverTests.cs
+++ b/Assets/Tests/Editor/ConsoleLogRetrieverTests.cs
@@ -68,6 +68,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 "Error should be retrieved even with mask off");
         }
 
+        /// <summary>
+        /// What: GetAllLogs routes assertion mode flags through the classifier and returns Error severity.
+        /// </summary>
+        [Test]
+        public void GetAllLogs_WhenDebugAssertFails_ReturnsErrorEntry()
+        {
+            string uniqueTestId = System.Guid.NewGuid().ToString("N")[..8];
+            string testMessage = $"AssertionMode_{uniqueTestId}";
+            LogAssert.Expect(LogType.Assert, testMessage);
+            Debug.Assert(false, testMessage);
+
+            List<LogEntryDto> logs = new ConsoleLogRetriever().GetAllLogs();
+
+            LogEntryDto assertionLog = logs.FirstOrDefault(log => log.Message.Contains(testMessage));
+            Assert.IsNotNull(assertionLog, "Assertion log should be found");
+            Assert.That(assertionLog.LogType, Is.EqualTo(UnityCliLoopLogType.Error));
+        }
+
 
         [Test]
         public void GetLogsByType_TemporarilyChangeMask_RestoresOriginalMask()

--- a/Packages/src/Editor/FirstPartyTools/Common/Console/ConsoleLogModeClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/Console/ConsoleLogModeClassifier.cs
@@ -1,0 +1,67 @@
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Classifies Unity Console entry mode flags without depending on Editor state.
+    /// </summary>
+    internal sealed class ConsoleLogModeClassifier
+    {
+        private const int AssertModeFlag = 1 << 1;
+        private const int ScriptingAssertionModeFlag = 1 << 21;
+
+        /// <summary>
+        /// Converts Unity's internal log mode to a LogType enum.
+        /// </summary>
+        internal LogType Classify(int mode)
+        {
+            // Assertion modes omit the scripting severity bits inspected below, so classify
+            // their dedicated flags first instead of allowing them to fall back to Log.
+            if ((mode & (AssertModeFlag | ScriptingAssertionModeFlag)) != 0)
+            {
+                return LogType.Assert;
+            }
+
+            // Analyze the observed patterns:
+            // 0x804400 = Log
+            // 0x804200 = Warning
+            // 0x804100 = Error
+
+            // Extract bits 8-11 (shift right 8, mask 4 bits)
+            int logType = (mode >> 8) & 0xF;
+
+            LogType result = logType switch
+            {
+                0x01 => LogType.Error, // 0x804100 -> (0x4100 >> 8) & 0xF = 0x41 & 0xF = 0x1
+                0x02 => LogType.Warning, // 0x804200 -> (0x4200 >> 8) & 0xF = 0x42 & 0xF = 0x2
+                0x04 => LogType.Log, // 0x804400 -> (0x4400 >> 8) & 0xF = 0x44 & 0xF = 0x4
+                _ => DetermineLogTypeFromModeAnalysis(mode)
+            };
+
+            return result;
+        }
+
+        /// <summary>
+        /// Analyzes mode values to determine log type when standard mapping fails.
+        /// </summary>
+        private LogType DetermineLogTypeFromModeAnalysis(int mode)
+        {
+            // Analyze the mode values we've seen:
+            // 8406016 (0x802000) - appears to be Log type
+            // 8405504 (0x801E00) - appears to be Warning type
+            // 8405248 (0x801D00) - appears to be Error type
+
+            // Let's try different bit extraction strategies
+            // int lowerBits = mode & 0x7; // Lower 3 bits
+            // int midBits = (mode >> 8) & 0x7; // Bits 8-10
+            // int higherBits = (mode >> 16) & 0x7; // Bits 16-18
+
+            // Based on observed patterns, try to determine type
+            if (mode == 8406016) return LogType.Log; // This is a test log message
+            if (mode == 8405504) return LogType.Warning; // This is a test warning message
+            if (mode == 8405248) return LogType.Error; // This is a test error message
+
+            return LogType.Log; // Default to Log for unknown types
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/Console/ConsoleLogModeClassifier.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/Console/ConsoleLogModeClassifier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 35899c5f12ddf41ae888b52f2ab0c544
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/Common/Console/ConsoleLogRetriever.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/Console/ConsoleLogRetriever.cs
@@ -25,6 +25,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly FieldInfo _messageField;
         private readonly FieldInfo _modeField;
         private readonly FieldInfo _callstackTextStartField;
+        private readonly ConsoleLogModeClassifier _logModeClassifier;
 
         /// <summary>
         /// Initializes the retriever with necessary reflection types
@@ -56,6 +57,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _messageField = _logEntryType.GetField("message", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
             _modeField = _logEntryType.GetField("mode", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
             _callstackTextStartField = _logEntryType.GetField("callstackTextStartUTF8", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            _logModeClassifier = new ConsoleLogModeClassifier();
 
             // Missing members would otherwise surface as silently empty or zeroed log data,
             // so an internal Unity API change must fail here instead.
@@ -299,7 +301,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int mode = (int)_modeField.GetValue(logEntryInstance);
             int callstackTextStart = (int)_callstackTextStartField.GetValue(logEntryInstance);
 
-            LogType logType = GetLogTypeFromMode(mode);
+            LogType logType = _logModeClassifier.Classify(mode);
 
             // Separate message and stack trace using Unity's internal boundary
             (string message, string stackTrace) = SeparateMessageAndStackTrace(fullMessage, callstackTextStart);
@@ -349,53 +351,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string stackTrace = fullMessage.Substring(charPosition).Trim();
 
             return (message, stackTrace);
-        }
-
-        /// <summary>
-        /// Converts Unity's internal log mode to a LogType enum
-        /// </summary>
-        private LogType GetLogTypeFromMode(int mode)
-        {
-            // Analyze the observed patterns:
-            // 0x804400 = Log
-            // 0x804200 = Warning  
-            // 0x804100 = Error
-
-            // Extract bits 8-11 (shift right 8, mask 4 bits)
-            int logType = (mode >> 8) & 0xF;
-
-            LogType result = logType switch
-            {
-                0x01 => LogType.Error, // 0x804100 -> (0x4100 >> 8) & 0xF = 0x41 & 0xF = 0x1
-                0x02 => LogType.Warning, // 0x804200 -> (0x4200 >> 8) & 0xF = 0x42 & 0xF = 0x2  
-                0x04 => LogType.Log, // 0x804400 -> (0x4400 >> 8) & 0xF = 0x44 & 0xF = 0x4
-                _ => DetermineLogTypeFromModeAnalysis(mode)
-            };
-
-            return result;
-        }
-
-        /// <summary>
-        /// Analyzes mode values to determine log type when standard mapping fails
-        /// </summary>
-        private LogType DetermineLogTypeFromModeAnalysis(int mode)
-        {
-            // Analyze the mode values we've seen:
-            // 8406016 (0x802000) - appears to be Log type
-            // 8405504 (0x801E00) - appears to be Warning type  
-            // 8405248 (0x801D00) - appears to be Error type
-
-            // Let's try different bit extraction strategies
-            // int lowerBits = mode & 0x7; // Lower 3 bits
-            // int midBits = (mode >> 8) & 0x7; // Bits 8-10
-            // int higherBits = (mode >> 16) & 0x7; // Bits 16-18
-
-            // Based on observed patterns, try to determine type
-            if (mode == 8406016) return LogType.Log; // This is a test log message
-            if (mode == 8405504) return LogType.Warning; // This is a test warning message
-            if (mode == 8405248) return LogType.Error; // This is a test error message
-
-            return LogType.Log; // Default to Log for unknown types
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- `get-logs` now reports assertion failures as `Error` instead of `Log` in unfiltered output.
- Error-filtered and unfiltered retrieval now agree on assertion severity.

## User Impact
- Previously, `Debug.Assert` entries appeared as `Log` when users requested all Console entries. A later error-family fallback still included them in `--log-type Error`, but the reported type depended on the selected filter.
- Assertion failures now consistently appear as `Error`, matching the Unity Console error family.

## Changes
- Extract Unity Console mode classification into an independently testable pure classifier.
- Recognize both native assertion and scripting assertion mode flags before the legacy severity mapping.
- Cover the existing Log, Warning, and Error modes plus both assertion modes.

## Verification
- Red: the new classifier test passed the three existing severity cases and failed both assertion cases as `Log` before the fix.
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value '(ConsoleLogModeClassifierTests|ConsoleLogRetrieverTests)' --project-path <PROJECT_ROOT>` (19 passed)
- Before the fix, an assertion probe appeared as `Type: Log` in `--log-type All`; after the fix it appears as `Type: Error` in both `All` and `Error` retrieval.
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>` (0 errors, 0 warnings)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

