### PR TITLE
fix(pause-point): accept --file/--line on clear-pause-point

### DIFF
--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -5,7 +5,7 @@ description: "Pauses Unity playback at any source file:line without editing code
 
 # uloop pause-point
 
-A pause point captures locals and branch reasons at an exact frame without a source edit. Use it instead of sleeps or after-the-fact reads when input delivery, event ordering, or transition-frame fidelity matters.
+A pause point captures locals at an exact frame without a source edit. Prefer it over sleeps when input timing or transition-frame fidelity matters.
 
 ## Quick Check
 
@@ -18,14 +18,13 @@ uloop enable-pause-point --file Assets/Scripts/Enemy.cs --line 42 --timeout-seco
 ```
 
 3. Read `CapturedVariables` in the hit response first, then gather extra evidence while still paused (`execute-dynamic-code`, one screenshot).
-4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point --id <marker-id>`.
+4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point --id <marker-id>` or `--file`/`--line`.
 
 Only `CapturedVariables` is evidence of the values at the patched line. Before deviating, read `references/quick-check-template.md`.
 
 ## Parameters
 
-The tables list only parameters Unity accepts; CLI-only flags (`--await`, `--trigger`,
-`--resume-play`, `--expect`, capture filters) are in the reference guides below.
+Unity-accepted parameters only; CLI-only flags (`--await`, `--trigger`, `--resume-play`, `--expect`) are in the references.
 
 ### enable-pause-point
 
@@ -52,6 +51,8 @@ Clear one or all named UloopPausePoint.Pause markers. The response field `Cleare
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--id` | string | - | Named pause point id to clear |
+| `--file` | string | - | Project-relative source file of a file:line pause point. Requires --line; mutually exclusive with --id and --all |
+| `--line` | integer | - | 1-based source line of a file:line pause point. Requires --file; mutually exclusive with --id and --all |
 | `--all` | flag | - | Clear every non-cleared pause point marker (armed, auto-disarmed, or expired) |
 
 ### enable-watch
@@ -83,13 +84,13 @@ Clear one or all registered C# watch expressions
 
 ## Status, Timeouts, Hot Reload
 
-`uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` takes the same two forms but always requires a target.
+`uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` and `clear-pause-point` take the same two forms; await always requires a target.
 
 On a wait timeout, `PAUSE_POINT_EXPIRED`, or an enable failure, read `Error.Details.Hint` or the failure `ErrorCode`, then `RecommendedNextAction`. After hot reload, use `--method <Type.Method>` to constrain `--line`.
 
 ## Requirements & Safety
 
-- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask the user mid-flow. The setting reverts on every Editor restart and each re-switch costs a full script recompile, so at the next natural stopping point, propose making Debug the startup default; only if the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It is a machine-wide preference affecting every Unity project; only the project's C# scripts run slower, mainly in Play Mode - the Editor itself is not slowed.
+- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask mid-flow. At the next stopping point, propose `uloop set-code-optimization debug --startup` only if the user approves (machine-wide; omit `--startup` for session-only). Each re-switch recompiles scripts.
 
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.

--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -5,7 +5,7 @@ description: "Pauses Unity playback at any source file:line without editing code
 
 # uloop pause-point
 
-A pause point captures locals at an exact frame without a source edit. Prefer it over sleeps when input timing or transition-frame fidelity matters.
+A pause point captures locals at an exact frame without a source edit. Prefer it over sleeps or after-the-fact reads when input delivery, event ordering, or transition-frame fidelity matters.
 
 ## Quick Check
 
@@ -18,13 +18,13 @@ uloop enable-pause-point --file Assets/Scripts/Enemy.cs --line 42 --timeout-seco
 ```
 
 3. Read `CapturedVariables` in the hit response first, then gather extra evidence while still paused (`execute-dynamic-code`, one screenshot).
-4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point --id <marker-id>` or `--file`/`--line`.
+4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point` (`--id`, or `--file`/`--line`).
 
 Only `CapturedVariables` is evidence of the values at the patched line. Before deviating, read `references/quick-check-template.md`.
 
 ## Parameters
 
-Unity-accepted parameters only; CLI-only flags (`--await`, `--trigger`, `--resume-play`, `--expect`) are in the references.
+Unity-accepted parameters only; CLI-only flags (`--await`, `--trigger`, `--resume-play`, `--expect`, capture filters) are in the references.
 
 ### enable-pause-point
 
@@ -90,9 +90,9 @@ On a wait timeout, `PAUSE_POINT_EXPIRED`, or an enable failure, read `Error.Deta
 
 ## Requirements & Safety
 
-- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask mid-flow. At the next stopping point, propose `uloop set-code-optimization debug --startup` only if the user approves (machine-wide; omit `--startup` for session-only). Each re-switch recompiles scripts.
+- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask mid-flow. The switch reverts on every Editor restart, so at the next stopping point propose `uloop set-code-optimization debug --startup` (session-only without `--startup`); only if the user approves. Trade-offs: `references/troubleshooting.md`.
 
-- Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
+- Patches do not survive compiles or domain reloads, including a Play entry with Domain Reload enabled (the enable response warns) — re-enable afterwards. `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.
 - An `--id` marker waits on a hand-written `UloopPausePoint.Pause(id)` call; its hits record no `CapturedVariables`.
 - For scripts under `Packages/`, pass the package-id path form (`Packages/<package-id>/...`); physical checkout paths do not resolve.

--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -18,13 +18,13 @@ uloop enable-pause-point --file Assets/Scripts/Enemy.cs --line 42 --timeout-seco
 ```
 
 3. Read `CapturedVariables` in the hit response first, then gather extra evidence while still paused (`execute-dynamic-code`, one screenshot).
-4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point` (`--id`, or `--file`/`--line`).
+4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point`.
 
 Only `CapturedVariables` is evidence of the values at the patched line. Before deviating, read `references/quick-check-template.md`.
 
 ## Parameters
 
-Unity-accepted parameters only; CLI-only flags (`--await`, `--trigger`, `--resume-play`, `--expect`, capture filters) are in the references.
+Tables list Unity-accepted parameters plus clear's CLI-only `--file`/`--line`; other CLI-only flags (`--await`, `--trigger`, `--resume-play`, `--expect`, capture filters) are in the references.
 
 ### enable-pause-point
 
@@ -84,13 +84,13 @@ Clear one or all registered C# watch expressions
 
 ## Status, Timeouts, Hot Reload
 
-`uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` and `clear-pause-point` take the same two forms; await always requires a target.
+`uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` and `clear-pause-point` take the same two forms; await always needs a target.
 
 On a wait timeout, `PAUSE_POINT_EXPIRED`, or an enable failure, read `Error.Details.Hint` or the failure `ErrorCode`, then `RecommendedNextAction`. After hot reload, use `--method <Type.Method>` to constrain `--line`.
 
 ## Requirements & Safety
 
-- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask mid-flow. The switch reverts on every Editor restart, so at the next stopping point propose `uloop set-code-optimization debug --startup` (session-only without `--startup`); only if the user approves. Trade-offs: `references/troubleshooting.md`.
+- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt or ask mid-flow. The switch reverts on every Editor restart, so at the next stopping point propose `uloop set-code-optimization debug --startup` (session-only without `--startup`); only if the user approves. See the troubleshooting reference.
 
 - Patches do not survive compiles or domain reloads, including a Play entry with Domain Reload enabled (the enable response warns) — re-enable afterwards. `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.

--- a/.agents/skills/uloop-pause-point/references/troubleshooting.md
+++ b/.agents/skills/uloop-pause-point/references/troubleshooting.md
@@ -60,3 +60,7 @@ If `enable-pause-point` fails, branch on the failure `ErrorCode` and follow `Rec
 If enable fails with `PAUSE_POINT_RESOLVE_FAILED` while the file has active hot-reload patches, `--line` was resolved against the last compiled source (the editor shows the edited file). `ResolvedMethod` and `ResolvedLineText` stay empty on that failure — follow `RecommendedNextAction` rather than those fields. Recompute the line against the last compiled source, or run `uloop compile` and re-enable.
 
 If enable fails with a "No sequence point found" error even for clearly executable lines, that script's assembly lacks debug sequence points and no line in the file can be patched. Move the pause point to a script in an assembly that carries them, such as a script under `Assets/`.
+
+## Debug-switch trade-offs
+
+The automatic Debug switch is a machine-wide Unity preference that applies to every project. Each re-switch costs a full script recompile, and the setting reverts on every Editor restart unless `uloop set-code-optimization debug --startup` makes Debug the startup default. Only the project's C# scripts run slower, mainly in Play Mode - the Editor itself is not slowed.

--- a/.agents/skills/uloop-pause-point/references/troubleshooting.md
+++ b/.agents/skills/uloop-pause-point/references/troubleshooting.md
@@ -63,4 +63,4 @@ If enable fails with a "No sequence point found" error even for clearly executab
 
 ## Debug-switch trade-offs
 
-The automatic Debug switch is a machine-wide Unity preference that applies to every project. Each re-switch costs a full script recompile, and the setting reverts on every Editor restart unless `uloop set-code-optimization debug --startup` makes Debug the startup default. Only the project's C# scripts run slower, mainly in Play Mode - the Editor itself is not slowed.
+The automatic Debug switch changes only the current project's code optimization for this Editor session; it reverts on every Editor restart, and each re-switch costs a full script recompile. `uloop set-code-optimization debug --startup` makes Debug the startup default through a machine-wide Unity preference that applies to every project. Only the project's C# scripts run slower, mainly in Play Mode - the Editor itself is not slowed.

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -5,7 +5,7 @@ description: "Pauses Unity playback at any source file:line without editing code
 
 # uloop pause-point
 
-A pause point captures locals and branch reasons at an exact frame without a source edit. Use it instead of sleeps or after-the-fact reads when input delivery, event ordering, or transition-frame fidelity matters.
+A pause point captures locals at an exact frame without a source edit. Prefer it over sleeps when input timing or transition-frame fidelity matters.
 
 ## Quick Check
 
@@ -18,14 +18,13 @@ uloop enable-pause-point --file Assets/Scripts/Enemy.cs --line 42 --timeout-seco
 ```
 
 3. Read `CapturedVariables` in the hit response first, then gather extra evidence while still paused (`execute-dynamic-code`, one screenshot).
-4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point --id <marker-id>`.
+4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point --id <marker-id>` or `--file`/`--line`.
 
 Only `CapturedVariables` is evidence of the values at the patched line. Before deviating, read `references/quick-check-template.md`.
 
 ## Parameters
 
-The tables list only parameters Unity accepts; CLI-only flags (`--await`, `--trigger`,
-`--resume-play`, `--expect`, capture filters) are in the reference guides below.
+Unity-accepted parameters only; CLI-only flags (`--await`, `--trigger`, `--resume-play`, `--expect`) are in the references.
 
 ### enable-pause-point
 
@@ -52,6 +51,8 @@ Clear one or all named UloopPausePoint.Pause markers. The response field `Cleare
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--id` | string | - | Named pause point id to clear |
+| `--file` | string | - | Project-relative source file of a file:line pause point. Requires --line; mutually exclusive with --id and --all |
+| `--line` | integer | - | 1-based source line of a file:line pause point. Requires --file; mutually exclusive with --id and --all |
 | `--all` | flag | - | Clear every non-cleared pause point marker (armed, auto-disarmed, or expired) |
 
 ### enable-watch
@@ -83,13 +84,13 @@ Clear one or all registered C# watch expressions
 
 ## Status, Timeouts, Hot Reload
 
-`uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` takes the same two forms but always requires a target.
+`uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` and `clear-pause-point` take the same two forms; await always requires a target.
 
 On a wait timeout, `PAUSE_POINT_EXPIRED`, or an enable failure, read `Error.Details.Hint` or the failure `ErrorCode`, then `RecommendedNextAction`. After hot reload, use `--method <Type.Method>` to constrain `--line`.
 
 ## Requirements & Safety
 
-- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask the user mid-flow. The setting reverts on every Editor restart and each re-switch costs a full script recompile, so at the next natural stopping point, propose making Debug the startup default; only if the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It is a machine-wide preference affecting every Unity project; only the project's C# scripts run slower, mainly in Play Mode - the Editor itself is not slowed.
+- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask mid-flow. At the next stopping point, propose `uloop set-code-optimization debug --startup` only if the user approves (machine-wide; omit `--startup` for session-only). Each re-switch recompiles scripts.
 
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -5,7 +5,7 @@ description: "Pauses Unity playback at any source file:line without editing code
 
 # uloop pause-point
 
-A pause point captures locals at an exact frame without a source edit. Prefer it over sleeps when input timing or transition-frame fidelity matters.
+A pause point captures locals at an exact frame without a source edit. Prefer it over sleeps or after-the-fact reads when input delivery, event ordering, or transition-frame fidelity matters.
 
 ## Quick Check
 
@@ -18,13 +18,13 @@ uloop enable-pause-point --file Assets/Scripts/Enemy.cs --line 42 --timeout-seco
 ```
 
 3. Read `CapturedVariables` in the hit response first, then gather extra evidence while still paused (`execute-dynamic-code`, one screenshot).
-4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point --id <marker-id>` or `--file`/`--line`.
+4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point` (`--id`, or `--file`/`--line`).
 
 Only `CapturedVariables` is evidence of the values at the patched line. Before deviating, read `references/quick-check-template.md`.
 
 ## Parameters
 
-Unity-accepted parameters only; CLI-only flags (`--await`, `--trigger`, `--resume-play`, `--expect`) are in the references.
+Unity-accepted parameters only; CLI-only flags (`--await`, `--trigger`, `--resume-play`, `--expect`, capture filters) are in the references.
 
 ### enable-pause-point
 
@@ -90,9 +90,9 @@ On a wait timeout, `PAUSE_POINT_EXPIRED`, or an enable failure, read `Error.Deta
 
 ## Requirements & Safety
 
-- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask mid-flow. At the next stopping point, propose `uloop set-code-optimization debug --startup` only if the user approves (machine-wide; omit `--startup` for session-only). Each re-switch recompiles scripts.
+- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask mid-flow. The switch reverts on every Editor restart, so at the next stopping point propose `uloop set-code-optimization debug --startup` (session-only without `--startup`); only if the user approves. Trade-offs: `references/troubleshooting.md`.
 
-- Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
+- Patches do not survive compiles or domain reloads, including a Play entry with Domain Reload enabled (the enable response warns) — re-enable afterwards. `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.
 - An `--id` marker waits on a hand-written `UloopPausePoint.Pause(id)` call; its hits record no `CapturedVariables`.
 - For scripts under `Packages/`, pass the package-id path form (`Packages/<package-id>/...`); physical checkout paths do not resolve.

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -18,13 +18,13 @@ uloop enable-pause-point --file Assets/Scripts/Enemy.cs --line 42 --timeout-seco
 ```
 
 3. Read `CapturedVariables` in the hit response first, then gather extra evidence while still paused (`execute-dynamic-code`, one screenshot).
-4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point` (`--id`, or `--file`/`--line`).
+4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point`.
 
 Only `CapturedVariables` is evidence of the values at the patched line. Before deviating, read `references/quick-check-template.md`.
 
 ## Parameters
 
-Unity-accepted parameters only; CLI-only flags (`--await`, `--trigger`, `--resume-play`, `--expect`, capture filters) are in the references.
+Tables list Unity-accepted parameters plus clear's CLI-only `--file`/`--line`; other CLI-only flags (`--await`, `--trigger`, `--resume-play`, `--expect`, capture filters) are in the references.
 
 ### enable-pause-point
 
@@ -84,13 +84,13 @@ Clear one or all registered C# watch expressions
 
 ## Status, Timeouts, Hot Reload
 
-`uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` and `clear-pause-point` take the same two forms; await always requires a target.
+`uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` and `clear-pause-point` take the same two forms; await always needs a target.
 
 On a wait timeout, `PAUSE_POINT_EXPIRED`, or an enable failure, read `Error.Details.Hint` or the failure `ErrorCode`, then `RecommendedNextAction`. After hot reload, use `--method <Type.Method>` to constrain `--line`.
 
 ## Requirements & Safety
 
-- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask mid-flow. The switch reverts on every Editor restart, so at the next stopping point propose `uloop set-code-optimization debug --startup` (session-only without `--startup`); only if the user approves. Trade-offs: `references/troubleshooting.md`.
+- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt or ask mid-flow. The switch reverts on every Editor restart, so at the next stopping point propose `uloop set-code-optimization debug --startup` (session-only without `--startup`); only if the user approves. See the troubleshooting reference.
 
 - Patches do not survive compiles or domain reloads, including a Play entry with Domain Reload enabled (the enable response warns) — re-enable afterwards. `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.

--- a/.claude/skills/uloop-pause-point/references/troubleshooting.md
+++ b/.claude/skills/uloop-pause-point/references/troubleshooting.md
@@ -60,3 +60,7 @@ If `enable-pause-point` fails, branch on the failure `ErrorCode` and follow `Rec
 If enable fails with `PAUSE_POINT_RESOLVE_FAILED` while the file has active hot-reload patches, `--line` was resolved against the last compiled source (the editor shows the edited file). `ResolvedMethod` and `ResolvedLineText` stay empty on that failure — follow `RecommendedNextAction` rather than those fields. Recompute the line against the last compiled source, or run `uloop compile` and re-enable.
 
 If enable fails with a "No sequence point found" error even for clearly executable lines, that script's assembly lacks debug sequence points and no line in the file can be patched. Move the pause point to a script in an assembly that carries them, such as a script under `Assets/`.
+
+## Debug-switch trade-offs
+
+The automatic Debug switch is a machine-wide Unity preference that applies to every project. Each re-switch costs a full script recompile, and the setting reverts on every Editor restart unless `uloop set-code-optimization debug --startup` makes Debug the startup default. Only the project's C# scripts run slower, mainly in Play Mode - the Editor itself is not slowed.

--- a/.claude/skills/uloop-pause-point/references/troubleshooting.md
+++ b/.claude/skills/uloop-pause-point/references/troubleshooting.md
@@ -63,4 +63,4 @@ If enable fails with a "No sequence point found" error even for clearly executab
 
 ## Debug-switch trade-offs
 
-The automatic Debug switch is a machine-wide Unity preference that applies to every project. Each re-switch costs a full script recompile, and the setting reverts on every Editor restart unless `uloop set-code-optimization debug --startup` makes Debug the startup default. Only the project's C# scripts run slower, mainly in Play Mode - the Editor itself is not slowed.
+The automatic Debug switch changes only the current project's code optimization for this Editor session; it reverts on every Editor restart, and each re-switch costs a full script recompile. `uloop set-code-optimization debug --startup` makes Debug the startup default through a machine-wide Unity preference that applies to every project. Only the project's C# scripts run slower, mainly in Play Mode - the Editor itself is not slowed.

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -5,7 +5,7 @@ description: "Pauses Unity playback at any source file:line without editing code
 
 # uloop pause-point
 
-A pause point captures locals and branch reasons at an exact frame without a source edit. Use it instead of sleeps or after-the-fact reads when input delivery, event ordering, or transition-frame fidelity matters.
+A pause point captures locals at an exact frame without a source edit. Prefer it over sleeps when input timing or transition-frame fidelity matters.
 
 ## Quick Check
 
@@ -18,14 +18,13 @@ uloop enable-pause-point --file Assets/Scripts/Enemy.cs --line 42 --timeout-seco
 ```
 
 3. Read `CapturedVariables` in the hit response first, then gather extra evidence while still paused (`execute-dynamic-code`, one screenshot).
-4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point --id <marker-id>`.
+4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point --id <marker-id>` or `--file`/`--line`.
 
 Only `CapturedVariables` is evidence of the values at the patched line. Before deviating, read `references/quick-check-template.md`.
 
 ## Parameters
 
-The tables list only parameters Unity accepts; CLI-only flags (`--await`, `--trigger`,
-`--resume-play`, `--expect`, capture filters) are in the reference guides below.
+Unity-accepted parameters only; CLI-only flags (`--await`, `--trigger`, `--resume-play`, `--expect`) are in the references.
 
 ### enable-pause-point
 
@@ -52,6 +51,8 @@ Clear one or all named UloopPausePoint.Pause markers. The response field `Cleare
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--id` | string | - | Named pause point id to clear |
+| `--file` | string | - | Project-relative source file of a file:line pause point. Requires --line; mutually exclusive with --id and --all |
+| `--line` | integer | - | 1-based source line of a file:line pause point. Requires --file; mutually exclusive with --id and --all |
 | `--all` | flag | - | Clear every non-cleared pause point marker (armed, auto-disarmed, or expired) |
 
 ### enable-watch
@@ -83,13 +84,13 @@ Clear one or all registered C# watch expressions
 
 ## Status, Timeouts, Hot Reload
 
-`uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` takes the same two forms but always requires a target.
+`uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` and `clear-pause-point` take the same two forms; await always requires a target.
 
 On a wait timeout, `PAUSE_POINT_EXPIRED`, or an enable failure, read `Error.Details.Hint` or the failure `ErrorCode`, then `RecommendedNextAction`. After hot reload, use `--method <Type.Method>` to constrain `--line`.
 
 ## Requirements & Safety
 
-- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask the user mid-flow. The setting reverts on every Editor restart and each re-switch costs a full script recompile, so at the next natural stopping point, propose making Debug the startup default; only if the user approves, run `uloop set-code-optimization debug --startup` (without `--startup` the switch is session-only). It is a machine-wide preference affecting every Unity project; only the project's C# scripts run slower, mainly in Play Mode - the Editor itself is not slowed.
+- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask mid-flow. At the next stopping point, propose `uloop set-code-optimization debug --startup` only if the user approves (machine-wide; omit `--startup` for session-only). Each re-switch recompiles scripts.
 
 - Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -5,7 +5,7 @@ description: "Pauses Unity playback at any source file:line without editing code
 
 # uloop pause-point
 
-A pause point captures locals at an exact frame without a source edit. Prefer it over sleeps when input timing or transition-frame fidelity matters.
+A pause point captures locals at an exact frame without a source edit. Prefer it over sleeps or after-the-fact reads when input delivery, event ordering, or transition-frame fidelity matters.
 
 ## Quick Check
 
@@ -18,13 +18,13 @@ uloop enable-pause-point --file Assets/Scripts/Enemy.cs --line 42 --timeout-seco
 ```
 
 3. Read `CapturedVariables` in the hit response first, then gather extra evidence while still paused (`execute-dynamic-code`, one screenshot).
-4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point --id <marker-id>` or `--file`/`--line`.
+4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point` (`--id`, or `--file`/`--line`).
 
 Only `CapturedVariables` is evidence of the values at the patched line. Before deviating, read `references/quick-check-template.md`.
 
 ## Parameters
 
-Unity-accepted parameters only; CLI-only flags (`--await`, `--trigger`, `--resume-play`, `--expect`) are in the references.
+Unity-accepted parameters only; CLI-only flags (`--await`, `--trigger`, `--resume-play`, `--expect`, capture filters) are in the references.
 
 ### enable-pause-point
 
@@ -90,9 +90,9 @@ On a wait timeout, `PAUSE_POINT_EXPIRED`, or an enable failure, read `Error.Deta
 
 ## Requirements & Safety
 
-- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask mid-flow. At the next stopping point, propose `uloop set-code-optimization debug --startup` only if the user approves (machine-wide; omit `--startup` for session-only). Each re-switch recompiles scripts.
+- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask mid-flow. The switch reverts on every Editor restart, so at the next stopping point propose `uloop set-code-optimization debug --startup` (session-only without `--startup`); only if the user approves. Trade-offs: `references/troubleshooting.md`.
 
-- Patches do not survive compiles or domain reloads — re-enable afterwards (a Play entry with Domain Reload enabled removes every source pause point; the enable response warns). `uloop compile` during PlayMode also resets the session.
+- Patches do not survive compiles or domain reloads, including a Play entry with Domain Reload enabled (the enable response warns) — re-enable afterwards. `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.
 - An `--id` marker waits on a hand-written `UloopPausePoint.Pause(id)` call; its hits record no `CapturedVariables`.
 - For scripts under `Packages/`, pass the package-id path form (`Packages/<package-id>/...`); physical checkout paths do not resolve.

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -18,13 +18,13 @@ uloop enable-pause-point --file Assets/Scripts/Enemy.cs --line 42 --timeout-seco
 ```
 
 3. Read `CapturedVariables` in the hit response first, then gather extra evidence while still paused (`execute-dynamic-code`, one screenshot).
-4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point` (`--id`, or `--file`/`--line`).
+4. A `single-shot` marker (the default) disarms after the hit; clear other modes with `uloop clear-pause-point`.
 
 Only `CapturedVariables` is evidence of the values at the patched line. Before deviating, read `references/quick-check-template.md`.
 
 ## Parameters
 
-Unity-accepted parameters only; CLI-only flags (`--await`, `--trigger`, `--resume-play`, `--expect`, capture filters) are in the references.
+Tables list Unity-accepted parameters plus clear's CLI-only `--file`/`--line`; other CLI-only flags (`--await`, `--trigger`, `--resume-play`, `--expect`, capture filters) are in the references.
 
 ### enable-pause-point
 
@@ -84,13 +84,13 @@ Clear one or all registered C# watch expressions
 
 ## Status, Timeouts, Hot Reload
 
-`uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` and `clear-pause-point` take the same two forms; await always requires a target.
+`uloop pause-point-status` with no target lists every marker; inspect one with `--id "<file>:<line>"` or with `--file`/`--line` together (never both). `await-pause-point` and `clear-pause-point` take the same two forms; await always needs a target.
 
 On a wait timeout, `PAUSE_POINT_EXPIRED`, or an enable failure, read `Error.Details.Hint` or the failure `ErrorCode`, then `RecommendedNextAction`. After hot reload, use `--method <Type.Method>` to constrain `--line`.
 
 ## Requirements & Safety
 
-- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt the task or ask mid-flow. The switch reverts on every Editor restart, so at the next stopping point propose `uloop set-code-optimization debug --startup` (session-only without `--startup`); only if the user approves. Trade-offs: `references/troubleshooting.md`.
+- On the automatic Debug-switch warning: the pause point is already armed - do not interrupt or ask mid-flow. The switch reverts on every Editor restart, so at the next stopping point propose `uloop set-code-optimization debug --startup` (session-only without `--startup`); only if the user approves. See the troubleshooting reference.
 
 - Patches do not survive compiles or domain reloads, including a Play entry with Domain Reload enabled (the enable response warns) — re-enable afterwards. `uloop compile` during PlayMode also resets the session.
 - Physics message methods, their helpers, and pre-bound delegates can miss hits on pre-existing GameObjects; the enable response warns where detectable.

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/references/troubleshooting.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/references/troubleshooting.md
@@ -60,3 +60,7 @@ If `enable-pause-point` fails, branch on the failure `ErrorCode` and follow `Rec
 If enable fails with `PAUSE_POINT_RESOLVE_FAILED` while the file has active hot-reload patches, `--line` was resolved against the last compiled source (the editor shows the edited file). `ResolvedMethod` and `ResolvedLineText` stay empty on that failure — follow `RecommendedNextAction` rather than those fields. Recompute the line against the last compiled source, or run `uloop compile` and re-enable.
 
 If enable fails with a "No sequence point found" error even for clearly executable lines, that script's assembly lacks debug sequence points and no line in the file can be patched. Move the pause point to a script in an assembly that carries them, such as a script under `Assets/`.
+
+## Debug-switch trade-offs
+
+The automatic Debug switch is a machine-wide Unity preference that applies to every project. Each re-switch costs a full script recompile, and the setting reverts on every Editor restart unless `uloop set-code-optimization debug --startup` makes Debug the startup default. Only the project's C# scripts run slower, mainly in Play Mode - the Editor itself is not slowed.

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/references/troubleshooting.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/references/troubleshooting.md
@@ -63,4 +63,4 @@ If enable fails with a "No sequence point found" error even for clearly executab
 
 ## Debug-switch trade-offs
 
-The automatic Debug switch is a machine-wide Unity preference that applies to every project. Each re-switch costs a full script recompile, and the setting reverts on every Editor restart unless `uloop set-code-optimization debug --startup` makes Debug the startup default. Only the project's C# scripts run slower, mainly in Play Mode - the Editor itself is not slowed.
+The automatic Debug switch changes only the current project's code optimization for this Editor session; it reverts on every Editor restart, and each re-switch costs a full script recompile. `uloop set-code-optimization debug --startup` makes Debug the startup default through a machine-wide Unity preference that applies to every project. Only the project's C# scripts run slower, mainly in Play Mode - the Editor itself is not slowed.

--- a/cli/common/tooldocs/pause_point_cli_options.go
+++ b/cli/common/tooldocs/pause_point_cli_options.go
@@ -32,7 +32,10 @@ const (
 // pausePointEnableCommandName is private to this package: importing the clicore package that owns
 // the command-name constants would be an import cycle, the same reason
 // executeDynamicCodeCommandName is declared locally.
-const pausePointEnableCommandName = "enable-pause-point"
+const (
+	pausePointEnableCommandName = "enable-pause-point"
+	pausePointClearCommandName  = "clear-pause-point"
+)
 
 // PausePointCLIOnlyOption describes one CLI-only pause-point flag in the shape both listings need:
 // `--help` renders FlagName/Type/Description, and `uloop list` additionally reports Type and Values
@@ -90,6 +93,8 @@ const (
 	pausePointIDDescription                    = "Pause-point marker id matching UloopPausePoint.Pause or the id returned by enable-pause-point"
 	pausePointFileDescription                  = "Project-relative source file of a file:line pause point. Requires --line; mutually exclusive with --id"
 	pausePointLineDescription                  = "1-based source line of a file:line pause point. Requires --file; mutually exclusive with --id"
+	pausePointClearFileDescription             = "Project-relative source file of a file:line pause point. Requires --line; mutually exclusive with --id and --all"
+	pausePointClearLineDescription             = "1-based source line of a file:line pause point. Requires --file; mutually exclusive with --id and --all"
 	pausePointTimeoutSecondsDescription        = "Seconds to wait for a hit before timing out"
 	pausePointMatchingLogsMaxCountDescription  = "Maximum Console logs matching the marker id to include on a hit"
 	pausePointCapturedVariablesDescription     = "How much of each captured variable to include in the response"
@@ -176,6 +181,23 @@ func PausePointStatusCLIOnlyOptions() []PausePointCLIOnlyOption {
 	return pausePointSharedQueryCLIOnlyOptions()
 }
 
+// PausePointClearCLIOnlyOptions returns clear-pause-point's CLI-only --file/--line flags. A
+// fresh slice is built per call so a caller that sorts or appends cannot mutate the shared table.
+func PausePointClearCLIOnlyOptions() []PausePointCLIOnlyOption {
+	return []PausePointCLIOnlyOption{
+		{
+			FlagName:    PausePointFileFlagName,
+			Type:        "string",
+			Description: pausePointClearFileDescription,
+		},
+		{
+			FlagName:    PausePointLineFlagName,
+			Type:        "integer",
+			Description: pausePointClearLineDescription,
+		},
+	}
+}
+
 // PausePointCLIOnlyHelpEntries converts a CLI-only option table into --help rows.
 func PausePointCLIOnlyHelpEntries(options []PausePointCLIOnlyOption) []OptionHelpEntry {
 	entries := make([]OptionHelpEntry, 0, len(options))
@@ -199,6 +221,23 @@ func appendPausePointEnableCLIOnlyOptionHelpEntries(
 	}
 
 	for _, entry := range PausePointCLIOnlyHelpEntries(PausePointEnableCLIOnlyOptions()) {
+		if hasOptionHelpEntry(entries, entry.Name) {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func appendPausePointClearCLIOnlyOptionHelpEntries(
+	toolName string,
+	entries []OptionHelpEntry,
+) []OptionHelpEntry {
+	if toolName != pausePointClearCommandName {
+		return entries
+	}
+
+	for _, entry := range PausePointCLIOnlyHelpEntries(PausePointClearCLIOnlyOptions()) {
 		if hasOptionHelpEntry(entries, entry.Name) {
 			continue
 		}

--- a/cli/common/tooldocs/pause_point_cli_options_test.go
+++ b/cli/common/tooldocs/pause_point_cli_options_test.go
@@ -86,6 +86,30 @@ func TestPausePointAwaitAndStatusCLIOnlyHelpEntries(t *testing.T) {
 	}
 }
 
+// Verifies clear-pause-point's --help lists the CLI-only --file/--line flags. They are not in
+// ClearPausePointSchema, so the schema-driven loop cannot produce them.
+func TestVisibleOptionHelpEntriesIncludePausePointClearCLIOnlyOptions(t *testing.T) {
+	tool, ok := tools.Find(tools.LoadDefault(), pausePointClearCommandName)
+	if !ok {
+		t.Fatalf("embedded catalog has no %q tool", pausePointClearCommandName)
+	}
+
+	entries := VisibleOptionHelpEntriesForTool(tool)
+	for _, option := range PausePointClearCLIOnlyOptions() {
+		optionName := "--" + option.FlagName
+		entry, found := findOptionHelpEntry(entries, optionName)
+		if !found {
+			t.Fatalf("clear-pause-point --help is missing CLI-only option %s", optionName)
+		}
+		if entry.Description == "" {
+			t.Errorf("option %s has no description in --help", optionName)
+		}
+		if !strings.HasSuffix(entry.Usage, " <value>") {
+			t.Errorf("valued flag usage = %q, want a value placeholder", entry.Usage)
+		}
+	}
+}
+
 // Verifies both query commands describe the file:line target flags with the fixed contract text.
 func TestPausePointQueryCLIOnlyOptionsDescribeFileLineTarget(t *testing.T) {
 	for _, options := range [][]PausePointCLIOnlyOption{
@@ -107,6 +131,26 @@ func TestPausePointQueryCLIOnlyOptionsDescribeFileLineTarget(t *testing.T) {
 		if lineOption.Description != "1-based source line of a file:line pause point. Requires --file; mutually exclusive with --id" {
 			t.Fatalf("--line description = %q", lineOption.Description)
 		}
+	}
+}
+
+// Verifies clear-pause-point's CLI-only table describes --file/--line as exclusive with --id and --all.
+func TestPausePointClearCLIOnlyOptionsDescribeFileLineTarget(t *testing.T) {
+	options := PausePointClearCLIOnlyOptions()
+	fileOption, found := findPausePointCLIOnlyOption(options, "file")
+	if !found {
+		t.Fatal("missing --file option")
+	}
+	if fileOption.Description != "Project-relative source file of a file:line pause point. Requires --line; mutually exclusive with --id and --all" {
+		t.Fatalf("--file description = %q", fileOption.Description)
+	}
+
+	lineOption, found := findPausePointCLIOnlyOption(options, "line")
+	if !found {
+		t.Fatal("missing --line option")
+	}
+	if lineOption.Description != "1-based source line of a file:line pause point. Requires --file; mutually exclusive with --id and --all" {
+		t.Fatalf("--line description = %q", lineOption.Description)
 	}
 }
 

--- a/cli/common/tooldocs/tool_option_help.go
+++ b/cli/common/tooldocs/tool_option_help.go
@@ -62,6 +62,7 @@ func VisibleOptionHelpEntriesForTool(tool tools.ToolDefinition) []OptionHelpEntr
 	entries = appendDynamicCodeFileOptionHelpEntry(tool, entries)
 	entries = appendRunTestsSkipCompileOptionHelpEntry(tool, entries)
 	entries = appendPausePointEnableCLIOnlyOptionHelpEntries(tool.Name, entries)
+	entries = appendPausePointClearCLIOnlyOptionHelpEntries(tool.Name, entries)
 	sort.Slice(entries, func(i int, j int) bool {
 		return entries[i].Name < entries[j].Name
 	})

--- a/cli/dispatcher/internal/dispatcher/help_test.go
+++ b/cli/dispatcher/internal/dispatcher/help_test.go
@@ -441,6 +441,33 @@ func TestRunDispatcherExecuteDynamicCodeHelpDoesNotRequireUnityProject(t *testin
 	}
 }
 
+// Tests that clear-pause-point --help lists CLI-only --file/--line without resolving a Unity project.
+func TestRunDispatcherClearPausePointHelpListsFileLine(t *testing.T) {
+	t.Chdir(t.TempDir())
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := RunDispatcher(context.Background(), []string{"clear-pause-point", "--help"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("clear-pause-point help failed: code=%d stderr=%s", code, stderr.String())
+	}
+	output := stdout.String()
+	for _, expected := range []string{
+		"Usage:",
+		"uloop clear-pause-point",
+		"--id <value>",
+		"--all",
+		"--file <value>",
+		"--line <value>",
+		"mutually exclusive with --id and --all",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("clear-pause-point help missing %q:\n%s", expected, output)
+		}
+	}
+}
+
 // Tests that command help wins even after other tool options.
 func TestRunDispatcherCompileHelpWinsAfterOtherOptions(t *testing.T) {
 	t.Chdir(t.TempDir())

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "9ab982e59c1c9ea651cedebd1db37a94288a2d2a"
+  "sharedInputsHash": "06f89ed9c07c136ce70f9811728bff366eb21467"
 }

--- a/cli/project-runner/internal/projectrunner/list_output.go
+++ b/cli/project-runner/internal/projectrunner/list_output.go
@@ -110,6 +110,7 @@ func listOptionsForTool(tool clicore.ToolDefinition) []listOption {
 	options = appendDynamicCodeFileListOption(tool, options)
 	options = appendRunTestsSkipCompileListOption(tool, options)
 	options = appendPausePointEnableAwaitListOptions(tool, options)
+	options = appendPausePointClearListOptions(tool, options)
 	sort.Slice(options, func(i int, j int) bool {
 		return options[i].Name < options[j].Name
 	})
@@ -181,6 +182,28 @@ func appendPausePointEnableAwaitListOptions(tool clicore.ToolDefinition, options
 	}
 
 	for _, option := range tooldocs.PausePointEnableCLIOnlyOptions() {
+		optionName := "--" + option.FlagName
+		if hasListOption(options, optionName) {
+			continue
+		}
+		options = append(options, listOption{
+			Name:        optionName,
+			Type:        option.Type,
+			Description: option.Description,
+			Values:      option.Values,
+		})
+	}
+	return options
+}
+
+// appendPausePointClearListOptions documents clear-pause-point's CLI-only --file/--line flags.
+// They are not part of ClearPausePointSchema, so the schema-driven loop above never emits them.
+func appendPausePointClearListOptions(tool clicore.ToolDefinition, options []listOption) []listOption {
+	if tool.Name != pausePointClearCommandName {
+		return options
+	}
+
+	for _, option := range tooldocs.PausePointClearCLIOnlyOptions() {
 		optionName := "--" + option.FlagName
 		if hasListOption(options, optionName) {
 			continue

--- a/cli/project-runner/internal/projectrunner/list_output_test.go
+++ b/cli/project-runner/internal/projectrunner/list_output_test.go
@@ -169,6 +169,21 @@ func TestNewListCatalogIncludesEnablePausePointAwaitOptions(t *testing.T) {
 	findListOption(t, enablePausePoint, "--"+tooldocs.PausePointResumePlayFlagName)
 }
 
+// Tests that list output includes clear-pause-point's CLI-only --file/--line flags, which are
+// not part of the Unity-side ClearPausePointSchema.
+func TestNewListCatalogIncludesClearPausePointFileLineOptions(t *testing.T) {
+	tool, ok := clicore.FindTool(clicore.LoadDefaultTools(), pausePointClearCommandName)
+	if !ok {
+		t.Fatal("clear-pause-point was not found in default tools")
+	}
+
+	catalog := newListCatalog(clicore.ToolsCache{Tools: []clicore.ToolDefinition{tool}})
+	clearPausePoint := findListTool(t, catalog, pausePointClearCommandName)
+
+	findListOption(t, clearPausePoint, "--"+tooldocs.PausePointFileFlagName)
+	findListOption(t, clearPausePoint, "--"+tooldocs.PausePointLineFlagName)
+}
+
 // Tests that list replaces Unity's generated placeholder descriptions with the embedded catalog's
 // real text. list formats the raw get-tool-details response, so it does not inherit the fallback the
 // project-cache loader applies for `--help`.

--- a/cli/project-runner/internal/projectrunner/pause_point_clear_file_line.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_clear_file_line.go
@@ -1,0 +1,145 @@
+package projectrunner
+
+import (
+	"strings"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+)
+
+// pausePointClearCommandName keeps clear-pause-point as the schema-driven Unity tool it already
+// is. --file/--line are CLI-only sugar converted to Id before schema parsing, the same way
+// extractDynamicCodeFileFlag converts --code-file to Code.
+const pausePointClearCommandName = "clear-pause-point"
+
+const (
+	pausePointClearIdPropertyName = "Id"
+	pausePointAllFlagName         = "all"
+)
+
+// extractPausePointClearFileLineFlags pulls --file/--line out of clear-pause-point args before
+// generic tool parsing, because those flags are CLI-side sugar and not part of the Unity schema.
+func extractPausePointClearFileLineFlags(command string, args []string) ([]string, string, error) {
+	if command != pausePointClearCommandName {
+		return args, "", nil
+	}
+
+	remaining, target, err := collectPausePointClearFileLineTarget(args)
+	if err != nil {
+		return nil, "", err
+	}
+	id, idProvided, hasAll, inspectErr := inspectPausePointClearSchemaFlags(remaining)
+	if inspectErr != nil {
+		return nil, "", inspectErr
+	}
+	if hasAll && (target.hasFile || target.hasLine) {
+		return nil, "", &clierrors.ArgumentError{
+			Message: "--all cannot be combined with --file or --line.",
+			Option:  "--" + pausePointAllFlagName,
+			Command: command,
+		}
+	}
+	if !target.hasFile && !target.hasLine {
+		return remaining, "", nil
+	}
+
+	queryID, resolveErr := resolvePausePointQueryID(id, idProvided, target, command)
+	if resolveErr != nil {
+		return nil, "", resolveErr
+	}
+	return remaining, queryID, nil
+}
+
+// applyPausePointClearFileLineID writes the composed marker id into Id so Unity sees the same
+// parameter it already accepts for a named marker.
+func applyPausePointClearFileLineID(params map[string]any, queryID string) error {
+	if queryID == "" {
+		return nil
+	}
+	if _, exists := params[pausePointClearIdPropertyName]; exists {
+		return &clierrors.ArgumentError{
+			Message: "--id cannot be combined with --file or --line.",
+			Option:  "--" + PausePointIDFlagName,
+			Command: pausePointClearCommandName,
+		}
+	}
+	params[pausePointClearIdPropertyName] = queryID
+	return nil
+}
+
+func collectPausePointClearFileLineTarget(args []string) ([]string, pausePointQueryTarget, error) {
+	remaining := make([]string, 0, len(args))
+	target := pausePointQueryTarget{}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		if !isPausePointFileOrLineArg(arg) {
+			remaining = append(remaining, arg)
+			continue
+		}
+
+		name, value, consumedNext, err := clicore.ParseFlagValue(arg, args, index)
+		if err != nil {
+			return nil, pausePointQueryTarget{}, err
+		}
+		if assignErr := assignPausePointClearFileLineTarget(&target, name, value); assignErr != nil {
+			return nil, pausePointQueryTarget{}, assignErr
+		}
+		if consumedNext {
+			index++
+		}
+	}
+	return remaining, target, nil
+}
+
+func assignPausePointClearFileLineTarget(target *pausePointQueryTarget, name string, value string) error {
+	switch name {
+	case PausePointFileFlagName:
+		target.file = value
+		target.hasFile = true
+		return nil
+	case PausePointLineFlagName:
+		return setPausePointQueryTargetLine(target, value)
+	default:
+		return nil
+	}
+}
+
+func inspectPausePointClearSchemaFlags(args []string) (string, bool, bool, error) {
+	id := ""
+	idProvided := false
+	hasAll := false
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		if isExactOrEqualsFlag(arg, pausePointAllFlagName) {
+			hasAll = true
+			continue
+		}
+		if !isExactOrEqualsFlag(arg, PausePointIDFlagName) {
+			continue
+		}
+
+		name, value, consumedNext, err := clicore.ParseFlagValue(arg, args, index)
+		if err != nil {
+			return "", false, false, err
+		}
+		if name != PausePointIDFlagName {
+			continue
+		}
+		id = value
+		idProvided = true
+		if consumedNext {
+			index++
+		}
+	}
+	return id, idProvided, hasAll, nil
+}
+
+func isPausePointFileOrLineArg(arg string) bool {
+	return isExactOrEqualsFlag(arg, PausePointFileFlagName) || isExactOrEqualsFlag(arg, PausePointLineFlagName)
+}
+
+func isExactOrEqualsFlag(arg string, flagName string) bool {
+	option := "--" + flagName
+	return arg == option || strings.HasPrefix(arg, option+"=")
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_clear_file_line_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_clear_file_line_test.go
@@ -1,7 +1,12 @@
 package projectrunner
 
 import (
+	"bytes"
+	"strings"
 	"testing"
+
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
 
 // Verifies --all cannot be combined with --file or --line on clear-pause-point.
@@ -43,5 +48,56 @@ func TestExtractPausePointClearFileLineFlagsIgnoresOtherCommands(t *testing.T) {
 	}
 	if queryID != "" || len(remaining) != 4 {
 		t.Fatalf("other commands must pass args through: %s %#v", queryID, remaining)
+	}
+}
+
+// Verifies prepareDynamicToolParams injects the composed file:line id into params["Id"],
+// so removing the extract or apply wiring in runner_commands.go fails this test.
+func TestPrepareDynamicToolParamsInjectsClearPausePointFileLineID(t *testing.T) {
+	tool, ok := clicore.FindTool(clicore.LoadDefaultTools(), pausePointClearCommandName)
+	if !ok {
+		t.Fatal("clear-pause-point was not found in default tools")
+	}
+
+	var stderr bytes.Buffer
+	params, _, ok := prepareDynamicToolParams(
+		pausePointClearCommandName,
+		[]string{"--file", "Assets/Scripts/Marker.cs", "--line", "42"},
+		tool,
+		unityipc.Connection{ProjectRoot: t.TempDir()},
+		"",
+		&stderr,
+	)
+	if !ok {
+		t.Fatalf("prepare failed: %s", stderr.String())
+	}
+	id, isString := params["Id"].(string)
+	if !isString || id != "Assets/Scripts/Marker.cs:42" {
+		t.Fatalf("Id = %#v, want Assets/Scripts/Marker.cs:42", params["Id"])
+	}
+}
+
+// Verifies prepareDynamicToolParams rejects --id combined with --file/--line and writes
+// the ArgumentError to stderr, so the production extract call is not a no-op.
+func TestPrepareDynamicToolParamsRejectsClearPausePointCombinedIDAndFile(t *testing.T) {
+	tool, ok := clicore.FindTool(clicore.LoadDefaultTools(), pausePointClearCommandName)
+	if !ok {
+		t.Fatal("clear-pause-point was not found in default tools")
+	}
+
+	var stderr bytes.Buffer
+	params, _, ok := prepareDynamicToolParams(
+		pausePointClearCommandName,
+		[]string{"--id", "marker", "--file", "Assets/Scripts/Marker.cs", "--line", "42"},
+		tool,
+		unityipc.Connection{ProjectRoot: t.TempDir()},
+		"",
+		&stderr,
+	)
+	if ok || params != nil {
+		t.Fatalf("expected failure, got ok=%v params=%#v", ok, params)
+	}
+	if !strings.Contains(stderr.String(), "--id cannot be combined with --file or --line.") {
+		t.Fatalf("stderr missing combination error: %s", stderr.String())
 	}
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_clear_file_line_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_clear_file_line_test.go
@@ -1,0 +1,47 @@
+package projectrunner
+
+import (
+	"testing"
+)
+
+// Verifies --all cannot be combined with --file or --line on clear-pause-point.
+func TestExtractPausePointClearFileLineFlagsRejectsAllWithFileLine(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "all with file and line",
+			args: []string{"--all", "--file", "Assets/Scripts/Marker.cs", "--line", "42"},
+		},
+		{
+			name: "all with file only",
+			args: []string{"--all", "--file", "Assets/Scripts/Marker.cs"},
+		},
+		{
+			name: "all with line only",
+			args: []string{"--all", "--line", "42"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := extractPausePointClearFileLineFlags(pausePointClearCommandName, test.args)
+			if err == nil || err.Error() != "--all cannot be combined with --file or --line." {
+				t.Fatalf("clear --all with file:line error = %v", err)
+			}
+		})
+	}
+}
+
+// Verifies --file/--line on a different command are left untouched.
+func TestExtractPausePointClearFileLineFlagsIgnoresOtherCommands(t *testing.T) {
+	args := []string{"--file", "Assets/Scripts/Marker.cs", "--line", "42"}
+	remaining, queryID, err := extractPausePointClearFileLineFlags("get-logs", args)
+	if err != nil {
+		t.Fatalf("extract failed: %v", err)
+	}
+	if queryID != "" || len(remaining) != 4 {
+		t.Fatalf("other commands must pass args through: %s %#v", queryID, remaining)
+	}
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_cli_options_contract_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_cli_options_contract_test.go
@@ -2,6 +2,7 @@ package projectrunner
 
 import (
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/hatayama/unity-cli-loop/common/tooldocs"
@@ -255,4 +256,48 @@ func TestPausePointAwaitAndStatusCLIOnlyOptionsHaveDescriptions(t *testing.T) {
 			t.Errorf("pause-point-status --%s has an empty description", option.FlagName)
 		}
 	}
+	for _, option := range tooldocs.PausePointClearCLIOnlyOptions() {
+		if option.Description == "" {
+			t.Errorf("clear-pause-point --%s has an empty description", option.FlagName)
+		}
+	}
+}
+
+// pausePointClearAdvertisedFlagNames is the clear-pause-point CLI-only advertised flag set.
+// Test-local literals so deleting a table row fails even when the extractor still accepts the flag.
+var pausePointClearAdvertisedFlagNames = []string{
+	"file",
+	"line",
+}
+
+// Verifies every CLI-only flag that clear-pause-point's --help advertises is consumed by the
+// clear-pause-point file:line extractor. Schema parsing never sees --file/--line.
+func TestPausePointClearHelpOptionsAreAcceptedByTheClearExtractor(t *testing.T) {
+	for _, option := range tooldocs.PausePointClearCLIOnlyOptions() {
+		optionName := "--" + option.FlagName
+		args, ok := runnerNativeCommandSampleArgs[optionName]
+		if !ok {
+			t.Fatalf("no sample argv for %s: add one to runnerNativeCommandSampleArgs", optionName)
+		}
+
+		remaining, queryID, err := extractPausePointClearFileLineFlags(pausePointClearCommandName, args)
+		if err != nil {
+			t.Errorf("clear-pause-point extractor rejected advertised option %s: %v", optionName, err)
+			continue
+		}
+		if queryID == "" {
+			t.Errorf("clear-pause-point extractor did not compose an id from %s", optionName)
+		}
+		for _, leftover := range remaining {
+			if leftover == "--file" || leftover == "--line" ||
+				strings.HasPrefix(leftover, "--file=") || strings.HasPrefix(leftover, "--line=") {
+				t.Errorf("clear-pause-point extractor left advertised option in remaining: %v", remaining)
+			}
+		}
+	}
+}
+
+// Verifies the clear-pause-point option table's flag names equal the advertised set.
+func TestPausePointClearCLIOnlyOptionsMatchFixedFlagSet(t *testing.T) {
+	assertPausePointCLIOnlyFlagNames(t, tooldocs.PausePointClearCLIOnlyOptions(), pausePointClearAdvertisedFlagNames)
 }

--- a/cli/project-runner/internal/projectrunner/pause_point_cli_options_contract_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_cli_options_contract_test.go
@@ -242,10 +242,10 @@ func assertPausePointCLIOnlyFlagNames(
 	}
 }
 
-// Verifies every await-pause-point and pause-point-status help table row has a description. A
+// Verifies every await, status, and clear CLI-only help table row has a description. A
 // names-only listing is how --help used to render these commands, so an empty Description would
 // recreate that gap even after the renderer learned to print a second column.
-func TestPausePointAwaitAndStatusCLIOnlyOptionsHaveDescriptions(t *testing.T) {
+func TestPausePointAwaitStatusAndClearCLIOnlyOptionsHaveDescriptions(t *testing.T) {
 	for _, option := range tooldocs.PausePointAwaitCLIOnlyOptions() {
 		if option.Description == "" {
 			t.Errorf("await-pause-point --%s has an empty description", option.FlagName)

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -2744,6 +2744,16 @@ func TestParsePausePointQueryOptionsComposeFileLineID(t *testing.T) {
 	if statusOptions.id != "/source/Assets/Scripts/Marker.cs:7" {
 		t.Fatalf("status id = %q", statusOptions.id)
 	}
+
+	_, clearID, clearErr := extractPausePointClearFileLineFlags(pausePointClearCommandName, []string{
+		"--file", `Assets\Scripts\Marker.cs`, "--line", "0042",
+	})
+	if clearErr != nil {
+		t.Fatalf("clear file:line parse failed: %v", clearErr)
+	}
+	if clearID != "Assets/Scripts/Marker.cs:42" {
+		t.Fatalf("clear id = %q", clearID)
+	}
 }
 
 // Verifies file and line must be supplied together for both pause-point query commands.
@@ -2764,6 +2774,17 @@ func TestParsePausePointQueryOptionsRequireCompleteFileLinePair(t *testing.T) {
 	_, statusLineErr := parsePausePointStatusOptions([]string{"--line", "42"})
 	if statusLineErr == nil || statusLineErr.Error() != "--line requires --file." {
 		t.Fatalf("status line-only error = %v", statusLineErr)
+	}
+
+	_, _, clearFileErr := extractPausePointClearFileLineFlags(
+		pausePointClearCommandName, []string{"--file", "Assets/Scripts/Marker.cs"})
+	if clearFileErr == nil || clearFileErr.Error() != "--file requires --line." {
+		t.Fatalf("clear file-only error = %v", clearFileErr)
+	}
+	_, _, clearLineErr := extractPausePointClearFileLineFlags(
+		pausePointClearCommandName, []string{"--line", "42"})
+	if clearLineErr == nil || clearLineErr.Error() != "--line requires --file." {
+		t.Fatalf("clear line-only error = %v", clearLineErr)
 	}
 }
 
@@ -2797,6 +2818,11 @@ func TestParsePausePointQueryOptionsRejectCombinedIDAndFileLineTarget(t *testing
 			_, statusErr := parsePausePointStatusOptions(test.args)
 			if statusErr == nil || statusErr.Error() != "--id cannot be combined with --file or --line." {
 				t.Fatalf("status combined-target error = %v", statusErr)
+			}
+
+			_, _, clearErr := extractPausePointClearFileLineFlags(pausePointClearCommandName, test.args)
+			if clearErr == nil || clearErr.Error() != "--id cannot be combined with --file or --line." {
+				t.Fatalf("clear combined-target error = %v", clearErr)
 			}
 		})
 	}
@@ -2837,6 +2863,11 @@ func TestParsePausePointQueryOptionsRejectInvalidLine(t *testing.T) {
 			_, statusErr := parsePausePointStatusOptions(args)
 			if statusErr == nil || statusErr.Error() != test.wantError {
 				t.Fatalf("status line error = %v", statusErr)
+			}
+
+			_, _, clearErr := extractPausePointClearFileLineFlags(pausePointClearCommandName, args)
+			if clearErr == nil || clearErr.Error() != test.wantError {
+				t.Fatalf("clear line error = %v", clearErr)
 			}
 		})
 	}

--- a/cli/project-runner/internal/projectrunner/runner_commands.go
+++ b/cli/project-runner/internal/projectrunner/runner_commands.go
@@ -137,6 +137,14 @@ func prepareDynamicToolParams(
 		})
 		return nil, "", false
 	}
+	commandArgs, pausePointClearID, err := extractPausePointClearFileLineFlags(command, commandArgs)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
+			ProjectRoot: connection.ProjectRoot,
+			Command:     command,
+		})
+		return nil, "", false
+	}
 
 	params, nestedProjectPath, err := buildToolParams(commandArgs, tool)
 	if err != nil {
@@ -147,6 +155,13 @@ func prepareDynamicToolParams(
 		return nil, "", false
 	}
 	if err := applyDynamicCodeFileParam(params, dynamicCodeFilePath); err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
+			ProjectRoot: connection.ProjectRoot,
+			Command:     command,
+		})
+		return nil, "", false
+	}
+	if err := applyPausePointClearFileLineID(params, pausePointClearID); err != nil {
 		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
 			ProjectRoot: connection.ProjectRoot,
 			Command:     command,

--- a/cli/project-runner/internal/projectrunner/tool_param_suggestions.go
+++ b/cli/project-runner/internal/projectrunner/tool_param_suggestions.go
@@ -154,7 +154,8 @@ func visibleToolOptions(tool clicore.ToolDefinition) []visibleToolOption {
 	}
 	options = appendDynamicCodeFileSuggestionOption(tool, options)
 	options = appendRunTestsSkipCompileSuggestionOption(tool, options)
-	return appendPausePointEnableSuggestionOptions(tool, options)
+	options = appendPausePointEnableSuggestionOptions(tool, options)
+	return appendPausePointClearSuggestionOptions(tool, options)
 }
 
 func appendDynamicCodeFileSuggestionOption(tool clicore.ToolDefinition, options []visibleToolOption) []visibleToolOption {
@@ -176,6 +177,16 @@ func appendPausePointEnableSuggestionOptions(tool clicore.ToolDefinition, option
 		return options
 	}
 	for _, option := range tooldocs.PausePointEnableCLIOnlyOptions() {
+		options = appendSuggestionOption(options, option.FlagName)
+	}
+	return options
+}
+
+func appendPausePointClearSuggestionOptions(tool clicore.ToolDefinition, options []visibleToolOption) []visibleToolOption {
+	if tool.Name != pausePointClearCommandName {
+		return options
+	}
+	for _, option := range tooldocs.PausePointClearCLIOnlyOptions() {
 		options = appendSuggestionOption(options, option.FlagName)
 	}
 	return options

--- a/cli/project-runner/internal/projectrunner/tool_params_test.go
+++ b/cli/project-runner/internal/projectrunner/tool_params_test.go
@@ -280,6 +280,31 @@ func TestBuildToolParamsUnknownOptionSuggestsDynamicCodeFileFromSharedLaterToken
 	})
 }
 
+// Verifies clear-pause-point suggests its CLI-only file option when a supplied flag is a close typo.
+func TestBuildToolParamsUnknownOptionSuggestsClearPausePointFile(t *testing.T) {
+	tool, ok := clicore.FindTool(clicore.LoadDefaultTools(), pausePointClearCommandName)
+	if !ok {
+		t.Fatal("clear-pause-point was not found in default tools")
+	}
+
+	_, _, err := buildToolParams([]string{"--fil"}, tool)
+	requireNextActions(t, err, []string{
+		"Did you mean: uloop clear-pause-point --file",
+		"Run `uloop clear-pause-point --help` to inspect supported options.",
+	})
+}
+
+// Verifies clear-pause-point --file without --line is rejected before schema parsing.
+func TestExtractPausePointClearFileLineFlagsRequiresLine(t *testing.T) {
+	_, _, err := extractPausePointClearFileLineFlags(
+		pausePointClearCommandName,
+		[]string{"--file", "Assets/Scripts/Marker.cs"},
+	)
+	if err == nil || err.Error() != "--file requires --line." {
+		t.Fatalf("clear file-only error = %v", err)
+	}
+}
+
 // Verifies run-tests suggests test-mode when a supplied flag shares a later kebab token.
 func TestBuildToolParamsUnknownOptionSuggestsTestModeFromSharedLaterToken(t *testing.T) {
 	tool, ok := clicore.FindTool(clicore.LoadDefaultTools(), "run-tests")

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "4b3a32635b09d941c9e386b204e182587c7a0bed"
+  "sharedInputsHash": "8531c47ad0b7541afadba4636346e01d5eafb5ef"
 }

--- a/cli/release-automation/internal/automation/tool_docs_sync.go
+++ b/cli/release-automation/internal/automation/tool_docs_sync.go
@@ -44,6 +44,10 @@ var cliOnlyParameterTableOptions = map[string]map[string]bool{
 	"run-tests": {
 		tooldocs.RunTestsSkipCompileFlagName: true,
 	},
+	"clear-pause-point": {
+		tooldocs.PausePointFileFlagName: true,
+		tooldocs.PausePointLineFlagName: true,
+	},
 }
 
 // descriptionKey identifies one description in the catalog. Property is empty for the tool's own


### PR DESCRIPTION
## Summary
- `clear-pause-point` now accepts the same `--file` / `--line` target form as enable, await, and status.
- `--help`, `uloop list`, and Did-you-mean suggestions advertise those flags.

## User Impact
- Before: agents that armed a marker with `--file` / `--line` had to remember the composed `file:line` id to clear it. `clear-pause-point --file` was an unknown option.
- After: `uloop clear-pause-point --file <path> --line <n>` clears that file:line marker. Combining `--file`/`--line` with `--id` or `--all` is rejected.

## Changes
- The runner converts `--file`/`--line` to `Id` before Unity schema parsing. The Unity schema and `default-tools.json` shape are unchanged.
- Help, list, and unknown-option suggestions include the CLI-only flags.
- The pause-point skill documents the new clear options.
- The skill body was already at the 8,000-byte cap, so the Debug-switch trade-offs moved to references/troubleshooting.md to make room for the new rows.

## Verification
Go CLI: `scripts/check-go-cli.sh` passed.

Unity EditMode: `uloop run-tests --filter-type class --filter-value DefaultToolsCatalogDriftTests` — Passed (1/1).

Live Editor on this worktree:

```
uloop enable-pause-point --file Assets/RegressionHarness/KeyStateAfterPauseInterruption/SpaceHoldPoller.cs --line 19
```

```json
{
  "Id": "Assets/RegressionHarness/KeyStateAfterPauseInterruption/SpaceHoldPoller.cs:19",
  "Status": "Enabled",
  "IsEnabled": true,
  "Success": true
}
```

```
uloop clear-pause-point --file Assets/RegressionHarness/KeyStateAfterPauseInterruption/SpaceHoldPoller.cs --line 19
```

```json
{
  "Id": "Assets/RegressionHarness/KeyStateAfterPauseInterruption/SpaceHoldPoller.cs:19",
  "Status": "Cleared",
  "ClearedCount": 1,
  "ClearedReason": "ExplicitClear",
  "StatusBeforeClear": "Enabled",
  "Message": "Pause point cleared.",
  "Success": true
}
```
