### PR TITLE
refactor(hot-reload): extract run aggregation out of HotReloadOrchestrator

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -3544,10 +3544,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 new[] { e2ePath, applyPath },
                 contentPathOverride: null,
                 CancellationToken.None,
-                new[]
+                new Dictionary<string, string>
                 {
-                    WriteEditedSource("AddedFieldSortE2E.cs", e2eEdited),
-                    WriteEditedSource("AddedFieldSortApply.cs", applyEdited)
+                    [e2ePath] = WriteEditedSource("AddedFieldSortE2E.cs", e2eEdited),
+                    [applyPath] = WriteEditedSource("AddedFieldSortApply.cs", applyEdited)
                 });
 
             AssertNoFileLevelFailure(result);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,23 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(files.Count > 0, "files must not be empty.");
 
             string correlationId = VibeLogger.GenerateCorrelationId();
-            List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
-            List<string> warnings = new List<string>();
-            List<string> suppressedPausePointIds = new List<string>();
-            List<string> retargetedPausePointIds = new List<string>();
-            List<string> inlineRiskMethodLabels = new List<string>();
-            List<string> addedFields = new List<string>();
-            List<string> addedConsts = new List<string>();
-            List<string> siblingDerivedWarnings = new List<string>();
-            List<HotReloadOneShotCallerNoteEnricher.Candidate> oneShotCallerNoteCandidates =
-                new List<HotReloadOneShotCallerNoteEnricher.Candidate>();
-            int patchedTotal = 0;
-            int unchangedTotal = 0;
-            int revertedUnchangedTotal = 0;
-            // Why after the file loop (not inside ProcessFileAsync): duplicate paths in one
-            // run must still apply twice; recording mid-run would short-circuit the second copy.
-            Dictionary<string, (string Hash, bool IsFullyApplied)> appliedSourceHashByPath =
-                new Dictionary<string, (string Hash, bool IsFullyApplied)>(StringComparer.Ordinal);
+            HotReloadRunAccumulator run = new HotReloadRunAccumulator();
 
             for (int index = 0; index < files.Count; index++)
             {
@@ -72,90 +55,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     filePath,
                     workerSourcePath,
                     correlationId,
-                    siblingDerivedWarnings,
-                    oneShotCallerNoteCandidates,
+                    run.SiblingDerivedWarnings,
+                    run.OneShotCallerNoteCandidates,
                     ct).ConfigureAwait(false);
 
-                outcomes.AddRange(fileResult.Outcomes);
-                warnings.AddRange(fileResult.Warnings);
-                HotReloadOutcomeAggregation.AppendDistinct(suppressedPausePointIds, fileResult.SuppressedPausePointIds);
-                HotReloadOutcomeAggregation.AppendDistinct(retargetedPausePointIds, fileResult.RetargetedPausePointIds);
-                HotReloadOutcomeAggregation.AppendDistinct(inlineRiskMethodLabels, fileResult.InlineRiskMethodLabels);
-                patchedTotal += fileResult.PatchedCount;
-                unchangedTotal += fileResult.UnchangedMethodCount;
-                revertedUnchangedTotal += fileResult.RevertedUnchangedCount;
-                addedFields.AddRange(fileResult.AddedFieldNames);
-                addedConsts.AddRange(fileResult.AddedConstNames);
-                HotReloadAppliedSourceLifecycle.StageAppliedSourceHash(
-                    appliedSourceHashByPath,
-                    HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(filePath),
-                    fileResult.SourceContentSha256,
-                    fileResult.Outcomes);
+                run.Add(HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(filePath), fileResult);
             }
 
-            foreach (KeyValuePair<string, (string Hash, bool IsFullyApplied)> pair in appliedSourceHashByPath)
-            {
-                HotReloadAppliedSourceLedger.Record(pair.Key, pair.Value.Hash, pair.Value.IsFullyApplied);
-            }
+            run.RecordAppliedSourceHashes();
 
             await MainThreadSwitcher.SwitchToMainThread(ct);
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
-            HotReloadOneShotCallerNoteEnricher.ApplyNotes(
-                projectRoot,
-                outcomes,
-                oneShotCallerNoteCandidates,
-                (ignoredAssemblyName, identities) => HotReloadCallSiteScanner.FindCallSites(projectRoot, identities));
-
-            if (inlineRiskMethodLabels.Count > 0)
-            {
-                warnings.Add(
-                    HotReloadOutcomeAggregation.FormatInlineRiskAggregatedWarning(
-                        inlineRiskMethodLabels.Count,
-                        patchedTotal,
-                        inlineRiskMethodLabels));
-            }
+            run.ApplyOneShotCallerNotes(projectRoot);
 
             await MainThreadSwitcher.SwitchToMainThread(ct);
-            addedFields.Sort(StringComparer.Ordinal);
-            addedConsts.Sort(StringComparer.Ordinal);
-            if (addedFields.Count > 0)
-            {
-                // Why from this list: AddedFields and the lifetime warning must name the same
-                // applied fields. Worker-side classified sets include unused and unavailable
-                // declarations, and retry overwrites names without replacing first-pass warnings.
-                warnings.Add(
-                    string.Format(
-                        CultureInfo.InvariantCulture,
-                        HotReloadConstants.AddedFieldsLifetimeWarningFormat,
-                        string.Join(", ", addedFields)));
-            }
-
-            (int patchedCount, int failedCount, int skippedCount, int alreadyActiveCount, int addedCount, int staleCount) =
-                HotReloadOutcomeAggregation.CountMethodOutcomeKinds(outcomes);
-            HotReloadOrchestratorLog.LogHotReloadApplySummary(
-                patchedCount,
-                failedCount,
-                skippedCount,
-                alreadyActiveCount,
-                addedCount,
-                staleCount,
-                failedCount == 0,
-                correlationId);
-            HotReloadOutcomeAggregation.AppendSiblingDerivedWarnings(warnings, siblingDerivedWarnings);
-            HotReloadAutoRefreshHoldSyncResult autoRefreshHold =
-                HotReloadAutoRefreshHold.Sync(HotReloadPatcher.ActiveChangeCount);
-            return new HotReloadOrchestratorResult(
-                outcomes,
-                warnings,
-                patchedTotal,
-                HotReloadPatcher.ActiveChangeCount,
-                suppressedPausePointIds,
-                unchangedTotal,
-                retargetedPausePointIds,
-                addedFields.ToArray(),
-                addedConsts.ToArray(),
-                revertedUnchangedTotal,
-                autoRefreshHold);
+            return run.BuildResult(correlationId);
         }
 
         private static async Task<HotReloadFileProcessResult> ProcessFileAsync(
@@ -244,7 +158,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             TransformWorkerOutputDto workerOutput = workerResult.Output;
             string[] addedFieldNames = workerOutput.addedFieldNames;
-            AppendWorkerNotices(
+            HotReloadWorkerNoticeAppender.AppendWorkerNotices(
                 workerOutput,
                 snapshotSource,
                 projectRelativePath,
@@ -277,7 +191,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 projectRelativePath,
                 correlationId,
                 ct).ConfigureAwait(false);
-            AppendRetrySiblingConstDriftWarnings(siblingDerivedWarnings, gateResult.Isolation);
+            HotReloadWorkerNoticeAppender.AppendRetrySiblingConstDriftWarnings(siblingDerivedWarnings, gateResult.Isolation);
             // Why after the gate: a gated replacement is not applied, so listing it under
             // "Removed members stay present... edited bodies no longer call them" is false.
             string removedMembersWarning = HotReloadRemovedMembersWarning.FormatRemovedMembersWarning(
@@ -441,102 +355,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return false;
-        }
-
-        // Why after the worker: const-only / empty files have no patch candidates, so the
-        // missing-baseline warning was pure noise (FB E). Emit only when the worker saw at
-        // least one method or accessor row.
-        private static void AppendWorkerNotices(
-            TransformWorkerOutputDto workerOutput,
-            string snapshotSource,
-            string projectRelativePath,
-            string assemblyName,
-            string assemblyResolvePath,
-            List<HotReloadMethodOutcome> outcomes,
-            List<string> warnings,
-            List<string> siblingDerivedWarnings)
-        {
-            Debug.Assert(siblingDerivedWarnings != null, "siblingDerivedWarnings must not be null.");
-            if (snapshotSource == null
-                && CountPatchCandidateRows(workerOutput) >= 1)
-            {
-                warnings.Add(
-                    string.Format(
-                        HotReloadConstants.NoVerifiedSourceSnapshotWarningFormat,
-                        Path.GetFileName(projectRelativePath),
-                        assemblyName));
-            }
-
-            if (workerOutput.baselineDisabledByDuplicateKeys)
-            {
-                warnings.Add(
-                    string.Format(
-                        HotReloadConstants.BaselineDisabledByDuplicateKeysWarningFormat,
-                        Path.GetFileName(projectRelativePath),
-                        assemblyName));
-            }
-
-            if (workerOutput.parseErrors != null)
-            {
-                foreach (string parseError in workerOutput.parseErrors)
-                {
-                    warnings.Add(parseError);
-                }
-            }
-
-            if (workerOutput.skipped != null)
-            {
-                foreach (TransformWorkerSkippedDto skipped in workerOutput.skipped)
-                {
-                    outcomes.Add(
-                        HotReloadMethodOutcome.Skipped(
-                            skipped.method ?? "(unknown)",
-                            skipped.reason ?? string.Empty,
-                            assemblyResolvePath));
-                }
-            }
-
-            if (workerOutput.declarationDriftWarnings != null)
-            {
-                // Surfaced before the empty-entries early return so const drift still reaches
-                // the response when every method in the file is skipped or unchanged.
-                foreach (string driftWarning in workerOutput.declarationDriftWarnings)
-                {
-                    warnings.Add(driftWarning);
-                }
-            }
-
-            if (workerOutput.siblingConstDriftWarnings != null)
-            {
-                foreach (string siblingWarning in workerOutput.siblingConstDriftWarnings)
-                {
-                    siblingDerivedWarnings.Add(siblingWarning);
-                }
-            }
-        }
-
-        private static void AppendRetrySiblingConstDriftWarnings(
-            List<string> siblingDerivedWarnings,
-            HotReloadShimIsolation.HotReloadShimIsolationResult isolation)
-        {
-            if (isolation == null || isolation.SiblingConstDriftWarnings == null)
-            {
-                return;
-            }
-
-            foreach (string siblingWarning in isolation.SiblingConstDriftWarnings)
-            {
-                siblingDerivedWarnings.Add(siblingWarning);
-            }
-        }
-
-        private static int CountPatchCandidateRows(TransformWorkerOutputDto workerOutput)
-        {
-            int entryCount = workerOutput.entries != null ? workerOutput.entries.Length : 0;
-            int skippedCount = workerOutput.skipped != null ? workerOutput.skipped.Length : 0;
-            int unchangedCount =
-                workerOutput.unchangedMethods != null ? workerOutput.unchangedMethods.Length : 0;
-            return entryCount + skippedCount + unchangedCount;
         }
 
         // Why a list hook: one contentPathOverride cannot feed two edited copies, and

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -22,13 +22,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <paramref name="contentPathOverride"/> is test-only: when set, the worker reads that
         /// path while assembly resolution still uses <paramref name="files"/> (so edited copies
         /// can live under <c>Library/UloopHotReload/TestSources/</c> without provoking AssetDatabase).
-        /// <paramref name="contentPathOverrides"/> is the per-file form of that hook.
+        /// <paramref name="contentPathOverrideByFile"/> is the per-file form of that hook, keyed by
+        /// the entry in <paramref name="files"/>; it wins over the single override.
         /// </summary>
         public static async Task<HotReloadOrchestratorResult> RunAsync(
             IReadOnlyList<string> files,
             string contentPathOverride,
             CancellationToken ct,
-            IReadOnlyList<string> contentPathOverrides = null)
+            IReadOnlyDictionary<string, string> contentPathOverrideByFile = null)
         {
             Debug.Assert(files != null, "files must not be null.");
             Debug.Assert(files.Count > 0, "files must not be empty.");
@@ -43,8 +44,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 string workerSourcePath = ResolveWorkerSourcePath(
                     filePath,
                     contentPathOverride,
-                    contentPathOverrides,
-                    index);
+                    contentPathOverrideByFile);
 
                 // Why ConfigureAwait(false): UnityCliLoopTool forbids capturing Unity's
                 // SynchronizationContext across awaits — while Play Mode is paused that context
@@ -357,19 +357,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return false;
         }
 
-        // Why a list hook: one contentPathOverride cannot feed two edited copies, and
-        // AddRange+Sort across files is otherwise untestable.
+        // Why keyed by path (not by index): one contentPathOverride cannot feed two edited
+        // copies, and a positional list would silently misalign once files are grouped or
+        // reordered before the worker runs.
         private static string ResolveWorkerSourcePath(
             string filePath,
             string contentPathOverride,
-            IReadOnlyList<string> contentPathOverrides,
-            int index)
+            IReadOnlyDictionary<string, string> contentPathOverrideByFile)
         {
-            if (contentPathOverrides != null
-                && index < contentPathOverrides.Count
-                && !string.IsNullOrEmpty(contentPathOverrides[index]))
+            if (contentPathOverrideByFile != null
+                && contentPathOverrideByFile.TryGetValue(filePath, out string perFileOverride)
+                && !string.IsNullOrEmpty(perFileOverride))
             {
-                return contentPathOverrides[index];
+                return perFileOverride;
             }
 
             if (string.IsNullOrEmpty(contentPathOverride))

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRunAccumulator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRunAccumulator.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Merges per-file apply results into one run: outcome and warning lists, distinct pause-point
+    /// and inline-risk ids, added-member names, totals, and the applied-source hashes to record.
+    /// The orchestrator feeds it one <see cref="HotReloadFileProcessResult"/> per processed file
+    /// and asks it for the final <see cref="HotReloadOrchestratorResult"/> once every file is done.
+    /// </summary>
+    internal sealed class HotReloadRunAccumulator
+    {
+        private readonly List<HotReloadMethodOutcome> _outcomes = new List<HotReloadMethodOutcome>();
+        private readonly List<string> _warnings = new List<string>();
+        private readonly List<string> _suppressedPausePointIds = new List<string>();
+        private readonly List<string> _retargetedPausePointIds = new List<string>();
+        private readonly List<string> _inlineRiskMethodLabels = new List<string>();
+        private readonly List<string> _addedFields = new List<string>();
+        private readonly List<string> _addedConsts = new List<string>();
+        private readonly List<string> _siblingDerivedWarnings = new List<string>();
+        private readonly List<HotReloadOneShotCallerNoteEnricher.Candidate> _oneShotCallerNoteCandidates =
+            new List<HotReloadOneShotCallerNoteEnricher.Candidate>();
+        // Why staged (not recorded per file): duplicate paths in one run must still apply
+        // twice; recording mid-run would short-circuit the second copy.
+        private readonly Dictionary<string, (string Hash, bool IsFullyApplied)> _appliedSourceHashByPath =
+            new Dictionary<string, (string Hash, bool IsFullyApplied)>(StringComparer.Ordinal);
+        private int _patchedTotal;
+        private int _unchangedTotal;
+        private int _revertedUnchangedTotal;
+
+        /// <summary>Warning sink shared with the per-file stage for sibling-derived notices.</summary>
+        public List<string> SiblingDerivedWarnings => _siblingDerivedWarnings;
+
+        /// <summary>Candidate sink shared with the per-file stage for one-shot lifecycle notes.</summary>
+        public List<HotReloadOneShotCallerNoteEnricher.Candidate> OneShotCallerNoteCandidates =>
+            _oneShotCallerNoteCandidates;
+
+        public IReadOnlyList<HotReloadMethodOutcome> Outcomes => _outcomes;
+
+        public int PatchedTotal => _patchedTotal;
+
+        /// <summary>Merges one processed file into the run.</summary>
+        public void Add(string projectRelativePath, HotReloadFileProcessResult fileResult)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be null or empty.");
+            Debug.Assert(fileResult != null, "fileResult must not be null.");
+
+            _outcomes.AddRange(fileResult.Outcomes);
+            _warnings.AddRange(fileResult.Warnings);
+            HotReloadOutcomeAggregation.AppendDistinct(_suppressedPausePointIds, fileResult.SuppressedPausePointIds);
+            HotReloadOutcomeAggregation.AppendDistinct(_retargetedPausePointIds, fileResult.RetargetedPausePointIds);
+            HotReloadOutcomeAggregation.AppendDistinct(_inlineRiskMethodLabels, fileResult.InlineRiskMethodLabels);
+            _patchedTotal += fileResult.PatchedCount;
+            _unchangedTotal += fileResult.UnchangedMethodCount;
+            _revertedUnchangedTotal += fileResult.RevertedUnchangedCount;
+            _addedFields.AddRange(fileResult.AddedFieldNames);
+            _addedConsts.AddRange(fileResult.AddedConstNames);
+            HotReloadAppliedSourceLifecycle.StageAppliedSourceHash(
+                _appliedSourceHashByPath,
+                projectRelativePath,
+                fileResult.SourceContentSha256,
+                fileResult.Outcomes);
+        }
+
+        /// <summary>Writes the staged applied-source hashes to the ledger. Call once after every file was added.</summary>
+        public void RecordAppliedSourceHashes()
+        {
+            foreach (KeyValuePair<string, (string Hash, bool IsFullyApplied)> pair in _appliedSourceHashByPath)
+            {
+                HotReloadAppliedSourceLedger.Record(pair.Key, pair.Value.Hash, pair.Value.IsFullyApplied);
+            }
+        }
+
+        /// <summary>
+        /// Attaches one-shot lifecycle notes to the merged outcomes. Requires the Unity main thread
+        /// because the call-site scan reads compiled assemblies through Editor APIs.
+        /// </summary>
+        public void ApplyOneShotCallerNotes(string projectRoot)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty.");
+            HotReloadOneShotCallerNoteEnricher.ApplyNotes(
+                projectRoot,
+                _outcomes,
+                _oneShotCallerNoteCandidates,
+                (ignoredAssemblyName, identities) => HotReloadCallSiteScanner.FindCallSites(projectRoot, identities));
+        }
+
+        /// <summary>
+        /// Appends the run-level warnings, logs the summary, syncs the Auto Refresh hold, and
+        /// builds the final result. Requires the Unity main thread for the Auto Refresh sync.
+        /// </summary>
+        public HotReloadOrchestratorResult BuildResult(string correlationId)
+        {
+            AppendInlineRiskWarning();
+            AppendAddedFieldsLifetimeWarning();
+            LogSummary(correlationId);
+            HotReloadOutcomeAggregation.AppendSiblingDerivedWarnings(_warnings, _siblingDerivedWarnings);
+            HotReloadAutoRefreshHoldSyncResult autoRefreshHold =
+                HotReloadAutoRefreshHold.Sync(HotReloadPatcher.ActiveChangeCount);
+            return new HotReloadOrchestratorResult(
+                _outcomes,
+                _warnings,
+                _patchedTotal,
+                HotReloadPatcher.ActiveChangeCount,
+                _suppressedPausePointIds,
+                _unchangedTotal,
+                _retargetedPausePointIds,
+                _addedFields.ToArray(),
+                _addedConsts.ToArray(),
+                _revertedUnchangedTotal,
+                autoRefreshHold);
+        }
+
+        private void AppendInlineRiskWarning()
+        {
+            if (_inlineRiskMethodLabels.Count == 0)
+            {
+                return;
+            }
+
+            _warnings.Add(
+                HotReloadOutcomeAggregation.FormatInlineRiskAggregatedWarning(
+                    _inlineRiskMethodLabels.Count,
+                    _patchedTotal,
+                    _inlineRiskMethodLabels));
+        }
+
+        private void AppendAddedFieldsLifetimeWarning()
+        {
+            _addedFields.Sort(StringComparer.Ordinal);
+            _addedConsts.Sort(StringComparer.Ordinal);
+            if (_addedFields.Count == 0)
+            {
+                return;
+            }
+
+            // Why from this list: AddedFields and the lifetime warning must name the same
+            // applied fields. Worker-side classified sets include unused and unavailable
+            // declarations, and retry overwrites names without replacing first-pass warnings.
+            _warnings.Add(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    HotReloadConstants.AddedFieldsLifetimeWarningFormat,
+                    string.Join(", ", _addedFields)));
+        }
+
+        private void LogSummary(string correlationId)
+        {
+            (int patchedCount, int failedCount, int skippedCount, int alreadyActiveCount, int addedCount, int staleCount) =
+                HotReloadOutcomeAggregation.CountMethodOutcomeKinds(_outcomes);
+            HotReloadOrchestratorLog.LogHotReloadApplySummary(
+                patchedCount,
+                failedCount,
+                skippedCount,
+                alreadyActiveCount,
+                addedCount,
+                staleCount,
+                failedCount == 0,
+                correlationId);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRunAccumulator.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRunAccumulator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 18a00603e7ff94106af5ac5cd0ac6170
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerNoticeAppender.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerNoticeAppender.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using System.IO;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Turns worker-side notices (missing baseline, parse errors, skipped rows, declaration drift)
+    /// into per-file outcomes and warnings before any patch decision is made.
+    /// </summary>
+    internal static class HotReloadWorkerNoticeAppender
+    {
+        // Why after the worker: const-only / empty files have no patch candidates, so the
+        // missing-baseline warning was pure noise (FB E). Emit only when the worker saw at
+        // least one method or accessor row.
+        internal static void AppendWorkerNotices(
+            TransformWorkerOutputDto workerOutput,
+            string snapshotSource,
+            string projectRelativePath,
+            string assemblyName,
+            string assemblyResolvePath,
+            List<HotReloadMethodOutcome> outcomes,
+            List<string> warnings,
+            List<string> siblingDerivedWarnings)
+        {
+            Debug.Assert(workerOutput != null, "workerOutput must not be null.");
+            Debug.Assert(outcomes != null, "outcomes must not be null.");
+            Debug.Assert(warnings != null, "warnings must not be null.");
+            Debug.Assert(siblingDerivedWarnings != null, "siblingDerivedWarnings must not be null.");
+
+            AppendBaselineNotices(workerOutput, snapshotSource, projectRelativePath, assemblyName, warnings);
+            AppendAll(warnings, workerOutput.parseErrors);
+            AppendSkippedOutcomes(workerOutput.skipped, assemblyResolvePath, outcomes);
+            // Surfaced before the empty-entries early return so const drift still reaches
+            // the response when every method in the file is skipped or unchanged.
+            AppendAll(warnings, workerOutput.declarationDriftWarnings);
+            AppendAll(siblingDerivedWarnings, workerOutput.siblingConstDriftWarnings);
+        }
+
+        internal static void AppendRetrySiblingConstDriftWarnings(
+            List<string> siblingDerivedWarnings,
+            HotReloadShimIsolation.HotReloadShimIsolationResult isolation)
+        {
+            Debug.Assert(siblingDerivedWarnings != null, "siblingDerivedWarnings must not be null.");
+            if (isolation == null)
+            {
+                return;
+            }
+
+            AppendAll(siblingDerivedWarnings, isolation.SiblingConstDriftWarnings);
+        }
+
+        private static void AppendBaselineNotices(
+            TransformWorkerOutputDto workerOutput,
+            string snapshotSource,
+            string projectRelativePath,
+            string assemblyName,
+            List<string> warnings)
+        {
+            if (snapshotSource == null && CountPatchCandidateRows(workerOutput) >= 1)
+            {
+                warnings.Add(
+                    string.Format(
+                        HotReloadConstants.NoVerifiedSourceSnapshotWarningFormat,
+                        Path.GetFileName(projectRelativePath),
+                        assemblyName));
+            }
+
+            if (workerOutput.baselineDisabledByDuplicateKeys)
+            {
+                warnings.Add(
+                    string.Format(
+                        HotReloadConstants.BaselineDisabledByDuplicateKeysWarningFormat,
+                        Path.GetFileName(projectRelativePath),
+                        assemblyName));
+            }
+        }
+
+        private static void AppendSkippedOutcomes(
+            TransformWorkerSkippedDto[] skippedRows,
+            string assemblyResolvePath,
+            List<HotReloadMethodOutcome> outcomes)
+        {
+            if (skippedRows == null)
+            {
+                return;
+            }
+
+            foreach (TransformWorkerSkippedDto skipped in skippedRows)
+            {
+                outcomes.Add(
+                    HotReloadMethodOutcome.Skipped(
+                        skipped.method ?? "(unknown)",
+                        skipped.reason ?? string.Empty,
+                        assemblyResolvePath));
+            }
+        }
+
+        private static void AppendAll(List<string> target, IReadOnlyList<string> additions)
+        {
+            if (additions == null)
+            {
+                return;
+            }
+
+            for (int index = 0; index < additions.Count; index++)
+            {
+                target.Add(additions[index]);
+            }
+        }
+
+        private static int CountPatchCandidateRows(TransformWorkerOutputDto workerOutput)
+        {
+            int entryCount = workerOutput.entries != null ? workerOutput.entries.Length : 0;
+            int skippedCount = workerOutput.skipped != null ? workerOutput.skipped.Length : 0;
+            int unchangedCount =
+                workerOutput.unchangedMethods != null ? workerOutput.unchangedMethods.Length : 0;
+            return entryCount + skippedCount + unchangedCount;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerNoticeAppender.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerNoticeAppender.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d42acb50d3ed144e3904225b8b8c6d5d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Move per-run aggregation (outcomes, warnings, totals, applied-source hash staging, one-shot caller notes, final result) out of `HotReloadOrchestrator.RunAsync` into a new `HotReloadRunAccumulator` instance class.
- Move worker-notice translation (baseline warnings, parse errors, skipped rows, declaration drift) into `HotReloadWorkerNoticeAppender`.
- Replace the positional `contentPathOverrides` test hook with a dictionary keyed by the `files[]` entry, so the mapping survives reordering or grouping of files before the worker runs.

No behavior change. Groundwork for grouping several edited files of one assembly into a single shim assembly.

## Verification
- compile: 0 errors
- `HotReloadOrchestratorTests`: 152/152 passed
- file-length and code-complexity checks: clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

