### PR TITLE
fix: build .uloop/outputs paths with the native separator on Windows

### DIFF
--- a/Assets/Tests/Editor/OutputDirectoryConstantsTests.cs
+++ b/Assets/Tests/Editor/OutputDirectoryConstantsTests.cs
@@ -1,0 +1,51 @@
+#nullable enable
+using System.IO;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies output-directory constants stay separator-free so Path.Combine supplies the platform separator.
+    /// </summary>
+    [TestFixture]
+    public sealed class OutputDirectoryConstantsTests
+    {
+        private const string NoEmbeddedSeparatorMessage =
+            "Segments must not embed a separator; Path.Combine supplies the platform separator on Windows.";
+
+        /// <summary>
+        /// Verifies OUTPUT_ROOT_DIR equals Path.Combine of ULOOP_DIR and OUTPUTS_DIR.
+        /// </summary>
+        [Test]
+        public void OutputRootDir_IsBuiltFromSeparatorFreeSegments()
+        {
+            string expected = Path.Combine(UnityCliLoopConstants.ULOOP_DIR, UnityCliLoopConstants.OUTPUTS_DIR);
+            Assert.That(UnityCliLoopConstants.OUTPUT_ROOT_DIR, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// Verifies each output-directory segment constant contains neither '/' nor '\'.
+        /// </summary>
+        [Test]
+        public void OutputDirectorySegments_ContainNoPathSeparators()
+        {
+            AssertSegmentHasNoPathSeparator(nameof(UnityCliLoopConstants.ULOOP_DIR), UnityCliLoopConstants.ULOOP_DIR);
+            AssertSegmentHasNoPathSeparator(nameof(UnityCliLoopConstants.OUTPUTS_DIR), UnityCliLoopConstants.OUTPUTS_DIR);
+            AssertSegmentHasNoPathSeparator(nameof(UnityCliLoopConstants.TEST_RESULTS_DIR), UnityCliLoopConstants.TEST_RESULTS_DIR);
+            AssertSegmentHasNoPathSeparator(nameof(UnityCliLoopConstants.HIERARCHY_RESULTS_DIR), UnityCliLoopConstants.HIERARCHY_RESULTS_DIR);
+            AssertSegmentHasNoPathSeparator(nameof(UnityCliLoopConstants.FIND_GAMEOBJECTS_RESULTS_DIR), UnityCliLoopConstants.FIND_GAMEOBJECTS_RESULTS_DIR);
+            AssertSegmentHasNoPathSeparator(nameof(UnityCliLoopConstants.SCREENSHOTS_DIR), UnityCliLoopConstants.SCREENSHOTS_DIR);
+            AssertSegmentHasNoPathSeparator(nameof(UnityCliLoopConstants.VIBE_LOGS_DIR), UnityCliLoopConstants.VIBE_LOGS_DIR);
+            AssertSegmentHasNoPathSeparator(nameof(RecordInputConstants.INPUT_RECORDINGS_DIR), RecordInputConstants.INPUT_RECORDINGS_DIR);
+        }
+
+        private static void AssertSegmentHasNoPathSeparator(string name, string value)
+        {
+            Assert.That(value, Does.Not.Contain("/"), NoEmbeddedSeparatorMessage + " (" + name + ")");
+            Assert.That(value, Does.Not.Contain("\\"), NoEmbeddedSeparatorMessage + " (" + name + ")");
+        }
+    }
+}

--- a/Assets/Tests/Editor/OutputDirectoryConstantsTests.cs
+++ b/Assets/Tests/Editor/OutputDirectoryConstantsTests.cs
@@ -1,5 +1,7 @@
 #nullable enable
+using System;
 using System.IO;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
@@ -15,6 +17,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     {
         private const string NoEmbeddedSeparatorMessage =
             "Segments must not embed a separator; Path.Combine supplies the platform separator on Windows.";
+        private const string ConstantsSourceRelativePath =
+            "Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs";
+        private const string FileOutputDirectoriesMarker = "// File output directories";
+        private const string OutputRootDirCombineDeclarationPattern =
+            @"static\s+readonly\s+string\s+OUTPUT_ROOT_DIR\s*=\s*Path\.Combine\(";
+        private const string StringLiteralPattern = "\"([^\"\\\\]|\\\\.)*\"";
+        private const string SourceDeclarationRequiredMessage =
+            "OUTPUT_ROOT_DIR must be declared as Path.Combine in source. Runtime equality cannot catch a revert to \".uloop/outputs\" on macOS because Path.Combine(\".uloop\", \"outputs\") yields the same string.";
+        private const string SourceLiteralSeparatorMessage =
+            "File output directory string literals must not embed a separator; Path.Combine supplies the platform separator on Windows.";
 
         /// <summary>
         /// Verifies OUTPUT_ROOT_DIR equals Path.Combine of ULOOP_DIR and OUTPUTS_DIR.
@@ -40,6 +52,70 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             AssertSegmentHasNoPathSeparator(nameof(UnityCliLoopConstants.SCREENSHOTS_DIR), UnityCliLoopConstants.SCREENSHOTS_DIR);
             AssertSegmentHasNoPathSeparator(nameof(UnityCliLoopConstants.VIBE_LOGS_DIR), UnityCliLoopConstants.VIBE_LOGS_DIR);
             AssertSegmentHasNoPathSeparator(nameof(RecordInputConstants.INPUT_RECORDINGS_DIR), RecordInputConstants.INPUT_RECORDINGS_DIR);
+        }
+
+        /// <summary>
+        /// Verifies OUTPUT_ROOT_DIR is declared as Path.Combine in source and that File output
+        /// directory string literals embed no separator. Runtime checks cannot distinguish a
+        /// literal ".uloop/outputs" on macOS because Path.Combine(".uloop", "outputs") is identical.
+        /// </summary>
+        [Test]
+        public void OutputRootDir_IsDeclaredWithPathCombineInSource()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string sourcePath = Path.Combine(projectRoot, ConstantsSourceRelativePath);
+            string source = File.ReadAllText(sourcePath);
+
+            Assert.That(
+                Regex.IsMatch(source, OutputRootDirCombineDeclarationPattern),
+                Is.True,
+                SourceDeclarationRequiredMessage);
+
+            string block = ReadFileOutputDirectoriesBlock(source);
+            string codeOnly = StripLineComments(block);
+            MatchCollection literals = Regex.Matches(codeOnly, StringLiteralPattern);
+            for (int index = 0; index < literals.Count; index++)
+            {
+                string literal = literals[index].Value;
+                Assert.That(literal, Does.Not.Contain("/"), SourceLiteralSeparatorMessage + " (" + literal + ")");
+                Assert.That(literal, Does.Not.Contain("\\"), SourceLiteralSeparatorMessage + " (" + literal + ")");
+            }
+        }
+
+        private static string ReadFileOutputDirectoriesBlock(string source)
+        {
+            int startIndex = source.IndexOf(FileOutputDirectoriesMarker, StringComparison.Ordinal);
+            Assert.That(startIndex, Is.GreaterThanOrEqualTo(0), "File output directories block is missing.");
+
+            int windowsBlankLineIndex = source.IndexOf("\r\n\r\n", startIndex, StringComparison.Ordinal);
+            int unixBlankLineIndex = source.IndexOf("\n\n", startIndex, StringComparison.Ordinal);
+            int endIndex = FirstPositiveIndex(windowsBlankLineIndex, unixBlankLineIndex);
+            Assert.That(endIndex, Is.GreaterThan(startIndex), "File output directories block has no trailing blank line.");
+            return source.Substring(startIndex, endIndex - startIndex);
+        }
+
+        private static int FirstPositiveIndex(int firstIndex, int secondIndex)
+        {
+            if (firstIndex >= 0 && (secondIndex < 0 || firstIndex <= secondIndex))
+            {
+                return firstIndex;
+            }
+
+            return secondIndex;
+        }
+
+        private static string StripLineComments(string block)
+        {
+            string[] lines = block.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+            string[] stripped = new string[lines.Length];
+            for (int index = 0; index < lines.Length; index++)
+            {
+                string line = lines[index];
+                int commentIndex = line.IndexOf("//", StringComparison.Ordinal);
+                stripped[index] = commentIndex >= 0 ? line.Substring(0, commentIndex) : line;
+            }
+
+            return string.Join("\n", stripped);
         }
 
         private static void AssertSegmentHasNoPathSeparator(string name, string value)

--- a/Assets/Tests/Editor/OutputDirectoryConstantsTests.cs.meta
+++ b/Assets/Tests/Editor/OutputDirectoryConstantsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 650fae7165cea42c3975ba1c418f4b6b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace io.github.hatayama.UnityCliLoop.ToolContracts
 {
     /// <summary>
@@ -91,7 +93,9 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public const string PACKAGE_NAME_TEST_FRAMEWORK = "com.unity.test-framework";
 
         // File output directories
-        public const string OUTPUT_ROOT_DIR = ".uloop/outputs";
+        public const string OUTPUTS_DIR = "outputs";
+        // Built with Path.Combine so Windows never receives an embedded "/" that Path.Combine would keep as-is.
+        public static readonly string OUTPUT_ROOT_DIR = Path.Combine(ULOOP_DIR, OUTPUTS_DIR);
         public const string TEST_RESULTS_DIR = "TestResults";
         public const string HIERARCHY_RESULTS_DIR = "HierarchyResults";
         public const string FIND_GAMEOBJECTS_RESULTS_DIR = "FindGameObjectsResults";


### PR DESCRIPTION
## Summary
- Windows output paths under `.uloop/outputs` now use only the native `\` separator instead of mixing `/` and `\`.

## User Impact
- Before: Windows responses such as screenshot `ImagePath` looked like `C:\...\ .uloop/outputs\Screenshots\...` (mixed separators). The file was written correctly, but the path was awkward to paste into other tools.
- After: those paths use `\` only on Windows (and `/` only on macOS/Linux). The same fix applies to test-result XML, hierarchy and find-gameobjects exports, input recordings, and VibeLogs.

## Changes
- Build the output-root directory from separator-free segments via `Path.Combine` instead of embedding `/` in the constant.
- Add a regression test that locks those segments to contain neither `/` nor `\`, so macOS CI can still catch a recurrence.

## Verification
- `uloop compile` after the constant change: ErrorCount 0.
- `uloop run-tests --filter-type class --filter-value OutputDirectoryConstantsTests`: PassedCount 2, FailedCount 0.
- `uloop run-tests --filter-type regex --filter-value 'ScreenshotUseCase.*Tests|VibeLogger.*Tests|InputRecording.*Tests'`: PassedCount 20, FailedCount 0. No InputRecording test classes exist under the Editor test folder; ScreenshotUseCase and VibeLogger tests ran.
- Mutation: temporarily set the outputs-segment constant to `"outputs/"`. `OutputDirectorySegments_ContainNoPathSeparators` failed (FailedCount 1) with the expected separator message. Restored, then FailedCount 0.
- Windows on-device check of `uloop screenshot` ImagePath was not run.

Closes #2465


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

