### PR TITLE
chore: manage per-file hot reload generation state from one entry point

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAppliedSourceLifecycle.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAppliedSourceLifecycle.cs
@@ -148,7 +148,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
             HashSet<string> labels = new HashSet<string>(StringComparer.Ordinal);
             IReadOnlyList<string> addedKeys =
-                HotReloadAddedMemberRegistry.ListActiveMethodKeys(projectRelativePath);
+                HotReloadFileGenerations.ListActiveAddedMethodKeys(projectRelativePath);
             for (int index = 0; index < addedKeys.Count; index++)
             {
                 labels.Add(addedKeys[index]);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
@@ -53,12 +53,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     revertedUnchangedCount: revertedUnchangedCount);
             }
 
-            HotReloadShimRegistry.BeginFileGeneration(
+            HotReloadFileGenerations.BeginFileGeneration(
                 context.ProjectRelativePath,
                 compileResult.AssemblyBytes,
                 compileResult.PdbBytes,
                 compileResult.Assembly);
-            HotReloadAddedMemberRegistry.BeginFileGeneration(context.ProjectRelativePath);
             CommitAddedFieldsForFile(context.ProjectRelativePath, addedFieldNames);
             // Why bind again: phase 1 already bound to detect failures; phase 2 keeps the
             // historical apply order so a successful preflight still runs Bind before Patch.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileGenerations.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileGenerations.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Reflection;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// The single entry point for starting and resetting a file's hot reload generation state.
+    /// </summary>
+    /// <remarks>
+    /// Why: per-file generation state lives in two registries that must start and reset together.
+    /// Routing both through one place keeps them in lockstep, and gives the per-assembly grouping
+    /// of the next stage one place to widen from file to group.
+    /// Static because the registries it fronts are static; it adds no state of its own.
+    /// </remarks>
+    internal static class HotReloadFileGenerations
+    {
+        /// <summary>
+        /// Starts a new generation for one file, replacing whatever the previous apply left.
+        /// </summary>
+        internal static void BeginFileGeneration(
+            string projectRelativePath,
+            byte[] assemblyBytes,
+            byte[] pdbBytes,
+            Assembly loadedAssembly)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+
+            HotReloadShimRegistry.BeginFileGeneration(
+                projectRelativePath,
+                assemblyBytes,
+                pdbBytes,
+                loadedAssembly);
+            HotReloadAddedMemberRegistry.BeginFileGeneration(projectRelativePath);
+        }
+
+        /// <summary>
+        /// Drops the generation state of every file. Paired with a full revert.
+        /// </summary>
+        internal static void ClearAll()
+        {
+            HotReloadShimRegistry.Clear();
+            HotReloadAddedMemberRegistry.Clear();
+        }
+
+        /// <summary>
+        /// Lists the method keys of the added members currently active for one file.
+        /// </summary>
+        internal static IReadOnlyList<string> ListActiveAddedMethodKeys(string projectRelativePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+
+            return HotReloadAddedMemberRegistry.ListActiveMethodKeys(projectRelativePath);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileGenerations.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileGenerations.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9516f1699add241898823f449a835a28
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -107,7 +107,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // after the worker. The worker itself does not.
             HashSet<string> snapshotLabels = HotReloadAppliedSourceLifecycle.CollectActiveLabelsForFile(projectRelativePath);
             HashSet<string> snapshotAddedLabels = new HashSet<string>(
-                HotReloadAddedMemberRegistry.ListActiveMethodKeys(projectRelativePath),
+                HotReloadFileGenerations.ListActiveAddedMethodKeys(projectRelativePath),
                 StringComparer.Ordinal);
 
             string[] defines = compilationAssembly.defines ?? Array.Empty<string>();

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -236,8 +236,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<MethodBase> revertedMethods = new List<MethodBase>(ShimByMethod.Keys);
             ShimByMethod.Clear();
             FilePathByMethod.Clear();
-            HotReloadShimRegistry.Clear();
-            HotReloadAddedMemberRegistry.Clear();
+            HotReloadFileGenerations.ClearAll();
             HotReloadAddedFieldStore.Clear();
             HotReloadAddedFieldRegistry.ClearAll();
             TransplantLocalsByMethod.Clear();

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
@@ -79,8 +79,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // clearing — same as leaving existing Harmony patches in place when apply does
                 // not succeed.
                 IReadOnlyList<string> addedLabelsAtClear =
-                    HotReloadAddedMemberRegistry.ListActiveMethodKeys(context.ProjectRelativePath);
+                    HotReloadFileGenerations.ListActiveAddedMethodKeys(context.ProjectRelativePath);
                 HotReloadOrchestratorLog.LogHotReloadEmptyEntriesClear(addedLabelsAtClear, context.CorrelationId);
+                // Why not HotReloadFileGenerations.BeginFileGeneration: there is no shim assembly
+                // on this path — entries are empty, so nothing was compiled. Only the added-member
+                // side has stale rows to drop; starting a shim generation would need bytes that
+                // do not exist.
                 HotReloadAddedMemberRegistry.BeginFileGeneration(context.ProjectRelativePath);
                 HotReloadEntryApplier.CommitAddedFieldsForFile(context.ProjectRelativePath, context.WorkerOutput.addedFieldNames);
                 // Why after the clear: a still-declared added method can be worker-skipped


### PR DESCRIPTION
## Summary
- Pure refactor. No behavior change for hot reload users.
- Starting and resetting a file's generation state now goes through one entry point instead of paired calls repeated at each site.

## User Impact
- None. Same registries, same order, same effects.
- Preparation only. The next stage widens this state from a single file to an assembly's group of files; with one entry point, that change lands in one place rather than at every call site.

## Changes
- Add `HotReloadFileGenerations` with three members: `BeginFileGeneration`, `ClearAll`, and `ListActiveAddedMethodKeys`. Static, because the two registries it fronts are static; it holds no state of its own.
- Route the paired calls through it: the apply path's begin, the full revert's clear, and the three added-member key listings.
- `HotReloadAppliedSourceLedger` stays outside the facade. It records a file's applied source hash rather than a generation, and the grouping stage may key it differently.
- The lone added-member `BeginFileGeneration` in the empty-entries clear stays a direct call: that path compiled no shim assembly, so there is no shim generation to start. A comment now states this, since the asymmetry is otherwise easy to read as an oversight.
- Row-level operations (`Register`, `RegisterMethod`, `RemoveMethod`, `IsActiveMember`, `Describe`, `Count`) stay on the registries — they are not generation management.

## Verification

Run from this checkout with the development binary.

- `dist/darwin-arm64/uloop compile` — `"Success": true`, `"ErrorCount": 0`
- `dist/darwin-arm64/uloop run-tests --skip-compile --filter-type regex --filter-value 'io\.github\.hatayama\.UnityCliLoop\.Tests\.Editor\.HotReload\.(HotReloadOrchestratorTests|HotReloadShimRegistryTests|HotReloadAddedMemberRegistryTests|HotReloadPatcherTests)'` — 178 passed, 0 failed, 0 skipped
- `scripts/check-file-length.sh` — "No files exceeded the file-length limit."
- `scripts/check-code-complexity.sh` — "No CA1502 complexity issues found above threshold 15."
- The generated `.meta` for the new source is committed alongside it.

Note on CI: this pull request targets the integration branch, so the repository build and Unity test workflows do not fire on it. The checks above were run locally instead. The full CI gate applies when the integration branch is proposed to `main`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

