### PR TITLE
fix(hot-reload): name the same-file added method as the hot-reloadable alternative to an added property

### DIFF
--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -82,7 +82,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             const string expectedReason =
                 "Added properties are out of scope for hot reload; the compiled assembly has no such member. "
-                + "Use a 'const' or a plain added field for the value, or run 'uloop compile'.";
+                + "For a computed value, add a same-file method instead (e.g. 'private T GetX()'), which applies "
+                + "through hot reload; for a constant, use a 'const' or a plain added field; otherwise run "
+                + "'uloop compile'.";
             string onDisk = File.ReadAllText(ResolveHostPath());
             string edited = WithHostMembers(
                 onDisk,

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -951,7 +951,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private const string ExpectedAddedPropertySkipReason =
             "Added properties are out of scope for hot reload; the compiled assembly has no such member. "
-            + "Use a 'const' or a plain added field for the value, or run 'uloop compile'.";
+            + "For a computed value, add a same-file method instead (e.g. 'private T GetX()'), which applies "
+            + "through hot reload; for a constant, use a 'const' or a plain added field; otherwise run "
+            + "'uloop compile'.";
 
         private const string ExpectedExplicitAccessorSkipReason =
             "Property setter, init, or indexer accessors are out of scope for v1; "
@@ -980,6 +982,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 });
 
             AssertSkippedContains(result, "get_AddedProbe", ExpectedAddedPropertySkipReason);
+            AssertSkippedReasonContains(result, "get_AddedProbe", "same-file method");
             AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
             AssertPatchedComputeWithPrivate(result);
         }
@@ -2143,6 +2146,28 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.Fail(
                 "Expected skip containing '" + methodFragment + "' with the unsupported-member reason; got: "
+                + FormatSkippedMethodNames(result.Output.skipped));
+        }
+
+        private static void AssertSkippedReasonContains(
+            TransformWorkerClientResult result,
+            string methodFragment,
+            string expectedReasonFragment)
+        {
+            Assert.That(result.Output.skipped, Is.Not.Null, "Expected a skipped list from the worker.");
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                if (skipped.method != null
+                    && skipped.method.Contains(methodFragment)
+                    && skipped.reason.Contains(expectedReasonFragment))
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail(
+                "Expected skip containing '" + methodFragment + "' with reason fragment '"
+                + expectedReasonFragment + "'; got: "
                 + FormatSkippedMethodNames(result.Output.skipped));
         }
 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -982,7 +982,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 });
 
             AssertSkippedContains(result, "get_AddedProbe", ExpectedAddedPropertySkipReason);
-            AssertSkippedReasonContains(result, "get_AddedProbe", "same-file method");
             AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
             AssertPatchedComputeWithPrivate(result);
         }
@@ -2146,28 +2145,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.Fail(
                 "Expected skip containing '" + methodFragment + "' with the unsupported-member reason; got: "
-                + FormatSkippedMethodNames(result.Output.skipped));
-        }
-
-        private static void AssertSkippedReasonContains(
-            TransformWorkerClientResult result,
-            string methodFragment,
-            string expectedReasonFragment)
-        {
-            Assert.That(result.Output.skipped, Is.Not.Null, "Expected a skipped list from the worker.");
-            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
-            {
-                if (skipped.method != null
-                    && skipped.method.Contains(methodFragment)
-                    && skipped.reason.Contains(expectedReasonFragment))
-                {
-                    return;
-                }
-            }
-
-            Assert.Fail(
-                "Expected skip containing '" + methodFragment + "' with reason fragment '"
-                + expectedReasonFragment + "'; got: "
                 + FormatSkippedMethodNames(result.Output.skipped));
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMethodSkipReasons.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMethodSkipReasons.cs
@@ -23,7 +23,9 @@ internal static class AddedMethodSkipReasons
 
     public const string AddedProperty =
         "Added properties are out of scope for hot reload; the compiled assembly has no such member. "
-        + "Use a 'const' or a plain added field for the value, or run 'uloop compile'.";
+        + "For a computed value, add a same-file method instead (e.g. 'private T GetX()'), which applies "
+        + "through hot reload; for a constant, use a 'const' or a plain added field; otherwise run "
+        + "'uloop compile'.";
 
     public const string Generic =
         "Added generic methods are skipped; hot reload cannot emit a typed shim for them. "


### PR DESCRIPTION
## Summary

- Point added-property skip guidance for computed values to a same-file method that hot reload can apply.
- Keep the constant, plain-field, and full-compile alternatives explicit.

## User Impact

Previously, the skip reason could imply that a computed added property always required a full compile. The result now names the hot-reloadable same-file method alternative directly.

## Changes

- Expand the added-property skip reason with a concrete same-file method example.
- Verify the exact reason and the `same-file method` guidance through the transform worker path.

## Verification

- Red: the focused transform worker test failed because the skip reason omitted `same-file method`.
- Green: the focused transform worker test passed (1 test).
- Actual hot reload: a temporary MonoBehaviour property was skipped with the new reason while the edited `Update` method was patched; the fixture was restored and all patches were reverted.
- Unity compile completed with 0 errors and 0 warnings.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

