### PR TITLE
docs(agents-md): require scoped EditMode runs instead of the full suite before a PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,9 +200,10 @@ tests (especially anything touching async execution, cancellation, threads, or d
 runtime paths), read `docs/unity-editmode-test-guardrails.md` and follow its rules. If a new
 test makes `uloop run-tests` stall, remove or disable it instead of retrying the suite. If
 Unity freezes or stops responding to `uloop`, restart the Editor with `uloop launch -r`.
-CI runs the full EditMode suite only on a schedule or a manual `workflow_dispatch` of
-`unity-editmode-tests.yml` — pull-request CI never runs it. Do not run the full suite locally
-before a commit or pull request: it takes far too long. Run only the tests that cover the code
-you changed, scoped with `--filter-type class` / `--filter-value <TestClass>` (or `regex` for a
-few classes, `assembly` for one test assembly). Run the full unfiltered suite only when the
-change touches shared test infrastructure or a reviewer explicitly asks for it.
+CI runs the full EditMode suite on a schedule (and on a manual `workflow_dispatch` of
+`unity-editmode-tests.yml`); that scheduled run is the full-suite gate. Pull-request CI and local
+pre-commit verification do not run the full suite — it takes far too long. Before a commit or
+pull request, run only the tests that cover the code you changed, scoped with
+`--filter-type class` / `--filter-value <TestClass>` (`regex` for a few classes, `assembly` for
+one test assembly). Run the full unfiltered suite locally only when the change touches shared
+test infrastructure or a reviewer explicitly asks for it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,4 +200,9 @@ tests (especially anything touching async execution, cancellation, threads, or d
 runtime paths), read `docs/unity-editmode-test-guardrails.md` and follow its rules. If a new
 test makes `uloop run-tests` stall, remove or disable it instead of retrying the suite. If
 Unity freezes or stops responding to `uloop`, restart the Editor with `uloop launch -r`.
-CI runs the full EditMode suite only on a schedule or a manual `workflow_dispatch` of `unity-editmode-tests.yml` — pull-request CI never runs it, so full-suite EditMode verification before a merge has to happen locally with `uloop run-tests`.
+CI runs the full EditMode suite only on a schedule or a manual `workflow_dispatch` of
+`unity-editmode-tests.yml` — pull-request CI never runs it. Do not run the full suite locally
+before a commit or pull request: it takes far too long. Run only the tests that cover the code
+you changed, scoped with `--filter-type class` / `--filter-value <TestClass>` (or `regex` for a
+few classes, `assembly` for one test assembly). Run the full unfiltered suite only when the
+change touches shared test infrastructure or a reviewer explicitly asks for it.


### PR DESCRIPTION
## Problem

Workers read the EditMode section of AGENTS.md (CLAUDE.md) as an instruction to run the full EditMode suite locally before every pull request. The full suite takes far too long for that cadence.

## Change

The section now says not to run the full suite before a commit or PR, to scope `uloop run-tests` to the test classes covering the change (`--filter-type class` / `regex` / `assembly`), and to reserve the full unfiltered run for shared test infrastructure changes or an explicit reviewer request.

https://claude.ai/code/session_01XbhSMKK4LFud57iAmowDz7


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

