### PR TITLE
chore: add cubic.yaml to stop cubic reviewing generated skill copies

### DIFF
--- a/cubic.yaml
+++ b/cubic.yaml
@@ -32,8 +32,12 @@ reviews:
     the source is edited first and the copies are regenerated in the same
     commit, so both sides appear in the diff together. Review the source file.
 
-    The same holds for `cli/common/tools/default-tools.json`, which is
-    generated from the skill parameter tables by `scripts/sync-tool-docs.sh`.
+    `cli/common/tools/default-tools.json` is a narrower case. Only the
+    description strings in it are generated from the skill parameter tables by
+    `scripts/sync-tool-docs.sh`; treat those as belonging to the skill source.
+    Everything else in that catalog — option names, JSON types, defaults,
+    required flags, enum values — is hand-authored, so review it normally and
+    do report a defect there.
 
     ## The bar for a comment
 

--- a/cubic.yaml
+++ b/cubic.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://cubic.dev/schema/cubic-repository-config.schema.json
+
+# cubic.yaml — versioned configuration for the cubic AI reviewer.
+# Settings here take precedence over the cubic dashboard UI settings, and any
+# field left unset falls through to the UI value. Keep this file minimal so the
+# dashboard stays usable for everything it does not need to pin.
+# Reference: https://docs.cubic.dev/configure/cubic-yaml
+
+version: 1
+
+reviews:
+  ignore:
+    # Generated skill copies. `uloop skills install --claude --agents` rewrites
+    # these wholesale from the sources under Packages/src/Editor, so a finding
+    # here can never be actioned in place — it belongs on the source file, which
+    # is part of the same pull request and reviewed on its own.
+    # Scoped to the generated subtree on purpose: a hand-written file such as
+    # .claude/settings.json (hooks, permissions) must stay reviewable.
+    files:
+      - '.agents/skills/**'
+      - '.claude/skills/**'
+
+  custom_instructions: |-
+    ## Generated skill copies
+
+    Everything under `.agents/skills/` and `.claude/skills/` is a generated
+    copy of a skill source under `Packages/src/Editor/`, produced by
+    `uloop skills install`.
+    The copies are committed on purpose and are always regenerated, never
+    edited by hand. Never report a change to those paths as a direct edit of a
+    generated file, and never ask for the change to be relocated to the source:
+    the source is edited first and the copies are regenerated in the same
+    commit, so both sides appear in the diff together. Review the source file.
+
+    The same holds for `cli/common/tools/default-tools.json`, which is
+    generated from the skill parameter tables by `scripts/sync-tool-docs.sh`.
+
+    ## The bar for a comment
+
+    State the concrete failure — the input, state, or sequence that makes the
+    code wrong — and then the fix. A finding that cannot name what breaks is
+    not worth a round trip.
+
+    Do not open a thread whose only subject is comment wording, indentation,
+    whitespace, trailing spaces, or documentation phrasing. Prose is worth a
+    comment only when it is factually wrong about how the code behaves: a
+    documented contract that the implementation does not honor, a stated output
+    format that the code does not produce, or guidance that contradicts another
+    document. Report that as the behavioral mismatch it is, not as a wording
+    preference.


### PR DESCRIPTION
## Why

Over the last 25 merged pull requests the cubic AI reviewer posted 87 top-level findings (P1 4 / P2 51 / P3 32). Roughly three quarters of the ones we replied to were adopted, so the reviewer earns its place — but two classes of finding were pure noise and cost a reply every time.

**1. A repeated false positive about generated files.** cubic reads a change under `.agents/skills/` or `.claude/skills/` as a direct edit of a generated file and asks for it to be relocated to the source. It raised this on #2586, #2579 and #2577, and the answer was the same each time: those copies are produced by `uloop skills install`, and the source under `Packages/src/Editor/` is edited first in the very same commit, so there is nothing to move.

**2. P3 nits whose only subject is wording.** Comment indentation, trailing spaces inside a code span, documentation phrasing.

## What

Adds `cubic.yaml`, cubic's documented in-repository configuration. It takes precedence over the dashboard UI, so both fixes are versioned alongside the code rather than living in a web console where they are invisible to review.

| Key | Effect |
| --- | --- |
| `reviews.ignore.files` | Skips `.agents/skills/**` and `.claude/skills/**` entirely. |
| `reviews.custom_instructions` | Explains the generation flow, and raises the bar for a comment. |

Two deliberate choices:

- **The globs stop at `skills/`,** not `.claude/**`. Every one of the 78 tracked files happens to sit under `skills/` today, but a hand-written `.claude/settings.json` carries hooks and permissions and must stay reviewable. Scoping the pattern means a future one cannot slip past review unnoticed.
- **The instruction still asks for prose findings when the text is factually wrong about behaviour** — a documented contract the implementation does not honour, a stated output format the code does not produce, guidance that contradicts another document. Those were being adopted (#2588, #2580, #2570) and are worth keeping. Only the pure wording and indentation nits are ruled out.

`cli/common/tools/default-tools.json` is named in the instructions too, since it is generated by `scripts/sync-tool-docs.sh` and is open to the same misreading.

## Chosen over `.gitattributes`

Marking the paths `linguist-generated=true` reaches the same exclusion and is the route the AI-review settings page documents, but it also makes **GitHub collapse all 78 generated skill diffs** for human reviewers. Given how much of this repository's discipline is about skill content being correct, degrading human review to fix a bot problem is the wrong trade. `cubic.yaml` achieves the exclusion with no effect on the GitHub diff view, and carries the review instructions as well, which `.gitattributes` cannot.

## Verification

- Validated against the official schema (`https://cubic.dev/schema/cubic-repository-config.schema.json`) — passes; `reviews` is `additionalProperties: false`, so every key here is confirmed real rather than guessed.
- Every path named in the file exists in the tree.
- `check-release-triggers --base origin/main` passes; `cubic.yaml` is not a shared release input.
- No yamllint in CI; `*.yaml` is already pinned to LF by `.gitattributes`.

## Not covered here

cubic exposes no P3 or severity filter — `reviews.sensitivity` (`low`/`medium`/`high`) is the only such lever, and it is left unset so the current dashboard value stands. The wording noise is addressed through `custom_instructions` instead. Dashboard **Ignore patterns** and **Review instructions** now need no manual edit: this file overrides both.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

