### PR TITLE
fix(pause-point): warn before clear-pause-point resumes Play Mode

### DIFF
--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -5,7 +5,7 @@ description: "Pauses Unity playback at any source file:line without editing code
 
 # uloop pause-point
 
-A pause point captures locals and branch reasons at an exact frame without a source edit. Use it instead of sleeps or after-the-fact reads when input delivery, event ordering, or transition-frame fidelity matters.
+A pause point captures locals and branch reasons at an exact frame without a source edit.
 
 ## Quick Check
 
@@ -47,7 +47,7 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state).
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state). Clearing the marker that owns the current pause resumes Play Mode and consumes any state you arranged while paused: arm the next marker first, then clear the old id, or re-arm the same marker with `--await --resume-play` instead of clearing.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -85,7 +85,7 @@ Clear one or all registered C# watch expressions
 
 `uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` takes the same two forms but always requires a target.
 
-On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `RecommendedNextAction`; see `references/troubleshooting.md` for diagnosis. After hot reload, use `--method <Type.Method>` to constrain `--line`.
+On a wait timeout, `PAUSE_POINT_EXPIRED`, or an enable failure, read `Error.Details.Hint` or the failure `ErrorCode`, then `RecommendedNextAction`. After hot reload, use `--method <Type.Method>` to constrain `--line`.
 
 ## Requirements & Safety
 
@@ -94,12 +94,11 @@ On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `Rec
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.
 - An `--id` marker waits on a hand-written `UloopPausePoint.Pause(id)` call; its hits record no `CapturedVariables`.
-- On an enable failure, branch on the failure `ErrorCode` and follow `RecommendedNextAction`.
 - For scripts under `Packages/`, pass the package-id path form (`Packages/<package-id>/...`); physical checkout paths do not resolve.
 
 ## Reference Guides
 
-All live in `references/` beside this skill; read the one whose trigger matches:
+Read the one whose trigger matches:
 
 - `references/quick-check-template.md` — full `--trigger`/`--await`/`--resume-play` loop, timeouts, hit fields.
 - `references/captured-variables.md` — captures, name filters, `--expect` value forms, caller frames, raw values.

--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -47,7 +47,7 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state). Clearing the marker that owns the current pause resumes Play Mode and consumes any state you arranged while paused: arm the next marker first, then clear the old id, or re-arm the same marker with `--await --resume-play` instead of clearing.
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state). Clearing the marker that owns the current pause releases the Editor pause and lets the game consume any state you arranged while paused: arm the next marker first, then clear the old id, or re-arm it with `--await --resume-play` instead of clearing.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -5,7 +5,7 @@ description: "Pauses Unity playback at any source file:line without editing code
 
 # uloop pause-point
 
-A pause point captures locals and branch reasons at an exact frame without a source edit.
+A pause point captures locals and branch reasons at an exact frame without a source edit. Use it instead of sleeps or after-the-fact reads when input delivery, event ordering, or transition-frame fidelity matters.
 
 ## Quick Check
 
@@ -20,7 +20,7 @@ uloop enable-pause-point --file Assets/Scripts/Enemy.cs --line 42 --timeout-seco
 3. Read `CapturedVariables` in the hit response first, then gather extra evidence while still paused (`execute-dynamic-code`, one screenshot).
 4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point --id <marker-id>`.
 
-A hit pauses Unity at the next frame boundary — the rest of that frame still runs. Only `CapturedVariables` is evidence of the values at the patched line. Before deviating from this template, read `references/quick-check-template.md`.
+Only `CapturedVariables` is evidence of the values at the patched line. Before deviating, read `references/quick-check-template.md`.
 
 ## Parameters
 

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -5,7 +5,7 @@ description: "Pauses Unity playback at any source file:line without editing code
 
 # uloop pause-point
 
-A pause point captures locals and branch reasons at an exact frame without a source edit. Use it instead of sleeps or after-the-fact reads when input delivery, event ordering, or transition-frame fidelity matters.
+A pause point captures locals and branch reasons at an exact frame without a source edit.
 
 ## Quick Check
 
@@ -47,7 +47,7 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state).
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state). Clearing the marker that owns the current pause resumes Play Mode and consumes any state you arranged while paused: arm the next marker first, then clear the old id, or re-arm the same marker with `--await --resume-play` instead of clearing.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -85,7 +85,7 @@ Clear one or all registered C# watch expressions
 
 `uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` takes the same two forms but always requires a target.
 
-On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `RecommendedNextAction`; see `references/troubleshooting.md` for diagnosis. After hot reload, use `--method <Type.Method>` to constrain `--line`.
+On a wait timeout, `PAUSE_POINT_EXPIRED`, or an enable failure, read `Error.Details.Hint` or the failure `ErrorCode`, then `RecommendedNextAction`. After hot reload, use `--method <Type.Method>` to constrain `--line`.
 
 ## Requirements & Safety
 
@@ -94,12 +94,11 @@ On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `Rec
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.
 - An `--id` marker waits on a hand-written `UloopPausePoint.Pause(id)` call; its hits record no `CapturedVariables`.
-- On an enable failure, branch on the failure `ErrorCode` and follow `RecommendedNextAction`.
 - For scripts under `Packages/`, pass the package-id path form (`Packages/<package-id>/...`); physical checkout paths do not resolve.
 
 ## Reference Guides
 
-All live in `references/` beside this skill; read the one whose trigger matches:
+Read the one whose trigger matches:
 
 - `references/quick-check-template.md` — full `--trigger`/`--await`/`--resume-play` loop, timeouts, hit fields.
 - `references/captured-variables.md` — captures, name filters, `--expect` value forms, caller frames, raw values.

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -47,7 +47,7 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state). Clearing the marker that owns the current pause resumes Play Mode and consumes any state you arranged while paused: arm the next marker first, then clear the old id, or re-arm the same marker with `--await --resume-play` instead of clearing.
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state). Clearing the marker that owns the current pause releases the Editor pause and lets the game consume any state you arranged while paused: arm the next marker first, then clear the old id, or re-arm it with `--await --resume-play` instead of clearing.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -5,7 +5,7 @@ description: "Pauses Unity playback at any source file:line without editing code
 
 # uloop pause-point
 
-A pause point captures locals and branch reasons at an exact frame without a source edit.
+A pause point captures locals and branch reasons at an exact frame without a source edit. Use it instead of sleeps or after-the-fact reads when input delivery, event ordering, or transition-frame fidelity matters.
 
 ## Quick Check
 
@@ -20,7 +20,7 @@ uloop enable-pause-point --file Assets/Scripts/Enemy.cs --line 42 --timeout-seco
 3. Read `CapturedVariables` in the hit response first, then gather extra evidence while still paused (`execute-dynamic-code`, one screenshot).
 4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point --id <marker-id>`.
 
-A hit pauses Unity at the next frame boundary — the rest of that frame still runs. Only `CapturedVariables` is evidence of the values at the patched line. Before deviating from this template, read `references/quick-check-template.md`.
+Only `CapturedVariables` is evidence of the values at the patched line. Before deviating, read `references/quick-check-template.md`.
 
 ## Parameters
 

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -1133,11 +1133,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(
                 response.RecommendedNextAction,
-                Is.EqualTo(SourcePausePointConstants.ClearResumedPlayModeRecommendedNextAction));
+                Is.EqualTo(SourcePausePointConstants.ClearReleasedPauseRecommendedNextAction));
         }
 
         /// <summary>
-        /// Verifies clear-pause-point --id recommends nothing when it preserved a manual pause instead of resuming.
+        /// Verifies clear-pause-point --id recommends nothing and keeps the pause when the pause was manual.
         /// </summary>
         [Test]
         public async Task Clear_WhenManualPausePreserved_SetsNoRecommendedNextAction()
@@ -1150,6 +1150,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
 
             Assert.That(response.RecommendedNextAction, Is.Empty);
+            Assert.That(_pauseController.IsPaused, Is.True);
         }
 
         /// <summary>
@@ -1167,7 +1168,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(
                 response.RecommendedNextAction,
-                Is.EqualTo(SourcePausePointConstants.ClearResumedPlayModeRecommendedNextAction));
+                Is.EqualTo(SourcePausePointConstants.ClearReleasedPauseRecommendedNextAction));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -1118,6 +1118,73 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Is.EqualTo(new[] { SourcePausePointConstants.ClearReleasedOwnedPauseWarning }));
         }
 
+        /// <summary>
+        /// Verifies clear-pause-point --id tells the caller how to recover the paused state it just resumed.
+        /// </summary>
+        [Test]
+        public async Task Clear_WhenReleasingPausePointOwnedPause_SetsResumedPlayModeRecommendedNextAction()
+        {
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+
+            ClearPausePointTool tool = new();
+            JObject parameters = new() { ["id"] = "jump" };
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(
+                response.RecommendedNextAction,
+                Is.EqualTo(SourcePausePointConstants.ClearResumedPlayModeRecommendedNextAction));
+        }
+
+        /// <summary>
+        /// Verifies clear-pause-point --id recommends nothing when it preserved a manual pause instead of resuming.
+        /// </summary>
+        [Test]
+        public async Task Clear_WhenManualPausePreserved_SetsNoRecommendedNextAction()
+        {
+            UloopPausePointRegistry.Enable("jump", 30);
+            _pauseController.PauseExternally();
+
+            ClearPausePointTool tool = new();
+            JObject parameters = new() { ["id"] = "jump" };
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.RecommendedNextAction, Is.Empty);
+        }
+
+        /// <summary>
+        /// Verifies clear-pause-point --all tells the caller how to recover the paused state it just resumed.
+        /// </summary>
+        [Test]
+        public async Task ClearAll_WhenReleasingPausePointOwnedPause_SetsResumedPlayModeRecommendedNextAction()
+        {
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+
+            ClearPausePointTool tool = new();
+            JObject parameters = new() { ["all"] = true };
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(
+                response.RecommendedNextAction,
+                Is.EqualTo(SourcePausePointConstants.ClearResumedPlayModeRecommendedNextAction));
+        }
+
+        /// <summary>
+        /// Verifies clear-pause-point --all recommends nothing when no pause-point-owned pause was released.
+        /// </summary>
+        [Test]
+        public async Task ClearAll_WhenNoPauseReleased_SetsNoRecommendedNextAction()
+        {
+            UloopPausePointRegistry.Enable("jump", 30);
+
+            ClearPausePointTool tool = new();
+            JObject parameters = new() { ["all"] = true };
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.RecommendedNextAction, Is.Empty);
+        }
+
         [Test]
         public async Task Enable_WhenMarkerCreated_ReturnsStateManagementFields()
         {

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -5,7 +5,7 @@ description: "Pauses Unity playback at any source file:line without editing code
 
 # uloop pause-point
 
-A pause point captures locals and branch reasons at an exact frame without a source edit. Use it instead of sleeps or after-the-fact reads when input delivery, event ordering, or transition-frame fidelity matters.
+A pause point captures locals and branch reasons at an exact frame without a source edit.
 
 ## Quick Check
 
@@ -47,7 +47,7 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state).
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state). Clearing the marker that owns the current pause resumes Play Mode and consumes any state you arranged while paused: arm the next marker first, then clear the old id, or re-arm the same marker with `--await --resume-play` instead of clearing.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -85,7 +85,7 @@ Clear one or all registered C# watch expressions
 
 `uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` takes the same two forms but always requires a target.
 
-On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `RecommendedNextAction`; see `references/troubleshooting.md` for diagnosis. After hot reload, use `--method <Type.Method>` to constrain `--line`.
+On a wait timeout, `PAUSE_POINT_EXPIRED`, or an enable failure, read `Error.Details.Hint` or the failure `ErrorCode`, then `RecommendedNextAction`. After hot reload, use `--method <Type.Method>` to constrain `--line`.
 
 ## Requirements & Safety
 
@@ -94,12 +94,11 @@ On a wait timeout or `PAUSE_POINT_EXPIRED`, read `Error.Details.Hint`, then `Rec
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.
 - An `--id` marker waits on a hand-written `UloopPausePoint.Pause(id)` call; its hits record no `CapturedVariables`.
-- On an enable failure, branch on the failure `ErrorCode` and follow `RecommendedNextAction`.
 - For scripts under `Packages/`, pass the package-id path form (`Packages/<package-id>/...`); physical checkout paths do not resolve.
 
 ## Reference Guides
 
-All live in `references/` beside this skill; read the one whose trigger matches:
+Read the one whose trigger matches:
 
 - `references/quick-check-template.md` — full `--trigger`/`--await`/`--resume-play` loop, timeouts, hit fields.
 - `references/captured-variables.md` — captures, name filters, `--expect` value forms, caller frames, raw values.

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -47,7 +47,7 @@ Enable a pause point so Unity pauses when that code path is reached, either by a
 
 ### clear-pause-point
 
-Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state). Clearing the marker that owns the current pause resumes Play Mode and consumes any state you arranged while paused: arm the next marker first, then clear the old id, or re-arm the same marker with `--await --resume-play` instead of clearing.
+Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state). Clearing the marker that owns the current pause releases the Editor pause and lets the game consume any state you arranged while paused: arm the next marker first, then clear the old id, or re-arm it with `--await --resume-play` instead of clearing.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -5,7 +5,7 @@ description: "Pauses Unity playback at any source file:line without editing code
 
 # uloop pause-point
 
-A pause point captures locals and branch reasons at an exact frame without a source edit.
+A pause point captures locals and branch reasons at an exact frame without a source edit. Use it instead of sleeps or after-the-fact reads when input delivery, event ordering, or transition-frame fidelity matters.
 
 ## Quick Check
 
@@ -20,7 +20,7 @@ uloop enable-pause-point --file Assets/Scripts/Enemy.cs --line 42 --timeout-seco
 3. Read `CapturedVariables` in the hit response first, then gather extra evidence while still paused (`execute-dynamic-code`, one screenshot).
 4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point --id <marker-id>`.
 
-A hit pauses Unity at the next frame boundary — the rest of that frame still runs. Only `CapturedVariables` is evidence of the values at the patched line. Before deviating from this template, read `references/quick-check-template.md`.
+Only `CapturedVariables` is evidence of the values at the patched line. Before deviating, read `references/quick-check-template.md`.
 
 ## Parameters
 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -178,7 +178,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     : string.Empty,
                 Warnings = result.ResumedFromPause
                     ? new[] { SourcePausePointConstants.ClearReleasedOwnedPauseWarning }
-                    : Array.Empty<string>()
+                    : Array.Empty<string>(),
+                RecommendedNextAction = result.ResumedFromPause
+                    ? SourcePausePointConstants.ClearResumedPlayModeRecommendedNextAction
+                    : string.Empty
             };
         }
 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -180,7 +180,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     ? new[] { SourcePausePointConstants.ClearReleasedOwnedPauseWarning }
                     : Array.Empty<string>(),
                 RecommendedNextAction = result.ResumedFromPause
-                    ? SourcePausePointConstants.ClearResumedPlayModeRecommendedNextAction
+                    ? SourcePausePointConstants.ClearReleasedPauseRecommendedNextAction
                     : string.Empty
             };
         }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
@@ -186,11 +186,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     SourcePausePointConstants.ClearReleasedOwnedPauseWarning);
                 PausePointEnableWarningList.Assign(response, warningEntries);
 
-                // Overwrites whatever FromSnapshot derived from StatusBeforeClear (the expired
-                // hint, for instance): the caller has just lost the paused state to a resume that
-                // happened during this call, so recovering it comes before re-arming advice.
+                // FromSnapshot leaves this empty on a clear: the snapshot only carries a
+                // recommendation while Status is Expired, and Status is Cleared by now. So this
+                // fills the field rather than competing with an existing recommendation.
                 response.RecommendedNextAction =
-                    SourcePausePointConstants.ClearResumedPlayModeRecommendedNextAction;
+                    SourcePausePointConstants.ClearReleasedPauseRecommendedNextAction;
             }
 
             return response;

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
@@ -185,6 +185,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     warningEntries,
                     SourcePausePointConstants.ClearReleasedOwnedPauseWarning);
                 PausePointEnableWarningList.Assign(response, warningEntries);
+
+                // Overwrites whatever FromSnapshot derived from StatusBeforeClear (the expired
+                // hint, for instance): the caller has just lost the paused state to a resume that
+                // happened during this call, so recovering it comes before re-arming advice.
+                response.RecommendedNextAction =
+                    SourcePausePointConstants.ClearResumedPlayModeRecommendedNextAction;
             }
 
             return response;

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -199,14 +199,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             + "A manual pause set outside the pause-point workflow would have been left untouched.";
 
         // Paired with ClearReleasedOwnedPauseWarning, which only explains what happened. Callers
-        // that arranged a scenario while paused lose it the moment the clear resumes playback, so
-        // the recovery path (re-pause, re-arrange) and the ordering that avoids the loss next time
-        // (arm the replacement marker before clearing the current one) have to be stated as the
-        // next action, not left for the caller to infer from the warning.
-        public const string ClearResumedPlayModeRecommendedNextAction =
-            "Play Mode is running again. If the paused state was needed, pause with "
-            + "control-play-mode --action Pause, re-arrange it, and next time arm the new marker "
-            + "before clearing this one.";
+        // that arranged a scenario while paused lose it the moment the clear releases the pause,
+        // so the recovery path (re-pause, re-arrange) and the ordering that avoids the loss next
+        // time (arm the replacement marker before clearing the current one) have to be stated as
+        // the next action, not left for the caller to infer from the warning. Worded around the
+        // Editor pause for the same reason as that warning: a marker reached through
+        // execute-dynamic-code pauses in EditMode, where naming Play Mode would be false.
+        public const string ClearReleasedPauseRecommendedNextAction =
+            "The Editor pause was released. If you needed the paused state, pause again "
+            + "(control-play-mode --action Pause while in Play Mode), re-arrange it, and next "
+            + "time arm the new marker before clearing this one.";
 
         // Release code optimization strips most sequence points and hoists/elides locals, so the
         // Resolver's PDB-driven lookup cannot reliably find a patch location; rejecting up front

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -198,6 +198,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             "This clear released the Editor pause because it was owned by a pause-point hit. "
             + "A manual pause set outside the pause-point workflow would have been left untouched.";
 
+        // Paired with ClearReleasedOwnedPauseWarning, which only explains what happened. Callers
+        // that arranged a scenario while paused lose it the moment the clear resumes playback, so
+        // the recovery path (re-pause, re-arrange) and the ordering that avoids the loss next time
+        // (arm the replacement marker before clearing the current one) have to be stated as the
+        // next action, not left for the caller to infer from the warning.
+        public const string ClearResumedPlayModeRecommendedNextAction =
+            "Play Mode is running again. If the paused state was needed, pause with "
+            + "control-play-mode --action Pause, re-arrange it, and next time arm the new marker "
+            + "before clearing this one.";
+
         // Release code optimization strips most sequence points and hoists/elides locals, so the
         // Resolver's PDB-driven lookup cannot reliably find a patch location; rejecting up front
         // avoids patching the wrong instruction instead of failing later in a confusing way.

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -433,7 +433,7 @@
     },
     {
       "name": "clear-pause-point",
-      "description": "Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state).",
+      "description": "Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state). Clearing the marker that owns the current pause resumes Play Mode and consumes any state you arranged while paused: arm the next marker first, then clear the old id, or re-arm the same marker with `--await --resume-play` instead of clearing.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -433,7 +433,7 @@
     },
     {
       "name": "clear-pause-point",
-      "description": "Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state). Clearing the marker that owns the current pause resumes Play Mode and consumes any state you arranged while paused: arm the next marker first, then clear the old id, or re-arm the same marker with `--await --resume-play` instead of clearing.",
+      "description": "Clear one or all named UloopPausePoint.Pause markers. The response field `ClearedCount` is the number of markers this call transitioned to Cleared: 0 or 1 for `--id`, and the number transitioned for `--all`. Auto-disarmed and expired markers still count as 1; the record stays readable via `pause-point-status` (`StatusBeforeClear` keeps the prior state). Clearing the marker that owns the current pause releases the Editor pause and lets the game consume any state you arranged while paused: arm the next marker first, then clear the old id, or re-arm it with `--await --resume-play` instead of clearing.",
       "inputSchema": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Problem

Clearing the marker that owns the current pause resumes Play Mode, and any scenario arranged while paused is consumed the moment gameplay continues. Two separate verification rounds lost a hand-arranged setup to this.

Neither surface warned in time:

- The clear response carried only `ClearReleasedOwnedPauseWarning`, which explains what happened after the fact — not how to recover the lost state, nor the ordering that avoids the loss next time.
- The ordering rule existed only in `references/fast-progressing-games.md`. The `### clear-pause-point` section of `SKILL.md` gave no reason to suspect the call had a run-state side effect, so an agent reading the section it was told to read never saw it.

## Change

**Response (`RecommendedNextAction`).** Both clear paths now name the recovery and the safe ordering, sharing one constant:

- `--all` — `PausePointResponse.FromClearAll`
- `--id` — `PausePointUseCase.Clear`, where it takes precedence over the `StatusBeforeClear`-derived hint, because the state was lost during this very call.

**Skill.** The `### clear-pause-point` section states the trap inline. `SKILL.md` had 14 bytes of headroom under the 8,000-byte injection cap, so the new sentence is paid for by removing passages that are stated elsewhere:

| Removed | Already stated in |
|---|---|
| the frame-boundary sentence in the Quick Check closing paragraph | `references/quick-check-template.md` (more completely: the patched method plus the rest of the frame, and how far post-pause reads can drift) and `references/captured-variables.md`; the same line already sends the reader there |
| the `references/troubleshooting.md` pointer on the timeout line | the Reference Guides list |
| the standalone enable-failure bullet | folded into that same timeout line, keeping `ErrorCode` |
| "All live in `references/` beside this skill;" from the Reference Guides intro | every bullet below it already carries the `references/` path — byte offset with no information dropped |
| "from this template" in "Before deviating from this template, read …" | the sentence sits in the Quick Check section it refers to |

The "Only `CapturedVariables` is evidence of the values at the patched line" rule stays in the body: acting on it cannot wait for a reference read.

**Review follow-up (blind review finding 1).** An earlier revision of this PR also removed "use it instead of sleeps or after-the-fact reads when input delivery, event ordering, or transition-frame fidelity matters" as a byte offset. That framing appears nowhere else — the frontmatter `description` lists what to investigate, not what to use the tool instead of, and no `references/` file carries it. It is **restored in the `SKILL.md` body** (commit `a907f96`) rather than moved into a reference, paid for by the frame-boundary trim above.

Result: 7,981 bytes, against 7,986 before this PR. The regenerated tool catalog carries the new `clear-pause-point` description (description-only, so no release-input stamp is required).

## Verification

- `uloop run-tests --filter-type regex --filter-value '.*PausePointTests.*'` — 122 passed, 0 failed (re-run after the skill revision).
- Four new tests, added first and confirmed failing before the wiring: both clear paths set the guidance when a pause-point-owned pause is released, and both leave `RecommendedNextAction` empty when nothing was released (manual pause preserved / no pause open).
- `uloop compile` — 0 errors.
- `scripts/check-go-cli.sh` — 0 issues, all suites pass.
- `check-skill-size` — no skill over the byte limit.
- `sync-tool-docs --check` — catalog matches the skill parameter tables.

https://claude.ai/code/session_01XbhSMKK4LFud57iAmowDz7
