### PR TITLE
chore: Stop stacking duplicate winget New-Package pull requests while the first submission awaits moderation

### DIFF
--- a/cli/release-automation/internal/automation/winget_manifest_update.go
+++ b/cli/release-automation/internal/automation/winget_manifest_update.go
@@ -155,15 +155,15 @@ func runUpdateWingetManifestWithDeps(
 		return 0
 	}
 
-	versionPath := wingetPackageManifestPath() + "/" + version
-	versionExists, err := wingetUpstreamPathExists(ctx, deps, token, versionPath)
+	skipReason, err := wingetUpstreamSkipReason(ctx, deps, token, version)
 	if err != nil {
 		return writeWingetManifestUpdateError(stderr, err)
 	}
-	if versionExists {
-		writeWingetManifestUpdateLine(stdout, fmt.Sprintf("winget manifest for %s already exists upstream; skipping.", version))
+	if skipReason != "" {
+		writeWingetManifestUpdateLine(stdout, skipReason)
 		return 0
 	}
+	versionPath := wingetPackageManifestPath() + "/" + version
 	metadata, err := downloadWingetReleaseMetadata(ctx, deps, config.repository, config.tag)
 	if err != nil {
 		return writeWingetManifestUpdateError(stderr, err)
@@ -177,10 +177,6 @@ func runUpdateWingetManifestWithDeps(
 		return writeWingetManifestUpdateError(stderr, err)
 	}
 
-	packageExists, err := wingetUpstreamPathExists(ctx, deps, token, wingetPackageManifestPath())
-	if err != nil {
-		return writeWingetManifestUpdateError(stderr, err)
-	}
 	manifests, err := renderWingetManifests(data)
 	if err != nil {
 		return writeWingetManifestUpdateError(stderr, err)
@@ -200,7 +196,7 @@ func runUpdateWingetManifestWithDeps(
 		return 0
 	}
 
-	title := wingetPullRequestTitle(packageExists, version)
+	title := wingetPullRequestTitle(version)
 	body := "Automated submission from https://github.com/" + config.repository + "/releases/tag/" + config.tag
 	pullRequestURL, err := openWingetPullRequest(ctx, deps, token, forkOwner, branch, title, body)
 	if err != nil {
@@ -350,12 +346,36 @@ func publishWingetManifestBranch(
 	return nil
 }
 
-func wingetPullRequestTitle(packageExists bool, version string) string {
-	prefix := "New package:"
-	if packageExists {
-		prefix = "New version:"
+// wingetUpstreamSkipReason reports why a release must not be submitted, or "" when it should be.
+// The initial New-Package submission is manual: it needs the CLA, moderator review,
+// and possibly manifest fixes, and automated resubmission on every release stacks
+// duplicate New-Package pull requests while the first one is still in moderation.
+func wingetUpstreamSkipReason(
+	ctx context.Context,
+	deps wingetManifestUpdateDeps,
+	token string,
+	version string,
+) (string, error) {
+	packageExists, err := wingetUpstreamPathExists(ctx, deps, token, wingetPackageManifestPath())
+	if err != nil {
+		return "", err
 	}
-	return fmt.Sprintf("%s %s version %s", prefix, wingetPackageIdentifier, version)
+	if !packageExists {
+		return fmt.Sprintf("%s is not in winget-pkgs yet; the initial submission is manual. Skipping.", wingetPackageIdentifier), nil
+	}
+	versionExists, err := wingetUpstreamPathExists(ctx, deps, token, wingetPackageManifestPath()+"/"+version)
+	if err != nil {
+		return "", err
+	}
+	if versionExists {
+		return fmt.Sprintf("winget manifest for %s already exists upstream; skipping.", version), nil
+	}
+	return "", nil
+}
+
+// Automation only ever submits version updates; see wingetUpstreamSkipReason.
+func wingetPullRequestTitle(version string) string {
+	return fmt.Sprintf("New version: %s version %s", wingetPackageIdentifier, version)
 }
 
 func wingetPackageManifestPath() string {

--- a/cli/release-automation/internal/automation/winget_manifest_update_test.go
+++ b/cli/release-automation/internal/automation/winget_manifest_update_test.go
@@ -230,18 +230,25 @@ func TestUpdateWingetManifestSkipsExistingVersion(t *testing.T) {
 	assertWingetPublishSetupNotCalled(t, scenario)
 }
 
-// TestUpdateWingetManifestUsesNewPackageTitle verifies a missing upstream package uses the initial-submission PR title.
-func TestUpdateWingetManifestUsesNewPackageTitle(t *testing.T) {
+// TestUpdateWingetManifestSkipsUntilPackageExistsUpstream verifies a package missing upstream skips every fork write and PR creation because the initial submission is manual.
+func TestUpdateWingetManifestSkipsUntilPackageExistsUpstream(t *testing.T) {
 	scenario := newWingetTestScenario()
 	scenario.packageExists = false
-	_, code := runWingetTestScenario(t, scenario)
+	stdout, code := runWingetTestScenario(t, scenario)
 
 	if code != 0 {
 		t.Fatalf("exit code = %d", code)
 	}
-	if scenario.pullRequestTitle != "New package: hatayama.uloop version 3.1.0" {
-		t.Fatalf("PR title = %q", scenario.pullRequestTitle)
+	if !strings.Contains(stdout, "hatayama.uloop is not in winget-pkgs yet; the initial submission is manual. Skipping.") {
+		t.Fatalf("unexpected stdout: %s", stdout)
 	}
+	if scenario.putCalls != 0 || scenario.pullRequestCreateCalls != 0 {
+		t.Fatalf("PUT calls = %d, PR creation calls = %d", scenario.putCalls, scenario.pullRequestCreateCalls)
+	}
+	if scenario.releaseDownloadCalls != 0 || scenario.releaseViewCalls != 0 {
+		t.Fatalf("release download calls = %d, release view calls = %d", scenario.releaseDownloadCalls, scenario.releaseViewCalls)
+	}
+	assertWingetPublishSetupNotCalled(t, scenario)
 }
 
 // TestUpdateWingetManifestUsesNewVersionTitle verifies an existing upstream package uses the update PR title.

--- a/docs/package-manager-distribution.md
+++ b/docs/package-manager-distribution.md
@@ -29,6 +29,12 @@ winget receives stable dispatcher releases only. Prereleases are not submitted.
 - When `WINGET_PKGS_TOKEN` is unset, the winget update command logs an explicit
   skip and exits 0. It also skips prereleases, versions that already exist
   upstream, and versions with an open submission pull request.
+- Automation submits version updates only. While `manifests/h/hatayama/uloop`
+  does not exist upstream, the command logs a skip and exits 0 instead of opening
+  a `New package:` pull request: the initial submission needs the CLA, moderator
+  review, and possibly manifest fixes, and resubmitting on every release stacked
+  duplicate New-Package pull requests while the first one sat in moderation. Open
+  the initial submission by hand; automation resumes once it merges.
 - New winget-pkgs pull requests must pass the upstream bot validation and human
   moderation. Moderation commonly takes several days and can take up to two
   weeks.


### PR DESCRIPTION
## Summary
- Release automation no longer opens a new `New package:` pull request against microsoft/winget-pkgs on every stable dispatcher release while the initial winget submission is still waiting for moderation.
- Automation now handles version updates only; the first submission of the package is done by hand.

## User Impact
- Before: each stable release stacked another New-Package pull request in winget-pkgs while the first one sat in the moderation queue (3.2.0, 3.2.1, 3.2.2 and 3.3.0 were all open at once), which confuses moderators and slows down the very approval we are waiting for.
- After: while `manifests/h/hatayama/uloop` does not exist upstream, the publish step logs a skip and exits 0. Once the initial submission (microsoft/winget-pkgs#427976) merges, the next stable release resumes submitting `New version:` pull requests automatically with no further change.

## Changes
- The duplicate guard only looked for an open pull request on the same version branch, and the branch name changes every release, so it never suppressed a second New-Package submission. Instead of widening that search, automation now refuses to submit at all until the package exists upstream — the initial submission is inherently manual (CLA, moderator review, manifest fixes).
- Upstream skip checks (package missing, version already present) are extracted into one helper to keep the main flow under the cyclomatic complexity limit; the now-unreachable `New package:` title path is removed.
- `docs/package-manager-distribution.md` documents that automation submits version updates only and the initial submission is manual.

## Verification
- `go test ./internal/automation/ -run TestUpdateWingetManifest` in `cli/release-automation` — new `TestUpdateWingetManifestSkipsUntilPackageExistsUpstream` fails before the change (a pull request was opened) and passes after.
- `scripts/check-go-cli.sh` — exit 0 (format, vet, lint 0 issues, tests, build).
- `gocyclo` on `runUpdateWingetManifestWithDeps`: 15 → 14.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

