### PR TITLE
chore: Fail CI and pre-commit on asmdef references that break the package architecture

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -106,6 +106,10 @@ jobs:
         working-directory: cli/release-automation
         run: go run ./cmd/check-skill-size --root "$GITHUB_WORKSPACE"
 
+      - name: Check asmdef reference policy
+        working-directory: cli/release-automation
+        run: go run ./cmd/check-asmdef-policy --root "$GITHUB_WORKSPACE"
+
       - name: Test shared-inputs stamp script
         run: scripts/test-stamp-release-inputs.sh
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -57,6 +57,16 @@ changed_asmdef_inputs="$(git diff --cached --name-only --diff-filter=ACMRD \
   | grep -E '^(Packages/src/.*\.asmdef|tools/asmdef-policy-allowlist\.json)$' || true)"
 
 if [ -n "$changed_asmdef_inputs" ]; then
+  # The checker reads the working tree, so a partially staged .asmdef or allowlist would be judged
+  # on content this commit does not contain. Stop instead of passing or failing the wrong snapshot.
+  for asmdef_input in $changed_asmdef_inputs; do
+    if [ -n "$(git diff --name-only -- "$asmdef_input")" ]; then
+      echo "$asmdef_input is only partially staged." >&2
+      echo "The asmdef policy check reads the working tree, so stage the file fully or unstage it." >&2
+      exit 1
+    fi
+  done
+
   (cd cli/release-automation && go run ./cmd/check-asmdef-policy --root ../..) || exit 1
 fi
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -50,6 +50,16 @@ if [ -n "$changed_skill_md" ]; then
   git add cli/common/tools/default-tools.json
 fi
 
+# A forbidden asmdef reference is cheap to fix while the code is being written and expensive
+# once a whole tool has been built on top of it, so run the policy check here rather than only
+# in CI. The check reads every .asmdef under Packages/src, so it runs when any of them changes.
+changed_asmdef_inputs="$(git diff --cached --name-only --diff-filter=ACMRD \
+  | grep -E '^(Packages/src/.*\.asmdef|tools/asmdef-policy-allowlist\.json)$' || true)"
+
+if [ -n "$changed_asmdef_inputs" ]; then
+  (cd cli/release-automation && go run ./cmd/check-asmdef-policy --root ../..) || exit 1
+fi
+
 # Shared release inputs feed the stamp files via git ls-files + working-tree hashing, so a
 # commit that changes them without restamping would carry stale stamps that CI's
 # regenerate-and-diff check rejects. The path filter is intentionally coarser than the stamp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,16 @@ When you touch a reported file, split it before adding behavior. Commands, the
 exclusion list, and the two places the threshold is declared:
 `docs/file-length.md`.
 
+## Asmdef Reference Policy
+
+Assembly definitions under `Packages/src` may only reference each other in the directions the
+package architecture allows: no tool references another tool, shared tool utilities
+(`FirstPartyTools.Common.*`) stay below `Application`, and no layer references an outer layer.
+The `Check asmdef reference policy` step in `build-and-test.yml` and the pre-commit hook fail on
+a forbidden reference. Prefer removing the reference (promote to Common, or invert it through a
+`ToolContracts` port); only when that must wait, add the edge with a reason to
+`tools/asmdef-policy-allowlist.json`. Categories, rules, and remedies: `docs/asmdef-policy.md`.
+
 ## Native Go CLI Validation
 
 When running `uloop` commands for this project during CLI development, do not use the `uloop`

--- a/cli/release-automation/cmd/check-asmdef-policy/main.go
+++ b/cli/release-automation/cmd/check-asmdef-policy/main.go
@@ -1,0 +1,25 @@
+// check-asmdef-policy fails when an assembly definition under Packages/src
+// references another assembly in a direction the package architecture forbids
+// (tool to tool, shared tool utilities to Application or above, or a layer
+// referencing an outer layer). Tolerated references are listed with a reason in
+// tools/asmdef-policy-allowlist.json; an entry whose reference no longer exists
+// also fails so the allowlist shrinks as debts are repaid.
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/hatayama/unity-cli-loop/tools/release-automation/internal/automation"
+)
+
+func main() {
+	root := flag.String("root", ".", "repository root to scan")
+	allowlist := flag.String("allowlist", "", "allowlist path (default: <root>/"+automation.DefaultAsmdefPolicyAllowlistPath+")")
+	flag.Parse()
+
+	os.Exit(automation.RunAsmdefPolicyCheck(os.Stdout, os.Stderr, automation.AsmdefPolicyCheckOptions{
+		Root:          *root,
+		AllowlistPath: *allowlist,
+	}))
+}

--- a/cli/release-automation/internal/automation/asmdef_policy.go
+++ b/cli/release-automation/internal/automation/asmdef_policy.go
@@ -1,0 +1,261 @@
+package automation
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// asmdefSourceRoot is the only tree the policy checker walks. Test assemblies
+// under Assets/Tests legitimately reference several tools at once, so they stay
+// out of scope by omission.
+const asmdefSourceRoot = "Packages/src"
+
+// DefaultAsmdefPolicyAllowlistPath is where exemptions live, relative to the
+// repository root. Every entry names one (from, to) reference and the reason it
+// is tolerated for now.
+const DefaultAsmdefPolicyAllowlistPath = "tools/asmdef-policy-allowlist.json"
+
+// asmdefGUIDReferencePrefix marks a reference that names its target by asset
+// GUID rather than by assembly name.
+const asmdefGUIDReferencePrefix = "GUID:"
+
+// asmdefMetaGUIDPattern matches the guid line of a .asmdef.meta file. The
+// trailing whitespace class tolerates CRLF line endings on Windows checkouts.
+var asmdefMetaGUIDPattern = regexp.MustCompile(`(?m)^guid: ([0-9a-f]{32})\s*$`)
+
+// AsmdefAssembly is one assembly definition with its references resolved to
+// assembly names. References to assemblies outside Packages/src are dropped.
+type AsmdefAssembly struct {
+	Name       string
+	Path       string
+	References []string
+}
+
+// AsmdefPolicyFinding is one reference that the policy forbids.
+type AsmdefPolicyFinding struct {
+	From string
+	To   string
+	Rule string
+	Path string
+}
+
+// AsmdefPolicyCheckOptions configures RunAsmdefPolicyCheck.
+type AsmdefPolicyCheckOptions struct {
+	Root          string
+	AllowlistPath string
+}
+
+type asmdefAllowedReference struct {
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Reason string `json:"reason"`
+}
+
+type asmdefAllowlist struct {
+	AllowedReferences []asmdefAllowedReference `json:"allowedReferences"`
+}
+
+type asmdefDocument struct {
+	Name       string   `json:"name"`
+	References []string `json:"references"`
+}
+
+type asmdefRawAssembly struct {
+	document asmdefDocument
+	guid     string
+	path     string
+}
+
+// LoadAsmdefAssemblies reads every .asmdef under Packages/src and resolves its
+// references to assembly names. GUID references are resolved through the
+// sibling .asmdef.meta files; references that match no loaded assembly are
+// external packages and are dropped.
+func LoadAsmdefAssemblies(root string) ([]AsmdefAssembly, error) {
+	rawAssemblies, err := readAsmdefFiles(root)
+	if err != nil {
+		return nil, err
+	}
+	// A run that found nothing must not pass: with the default --root of ".",
+	// running from the wrong directory would otherwise report success without
+	// having looked at a single assembly definition.
+	if len(rawAssemblies) == 0 {
+		return nil, fmt.Errorf("no .asmdef files found under %s; pass --root <repository root>", filepath.Join(root, asmdefSourceRoot))
+	}
+
+	nameByGUID := map[string]string{}
+	knownNames := map[string]bool{}
+	for _, raw := range rawAssemblies {
+		nameByGUID[raw.guid] = raw.document.Name
+		knownNames[raw.document.Name] = true
+	}
+
+	assemblies := make([]AsmdefAssembly, 0, len(rawAssemblies))
+	for _, raw := range rawAssemblies {
+		assemblies = append(assemblies, AsmdefAssembly{
+			Name:       raw.document.Name,
+			Path:       raw.path,
+			References: resolveAsmdefReferences(raw.document.References, nameByGUID, knownNames),
+		})
+	}
+	sort.Slice(assemblies, func(left int, right int) bool {
+		return assemblies[left].Name < assemblies[right].Name
+	})
+	return assemblies, nil
+}
+
+func readAsmdefFiles(root string) ([]asmdefRawAssembly, error) {
+	absoluteRoot := filepath.Join(root, filepath.FromSlash(asmdefSourceRoot))
+	if _, err := os.Stat(absoluteRoot); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	rawAssemblies := []asmdefRawAssembly{}
+	walkErr := filepath.WalkDir(absoluteRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		// Unity ignores tilde-suffixed folders and generates no .meta files for
+		// them, so an .asmdef inside one is not part of the compiled package.
+		if entry.IsDir() && strings.HasSuffix(entry.Name(), "~") {
+			return fs.SkipDir
+		}
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".asmdef") {
+			return nil
+		}
+		raw, err := readAsmdefFile(root, path)
+		if err != nil {
+			return err
+		}
+		rawAssemblies = append(rawAssemblies, raw)
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return rawAssemblies, nil
+}
+
+func readAsmdefFile(root string, path string) (asmdefRawAssembly, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return asmdefRawAssembly{}, err
+	}
+	document := asmdefDocument{}
+	if err := json.Unmarshal(content, &document); err != nil {
+		return asmdefRawAssembly{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if document.Name == "" {
+		return asmdefRawAssembly{}, fmt.Errorf("%s has no assembly name", path)
+	}
+	guid, err := readAsmdefGUID(path + ".meta")
+	if err != nil {
+		return asmdefRawAssembly{}, err
+	}
+	relativePath, err := filepath.Rel(root, path)
+	if err != nil {
+		return asmdefRawAssembly{}, err
+	}
+	return asmdefRawAssembly{
+		document: document,
+		guid:     guid,
+		path:     filepath.ToSlash(relativePath),
+	}, nil
+}
+
+func readAsmdefGUID(metaPath string) (string, error) {
+	content, err := os.ReadFile(metaPath)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w (every .asmdef under Packages/src needs its Unity .meta file)", metaPath, err)
+	}
+	match := asmdefMetaGUIDPattern.FindSubmatch(content)
+	if match == nil {
+		return "", fmt.Errorf("%s has no guid line", metaPath)
+	}
+	return string(match[1]), nil
+}
+
+func resolveAsmdefReferences(references []string, nameByGUID map[string]string, knownNames map[string]bool) []string {
+	resolved := []string{}
+	for _, reference := range references {
+		name := reference
+		if strings.HasPrefix(reference, asmdefGUIDReferencePrefix) {
+			name = nameByGUID[strings.TrimPrefix(reference, asmdefGUIDReferencePrefix)]
+		}
+		if !knownNames[name] {
+			continue
+		}
+		resolved = append(resolved, name)
+	}
+	sort.Strings(resolved)
+	return resolved
+}
+
+func loadAsmdefAllowlist(path string) (asmdefAllowlist, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return asmdefAllowlist{}, fmt.Errorf("read allowlist %s: %w", path, err)
+	}
+	allowlist := asmdefAllowlist{}
+	if err := json.Unmarshal(content, &allowlist); err != nil {
+		return asmdefAllowlist{}, fmt.Errorf("parse allowlist %s: %w", path, err)
+	}
+	for _, entry := range allowlist.AllowedReferences {
+		if entry.From == "" || entry.To == "" || entry.Reason == "" {
+			return asmdefAllowlist{}, fmt.Errorf("allowlist %s: every entry needs from, to, and reason", path)
+		}
+	}
+	return allowlist, nil
+}
+
+// RunAsmdefPolicyCheck prints findings and returns the process exit code. Any
+// reference outside the policy and outside the allowlist fails the check, and
+// so does an allowlist entry whose reference no longer exists, so the allowlist
+// shrinks as debts are repaid instead of accumulating dead entries.
+func RunAsmdefPolicyCheck(stdout io.Writer, stderr io.Writer, options AsmdefPolicyCheckOptions) int {
+	assemblies, err := LoadAsmdefAssemblies(options.Root)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "check-asmdef-policy:", err)
+		return 1
+	}
+	findings, err := evaluateAsmdefPolicy(assemblies)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "check-asmdef-policy:", err)
+		return 1
+	}
+	allowlistPath := options.AllowlistPath
+	if allowlistPath == "" {
+		allowlistPath = filepath.Join(options.Root, filepath.FromSlash(DefaultAsmdefPolicyAllowlistPath))
+	}
+	allowlist, err := loadAsmdefAllowlist(allowlistPath)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "check-asmdef-policy:", err)
+		return 1
+	}
+	remaining, stale := applyAsmdefAllowlist(findings, allowlist)
+
+	_, _ = fmt.Fprintln(stdout, "=== asmdef reference policy ===")
+	if len(remaining) == 0 && len(stale) == 0 {
+		_, _ = fmt.Fprintln(stdout, "No asmdef reference violated the policy.")
+		return 0
+	}
+	for _, finding := range remaining {
+		_, _ = fmt.Fprintf(stdout, "%s -> %s: %s (%s)\n", finding.From, finding.To, finding.Rule, finding.Path)
+	}
+	if len(remaining) > 0 {
+		_, _ = fmt.Fprintf(stdout, "%d asmdef references violate the policy; remove the reference or add it to %s with a reason.\n", len(remaining), DefaultAsmdefPolicyAllowlistPath)
+	}
+	for _, entry := range stale {
+		_, _ = fmt.Fprintf(stdout, "stale allowlist entry: %s -> %s (reference no longer exists; remove it from the allowlist)\n", entry.From, entry.To)
+	}
+	return 1
+}

--- a/cli/release-automation/internal/automation/asmdef_policy_rules.go
+++ b/cli/release-automation/internal/automation/asmdef_policy_rules.go
@@ -68,18 +68,22 @@ var asmdefLayerAllowedCategories = map[string][]asmdefCategory{
 	asmdefLayerCompositionRoot: {asmdefCategoryToolsUmbrella, asmdefCategoryRuntime, asmdefCategoryInternalBridge},
 }
 
+// classifyAsmdef derives the category from the assembly name. Runtime is
+// tested before the FirstPartyTools prefixes so that a tool-owned runtime
+// assembly (FirstPartyTools.<Tool>.Runtime) is held to the Runtime rules rather
+// than being granted a tool's wider permissions.
 func classifyAsmdef(name string) asmdefCategory {
 	switch {
 	case name == asmdefInternalBridgeName:
 		return asmdefCategoryInternalBridge
 	case name == asmdefToolsUmbrellaName:
 		return asmdefCategoryToolsUmbrella
-	case strings.HasPrefix(name, asmdefToolCommonPrefix):
-		return asmdefCategoryToolCommon
-	case strings.HasPrefix(name, asmdefToolPrefix):
-		return asmdefCategoryTool
 	case strings.HasSuffix(name, asmdefRuntimeSuffix):
 		return asmdefCategoryRuntime
+	case strings.HasPrefix(name, asmdefToolCommonPrefix) && strings.HasSuffix(name, asmdefToolSuffix):
+		return asmdefCategoryToolCommon
+	case strings.HasPrefix(name, asmdefToolPrefix) && strings.HasSuffix(name, asmdefToolSuffix):
+		return asmdefCategoryTool
 	}
 	if _, isLayer := asmdefLayerAllowedTargets[name]; isLayer {
 		return asmdefCategoryLayer
@@ -119,45 +123,70 @@ func evaluateAsmdefPolicy(assemblies []AsmdefAssembly) ([]AsmdefPolicyFinding, e
 	return findings, nil
 }
 
+// asmdefCategoryPermit lists what one non-layer category may reference: named
+// layer assemblies and whole categories.
+type asmdefCategoryPermit struct {
+	targets    []string
+	categories []asmdefCategory
+}
+
+// asmdefCategoryPermits is the permit table for the non-layer categories.
+// Layers are handled by asmdefLayerAllowedTargets / asmdefLayerAllowedCategories
+// because their permissions differ per assembly, not per category.
+var asmdefCategoryPermits = map[asmdefCategory]asmdefCategoryPermit{
+	asmdefCategoryInternalBridge: {},
+	asmdefCategoryRuntime:        {categories: []asmdefCategory{asmdefCategoryRuntime}},
+	asmdefCategoryToolsUmbrella: {
+		targets:    []string{asmdefLayerToolContracts, asmdefLayerDomain},
+		categories: []asmdefCategory{asmdefCategoryTool, asmdefCategoryToolCommon},
+	},
+	asmdefCategoryToolCommon: {
+		targets:    []string{asmdefLayerToolContracts, asmdefLayerDomain},
+		categories: []asmdefCategory{asmdefCategoryToolCommon, asmdefCategoryRuntime, asmdefCategoryInternalBridge},
+	},
+	asmdefCategoryTool: {
+		targets:    []string{asmdefLayerToolContracts, asmdefLayerDomain, asmdefLayerApplication},
+		categories: []asmdefCategory{asmdefCategoryToolCommon, asmdefCategoryRuntime, asmdefCategoryInternalBridge},
+	},
+}
+
+// asmdefCategoryRules names the rule a non-layer category violates when it
+// references something outside its permit. Tool is absent because its rule
+// depends on the target (see asmdefToolReferenceViolation).
+var asmdefCategoryRules = map[asmdefCategory]string{
+	asmdefCategoryInternalBridge: asmdefRuleLayerDirection,
+	asmdefCategoryRuntime:        asmdefRuleRuntimeIsolation,
+	asmdefCategoryToolsUmbrella:  asmdefRuleUmbrellaScope,
+	asmdefCategoryToolCommon:     asmdefRuleCommonLayering,
+}
+
 // asmdefReferenceViolation returns the violated rule identifier, or "" when the
 // reference is allowed.
 func asmdefReferenceViolation(from string, to string) string {
+	fromCategory := classifyAsmdef(from)
 	toCategory := classifyAsmdef(to)
-	switch classifyAsmdef(from) {
-	case asmdefCategoryLayer:
+	if fromCategory == asmdefCategoryLayer {
 		if asmdefLayerMayReference(from, to, toCategory) {
 			return ""
 		}
 		return asmdefRuleLayerDirection
-	case asmdefCategoryInternalBridge:
-		return asmdefRuleLayerDirection
-	case asmdefCategoryRuntime:
-		if toCategory == asmdefCategoryRuntime {
-			return ""
-		}
-		return asmdefRuleRuntimeIsolation
-	case asmdefCategoryToolsUmbrella:
-		if toCategory == asmdefCategoryTool || toCategory == asmdefCategoryToolCommon || to == asmdefLayerToolContracts || to == asmdefLayerDomain {
-			return ""
-		}
-		return asmdefRuleUmbrellaScope
-	case asmdefCategoryToolCommon:
-		if to == asmdefLayerToolContracts || to == asmdefLayerDomain || toCategory == asmdefCategoryToolCommon || toCategory == asmdefCategoryRuntime || toCategory == asmdefCategoryInternalBridge {
-			return ""
-		}
-		return asmdefRuleCommonLayering
-	default:
+	}
+	if asmdefPermitAllows(asmdefCategoryPermits[fromCategory], to, toCategory) {
+		return ""
+	}
+	if fromCategory == asmdefCategoryTool {
 		return asmdefToolReferenceViolation(from, to, toCategory)
 	}
+	return asmdefCategoryRules[fromCategory]
 }
 
-func asmdefLayerMayReference(from string, to string, toCategory asmdefCategory) bool {
-	for _, allowed := range asmdefLayerAllowedTargets[from] {
+func asmdefPermitAllows(permit asmdefCategoryPermit, to string, toCategory asmdefCategory) bool {
+	for _, allowed := range permit.targets {
 		if allowed == to {
 			return true
 		}
 	}
-	for _, allowed := range asmdefLayerAllowedCategories[from] {
+	for _, allowed := range permit.categories {
 		if allowed == toCategory {
 			return true
 		}
@@ -165,25 +194,24 @@ func asmdefLayerMayReference(from string, to string, toCategory asmdefCategory) 
 	return false
 }
 
-// asmdefToolReferenceViolation applies the Tool rules: a tool may use the
-// contracts, Domain, Application, shared tool utilities, runtime assemblies,
-// the internal bridge, and its own parent tool. Another tool is a
-// tool-isolation violation; any other layer is a layer-direction violation.
+func asmdefLayerMayReference(from string, to string, toCategory asmdefCategory) bool {
+	return asmdefPermitAllows(asmdefCategoryPermit{
+		targets:    asmdefLayerAllowedTargets[from],
+		categories: asmdefLayerAllowedCategories[from],
+	}, to, toCategory)
+}
+
+// asmdefToolReferenceViolation names the rule for a tool reference outside the
+// Tool permit: another tool is a tool-isolation violation unless it is the
+// tool's own parent; any other target is a layer-direction violation.
 func asmdefToolReferenceViolation(from string, to string, toCategory asmdefCategory) string {
-	if to == asmdefLayerToolContracts || to == asmdefLayerDomain || to == asmdefLayerApplication {
-		return ""
-	}
-	switch toCategory {
-	case asmdefCategoryToolCommon, asmdefCategoryRuntime, asmdefCategoryInternalBridge:
-		return ""
-	case asmdefCategoryTool:
-		if asmdefIsParentTool(from, to) {
-			return ""
-		}
-		return asmdefRuleToolIsolation
-	default:
+	if toCategory != asmdefCategoryTool {
 		return asmdefRuleLayerDirection
 	}
+	if asmdefIsParentTool(from, to) {
+		return ""
+	}
+	return asmdefRuleToolIsolation
 }
 
 // asmdefIsParentTool reports whether to is an ancestor tool of from, e.g.

--- a/cli/release-automation/internal/automation/asmdef_policy_rules.go
+++ b/cli/release-automation/internal/automation/asmdef_policy_rules.go
@@ -1,0 +1,227 @@
+package automation
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// asmdefCategory is the role an assembly plays in the package architecture.
+// It is derived from the assembly name alone so that a new assembly following
+// the naming convention is classified without touching the checker.
+type asmdefCategory string
+
+const (
+	asmdefCategoryLayer          asmdefCategory = "Layer"
+	asmdefCategoryInternalBridge asmdefCategory = "InternalBridge"
+	asmdefCategoryRuntime        asmdefCategory = "Runtime"
+	asmdefCategoryToolsUmbrella  asmdefCategory = "ToolsUmbrella"
+	asmdefCategoryToolCommon     asmdefCategory = "ToolCommon"
+	asmdefCategoryTool           asmdefCategory = "Tool"
+	asmdefCategoryUnknown        asmdefCategory = "Unknown"
+)
+
+const (
+	asmdefLayerDomain          = "UnityCLILoop.Domain"
+	asmdefLayerApplication     = "UnityCLILoop.Application"
+	asmdefLayerInfrastructure  = "UnityCLILoop.Infrastructure"
+	asmdefLayerPresentation    = "UnityCLILoop.Presentation"
+	asmdefLayerCompositionRoot = "UnityCLILoop.CompositionRoot.Editor"
+	asmdefLayerToolContracts   = "UnityCLILoop.ToolContracts"
+
+	asmdefInternalBridgeName = "Unity.InternalAPIEditorBridge.024"
+	asmdefToolsUmbrellaName  = "UnityCLILoop.FirstPartyTools.Editor"
+	asmdefToolPrefix         = "UnityCLILoop.FirstPartyTools."
+	asmdefToolCommonPrefix   = "UnityCLILoop.FirstPartyTools.Common."
+	asmdefToolSuffix         = ".Editor"
+	asmdefRuntimeSuffix      = ".Runtime"
+)
+
+// Rule identifiers reported in findings. Each names the architectural
+// boundary that the reference crosses.
+const (
+	asmdefRuleLayerDirection   = "layer-direction"
+	asmdefRuleRuntimeIsolation = "runtime-isolation"
+	asmdefRuleUmbrellaScope    = "umbrella-scope"
+	asmdefRuleCommonLayering   = "common-layering"
+	asmdefRuleToolIsolation    = "tool-isolation"
+)
+
+// asmdefLayerAllowedTargets lists, per layer assembly, the layer assemblies it
+// may reference. Non-layer categories a layer may reference are handled in
+// asmdefLayerAllowedCategories.
+var asmdefLayerAllowedTargets = map[string][]string{
+	asmdefLayerToolContracts:   {},
+	asmdefLayerDomain:          {asmdefLayerToolContracts},
+	asmdefLayerApplication:     {asmdefLayerDomain, asmdefLayerToolContracts},
+	asmdefLayerInfrastructure:  {asmdefLayerApplication, asmdefLayerDomain, asmdefLayerToolContracts},
+	asmdefLayerPresentation:    {asmdefLayerApplication, asmdefLayerDomain, asmdefLayerToolContracts},
+	asmdefLayerCompositionRoot: {asmdefLayerApplication, asmdefLayerDomain, asmdefLayerInfrastructure, asmdefLayerPresentation, asmdefLayerToolContracts},
+}
+
+// asmdefLayerAllowedCategories lists, per layer assembly, the non-layer
+// categories it may reference. Infrastructure may use shared tool utilities
+// (Console log access lives there) and the Unity internal bridge; the
+// composition root wires everything and may see the tools umbrella.
+var asmdefLayerAllowedCategories = map[string][]asmdefCategory{
+	asmdefLayerInfrastructure:  {asmdefCategoryInternalBridge, asmdefCategoryRuntime, asmdefCategoryToolCommon},
+	asmdefLayerCompositionRoot: {asmdefCategoryToolsUmbrella, asmdefCategoryRuntime, asmdefCategoryInternalBridge},
+}
+
+func classifyAsmdef(name string) asmdefCategory {
+	switch {
+	case name == asmdefInternalBridgeName:
+		return asmdefCategoryInternalBridge
+	case name == asmdefToolsUmbrellaName:
+		return asmdefCategoryToolsUmbrella
+	case strings.HasPrefix(name, asmdefToolCommonPrefix):
+		return asmdefCategoryToolCommon
+	case strings.HasPrefix(name, asmdefToolPrefix):
+		return asmdefCategoryTool
+	case strings.HasSuffix(name, asmdefRuntimeSuffix):
+		return asmdefCategoryRuntime
+	}
+	if _, isLayer := asmdefLayerAllowedTargets[name]; isLayer {
+		return asmdefCategoryLayer
+	}
+	return asmdefCategoryUnknown
+}
+
+// evaluateAsmdefPolicy returns every reference the policy forbids, sorted by
+// (from, to). An assembly whose name matches no category is an error rather
+// than a finding: the naming convention must be extended before the checker
+// can say anything meaningful about it.
+func evaluateAsmdefPolicy(assemblies []AsmdefAssembly) ([]AsmdefPolicyFinding, error) {
+	findings := []AsmdefPolicyFinding{}
+	for _, assembly := range assemblies {
+		if classifyAsmdef(assembly.Name) == asmdefCategoryUnknown {
+			return nil, fmt.Errorf("%s (%s) matches no assembly category; follow the naming convention in docs/asmdef-policy.md", assembly.Name, assembly.Path)
+		}
+		for _, target := range assembly.References {
+			rule := asmdefReferenceViolation(assembly.Name, target)
+			if rule == "" {
+				continue
+			}
+			findings = append(findings, AsmdefPolicyFinding{
+				From: assembly.Name,
+				To:   target,
+				Rule: rule,
+				Path: assembly.Path,
+			})
+		}
+	}
+	sort.Slice(findings, func(left int, right int) bool {
+		if findings[left].From != findings[right].From {
+			return findings[left].From < findings[right].From
+		}
+		return findings[left].To < findings[right].To
+	})
+	return findings, nil
+}
+
+// asmdefReferenceViolation returns the violated rule identifier, or "" when the
+// reference is allowed.
+func asmdefReferenceViolation(from string, to string) string {
+	toCategory := classifyAsmdef(to)
+	switch classifyAsmdef(from) {
+	case asmdefCategoryLayer:
+		if asmdefLayerMayReference(from, to, toCategory) {
+			return ""
+		}
+		return asmdefRuleLayerDirection
+	case asmdefCategoryInternalBridge:
+		return asmdefRuleLayerDirection
+	case asmdefCategoryRuntime:
+		if toCategory == asmdefCategoryRuntime {
+			return ""
+		}
+		return asmdefRuleRuntimeIsolation
+	case asmdefCategoryToolsUmbrella:
+		if toCategory == asmdefCategoryTool || toCategory == asmdefCategoryToolCommon || to == asmdefLayerToolContracts || to == asmdefLayerDomain {
+			return ""
+		}
+		return asmdefRuleUmbrellaScope
+	case asmdefCategoryToolCommon:
+		if to == asmdefLayerToolContracts || to == asmdefLayerDomain || toCategory == asmdefCategoryToolCommon || toCategory == asmdefCategoryRuntime || toCategory == asmdefCategoryInternalBridge {
+			return ""
+		}
+		return asmdefRuleCommonLayering
+	default:
+		return asmdefToolReferenceViolation(from, to, toCategory)
+	}
+}
+
+func asmdefLayerMayReference(from string, to string, toCategory asmdefCategory) bool {
+	for _, allowed := range asmdefLayerAllowedTargets[from] {
+		if allowed == to {
+			return true
+		}
+	}
+	for _, allowed := range asmdefLayerAllowedCategories[from] {
+		if allowed == toCategory {
+			return true
+		}
+	}
+	return false
+}
+
+// asmdefToolReferenceViolation applies the Tool rules: a tool may use the
+// contracts, Domain, Application, shared tool utilities, runtime assemblies,
+// the internal bridge, and its own parent tool. Another tool is a
+// tool-isolation violation; any other layer is a layer-direction violation.
+func asmdefToolReferenceViolation(from string, to string, toCategory asmdefCategory) string {
+	if to == asmdefLayerToolContracts || to == asmdefLayerDomain || to == asmdefLayerApplication {
+		return ""
+	}
+	switch toCategory {
+	case asmdefCategoryToolCommon, asmdefCategoryRuntime, asmdefCategoryInternalBridge:
+		return ""
+	case asmdefCategoryTool:
+		if asmdefIsParentTool(from, to) {
+			return ""
+		}
+		return asmdefRuleToolIsolation
+	default:
+		return asmdefRuleLayerDirection
+	}
+}
+
+// asmdefIsParentTool reports whether to is an ancestor tool of from, e.g.
+// RunTests is the parent of RunTests.TestFramework. Sub-assemblies of a tool
+// may reference the tool they belong to.
+func asmdefIsParentTool(from string, to string) bool {
+	fromTool := asmdefToolName(from)
+	toTool := asmdefToolName(to)
+	return strings.HasPrefix(fromTool, toTool+".")
+}
+
+func asmdefToolName(name string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(name, asmdefToolPrefix), asmdefToolSuffix)
+}
+
+// applyAsmdefAllowlist removes allowlisted findings and returns the allowlist
+// entries that matched nothing, which means the reference was repaid and the
+// entry must be deleted.
+func applyAsmdefAllowlist(findings []AsmdefPolicyFinding, allowlist asmdefAllowlist) ([]AsmdefPolicyFinding, []asmdefAllowedReference) {
+	matched := make([]bool, len(allowlist.AllowedReferences))
+	remaining := []AsmdefPolicyFinding{}
+	for _, finding := range findings {
+		allowed := false
+		for index, entry := range allowlist.AllowedReferences {
+			if entry.From == finding.From && entry.To == finding.To {
+				matched[index] = true
+				allowed = true
+			}
+		}
+		if !allowed {
+			remaining = append(remaining, finding)
+		}
+	}
+	stale := []asmdefAllowedReference{}
+	for index, entry := range allowlist.AllowedReferences {
+		if !matched[index] {
+			stale = append(stale, entry)
+		}
+	}
+	return remaining, stale
+}

--- a/cli/release-automation/internal/automation/asmdef_policy_test.go
+++ b/cli/release-automation/internal/automation/asmdef_policy_test.go
@@ -210,6 +210,7 @@ func TestEvaluateAsmdefPolicyReportsForbiddenReferences(t *testing.T) {
 		{name: "tool contracts to domain", from: asmdefLayerToolContracts, to: asmdefLayerDomain, rule: asmdefRuleLayerDirection},
 		{name: "presentation to infrastructure", from: asmdefLayerPresentation, to: asmdefLayerInfrastructure, rule: asmdefRuleLayerDirection},
 		{name: "runtime to layer", from: "UnityCLILoop.Runtime", to: asmdefLayerDomain, rule: asmdefRuleRuntimeIsolation},
+		{name: "tool-owned runtime to application", from: asmdefToolPrefix + "A.Runtime", to: asmdefLayerApplication, rule: asmdefRuleRuntimeIsolation},
 		{name: "internal bridge to layer", from: asmdefInternalBridgeName, to: asmdefLayerDomain, rule: asmdefRuleLayerDirection},
 		{name: "umbrella to infrastructure", from: asmdefToolsUmbrellaName, to: asmdefLayerInfrastructure, rule: asmdefRuleUmbrellaScope},
 	}
@@ -261,6 +262,7 @@ func TestEvaluateAsmdefPolicyAcceptsAllowedReferences(t *testing.T) {
 		{name: "tool to application", from: toolName("A"), to: asmdefLayerApplication},
 		{name: "tool to common", from: toolName("A"), to: commonName("X")},
 		{name: "tool to runtime", from: toolName("A"), to: "UnityCLILoop.PausePoints.Runtime"},
+		{name: "tool to its own runtime assembly", from: toolName("A"), to: asmdefToolPrefix + "A.Runtime"},
 		{name: "tool to internal bridge", from: toolName("A"), to: asmdefInternalBridgeName},
 		{name: "sub-assembly to parent tool", from: toolName("RunTests.TestFramework"), to: toolName("RunTests")},
 	}
@@ -282,10 +284,14 @@ func TestEvaluateAsmdefPolicyAcceptsAllowedReferences(t *testing.T) {
 
 // evaluateAsmdefPolicy fails on an assembly whose name matches no category,
 // so a new assembly must follow the naming convention before it is accepted.
+// A FirstPartyTools assembly without the .Editor or .Runtime suffix is one
+// such name.
 func TestEvaluateAsmdefPolicyRejectsUnknownAssembly(t *testing.T) {
-	_, err := evaluateAsmdefPolicy([]AsmdefAssembly{{Name: "UnityCLILoop.Mystery", Path: "mystery.asmdef"}})
-	if err == nil || !strings.Contains(err.Error(), "UnityCLILoop.Mystery") {
-		t.Fatalf("expected an unknown-category error, got %v", err)
+	for _, name := range []string{"UnityCLILoop.Mystery", asmdefToolPrefix + "A"} {
+		_, err := evaluateAsmdefPolicy([]AsmdefAssembly{{Name: name, Path: "mystery.asmdef"}})
+		if err == nil || !strings.Contains(err.Error(), name) {
+			t.Fatalf("expected an unknown-category error for %s, got %v", name, err)
+		}
 	}
 }
 

--- a/cli/release-automation/internal/automation/asmdef_policy_test.go
+++ b/cli/release-automation/internal/automation/asmdef_policy_test.go
@@ -1,0 +1,402 @@
+package automation
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type asmdefFixture struct {
+	dir        string
+	name       string
+	guid       string
+	references []string
+}
+
+func writeAsmdefFixture(t *testing.T, root string, fixture asmdefFixture) {
+	t.Helper()
+	writeAsmdefFixtureWithMeta(t, root, fixture, "fileFormatVersion: 2\nguid: "+fixture.guid+"\nAssemblyDefinitionImporter:\n")
+}
+
+func writeAsmdefFixtureWithMeta(t *testing.T, root string, fixture asmdefFixture, meta string) {
+	t.Helper()
+	directory := filepath.Join(root, filepath.FromSlash("Packages/src/"+fixture.dir))
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	document, err := json.Marshal(map[string]any{"name": fixture.name, "references": fixture.references})
+	if err != nil {
+		t.Fatal(err)
+	}
+	asmdefPath := filepath.Join(directory, fixture.name+".asmdef")
+	if err := os.WriteFile(asmdefPath, document, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if meta == "" {
+		return
+	}
+	if err := os.WriteFile(asmdefPath+".meta", []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeAsmdefAllowlist(t *testing.T, path string, entries []asmdefAllowedReference) {
+	t.Helper()
+	content, err := json.Marshal(asmdefAllowlist{AllowedReferences: entries})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func guidReference(guid string) string {
+	return asmdefGUIDReferencePrefix + guid
+}
+
+const (
+	fixtureGUIDDomain        = "11111111111111111111111111111111"
+	fixtureGUIDApplication   = "22222222222222222222222222222222"
+	fixtureGUIDToolA         = "33333333333333333333333333333333"
+	fixtureGUIDToolB         = "44444444444444444444444444444444"
+	fixtureGUIDToolContracts = "55555555555555555555555555555555"
+)
+
+func findAssembly(t *testing.T, assemblies []AsmdefAssembly, name string) AsmdefAssembly {
+	t.Helper()
+	for _, assembly := range assemblies {
+		if assembly.Name == name {
+			return assembly
+		}
+	}
+	t.Fatalf("assembly %s not loaded: %v", name, assemblies)
+	return AsmdefAssembly{}
+}
+
+// LoadAsmdefAssemblies resolves GUID references to assembly names through the
+// sibling .asmdef.meta files.
+func TestLoadAsmdefAssembliesResolvesGUIDReferences(t *testing.T) {
+	root := t.TempDir()
+	writeAsmdefFixture(t, root, asmdefFixture{dir: "Editor/Domain", name: asmdefLayerDomain, guid: fixtureGUIDDomain})
+	writeAsmdefFixture(t, root, asmdefFixture{dir: "Editor/Application", name: asmdefLayerApplication, guid: fixtureGUIDApplication, references: []string{guidReference(fixtureGUIDDomain)}})
+
+	assemblies, err := LoadAsmdefAssemblies(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	application := findAssembly(t, assemblies, asmdefLayerApplication)
+	if len(application.References) != 1 || application.References[0] != asmdefLayerDomain {
+		t.Fatalf("expected Application to reference Domain by name, got %v", application.References)
+	}
+	if application.Path != "Packages/src/Editor/Application/UnityCLILoop.Application.asmdef" {
+		t.Fatalf("unexpected path: %s", application.Path)
+	}
+}
+
+// LoadAsmdefAssemblies drops GUID references that match no loaded assembly:
+// they point at external packages and are outside the policy.
+func TestLoadAsmdefAssembliesIgnoresExternalGUIDReferences(t *testing.T) {
+	root := t.TempDir()
+	writeAsmdefFixture(t, root, asmdefFixture{dir: "Editor/Domain", name: asmdefLayerDomain, guid: fixtureGUIDDomain, references: []string{guidReference("99999999999999999999999999999999")}})
+
+	assemblies, err := LoadAsmdefAssemblies(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findAssembly(t, assemblies, asmdefLayerDomain).References) != 0 {
+		t.Fatalf("expected the external GUID reference to be dropped, got %v", assemblies)
+	}
+}
+
+// LoadAsmdefAssemblies keeps plain-name references that match a loaded
+// assembly and drops plain names of external assemblies such as the Unity
+// test runner, so those never surface as violations.
+func TestLoadAsmdefAssembliesHandlesPlainNameReferences(t *testing.T) {
+	root := t.TempDir()
+	writeAsmdefFixture(t, root, asmdefFixture{dir: "Editor/Domain", name: asmdefLayerDomain, guid: fixtureGUIDDomain})
+	writeAsmdefFixture(t, root, asmdefFixture{dir: "Editor/Application", name: asmdefLayerApplication, guid: fixtureGUIDApplication, references: []string{asmdefLayerDomain, "UnityEditor.TestRunner"}})
+
+	assemblies, err := LoadAsmdefAssemblies(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	references := findAssembly(t, assemblies, asmdefLayerApplication).References
+	if len(references) != 1 || references[0] != asmdefLayerDomain {
+		t.Fatalf("expected only the internal plain-name reference, got %v", references)
+	}
+}
+
+// LoadAsmdefAssemblies reads the guid from a .meta file with CRLF line endings,
+// which Windows checkouts produce.
+func TestLoadAsmdefAssembliesReadsCRLFMeta(t *testing.T) {
+	root := t.TempDir()
+	writeAsmdefFixtureWithMeta(t, root, asmdefFixture{dir: "Editor/Domain", name: asmdefLayerDomain, guid: fixtureGUIDDomain}, "fileFormatVersion: 2\r\nguid: "+fixtureGUIDDomain+"\r\nAssemblyDefinitionImporter:\r\n")
+	writeAsmdefFixture(t, root, asmdefFixture{dir: "Editor/Application", name: asmdefLayerApplication, guid: fixtureGUIDApplication, references: []string{guidReference(fixtureGUIDDomain)}})
+
+	assemblies, err := LoadAsmdefAssemblies(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if references := findAssembly(t, assemblies, asmdefLayerApplication).References; len(references) != 1 {
+		t.Fatalf("expected the CRLF meta guid to resolve, got %v", references)
+	}
+}
+
+// LoadAsmdefAssemblies fails when an .asmdef has no .meta file, because the GUID
+// needed to resolve references to it is missing.
+func TestLoadAsmdefAssembliesFailsWithoutMeta(t *testing.T) {
+	root := t.TempDir()
+	writeAsmdefFixtureWithMeta(t, root, asmdefFixture{dir: "Editor/Domain", name: asmdefLayerDomain, guid: fixtureGUIDDomain}, "")
+
+	_, err := LoadAsmdefAssemblies(root)
+	if err == nil || !strings.Contains(err.Error(), ".meta") {
+		t.Fatalf("expected a missing-meta error, got %v", err)
+	}
+}
+
+// LoadAsmdefAssemblies fails when no .asmdef exists under the root, so running
+// from the wrong directory cannot pass as a silent no-op.
+func TestLoadAsmdefAssembliesFailsWhenNothingFound(t *testing.T) {
+	_, err := LoadAsmdefAssemblies(t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "no .asmdef files found") {
+		t.Fatalf("expected an empty-scan error, got %v", err)
+	}
+}
+
+// LoadAsmdefAssemblies skips tilde-suffixed directories, which Unity ignores.
+func TestLoadAsmdefAssembliesSkipsTildeDirectories(t *testing.T) {
+	root := t.TempDir()
+	writeAsmdefFixture(t, root, asmdefFixture{dir: "Editor/Domain", name: asmdefLayerDomain, guid: fixtureGUIDDomain})
+	writeAsmdefFixtureWithMeta(t, root, asmdefFixture{dir: "Editor/Ignored~", name: "UnityCLILoop.Mystery", guid: fixtureGUIDToolA}, "")
+
+	assemblies, err := LoadAsmdefAssemblies(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(assemblies) != 1 {
+		t.Fatalf("expected only the Domain assembly, got %v", assemblies)
+	}
+}
+
+func toolName(tool string) string {
+	return asmdefToolPrefix + tool + asmdefToolSuffix
+}
+
+func commonName(utility string) string {
+	return asmdefToolCommonPrefix + utility + asmdefToolSuffix
+}
+
+// evaluateAsmdefPolicy reports each forbidden reference with the rule it
+// violates. The table covers the current violations in the repository and the
+// rules that currently have no violating reference, so a checker that
+// accidentally allows everything still fails here.
+func TestEvaluateAsmdefPolicyReportsForbiddenReferences(t *testing.T) {
+	cases := []struct {
+		name string
+		from string
+		to   string
+		rule string
+	}{
+		{name: "tool to tool", from: toolName("A"), to: toolName("B"), rule: asmdefRuleToolIsolation},
+		{name: "tool to infrastructure", from: toolName("A"), to: asmdefLayerInfrastructure, rule: asmdefRuleLayerDirection},
+		{name: "tool to composition root", from: toolName("A"), to: asmdefLayerCompositionRoot, rule: asmdefRuleLayerDirection},
+		{name: "common to application", from: commonName("X"), to: asmdefLayerApplication, rule: asmdefRuleCommonLayering},
+		{name: "common to tool", from: commonName("X"), to: toolName("A"), rule: asmdefRuleCommonLayering},
+		{name: "domain to application", from: asmdefLayerDomain, to: asmdefLayerApplication, rule: asmdefRuleLayerDirection},
+		{name: "tool contracts to domain", from: asmdefLayerToolContracts, to: asmdefLayerDomain, rule: asmdefRuleLayerDirection},
+		{name: "presentation to infrastructure", from: asmdefLayerPresentation, to: asmdefLayerInfrastructure, rule: asmdefRuleLayerDirection},
+		{name: "runtime to layer", from: "UnityCLILoop.Runtime", to: asmdefLayerDomain, rule: asmdefRuleRuntimeIsolation},
+		{name: "internal bridge to layer", from: asmdefInternalBridgeName, to: asmdefLayerDomain, rule: asmdefRuleLayerDirection},
+		{name: "umbrella to infrastructure", from: asmdefToolsUmbrellaName, to: asmdefLayerInfrastructure, rule: asmdefRuleUmbrellaScope},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			findings, err := evaluateAsmdefPolicy([]AsmdefAssembly{
+				{Name: testCase.from, Path: "from.asmdef", References: []string{testCase.to}},
+				{Name: testCase.to, Path: "to.asmdef"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(findings) != 1 {
+				t.Fatalf("expected one finding, got %v", findings)
+			}
+			if findings[0].Rule != testCase.rule || findings[0].From != testCase.from || findings[0].To != testCase.to {
+				t.Fatalf("unexpected finding %+v", findings[0])
+			}
+		})
+	}
+}
+
+// evaluateAsmdefPolicy accepts one representative reference for every allowed
+// row of the policy table, so a rule that accidentally forbids a legitimate
+// direction is caught as well.
+func TestEvaluateAsmdefPolicyAcceptsAllowedReferences(t *testing.T) {
+	cases := []struct {
+		name string
+		from string
+		to   string
+	}{
+		{name: "domain to contracts", from: asmdefLayerDomain, to: asmdefLayerToolContracts},
+		{name: "application to domain", from: asmdefLayerApplication, to: asmdefLayerDomain},
+		{name: "infrastructure to application", from: asmdefLayerInfrastructure, to: asmdefLayerApplication},
+		{name: "infrastructure to internal bridge", from: asmdefLayerInfrastructure, to: asmdefInternalBridgeName},
+		{name: "infrastructure to runtime", from: asmdefLayerInfrastructure, to: "UnityCLILoop.PausePoints.Runtime"},
+		{name: "infrastructure to common", from: asmdefLayerInfrastructure, to: commonName("Console")},
+		{name: "presentation to application", from: asmdefLayerPresentation, to: asmdefLayerApplication},
+		{name: "composition root to infrastructure", from: asmdefLayerCompositionRoot, to: asmdefLayerInfrastructure},
+		{name: "composition root to umbrella", from: asmdefLayerCompositionRoot, to: asmdefToolsUmbrellaName},
+		{name: "runtime to runtime", from: "UnityCLILoop.PausePoints.Runtime", to: "UnityCLILoop.Runtime"},
+		{name: "umbrella to tool", from: asmdefToolsUmbrellaName, to: toolName("A")},
+		{name: "umbrella to common", from: asmdefToolsUmbrellaName, to: commonName("X")},
+		{name: "common to contracts", from: commonName("X"), to: asmdefLayerToolContracts},
+		{name: "common to common", from: commonName("X"), to: commonName("Y")},
+		{name: "common to runtime", from: commonName("X"), to: "UnityCLILoop.Runtime"},
+		{name: "tool to contracts", from: toolName("A"), to: asmdefLayerToolContracts},
+		{name: "tool to domain", from: toolName("A"), to: asmdefLayerDomain},
+		{name: "tool to application", from: toolName("A"), to: asmdefLayerApplication},
+		{name: "tool to common", from: toolName("A"), to: commonName("X")},
+		{name: "tool to runtime", from: toolName("A"), to: "UnityCLILoop.PausePoints.Runtime"},
+		{name: "tool to internal bridge", from: toolName("A"), to: asmdefInternalBridgeName},
+		{name: "sub-assembly to parent tool", from: toolName("RunTests.TestFramework"), to: toolName("RunTests")},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			findings, err := evaluateAsmdefPolicy([]AsmdefAssembly{
+				{Name: testCase.from, Path: "from.asmdef", References: []string{testCase.to}},
+				{Name: testCase.to, Path: "to.asmdef"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(findings) != 0 {
+				t.Fatalf("expected no findings, got %v", findings)
+			}
+		})
+	}
+}
+
+// evaluateAsmdefPolicy fails on an assembly whose name matches no category,
+// so a new assembly must follow the naming convention before it is accepted.
+func TestEvaluateAsmdefPolicyRejectsUnknownAssembly(t *testing.T) {
+	_, err := evaluateAsmdefPolicy([]AsmdefAssembly{{Name: "UnityCLILoop.Mystery", Path: "mystery.asmdef"}})
+	if err == nil || !strings.Contains(err.Error(), "UnityCLILoop.Mystery") {
+		t.Fatalf("expected an unknown-category error, got %v", err)
+	}
+}
+
+// applyAsmdefAllowlist drops findings that match an entry and reports entries
+// that matched nothing as stale.
+func TestApplyAsmdefAllowlistSeparatesMatchedAndStaleEntries(t *testing.T) {
+	findings := []AsmdefPolicyFinding{
+		{From: toolName("A"), To: toolName("B"), Rule: asmdefRuleToolIsolation},
+		{From: toolName("A"), To: toolName("C"), Rule: asmdefRuleToolIsolation},
+	}
+	allowlist := asmdefAllowlist{AllowedReferences: []asmdefAllowedReference{
+		{From: toolName("A"), To: toolName("B"), Reason: "kept"},
+		{From: asmdefLayerDomain, To: asmdefLayerApplication, Reason: "repaid"},
+	}}
+
+	remaining, stale := applyAsmdefAllowlist(findings, allowlist)
+	if len(remaining) != 1 || remaining[0].To != toolName("C") {
+		t.Fatalf("expected only the unlisted finding to remain, got %v", remaining)
+	}
+	if len(stale) != 1 || stale[0].From != asmdefLayerDomain {
+		t.Fatalf("expected the repaid entry to be stale, got %v", stale)
+	}
+}
+
+func writePolicyFixtureRepository(t *testing.T, root string, toolAReferences []string) {
+	t.Helper()
+	writeAsmdefFixture(t, root, asmdefFixture{dir: "Editor/ToolContracts", name: asmdefLayerToolContracts, guid: fixtureGUIDToolContracts})
+	writeAsmdefFixture(t, root, asmdefFixture{dir: "Editor/FirstPartyTools/A", name: toolName("A"), guid: fixtureGUIDToolA, references: toolAReferences})
+	writeAsmdefFixture(t, root, asmdefFixture{dir: "Editor/FirstPartyTools/B", name: toolName("B"), guid: fixtureGUIDToolB, references: []string{guidReference(fixtureGUIDToolContracts)}})
+}
+
+// RunAsmdefPolicyCheck exits 0 when every reference is allowed and the
+// allowlist is empty.
+func TestRunAsmdefPolicyCheckPassesCompliantRepository(t *testing.T) {
+	root := t.TempDir()
+	writePolicyFixtureRepository(t, root, []string{guidReference(fixtureGUIDToolContracts)})
+	allowlistPath := filepath.Join(root, "allowlist.json")
+	writeAsmdefAllowlist(t, allowlistPath, []asmdefAllowedReference{})
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	exitCode := RunAsmdefPolicyCheck(&stdout, &stderr, AsmdefPolicyCheckOptions{Root: root, AllowlistPath: allowlistPath})
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d (stdout %q, stderr %q)", exitCode, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "No asmdef reference violated the policy.") {
+		t.Fatalf("stdout did not report success: %q", stdout.String())
+	}
+}
+
+// RunAsmdefPolicyCheck exits 1 and names the reference and rule when a tool
+// references another tool that is not allowlisted.
+func TestRunAsmdefPolicyCheckFailsOnUnlistedViolation(t *testing.T) {
+	root := t.TempDir()
+	writePolicyFixtureRepository(t, root, []string{guidReference(fixtureGUIDToolB)})
+	allowlistPath := filepath.Join(root, "allowlist.json")
+	writeAsmdefAllowlist(t, allowlistPath, []asmdefAllowedReference{})
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	exitCode := RunAsmdefPolicyCheck(&stdout, &stderr, AsmdefPolicyCheckOptions{Root: root, AllowlistPath: allowlistPath})
+	if exitCode != 1 {
+		t.Fatalf("expected exit 1, got %d", exitCode)
+	}
+	expected := toolName("A") + " -> " + toolName("B") + ": " + asmdefRuleToolIsolation + " (Packages/src/Editor/FirstPartyTools/A/" + toolName("A") + ".asmdef)"
+	if !strings.Contains(stdout.String(), expected) {
+		t.Fatalf("stdout did not name the violation %q: %q", expected, stdout.String())
+	}
+}
+
+// RunAsmdefPolicyCheck exits 0 when the only violation is allowlisted, and
+// exits 1 with a stale message once that reference has been removed but the
+// allowlist entry remains.
+func TestRunAsmdefPolicyCheckHonoursAndExpiresAllowlist(t *testing.T) {
+	root := t.TempDir()
+	writePolicyFixtureRepository(t, root, []string{guidReference(fixtureGUIDToolB)})
+	allowlistPath := filepath.Join(root, "allowlist.json")
+	writeAsmdefAllowlist(t, allowlistPath, []asmdefAllowedReference{{From: toolName("A"), To: toolName("B"), Reason: "pending extraction"}})
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	if exitCode := RunAsmdefPolicyCheck(&stdout, &stderr, AsmdefPolicyCheckOptions{Root: root, AllowlistPath: allowlistPath}); exitCode != 0 {
+		t.Fatalf("expected the allowlisted violation to pass, got exit %d: %q", exitCode, stdout.String())
+	}
+
+	// Repay the debt without touching the allowlist: the entry is now stale.
+	writeAsmdefFixture(t, root, asmdefFixture{dir: "Editor/FirstPartyTools/A", name: toolName("A"), guid: fixtureGUIDToolA, references: []string{guidReference(fixtureGUIDToolContracts)}})
+	stdout.Reset()
+	exitCode := RunAsmdefPolicyCheck(&stdout, &stderr, AsmdefPolicyCheckOptions{Root: root, AllowlistPath: allowlistPath})
+	if exitCode != 1 {
+		t.Fatalf("expected the stale allowlist entry to fail, got exit %d", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "stale allowlist entry: "+toolName("A")+" -> "+toolName("B")) {
+		t.Fatalf("stdout did not report the stale entry: %q", stdout.String())
+	}
+}
+
+// RunAsmdefPolicyCheck exits 1 when the allowlist file is missing or an entry
+// lacks a reason, so exemptions cannot be added silently.
+func TestRunAsmdefPolicyCheckRejectsMalformedAllowlist(t *testing.T) {
+	root := t.TempDir()
+	writePolicyFixtureRepository(t, root, []string{guidReference(fixtureGUIDToolContracts)})
+	allowlistPath := filepath.Join(root, "allowlist.json")
+	writeAsmdefAllowlist(t, allowlistPath, []asmdefAllowedReference{{From: toolName("A"), To: toolName("B")}})
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	if exitCode := RunAsmdefPolicyCheck(&stdout, &stderr, AsmdefPolicyCheckOptions{Root: root, AllowlistPath: allowlistPath}); exitCode != 1 {
+		t.Fatalf("expected exit 1 for an entry without a reason, got %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "reason") {
+		t.Fatalf("stderr did not explain the malformed entry: %q", stderr.String())
+	}
+}

--- a/docs/asmdef-policy.md
+++ b/docs/asmdef-policy.md
@@ -1,0 +1,140 @@
+# Asmdef Reference Policy
+
+Assembly definitions (`.asmdef`) under `Packages/src` encode the package
+architecture: Clean Architecture layers, a set of independent first-party tools,
+and shared utilities between them. Unity already rejects reference cycles, and
+the layer assemblies already fail to compile when a reference is missing, but
+nothing stopped an *extra* reference from being added in a direction the
+architecture forbids — for example one tool referencing another to borrow a
+helper. `check-asmdef-policy` closes that gap.
+
+## What it enforces
+
+The checker reads every `.asmdef` under `Packages/src` (Unity-ignored `~`
+folders excluded), resolves `GUID:` references through the sibling `.asmdef.meta`
+files, drops references to assemblies outside the tree (Unity packages, the test
+runner), classifies each assembly by name, and fails on any reference that the
+table below does not allow.
+
+### Categories
+
+| Category | Assembly names |
+|----------|----------------|
+| Layer | `UnityCLILoop.ToolContracts`, `UnityCLILoop.Domain`, `UnityCLILoop.Application`, `UnityCLILoop.Infrastructure`, `UnityCLILoop.Presentation`, `UnityCLILoop.CompositionRoot.Editor` |
+| InternalBridge | `Unity.InternalAPIEditorBridge.024` |
+| Runtime | `*.Runtime` |
+| ToolsUmbrella | `UnityCLILoop.FirstPartyTools.Editor` |
+| ToolCommon | `UnityCLILoop.FirstPartyTools.Common.<Name>.Editor` |
+| Tool | `UnityCLILoop.FirstPartyTools.<Tool>.Editor` (sub-assemblies such as `RunTests.TestFramework` belong to their parent tool) |
+
+An assembly whose name matches none of these is an error, not a finding: extend
+the naming convention (and this table) before adding it.
+
+### Allowed references
+
+| From | May reference | Rule id on violation |
+|------|---------------|----------------------|
+| ToolContracts | nothing inside the package | `layer-direction` |
+| Domain | ToolContracts | `layer-direction` |
+| Application | Domain, ToolContracts | `layer-direction` |
+| Infrastructure | Application, Domain, ToolContracts, InternalBridge, Runtime, ToolCommon | `layer-direction` |
+| Presentation | Application, Domain, ToolContracts | `layer-direction` |
+| CompositionRoot | every layer, ToolsUmbrella, Runtime, InternalBridge | `layer-direction` |
+| InternalBridge | nothing inside the package | `layer-direction` |
+| Runtime | other Runtime assemblies | `runtime-isolation` |
+| ToolsUmbrella | Tool, ToolCommon, ToolContracts, Domain | `umbrella-scope` |
+| ToolCommon | ToolContracts, Domain, ToolCommon, Runtime, InternalBridge | `common-layering` |
+| Tool | ToolContracts, Domain, Application, ToolCommon, Runtime, InternalBridge, its own parent tool | `tool-isolation` for another Tool, `layer-direction` otherwise |
+
+The two rules that motivated the checker:
+
+- **tool-isolation** — a tool must not reference another tool. Tools are meant
+  to be independently removable; a tool-to-tool reference turns a helper into a
+  hidden shared dependency.
+- **common-layering** — `FirstPartyTools.Common.*` sits below the tools *and*
+  below `Application`. A Common assembly that reaches into `Application` can no
+  longer be reused by anything that must stay lightweight.
+
+There is no cycle rule. Unity refuses to import an asmdef cycle, and the
+`unity-compile-check-and-test-runner.yml` workflow already surfaces that.
+
+## Allowlist
+
+`tools/asmdef-policy-allowlist.json` lists the references that violate the
+policy today and are tolerated until they are repaid:
+
+```json
+{
+  "allowedReferences": [
+    {
+      "from": "UnityCLILoop.FirstPartyTools.Watch.Editor",
+      "to": "UnityCLILoop.FirstPartyTools.PausePoint.Editor",
+      "reason": "Why the reference exists today. Resolution: how it will be removed."
+    }
+  ]
+}
+```
+
+Rules for the file:
+
+- Every entry needs `from`, `to`, and a non-empty `reason`. The reason states
+  *why* the reference exists and the *planned resolution*; "needed" is not a
+  reason.
+- An entry whose reference no longer exists is a **stale entry and fails the
+  check**. Delete it in the same commit that removes the reference. The
+  allowlist can only shrink by accident, never grow by accident.
+- Adding an entry is a reviewable decision. Prefer removing the reference; add an
+  entry only when the removal genuinely has to wait.
+
+## Removing a tool-to-tool reference
+
+Three remedies cover every case seen so far:
+
+1. **Promote to Common.** When the borrowed code is a pure utility (a formatter,
+   a constant set, a compiler wrapper), move it into a
+   `FirstPartyTools.Common.<Name>.Editor` assembly and have both tools reference
+   that.
+2. **Invert the dependency.** When the borrowed code is a tool *behaviour*
+   (stopping Play Mode, recording a session value), declare a port interface in
+   `ToolContracts`, implement it in the owning tool, and wire the implementation
+   in `CompositionRoot`. The consuming tool depends only on the port.
+3. **Extract a foundation.** When several tools share a large capability
+   (dynamic compilation), give it its own Common assembly and make the original
+   tool depend on it too, so the tool becomes one consumer among others.
+
+## Adding a new assembly
+
+Name it so that it lands in exactly one category:
+
+- A new tool: `UnityCLILoop.FirstPartyTools.<Tool>.Editor`, referenced from the
+  umbrella `UnityCLILoop.FirstPartyTools.Editor`.
+- A sub-assembly of a tool: `UnityCLILoop.FirstPartyTools.<Tool>.<Part>.Editor`.
+- A shared utility: `UnityCLILoop.FirstPartyTools.Common.<Name>.Editor`.
+- Runtime code: `<Anything>.Runtime`.
+
+A name outside these shapes makes the check fail with
+`matches no assembly category` until the convention is extended in
+`cli/release-automation/internal/automation/asmdef_policy_rules.go`.
+
+## Local usage
+
+From `cli/release-automation`:
+
+```sh
+go run ./cmd/check-asmdef-policy --root "$(git rev-parse --show-toplevel)"
+```
+
+Exit code 0 prints `No asmdef reference violated the policy.`; exit code 1 lists
+each violation as `From -> To: rule (path)` and each stale allowlist entry.
+`--allowlist <path>` points at a different allowlist for experiments.
+
+## Where it runs
+
+1. **Pre-commit hook** (`.husky/pre-commit`) — when a staged change touches any
+   `Packages/src/**/*.asmdef` or the allowlist. Catches the reference while the
+   code that needs it is still small.
+2. **Pull-request CI** — the `Check asmdef reference policy` step in
+   `.github/workflows/build-and-test.yml`.
+3. **Unit tests** — `asmdef_policy_test.go` covers every row of the permit table
+   and one violation per rule, so a checker that accidentally allows everything
+   fails its own tests.

--- a/tools/asmdef-policy-allowlist.json
+++ b/tools/asmdef-policy-allowlist.json
@@ -1,0 +1,34 @@
+{
+  "allowedReferences": [
+    {
+      "from": "UnityCLILoop.FirstPartyTools.HotReload.Editor",
+      "to": "UnityCLILoop.FirstPartyTools.ExecuteDynamicCode.Editor",
+      "reason": "Hot reload reuses the external compiler path resolver and the compiled assembly loader. Resolution: promote those two pieces to a FirstPartyTools.Common.DynamicCompilation assembly; ExecuteDynamicCode then depends on it as well."
+    },
+    {
+      "from": "UnityCLILoop.FirstPartyTools.Watch.Editor",
+      "to": "UnityCLILoop.FirstPartyTools.ExecuteDynamicCode.Editor",
+      "reason": "Watch evaluates expressions with DynamicCodeCompiler and reports CompilationError. The compiler is a shared foundation, not a tool feature. Resolution: move dynamic compilation into FirstPartyTools.Common.DynamicCompilation (same target as the HotReload entry)."
+    },
+    {
+      "from": "UnityCLILoop.FirstPartyTools.Watch.Editor",
+      "to": "UnityCLILoop.FirstPartyTools.PausePoint.Editor",
+      "reason": "Watch history formats captured variables with SourcePausePointVariableFormatter and SourcePausePointConstants. Resolution: promote the formatter and constants to a FirstPartyTools.Common assembly shared by both tools."
+    },
+    {
+      "from": "UnityCLILoop.FirstPartyTools.Compile.Editor",
+      "to": "UnityCLILoop.FirstPartyTools.ControlPlayMode.Editor",
+      "reason": "Compile stops Play Mode before compiling and records the stop reason in PlayModeStopReasonSessionStore. Resolution: expose Play Mode stop-reason recording as a port in ToolContracts implemented by ControlPlayMode and wired in CompositionRoot (dependency inversion), or promote the store to a FirstPartyTools.Common assembly."
+    },
+    {
+      "from": "UnityCLILoop.FirstPartyTools.RunTests.TestFramework.Editor",
+      "to": "UnityCLILoop.FirstPartyTools.ControlPlayMode.Editor",
+      "reason": "Test cancellation restores Play Mode state through PlayModeStopReasonSessionStore. Resolution: same as the Compile entry; both edges disappear together."
+    },
+    {
+      "from": "UnityCLILoop.FirstPartyTools.Common.InputSystem.Editor",
+      "to": "UnityCLILoop.Application",
+      "reason": "Input System frame waiters depend on Application-layer editor state services. Resolution: move the frame waiters that need Application into the tools that use them, or invert the dependency through a ToolContracts port so Common stays below Application."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Pull requests and local commits now fail when an assembly definition under `Packages/src` references another assembly in a direction the package architecture forbids: a tool referencing another tool, a `FirstPartyTools.Common.*` assembly referencing `Application` or above, or a layer referencing an outer layer.
- The six references that violate the policy today are tolerated through a reasoned allowlist; each entry states why it exists and how it will be removed.

## User Impact
- Before: Unity rejected asmdef cycles and missing references failed to compile, but an extra reference in a forbidden direction (e.g. one tool borrowing a helper from another) went unnoticed until a reviewer happened to open the `.asmdef`.
- After: the pre-commit hook reports the reference the moment an `.asmdef` or the allowlist is staged, and CI reports it on the pull request. Repaying a tolerated reference without deleting its allowlist entry also fails, so the allowlist can only shrink.

## Changes
- New Go command `cli/release-automation/cmd/check-asmdef-policy` (assembly loading with GUID resolution through `.meta` files, name-based category classification, permit table, allowlist with stale detection).
- `tools/asmdef-policy-allowlist.json` with the six current violations and their planned resolutions.
- `Check asmdef reference policy` step in `build-and-test.yml`; `.husky/pre-commit` runs the check when a staged change touches an `.asmdef` or the allowlist.
- `docs/asmdef-policy.md` (categories, permit table, allowlist rules, remedies for tool-to-tool references, naming for new assemblies) and a pointer section in `AGENTS.md`.
- No cycle rule: Unity already refuses asmdef cycles and the compile workflow surfaces that.

## Verification
- `go test ./internal/automation/ -run Asmdef` — 18 tests: GUID/plain-name/CRLF resolution, missing `.meta`, empty scan, tilde folders, one violation per rule, every row of the permit table, allowlist match/stale, exit codes.
- `go run ./cmd/check-asmdef-policy --root "$(git rev-parse --show-toplevel)"` on this repository → `No asmdef reference violated the policy.` (exit 0).
- Fault injection: removing one allowlist entry → `tool-isolation` finding, exit 1; adding an entry for a removed reference → `stale allowlist entry`, exit 1; wrong `--root` → error, exit 1. Same injection through `sh .husky/pre-commit` with the allowlist staged → exit 1.
- `scripts/check-go-cli.sh` → exit 0.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

