### PR TITLE
fix(execute-dynamic-code): explain that --code takes top-level statements when no Execute method is found

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerTests.cs
@@ -34,9 +34,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.That(
                 result.ErrorMessage,
                 Is.EqualTo(UnityCliLoopConstants.ERROR_MESSAGE_NO_EXECUTE_METHOD));
+            // The literal keeps the guidance itself under test: comparing against the shared
+            // constant alone would still pass if that constant were emptied or reworded.
+            Assert.That(result.NextActions, Has.Count.EqualTo(1));
             Assert.That(
-                result.NextActions,
-                Is.EqualTo(UnityCliLoopConstants.DYNAMIC_CODE_NO_EXECUTE_METHOD_NEXT_ACTIONS));
+                result.NextActions[0],
+                Is.EqualTo(
+                    "Remove the class and method wrapper and pass the statements themselves, e.g. " +
+                    "--code \"return GameObject.Find(\\\"Player\\\").transform.position;\""));
         }
 
         private static Assembly CreateAssemblyWithoutExecuteMethod()

--- a/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerTests.cs
@@ -23,13 +23,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         public async Task ExecuteAsync_WhenDynamicCommandHasNoExecuteMethod_ReturnsRecoveryGuidance()
         {
             Assembly assembly = CreateAssemblyWithoutExecuteMethod();
+
+            ExecutionResult result = await ExecuteAsync(assembly);
+
+            AssertRecoveryGuidance(result);
+        }
+
+        /// <summary>
+        /// What: a class-wrapped snippet whose Execute is static (the reported input shape) is not
+        /// picked up as the entry point and receives the same recovery guidance.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenDynamicCommandOnlyHasStaticExecute_ReturnsRecoveryGuidance()
+        {
+            Assembly assembly = CreateAssemblyWithStaticExecuteMethod();
+
+            ExecutionResult result = await ExecuteAsync(assembly);
+
+            AssertRecoveryGuidance(result);
+        }
+
+        private static async Task<ExecutionResult> ExecuteAsync(Assembly assembly)
+        {
             DynamicExecutionContext context = new()
             {
                 CompiledAssembly = assembly,
                 CancellationToken = CancellationToken.None
             };
-            ExecutionResult result = await new CommandRunner().ExecuteAsync(context);
+            return await new CommandRunner().ExecuteAsync(context);
+        }
 
+        private static void AssertRecoveryGuidance(ExecutionResult result)
+        {
             Assert.That(result.Success, Is.False);
             Assert.That(
                 result.ErrorMessage,
@@ -40,22 +65,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.That(
                 result.NextActions[0],
                 Is.EqualTo(
-                    "Remove the class and method wrapper and pass the statements themselves, e.g. " +
+                    "Remove the class, namespace, and method wrapper and pass the statements themselves, e.g. " +
                     "--code \"return GameObject.Find(\\\"Player\\\").transform.position;\""));
         }
 
         private static Assembly CreateAssemblyWithoutExecuteMethod()
         {
-            AssemblyName assemblyName = new("CommandRunnerWithoutExecuteMethodTests");
+            TypeBuilder typeBuilder = DefineDynamicCommandType("CommandRunnerWithoutExecuteMethodTests");
+            typeBuilder.CreateType();
+            return typeBuilder.Assembly;
+        }
+
+        private static Assembly CreateAssemblyWithStaticExecuteMethod()
+        {
+            TypeBuilder typeBuilder = DefineDynamicCommandType("CommandRunnerStaticExecuteMethodTests");
+            MethodBuilder executeMethod = typeBuilder.DefineMethod(
+                "Execute",
+                MethodAttributes.Public | MethodAttributes.Static,
+                typeof(object),
+                System.Type.EmptyTypes);
+            ILGenerator il = executeMethod.GetILGenerator();
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ret);
+            typeBuilder.CreateType();
+            return typeBuilder.Assembly;
+        }
+
+        private static TypeBuilder DefineDynamicCommandType(string assemblyNameText)
+        {
+            AssemblyName assemblyName = new(assemblyNameText);
             AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
                 assemblyName,
                 AssemblyBuilderAccess.Run);
             ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name);
-            TypeBuilder typeBuilder = moduleBuilder.DefineType(
+            return moduleBuilder.DefineType(
                 "UnityCliLoop.Dynamic.DynamicCommand",
                 TypeAttributes.Public | TypeAttributes.Class);
-            typeBuilder.CreateType();
-            return assemblyBuilder;
         }
     }
 }

--- a/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerTests.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+using DynamicExecutionContext = io.github.hatayama.UnityCliLoop.FirstPartyTools.ExecutionContext;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
+{
+    /// <summary>
+    /// Test fixture that verifies CommandRunner execution results.
+    /// </summary>
+    [TestFixture]
+    public class CommandRunnerTests
+    {
+        /// <summary>
+        /// What: a generated command type without Execute returns the statement-input recovery guidance.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenDynamicCommandHasNoExecuteMethod_ReturnsRecoveryGuidance()
+        {
+            Assembly assembly = CreateAssemblyWithoutExecuteMethod();
+            DynamicExecutionContext context = new()
+            {
+                CompiledAssembly = assembly,
+                CancellationToken = CancellationToken.None
+            };
+            ExecutionResult result = await new CommandRunner().ExecuteAsync(context);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(
+                result.ErrorMessage,
+                Is.EqualTo(UnityCliLoopConstants.ERROR_MESSAGE_NO_EXECUTE_METHOD));
+            Assert.That(
+                result.NextActions,
+                Is.EqualTo(UnityCliLoopConstants.DYNAMIC_CODE_NO_EXECUTE_METHOD_NEXT_ACTIONS));
+        }
+
+        private static Assembly CreateAssemblyWithoutExecuteMethod()
+        {
+            AssemblyName assemblyName = new("CommandRunnerWithoutExecuteMethodTests");
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
+                assemblyName,
+                AssemblyBuilderAccess.Run);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name);
+            TypeBuilder typeBuilder = moduleBuilder.DefineType(
+                "UnityCliLoop.Dynamic.DynamicCommand",
+                TypeAttributes.Public | TypeAttributes.Class);
+            typeBuilder.CreateType();
+            return assemblyBuilder;
+        }
+    }
+}

--- a/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f07a022460b462f90b7e8fdf9ed1d46
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionResponseFactoryTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionResponseFactoryTests.cs
@@ -39,6 +39,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
+        /// Verifies execution result next actions are exposed in the tool response.
+        /// </summary>
+        [Test]
+        public void ConvertExecutionResultToResponse_WhenNextActionsExist_MapsNextActions()
+        {
+            DynamicCodeExecutionResponseFactory factory = new();
+            ExecutionResult result = new()
+            {
+                Success = false,
+                NextActions = new List<string> { "Retry with statements only." }
+            };
+
+            ExecuteDynamicCodeResponse response = factory.ConvertExecutionResultToResponse(result);
+
+            Assert.That(response.NextActions, Is.EqualTo(new[] { "Retry with statements only." }));
+        }
+
+        /// <summary>
+        /// Verifies an empty execution result action list stays absent from the tool response.
+        /// </summary>
+        [Test]
+        public void ConvertExecutionResultToResponse_WhenNextActionsAreEmpty_LeavesNextActionsNull()
+        {
+            DynamicCodeExecutionResponseFactory factory = new();
+            ExecutionResult result = new()
+            {
+                Success = true,
+                NextActions = new List<string>()
+            };
+
+            ExecuteDynamicCodeResponse response = factory.ConvertExecutionResultToResponse(result);
+
+            Assert.That(response.NextActions, Is.Null);
+        }
+
+        /// <summary>
         /// Verifies compilation failures expose deduplicated diagnostics, summary, hints, suggestions, and source context.
         /// </summary>
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
@@ -96,7 +96,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 PartialResults = result.PartialResults != null
                     ? new Dictionary<string, string>(result.PartialResults)
                     : new Dictionary<string, string>(),
-                Timings = result.Timings != null ? new List<string>(result.Timings) : new List<string>()
+                Timings = result.Timings != null ? new List<string>(result.Timings) : new List<string>(),
+                NextActions = result.NextActions.Count > 0 ? result.NextActions.ToArray() : null
             };
 
             if (!result.Success)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
@@ -221,10 +221,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 
                 if (targetType == null || executeMethod == null)
                 {
-                    return CapturePartialResults(
-                        CreateErrorResult(
-                            UnityCliLoopConstants.ERROR_MESSAGE_NO_EXECUTE_METHOD,
-                            new List<string> { "Assembly types checked but no Execute method found" }));
+                    ExecutionResult result = CreateErrorResult(
+                        UnityCliLoopConstants.ERROR_MESSAGE_NO_EXECUTE_METHOD,
+                        new List<string> { "Assembly types checked but no Execute method found" });
+                    result.NextActions = new List<string>(
+                        UnityCliLoopConstants.DYNAMIC_CODE_NO_EXECUTE_METHOD_NEXT_ACTIONS);
+                    return CapturePartialResults(result);
                 }
 
                 // Create instance

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Models/ExecutionResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Models/ExecutionResult.cs
@@ -28,6 +28,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <summary>Logs</summary>
         public List<string> Logs { get; set; } = new();
 
+        /// <summary>Suggested recovery steps for the caller.</summary>
+        public List<string> NextActions { get; set; } = new();
+
         /// <summary>
         /// Values explicitly saved by a dynamic-code snippet before execution completed or failed.
         /// </summary>

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -138,7 +138,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         /// </summary>
         public static readonly string[] DYNAMIC_CODE_NO_EXECUTE_METHOD_NEXT_ACTIONS =
         {
-            "Remove the class and method wrapper and pass the statements themselves, e.g. " +
+            "Remove the class, namespace, and method wrapper and pass the statements themselves, e.g. " +
             "--code \"return GameObject.Find(\\\"Player\\\").transform.position;\"",
         };
 

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -126,9 +126,21 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public const string ERROR_MESSAGE_DYNAMIC_CODE_RUNTIME_RESTARTING =
             "Dynamic-code runtime was disposed during a server reset or domain reload; retry the same command shortly.";
         public const string ERROR_MESSAGE_NO_COMPILED_ASSEMBLY = "No compiled assembly provided";
-        public const string ERROR_MESSAGE_NO_EXECUTE_METHOD = "No Execute method found in compiled assembly";
+        public const string ERROR_MESSAGE_NO_EXECUTE_METHOD =
+            "No Execute method found in compiled assembly. --code is compiled as the body of a generated Execute method, " +
+            "so write top-level statements directly (no class, namespace, or entry-point method); 'return' is optional " +
+            "and 'using' directives may appear at the top.";
         public const string ERROR_MESSAGE_FAILED_TO_CREATE_INSTANCE = "Failed to create instance of target type";
         public const string ERROR_MESSAGE_UNSUPPORTED_SIGNATURE = "Execute method signature not supported";
+
+        /// <summary>
+        /// Recovery step when execute-dynamic-code receives an entry-point wrapper instead of statements.
+        /// </summary>
+        public static readonly string[] DYNAMIC_CODE_NO_EXECUTE_METHOD_NEXT_ACTIONS =
+        {
+            "Remove the class and method wrapper and pass the statements themselves, e.g. " +
+            "--code \"return GameObject.Find(\\\"Player\\\").transform.position;\"",
+        };
 
         /// <summary>
         /// Recovery steps when execute-dynamic-code hits a disposed runtime during reset/reload.


### PR DESCRIPTION
## Summary
- Explain that `--code` accepts statements inside a generated entry point when no executable method is found.
- Return a concrete `NextActions` recovery hint that shows how to remove class and method wrappers.

## User Impact
- Previously, the error only said that no Execute method was found, which could lead users to rename their own method without fixing the input shape.
- The response now explains the generated wrapper and gives a directly usable statement-only example.

## Changes
- Expanded the no-Execute error message with the accepted snippet structure.
- Propagated optional next actions from execution results to tool responses while omitting empty actions.
- Added response-factory coverage for present and empty next actions.
- The concrete sealed entry-point resolver does not provide a substitutable test seam, so no resolver-injection test was added.

## Verification
- `git diff --check`
- Unity tests not run in this worktree as requested; EditMode verification is delegated to the orchestrator in the main checkout.

Closes #2559


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

