### PR TITLE
chore: record the originating file on every transform worker row

### DIFF
--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -687,6 +687,67 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: every entry, skipped and unchangedMethod row the worker returns carries the
+        /// projectRelativePath of the file the run was given.
+        /// </summary>
+        [Test]
+        public async Task Run_OnE2EFixture_StampsEveryRowWithTheSourceProjectRelativePath()
+        {
+            string expectedPath = ResolveE2EFixtureProjectRelativePath();
+
+            // Why two runs: a baseline-less run is the only one that produces skipped rows, and a
+            // run with a one-method-edit snapshot is the only one that produces unchanged rows.
+            TransformWorkerClientResult withoutSnapshot = await RunWorkerOnE2EFixtureAsync();
+            Assert.That(withoutSnapshot.Success, Is.True, withoutSnapshot.ErrorMessage);
+            Assert.That(withoutSnapshot.Output.entries, Is.Not.Empty);
+            Assert.That(withoutSnapshot.Output.skipped, Is.Not.Empty);
+            AssertRowsCarrySourcePath(withoutSnapshot, expectedPath);
+
+            string onDisk = File.ReadAllText(ResolveE2EFixturePath());
+            string snapshotSource = onDisk.Replace(
+                "return _secret + delta;",
+                "return _secret + delta + 999;",
+                StringComparison.Ordinal);
+            Assert.That(snapshotSource, Is.Not.EqualTo(onDisk), "Precondition: snapshot must differ.");
+
+            TransformWorkerClientResult withSnapshot = await RunWorkerOnE2EFixtureAsync(snapshotSource);
+            Assert.That(withSnapshot.Success, Is.True, withSnapshot.ErrorMessage);
+            Assert.That(withSnapshot.Output.entries, Is.Not.Empty);
+            Assert.That(withSnapshot.Output.unchangedMethods, Is.Not.Empty);
+            AssertRowsCarrySourcePath(withSnapshot, expectedPath);
+        }
+
+        /// <summary>
+        /// What: asserts every worker row of a result names <paramref name="expectedPath"/> as its source file.
+        /// </summary>
+        private static void AssertRowsCarrySourcePath(TransformWorkerClientResult result, string expectedPath)
+        {
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                Assert.That(
+                    entry.sourceProjectRelativePath,
+                    Is.EqualTo(expectedPath),
+                    "entry " + entry.methodName + " must name the edited file.");
+            }
+
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                Assert.That(
+                    skipped.sourceProjectRelativePath,
+                    Is.EqualTo(expectedPath),
+                    "skipped " + skipped.method + " must name the edited file.");
+            }
+
+            foreach (TransformWorkerUnchangedMethodDto unchanged in result.Output.unchangedMethods)
+            {
+                Assert.That(
+                    unchanged.sourceProjectRelativePath,
+                    Is.EqualTo(expectedPath),
+                    "unchangedMethod " + unchanged.methodName + " must name the edited file.");
+            }
+        }
+
+        /// <summary>
         /// What: a snapshot that differs only by EOL (LF↔CRLF) treats every method as unchanged —
         /// Windows guardrail for line-ending noise — and lists ComputeWithPrivate in
         /// unchangedMethods.

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -696,7 +696,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string expectedPath = ResolveE2EFixtureProjectRelativePath();
 
             // Why two runs: a baseline-less run is the only one that produces skipped rows, and a
-            // run with a one-method-edit snapshot is the only one that produces unchanged rows.
+            // run against a partly matching snapshot is the only one that produces unchanged rows.
+            // The snapshot below need not isolate a single method — any edit that leaves some
+            // methods matching gives this test both entries and unchanged rows.
             TransformWorkerClientResult withoutSnapshot = await RunWorkerOnE2EFixtureAsync();
             Assert.That(withoutSnapshot.Success, Is.True, withoutSnapshot.ErrorMessage);
             Assert.That(withoutSnapshot.Output.entries, Is.Not.Empty);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerNoticeAppender.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerNoticeAppender.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -28,6 +29,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(outcomes != null, "outcomes must not be null.");
             Debug.Assert(warnings != null, "warnings must not be null.");
             Debug.Assert(siblingDerivedWarnings != null, "siblingDerivedWarnings must not be null.");
+            AssertEntryRowsCameFromTheEditedFile(workerOutput, projectRelativePath);
 
             AppendBaselineNotices(workerOutput, snapshotSource, projectRelativePath, assemblyName, warnings);
             AppendAll(warnings, workerOutput.parseErrors);
@@ -36,6 +38,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // the response when every method in the file is skipped or unchanged.
             AppendAll(warnings, workerOutput.declarationDriftWarnings);
             AppendAll(siblingDerivedWarnings, workerOutput.siblingConstDriftWarnings);
+        }
+
+        // States today's contract: one worker run covers one file, so every entry row it returns
+        // must name that file. Grouping several files into one shim assembly will relax this.
+        private static void AssertEntryRowsCameFromTheEditedFile(
+            TransformWorkerOutputDto workerOutput,
+            string projectRelativePath)
+        {
+            if (workerOutput.entries == null)
+            {
+                return;
+            }
+
+            foreach (TransformWorkerEntryDto entry in workerOutput.entries)
+            {
+                Debug.Assert(
+                    string.Equals(entry.sourceProjectRelativePath, projectRelativePath, StringComparison.Ordinal),
+                    "Worker entry row reports a different source file than the one this run edited.");
+            }
         }
 
         internal static void AppendRetrySiblingConstDriftWarnings(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -117,6 +117,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     [Serializable]
     internal sealed class TransformWorkerUnchangedMethodDto
     {
+        // Project-relative forward-slash path of the file this row was produced from.
+        // Why: once several edited files share one shim assembly, a row must say which file it
+        // came from; today it always equals TransformWorkerInputDto.projectRelativePath.
+        public string sourceProjectRelativePath;
+
         public string typeMetadataName;
         public string methodName;
         public string[] parameterTypeFullNames;
@@ -128,6 +133,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     [Serializable]
     internal sealed class TransformWorkerEntryDto
     {
+        // Project-relative forward-slash path of the file this row was produced from.
+        // Why: once several edited files share one shim assembly, a row must say which file it
+        // came from; today it always equals TransformWorkerInputDto.projectRelativePath.
+        public string sourceProjectRelativePath;
+
         public string typeMetadataName;
         public string methodName;
         public string[] parameterTypeFullNames;
@@ -161,6 +171,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     [Serializable]
     internal sealed class TransformWorkerSkippedDto
     {
+        // Project-relative forward-slash path of the file this row was produced from.
+        // Why: once several edited files share one shim assembly, a row must say which file it
+        // came from; today it always equals TransformWorkerInputDto.projectRelativePath.
+        public string sourceProjectRelativePath;
+
         public string method;
         public string reason;
         // Wire key of the skipped method. Why: the isolation-retry closure must add this in

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -411,6 +411,10 @@ public static class TransformWorkerProgram
             }
         }
 
+        // Why stamp here instead of at each row's producer: six separate producers emit these
+        // rows, and stamping at the single output point cannot leave one of them behind.
+        StampSourceProjectRelativePath(entries, skipped, unchangedMethods, projectRelativePath);
+
         string shimSource = ShimSourceEmitter.Emit(root, shimTypes, projectRelativePath);
         return new WorkerOutput
         {
@@ -430,6 +434,29 @@ public static class TransformWorkerProgram
             AddedConstNames = addedFieldCatalog.ListFoldedConstDisplayNames(),
             SourceContentSha256 = sourceContentSha256
         };
+    }
+
+    // Records which edited file every worker row came from, right before the rows leave the worker.
+    private static void StampSourceProjectRelativePath(
+        List<WorkerEntry> entries,
+        List<WorkerSkipped> skipped,
+        List<WorkerUnchangedMethod> unchangedMethods,
+        string projectRelativePath)
+    {
+        foreach (WorkerEntry entry in entries)
+        {
+            entry.SourceProjectRelativePath = projectRelativePath;
+        }
+
+        foreach (WorkerSkipped skippedRow in skipped)
+        {
+            skippedRow.SourceProjectRelativePath = projectRelativePath;
+        }
+
+        foreach (WorkerUnchangedMethod unchangedMethod in unchangedMethods)
+        {
+            unchangedMethod.SourceProjectRelativePath = projectRelativePath;
+        }
     }
 
     // Keep in sync with HotReloadAppliedSourceLedger.ComputeContentHash (lowercase hex SHA-256).

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerEntry.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerEntry.cs
@@ -17,6 +17,10 @@ using Microsoft.CodeAnalysis.Text;
 
 internal sealed class WorkerEntry
 {
+    // Project-relative forward-slash path of the file this row was produced from.
+    // Keep in sync with TransformWorkerEntryDto.sourceProjectRelativePath.
+    public string SourceProjectRelativePath { get; set; }
+
     public string TypeMetadataName { get; set; }
 
     public string MethodName { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSkipped.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSkipped.cs
@@ -17,6 +17,10 @@ using Microsoft.CodeAnalysis.Text;
 
 internal sealed class WorkerSkipped
 {
+    // Project-relative forward-slash path of the file this row was produced from.
+    // Keep in sync with TransformWorkerSkippedDto.sourceProjectRelativePath.
+    public string SourceProjectRelativePath { get; set; }
+
     public string Method { get; set; }
 
     public string Reason { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerUnchangedMethod.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerUnchangedMethod.cs
@@ -17,6 +17,10 @@ using Microsoft.CodeAnalysis.Text;
 
 internal sealed class WorkerUnchangedMethod
 {
+    // Project-relative forward-slash path of the file this row was produced from.
+    // Keep in sync with TransformWorkerUnchangedMethodDto.sourceProjectRelativePath.
+    public string SourceProjectRelativePath { get; set; }
+
     public string TypeMetadataName { get; set; }
 
     public string MethodName { get; set; }


### PR DESCRIPTION
## Summary
- Pure refactor. No behavior change for hot reload users.
- Every row the transform worker returns now records which source file it came from.

## User Impact
- None today: one worker run still covers exactly one edited file, so the new value always equals the file the run was given.
- Preparation only. Once the edited files of a compilation assembly share a single shim assembly, a row keyed by method identity alone can no longer be attributed to a file; carrying the path now keeps that change from having to touch every row producer at once.

## Changes
- Add `sourceProjectRelativePath` to the entry, skipped and unchanged-method DTOs on the Unity side, and the mirrored `SourceProjectRelativePath` property on the worker side.
- Stamp the value once in `BuildWorkerOutput`, immediately before the rows leave the worker, instead of at each of the six row producers. A single output point cannot leave one producer behind. The two early-return paths return empty row arrays and need no stamp.
- Assert in `HotReloadWorkerNoticeAppender` that every entry row names the file the run was given, making today's one-file-per-run contract explicit rather than implied.
- Add a test covering all three row kinds.

## Verification

Run from this checkout with the development binary.

- `dist/darwin-arm64/uloop compile` — `"Success": true`, `"ErrorCount": 0`
- `dist/darwin-arm64/uloop run-tests --skip-compile --filter-type regex --filter-value 'io\.github\.hatayama\.UnityCliLoop\.Tests\.Editor\.HotReload\.(TransformWorkerClientTests|HotReloadOrchestratorTests)'` — 205 passed, 0 failed, 0 skipped
- The new test was confirmed to actually execute, not merely compile: temporarily breaking its expected path turned the `TransformWorkerClientTests` run from 53 passed / 0 failed into 52 passed / 1 failed, and restoring it returned 53 / 0.
- `scripts/check-file-length.sh` — "No files exceeded the file-length limit."
- `scripts/check-code-complexity.sh` — "No CA1502 complexity issues found above threshold 15."

Note on CI: this pull request targets the integration branch, so the repository build and Unity test workflows do not fire on it. The checks above were run locally instead. The full CI gate applies when the integration branch is proposed to `main`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

