### PR TITLE
feat(hot-reload): patch methods that raise field-like events and explain the initializer-less added field

### DIFF
--- a/.agents/skills/uloop-hot-reload/references/scope-and-limits.md
+++ b/.agents/skills/uloop-hot-reload/references/scope-and-limits.md
@@ -34,8 +34,9 @@ for statics. Initializer expressions are limited to literals and externally visi
 static calls (`= 5`, `= Math.Abs(x)`); object creation (`= new List<int>()`) and
 anything touching the host type or instance state skips the field's readers and
 writers with a per-method reason. To apply such a field without compiling, declare it
-without an initializer and assign it lazily inside the patched method with
-`if (_field == null) { _field = new List<int>(); }`; `??=` is not rewritable and keeps
+without an initializer — it starts at `default(T)` — and assign it inside the patched
+method instead; for a reference type, guard that with
+`if (_field == null) { _field = new List<int>(); }`. `??=` is not rewritable and keeps
 the method `Skipped`. Added `const` values are folded into edited bodies as literals,
 like `nameof`. Pause-point
 `CapturedVariables` never includes added fields; `enable-pause-point` warns when the
@@ -188,8 +189,10 @@ body works, and so does raising or reading one (`E?.Invoke(x)`, `E(x)`,
 Harmony accessor, which puts that method on the delegation path. Four shapes have no
 backing field to reach and stay `Skipped` (see the table below): an event with custom
 `add`/`remove` accessors, an `abstract`/`extern`/interface event, an event whose
-delegate type is not visible outside the assembly, and an event added in this edit.
-`nameof(E)` also stays `Skipped`.
+delegate type is not visible outside the assembly, and an event added in this edit
+(including one that had custom accessors when the assembly was last compiled).
+Raising through a conditional receiver (`other?.E?.Invoke(x)`) and `nameof(E)` also
+stay `Skipped`.
 
 ## Skipped — reported per method and in `Warnings`, never flips `Success`
 
@@ -206,6 +209,7 @@ delegate type is not visible outside the assembly, and an event added in this ed
 | Property setter, init, or indexer accessor with an explicit body | Accessor patching covers getters only; `uloop compile` applies setter/init/indexer edits |
 | Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Out of scope for v1; `uloop compile` applies these edits |
 | Method raises or reads a field-like event that has no reachable backing field | Custom `add`/`remove` accessors, an `abstract`/`extern`/interface event, a delegate type that is not visible outside the assembly, or an event added in this edit leave nothing for the shim's Harmony accessor to bind |
+| Method raises or reads a field-like event through a conditional receiver (`other?.E`) | The shim has no name for the conditional receiver to pass to the accessor call |
 | Method names a field-like event inside `nameof` | The shim is a different type and cannot keep the bare event name |
 
 ## Failed — flips `Success` to `false`

--- a/.agents/skills/uloop-hot-reload/references/scope-and-limits.md
+++ b/.agents/skills/uloop-hot-reload/references/scope-and-limits.md
@@ -31,9 +31,13 @@ An added field's values live in a side table that follows each instance's lifeti
 (statics live per domain). Its initializer does not run at construction time; it runs
 on the field's first access from edited code — once per instance, or once per domain
 for statics. Initializer expressions are limited to literals and externally visible
-static calls (`= 5`, `= Math.Abs(x)`); anything touching the host type or instance
-state skips the field's readers and writers with a per-method reason. Added `const`
-values are folded into edited bodies as literals, like `nameof`. Pause-point
+static calls (`= 5`, `= Math.Abs(x)`); object creation (`= new List<int>()`) and
+anything touching the host type or instance state skips the field's readers and
+writers with a per-method reason. To apply such a field without compiling, declare it
+without an initializer and assign it lazily inside the patched method with
+`if (_field == null) { _field = new List<int>(); }`; `??=` is not rewritable and keeps
+the method `Skipped`. Added `const` values are folded into edited bodies as literals,
+like `nameof`. Pause-point
 `CapturedVariables` never includes added fields; `enable-pause-point` warns when the
 resolved type has any — read them from a patched method body or
 `uloop execute-dynamic-code` instead.

--- a/.agents/skills/uloop-hot-reload/references/scope-and-limits.md
+++ b/.agents/skills/uloop-hot-reload/references/scope-and-limits.md
@@ -183,8 +183,13 @@ reported per-accessor as `Skipped`, so an edited accessor never disappears from 
 response silently; with a verified baseline, accessors unchanged from it produce no row.
 
 Subscribing to or unsubscribing from a field-like event (`+=`/`-=`) inside an edited
-body works. Methods that raise the event are reported as `Skipped` (see the table
-below) — raising is only expressible inside the declaring type, which a shim is not.
+body works, and so does raising or reading one (`E?.Invoke(x)`, `E(x)`,
+`if (E != null)`, `E = null`): the shim reads the event's backing field through a
+Harmony accessor, which puts that method on the delegation path. Four shapes have no
+backing field to reach and stay `Skipped` (see the table below): an event with custom
+`add`/`remove` accessors, an `abstract`/`extern`/interface event, an event whose
+delegate type is not visible outside the assembly, and an event added in this edit.
+`nameof(E)` also stays `Skipped`.
 
 ## Skipped — reported per method and in `Warnings`, never flips `Success`
 
@@ -200,7 +205,8 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
 | Property setter, init, or indexer accessor with an explicit body | Accessor patching covers getters only; `uloop compile` applies setter/init/indexer edits |
 | Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Out of scope for v1; `uloop compile` applies these edits |
-| Method raises, invokes, or reads a field-like event (anything beyond `+=`/`-=`) | C# only allows `+=`/`-=` on an event outside its declaring type, so the raising body cannot compile from the shim assembly |
+| Method raises or reads a field-like event that has no reachable backing field | Custom `add`/`remove` accessors, an `abstract`/`extern`/interface event, a delegate type that is not visible outside the assembly, or an event added in this edit leave nothing for the shim's Harmony accessor to bind |
+| Method names a field-like event inside `nameof` | The shim is a different type and cannot keep the bare event name |
 
 ## Failed — flips `Success` to `false`
 

--- a/.claude/skills/uloop-hot-reload/references/scope-and-limits.md
+++ b/.claude/skills/uloop-hot-reload/references/scope-and-limits.md
@@ -34,8 +34,9 @@ for statics. Initializer expressions are limited to literals and externally visi
 static calls (`= 5`, `= Math.Abs(x)`); object creation (`= new List<int>()`) and
 anything touching the host type or instance state skips the field's readers and
 writers with a per-method reason. To apply such a field without compiling, declare it
-without an initializer and assign it lazily inside the patched method with
-`if (_field == null) { _field = new List<int>(); }`; `??=` is not rewritable and keeps
+without an initializer — it starts at `default(T)` — and assign it inside the patched
+method instead; for a reference type, guard that with
+`if (_field == null) { _field = new List<int>(); }`. `??=` is not rewritable and keeps
 the method `Skipped`. Added `const` values are folded into edited bodies as literals,
 like `nameof`. Pause-point
 `CapturedVariables` never includes added fields; `enable-pause-point` warns when the
@@ -188,8 +189,10 @@ body works, and so does raising or reading one (`E?.Invoke(x)`, `E(x)`,
 Harmony accessor, which puts that method on the delegation path. Four shapes have no
 backing field to reach and stay `Skipped` (see the table below): an event with custom
 `add`/`remove` accessors, an `abstract`/`extern`/interface event, an event whose
-delegate type is not visible outside the assembly, and an event added in this edit.
-`nameof(E)` also stays `Skipped`.
+delegate type is not visible outside the assembly, and an event added in this edit
+(including one that had custom accessors when the assembly was last compiled).
+Raising through a conditional receiver (`other?.E?.Invoke(x)`) and `nameof(E)` also
+stay `Skipped`.
 
 ## Skipped — reported per method and in `Warnings`, never flips `Success`
 
@@ -206,6 +209,7 @@ delegate type is not visible outside the assembly, and an event added in this ed
 | Property setter, init, or indexer accessor with an explicit body | Accessor patching covers getters only; `uloop compile` applies setter/init/indexer edits |
 | Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Out of scope for v1; `uloop compile` applies these edits |
 | Method raises or reads a field-like event that has no reachable backing field | Custom `add`/`remove` accessors, an `abstract`/`extern`/interface event, a delegate type that is not visible outside the assembly, or an event added in this edit leave nothing for the shim's Harmony accessor to bind |
+| Method raises or reads a field-like event through a conditional receiver (`other?.E`) | The shim has no name for the conditional receiver to pass to the accessor call |
 | Method names a field-like event inside `nameof` | The shim is a different type and cannot keep the bare event name |
 
 ## Failed — flips `Success` to `false`

--- a/.claude/skills/uloop-hot-reload/references/scope-and-limits.md
+++ b/.claude/skills/uloop-hot-reload/references/scope-and-limits.md
@@ -31,9 +31,13 @@ An added field's values live in a side table that follows each instance's lifeti
 (statics live per domain). Its initializer does not run at construction time; it runs
 on the field's first access from edited code — once per instance, or once per domain
 for statics. Initializer expressions are limited to literals and externally visible
-static calls (`= 5`, `= Math.Abs(x)`); anything touching the host type or instance
-state skips the field's readers and writers with a per-method reason. Added `const`
-values are folded into edited bodies as literals, like `nameof`. Pause-point
+static calls (`= 5`, `= Math.Abs(x)`); object creation (`= new List<int>()`) and
+anything touching the host type or instance state skips the field's readers and
+writers with a per-method reason. To apply such a field without compiling, declare it
+without an initializer and assign it lazily inside the patched method with
+`if (_field == null) { _field = new List<int>(); }`; `??=` is not rewritable and keeps
+the method `Skipped`. Added `const` values are folded into edited bodies as literals,
+like `nameof`. Pause-point
 `CapturedVariables` never includes added fields; `enable-pause-point` warns when the
 resolved type has any — read them from a patched method body or
 `uloop execute-dynamic-code` instead.

--- a/.claude/skills/uloop-hot-reload/references/scope-and-limits.md
+++ b/.claude/skills/uloop-hot-reload/references/scope-and-limits.md
@@ -183,8 +183,13 @@ reported per-accessor as `Skipped`, so an edited accessor never disappears from 
 response silently; with a verified baseline, accessors unchanged from it produce no row.
 
 Subscribing to or unsubscribing from a field-like event (`+=`/`-=`) inside an edited
-body works. Methods that raise the event are reported as `Skipped` (see the table
-below) — raising is only expressible inside the declaring type, which a shim is not.
+body works, and so does raising or reading one (`E?.Invoke(x)`, `E(x)`,
+`if (E != null)`, `E = null`): the shim reads the event's backing field through a
+Harmony accessor, which puts that method on the delegation path. Four shapes have no
+backing field to reach and stay `Skipped` (see the table below): an event with custom
+`add`/`remove` accessors, an `abstract`/`extern`/interface event, an event whose
+delegate type is not visible outside the assembly, and an event added in this edit.
+`nameof(E)` also stays `Skipped`.
 
 ## Skipped — reported per method and in `Warnings`, never flips `Success`
 
@@ -200,7 +205,8 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
 | Property setter, init, or indexer accessor with an explicit body | Accessor patching covers getters only; `uloop compile` applies setter/init/indexer edits |
 | Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Out of scope for v1; `uloop compile` applies these edits |
-| Method raises, invokes, or reads a field-like event (anything beyond `+=`/`-=`) | C# only allows `+=`/`-=` on an event outside its declaring type, so the raising body cannot compile from the shim assembly |
+| Method raises or reads a field-like event that has no reachable backing field | Custom `add`/`remove` accessors, an `abstract`/`extern`/interface event, a delegate type that is not visible outside the assembly, or an event added in this edit leave nothing for the shim's Harmony accessor to bind |
+| Method names a field-like event inside `nameof` | The shim is a different type and cannot keep the bare event name |
 
 ## Failed — flips `Success` to `false`
 

--- a/Assets/Tests/Editor/HotReload/HotReloadEventAccessorHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadEventAccessorHost.cs
@@ -1,0 +1,56 @@
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    public delegate void HotReloadScoreDelegate(int amount);
+
+    // Not visible outside the assembly, so an event of this type cannot be named by the shim.
+    internal delegate void HotReloadHiddenScoreDelegate(int amount);
+
+    /// <summary>
+    /// Compiled host for event-accessor worker tests: a field-like instance event, a static one,
+    /// and one whose delegate type is not externally visible. Tests copy this source, replace the
+    /// method bodies with event raises, and run the transform worker against the compiled
+    /// assembly as ground truth.
+    /// </summary>
+    public class HotReloadEventAccessorHost
+    {
+        public event HotReloadScoreDelegate Scored;
+
+        public static event HotReloadScoreDelegate StaticScored;
+
+        internal event HotReloadHiddenScoreDelegate HiddenScored;
+
+        public int Total;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void RaiseScored(int amount)
+        {
+            Total = amount;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void RaiseStaticScored(int amount)
+        {
+            Total = amount;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void ClearScored()
+        {
+            Total = 0;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void RaiseHiddenScored(int amount)
+        {
+            Total = amount;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void OnScored(int amount)
+        {
+            Total = Total + amount;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadEventAccessorHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadEventAccessorHost.cs
@@ -21,7 +21,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         internal event HotReloadHiddenScoreDelegate HiddenScored;
 
+        // Custom accessors mean no compiler-generated backing field, so a test can edit this
+        // declaration into a field-like event and check that the raiser is still skipped.
+        public event HotReloadScoreDelegate CustomScored
+        {
+            add { _customScored = _customScored + value; }
+            remove { _customScored = _customScored - value; }
+        }
+
+        private HotReloadScoreDelegate _customScored;
+
         public int Total;
+
+        // Lets a test raise an event through a conditional receiver ('Other?.Scored').
+        public HotReloadEventAccessorHost Other;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void RaiseScored(int amount)
@@ -43,6 +56,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void RaiseHiddenScored(int amount)
+        {
+            Total = amount;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void RaiseCustomScored(int amount)
+        {
+            Total = amount;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void RaiseOtherScored(int amount)
         {
             Total = amount;
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadEventAccessorHost.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadEventAccessorHost.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 083758c79ac514612a2b9615b84cabdb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadEventLambdaFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadEventLambdaFixture.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled fixture for raising a field-like event from inside a lambda: the closure body
+    /// already forces the accessor-rewrite path, so this pins that the event rewrite composes
+    /// with it instead of skipping the method.
+    /// </summary>
+    public class HotReloadEventLambdaFixture
+    {
+        public event Action ScoreChanged;
+
+        public int HandledCount;
+
+        // Why NoInlining: assertions must measure the patch detour, not JIT inlining.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void EnableCounting()
+        {
+            ScoreChanged += HandleScoreChanged;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void HandleScoreChanged()
+        {
+            HandledCount = HandledCount + 1;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void RaiseScoreFromLambda()
+        {
+            Action raise = () => ScoreChanged?.Invoke();
+            raise();
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadEventLambdaFixture.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadEventLambdaFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1152789b028c14bd9ad15ef61ba50e95
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1854,6 +1854,41 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a static field-like event raised from a patched method actually runs, which
+        /// exercises the StaticFieldRefAccess binding rather than only the generated shim text:
+        /// a wrong backing-field name or FieldInfo would fail the bind and leave the compiled
+        /// body in place. 20 means every patch ran (2 net subscriptions x 5 per handled x 2
+        /// invokes); 2 means the compiled bodies did.
+        /// </summary>
+        [Test]
+        public async Task Run_StaticFieldLikeEventFile_PatchesRaiserAndRunsThroughStaticAccessor()
+        {
+            string fixturePath = ResolveStaticEventFixturePath();
+            string editedPath = WriteEditedSource(
+                "StaticEventFixtureEdit.cs",
+                BuildStaticEventFixtureSource());
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadStaticEventFixture.RaiseScore));
+            AssertHasPatched(result, nameof(HotReloadStaticEventFixture.EnableCounting));
+
+            HotReloadStaticEventFixture fixture = new HotReloadStaticEventFixture();
+            fixture.ResetCounting();
+            fixture.EnableCounting();
+            fixture.RaiseScore();
+            Assert.That(
+                HotReloadStaticEventFixture.HandledCount,
+                Is.EqualTo(20),
+                "20 means the static accessor bound and every patch ran; 2 means the compiled "
+                + "bodies did.\n" + FormatOutcomes(result));
+        }
+
+        /// <summary>
         /// What: a field-like event raised from inside a lambda patches too. The closure body
         /// already needs the accessor-rewrite path, so this pins that the event rewrite composes
         /// with it. 20 means all three patches ran (2 subscriptions x 5 per handled x 2 invokes);
@@ -6898,6 +6933,58 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Application.dataPath, "Tests", "Editor", "HotReload", "HotReloadEventFixtures.cs");
             Assert.That(File.Exists(path), Is.True, "Event fixture source missing: " + path);
             return Path.GetFullPath(path);
+        }
+
+        private static string ResolveStaticEventFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath, "Tests", "Editor", "HotReload", "HotReloadStaticEventFixture.cs");
+            Assert.That(File.Exists(path), Is.True, "Static event fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string BuildStaticEventFixtureSource()
+        {
+            return @"using System;
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    public class HotReloadStaticEventFixture
+    {
+        public static event Action ScoreChanged;
+
+        public static int HandledCount;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void EnableCounting()
+        {
+            ScoreChanged += HandleScoreChanged;
+            ScoreChanged += HandleScoreChanged;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void HandleScoreChanged()
+        {
+            HandledCount = HandledCount + 5;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void RaiseScore()
+        {
+            ScoreChanged?.Invoke();
+            ScoreChanged?.Invoke();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void ResetCounting()
+        {
+            ScoreChanged = null;
+            HandledCount = 0;
+        }
+    }
+}
+";
         }
 
         private static string ResolveEventLambdaFixturePath()

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1817,15 +1817,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a file declaring a field-like event hot-reloads its subscriber and handler methods
-        /// (no CS0229 from the publicized backing field) — the edited subscriber body (net two
-        /// subscriptions via += / -=) must actually apply (HandledCount == 10, not the original
-        /// body's 5) and EnableCounting must be Patched — while the raising method (edited to a
-        /// double Invoke so it is not treated as unchanged) is Skipped instead of killing the
-        /// whole file.
+        /// What: a file declaring a field-like event hot-reloads every method in it, raiser
+        /// included. The count is exact rather than "increased" so a Patched Kind alone cannot
+        /// satisfy it: the edited subscriber nets two subscriptions, the edited handler adds 5,
+        /// and the edited raiser invokes twice, so all three patches give 20. A raiser left on
+        /// the compiled single-Invoke body would give 10.
         /// </summary>
         [Test]
-        public async Task Run_FieldLikeEventFile_PatchesHandlerAndSkipsRaiser()
+        public async Task Run_FieldLikeEventFile_PatchesHandlerAndRaiser()
         {
             string fixturePath = ResolveEventFixturePath();
             string editedPath = WriteEditedSource(
@@ -1841,25 +1840,48 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertNoFileLevelFailure(result);
             AssertHasPatched(result, nameof(HotReloadEventFixture.HandleScoreChanged));
             AssertHasPatched(result, nameof(HotReloadEventFixture.EnableCounting));
-
-            bool raiserSkipped = false;
-            foreach (HotReloadMethodOutcome outcome in result.Methods)
-            {
-                if (outcome.Kind == HotReloadMethodOutcomeKind.Skipped
-                    && outcome.Method.Contains(nameof(HotReloadEventFixture.RaiseScore))
-                    && outcome.Reason.Contains("event"))
-                {
-                    raiserSkipped = true;
-                }
-            }
-
-            Assert.That(raiserSkipped, Is.True,
-                "RaiseScore must be Skipped with the event-use reason.\n" + FormatOutcomes(result));
+            AssertHasPatched(result, nameof(HotReloadEventFixture.RaiseScore));
 
             HotReloadEventFixture fixture = new HotReloadEventFixture();
             fixture.EnableCounting();
             fixture.RaiseScore();
-            Assert.That(fixture.HandledCount, Is.EqualTo(10));
+            Assert.That(
+                fixture.HandledCount,
+                Is.EqualTo(20),
+                "20 means every patch ran: 2 net subscriptions x 5 per handled x 2 invokes. "
+                + "10 means the raiser stayed on the compiled single-Invoke body.\n"
+                + FormatOutcomes(result));
+        }
+
+        /// <summary>
+        /// What: a field-like event raised from inside a lambda patches too. The closure body
+        /// already needs the accessor-rewrite path, so this pins that the event rewrite composes
+        /// with it. 20 means all three patches ran (2 subscriptions x 5 per handled x 2 invokes);
+        /// 2 means none of them did.
+        /// </summary>
+        [Test]
+        public async Task Run_FieldLikeEventRaisedInLambda_PatchesRaiser()
+        {
+            string fixturePath = ResolveEventLambdaFixturePath();
+            string editedPath = WriteEditedSource(
+                "EventLambdaFixtureEdit.cs",
+                BuildEventLambdaFixtureSource());
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(result);
+            AssertHasPatched(result, nameof(HotReloadEventLambdaFixture.RaiseScoreFromLambda));
+
+            HotReloadEventLambdaFixture fixture = new HotReloadEventLambdaFixture();
+            fixture.EnableCounting();
+            fixture.RaiseScoreFromLambda();
+            Assert.That(
+                fixture.HandledCount,
+                Is.EqualTo(20),
+                "20 means every patch ran; 2 means the compiled bodies did.\n" + FormatOutcomes(result));
         }
 
         /// <summary>
@@ -6876,6 +6898,55 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Application.dataPath, "Tests", "Editor", "HotReload", "HotReloadEventFixtures.cs");
             Assert.That(File.Exists(path), Is.True, "Event fixture source missing: " + path);
             return Path.GetFullPath(path);
+        }
+
+        private static string ResolveEventLambdaFixturePath()
+        {
+            string path = Path.Combine(
+                Application.dataPath, "Tests", "Editor", "HotReload", "HotReloadEventLambdaFixture.cs");
+            Assert.That(File.Exists(path), Is.True, "Event lambda fixture source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string BuildEventLambdaFixtureSource()
+        {
+            return @"using System;
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    public class HotReloadEventLambdaFixture
+    {
+        public event Action ScoreChanged;
+
+        public int HandledCount;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void EnableCounting()
+        {
+            ScoreChanged += HandleScoreChanged;
+            ScoreChanged += HandleScoreChanged;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void HandleScoreChanged()
+        {
+            HandledCount = HandledCount + 5;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void RaiseScoreFromLambda()
+        {
+            Action raise = () =>
+            {
+                ScoreChanged?.Invoke();
+                ScoreChanged?.Invoke();
+            };
+            raise();
+        }
+    }
+}
+";
         }
 
         private static string BuildEventFixtureSource(string handleScoreChangedMethod)

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1858,7 +1858,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// exercises the StaticFieldRefAccess binding rather than only the generated shim text:
         /// a wrong backing-field name or FieldInfo would fail the bind and leave the compiled
         /// body in place. 20 means every patch ran (2 net subscriptions x 5 per handled x 2
-        /// invokes); 2 means the compiled bodies did.
+        /// invokes); 1 means the compiled bodies did.
         /// </summary>
         [Test]
         public async Task Run_StaticFieldLikeEventFile_PatchesRaiserAndRunsThroughStaticAccessor()
@@ -1884,7 +1884,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 HotReloadStaticEventFixture.HandledCount,
                 Is.EqualTo(20),
-                "20 means the static accessor bound and every patch ran; 2 means the compiled "
+                "20 means the static accessor bound and every patch ran; 1 means the compiled "
                 + "bodies did.\n" + FormatOutcomes(result));
         }
 
@@ -1892,7 +1892,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// What: a field-like event raised from inside a lambda patches too. The closure body
         /// already needs the accessor-rewrite path, so this pins that the event rewrite composes
         /// with it. 20 means all three patches ran (2 subscriptions x 5 per handled x 2 invokes);
-        /// 2 means none of them did.
+        /// 1 means none of them did.
         /// </summary>
         [Test]
         public async Task Run_FieldLikeEventRaisedInLambda_PatchesRaiser()
@@ -1916,7 +1916,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 fixture.HandledCount,
                 Is.EqualTo(20),
-                "20 means every patch ran; 2 means the compiled bodies did.\n" + FormatOutcomes(result));
+                "20 means every patch ran; 1 means the compiled bodies did.\n" + FormatOutcomes(result));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadStaticEventFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadStaticEventFixture.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled fixture for raising a static field-like event: the shim binds it through
+    /// StaticFieldRefAccess, so this exercises that binding at runtime rather than only in the
+    /// generated shim text.
+    /// </summary>
+    public class HotReloadStaticEventFixture
+    {
+        public static event Action ScoreChanged;
+
+        public static int HandledCount;
+
+        // Why NoInlining: assertions must measure the patch detour, not JIT inlining.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void EnableCounting()
+        {
+            ScoreChanged += HandleScoreChanged;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void HandleScoreChanged()
+        {
+            HandledCount = HandledCount + 1;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void RaiseScore()
+        {
+            ScoreChanged?.Invoke();
+        }
+
+        // Static event state outlives an instance, so a test must clear it before subscribing.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void ResetCounting()
+        {
+            ScoreChanged = null;
+            HandledCount = 0;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadStaticEventFixture.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadStaticEventFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a37dab9537b7e421b810332fc88e28bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -526,7 +526,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HostProjectRelativePath,
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "literal or externally visible static");
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "Drop the initializer");
             Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
         }
 
@@ -550,7 +550,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HostProjectRelativePath,
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "literal or externally visible static");
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "Drop the initializer");
             Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
         }
 
@@ -582,6 +582,104 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(slice, Does.Contain("static () =>"));
             Assert.That(slice, Does.Contain("Abs"));
             Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
+        }
+
+        /// <summary>
+        /// What: an added reference-type field declared without an initializer and assigned
+        /// lazily inside the patched body applies; this is the documented workaround the
+        /// initializer skip reason points at.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_LazyInitializedAddedField_PatchesAndListsAddedField()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public System.Collections.Generic.Dictionary<string, int> AddedLazyMap;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            if (AddedLazyMap == null)\n            {\n"
+                + "                AddedLazyMap = new System.Collections.Generic.Dictionary<string, int>();\n"
+                + "            }\n\n"
+                + "            return AddedLazyMap.Count + value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldLazyInit.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller)),
+                Is.Not.Null,
+                "Lazy initialization inside the body must not skip the method. Skipped="
+                + FormatSkipped(result.Output.skipped));
+            Assert.That(
+                result.Output.addedFieldNames,
+                Is.EqualTo(new[] { typeof(HotReloadAddedMemberHost).FullName + ".AddedLazyMap" }));
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
+        }
+
+        /// <summary>
+        /// What: an object-creation initializer on an added field skips, and the reason names
+        /// the lazy-assignment workaround rather than only telling the caller to compile.
+        /// </summary>
+        [Test]
+        public async Task Skip_ObjectCreationInitializer_ReasonNamesLazyAssignmentWorkaround()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public System.Collections.Generic.Dictionary<string, int> AddedEagerMap"
+                + " = new System.Collections.Generic.Dictionary<string, int>();");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return AddedEagerMap.Count + value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldObjectCreationInit.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(
+                result,
+                nameof(HotReloadAddedMemberHost.ExistingCaller),
+                "Drop the initializer and assign the field lazily inside the patched method");
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
+        }
+
+        /// <summary>
+        /// What: '??=' on an added field stays skipped because the compound assignment is not
+        /// rewritable. The reason is the unavailable-added-field text, not the initializer one,
+        /// so the initializer reason must keep steering callers to the 'if (x == null)' form.
+        /// </summary>
+        [Test]
+        public async Task Skip_CoalesceAssignmentOnAddedField_UsesUnavailableAddedFieldReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public System.Collections.Generic.Dictionary<string, int> AddedCoalesceMap;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            AddedCoalesceMap ??= new System.Collections.Generic.Dictionary<string, int>();\n"
+                + "            return AddedCoalesceMap.Count + value;\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("AddedFieldCoalesceAssignment.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(
+                result,
+                nameof(HotReloadAddedMemberHost.ExistingCaller),
+                "Uses an added field that hot reload cannot emit.");
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -647,7 +647,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertHasSkip(
                 result,
                 nameof(HotReloadAddedMemberHost.ExistingCaller),
-                "Drop the initializer and assign the field lazily inside the patched method");
+                "Drop the initializer and assign the field inside the patched method");
             Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
         }
 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerEventAccessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerEventAccessorTests.cs
@@ -1,0 +1,456 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Worker coverage for methods that raise, read, or clear a field-like event: they become
+    /// delegation entries whose event access is rewritten to a Harmony backing-field accessor,
+    /// while += / -= keep using the publicized add/remove accessors.
+    /// </summary>
+    public class TransformWorkerEventAccessorTests
+    {
+        private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+
+        // The shim method's receiver parameter name, emitted by the transform worker.
+        private const string InstanceParameterName = "__uloopInstance";
+
+        private const string HostProjectRelativePath =
+            "Assets/Tests/Editor/HotReload/HotReloadEventAccessorHost.cs";
+
+        private const string RaiseScoredOriginal =
+            "        public void RaiseScored(int amount)\n        {\n            Total = amount;\n        }";
+
+        private const string RaiseStaticScoredOriginal =
+            "        public void RaiseStaticScored(int amount)\n        {\n            Total = amount;\n        }";
+
+        private const string ClearScoredOriginal =
+            "        public void ClearScored()\n        {\n            Total = 0;\n        }";
+
+        private const string RaiseHiddenScoredOriginal =
+            "        public void RaiseHiddenScored(int amount)\n        {\n            Total = amount;\n        }";
+
+        private const string DelegationPatchKind = "delegation";
+
+        private const string EventAccessorFieldName = "__EV_Scored";
+
+        private const string StaticEventAccessorFieldName = "__EV_StaticScored";
+
+        /// <summary>
+        /// What: 'E?.Invoke(a)' turns the method into a delegation entry whose event read goes
+        /// through the Harmony backing-field accessor instead of the event member.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_ConditionalInvoke_ReadsEventThroughBackingFieldAccessor()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "EventRaiseConditionalInvoke.cs",
+                RaiseScoredOriginal,
+                "        public void RaiseScored(int amount)\n        {\n"
+                + "            Scored?.Invoke(amount);\n        }");
+
+            TransformWorkerEntryDto entry = FindEntry(result, nameof(HotReloadEventAccessorHost.RaiseScored));
+            Assert.That(
+                entry,
+                Is.Not.Null,
+                "Raising a field-like event must patch, not skip. Skipped=" + FormatSkipped(result.Output.skipped));
+            Assert.That(entry.patchKind, Is.EqualTo(DelegationPatchKind));
+            string slice = SliceShimMethod(result.Output.shimSource, entry.shimMethodName);
+            Assert.That(slice, Does.Contain(EventAccessorFieldName + "("));
+            Assert.That(result.Output.hasAccessorDelegates, Is.True);
+        }
+
+        /// <summary>
+        /// What: the bare-delegate raise form 'E(a)' is rewritten the same way as E?.Invoke(a).
+        /// </summary>
+        [Test]
+        public async Task Rewrite_DirectDelegateInvoke_ReadsEventThroughBackingFieldAccessor()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "EventRaiseDirectInvoke.cs",
+                RaiseScoredOriginal,
+                "        public void RaiseScored(int amount)\n        {\n"
+                + "            Scored(amount);\n        }");
+
+            TransformWorkerEntryDto entry = FindEntry(result, nameof(HotReloadEventAccessorHost.RaiseScored));
+            Assert.That(
+                entry,
+                Is.Not.Null,
+                "Skipped=" + FormatSkipped(result.Output.skipped));
+            Assert.That(entry.patchKind, Is.EqualTo(DelegationPatchKind));
+            Assert.That(
+                SliceShimMethod(result.Output.shimSource, entry.shimMethodName),
+                Does.Contain(EventAccessorFieldName + "("));
+        }
+
+        /// <summary>
+        /// What: a null check on the event is a read as well, so 'if (E != null) E(a)' patches
+        /// and both reads go through the accessor.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_NullCheckThenInvoke_ReadsEventThroughBackingFieldAccessor()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "EventRaiseNullCheck.cs",
+                RaiseScoredOriginal,
+                "        public void RaiseScored(int amount)\n        {\n"
+                + "            if (Scored != null)\n            {\n"
+                + "                Scored(amount);\n            }\n        }");
+
+            TransformWorkerEntryDto entry = FindEntry(result, nameof(HotReloadEventAccessorHost.RaiseScored));
+            Assert.That(
+                entry,
+                Is.Not.Null,
+                "Skipped=" + FormatSkipped(result.Output.skipped));
+            string slice = SliceShimMethod(result.Output.shimSource, entry.shimMethodName);
+            Assert.That(slice, Does.Not.Contain(InstanceParameterName + ".Scored"));
+            Assert.That(slice, Does.Contain(EventAccessorFieldName + "("));
+        }
+
+        /// <summary>
+        /// What: a static field-like event binds through StaticFieldRefAccess, so the accessor
+        /// call takes no receiver argument.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_StaticEventRaise_BindsThroughStaticFieldRefAccess()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "EventRaiseStatic.cs",
+                RaiseStaticScoredOriginal,
+                "        public void RaiseStaticScored(int amount)\n        {\n"
+                + "            StaticScored?.Invoke(amount);\n        }");
+
+            TransformWorkerEntryDto entry =
+                FindEntry(result, nameof(HotReloadEventAccessorHost.RaiseStaticScored));
+            Assert.That(
+                entry,
+                Is.Not.Null,
+                "Skipped=" + FormatSkipped(result.Output.skipped));
+            Assert.That(
+                SliceShimMethod(result.Output.shimSource, entry.shimMethodName),
+                Does.Contain(StaticEventAccessorFieldName + "()"));
+            Assert.That(result.Output.shimSource, Does.Contain("StaticFieldRefAccess"));
+        }
+
+        /// <summary>
+        /// What: 'E = null' writes through the ref-returning accessor rather than the event
+        /// member, which C# would reject outside the declaring type.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_NullAssignment_WritesThroughBackingFieldAccessor()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "EventClearAssignment.cs",
+                ClearScoredOriginal,
+                "        public void ClearScored()\n        {\n"
+                + "            Scored = null;\n        }");
+
+            TransformWorkerEntryDto entry = FindEntry(result, nameof(HotReloadEventAccessorHost.ClearScored));
+            Assert.That(
+                entry,
+                Is.Not.Null,
+                "Skipped=" + FormatSkipped(result.Output.skipped));
+            string slice = SliceShimMethod(result.Output.shimSource, entry.shimMethodName);
+            Assert.That(slice, Does.Contain(EventAccessorFieldName + "(" + InstanceParameterName + ") = null"));
+        }
+
+        /// <summary>
+        /// What: when a body both subscribes and raises, the subscription keeps the publicized
+        /// add accessor (preserving Interlocked semantics) while only the raise goes through the
+        /// backing-field accessor.
+        /// </summary>
+        [Test]
+        public async Task Rewrite_SubscribeAndRaiseInSameBody_KeepsSubscriptionOnEventAccessor()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "EventSubscribeAndRaise.cs",
+                RaiseScoredOriginal,
+                "        public void RaiseScored(int amount)\n        {\n"
+                + "            Scored += OnScored;\n"
+                + "            Scored -= OnScored;\n"
+                + "            Scored += OnScored;\n"
+                + "            Scored?.Invoke(amount);\n        }");
+
+            TransformWorkerEntryDto entry = FindEntry(result, nameof(HotReloadEventAccessorHost.RaiseScored));
+            Assert.That(
+                entry,
+                Is.Not.Null,
+                "Skipped=" + FormatSkipped(result.Output.skipped));
+            string slice = SliceShimMethod(result.Output.shimSource, entry.shimMethodName);
+            Assert.That(slice, Does.Contain(InstanceParameterName + ".Scored += "));
+            Assert.That(slice, Does.Contain(InstanceParameterName + ".Scored -= "));
+            Assert.That(slice, Does.Contain(EventAccessorFieldName + "("));
+            Assert.That(slice, Does.Not.Contain(EventAccessorFieldName + "(" + InstanceParameterName + ") +="));
+        }
+
+        /// <summary>
+        /// What: an event whose delegate type is not visible outside the assembly is skipped,
+        /// because the shim cannot name the accessor's field type.
+        /// </summary>
+        [Test]
+        public async Task Skip_EventWithNonVisibleDelegateType_ReportsDelegateTypeReason()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "EventRaiseHiddenDelegateType.cs",
+                RaiseHiddenScoredOriginal,
+                "        public void RaiseHiddenScored(int amount)\n        {\n"
+                + "            HiddenScored?.Invoke(amount);\n        }");
+
+            AssertHasSkip(
+                result,
+                nameof(HotReloadEventAccessorHost.RaiseHiddenScored),
+                "delegate type is not visible from an external assembly");
+        }
+
+        /// <summary>
+        /// What: an event declared in this edit has no backing field in the compiled assembly, so
+        /// the raiser is skipped with a reason that names compiling as the way forward.
+        /// </summary>
+        [Test]
+        public async Task Skip_EventAddedInThisEdit_ReportsMissingCompiledBackingField()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int Total;",
+                "        public event HotReloadScoreDelegate AddedScored;\n\n        public int Total;",
+                StringComparison.Ordinal);
+            edited = ReplaceMember(
+                edited,
+                RaiseScoredOriginal,
+                "        public void RaiseScored(int amount)\n        {\n"
+                + "            AddedScored?.Invoke(amount);\n        }");
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("EventRaiseAddedInThisEdit.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(
+                result,
+                nameof(HotReloadEventAccessorHost.RaiseScored),
+                "the compiled assembly has no backing field yet");
+        }
+
+        /// <summary>
+        /// What: nameof(E) stays Skipped — the shim is a different static type, so the bare event
+        /// name it would have to keep does not resolve there.
+        /// </summary>
+        [Test]
+        public async Task Skip_NameofEvent_StaysSkipped()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "EventNameofUse.cs",
+                RaiseScoredOriginal,
+                "        public void RaiseScored(int amount)\n        {\n"
+                + "            Total = amount + nameof(Scored).Length;\n        }");
+
+            AssertHasSkip(result, nameof(HotReloadEventAccessorHost.RaiseScored), "nameof");
+        }
+
+        private static async Task<TransformWorkerClientResult> RunEditedHostAsync(
+            string editedFileName,
+            string originalMember,
+            string replacementMember)
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = ReplaceMember(onDisk, originalMember, replacementMember);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited(editedFileName, edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            return result;
+        }
+
+        private static string ReplaceMember(string source, string originalMember, string replacementMember)
+        {
+            Assert.That(source, Does.Contain(originalMember), "Host fixture member drifted: " + originalMember);
+            return source.Replace(originalMember, replacementMember, StringComparison.Ordinal);
+        }
+
+        private static TransformWorkerEntryDto FindEntry(TransformWorkerClientResult result, string methodName)
+        {
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                if (entry.methodName == methodName)
+                {
+                    return entry;
+                }
+            }
+
+            return null;
+        }
+
+        private static void AssertHasSkip(
+            TransformWorkerClientResult result,
+            string methodNameFragment,
+            string reasonFragment)
+        {
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                if (skipped.method != null
+                    && skipped.method.Contains(methodNameFragment)
+                    && skipped.reason != null
+                    && skipped.reason.Contains(reasonFragment))
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail(
+                "Expected skip for '" + methodNameFragment + "' with reason containing '"
+                + reasonFragment + "'. Skipped=" + FormatSkipped(result.Output.skipped));
+        }
+
+        private static string FormatSkipped(TransformWorkerSkippedDto[] skipped)
+        {
+            if (skipped == null || skipped.Length == 0)
+            {
+                return "(none)";
+            }
+
+            List<string> rows = new List<string>();
+            foreach (TransformWorkerSkippedDto entry in skipped)
+            {
+                rows.Add(entry.method + " :: " + entry.reason);
+            }
+
+            return string.Join("\n", rows);
+        }
+
+        private static string SliceShimMethod(string shimSource, string shimMethodName)
+        {
+            int nameIndex = shimSource.IndexOf(shimMethodName, StringComparison.Ordinal);
+            Assert.That(nameIndex, Is.GreaterThanOrEqualTo(0), "Shim method missing: " + shimMethodName);
+            int declarationStart = shimSource.LastIndexOf("public static", nameIndex, StringComparison.Ordinal);
+            int openBrace = shimSource.IndexOf('{', nameIndex);
+            Assert.That(openBrace, Is.GreaterThan(0));
+            int depth = 0;
+            for (int index = openBrace; index < shimSource.Length; index++)
+            {
+                if (shimSource[index] == '{')
+                {
+                    depth++;
+                }
+                else if (shimSource[index] == '}')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        return shimSource.Substring(declarationStart, index - declarationStart + 1);
+                    }
+                }
+            }
+
+            Assert.Fail("Unbalanced shim method: " + shimMethodName);
+            return string.Empty;
+        }
+
+        private static string WriteEdited(string fileName, string contents)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string path = Path.Combine(directory, fileName);
+            File.WriteAllText(path, contents);
+            return path;
+        }
+
+        private static string ResolveHostPath()
+        {
+            string path = Path.Combine(
+                Application.dataPath, "Tests", "Editor", "HotReload", "HotReloadEventAccessorHost.cs");
+            Assert.That(File.Exists(path), Is.True, "Event accessor host source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static async Task<TransformWorkerClientResult> RunWorkerOnSourceAsync(
+            string sourcePath,
+            string projectRelativePath,
+            string snapshotSource = null)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string targetDllPath = Path.Combine(
+                projectRoot, "Library", "ScriptAssemblies", TestAssemblyName + ".dll");
+            Assert.That(File.Exists(targetDllPath), Is.True, "Test assembly dll missing: " + targetDllPath);
+
+            UnityEditor.Compilation.Assembly compilationAssembly = null;
+            foreach (UnityEditor.Compilation.Assembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name == TestAssemblyName)
+                {
+                    compilationAssembly = assembly;
+                    break;
+                }
+            }
+
+            Assert.That(compilationAssembly, Is.Not.Null, "CompilationPipeline assembly not found.");
+
+            TransformWorkerInputDto input = new TransformWorkerInputDto
+            {
+                sourcePath = sourcePath,
+                defines = compilationAssembly.defines ?? Array.Empty<string>(),
+                referencePaths = BuildAbsoluteReferencePaths(compilationAssembly.allReferences, targetDllPath),
+                targetTypesAssemblyPath = targetDllPath,
+                snapshotSource = snapshotSource,
+                projectRelativePath = projectRelativePath,
+                assemblySourcePaths = BuildAbsoluteAssemblySourcePaths(compilationAssembly.sourceFiles),
+                excludedMethodKeys = Array.Empty<string>(),
+                excludedAddedMethodKeys = Array.Empty<string>()
+            };
+
+            return await TransformWorkerClient.RunAsync(input, CancellationToken.None);
+        }
+
+        private static string[] BuildAbsoluteReferencePaths(string[] allReferences, string targetDllPath)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            List<string> paths = new List<string>();
+            bool hasTarget = false;
+            foreach (string reference in allReferences ?? Array.Empty<string>())
+            {
+                string full = Path.IsPathRooted(reference)
+                    ? Path.GetFullPath(reference)
+                    : Path.GetFullPath(Path.Combine(projectRoot, reference));
+                if (string.Equals(full, Path.GetFullPath(targetDllPath), StringComparison.Ordinal))
+                {
+                    hasTarget = true;
+                }
+
+                paths.Add(full);
+            }
+
+            if (!hasTarget)
+            {
+                paths.Add(Path.GetFullPath(targetDllPath));
+            }
+
+            return paths.ToArray();
+        }
+
+        private static string[] BuildAbsoluteAssemblySourcePaths(string[] sourceFiles)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            List<string> paths = new List<string>();
+            foreach (string sourceFile in sourceFiles ?? Array.Empty<string>())
+            {
+                paths.Add(Path.IsPathRooted(sourceFile)
+                    ? Path.GetFullPath(sourceFile)
+                    : Path.GetFullPath(Path.Combine(projectRoot, sourceFile)));
+            }
+
+            return paths.ToArray();
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerEventAccessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerEventAccessorTests.cs
@@ -38,6 +38,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string ClearScoredOriginal =
             "        public void ClearScored()\n        {\n            Total = 0;\n        }";
 
+        private const string CustomScoredDeclarationOriginal =
+            "        public event HotReloadScoreDelegate CustomScored\n        {\n"
+            + "            add { _customScored = _customScored + value; }\n"
+            + "            remove { _customScored = _customScored - value; }\n        }";
+
+        private const string RaiseCustomScoredOriginal =
+            "        public void RaiseCustomScored(int amount)\n        {\n            Total = amount;\n        }";
+
+        private const string RaiseOtherScoredOriginal =
+            "        public void RaiseOtherScored(int amount)\n        {\n            Total = amount;\n        }";
+
         private const string RaiseHiddenScoredOriginal =
             "        public void RaiseHiddenScored(int amount)\n        {\n            Total = amount;\n        }";
 
@@ -192,6 +203,62 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(slice, Does.Contain(InstanceParameterName + ".Scored -= "));
             Assert.That(slice, Does.Contain(EventAccessorFieldName + "("));
             Assert.That(slice, Does.Not.Contain(EventAccessorFieldName + "(" + InstanceParameterName + ") +="));
+        }
+
+        /// <summary>
+        /// What: turning an event with custom accessors into a field-like one does not make its
+        /// backing field exist in the compiled assembly, so the raiser is still skipped.
+        /// </summary>
+        [Test]
+        public async Task Skip_EventTurnedFieldLikeInThisEdit_ReportsMissingCompiledBackingField()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = ReplaceMember(
+                onDisk,
+                CustomScoredDeclarationOriginal,
+                "        public event HotReloadScoreDelegate CustomScored;");
+            edited = ReplaceMember(
+                edited,
+                RaiseCustomScoredOriginal,
+                "        public void RaiseCustomScored(int amount)\n        {\n"
+                + "            CustomScored?.Invoke(amount);\n        }");
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("EventCustomTurnedFieldLike.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                FindEntry(result, nameof(HotReloadEventAccessorHost.RaiseCustomScored)),
+                Is.Null,
+                "shimSource=" + result.Output.shimSource);
+            AssertHasSkip(
+                result,
+                nameof(HotReloadEventAccessorHost.RaiseCustomScored),
+                "the compiled assembly has no backing field yet");
+        }
+
+        /// <summary>
+        /// What: raising an event through a conditional receiver is skipped, because the shim
+        /// cannot name the conditional receiver as the accessor call's argument.
+        /// </summary>
+        [Test]
+        public async Task Skip_EventRaisedThroughConditionalReceiver_ReportsConditionalReceiverReason()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "EventConditionalReceiver.cs",
+                RaiseOtherScoredOriginal,
+                "        public void RaiseOtherScored(int amount)\n        {\n"
+                + "            Other?.Scored?.Invoke(amount);\n        }");
+
+            Assert.That(
+                FindEntry(result, nameof(HotReloadEventAccessorHost.RaiseOtherScored)),
+                Is.Null,
+                "shimSource=" + result.Output.shimSource);
+            AssertHasSkip(
+                result,
+                nameof(HotReloadEventAccessorHost.RaiseOtherScored),
+                "conditional receiver");
         }
 
         /// <summary>
@@ -415,25 +482,36 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private static string[] BuildAbsoluteReferencePaths(string[] allReferences, string targetDllPath)
         {
-            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             List<string> paths = new List<string>();
-            bool hasTarget = false;
-            foreach (string reference in allReferences ?? Array.Empty<string>())
+            if (allReferences != null)
             {
-                string full = Path.IsPathRooted(reference)
-                    ? Path.GetFullPath(reference)
-                    : Path.GetFullPath(Path.Combine(projectRoot, reference));
-                if (string.Equals(full, Path.GetFullPath(targetDllPath), StringComparison.Ordinal))
+                foreach (string reference in allReferences)
+                {
+                    // A stale path from CompilationPipeline becomes a "Reference not found"
+                    // parse error in the worker, so drop references that no longer exist.
+                    if (string.IsNullOrEmpty(reference) || !File.Exists(reference))
+                    {
+                        continue;
+                    }
+
+                    paths.Add(Path.GetFullPath(reference));
+                }
+            }
+
+            string fullTarget = Path.GetFullPath(targetDllPath);
+            bool hasTarget = false;
+            foreach (string path in paths)
+            {
+                if (string.Equals(path, fullTarget, StringComparison.OrdinalIgnoreCase))
                 {
                     hasTarget = true;
+                    break;
                 }
-
-                paths.Add(full);
             }
 
             if (!hasTarget)
             {
-                paths.Add(Path.GetFullPath(targetDllPath));
+                paths.Add(fullTarget);
             }
 
             return paths.ToArray();

--- a/Assets/Tests/Editor/HotReload/TransformWorkerEventAccessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerEventAccessorTests.cs
@@ -58,6 +58,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private const string StaticEventAccessorFieldName = "__EV_StaticScored";
 
+        private const string ScoreDelegateFullName =
+            "global::io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadScoreDelegate";
+
         /// <summary>
         /// What: 'E?.Invoke(a)' turns the method into a delegation entry whose event read goes
         /// through the Harmony backing-field accessor instead of the event member.
@@ -78,7 +81,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Raising a field-like event must patch, not skip. Skipped=" + FormatSkipped(result.Output.skipped));
             Assert.That(entry.patchKind, Is.EqualTo(DelegationPatchKind));
             string slice = SliceShimMethod(result.Output.shimSource, entry.shimMethodName);
-            Assert.That(slice, Does.Contain(EventAccessorFieldName + "("));
+
+            // Read-once: 'E?.Invoke(a)' evaluates the event exactly once, so the accessor must be
+            // called once and its result cast, not called again for the invocation.
+            Assert.That(
+                CountOccurrences(slice, EventAccessorFieldName + "("),
+                Is.EqualTo(1),
+                "The accessor must be read once; a second call would re-read the event. slice=" + slice);
+            Assert.That(
+                slice,
+                Does.Contain(
+                    "((" + ScoreDelegateFullName + ")" + EventAccessorFieldName
+                    + "(" + InstanceParameterName + "))?.Invoke"));
             Assert.That(result.Output.hasAccessorDelegates, Is.True);
         }
 
@@ -126,7 +140,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Skipped=" + FormatSkipped(result.Output.skipped));
             string slice = SliceShimMethod(result.Output.shimSource, entry.shimMethodName);
             Assert.That(slice, Does.Not.Contain(InstanceParameterName + ".Scored"));
-            Assert.That(slice, Does.Contain(EventAccessorFieldName + "("));
+
+            // Both reads in the source stay reads: the null check and the invocation each go
+            // through the accessor, so the rewrite adds no third evaluation.
+            Assert.That(
+                CountOccurrences(slice, EventAccessorFieldName + "("),
+                Is.EqualTo(2),
+                "Two source reads must stay two accessor reads. slice=" + slice);
         }
 
         /// <summary>
@@ -357,6 +377,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             return null;
+        }
+
+        private static int CountOccurrences(string text, string fragment)
+        {
+            int count = 0;
+            for (int index = text.IndexOf(fragment, StringComparison.Ordinal);
+                index >= 0;
+                index = text.IndexOf(fragment, index + fragment.Length, StringComparison.Ordinal))
+            {
+                count++;
+            }
+
+            return count;
         }
 
         private static void AssertHasSkip(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerEventAccessorTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerEventAccessorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cd65e0aa5b7a4431989f90468df8bb34
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
@@ -34,8 +34,9 @@ for statics. Initializer expressions are limited to literals and externally visi
 static calls (`= 5`, `= Math.Abs(x)`); object creation (`= new List<int>()`) and
 anything touching the host type or instance state skips the field's readers and
 writers with a per-method reason. To apply such a field without compiling, declare it
-without an initializer and assign it lazily inside the patched method with
-`if (_field == null) { _field = new List<int>(); }`; `??=` is not rewritable and keeps
+without an initializer — it starts at `default(T)` — and assign it inside the patched
+method instead; for a reference type, guard that with
+`if (_field == null) { _field = new List<int>(); }`. `??=` is not rewritable and keeps
 the method `Skipped`. Added `const` values are folded into edited bodies as literals,
 like `nameof`. Pause-point
 `CapturedVariables` never includes added fields; `enable-pause-point` warns when the
@@ -188,8 +189,10 @@ body works, and so does raising or reading one (`E?.Invoke(x)`, `E(x)`,
 Harmony accessor, which puts that method on the delegation path. Four shapes have no
 backing field to reach and stay `Skipped` (see the table below): an event with custom
 `add`/`remove` accessors, an `abstract`/`extern`/interface event, an event whose
-delegate type is not visible outside the assembly, and an event added in this edit.
-`nameof(E)` also stays `Skipped`.
+delegate type is not visible outside the assembly, and an event added in this edit
+(including one that had custom accessors when the assembly was last compiled).
+Raising through a conditional receiver (`other?.E?.Invoke(x)`) and `nameof(E)` also
+stay `Skipped`.
 
 ## Skipped — reported per method and in `Warnings`, never flips `Success`
 
@@ -206,6 +209,7 @@ delegate type is not visible outside the assembly, and an event added in this ed
 | Property setter, init, or indexer accessor with an explicit body | Accessor patching covers getters only; `uloop compile` applies setter/init/indexer edits |
 | Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Out of scope for v1; `uloop compile` applies these edits |
 | Method raises or reads a field-like event that has no reachable backing field | Custom `add`/`remove` accessors, an `abstract`/`extern`/interface event, a delegate type that is not visible outside the assembly, or an event added in this edit leave nothing for the shim's Harmony accessor to bind |
+| Method raises or reads a field-like event through a conditional receiver (`other?.E`) | The shim has no name for the conditional receiver to pass to the accessor call |
 | Method names a field-like event inside `nameof` | The shim is a different type and cannot keep the bare event name |
 
 ## Failed — flips `Success` to `false`

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
@@ -31,9 +31,13 @@ An added field's values live in a side table that follows each instance's lifeti
 (statics live per domain). Its initializer does not run at construction time; it runs
 on the field's first access from edited code — once per instance, or once per domain
 for statics. Initializer expressions are limited to literals and externally visible
-static calls (`= 5`, `= Math.Abs(x)`); anything touching the host type or instance
-state skips the field's readers and writers with a per-method reason. Added `const`
-values are folded into edited bodies as literals, like `nameof`. Pause-point
+static calls (`= 5`, `= Math.Abs(x)`); object creation (`= new List<int>()`) and
+anything touching the host type or instance state skips the field's readers and
+writers with a per-method reason. To apply such a field without compiling, declare it
+without an initializer and assign it lazily inside the patched method with
+`if (_field == null) { _field = new List<int>(); }`; `??=` is not rewritable and keeps
+the method `Skipped`. Added `const` values are folded into edited bodies as literals,
+like `nameof`. Pause-point
 `CapturedVariables` never includes added fields; `enable-pause-point` warns when the
 resolved type has any — read them from a patched method body or
 `uloop execute-dynamic-code` instead.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
@@ -183,8 +183,13 @@ reported per-accessor as `Skipped`, so an edited accessor never disappears from 
 response silently; with a verified baseline, accessors unchanged from it produce no row.
 
 Subscribing to or unsubscribing from a field-like event (`+=`/`-=`) inside an edited
-body works. Methods that raise the event are reported as `Skipped` (see the table
-below) — raising is only expressible inside the declaring type, which a shim is not.
+body works, and so does raising or reading one (`E?.Invoke(x)`, `E(x)`,
+`if (E != null)`, `E = null`): the shim reads the event's backing field through a
+Harmony accessor, which puts that method on the delegation path. Four shapes have no
+backing field to reach and stay `Skipped` (see the table below): an event with custom
+`add`/`remove` accessors, an `abstract`/`extern`/interface event, an event whose
+delegate type is not visible outside the assembly, and an event added in this edit.
+`nameof(E)` also stays `Skipped`.
 
 ## Skipped — reported per method and in `Warnings`, never flips `Success`
 
@@ -200,7 +205,8 @@ below) — raising is only expressible inside the declaring type, which a shim i
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
 | Property setter, init, or indexer accessor with an explicit body | Accessor patching covers getters only; `uloop compile` applies setter/init/indexer edits |
 | Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Out of scope for v1; `uloop compile` applies these edits |
-| Method raises, invokes, or reads a field-like event (anything beyond `+=`/`-=`) | C# only allows `+=`/`-=` on an event outside its declaring type, so the raising body cannot compile from the shim assembly |
+| Method raises or reads a field-like event that has no reachable backing field | Custom `add`/`remove` accessors, an `abstract`/`extern`/interface event, a delegate type that is not visible outside the assembly, or an event added in this edit leave nothing for the shim's Harmony accessor to bind |
+| Method names a field-like event inside `nameof` | The shim is a different type and cannot keep the bare event name |
 
 ## Failed — flips `Success` to `false`
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AccessorAccessRegistrar.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AccessorAccessRegistrar.cs
@@ -285,10 +285,23 @@ internal static class AccessorAccessRegistrar
                 out rejectReason);
         }
 
-        if (leftSymbol is IEventSymbol)
+        if (leftSymbol is IEventSymbol eventSymbol)
         {
-            rejectReason = "inaccessible event add/remove is out of scope for accessor rewrite.";
-            return false;
+            if (EventAccessorRules.IsSubscriptionAssignment(assignment))
+            {
+                // += / -= stay on the publicized add/remove accessors, which keep the
+                // compiler's Interlocked.CompareExchange loop. Nothing to register.
+                return false;
+            }
+
+            if (!EventAccessorRules.IsBackingFieldWrite(assignment))
+            {
+                rejectReason = "compound assignment to an event has no accessor rewrite shape.";
+                return false;
+            }
+
+            plan.GetOrAddEventBackingField(eventSymbol);
+            return true;
         }
 
         return false;
@@ -405,10 +418,10 @@ internal static class AccessorAccessRegistrar
             return TryRegisterPropertyRead(propertySymbol, plan, out rejectReason);
         }
 
-        if (symbol is IEventSymbol)
+        if (symbol is IEventSymbol eventSymbol)
         {
-            rejectReason = "inaccessible event add/remove is out of scope for accessor rewrite.";
-            return false;
+            plan.GetOrAddEventBackingField(eventSymbol);
+            return true;
         }
 
         if (symbol is IMethodSymbol methodSymbol

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AccessorEntry.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AccessorEntry.cs
@@ -32,6 +32,8 @@ internal sealed class AccessorEntry
 
     public IPropertySymbol PropertySymbol { get; private set; }
 
+    public IEventSymbol EventSymbol { get; private set; }
+
     public static AccessorEntry ForField(
         IFieldSymbol fieldSymbol,
         string delegateFieldName,
@@ -88,6 +90,25 @@ internal sealed class AccessorEntry
         };
     }
 
+    /// <summary>
+    /// What: a FieldRef onto the compiler-generated backing field of a field-like event. The
+    /// backing field shares the event's name and stays private after publicizing, so the shim
+    /// reaches it by name through Harmony rather than by referencing the member.
+    /// </summary>
+    public static AccessorEntry ForEventBackingField(
+        IEventSymbol eventSymbol,
+        string delegateFieldName,
+        string registryKey)
+    {
+        return new AccessorEntry
+        {
+            Kind = AccessorKind.EventBackingFieldRef,
+            RegistryKey = registryKey,
+            DelegateFieldName = delegateFieldName,
+            EventSymbol = eventSymbol
+        };
+    }
+
     public bool TryGetVisibilityFailure(out string reason)
     {
         foreach (ITypeSymbol typeSymbol in EnumerateSignatureTypes())
@@ -131,6 +152,10 @@ internal sealed class AccessorEntry
                 yield return PropertySymbol.ContainingType;
                 yield return PropertySymbol.Type;
                 yield break;
+            case AccessorKind.EventBackingFieldRef:
+                yield return EventSymbol.ContainingType;
+                yield return EventSymbol.Type;
+                yield break;
         }
     }
 
@@ -162,6 +187,11 @@ internal sealed class AccessorEntry
             AccessorKind.PropertySetter => BuildMethodDelegateBindStatement(
                 PropertySymbol.SetMethod.Name,
                 PropertySymbol.SetMethod),
+            AccessorKind.EventBackingFieldRef => BuildBackingFieldRefBindStatement(
+                EventSymbol.ContainingType,
+                EventSymbol.Type,
+                EventSymbol.Name,
+                EventSymbol.IsStatic),
             _ => throw new InvalidOperationException("Unknown accessor kind.")
         };
 
@@ -173,21 +203,21 @@ internal sealed class AccessorEntry
         switch (Kind)
         {
             case AccessorKind.FieldRef:
-                if (FieldSymbol.IsStatic)
-                {
-                    return "global::HarmonyLib.AccessTools.FieldRef<"
-                        + TypeDisplay(FieldSymbol.Type) + ">";
-                }
-
-                return "global::HarmonyLib.AccessTools.FieldRef<"
-                    + TypeDisplay(FieldSymbol.ContainingType) + ", "
-                    + TypeDisplay(FieldSymbol.Type) + ">";
+                return BuildFieldRefTypeDisplayString(
+                    FieldSymbol.ContainingType,
+                    FieldSymbol.Type,
+                    FieldSymbol.IsStatic);
             case AccessorKind.MethodDelegate:
                 return BuildFuncOrActionType(MethodSymbol);
             case AccessorKind.PropertyGetter:
                 return BuildFuncOrActionType(PropertySymbol.GetMethod);
             case AccessorKind.PropertySetter:
                 return BuildFuncOrActionType(PropertySymbol.SetMethod);
+            case AccessorKind.EventBackingFieldRef:
+                return BuildFieldRefTypeDisplayString(
+                    EventSymbol.ContainingType,
+                    EventSymbol.Type,
+                    EventSymbol.IsStatic);
             default:
                 throw new InvalidOperationException("Unknown accessor kind.");
         }
@@ -217,21 +247,48 @@ internal sealed class AccessorEntry
 
     private string BuildFieldRefBindStatement()
     {
-        if (FieldSymbol.IsStatic)
+        return BuildBackingFieldRefBindStatement(
+            FieldSymbol.ContainingType,
+            FieldSymbol.Type,
+            FieldSymbol.Name,
+            FieldSymbol.IsStatic);
+    }
+
+    private static string BuildFieldRefTypeDisplayString(
+        INamedTypeSymbol containingType,
+        ITypeSymbol fieldType,
+        bool isStatic)
+    {
+        if (isStatic)
+        {
+            return "global::HarmonyLib.AccessTools.FieldRef<" + TypeDisplay(fieldType) + ">";
+        }
+
+        return "global::HarmonyLib.AccessTools.FieldRef<"
+            + TypeDisplay(containingType) + ", " + TypeDisplay(fieldType) + ">";
+    }
+
+    private string BuildBackingFieldRefBindStatement(
+        INamedTypeSymbol containingType,
+        ITypeSymbol fieldType,
+        string fieldName,
+        bool isStatic)
+    {
+        if (isStatic)
         {
             // Why FieldInfo: the Type+name StaticFieldRefAccess overloads return ref F,
             // not a FieldRef`1 that __BindAccessors can store.
             return DelegateFieldName + " = global::HarmonyLib.AccessTools.StaticFieldRefAccess<"
-                + TypeDisplay(FieldSymbol.Type)
+                + TypeDisplay(fieldType)
                 + ">(global::HarmonyLib.AccessTools.Field(typeof("
-                + TypeDisplay(FieldSymbol.ContainingType) + "), \""
-                + EscapeStringLiteral(FieldSymbol.Name) + "\"));";
+                + TypeDisplay(containingType) + "), \""
+                + EscapeStringLiteral(fieldName) + "\"));";
         }
 
         return DelegateFieldName + " = global::HarmonyLib.AccessTools.FieldRefAccess<"
-            + TypeDisplay(FieldSymbol.ContainingType) + ", "
-            + TypeDisplay(FieldSymbol.Type) + ">(\""
-            + EscapeStringLiteral(FieldSymbol.Name) + "\");";
+            + TypeDisplay(containingType) + ", "
+            + TypeDisplay(fieldType) + ">(\""
+            + EscapeStringLiteral(fieldName) + "\");";
     }
 
     private string BuildMethodDelegateBindStatement(string metadataName, IMethodSymbol methodSymbol)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AccessorKind.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AccessorKind.cs
@@ -20,5 +20,6 @@ internal enum AccessorKind
     FieldRef,
     MethodDelegate,
     PropertyGetter,
-    PropertySetter
+    PropertySetter,
+    EventBackingFieldRef
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AccessorPlan.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AccessorPlan.cs
@@ -86,6 +86,21 @@ internal sealed class AccessorPlan
         return entry;
     }
 
+    public AccessorEntry GetOrAddEventBackingField(IEventSymbol eventSymbol)
+    {
+        string key = "EV:" + BuildMemberKey(eventSymbol);
+        if (_byKey.TryGetValue(key, out AccessorEntry existing))
+        {
+            return existing;
+        }
+
+        string fieldName = AllocateName("__EV_" + SanitizeIdentifier(eventSymbol.Name));
+        AccessorEntry entry = AccessorEntry.ForEventBackingField(eventSymbol, fieldName, key);
+        _byKey[key] = entry;
+        _entries.Add(entry);
+        return entry;
+    }
+
     private string AllocateName(string preferred)
     {
         if (!_entries.Any(entry => entry.DelegateFieldName == preferred))

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldSkipReasons.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldSkipReasons.cs
@@ -26,9 +26,12 @@ internal static class AddedFieldSkipReasons
         + "Run 'uloop compile' to add them.";
 
     public const string InitializerNotLiteralOrExternalStatic =
-        "Added field initializer is not a literal or externally visible static member; "
-        + "the shim lambda cannot use instance, host-type, or same-file added members. "
-        + "Run 'uloop compile'.";
+        "Added field initializer is not a literal or an externally visible static member "
+        + "(object creation and instance, host-type, or same-file added members cannot run in "
+        + "the shim lambda). Drop the initializer and assign the field lazily inside the patched "
+        + "method with 'if (_field == null) { _field = ...; }' - an added field without an "
+        + "initializer applies without compiling ('??=' is not rewritable). "
+        + "Or run 'uloop compile'.";
 
     public const string FieldTypeNotExternallyVisible =
         "Added field type is not visible to the shim assembly. Run 'uloop compile'.";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldSkipReasons.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldSkipReasons.cs
@@ -28,9 +28,10 @@ internal static class AddedFieldSkipReasons
     public const string InitializerNotLiteralOrExternalStatic =
         "Added field initializer is not a literal or an externally visible static member "
         + "(object creation and instance, host-type, or same-file added members cannot run in "
-        + "the shim lambda). Drop the initializer and assign the field lazily inside the patched "
-        + "method with 'if (_field == null) { _field = ...; }' - an added field without an "
-        + "initializer applies without compiling ('??=' is not rewritable). "
+        + "the shim lambda). Drop the initializer and assign the field inside the patched method "
+        + "instead - an added field without an initializer applies without compiling and starts "
+        + "at default(T); for a reference type, guard the assignment with "
+        + "'if (_field == null) { _field = ...; }' ('??=' is not rewritable). "
         + "Or run 'uloop compile'.";
 
     public const string FieldTypeNotExternallyVisible =

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/EventAccessorRules.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/EventAccessorRules.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+/// <summary>
+/// What: decides how a body's field-like event uses are handled — rewritten through the event's
+/// backing field, left on the publicized add/remove accessors, or skipped.
+/// </summary>
+internal static class EventAccessorRules
+{
+    internal const string CustomAccessorReason =
+        "Methods that raise or read an event with custom add/remove accessors are skipped; "
+        + "there is no backing field for the shim to reach. Use uloop compile.";
+
+    internal const string NoBackingFieldReason =
+        "Methods that raise or read an abstract, extern, or interface event are skipped; "
+        + "there is no backing field for the shim to reach. Use uloop compile.";
+
+    internal const string DelegateTypeNotVisibleReason =
+        "Methods that raise or read an event whose delegate type is not visible from an external "
+        + "assembly are skipped; the shim cannot name the accessor field type. Use uloop compile.";
+
+    internal const string AddedInThisEditReason =
+        "Methods that raise a field-like event added in this edit are skipped; "
+        + "the compiled assembly has no backing field yet. Use uloop compile.";
+
+    internal const string NameofReason =
+        "Methods that name a field-like event inside nameof are skipped; the shim is a different "
+        + "type and cannot keep the bare event name. Use uloop compile.";
+
+    internal const string AccessorRewriteUnavailableReasonPrefix =
+        "Methods that raise or read a field-like event are skipped when the body cannot be "
+        + "rewritten into accessor delegates. Accessor rewrite unavailable: ";
+
+    /// <summary>
+    /// What: the skip reason for a body's event uses, or null when every use is either a
+    /// subscription (+= / -=) or rewritable through the backing field.
+    /// </summary>
+    internal static string EvaluateEventUseSkipReason(
+        SyntaxNode bodyNode,
+        SemanticModel semanticModel,
+        INamedTypeSymbol compiledType)
+    {
+        foreach (EventUse use in EnumerateEventUses(bodyNode, semanticModel))
+        {
+            if (use.IsSubscription)
+            {
+                continue;
+            }
+
+            if (NameofRules.IsInsideNameofArgument(use.Node))
+            {
+                return NameofReason;
+            }
+
+            string reason = EvaluateEventSkipReason(use.EventSymbol, compiledType);
+            if (reason != null)
+            {
+                return reason;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// What: whether the body needs the event rewrite, which forces delegation even when nothing
+    /// else in the body is inaccessible (a transplanted shim would not compile).
+    /// </summary>
+    internal static bool BodyRequiresEventAccessors(SyntaxNode bodyNode, SemanticModel semanticModel)
+    {
+        foreach (EventUse use in EnumerateEventUses(bodyNode, semanticModel))
+        {
+            if (!use.IsSubscription && !NameofRules.IsInsideNameofArgument(use.Node))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// What: whether an assignment writes the event's backing field (E = handler) rather than
+    /// subscribing to it. += / -= keep the publicized add/remove accessors so the compiler's
+    /// Interlocked.CompareExchange loop is preserved.
+    /// </summary>
+    internal static bool IsBackingFieldWrite(AssignmentExpressionSyntax assignment)
+    {
+        return assignment.IsKind(SyntaxKind.SimpleAssignmentExpression);
+    }
+
+    internal static bool IsSubscriptionAssignment(AssignmentExpressionSyntax assignment)
+    {
+        return assignment.IsKind(SyntaxKind.AddAssignmentExpression)
+            || assignment.IsKind(SyntaxKind.SubtractAssignmentExpression);
+    }
+
+    private static string EvaluateEventSkipReason(IEventSymbol eventSymbol, INamedTypeSymbol compiledType)
+    {
+        if (eventSymbol.IsAbstract || eventSymbol.IsExtern || eventSymbol.ContainingType.TypeKind == TypeKind.Interface)
+        {
+            return NoBackingFieldReason;
+        }
+
+        // A custom add/remove event has no compiler-generated backing field to reach. C# also
+        // rejects raising one from source (CS0079), so this is a guard, not a reachable path.
+        if (HasCustomAccessors(eventSymbol))
+        {
+            return CustomAccessorReason;
+        }
+
+        if (!AccessibilityRules.IsExternallyVisibleType(eventSymbol.Type)
+            || !AccessibilityRules.IsExternallyVisibleType(eventSymbol.ContainingType))
+        {
+            return DelegateTypeNotVisibleReason;
+        }
+
+        if (!CompiledEventExists(eventSymbol, compiledType))
+        {
+            return AddedInThisEditReason;
+        }
+
+        return null;
+    }
+
+    private static bool HasCustomAccessors(IEventSymbol eventSymbol)
+    {
+        foreach (SyntaxReference reference in eventSymbol.DeclaringSyntaxReferences)
+        {
+            if (reference.GetSyntax() is EventDeclarationSyntax)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool CompiledEventExists(IEventSymbol eventSymbol, INamedTypeSymbol compiledType)
+    {
+        // Raising is only legal inside the declaring type, so the event always belongs to the
+        // type currently being emitted; anything else is treated as not proven present.
+        if (compiledType == null)
+        {
+            return false;
+        }
+
+        foreach (ISymbol member in compiledType.GetMembers(eventSymbol.Name))
+        {
+            if (member is IEventSymbol compiledEvent && compiledEvent.IsStatic == eventSymbol.IsStatic)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<EventUse> EnumerateEventUses(SyntaxNode bodyNode, SemanticModel semanticModel)
+    {
+        foreach (SyntaxNode node in bodyNode.DescendantNodesAndSelf())
+        {
+            if (node is not IdentifierNameSyntax && node is not MemberAccessExpressionSyntax)
+            {
+                continue;
+            }
+
+            IEventSymbol eventSymbol = semanticModel.GetSymbolInfo(node).Symbol as IEventSymbol;
+            if (eventSymbol == null)
+            {
+                continue;
+            }
+
+            // this.E / instance.E resolve the same event on the IdentifierName and the outer
+            // MemberAccess; judge usage on the outer expression only.
+            SyntaxNode effective = node;
+            if (node.Parent is MemberAccessExpressionSyntax parentAccess && parentAccess.Name == node)
+            {
+                effective = parentAccess;
+            }
+
+            bool isSubscription = effective.Parent is AssignmentExpressionSyntax assignment
+                && IsSubscriptionAssignment(assignment)
+                && assignment.Left == effective;
+            yield return new EventUse(effective, eventSymbol, isSubscription);
+        }
+    }
+
+    private readonly struct EventUse
+    {
+        internal EventUse(SyntaxNode node, IEventSymbol eventSymbol, bool isSubscription)
+        {
+            Node = node;
+            EventSymbol = eventSymbol;
+            IsSubscription = isSubscription;
+        }
+
+        internal SyntaxNode Node { get; }
+
+        internal IEventSymbol EventSymbol { get; }
+
+        internal bool IsSubscription { get; }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/EventAccessorRules.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/EventAccessorRules.cs
@@ -41,6 +41,11 @@ internal static class EventAccessorRules
         "Methods that name a field-like event inside nameof are skipped; the shim is a different "
         + "type and cannot keep the bare event name. Use uloop compile.";
 
+    internal const string ConditionalReceiverReason =
+        "Methods that raise or read a field-like event through a conditional receiver "
+        + "('a?.E') are skipped; the shim cannot name the conditional receiver as the accessor "
+        + "call's argument. Use uloop compile.";
+
     internal const string AccessorRewriteUnavailableReasonPrefix =
         "Methods that raise or read a field-like event are skipped when the body cannot be "
         + "rewritten into accessor delegates. Accessor rewrite unavailable: ";
@@ -64,6 +69,13 @@ internal static class EventAccessorRules
             if (NameofRules.IsInsideNameofArgument(use.Node))
             {
                 return NameofReason;
+            }
+
+            // 'a?.E' binds the event on a receiver the shim has no name for, so the accessor
+            // call cannot be built and the raw event access would reach the shim source.
+            if (use.Node is MemberBindingExpressionSyntax)
+            {
+                return ConditionalReceiverReason;
             }
 
             string reason = EvaluateEventSkipReason(use.EventSymbol, compiledType);
@@ -129,7 +141,7 @@ internal static class EventAccessorRules
             return DelegateTypeNotVisibleReason;
         }
 
-        if (!CompiledEventExists(eventSymbol, compiledType))
+        if (!CompiledBackingFieldExists(eventSymbol, compiledType))
         {
             return AddedInThisEditReason;
         }
@@ -150,7 +162,11 @@ internal static class EventAccessorRules
         return false;
     }
 
-    private static bool CompiledEventExists(IEventSymbol eventSymbol, INamedTypeSymbol compiledType)
+    // Harmony looks the backing field up by the event's own name, so the compiled event must
+    // still be field-like and carry the same delegate type. The field itself is not visible:
+    // metadata symbols expose only accessible members, and the backing field stays private.
+    // A compiler-generated add accessor is the metadata evidence that the field exists.
+    private static bool CompiledBackingFieldExists(IEventSymbol eventSymbol, INamedTypeSymbol compiledType)
     {
         // Raising is only legal inside the declaring type, so the event always belongs to the
         // type currently being emitted; anything else is treated as not proven present.
@@ -159,9 +175,37 @@ internal static class EventAccessorRules
             return false;
         }
 
+        string eventTypeDisplay = eventSymbol.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
         foreach (ISymbol member in compiledType.GetMembers(eventSymbol.Name))
         {
-            if (member is IEventSymbol compiledEvent && compiledEvent.IsStatic == eventSymbol.IsStatic)
+            if (member is not IEventSymbol compiledEvent
+                || compiledEvent.IsStatic != eventSymbol.IsStatic
+                || compiledEvent.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+                    != eventTypeDisplay)
+            {
+                continue;
+            }
+
+            if (HasCompilerGeneratedAccessor(compiledEvent))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasCompilerGeneratedAccessor(IEventSymbol compiledEvent)
+    {
+        if (compiledEvent.AddMethod == null)
+        {
+            return false;
+        }
+
+        foreach (AttributeData attribute in compiledEvent.AddMethod.GetAttributes())
+        {
+            if (attribute.AttributeClass != null
+                && attribute.AttributeClass.Name == "CompilerGeneratedAttribute")
             {
                 return true;
             }
@@ -191,6 +235,10 @@ internal static class EventAccessorRules
             if (node.Parent is MemberAccessExpressionSyntax parentAccess && parentAccess.Name == node)
             {
                 effective = parentAccess;
+            }
+            else if (node.Parent is MemberBindingExpressionSyntax parentBinding && parentBinding.Name == node)
+            {
+                effective = parentBinding;
             }
 
             bool isSubscription = effective.Parent is AssignmentExpressionSyntax assignment

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/EventAccessorRules.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/EventAccessorRules.cs
@@ -204,8 +204,11 @@ internal static class EventAccessorRules
 
         foreach (AttributeData attribute in compiledEvent.AddMethod.GetAttributes())
         {
+            // Full name, not the short one: a user-defined CompilerGeneratedAttribute must not
+            // pass for the framework marker the C# compiler emits on field-like accessors.
             if (attribute.AttributeClass != null
-                && attribute.AttributeClass.Name == "CompilerGeneratedAttribute")
+                && attribute.AttributeClass.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+                    == "global::System.Runtime.CompilerServices.CompilerGeneratedAttribute")
             {
                 return true;
             }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/EventAccessorShimRewrite.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/EventAccessorShimRewrite.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+/// <summary>
+/// What: rewrites a field-like event's raise, read, and clear into calls on the Harmony
+/// backing-field accessor. C# only allows += / -= on an event outside its declaring type, so a
+/// shim that kept the event member would not compile.
+/// </summary>
+internal static class EventAccessorShimRewrite
+{
+    /// <summary>
+    /// What: an event read as a value — '((TDelegate)__EV_E(instance))'. The cast collapses the
+    /// accessor's ref return to a single read, so 'E?.Invoke()' keeps its read-once semantics
+    /// instead of reading the field again for the call.
+    /// </summary>
+    internal static ExpressionSyntax CreateEventRead(AccessorEntry entry, ExpressionSyntax visitedReceiver)
+    {
+        ExpressionSyntax accessorCall = CreateAccessorCall(entry, visitedReceiver);
+        TypeSyntax delegateType = SyntaxFactory.ParseTypeName(
+            entry.EventSymbol.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+        return SyntaxFactory.ParenthesizedExpression(
+            SyntaxFactory.CastExpression(delegateType, accessorCall));
+    }
+
+    /// <summary>
+    /// What: 'E = handler' as a write through the accessor's ref return, mirroring the
+    /// inaccessible-field assignment shape.
+    /// </summary>
+    internal static ExpressionSyntax CreateEventWriteTarget(
+        AccessorEntry entry,
+        ExpressionSyntax visitedReceiver)
+    {
+        return CreateAccessorCall(entry, visitedReceiver);
+    }
+
+    private static ExpressionSyntax CreateAccessorCall(AccessorEntry entry, ExpressionSyntax visitedReceiver)
+    {
+        if (entry.EventSymbol.IsStatic)
+        {
+            return HarmonyAccessorShimRewrite.CreateDelegateInvocation(
+                entry.DelegateFieldName,
+                Array.Empty<ExpressionSyntax>());
+        }
+
+        return HarmonyAccessorShimRewrite.CreateDelegateInvocation(
+            entry.DelegateFieldName,
+            new[] { visitedReceiver });
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/HarmonyAccessorShimRewrite.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/HarmonyAccessorShimRewrite.cs
@@ -94,6 +94,16 @@ internal sealed class HarmonyAccessorShimRewrite
                 .WithTriviaFrom(triviaSource);
         }
 
+        // Every field-like event read goes through the backing field, even a public one: C#
+        // rejects reading an event outside its declaring type regardless of accessibility.
+        if (symbol is IEventSymbol eventSymbol)
+        {
+            AccessorEntry eventEntry = _rewriter._accessorPlan.GetOrAddEventBackingField(eventSymbol);
+            return EventAccessorShimRewrite
+                .CreateEventRead(eventEntry, _rewriter.VisitReceiver(receiverSyntax))
+                .WithTriviaFrom(triviaSource);
+        }
+
         if (symbol is IPropertySymbol propertySymbol
             && !propertySymbol.IsIndexer
             && !propertySymbol.IsStatic

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/MethodTransformDecider.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/MethodTransformDecider.cs
@@ -24,7 +24,8 @@ internal static class MethodTransformDecider
         MethodDeclarationSyntax methodDeclaration,
         IMethodSymbol methodSymbol,
         SyntaxNode bodyNode,
-        SemanticModel semanticModel)
+        SemanticModel semanticModel,
+        INamedTypeSymbol compiledType)
     {
         string hardSkip = EvaluateHardSkipReason(
             typeDeclaration,
@@ -47,7 +48,10 @@ internal static class MethodTransformDecider
                 "Methods that call base. members are skipped; C# cannot express base calls outside the type.");
         }
 
-        string eventUseReason = EvaluateEventUseSkipReason(bodyNode, semanticModel);
+        string eventUseReason = EventAccessorRules.EvaluateEventUseSkipReason(
+            bodyNode,
+            semanticModel,
+            compiledType);
         if (eventUseReason != null)
         {
             return MethodTransformDecision.Skip(eventUseReason);
@@ -58,18 +62,17 @@ internal static class MethodTransformDecider
             FindClosureBodies(bodyNode));
         bool asyncIteratorInaccessible = IsAsyncOrIterator(methodDeclaration, bodyNode)
             && InaccessibleAccessScanner.SubtreeHasInaccessibleMemberAccess(semanticModel, new[] { bodyNode });
+        // Why delegation is forced: a transplanted shim body still has to compile as C#, and C#
+        // rejects raising or reading an event outside its declaring type whatever its visibility.
+        bool eventAccessorsRequired = EventAccessorRules.BodyRequiresEventAccessors(bodyNode, semanticModel);
 
-        if (!closureInaccessible && !asyncIteratorInaccessible)
+        if (!closureInaccessible && !asyncIteratorInaccessible && !eventAccessorsRequired)
         {
             return MethodTransformDecision.Transplant();
         }
 
         // Condition (a): only the v1 private-access skip reasons are eligible for accessor rewrite.
-        string v1Reason = closureInaccessible
-            ? "Lambda, local-function, or query-expression bodies that access private/internal members "
-                + "are skipped in v1 (closure methods JIT-compile normally and fail accessibility checks)."
-            : "Async or iterator methods whose bodies access private/internal members are skipped in v1 "
-                + "(state-machine MoveNext JIT-compiles normally and fails accessibility checks).";
+        string v1Reason = BuildAccessorRescueReason(closureInaccessible, asyncIteratorInaccessible);
 
         if (!AccessorEligibility.TryBuildPlan(
                 semanticModel,
@@ -80,17 +83,37 @@ internal static class MethodTransformDecider
                 out string accessorRejectReason))
         {
             return MethodTransformDecision.Skip(
-                v1Reason + " Accessor rewrite unavailable: " + accessorRejectReason);
+                v1Reason == null
+                    ? EventAccessorRules.AccessorRewriteUnavailableReasonPrefix + accessorRejectReason
+                    : v1Reason + " Accessor rewrite unavailable: " + accessorRejectReason);
         }
 
         // Safety net: detection said "needs accessors" but eligibility found nothing to rewrite
         // (e.g. local-function-only async body). Transplant is correct — the body is unchanged.
-        if (feasibilityPlan.Entries.Count == 0)
+        if (feasibilityPlan.Entries.Count == 0 && !eventAccessorsRequired)
         {
             return MethodTransformDecision.Transplant();
         }
 
         return MethodTransformDecision.Delegation();
+    }
+
+    // Null when the body needs accessors only for its event uses: there is no v1 skip to rescue.
+    private static string BuildAccessorRescueReason(bool closureInaccessible, bool asyncIteratorInaccessible)
+    {
+        if (closureInaccessible)
+        {
+            return "Lambda, local-function, or query-expression bodies that access private/internal members "
+                + "are skipped in v1 (closure methods JIT-compile normally and fail accessibility checks).";
+        }
+
+        if (asyncIteratorInaccessible)
+        {
+            return "Async or iterator methods whose bodies access private/internal members are skipped in v1 "
+                + "(state-machine MoveNext JIT-compiles normally and fails accessibility checks).";
+        }
+
+        return null;
     }
 
     internal static string EvaluateHardSkipReason(
@@ -127,51 +150,6 @@ internal static class MethodTransformDecider
         if (methodDeclaration != null && methodDeclaration.ExplicitInterfaceSpecifier != null)
         {
             return "Explicit interface implementations are skipped in v1.";
-        }
-
-        return null;
-    }
-
-    // Why skip event uses beyond +=/-=: outside the declaring type C# only allows those
-    // assignments, so a shim cannot compile Raise/Invoke/read. nameof(ScoreChanged) and
-    // similar non-runtime references are also skipped — Skip is an honest report and safer
-    // than a compile failure.
-    internal static string EvaluateEventUseSkipReason(SyntaxNode bodyNode, SemanticModel semanticModel)
-    {
-        foreach (SyntaxNode node in bodyNode.DescendantNodesAndSelf())
-        {
-            if (node is not IdentifierNameSyntax && node is not MemberAccessExpressionSyntax)
-            {
-                continue;
-            }
-
-            IEventSymbol eventSymbol = semanticModel.GetSymbolInfo(node).Symbol as IEventSymbol;
-            if (eventSymbol == null)
-            {
-                continue;
-            }
-
-            // this.E / instance.E resolve the same event on the IdentifierName and the outer
-            // MemberAccess; judge usage on the outer expression only.
-            SyntaxNode effective = node;
-            if (node.Parent is MemberAccessExpressionSyntax parentAccess && parentAccess.Name == node)
-            {
-                effective = parentAccess;
-            }
-
-            // += / -= on the left-hand side are the only event operations C# allows outside the
-            // declaring type.
-            if (effective.Parent is AssignmentExpressionSyntax assignment
-                && (assignment.IsKind(SyntaxKind.AddAssignmentExpression)
-                    || assignment.IsKind(SyntaxKind.SubtractAssignmentExpression))
-                && assignment.Left == effective)
-            {
-                continue;
-            }
-
-            return "Methods that raise, invoke, or read a field-like event are skipped; "
-                + "C# only allows += / -= on an event outside its declaring type, so the "
-                + "shim cannot compile this body. Use uloop compile.";
         }
 
         return null;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OrdinaryMethodQueue.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OrdinaryMethodQueue.cs
@@ -303,7 +303,8 @@ internal static class OrdinaryMethodQueue
                 methodDeclaration,
                 methodSymbol,
                 methodBodyNode,
-                semanticModel);
+                semanticModel,
+                typeState.CompiledType);
         if (isAddedMethod && decision.SkipReason == null)
         {
             decision = MethodTransformDecider.DecideAddedMethodAccessors(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterClassifier.cs
@@ -91,6 +91,7 @@ internal static class PropertyGetterClassifier
         IMethodSymbol getterSymbol,
         SyntaxNode getterBodyNode,
         SemanticModel semanticModel,
+        INamedTypeSymbol compiledType,
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog,
         List<WorkerSkipped> skipped)
@@ -101,7 +102,8 @@ internal static class PropertyGetterClassifier
             methodDeclaration: null,
             getterSymbol,
             getterBodyNode,
-            semanticModel);
+            semanticModel,
+            compiledType);
         if (decision.SkipReason != null)
         {
             skipped.Add(new WorkerSkipped

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
@@ -50,6 +50,7 @@ internal static class PropertyGetterEmitter
                     propertyDeclaration,
                     typeState.TypeDeclaration,
                     typeState.TypeSymbol,
+                    typeState.CompiledType,
                     typeState.TypeMetadataNameFromSyntax,
                     semanticModel,
                     root,
@@ -81,6 +82,7 @@ internal static class PropertyGetterEmitter
             PropertyDeclarationSyntax propertyDeclaration,
             TypeDeclarationSyntax typeDeclaration,
             INamedTypeSymbol typeSymbol,
+            INamedTypeSymbol compiledType,
             string typeMetadataNameFromSyntax,
             SemanticModel semanticModel,
             CompilationUnitSyntax root,
@@ -175,6 +177,7 @@ internal static class PropertyGetterEmitter
             getterSymbol,
             getterBodyNode,
             semanticModel,
+            compiledType,
             addedMethodCatalog,
             addedFieldCatalog,
             skipped);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimBodyRewriter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimBodyRewriter.cs
@@ -309,6 +309,19 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
             return HarmonyAccessors.RewritePropertyAssignment(node, propertySymbol);
         }
 
+        if (leftSymbol is IEventSymbol eventSymbol
+            && EventAccessorRules.IsBackingFieldWrite(node))
+        {
+            AccessorEntry eventEntry = _accessorPlan.GetOrAddEventBackingField(eventSymbol);
+            ExpressionSyntax eventTarget = EventAccessorShimRewrite.CreateEventWriteTarget(
+                eventEntry,
+                VisitReceiver(ExtractReceiver(node.Left)));
+            return node
+                .WithLeft(eventTarget)
+                .WithRight((ExpressionSyntax)Visit(node.Right))
+                .WithTriviaFrom(node);
+        }
+
         if (leftSymbol is IFieldSymbol fieldSymbol
             && !fieldSymbol.IsConst
             && AccessibilityRules.IsInaccessibleFromExternalAssembly(fieldSymbol))

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitPlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitPlanner.cs
@@ -145,6 +145,8 @@ internal static class TypeEmitPlanner
             return (shimTypeCounter, globalShimMethodCounter);
         }
 
+        typeState.CompiledType = compiledType;
+
         AddedFieldClassifier.ClassifyAddedFields(
             typeState,
             semanticModel,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitState.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitState.cs
@@ -21,6 +21,10 @@ internal sealed class TypeEmitState
 
     public INamedTypeSymbol TypeSymbol { get; set; }
 
+    // The matching type in the compiled assembly, or null when the type is not compiled yet.
+    // Event rewrites need it to tell an event added in this edit from one with a backing field.
+    public INamedTypeSymbol CompiledType { get; set; }
+
     public string TypeMetadataNameFromSyntax { get; set; }
 
     public ShimTypeBuilder CurrentShimType { get; set; }


### PR DESCRIPTION
## Summary

Two separate hot-reload gaps that both left an edit unapplied with no way forward short of a full compile.

- A method that raises or reads a field-like event was always `Skipped`. C# only allows `+=` / `-=` on an event outside its declaring type, so the generated shim body could not compile. The shim now reads the event's backing field through a Harmony accessor and the method is patched as a delegation entry.
- An added field with an initializer the shim lambda cannot run was `Skipped` with a reason that named no way out, even though the same field applies fine with no initializer and a lazy assignment in the patched body. The reason now names that workaround, and the skill documents it.

## User Impact

- Editing a method that raises an event (`E?.Invoke(x)`, `E(x)`, `if (E != null) E(x)`, `E = null`, static events) now hot-reloads instead of reporting `Skipped`.
- Subscriptions (`+=` / `-=`) keep using the publicized add/remove accessors, so the compiler's `Interlocked.CompareExchange` semantics are preserved.
- Events with no reachable backing field still report `Skipped`, but with a reason that says which case applies: custom add/remove accessors, an `abstract`/`extern`/interface event, a delegate type not visible outside the assembly, an event added in this edit, or `nameof`.
- An added field whose initializer cannot run in the shim lambda now gets a reason that tells the user to drop the initializer and assign lazily, and warns that `??=` is not rewritable.

## Changes

- New `EventAccessorRules.cs`: classifies event uses in a body, decides which assignment kinds register an accessor, and owns the skip-reason strings.
- New `EventAccessorShimRewrite.cs`: emits `((TDelegate)__EV_E(instance))` for a read (the cast collapses the ref return to one read, keeping `E?.Invoke()` read-once) and `__EV_E(instance)` as the write target.
- `AccessorKind` / `AccessorEntry` / `AccessorPlan`: new `EventBackingFieldRef` entries bound with `AccessTools.FieldRefAccess<Host, TDelegate>("E")` (`StaticFieldRefAccess` for a static event). The backing field's `IFieldSymbol` is never needed - the event symbol supplies containing type, delegate type, name, and staticness.
- `AccessorAccessRegistrar`: event reads and `E = null` register an accessor; `+=` / `-=` are allowed through untouched; other compound assignments keep being rejected.
- `MethodTransformDecider`: a body with an event use is never transplanted (a transplanted shim body still has to compile as C#), and the accessor-rescue reason is now optional so an event-only body gets its own "accessor rewrite unavailable" prefix.
- `TypeEmitState.CompiledType` threads the compiled type into the decider so an event added in this edit can be told apart from one with a backing field.
- `AddedFieldSkipReasons.InitializerNotLiteralOrExternalStatic` now names the lazy-assignment workaround.
- Skill reference `scope-and-limits.md` (and the generated `.claude` / `.agents` copies) updated for both halves.

## Reproduction

Before the fix, editing `HotReloadEventFixture.RaiseScore` (which does `ScoreChanged?.Invoke()`):

```
"Kind": "Skipped",
"Reason": "Methods that raise, invoke, or read a field-like event are skipped; C# only allows += / -= on an event outside its declaring type, so the shim cannot compile this body. Use uloop compile."
```

Adding `private Dictionary<string, int> _counters = new Dictionary<string, int>();` and using it:

```
"Kind": "Skipped",
"Reason": "Added field initializer is not a literal or an externally visible static member (object creation and instance, host-type, or same-file added members cannot run in the shim lambda). Or run 'uloop compile'."
```

## Verification

Real Editor, same edits, after the fix.

Raising method now patches:

```
"Kind": "Patched",
"Method": "...HotReloadEventFixture.RaiseScore()",
"PatchedTotal": 1, "ActivePatchTotal": 1, "Success": true
```

Added field with an unrunnable initializer now names the workaround:

```
"Reason": "Added field initializer is not a literal or an externally visible static member (...). Drop the initializer and assign the field lazily inside the patched method with 'if (_field == null) { _field = ...; }' - an added field without an initializer applies without compiling ('??=' is not rewritable). Or run 'uloop compile'."
```

Following that advice applies:

```
"Kind": "Patched", "AddedFieldTotal": 1,
"AddedFields": ["...HotReloadEventFixture._counters"]
```

EditMode tests (filtered to the changed classes):

- `TransformWorkerEventAccessorTests` - 9/9 passed (new class)
- `TransformWorker.*Tests` - 181/181 passed
- `HotReloadOrchestratorTests` - 148/148 passed
- `TransformWorkerAddedFieldTests` + `ReferencePublicizerTests` - 66/66 passed

Gates: the C# code-complexity host reports no findings above 15; `check-skill-size` and `sync-tool-docs --check` are both clean; every changed worker file stays under 500 SLOC.

Known limitation, deliberate: the custom-add/remove and abstract/extern/interface event cases cannot be reached from C# source (CS0079 forbids raising or reading such an event even inside the declaring type), so they are defensive guards without a source-level test.

Closes #2556
Closes #2550


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

