### PR TITLE
chore: group the per-file hot reload apply inputs into two objects

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2633,9 +2633,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             HotReloadFileProcessResult fileResult =
                 HotReloadEntryApplier.ApplyEntriesAndBuildResult(
-                    typeof(HotReloadE2EFixture).Assembly.GetName().Name,
-                    projectRelativePath,
-                    projectRelativePath,
+                    CreateApplyContext(
+                        typeof(HotReloadE2EFixture).Assembly.GetName().Name,
+                        projectRelativePath,
+                        workerOutput),
+                    new HotReloadFileSinks(new List<string>(), null),
                     HotReloadShimCompileResult.SuccessResult(
                         typeof(HotReloadEntryApplier).Assembly,
                         new byte[] { 1 },
@@ -2643,14 +2645,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     entries,
                     addedFieldNames,
                     Array.Empty<string>(),
-                    workerOutput,
-                    new HashSet<string>(),
-                    new HashSet<string>(),
-                    new List<HotReloadMethodOutcome>(),
-                    new List<string>(),
-                    new List<string>(),
-                    new List<string>(),
-                    unchangedMethodCount: 0);
+                    unchangedMethodCount: 0,
+                    revertedUnchangedCount: 0);
 
             HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
                 fileResult.Outcomes,
@@ -2895,9 +2891,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 sourceContentSha256 = "direct-apply-preflight"
             };
             return HotReloadEntryApplier.ApplyEntriesAndBuildResult(
-                typeof(HotReloadCoreFixture).Assembly.GetName().Name,
-                projectRelativePath,
-                projectRelativePath,
+                CreateApplyContext(
+                    typeof(HotReloadCoreFixture).Assembly.GetName().Name,
+                    projectRelativePath,
+                    workerOutput),
+                new HotReloadFileSinks(new List<string>(), null),
                 HotReloadShimCompileResult.SuccessResult(
                     typeof(HotReloadOrchestratorTests).Assembly,
                     new byte[] { 1 },
@@ -2905,14 +2903,49 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 entries,
                 Array.Empty<string>(),
                 Array.Empty<string>(),
+                unchangedMethodCount: 0,
+                revertedUnchangedCount: 0);
+        }
+
+        /// <summary>
+        /// What: builds the apply-pipeline context these direct-apply tests need. The applier
+        /// reads only the assembly name, the file path and the worker output; the remaining
+        /// fields exist to satisfy the context's own preconditions.
+        /// </summary>
+        private static HotReloadApplyContext CreateApplyContext(
+            string assemblyName,
+            string projectRelativePath,
+            TransformWorkerOutputDto workerOutput)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string targetDllPath = Path.Combine(
+                projectRoot,
+                HotReloadConstants.ScriptAssembliesRelativeDirectory,
+                assemblyName + ".dll");
+            UnityEditor.Compilation.Assembly compilationAssembly = null;
+            foreach (UnityEditor.Compilation.Assembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name == assemblyName)
+                {
+                    compilationAssembly = assembly;
+                    break;
+                }
+            }
+
+            Assert.That(compilationAssembly, Is.Not.Null, "Compilation assembly missing: " + assemblyName);
+            return new HotReloadApplyContext(
+                projectRoot,
+                assemblyName,
+                projectRelativePath,
+                projectRelativePath,
+                "direct-apply",
+                compilationAssembly,
+                targetDllPath,
+                compilationAssembly.defines ?? Array.Empty<string>(),
+                new TransformWorkerInputDto { projectRelativePath = projectRelativePath },
                 workerOutput,
                 new HashSet<string>(),
-                new HashSet<string>(),
-                new List<HotReloadMethodOutcome>(),
-                new List<string>(),
-                new List<string>(),
-                new List<string>(),
-                unchangedMethodCount: 0);
+                new HashSet<string>());
         }
 
         private static HotReloadOrchestratorResult ToOrchestratorResult(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyContext.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyContext.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+
+using UnityEngine;
+
+using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// The read-only inputs of one file's apply pipeline, fixed once the worker has run.
+    /// </summary>
+    /// <remarks>
+    /// Why: the gate, the first shim compile and the entry applier each took the same dozen
+    /// values as separate parameters, so every stage signature grew with the pipeline. Passing
+    /// them as one object keeps a stage's parameter list to what that stage itself computes.
+    /// </remarks>
+    internal sealed class HotReloadApplyContext
+    {
+        internal HotReloadApplyContext(
+            string projectRoot,
+            string assemblyName,
+            string assemblyResolvePath,
+            string projectRelativePath,
+            string correlationId,
+            UnityCompilationAssembly compilationAssembly,
+            string targetDllPath,
+            string[] defines,
+            TransformWorkerInputDto workerInput,
+            TransformWorkerOutputDto workerOutput,
+            HashSet<string> snapshotLabels,
+            HashSet<string> snapshotAddedLabels)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(assemblyResolvePath), "assemblyResolvePath must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(targetDllPath), "targetDllPath must not be empty.");
+            Debug.Assert(compilationAssembly != null, "compilationAssembly must not be null.");
+            Debug.Assert(defines != null, "defines must not be null.");
+            Debug.Assert(workerInput != null, "workerInput must not be null.");
+            Debug.Assert(workerOutput != null, "workerOutput must not be null.");
+            Debug.Assert(snapshotLabels != null, "snapshotLabels must not be null.");
+            Debug.Assert(snapshotAddedLabels != null, "snapshotAddedLabels must not be null.");
+
+            ProjectRoot = projectRoot;
+            AssemblyName = assemblyName;
+            AssemblyResolvePath = assemblyResolvePath;
+            ProjectRelativePath = projectRelativePath;
+            CorrelationId = correlationId;
+            CompilationAssembly = compilationAssembly;
+            TargetDllPath = targetDllPath;
+            Defines = defines;
+            WorkerInput = workerInput;
+            WorkerOutput = workerOutput;
+            SnapshotLabels = snapshotLabels;
+            SnapshotAddedLabels = snapshotAddedLabels;
+        }
+
+        internal string ProjectRoot { get; }
+
+        internal string AssemblyName { get; }
+
+        internal string AssemblyResolvePath { get; }
+
+        internal string ProjectRelativePath { get; }
+
+        internal string CorrelationId { get; }
+
+        internal UnityCompilationAssembly CompilationAssembly { get; }
+
+        internal string TargetDllPath { get; }
+
+        internal string[] Defines { get; }
+
+        internal TransformWorkerInputDto WorkerInput { get; }
+
+        internal TransformWorkerOutputDto WorkerOutput { get; }
+
+        // Patch labels already active for this file when its apply started. Snapshotted because
+        // a multi-file run mutates the ledgers between files.
+        internal HashSet<string> SnapshotLabels { get; }
+
+        internal HashSet<string> SnapshotAddedLabels { get; }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyContext.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6d3e503dd4ef4279a24047e5b274f73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
@@ -18,41 +18,34 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Why preflight before BeginFileGeneration: a match/bind/CheckPatchable failure
         // must not replace the file's shim or added-member generation.
         internal static HotReloadFileProcessResult ApplyEntriesAndBuildResult(
-            string assemblyName,
-            string assemblyResolvePath,
-            string projectRelativePath,
+            HotReloadApplyContext context,
+            HotReloadFileSinks sinks,
             HotReloadShimCompileResult compileResult,
             TransformWorkerEntryDto[] entriesToPatch,
             string[] addedFieldNames,
             string[] addedConstNames,
-            TransformWorkerOutputDto workerOutput,
-            HashSet<string> snapshotLabels,
-            HashSet<string> snapshotAddedLabels,
-            List<HotReloadMethodOutcome> outcomes,
-            List<string> warnings,
-            List<string> suppressedPausePointIds,
-            List<string> retargetedPausePointIds,
             int unchangedMethodCount,
-            List<HotReloadOneShotCallerNoteEnricher.Candidate> oneShotCallerNoteCandidates = null,
-            int revertedUnchangedCount = 0)
+            int revertedUnchangedCount)
         {
+            Debug.Assert(context != null, "context must not be null.");
+            Debug.Assert(sinks != null, "sinks must not be null.");
             HotReloadEntryResolution.Result resolution = HotReloadEntryResolution.ResolveEntries(
-                assemblyName,
-                assemblyResolvePath,
+                context.AssemblyName,
+                context.AssemblyResolvePath,
                 compileResult.Assembly,
                 entriesToPatch);
             if (!resolution.AllResolved)
             {
-                outcomes.AddRange(resolution.FailureOutcomes);
+                sinks.Outcomes.AddRange(resolution.FailureOutcomes);
                 return FinishFileResult(
-                    outcomes,
-                    warnings,
-                    snapshotLabels,
-                    snapshotAddedLabels,
-                    projectRelativePath,
-                    workerOutput,
-                    suppressedPausePointIds,
-                    retargetedPausePointIds,
+                    sinks.Outcomes,
+                    sinks.Warnings,
+                    context.SnapshotLabels,
+                    context.SnapshotAddedLabels,
+                    context.ProjectRelativePath,
+                    context.WorkerOutput,
+                    sinks.SuppressedPausePointIds,
+                    sinks.RetargetedPausePointIds,
                     unchangedMethodCount,
                     patchedCount: 0,
                     addedFieldNames: null,
@@ -61,12 +54,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             HotReloadShimRegistry.BeginFileGeneration(
-                projectRelativePath,
+                context.ProjectRelativePath,
                 compileResult.AssemblyBytes,
                 compileResult.PdbBytes,
                 compileResult.Assembly);
-            HotReloadAddedMemberRegistry.BeginFileGeneration(projectRelativePath);
-            CommitAddedFieldsForFile(projectRelativePath, addedFieldNames);
+            HotReloadAddedMemberRegistry.BeginFileGeneration(context.ProjectRelativePath);
+            CommitAddedFieldsForFile(context.ProjectRelativePath, addedFieldNames);
             // Why bind again: phase 1 already bound to detect failures; phase 2 keeps the
             // historical apply order so a successful preflight still runs Bind before Patch.
             BindShimAccessors(compileResult.Assembly);
@@ -74,25 +67,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int patchedCount = ApplyResolvedEntries(
                 resolution.ResolvedEntries,
                 entriesToPatch,
-                assemblyResolvePath,
-                projectRelativePath,
-                outcomes,
-                warnings,
+                context.AssemblyResolvePath,
+                context.ProjectRelativePath,
+                sinks.Outcomes,
+                sinks.Warnings,
                 inlineRiskMethodLabels,
-                suppressedPausePointIds,
-                retargetedPausePointIds,
-                assemblyName,
-                oneShotCallerNoteCandidates);
+                sinks.SuppressedPausePointIds,
+                sinks.RetargetedPausePointIds,
+                context.AssemblyName,
+                sinks.OneShotCallerNoteCandidates);
 
             return FinishFileResult(
-                outcomes,
-                warnings,
-                snapshotLabels,
-                snapshotAddedLabels,
-                projectRelativePath,
-                workerOutput,
-                suppressedPausePointIds,
-                retargetedPausePointIds,
+                sinks.Outcomes,
+                sinks.Warnings,
+                context.SnapshotLabels,
+                context.SnapshotAddedLabels,
+                context.ProjectRelativePath,
+                context.WorkerOutput,
+                sinks.SuppressedPausePointIds,
+                sinks.RetargetedPausePointIds,
                 unchangedMethodCount,
                 patchedCount,
                 addedFieldNames,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileSinks.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileSinks.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// The output buffers every stage of one file's apply pipeline appends to.
+    /// </summary>
+    /// <remarks>
+    /// Why separate from HotReloadApplyContext: these are the mutable half. Keeping them apart
+    /// makes it visible at each call site which stage writes results and which only reads inputs.
+    /// The two injected lists span the whole run, not one file, so the caller owns them.
+    /// </remarks>
+    internal sealed class HotReloadFileSinks
+    {
+        internal HotReloadFileSinks(
+            List<string> siblingDerivedWarnings,
+            List<HotReloadOneShotCallerNoteEnricher.Candidate> oneShotCallerNoteCandidates)
+        {
+            Debug.Assert(siblingDerivedWarnings != null, "siblingDerivedWarnings must not be null.");
+
+            Outcomes = new List<HotReloadMethodOutcome>();
+            Warnings = new List<string>();
+            SuppressedPausePointIds = new List<string>();
+            RetargetedPausePointIds = new List<string>();
+            SiblingDerivedWarnings = siblingDerivedWarnings;
+            OneShotCallerNoteCandidates = oneShotCallerNoteCandidates;
+        }
+
+        internal List<HotReloadMethodOutcome> Outcomes { get; }
+
+        internal List<string> Warnings { get; }
+
+        internal List<string> SuppressedPausePointIds { get; }
+
+        internal List<string> RetargetedPausePointIds { get; }
+
+        // Shared across the whole run so sibling-derived text can be deduped once at the end.
+        internal List<string> SiblingDerivedWarnings { get; }
+
+        // Shared across the whole run; null when the caller collects no one-shot caller notes.
+        internal List<HotReloadOneShotCallerNoteEnricher.Candidate> OneShotCallerNoteCandidates { get; }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileSinks.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileSinks.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8f8ee4ac88a7424394fe70a610c4494
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -81,10 +81,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             CancellationToken ct)
         {
             Debug.Assert(siblingDerivedWarnings != null, "siblingDerivedWarnings must not be null.");
-            List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
-            List<string> warnings = new List<string>();
-            List<string> suppressedPausePointIds = new List<string>();
-            List<string> retargetedPausePointIds = new List<string>();
+            HotReloadFileSinks sinks = new HotReloadFileSinks(siblingDerivedWarnings, oneShotCallerNoteCandidates);
 
             // CompilationPipeline / Application.dataPath require the Unity main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -97,8 +94,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 string projectRoot) = HotReloadPatchTargetSupport.ResolvePatchTarget(
                 assemblyResolvePath,
                 workerSourcePath,
-                outcomes,
-                warnings,
+                sinks.Outcomes,
+                sinks.Warnings,
                 correlationId);
             if (earlyResolve != null)
             {
@@ -131,7 +128,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 projectRelativePath);
             if (!string.IsNullOrEmpty(siblingScan.ScanLimitWarning))
             {
-                siblingDerivedWarnings.Add(siblingScan.ScanLimitWarning);
+                sinks.SiblingDerivedWarnings.Add(siblingScan.ScanLimitWarning);
             }
 
             TransformWorkerInputDto workerInput = new TransformWorkerInputDto
@@ -151,9 +148,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadOrchestratorLog.LogHotReloadWorkerResult(workerResult, correlationId);
             if (!workerResult.Success)
             {
-                outcomes.Add(
+                sinks.Outcomes.Add(
                     HotReloadMethodOutcome.Failed("(file)", workerResult.ErrorMessage, assemblyResolvePath));
-                return new HotReloadFileProcessResult(outcomes, warnings, 0);
+                return new HotReloadFileProcessResult(sinks.Outcomes, sinks.Warnings, 0);
             }
 
             TransformWorkerOutputDto workerOutput = workerResult.Output;
@@ -164,9 +161,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 projectRelativePath,
                 assemblyName,
                 assemblyResolvePath,
-                outcomes,
-                warnings,
-                siblingDerivedWarnings);
+                sinks.Outcomes,
+                sinks.Warnings,
+                sinks.SiblingDerivedWarnings);
 
             TransformWorkerUnchangedMethodDto[] unchangedMethods =
                 workerOutput.unchangedMethods ?? Array.Empty<TransformWorkerUnchangedMethodDto>();
@@ -179,19 +176,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 assemblyName,
                 unchangedMethods);
 
-            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult = await HotReloadSignatureChangeGate.TryApplySignatureChangeGateAsync(
+            HotReloadApplyContext context = new HotReloadApplyContext(
                 projectRoot,
                 assemblyName,
-                workerInput,
-                workerOutput,
-                compilationAssembly,
-                targetDllPath,
-                defines,
                 assemblyResolvePath,
                 projectRelativePath,
                 correlationId,
+                compilationAssembly,
+                targetDllPath,
+                defines,
+                workerInput,
+                workerOutput,
+                snapshotLabels,
+                snapshotAddedLabels);
+
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult = await HotReloadSignatureChangeGate.TryApplySignatureChangeGateAsync(
+                context,
                 ct).ConfigureAwait(false);
-            HotReloadWorkerNoticeAppender.AppendRetrySiblingConstDriftWarnings(siblingDerivedWarnings, gateResult.Isolation);
+            HotReloadWorkerNoticeAppender.AppendRetrySiblingConstDriftWarnings(sinks.SiblingDerivedWarnings, gateResult.Isolation);
             // Why after the gate: a gated replacement is not applied, so listing it under
             // "Removed members stay present... edited bodies no longer call them" is false.
             string removedMembersWarning = HotReloadRemovedMembersWarning.FormatRemovedMembersWarning(
@@ -200,11 +202,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 gateResult.GatedReplacementMethodKeys);
             if (removedMembersWarning != null)
             {
-                warnings.Add(removedMembersWarning);
+                sinks.Warnings.Add(removedMembersWarning);
             }
 
             HotReloadStalePatchOutcomes.Append(
-                outcomes,
+                sinks.Outcomes,
                 workerOutput,
                 gateResult.GatedReplacementMethodKeys,
                 projectRelativePath,
@@ -214,46 +216,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 // Why not apply first-pass entries: a gate retry null means the replacement was
                 // not isolated. Falling through would apply the unguarded return-type change.
-                outcomes.Add(
+                sinks.Outcomes.Add(
                     HotReloadMethodOutcome.Failed(
                         "(signature-change-gate)",
                         gateResult.FailureMessage,
                         assemblyResolvePath));
                 return new HotReloadFileProcessResult(
-                    outcomes,
-                    warnings,
+                    sinks.Outcomes,
+                    sinks.Warnings,
                     0,
                     unchangedMethodCount: unchangedMethodCount,
                     sourceContentSha256: workerOutput.sourceContentSha256,
                     revertedUnchangedCount: revertedUnchangedCount);
             }
 
-            outcomes.AddRange(gateResult.SkippedOutcomes);
-            warnings.AddRange(gateResult.Warnings);
+            sinks.Outcomes.AddRange(gateResult.SkippedOutcomes);
+            sinks.Warnings.AddRange(gateResult.Warnings);
 
             (HotReloadFileProcessResult earlyEntries,
                 TransformWorkerEntryDto[] entriesToPatch,
                 HotReloadShimCompileResult compileResult,
                 string[] resolvedAddedFieldNames,
                 string[] resolvedAddedConstNames) = await HotReloadShimFirstCompile.ResolveEntriesToPatchAsync(
+                context,
+                sinks,
                 gateResult,
-                workerInput,
-                workerOutput,
-                compilationAssembly,
-                targetDllPath,
-                defines,
-                assemblyResolvePath,
-                projectRelativePath,
-                correlationId,
                 addedFieldNames,
-                snapshotLabels,
-                snapshotAddedLabels,
-                outcomes,
-                warnings,
-                suppressedPausePointIds,
-                retargetedPausePointIds,
                 unchangedMethodCount,
-                siblingDerivedWarnings,
                 revertedUnchangedCount,
                 ct).ConfigureAwait(false);
             if (earlyEntries != null)
@@ -274,7 +263,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     gateResult.ScanTargetKeys);
                 if (lostReplacementKeys.Count > 0)
                 {
-                    outcomes.Add(
+                    sinks.Outcomes.Add(
                         HotReloadMethodOutcome.Failed(
                             "(signature-change-gate)",
                             string.Format(
@@ -282,8 +271,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                                 string.Join(", ", lostReplacementKeys)),
                             assemblyResolvePath));
                     return new HotReloadFileProcessResult(
-                        outcomes,
-                        warnings,
+                        sinks.Outcomes,
+                        sinks.Warnings,
                         0,
                         unchangedMethodCount: unchangedMethodCount,
                         sourceContentSha256: workerOutput.sourceContentSha256,
@@ -291,7 +280,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 HotReloadSignatureChangeCoverage.AppendSignatureChangeCallersRepatchedWarnings(
-                    warnings,
+                    sinks.Warnings,
                     entriesToPatch,
                     gateResult.Hits,
                     snapshotLabels);
@@ -300,22 +289,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Harmony Patch/Unpatch and method resolution against loaded modules require main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
             HotReloadFileProcessResult applied = HotReloadEntryApplier.ApplyEntriesAndBuildResult(
-                assemblyName,
-                assemblyResolvePath,
-                projectRelativePath,
+                context,
+                sinks,
                 compileResult,
                 entriesToPatch,
                 addedFieldNames,
                 resolvedAddedConstNames,
-                workerOutput,
-                snapshotLabels,
-                snapshotAddedLabels,
-                outcomes,
-                warnings,
-                suppressedPausePointIds,
-                retargetedPausePointIds,
                 unchangedMethodCount,
-                oneShotCallerNoteCandidates,
                 revertedUnchangedCount);
             // Why after apply: earlier returns (gate fail, shim compile, coverage loss)
             // never applied the replacement, so leftover Active rows must not claim they

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
@@ -26,28 +26,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadShimCompileResult CompileResult,
             string[] AddedFieldNames,
             string[] AddedConstNames)> ResolveEntriesToPatchAsync(
+            HotReloadApplyContext context,
+            HotReloadFileSinks sinks,
             HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult,
-            TransformWorkerInputDto workerInput,
-            TransformWorkerOutputDto workerOutput,
-            UnityCompilationAssembly compilationAssembly,
-            string targetDllPath,
-            string[] defines,
-            string assemblyResolvePath,
-            string projectRelativePath,
-            string correlationId,
             string[] addedFieldNames,
-            HashSet<string> snapshotLabels,
-            HashSet<string> snapshotAddedLabels,
-            List<HotReloadMethodOutcome> outcomes,
-            List<string> warnings,
-            List<string> suppressedPausePointIds,
-            List<string> retargetedPausePointIds,
             int unchangedMethodCount,
-            List<string> siblingDerivedWarnings,
             int revertedUnchangedCount,
             CancellationToken ct)
         {
-            string[] addedConstNames = workerOutput.addedConstNames;
+            Debug.Assert(context != null, "context must not be null.");
+            Debug.Assert(sinks != null, "sinks must not be null.");
+            string[] addedConstNames = context.WorkerOutput.addedConstNames;
             if (gateResult.UsedWorkerRetry)
             {
                 addedFieldNames = gateResult.Isolation.AddedFieldNames;
@@ -56,15 +45,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     return (
                         new HotReloadFileProcessResult(
-                            outcomes,
-                            warnings,
+                            sinks.Outcomes,
+                            sinks.Warnings,
                             0,
-                            suppressedPausePointIds,
+                            sinks.SuppressedPausePointIds,
                             new List<string>(),
                             unchangedMethodCount,
-                            retargetedPausePointIds,
+                            sinks.RetargetedPausePointIds,
                             addedFieldNames: null,
-                            sourceContentSha256: workerOutput.sourceContentSha256,
+                            sourceContentSha256: context.WorkerOutput.sourceContentSha256,
                             revertedUnchangedCount: revertedUnchangedCount),
                         null,
                         null,
@@ -80,9 +69,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     addedConstNames);
             }
 
-            if (string.IsNullOrEmpty(workerOutput.shimSource)
-                || workerOutput.entries == null
-                || workerOutput.entries.Length == 0)
+            if (string.IsNullOrEmpty(context.WorkerOutput.shimSource)
+                || context.WorkerOutput.entries == null
+                || context.WorkerOutput.entries.Length == 0)
             {
                 // Why only on this success path: deleting an added method and restoring callers
                 // yields empty entries, so the post-shim-compile BeginFileGeneration never runs.
@@ -90,26 +79,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // clearing — same as leaving existing Harmony patches in place when apply does
                 // not succeed.
                 IReadOnlyList<string> addedLabelsAtClear =
-                    HotReloadAddedMemberRegistry.ListActiveMethodKeys(projectRelativePath);
-                HotReloadOrchestratorLog.LogHotReloadEmptyEntriesClear(addedLabelsAtClear, correlationId);
-                HotReloadAddedMemberRegistry.BeginFileGeneration(projectRelativePath);
-                HotReloadEntryApplier.CommitAddedFieldsForFile(projectRelativePath, workerOutput.addedFieldNames);
+                    HotReloadAddedMemberRegistry.ListActiveMethodKeys(context.ProjectRelativePath);
+                HotReloadOrchestratorLog.LogHotReloadEmptyEntriesClear(addedLabelsAtClear, context.CorrelationId);
+                HotReloadAddedMemberRegistry.BeginFileGeneration(context.ProjectRelativePath);
+                HotReloadEntryApplier.CommitAddedFieldsForFile(context.ProjectRelativePath, context.WorkerOutput.addedFieldNames);
                 // Why after the clear: a still-declared added method can be worker-skipped
                 // (virtual/generic), leaving entries empty while the registry drop is real.
                 HotReloadAppliedSourceLifecycle.AppendDeactivatedPatchesWarning(
-                    warnings,
-                    snapshotLabels,
-                    snapshotAddedLabels,
-                    projectRelativePath,
-                    workerOutput,
-                    outcomes);
+                    sinks.Warnings,
+                    context.SnapshotLabels,
+                    context.SnapshotAddedLabels,
+                    context.ProjectRelativePath,
+                    context.WorkerOutput,
+                    sinks.Outcomes);
                 return (
                     new HotReloadFileProcessResult(
-                        outcomes,
-                        warnings,
+                        sinks.Outcomes,
+                        sinks.Warnings,
                         0,
                         unchangedMethodCount: unchangedMethodCount,
-                        sourceContentSha256: workerOutput.sourceContentSha256,
+                        sourceContentSha256: context.WorkerOutput.sourceContentSha256,
                         revertedUnchangedCount: revertedUnchangedCount),
                     null,
                     null,
@@ -118,14 +107,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             ShimFirstCompileResult firstCompile = await CompileShimFirstPassAsync(
-                workerInput,
-                workerOutput,
-                compilationAssembly,
-                targetDllPath,
-                defines,
-                assemblyResolvePath,
-                correlationId,
-                siblingDerivedWarnings,
+                context.WorkerInput,
+                context.WorkerOutput,
+                context.CompilationAssembly,
+                context.TargetDllPath,
+                context.Defines,
+                context.AssemblyResolvePath,
+                context.CorrelationId,
+                sinks.SiblingDerivedWarnings,
                 ct).ConfigureAwait(false);
             if (firstCompile.AddedFieldNames != null)
             {
@@ -134,14 +123,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (firstCompile.FileFailed)
             {
-                outcomes.AddRange(firstCompile.Outcomes);
+                sinks.Outcomes.AddRange(firstCompile.Outcomes);
                 return (
                     new HotReloadFileProcessResult(
-                        outcomes,
-                        warnings,
+                        sinks.Outcomes,
+                        sinks.Warnings,
                         0,
                         unchangedMethodCount: unchangedMethodCount,
-                        sourceContentSha256: workerOutput.sourceContentSha256,
+                        sourceContentSha256: context.WorkerOutput.sourceContentSha256,
                         revertedUnchangedCount: revertedUnchangedCount),
                     null,
                     null,
@@ -149,20 +138,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     addedConstNames);
             }
 
-            outcomes.AddRange(firstCompile.Outcomes);
+            sinks.Outcomes.AddRange(firstCompile.Outcomes);
             if (firstCompile.EntriesToPatch.Length == 0)
             {
                 return (
                     new HotReloadFileProcessResult(
-                        outcomes,
-                        warnings,
+                        sinks.Outcomes,
+                        sinks.Warnings,
                         0,
-                        suppressedPausePointIds,
+                        sinks.SuppressedPausePointIds,
                         new List<string>(),
                         unchangedMethodCount,
-                        retargetedPausePointIds,
+                        sinks.RetargetedPausePointIds,
                         addedFieldNames: null,
-                        sourceContentSha256: workerOutput.sourceContentSha256,
+                        sourceContentSha256: context.WorkerOutput.sourceContentSha256,
                         revertedUnchangedCount: revertedUnchangedCount),
                     null,
                     null,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
@@ -3,11 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-using UnityEditor.Compilation;
-
 using UnityEngine;
-
-using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
@@ -21,21 +17,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// trigger means the scanner is not called.
         /// </summary>
         internal static async Task<SignatureChangeGateResult> TryApplySignatureChangeGateAsync(
-            string projectRoot,
-            string assemblyName,
-            TransformWorkerInputDto workerInput,
-            TransformWorkerOutputDto workerOutput,
-            UnityCompilationAssembly compilationAssembly,
-            string targetDllPath,
-            string[] defines,
-            string assemblyResolvePath,
-            string projectRelativePath,
-            string correlationId,
+            HotReloadApplyContext context,
             CancellationToken ct)
         {
-            TransformWorkerEntryDto[] entries = workerOutput.entries ?? Array.Empty<TransformWorkerEntryDto>();
+            Debug.Assert(context != null, "context must not be null.");
+            TransformWorkerEntryDto[] entries = context.WorkerOutput.entries ?? Array.Empty<TransformWorkerEntryDto>();
             TransformWorkerRemovedMethodSignatureDto[] removedSignatures =
-                workerOutput.removedMethodSignatures
+                context.WorkerOutput.removedMethodSignatures
                 ?? Array.Empty<TransformWorkerRemovedMethodSignatureDto>();
             List<TransformWorkerEntryDto> replacementEntries = CollectReplacementEntries(entries);
             if (replacementEntries.Count == 0 && removedSignatures.Length == 0)
@@ -44,11 +32,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             HotReloadCallSiteScanner.CompiledMethodIdentity[] targets = CollectScanTargets(
-                assemblyName,
+                context.AssemblyName,
                 replacementEntries,
                 removedSignatures);
             List<HotReloadCallSiteScanner.CallSiteHit> hits =
-                HotReloadCallSiteScanner.FindCallSites(projectRoot, targets).Hits;
+                HotReloadCallSiteScanner.FindCallSites(context.ProjectRoot, targets).Hits;
             HashSet<string> coveredKeys = HotReloadSignatureChangeCoverage.CollectCoveredMethodKeys(entries, targets);
             Dictionary<string, List<string>> uncoveredCallersByTarget =
                 HotReloadSignatureChangeCoverage.CollectUncoveredCallersByTarget(hits, coveredKeys);
@@ -70,31 +58,31 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadShimIsolation.IsolationExclusions exclusions = HotReloadShimIsolation.BuildIsolationExclusions(gatedReplacements, entries);
             HashSet<string> editedFileMethodKeys = HotReloadSignatureChangeCoverage.CollectEditedFileMethodKeys(
                 entries,
-                workerOutput.unchangedMethods ?? Array.Empty<TransformWorkerUnchangedMethodDto>());
+                context.WorkerOutput.unchangedMethods ?? Array.Empty<TransformWorkerUnchangedMethodDto>());
             List<HotReloadMethodOutcome> skippedOutcomes = BuildGatedReplacementSkipOutcomes(
                 gatedReplacements,
                 uncoveredCallersByTarget,
                 editedFileMethodKeys,
-                assemblyResolvePath,
-                projectRelativePath);
+                context.AssemblyResolvePath,
+                context.ProjectRelativePath);
             skippedOutcomes.AddRange(
                 HotReloadShimIsolation.BuildSkippedCallerOutcomes(
                     exclusions.CallerEntries,
-                    assemblyResolvePath,
+                    context.AssemblyResolvePath,
                     HotReloadConstants.SignatureChangedGatedCallerSkipReason));
 
             HotReloadShimIsolation.IsolationRetryRunResult retry = await HotReloadShimIsolation.RunIsolationRetryAsync(
-                workerInput,
+                context.WorkerInput,
                 exclusions,
                 new List<HotReloadMethodOutcome>(),
                 new List<HotReloadMethodOutcome>(),
-                compilationAssembly,
-                targetDllPath,
-                defines,
-                workerOutput.skipped,
-                assemblyResolvePath,
+                context.CompilationAssembly,
+                context.TargetDllPath,
+                context.Defines,
+                context.WorkerOutput.skipped,
+                context.AssemblyResolvePath,
                 HotReloadConstants.VibeLogIsolationTriggerSignatureChangeGate,
-                correlationId,
+                context.CorrelationId,
                 ct).ConfigureAwait(false);
             List<string> gatedReplacementMethodKeys =
                 CollectGatedReplacementMethodKeys(gatedReplacements);


### PR DESCRIPTION
## Summary
- Pure refactor. No behavior change for hot reload users.
- The three stages that apply one edited file now take their shared inputs and output buffers as two objects instead of restating them as parameters.

## User Impact
- None. Same code paths, same outcomes, same warnings.
- Preparation only. Grouping the edited files of a compilation assembly into one shim assembly adds values to this pipeline; with the shared state in one place, that widening touches one type instead of three signatures.

## Changes
- Add `HotReloadApplyContext`: the read-only inputs of one file's apply, fixed once the worker has run (project root, assembly, paths, defines, worker input/output, and the label snapshots). Constructor checks its own preconditions.
- Add `HotReloadFileSinks`: the buffers each stage appends to. It creates the four per-file lists itself and takes the two run-wide lists from the caller, since those outlive a single file.
- Reduce the three stage signatures accordingly:
  - `TryApplySignatureChangeGateAsync` 11 → 2 parameters
  - `ResolveEntriesToPatchAsync` 19 → 7 parameters
  - `ApplyEntriesAndBuildResult` 17 → 8 parameters
- Drop the optional parameters (`= null`, `= 0`) from the applier; callers pass both values explicitly.
- Method bodies only substitute the old parameter names for `context.*` / `sinks.*`. No reordering, no extraction, so the diff reads as a substitution.
- Update the two tests that call `ApplyEntriesAndBuildResult` directly, via a helper that builds the context.
- Drop the now-unused `UnityEditor.Compilation` import and alias from the gate.

## Verification

Run from this checkout with the development binary.

- `dist/darwin-arm64/uloop compile` — `"Success": true`, `"ErrorCount": 0`
- `dist/darwin-arm64/uloop run-tests --skip-compile --filter-type class --filter-value io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadOrchestratorTests` — 152 passed, 0 failed, 0 skipped
- `scripts/check-file-length.sh` — "No files exceeded the file-length limit."
- `scripts/check-code-complexity.sh` — "No CA1502 complexity issues found above threshold 15."
- The two generated `.meta` files for the new sources are committed alongside them.

Note on CI: this pull request targets the integration branch, so the repository build and Unity test workflows do not fire on it. The checks above were run locally instead. The full CI gate applies when the integration branch is proposed to `main`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

