### PR TITLE
fix(execute-dynamic-code): drop the unfocused throttle hint while Play Mode is paused

### DIFF
--- a/Assets/Tests/Editor/EditorUnfocusedWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/EditorUnfocusedWarningBuilderTests.cs
@@ -98,7 +98,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             string hint = EditorUnfocusedWarningBuilder.BuildPlayModeProgressHint(
                 isPlaying: true,
-                isEditorFocused: false);
+                isEditorFocused: false,
+                isPaused: false);
 
             Assert.That(
                 hint,
@@ -114,7 +115,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             string hint = EditorUnfocusedWarningBuilder.BuildPlayModeProgressHint(
                 isPlaying: false,
-                isEditorFocused: false);
+                isEditorFocused: false,
+                isPaused: false);
 
             Assert.That(hint, Is.EqualTo(string.Empty));
         }
@@ -127,7 +129,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             string hint = EditorUnfocusedWarningBuilder.BuildPlayModeProgressHint(
                 isPlaying: true,
-                isEditorFocused: true);
+                isEditorFocused: true,
+                isPaused: false);
+
+            Assert.That(hint, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// What: paused Play Mode does not emit a progress-throttling hint while the Editor is unfocused.
+        /// </summary>
+        [Test]
+        public void BuildPlayModeProgressHint_WhenPausedAndEditorIsUnfocused_ReturnsEmpty()
+        {
+            string hint = EditorUnfocusedWarningBuilder.BuildPlayModeProgressHint(
+                isPlaying: true,
+                isEditorFocused: false,
+                isPaused: true);
 
             Assert.That(hint, Is.EqualTo(string.Empty));
         }

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnfocusedWarningBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnfocusedWarningBuilder.cs
@@ -28,11 +28,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
-        /// Builds the Play Mode progress hint when the Editor is unfocused during Play Mode.
+        /// Builds the Play Mode progress hint when the Editor is unfocused during active Play Mode.
         /// </summary>
-        public static string BuildPlayModeProgressHint(bool isPlaying, bool isEditorFocused)
+        public static string BuildPlayModeProgressHint(bool isPlaying, bool isEditorFocused, bool isPaused)
         {
-            if (!isPlaying || isEditorFocused)
+            if (!isPlaying || isEditorFocused || isPaused)
             {
                 return string.Empty;
             }

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
@@ -314,7 +314,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     action == PlayModeAction.Status
                         ? EditorUnfocusedWarningBuilder.BuildPlayModeProgressHint(
                             _editorStateService.IsPlaying,
-                            _editorFocusStateProvider.IsFocused)
+                            _editorFocusStateProvider.IsFocused,
+                            _editorStateService.IsPaused)
                         : string.Empty)
             };
             PlayModeStopReasonResponseFiller.CopyConfirmedIfNeeded(response, action, wasAlreadyStopped);

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
@@ -158,7 +158,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             response.ActivePausePointId = activePausePointId;
             response.Warning = EditorUnfocusedWarningBuilder.BuildPlayModeProgressHint(
                 response.EditorPlaying,
-                _editorFocusStateProvider.IsFocused);
+                _editorFocusStateProvider.IsFocused,
+                response.EditorPaused);
         }
 
         private static void LogExecutionStart(


### PR DESCRIPTION
## Summary

- Suppress the unfocused Play Mode progress hint while playback is paused.
- Pass the existing pause state through both execute-dynamic-code and control-play-mode response paths.

## User Impact

Paused playback cannot be throttled by an unfocused Editor, so responses no longer suggest focusing the window or using a pause-point flow when the session is already paused.

## Changes

- Extend `BuildPlayModeProgressHint` with the current pause state.
- Return no hint for paused Play Mode.
- Wire pause state from execute-dynamic-code and control-play-mode.
- Add focused coverage for playing, unfocused, paused behavior.

## Verification

- Preparatory signature wiring: existing builder tests passed (8 tests) before the behavior change.
- Red: the new paused test failed because the 206-character throttle hint was still returned.
- Green: the new test passed (1 test), and the builder test class passed (9 tests).
- Unity compile completed with 0 errors and 0 warnings.
- Runtime: active unfocused Play Mode retained the warning; after a source pause point hit, execute-dynamic-code and control-play-mode status omitted the warning. The marker was cleared and Play Mode was stopped.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

