### PR TITLE
feat: Bring the Unity Editor to the front faster on macOS

### DIFF
--- a/cli/common/unityprocess/focus_darwin.go
+++ b/cli/common/unityprocess/focus_darwin.go
@@ -6,8 +6,12 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-	"strconv"
-	"strings"
+)
+
+const (
+	lsappinfoCommand = "lsappinfo"
+	openCommand      = "open"
+	osascriptCommand = "osascript"
 )
 
 func FocusUnityProcess(ctx context.Context, pid int) error {
@@ -28,22 +32,76 @@ func FocusUnityProcessWithRestore(ctx context.Context, pid int) (RestoreFocusFun
 }
 
 func readFrontmostProcessIDMac(ctx context.Context) int {
-	commandContext, cancel := withCommandTimeout(ctx, FocusCommandTimeout)
-	defer cancel()
-	output, err := exec.CommandContext(commandContext, "osascript", "-e", `tell application "System Events" to get unix id of first process whose frontmost is true`).Output()
+	output, err := runFocusCommand(ctx, lsappinfoCommand, "front")
 	if err != nil {
 		return 0
 	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(output)))
+	asn := parseLsappinfoFrontASN(string(output))
+	if asn == "" {
+		return 0
+	}
+	pidOutput, err := runFocusCommand(ctx, lsappinfoCommand, "info", "-only", "pid", asn)
 	if err != nil {
 		return 0
 	}
-	return pid
+	return parseLsappinfoPID(string(pidOutput))
+}
+
+func bundlePathForPIDMac(ctx context.Context, pid int) string {
+	output, err := runFocusCommand(ctx, lsappinfoCommand, "find", fmt.Sprintf("pid=%d", pid))
+	if err != nil {
+		return ""
+	}
+	asn := parseLsappinfoFindASN(string(output))
+	if asn == "" {
+		return ""
+	}
+	pathOutput, err := runFocusCommand(ctx, lsappinfoCommand, "info", "-only", "LSBundlePath", asn)
+	if err != nil {
+		return ""
+	}
+	return parseLsappinfoBundlePath(string(pathOutput))
+}
+
+func countProcessesWithBundlePathMac(ctx context.Context, bundlePath string) int {
+	output, err := runFocusCommand(ctx, lsappinfoCommand, "list")
+	if err != nil {
+		return 0
+	}
+	return countLsappinfoBundlePath(string(output), bundlePath)
 }
 
 func setFrontmostProcessMac(ctx context.Context, pid int) error {
+	bundlePath := bundlePathForPIDMac(ctx, pid)
+	if bundlePath == "" {
+		return setFrontmostProcessViaOsascriptMac(ctx, pid)
+	}
+	if countProcessesWithBundlePathMac(ctx, bundlePath) >= 2 {
+		return setFrontmostProcessViaOsascriptMac(ctx, pid)
+	}
+	return activateAppViaOpenMac(ctx, bundlePath)
+}
+
+// setFrontmostProcessViaOsascriptMac activates a process by PID.
+// open -a can only name a bundle path, so it cannot choose one instance when
+// the same Unity version has two projects open.
+func setFrontmostProcessViaOsascriptMac(ctx context.Context, pid int) error {
+	script := fmt.Sprintf(`tell application "System Events" to set frontmost of (first process whose unix id is %d) to true`, pid)
+	return runFocusCommandNoOutput(ctx, osascriptCommand, "-e", script)
+}
+
+func activateAppViaOpenMac(ctx context.Context, bundlePath string) error {
+	return runFocusCommandNoOutput(ctx, openCommand, "-a", bundlePath)
+}
+
+func runFocusCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
 	commandContext, cancel := withCommandTimeout(ctx, FocusCommandTimeout)
 	defer cancel()
-	script := fmt.Sprintf(`tell application "System Events" to set frontmost of (first process whose unix id is %d) to true`, pid)
-	return exec.CommandContext(commandContext, "osascript", "-e", script).Run()
+	return exec.CommandContext(commandContext, name, args...).Output()
+}
+
+func runFocusCommandNoOutput(ctx context.Context, name string, args ...string) error {
+	commandContext, cancel := withCommandTimeout(ctx, FocusCommandTimeout)
+	defer cancel()
+	return exec.CommandContext(commandContext, name, args...).Run()
 }

--- a/cli/common/unityprocess/focus_darwin.go
+++ b/cli/common/unityprocess/focus_darwin.go
@@ -64,6 +64,8 @@ func bundlePathForPIDMac(ctx context.Context, pid int) string {
 }
 
 func countProcessesWithBundlePathMac(ctx context.Context, bundlePath string) int {
+	// 0 means the count could not be determined: list failed, or no matching process.
+	// open -a is only safe when this returns exactly 1.
 	output, err := runFocusCommand(ctx, lsappinfoCommand, "list")
 	if err != nil {
 		return 0
@@ -73,10 +75,11 @@ func countProcessesWithBundlePathMac(ctx context.Context, bundlePath string) int
 
 func setFrontmostProcessMac(ctx context.Context, pid int) error {
 	bundlePath := bundlePathForPIDMac(ctx, pid)
-	if bundlePath == "" {
-		return setFrontmostProcessViaOsascriptMac(ctx, pid)
+	matchingCount := 0
+	if bundlePath != "" {
+		matchingCount = countProcessesWithBundlePathMac(ctx, bundlePath)
 	}
-	if countProcessesWithBundlePathMac(ctx, bundlePath) >= 2 {
+	if shouldActivateViaOsascriptMac(bundlePath, matchingCount) {
 		return setFrontmostProcessViaOsascriptMac(ctx, pid)
 	}
 	return activateAppViaOpenMac(ctx, bundlePath)

--- a/cli/common/unityprocess/focus_mac_choice.go
+++ b/cli/common/unityprocess/focus_mac_choice.go
@@ -1,0 +1,8 @@
+package unityprocess
+
+// shouldActivateViaOsascriptMac reports whether open -a is unsafe for this process.
+// matchingProcessCount 0 means the count could not be determined, so PID-based
+// osascript is the only way to avoid activating the wrong Unity instance.
+func shouldActivateViaOsascriptMac(bundlePath string, matchingProcessCount int) bool {
+	return bundlePath == "" || matchingProcessCount != 1
+}

--- a/cli/common/unityprocess/focus_mac_choice_test.go
+++ b/cli/common/unityprocess/focus_mac_choice_test.go
@@ -1,0 +1,28 @@
+package unityprocess
+
+import "testing"
+
+// Verifies open -a is used only for a known unique bundle path; count 0 (unknown or none) falls back to osascript.
+func TestShouldActivateViaOsascriptMac(t *testing.T) {
+	cases := []struct {
+		name    string
+		bundle  string
+		count   int
+		wantOSA bool
+	}{
+		{name: "unique bundle", bundle: "/Applications/Unity.app", count: 1, wantOSA: false},
+		{name: "unknown count is zero", bundle: "/Applications/Unity.app", count: 0, wantOSA: true},
+		{name: "two instances", bundle: "/Applications/Unity.app", count: 2, wantOSA: true},
+		{name: "empty bundle path", bundle: "", count: 1, wantOSA: true},
+		{name: "empty bundle and zero count", bundle: "", count: 0, wantOSA: true},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := shouldActivateViaOsascriptMac(testCase.bundle, testCase.count)
+			if got != testCase.wantOSA {
+				t.Fatalf("shouldActivateViaOsascriptMac(%q, %d) = %t, want %t", testCase.bundle, testCase.count, got, testCase.wantOSA)
+			}
+		})
+	}
+}

--- a/cli/common/unityprocess/lsappinfo_output.go
+++ b/cli/common/unityprocess/lsappinfo_output.go
@@ -1,0 +1,72 @@
+package unityprocess
+
+import (
+	"strconv"
+	"strings"
+)
+
+func parseLsappinfoFrontASN(output string) string {
+	return parseLsappinfoASN(firstTrimmedLine(output))
+}
+
+func parseLsappinfoFindASN(output string) string {
+	return parseLsappinfoASN(firstTrimmedLine(output))
+}
+
+func parseLsappinfoPID(output string) int {
+	const prefix = `"pid"=`
+	line := strings.TrimSpace(output)
+	if !strings.HasPrefix(line, prefix) {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(line, prefix)))
+	if err != nil {
+		return 0
+	}
+	return pid
+}
+
+func parseLsappinfoBundlePath(output string) string {
+	const prefix = `"LSBundlePath"="`
+	line := strings.TrimSpace(output)
+	if !strings.HasPrefix(line, prefix) {
+		return ""
+	}
+	path, found := strings.CutSuffix(strings.TrimPrefix(line, prefix), `"`)
+	if !found || path == "" {
+		return ""
+	}
+	return path
+}
+
+func countLsappinfoBundlePath(listOutput string, bundlePath string) int {
+	// Exact match after TrimSpace: a prefix check would count Unity.app.bak as Unity.app.
+	target := `bundle path="` + bundlePath + `"`
+	count := 0
+	normalized := strings.ReplaceAll(listOutput, "\r\n", "\n")
+	normalized = strings.ReplaceAll(normalized, "\r", "\n")
+	for _, line := range strings.Split(normalized, "\n") {
+		if strings.TrimSpace(line) == target {
+			count++
+		}
+	}
+	return count
+}
+
+func parseLsappinfoASN(line string) string {
+	if !strings.HasPrefix(line, "ASN:") || !strings.HasSuffix(line, ":") {
+		return ""
+	}
+	asn := strings.TrimSuffix(line, ":")
+	if asn == "ASN" || !strings.HasPrefix(asn, "ASN:") {
+		return ""
+	}
+	return asn
+}
+
+func firstTrimmedLine(output string) string {
+	normalized := strings.ReplaceAll(output, "\r\n", "\n")
+	normalized = strings.ReplaceAll(normalized, "\r", "\n")
+	line, _, _ := strings.Cut(normalized, "\n")
+	return strings.TrimSpace(line)
+}

--- a/cli/common/unityprocess/lsappinfo_output_test.go
+++ b/cli/common/unityprocess/lsappinfo_output_test.go
@@ -1,0 +1,142 @@
+package unityprocess
+
+import "testing"
+
+// Verifies parseLsappinfoFrontASN strips the trailing colon from a valid ASN and rejects empty or malformed input.
+func TestParseLsappinfoFrontASN(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "valid", input: "ASN:0x0-0x110e10d:", want: "ASN:0x0-0x110e10d"},
+		{name: "trailing LF", input: "ASN:0x0-0x110e10d:\n", want: "ASN:0x0-0x110e10d"},
+		{name: "trailing CRLF", input: "ASN:0x0-0x110e10d:\r\n", want: "ASN:0x0-0x110e10d"},
+		{name: "empty", input: "", want: ""},
+		{name: "garbage", input: "not-an-asn", want: ""},
+		{name: "missing trailing colon", input: "ASN:0x0-0x110e10d", want: ""},
+		{name: "colon only", input: "ASN:", want: ""},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := parseLsappinfoFrontASN(testCase.input)
+			if got != testCase.want {
+				t.Fatalf("parseLsappinfoFrontASN(%q) = %q, want %q", testCase.input, got, testCase.want)
+			}
+		})
+	}
+}
+
+// Verifies parseLsappinfoFindASN keeps the quoted app name, uses the first line only, and rejects malformed input.
+func TestParseLsappinfoFindASN(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "valid", input: `ASN:0x0-0x110e10d-"cmux":`, want: `ASN:0x0-0x110e10d-"cmux"`},
+		{name: "trailing LF", input: "ASN:0x0-0x110e10d-\"cmux\":\n", want: `ASN:0x0-0x110e10d-"cmux"`},
+		{name: "trailing CRLF", input: "ASN:0x0-0x110e10d-\"cmux\":\r\n", want: `ASN:0x0-0x110e10d-"cmux"`},
+		{name: "first line only", input: "ASN:0x0-0x110e10d-\"cmux\":\nASN:0x0-0x220e20e-\"other\":\n", want: `ASN:0x0-0x110e10d-"cmux"`},
+		{name: "empty", input: "", want: ""},
+		{name: "garbage", input: "no asn here", want: ""},
+		{name: "missing trailing colon", input: `ASN:0x0-0x110e10d-"cmux"`, want: ""},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := parseLsappinfoFindASN(testCase.input)
+			if got != testCase.want {
+				t.Fatalf("parseLsappinfoFindASN(%q) = %q, want %q", testCase.input, got, testCase.want)
+			}
+		})
+	}
+}
+
+// Verifies parseLsappinfoPID reads the quoted pid field and returns 0 when the value is missing or not an integer.
+func TestParseLsappinfoPID(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{name: "valid", input: `"pid"=61295`, want: 61295},
+		{name: "trailing LF", input: "\"pid\"=61295\n", want: 61295},
+		{name: "trailing CRLF", input: "\"pid\"=61295\r\n", want: 61295},
+		{name: "empty", input: "", want: 0},
+		{name: "garbage", input: "pid=61295", want: 0},
+		{name: "non-integer", input: `"pid"=abc`, want: 0},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := parseLsappinfoPID(testCase.input)
+			if got != testCase.want {
+				t.Fatalf("parseLsappinfoPID(%q) = %d, want %d", testCase.input, got, testCase.want)
+			}
+		})
+	}
+}
+
+// Verifies parseLsappinfoBundlePath extracts the quoted path and returns empty for empty or malformed input.
+func TestParseLsappinfoBundlePath(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "valid", input: `"LSBundlePath"="/Applications/cmux.app"`, want: "/Applications/cmux.app"},
+		{name: "trailing LF", input: "\"LSBundlePath\"=\"/Applications/cmux.app\"\n", want: "/Applications/cmux.app"},
+		{name: "trailing CRLF", input: "\"LSBundlePath\"=\"/Applications/cmux.app\"\r\n", want: "/Applications/cmux.app"},
+		{name: "empty", input: "", want: ""},
+		{name: "garbage", input: "LSBundlePath=/Applications/cmux.app", want: ""},
+		{name: "missing closing quote", input: `"LSBundlePath"="/Applications/cmux.app`, want: ""},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := parseLsappinfoBundlePath(testCase.input)
+			if got != testCase.want {
+				t.Fatalf("parseLsappinfoBundlePath(%q) = %q, want %q", testCase.input, got, testCase.want)
+			}
+		})
+	}
+}
+
+// Verifies countLsappinfoBundlePath counts exact trimmed bundle-path lines, including 0/1/2 matches and rejecting prefix-only paths.
+func TestCountLsappinfoBundlePath(t *testing.T) {
+	listOutput := "" +
+		"    bundle path=\"/Applications/Unity.app\"\n" +
+		"    bundle path=\"/Applications/cmux.app\"\r\n" +
+		"    bundle path=\"/Applications/Unity.app.bak\"\n" +
+		"    bundle path=\"/Applications/Unity.app\"\n"
+
+	cases := []struct {
+		name       string
+		listOutput string
+		bundlePath string
+		want       int
+	}{
+		{name: "zero", listOutput: listOutput, bundlePath: "/Applications/Other.app", want: 0},
+		{name: "one", listOutput: listOutput, bundlePath: "/Applications/cmux.app", want: 1},
+		{name: "two", listOutput: listOutput, bundlePath: "/Applications/Unity.app", want: 2},
+		{name: "prefix must not match", listOutput: listOutput, bundlePath: "/Applications/Unity.app", want: 2},
+		{name: "empty list", listOutput: "", bundlePath: "/Applications/Unity.app", want: 0},
+		{name: "garbage", listOutput: "not a list", bundlePath: "/Applications/Unity.app", want: 0},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := countLsappinfoBundlePath(testCase.listOutput, testCase.bundlePath)
+			if got != testCase.want {
+				t.Fatalf("countLsappinfoBundlePath(..., %q) = %d, want %d", testCase.bundlePath, got, testCase.want)
+			}
+		})
+	}
+
+	bakCount := countLsappinfoBundlePath(listOutput, "/Applications/Unity.app.bak")
+	if bakCount != 1 {
+		t.Fatalf("expected Unity.app.bak to count as its own exact path, got %d", bakCount)
+	}
+}

--- a/cli/common/unityprocess/lsappinfo_output_test.go
+++ b/cli/common/unityprocess/lsappinfo_output_test.go
@@ -121,7 +121,7 @@ func TestCountLsappinfoBundlePath(t *testing.T) {
 		{name: "zero", listOutput: listOutput, bundlePath: "/Applications/Other.app", want: 0},
 		{name: "one", listOutput: listOutput, bundlePath: "/Applications/cmux.app", want: 1},
 		{name: "two", listOutput: listOutput, bundlePath: "/Applications/Unity.app", want: 2},
-		{name: "prefix must not match", listOutput: listOutput, bundlePath: "/Applications/Unity.app", want: 2},
+		{name: "prefix must not match", listOutput: listOutput, bundlePath: "/Applications/Unity", want: 0},
 		{name: "empty list", listOutput: "", bundlePath: "/Applications/Unity.app", want: 0},
 		{name: "garbage", listOutput: "not a list", bundlePath: "/Applications/Unity.app", want: 0},
 	}

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "73cc08a1bb0ab18f4a7cd9d29898426c43cfeebf"
+  "sharedInputsHash": "a5bf6c51a02edebe1424cb9e7a00931b73458e01"
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "8913badd0a20798c9e561cb72b8af309d80da4e8"
+  "sharedInputsHash": "9ab982e59c1c9ea651cedebd1db37a94288a2d2a"
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "a5bf6c51a02edebe1424cb9e7a00931b73458e01"
+  "sharedInputsHash": "8913badd0a20798c9e561cb72b8af309d80da4e8"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "60cebc601cc45d58545b029cf05cdf9ae3600db0"
+  "sharedInputsHash": "5afebaa1c5c758c661b840ce4c3e0051369941d1"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "5afebaa1c5c758c661b840ce4c3e0051369941d1"
+  "sharedInputsHash": "4b3a32635b09d941c9e386b204e182587c7a0bed"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "12cc0c0d4d356bf956ef76aca4b2d5db4d22dc81"
+  "sharedInputsHash": "60cebc601cc45d58545b029cf05cdf9ae3600db0"
 }


### PR DESCRIPTION
## Summary
- On macOS, bringing the Unity Editor to the front (and restoring the previous app) no longer launches `osascript` three times.
- The same focus commands now use `lsappinfo` and `open -a`, so the Editor comes forward in a fraction of a second instead of lingering in front for about a second.

## User Impact
- Before: each focus or restore paid about 0.25s per `osascript` launch (about 0.75s when capturing the front app, focusing Unity, then restoring). The Editor appeared to sit in front for 1–2 seconds.
- After: a warm `uloop focus-window` completed in 0.22–0.23s. Restore returned to the previous app in about 0.19s.

## Changes
- Parse `lsappinfo` output in a build-tag-free helper so the format can be tested on every OS.
- On Darwin, read the frontmost PID and bundle path with `lsappinfo`, activate with `open -a`, and keep the existing PID-based `osascript` path only when `open -a` cannot choose one instance (empty bundle path, or two or more processes share the same Unity.app).
- Callers (`focus-window`, stall restore, launch focus) are unchanged.
- Windows PowerShell focus code is not part of this PR.

## Verification
- `cd cli/common && go test ./unityprocess/... -run Lsappinfo` — all parser cases passed (empty/garbage/CRLF, 0/1/2 bundle-path counts, no prefix match on `Unity.app.bak`).
- `cd cli/common && go vet ./... && go build ./...` — success.
- `scripts/check-go-cli.sh` — exit 0 (format, vet, lint, tests, dist rebuild).
- `scripts/stamp-release-inputs.sh` — stamps already current after the commits that changed `cli/common`.
- Device checks used the one running Unity Editor, which had the `unity-cli-loop2` project open (not this branch's worktree). `lsappinfo list` showed one `Unity.app`, so the `open -a` path was exercised.
- Warm `uloop focus-window` against that Editor: `Success: true`, `real 0.23` then `0.22`. The Editor PID stayed the same, Unity Hub's PID stayed the same, `Unity.app` count stayed 1. No new Editor window and Hub did not launch.
- Compile did not trip stall focus (frontmost stayed on cmux for the whole 6.36s sample). Restore was checked by calling `FocusUnityProcessWithRestore` then the restorer from a throwaway Go program outside the repo:
  - before focus: front PID 61295 (cmux)
  - focus elapsed 181.95ms → front PID 97908 (Unity)
  - after 1s wait: front PID 97908
  - restore elapsed 191.94ms → front PID 61295 (cmux)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

