### PR TITLE
chore: Let one hot reload worker run describe several edited source files

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2627,8 +2627,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             TransformWorkerOutputDto workerOutput = new TransformWorkerOutputDto
             {
                 entries = entries,
-                addedFieldNames = addedFieldNames,
-                sourceContentSha256 = "preflight-match-failure"
+                files = new[]
+                {
+                    new TransformWorkerFileOutputDto
+                    {
+                        projectRelativePath = projectRelativePath,
+                        addedFieldNames = addedFieldNames,
+                        sourceContentSha256 = "preflight-match-failure"
+                    }
+                }
             };
 
             HotReloadFileProcessResult fileResult =
@@ -2887,8 +2894,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             TransformWorkerOutputDto workerOutput = new TransformWorkerOutputDto
             {
                 entries = entries,
-                addedFieldNames = Array.Empty<string>(),
-                sourceContentSha256 = "direct-apply-preflight"
+                files = new[]
+                {
+                    new TransformWorkerFileOutputDto
+                    {
+                        projectRelativePath = projectRelativePath,
+                        addedFieldNames = Array.Empty<string>(),
+                        sourceContentSha256 = "direct-apply-preflight"
+                    }
+                }
             };
             return HotReloadEntryApplier.ApplyEntriesAndBuildResult(
                 CreateApplyContext(
@@ -2942,8 +2956,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 compilationAssembly,
                 targetDllPath,
                 compilationAssembly.defines ?? Array.Empty<string>(),
-                new TransformWorkerInputDto { projectRelativePath = projectRelativePath },
+                new TransformWorkerInputDto
+                {
+                    sources = new[]
+                    {
+                        new TransformWorkerSourceDto { projectRelativePath = projectRelativePath }
+                    }
+                },
                 workerOutput,
+                workerOutput.files[0],
                 new HashSet<string>(),
                 new HashSet<string>());
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadShimErrorAttributionTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShimErrorAttributionTests.cs
@@ -68,5 +68,36 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(attribution, Is.Null);
         }
+
+        /// <summary>
+        /// What: two entries of the same file whose source ranges both contain the error line
+        /// make the error ambiguous, so the whole attribution is rejected instead of pinning it
+        /// on the first match.
+        /// </summary>
+        [Test]
+        public void AttributeErrorsToEntries_TwoEntriesOfSameFileContainErrorLine_ReturnsNull()
+        {
+            TransformWorkerEntryDto outerEntry = new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = "Assets/Scripts/First.cs",
+                sourceStartLine = 10,
+                sourceEndLine = 30
+            };
+            TransformWorkerEntryDto innerEntry = new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = "Assets/Scripts/First.cs",
+                sourceStartLine = 14,
+                sourceEndLine = 20
+            };
+            HotReloadShimCompileError error =
+                new HotReloadShimCompileError("Assets/Scripts/First.cs", 15, "CS0103: name not found");
+
+            HotReloadShimErrorAttribution.ShimCompileErrorAttribution attribution =
+                HotReloadShimErrorAttribution.AttributeErrorsToEntries(
+                    new[] { outerEntry, innerEntry },
+                    new List<HotReloadShimCompileError> { error });
+
+            Assert.That(attribution, Is.Null);
+        }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadShimErrorAttributionTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShimErrorAttributionTests.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for mapping shim compile diagnostics onto worker entries when one shim
+    /// assembly hosts entries from several edited files.
+    /// </summary>
+    public class HotReloadShimErrorAttributionTests
+    {
+        /// <summary>
+        /// What: two entries from different files share an original-source line range, and the
+        /// error is attributed to the entry whose file matches error.File instead of being
+        /// rejected as ambiguous.
+        /// </summary>
+        [Test]
+        public void AttributeErrorsToEntries_OverlappingRangesInDifferentFiles_AttributesToMatchingFile()
+        {
+            TransformWorkerEntryDto firstFileEntry = new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = "Assets/Scripts/First.cs",
+                sourceStartLine = 10,
+                sourceEndLine = 20
+            };
+            TransformWorkerEntryDto secondFileEntry = new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = "Assets/Scripts/Second.cs",
+                sourceStartLine = 10,
+                sourceEndLine = 20
+            };
+            HotReloadShimCompileError error =
+                new HotReloadShimCompileError("Assets/Scripts/Second.cs", 15, "CS0103: name not found");
+
+            HotReloadShimErrorAttribution.ShimCompileErrorAttribution attribution =
+                HotReloadShimErrorAttribution.AttributeErrorsToEntries(
+                    new[] { firstFileEntry, secondFileEntry },
+                    new List<HotReloadShimCompileError> { error });
+
+            Assert.That(attribution, Is.Not.Null);
+            Assert.That(attribution.FailedEntries, Is.EqualTo(new[] { secondFileEntry }));
+            Assert.That(attribution.ErrorMessagesByEntry.ContainsKey(firstFileEntry), Is.False);
+        }
+
+        /// <summary>
+        /// What: an error whose file matches no entry file is unattributable, so the whole
+        /// attribution is rejected rather than pinned on an entry with a containing line range.
+        /// </summary>
+        [Test]
+        public void AttributeErrorsToEntries_ErrorFileMatchesNoEntryFile_ReturnsNull()
+        {
+            TransformWorkerEntryDto entry = new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = "Assets/Scripts/First.cs",
+                sourceStartLine = 10,
+                sourceEndLine = 20
+            };
+            HotReloadShimCompileError error =
+                new HotReloadShimCompileError("Assets/Scripts/Third.cs", 15, "CS0103: name not found");
+
+            HotReloadShimErrorAttribution.ShimCompileErrorAttribution attribution =
+                HotReloadShimErrorAttribution.AttributeErrorsToEntries(
+                    new[] { entry },
+                    new List<HotReloadShimCompileError> { error });
+
+            Assert.That(attribution, Is.Null);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadShimErrorAttributionTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadShimErrorAttributionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f71d251b03c174b02b2b2d79fa8d2efb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -105,7 +105,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
 
             bool foundRemoved = false;
-            foreach (TransformWorkerRemovedMemberDto removed in result.Output.removedMembers)
+            foreach (TransformWorkerRemovedMemberDto removed in result.Output.files[0].removedMembers)
             {
                 if (removed.kind == HotReloadConstants.RemovedMemberKindField
                     && removed.name == nameof(HotReloadAddedMemberHost.Inner))
@@ -146,7 +146,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HostProjectRelativePath,
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            Assert.That(result.Output.addedFieldNames, Is.EqualTo(expectedNames));
+            Assert.That(result.Output.files[0].addedFieldNames, Is.EqualTo(expectedNames));
         }
 
         /// <summary>
@@ -170,8 +170,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller)), Is.Not.Null);
-            Assert.That(result.Output.addedFieldNames, Is.Not.Null);
-            Assert.That(result.Output.addedFieldNames, Is.Empty);
+            Assert.That(result.Output.files[0].addedFieldNames, Is.Not.Null);
+            Assert.That(result.Output.files[0].addedFieldNames, Is.Empty);
         }
 
         /// <summary>
@@ -196,8 +196,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HostProjectRelativePath,
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            Assert.That(result.Output.addedFieldNames, Is.Not.Null);
-            Assert.That(result.Output.addedFieldNames, Is.Empty);
+            Assert.That(result.Output.files[0].addedFieldNames, Is.Not.Null);
+            Assert.That(result.Output.files[0].addedFieldNames, Is.Empty);
         }
 
         /// <summary>
@@ -221,7 +221,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HostProjectRelativePath,
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            Assert.That(result.Output.addedFieldNames, Is.EqualTo(new[] { expectedName }));
+            Assert.That(result.Output.files[0].addedFieldNames, Is.EqualTo(new[] { expectedName }));
         }
 
         /// <summary>
@@ -252,9 +252,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(slice, Does.Not.Contain("HotReloadAddedFieldStore"));
             Assert.That(slice, Does.Not.Contain("AddedConst"));
             Assert.That(result.Output.hasAddedFieldRewrites, Is.False);
-            Assert.That(result.Output.addedFieldNames, Is.Empty);
+            Assert.That(result.Output.files[0].addedFieldNames, Is.Empty);
             Assert.That(
-                result.Output.addedConstNames,
+                result.Output.files[0].addedConstNames,
                 Is.EqualTo(new[] { typeof(HotReloadAddedMemberHost).FullName + ".AddedConst" }));
         }
 
@@ -491,17 +491,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HotReloadConstants.AddedFieldsLifetimeWarningFormat,
                 typeof(HotReloadAddedMemberHost).FullName + ".AddedCount");
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Does.Not.Contain(unexpectedLifetimeWarning),
                 "Worker must not emit the added-fields lifetime warning; the orchestrator owns it.");
             string expectedOutsideBodyWarning = string.Format(
                 OutsideMethodBodyDriftWarningFormat,
                 "AddedFieldNoDrift.cs");
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Does.Not.Contain(expectedOutsideBodyWarning),
                 "Handled added-field declarations must not fire the outside-body warning.\n"
-                + string.Join("\n", result.Output.declarationDriftWarnings));
+                + string.Join("\n", result.Output.files[0].declarationDriftWarnings));
 
             Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
         }
@@ -616,7 +616,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Lazy initialization inside the body must not skip the method. Skipped="
                 + FormatSkipped(result.Output.skipped));
             Assert.That(
-                result.Output.addedFieldNames,
+                result.Output.files[0].addedFieldNames,
                 Is.EqualTo(new[] { typeof(HotReloadAddedMemberHost).FullName + ".AddedLazyMap" }));
             Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
         }
@@ -1073,7 +1073,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Success, Is.True, result.ErrorMessage);
 
             bool foundDrift = false;
-            foreach (string warning in result.Output.declarationDriftWarnings)
+            foreach (string warning in result.Output.files[0].declarationDriftWarnings)
             {
                 if (warning != null && warning.Contains("Edits outside method bodies"))
                 {
@@ -1106,7 +1106,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Is.EqualTo(
                     new[]
                     {
@@ -1135,7 +1135,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Is.EqualTo(
                     new[]
                     {
@@ -1162,7 +1162,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Is.EqualTo(
                     new[]
                     {
@@ -1188,7 +1188,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Is.EqualTo(
                     new[]
                     {
@@ -1214,7 +1214,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Is.EqualTo(
                     new[]
                     {
@@ -1244,7 +1244,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: snapshotSource);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Is.EqualTo(
                     new[]
                     {
@@ -1308,7 +1308,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
 
             bool foundWarning = false;
-            foreach (string warning in result.Output.declarationDriftWarnings)
+            foreach (string warning in result.Output.files[0].declarationDriftWarnings)
             {
                 if (warning != null
                     && warning.Contains("AddedSerialized")
@@ -1462,7 +1462,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Is.EqualTo(
                     new[]
                     {
@@ -1488,7 +1488,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Is.EqualTo(
                     new[]
                     {
@@ -1518,7 +1518,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Is.EqualTo(
                     new[]
                     {
@@ -1549,7 +1549,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Is.EqualTo(
                     new[]
                     {
@@ -1784,7 +1784,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             TransformWorkerClientResult result,
             string expectedWarning)
         {
-            string[] warnings = result.Output.declarationDriftWarnings ?? Array.Empty<string>();
+            string[] warnings = result.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>();
             foreach (string warning in warnings)
             {
                 if (warning == expectedWarning)
@@ -1802,7 +1802,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             TransformWorkerClientResult result,
             string memberName)
         {
-            string[] warnings = result.Output.declarationDriftWarnings ?? Array.Empty<string>();
+            string[] warnings = result.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>();
             foreach (string warning in warnings)
             {
                 if (warning == null)
@@ -1867,14 +1867,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             TransformWorkerInputDto input = new TransformWorkerInputDto
             {
-                sourcePath = sourcePath,
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = sourcePath,
+                        projectRelativePath = projectRelativePath,
+                        snapshotSource = snapshotSource
+                    }
+                },
                 defines = compilationAssembly.defines ?? Array.Empty<string>(),
                 referencePaths = BuildAbsoluteReferencePaths(
                     compilationAssembly.allReferences,
                     targetDllPath),
                 targetTypesAssemblyPath = targetDllPath,
-                snapshotSource = snapshotSource,
-                projectRelativePath = projectRelativePath,
                 assemblySourcePaths = BuildAbsoluteAssemblySourcePaths(compilationAssembly.sourceFiles),
                 excludedMethodKeys = Array.Empty<string>(),
                 excludedAddedMethodKeys = Array.Empty<string>()
@@ -1987,14 +1993,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private static void AssertHasNoAddedFieldSerializeWarning(TransformWorkerClientResult result)
         {
-            foreach (string warning in result.Output.declarationDriftWarnings)
+            foreach (string warning in result.Output.files[0].declarationDriftWarnings)
             {
                 if (warning != null && warning.Contains("will not appear in the Inspector"))
                 {
                     Assert.Fail(
                         "Declaration-changed compiled fields must not emit the added-field "
                         + "Inspector warning. Warnings="
-                        + string.Join("\n", result.Output.declarationDriftWarnings));
+                        + string.Join("\n", result.Output.files[0].declarationDriftWarnings));
                 }
             }
         }

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -59,9 +59,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             TransformWorkerEntryDto existing = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingValue));
             Assert.That(existing, Is.Null, "Unedited ExistingValue must not be an entry when snapshot matches.");
 
-            Assert.That(result.Output.removedMembers, Is.Not.Null);
+            Assert.That(result.Output.files[0].removedMembers, Is.Not.Null);
             bool foundRemoved = false;
-            foreach (TransformWorkerRemovedMemberDto removed in result.Output.removedMembers)
+            foreach (TransformWorkerRemovedMemberDto removed in result.Output.files[0].removedMembers)
             {
                 if (removed.kind == HotReloadConstants.RemovedMemberKindMethod
                     && removed.name == nameof(HotReloadAddedMemberHost.ExistingFail))
@@ -383,7 +383,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(added, Is.Not.Null, "Added Update must still be an entry.");
             Assert.That(added.patchKind, Is.EqualTo(HotReloadConstants.PatchKindAddedMethod));
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.Some.Contain("Update").And.Contain("uloop compile"));
         }
 
@@ -404,10 +404,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(addedResult.Success, Is.True, addedResult.ErrorMessage);
             Assert.That(
-                addedResult.Output.declarationDriftWarnings,
+                addedResult.Output.files[0].declarationDriftWarnings,
                 Has.None.Contain("Edits outside method bodies"),
                 "Handled method addition must not fire outside-body drift.\n"
-                + string.Join("\n", addedResult.Output.declarationDriftWarnings ?? Array.Empty<string>()));
+                + string.Join("\n", addedResult.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>()));
 
             string removedOnly = onDisk.Replace(
                 "        [MethodImpl(MethodImplOptions.NoInlining)]\n"
@@ -420,10 +420,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(removedResult.Success, Is.True, removedResult.ErrorMessage);
             Assert.That(
-                removedResult.Output.declarationDriftWarnings,
+                removedResult.Output.files[0].declarationDriftWarnings,
                 Has.None.Contain("Edits outside method bodies"),
                 "Handled method removal must not fire outside-body drift.\n"
-                + string.Join("\n", removedResult.Output.declarationDriftWarnings ?? Array.Empty<string>()));
+                + string.Join("\n", removedResult.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>()));
 
             string fieldAndAdded = addedOnly.Replace(
                 "public int PublicSeed = 3;",
@@ -435,7 +435,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(fieldResult.Success, Is.True, fieldResult.ErrorMessage);
             Assert.That(
-                fieldResult.Output.declarationDriftWarnings,
+                fieldResult.Output.files[0].declarationDriftWarnings,
                 Has.Some.Contain("Edits outside method bodies"),
                 "Field initializer drift must still fire after handled method additions are stripped.");
         }
@@ -455,10 +455,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.None.Contain("Edits outside method bodies"),
                 "Handled return-type change must not fire outside-body drift.\n"
-                + string.Join("\n", result.Output.declarationDriftWarnings ?? Array.Empty<string>()));
+                + string.Join("\n", result.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>()));
         }
 
         /// <summary>
@@ -476,10 +476,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: null);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.None.Contain("Edits outside method bodies"),
                 "No-snapshot return-type change must not fire outside-body drift.\n"
-                + string.Join("\n", result.Output.declarationDriftWarnings ?? Array.Empty<string>()));
+                + string.Join("\n", result.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>()));
         }
 
         /// <summary>
@@ -501,7 +501,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.Some.Contain("Edits outside method bodies"),
                 "Field initializer drift must still fire after a handled return-type change is stripped.");
         }
@@ -525,7 +525,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.Some.Contain("Edits outside method bodies"),
                 "Attribute drift must still fire after a handled return-type change.");
         }
@@ -992,10 +992,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertHasSkip(result, "HotReloadBrandNewType.Fresh", "New types are out of scope");
             Assert.That(FindEntry(result, "Fresh"), Is.Null);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.None.Contain("Edits outside method bodies"),
                 "Skipped new-type declarations must not fire fields/initializers drift.\n"
-                + string.Join("\n", result.Output.declarationDriftWarnings ?? Array.Empty<string>()));
+                + string.Join("\n", result.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>()));
         }
 
         /// <summary>
@@ -1021,10 +1021,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertHasSkip(result, "IHotReloadBrandNewInterface.Fresh", "New types are out of scope");
             Assert.That(FindEntry(result, "Fresh"), Is.Null);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.None.Contain("Edits outside method bodies"),
                 "Skipped new-interface declarations must not fire fields/initializers drift.\n"
-                + string.Join("\n", result.Output.declarationDriftWarnings ?? Array.Empty<string>()));
+                + string.Join("\n", result.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>()));
         }
 
         /// <summary>
@@ -1111,10 +1111,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertHasSkip(result, "Extra", "Interface members are not patchable");
             Assert.That(FindEntry(result, "Extra"), Is.Null);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.None.Contain("Edits outside method bodies"),
                 "Added compiled-interface members must surface as Skipped, not drift.\n"
-                + string.Join("\n", result.Output.declarationDriftWarnings ?? Array.Empty<string>()));
+                + string.Join("\n", result.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>()));
         }
 
         /// <summary>
@@ -1268,10 +1268,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             AssertHasSkip(result, "AddedVirtual", "vtable slot");
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.None.Contain("Edits outside method bodies"),
                 "Skipped added declarations must not fire fields/initializers drift.\n"
-                + string.Join("\n", result.Output.declarationDriftWarnings ?? Array.Empty<string>()));
+                + string.Join("\n", result.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>()));
         }
 
         /// <summary>
@@ -1292,8 +1292,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HostProjectRelativePath,
                 snapshotSource: null);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            Assert.That(result.Output.removedMembers, Is.Not.Null);
-            Assert.That(result.Output.removedMembers, Is.Empty);
+            Assert.That(result.Output.files[0].removedMembers, Is.Not.Null);
+            Assert.That(result.Output.files[0].removedMembers, Is.Empty);
         }
 
         /// <summary>
@@ -1324,7 +1324,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertHasRemovedMemberName(result, nameof(HotReloadAddedMemberHost.ExistingValue));
             Assert.That(
                 HasRemovedSignature(
-                    result.Output,
+                    result.Output.files[0],
                     typeof(HotReloadAddedMemberHost).FullName,
                     nameof(HotReloadAddedMemberHost.ExistingValue)),
                 Is.True);
@@ -1351,8 +1351,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingValue), "vtable slot");
             Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingValue)), Is.Null);
-            Assert.That(result.Output.removedMembers, Is.Empty);
-            Assert.That(result.Output.removedMethodSignatures, Is.Empty);
+            Assert.That(result.Output.files[0].removedMembers, Is.Empty);
+            Assert.That(result.Output.files[0].removedMethodSignatures, Is.Empty);
         }
 
         /// <summary>
@@ -1403,7 +1403,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertHasRemovedMemberName(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
             Assert.That(
                 HasRemovedSignature(
-                    result.Output,
+                    result.Output.files[0],
                     typeof(HotReloadAddedMemberHost).FullName,
                     nameof(HotReloadAddedMemberHost.ExistingCaller),
                     "System.Int32"),
@@ -1430,8 +1430,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             AssertHasRemovedMemberName(result, nameof(HotReloadAddedMemberPartialHost.PartialRemoved));
-            Assert.That(result.Output.removedMethodSignatures, Is.Not.Null);
-            Assert.That(result.Output.removedMethodSignatures, Is.Empty);
+            Assert.That(result.Output.files[0].removedMethodSignatures, Is.Not.Null);
+            Assert.That(result.Output.files[0].removedMethodSignatures, Is.Empty);
         }
 
         /// <summary>
@@ -1513,8 +1513,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private static void AssertHasRemovedMemberName(TransformWorkerClientResult result, string name)
         {
-            Assert.That(result.Output.removedMembers, Is.Not.Null);
-            foreach (TransformWorkerRemovedMemberDto removed in result.Output.removedMembers)
+            Assert.That(result.Output.files[0].removedMembers, Is.Not.Null);
+            foreach (TransformWorkerRemovedMemberDto removed in result.Output.files[0].removedMembers)
             {
                 if (removed.kind == HotReloadConstants.RemovedMemberKindMethod && removed.name == name)
                 {
@@ -1526,17 +1526,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         private static bool HasRemovedSignature(
-            TransformWorkerOutputDto output,
+            TransformWorkerFileOutputDto fileOutput,
             string typeMetadataName,
             string methodName,
             params string[] parameterTypeFullNames)
         {
-            if (output.removedMethodSignatures == null)
+            if (fileOutput.removedMethodSignatures == null)
             {
                 return false;
             }
 
-            foreach (TransformWorkerRemovedMethodSignatureDto signature in output.removedMethodSignatures)
+            foreach (TransformWorkerRemovedMethodSignatureDto signature in fileOutput.removedMethodSignatures)
             {
                 if (signature.typeMetadataName != typeMetadataName || signature.methodName != methodName)
                 {
@@ -1720,12 +1720,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             TransformWorkerInputDto input = new TransformWorkerInputDto
             {
-                sourcePath = sourcePath,
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = sourcePath,
+                        projectRelativePath = projectRelativePath,
+                        snapshotSource = snapshotSource
+                    }
+                },
                 defines = compilationAssembly.defines ?? Array.Empty<string>(),
                 referencePaths = referencePaths,
                 targetTypesAssemblyPath = targetDllPath,
-                snapshotSource = snapshotSource,
-                projectRelativePath = projectRelativePath,
                 assemblySourcePaths = assemblySourcePaths,
                 excludedMethodKeys = excludedMethodKeys ?? Array.Empty<string>(),
                 excludedAddedMethodKeys = excludedAddedMethodKeys ?? Array.Empty<string>()

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -548,10 +548,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     continue;
                 }
 
-                if (result.Output.parseErrors != null && result.Output.parseErrors.Length > 0)
+                if (result.Output.files[0].parseErrors != null && result.Output.files[0].parseErrors.Length > 0)
                 {
                     fileFailures.Add(
-                        "parseErrors=[" + string.Join(" | ", result.Output.parseErrors) + "]");
+                        "parseErrors=[" + string.Join(" | ", result.Output.files[0].parseErrors) + "]");
                 }
 
                 if (result.Output.entries != null && result.Output.entries.Length > 0)
@@ -570,12 +570,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         + unchangedCount + ", skipped=" + skippedCount + ")");
                 }
 
-                if (result.Output.declarationDriftWarnings != null
-                    && result.Output.declarationDriftWarnings.Length > 0)
+                if (result.Output.files[0].declarationDriftWarnings != null
+                    && result.Output.files[0].declarationDriftWarnings.Length > 0)
                 {
                     fileFailures.Add(
                         "declarationDriftWarnings=["
-                        + string.Join(" | ", result.Output.declarationDriftWarnings) + "]");
+                        + string.Join(" | ", result.Output.files[0].declarationDriftWarnings) + "]");
                 }
 
                 if (fileFailures.Count > 0)
@@ -655,7 +655,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Output.unchangedMethods, Is.Not.Null);
             Assert.That(result.Output.unchangedMethods.Length, Is.GreaterThan(0));
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.None.Contain("Edits outside method bodies"),
                 "Method-body-only edits must not emit the outside-method-body drift warning.");
 
@@ -785,7 +785,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.True,
                 "EOL-only snapshot must list ComputeWithPrivate in unchangedMethods.");
             Assert.That(result.Output.skipped, Is.Empty);
-            Assert.That(result.Output.declarationDriftWarnings, Is.Empty);
+            Assert.That(result.Output.files[0].declarationDriftWarnings, Is.Empty);
         }
 
         /// <summary>
@@ -803,9 +803,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             TransformWorkerClientResult result = await RunWorkerOnE2EFixtureAsync(snapshotSource);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            Assert.That(result.Output.declarationDriftWarnings, Is.Not.Null);
+            Assert.That(result.Output.files[0].declarationDriftWarnings, Is.Not.Null);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.Some.Contain("Edits outside method bodies in HotReloadE2EFixtures.cs"));
         }
 
@@ -835,14 +835,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
 
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            Assert.That(result.Output.declarationDriftWarnings, Is.Not.Null);
+            Assert.That(result.Output.files[0].declarationDriftWarnings, Is.Not.Null);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.Some.Contain("TuningConst").And.Contain("is 4 in the edited source but 3"),
                 "Const-only edits must keep the dedicated const-drift warning.\n"
-                + string.Join("\n", result.Output.declarationDriftWarnings));
+                + string.Join("\n", result.Output.files[0].declarationDriftWarnings));
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.None.Contain("Edits outside method bodies"),
                 "Const-only edits must not also emit the generic outside-body warning.");
         }
@@ -885,7 +885,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Sibling const drift must use the same warning text as an edited-file const drift.\n"
                 + string.Join("\n", result.Output.siblingConstDriftWarnings));
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.None.EqualTo(
                     "const io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadSiblingConstDefinitions.SiblingTuning is 7 in the edited source but 6 in the compiled assembly; edits outside method bodies never take effect through hot reload - a method body patched in the same run still compiles against the compiled assembly and keeps the old value. Run 'uloop compile' to apply this change."),
                 "Sibling const-drift warnings must stay on siblingConstDriftWarnings, not declarationDriftWarnings.");
@@ -917,14 +917,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
 
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            Assert.That(result.Output.declarationDriftWarnings, Is.Not.Null);
+            Assert.That(result.Output.files[0].declarationDriftWarnings, Is.Not.Null);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.Some.Contain("HotReloadE2EMode.Active").And.Contain("is 2 in the edited source but 1"),
                 "Enum-member-only edits must keep the dedicated const-drift warning.\n"
-                + string.Join("\n", result.Output.declarationDriftWarnings));
+                + string.Join("\n", result.Output.files[0].declarationDriftWarnings));
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.None.Contain("Edits outside method bodies"),
                 "Enum-member-only edits must not also emit the generic outside-body warning.");
         }
@@ -955,13 +955,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
 
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            Assert.That(result.Output.declarationDriftWarnings, Is.Not.Null);
+            Assert.That(result.Output.files[0].declarationDriftWarnings, Is.Not.Null);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.Some.Contain("Edits outside method bodies"),
                 "Non-const field initializer edits must still emit the outside-body warning.");
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Does.Contain(
                     "Edits outside method bodies in NonConstFieldInitializerDrift.cs (field initializer: _secret) are not applied by hot reload; run uloop compile to pick them up."));
         }
@@ -1201,7 +1201,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.True,
                 "Duplicate-key fallback must not report unchanged methods.");
             Assert.That(
-                withCollision.Output.baselineDisabledByDuplicateKeys,
+                withCollision.Output.files[0].baselineDisabledByDuplicateKeys,
                 Is.True,
                 "Duplicate-key fallback must set baselineDisabledByDuplicateKeys.");
 
@@ -1227,7 +1227,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
 
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            Assert.That(result.Output.baselineDisabledByDuplicateKeys, Is.False);
+            Assert.That(result.Output.files[0].baselineDisabledByDuplicateKeys, Is.False);
             Assert.That(
                 result.Output.entries,
                 Is.Empty,
@@ -1271,7 +1271,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
 
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            Assert.That(result.Output.baselineDisabledByDuplicateKeys, Is.False);
+            Assert.That(result.Output.files[0].baselineDisabledByDuplicateKeys, Is.False);
             Assert.That(
                 result.Output.entries,
                 Is.Empty,
@@ -1472,7 +1472,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + "; skipped="
                 + FormatSkippedMethodNames(result.Output.skipped));
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.None.Contain("Edits outside method bodies"),
                 "Getter-body-only edits must not emit the outside-method-body drift warning.");
         }
@@ -1499,7 +1499,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Has.None.Contain("Edits outside method bodies"),
                 "Block getter-body-only edits must not emit outside-method-body drift.");
 
@@ -1559,7 +1559,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 additionalAssemblySourcePaths: new[] { globalPath });
 
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            Assert.That(result.Output.parseErrors, Is.Empty);
+            Assert.That(result.Output.files[0].parseErrors, Is.Empty);
             Assert.That(
                 result.Output.shimSource,
                 Does.Contain("using AliasProbe = System.Text.StringBuilder"));
@@ -1985,7 +1985,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "        public HotReloadUnsupportedKindCtorFixture() : this(0)\n        {");
 
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Does.Contain(
                     "Edits outside method bodies in UnsupportedKindCtorInitializerDrift.cs (constructor: .ctor) are not applied by hot reload; run uloop compile to pick them up."));
         }
@@ -2004,7 +2004,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "        [Obsolete]\n        public static HotReloadUnsupportedKindOperatorFixture operator +(");
 
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Does.Contain(
                     "Edits outside method bodies in UnsupportedKindOperatorAttributeDrift.cs (operator: +) are not applied by hot reload; run uloop compile to pick them up."));
         }
@@ -2023,7 +2023,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "        [Obsolete]\n        public static implicit operator int(HotReloadUnsupportedKindConversionFixture value)");
 
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Does.Contain(
                     "Edits outside method bodies in UnsupportedKindConversionAttributeDrift.cs (conversion: implicit->int) are not applied by hot reload; run uloop compile to pick them up."));
         }
@@ -2042,7 +2042,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "        [Obsolete]\n        public event Action Edited");
 
             Assert.That(
-                result.Output.declarationDriftWarnings,
+                result.Output.files[0].declarationDriftWarnings,
                 Does.Contain(
                     "Edits outside method bodies in UnsupportedKindEventAttributeDrift.cs (event: Edited) are not applied by hot reload; run uloop compile to pick them up."));
         }
@@ -2169,7 +2169,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string fileName)
         {
             string expectedWarning = string.Format(OutsideMethodBodyDriftWarningFormat, fileName);
-            string[] warnings = result.Output.declarationDriftWarnings ?? Array.Empty<string>();
+            string[] warnings = result.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>();
             Assert.That(
                 warnings,
                 Does.Not.Contain(expectedWarning),
@@ -2182,7 +2182,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string fileName)
         {
             string expectedWarning = string.Format(OutsideMethodBodyDriftWarningFormat, fileName);
-            string[] warnings = result.Output.declarationDriftWarnings ?? Array.Empty<string>();
+            string[] warnings = result.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>();
             Assert.That(
                 warnings,
                 Does.Contain(expectedWarning),
@@ -2337,12 +2337,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             TransformWorkerInputDto input = new TransformWorkerInputDto
             {
-                sourcePath = sourcePath,
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = sourcePath,
+                        projectRelativePath = projectRelativePath,
+                        snapshotSource = snapshotSource
+                    }
+                },
                 defines = compilationAssembly.defines ?? System.Array.Empty<string>(),
                 referencePaths = referencePaths,
                 targetTypesAssemblyPath = targetDllPath,
-                snapshotSource = snapshotSource,
-                projectRelativePath = projectRelativePath,
                 assemblySourcePaths = assemblySourcePaths,
                 changedSiblingSourcePaths = changedSiblingSourcePaths
             };
@@ -2528,36 +2534,39 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void Deserialize_RemovedMembersAndCalledAddedMethodKeys_NullAndEmptyRoundTrip()
         {
             string omittedJson =
-                "{\"shimSource\":\"\",\"entries\":[{\"methodName\":\"Caller\"}],\"skipped\":[],\"parseErrors\":[]}";
+                "{\"shimSource\":\"\",\"entries\":[{\"methodName\":\"Caller\"}],\"skipped\":[],"
+                + "\"parseErrors\":[],\"files\":[{\"projectRelativePath\":\"Assets/Edited.cs\"}]}";
             TransformWorkerOutputDto omitted =
                 JsonConvert.DeserializeObject<TransformWorkerOutputDto>(omittedJson);
-            Assert.That(omitted.removedMembers, Is.Null, "Omitted removedMembers must deserialize as null.");
-            Assert.That(omitted.addedFieldNames, Is.Null, "Omitted addedFieldNames must deserialize as null.");
-            Assert.That(omitted.addedConstNames, Is.Null, "Omitted addedConstNames must deserialize as null.");
+            Assert.That(omitted.files[0].removedMembers, Is.Null, "Omitted removedMembers must deserialize as null.");
+            Assert.That(omitted.files[0].addedFieldNames, Is.Null, "Omitted addedFieldNames must deserialize as null.");
+            Assert.That(omitted.files[0].addedConstNames, Is.Null, "Omitted addedConstNames must deserialize as null.");
             Assert.That(
                 omitted.entries[0].calledAddedMethodKeys,
                 Is.Null,
                 "Omitted calledAddedMethodKeys must deserialize as null.");
 
             TransformWorkerClient.CoalesceOutput(omitted);
-            Assert.That(omitted.removedMembers, Is.Not.Null);
-            Assert.That(omitted.removedMembers, Is.Empty);
-            Assert.That(omitted.removedMethodSignatures, Is.Not.Null);
-            Assert.That(omitted.removedMethodSignatures, Is.Empty);
-            Assert.That(omitted.addedFieldNames, Is.Not.Null);
-            Assert.That(omitted.addedFieldNames, Is.Empty);
-            Assert.That(omitted.addedConstNames, Is.Not.Null);
-            Assert.That(omitted.addedConstNames, Is.Empty);
-            string nullNamesJson = "{\"shimSource\":\"\",\"addedFieldNames\":null}";
+            Assert.That(omitted.files[0].removedMembers, Is.Not.Null);
+            Assert.That(omitted.files[0].removedMembers, Is.Empty);
+            Assert.That(omitted.files[0].removedMethodSignatures, Is.Not.Null);
+            Assert.That(omitted.files[0].removedMethodSignatures, Is.Empty);
+            Assert.That(omitted.files[0].addedFieldNames, Is.Not.Null);
+            Assert.That(omitted.files[0].addedFieldNames, Is.Empty);
+            Assert.That(omitted.files[0].addedConstNames, Is.Not.Null);
+            Assert.That(omitted.files[0].addedConstNames, Is.Empty);
+            string nullNamesJson =
+                "{\"shimSource\":\"\",\"files\":[{\"projectRelativePath\":\"Assets/Edited.cs\","
+                + "\"addedFieldNames\":null}]}";
             TransformWorkerOutputDto nullNames =
                 JsonConvert.DeserializeObject<TransformWorkerOutputDto>(nullNamesJson);
-            Assert.That(nullNames.addedFieldNames, Is.Null);
+            Assert.That(nullNames.files[0].addedFieldNames, Is.Null);
             TransformWorkerClient.CoalesceOutput(nullNames);
-            Assert.That(nullNames.addedFieldNames, Is.Not.Null);
-            Assert.That(nullNames.addedFieldNames, Is.Empty);
+            Assert.That(nullNames.files[0].addedFieldNames, Is.Not.Null);
+            Assert.That(nullNames.files[0].addedFieldNames, Is.Empty);
             Assert.That(omitted.entries[0].calledAddedMethodKeys, Is.Not.Null);
             Assert.That(omitted.entries[0].calledAddedMethodKeys, Is.Empty);
-            Assert.That(omitted.declarationDriftWarnings, Is.Not.Null);
+            Assert.That(omitted.files[0].declarationDriftWarnings, Is.Not.Null);
             Assert.That(omitted.siblingConstDriftWarnings, Is.Not.Null);
             Assert.That(omitted.unchangedMethods, Is.Not.Null);
             Assert.That(omitted.parseErrors, Is.Not.Null);
@@ -2567,21 +2576,58 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             string emptyJson =
                 "{\"shimSource\":\"\",\"entries\":[{\"methodName\":\"Caller\",\"calledAddedMethodKeys\":[]}],"
-                + "\"removedMembers\":[]}";
+                + "\"files\":[{\"projectRelativePath\":\"Assets/Edited.cs\",\"removedMembers\":[]}]}";
             TransformWorkerOutputDto empty = JsonConvert.DeserializeObject<TransformWorkerOutputDto>(emptyJson);
-            Assert.That(empty.removedMembers, Is.Not.Null);
-            Assert.That(empty.removedMembers.Length, Is.EqualTo(0));
+            Assert.That(empty.files[0].removedMembers, Is.Not.Null);
+            Assert.That(empty.files[0].removedMembers.Length, Is.EqualTo(0));
             Assert.That(empty.entries[0].calledAddedMethodKeys, Is.Not.Null);
             Assert.That(empty.entries[0].calledAddedMethodKeys.Length, Is.EqualTo(0));
 
             string nestedJson =
-                "{\"removedMembers\":[{\"kind\":\"method\",\"name\":\"Gone\"}],"
+                "{\"files\":[{\"projectRelativePath\":\"Assets/Edited.cs\","
+                + "\"removedMembers\":[{\"kind\":\"method\",\"name\":\"Gone\"}]}],"
                 + "\"entries\":[{\"methodName\":\"Caller\",\"calledAddedMethodKeys\":[\"T::Added()\"]}]}";
             TransformWorkerOutputDto nested = JsonConvert.DeserializeObject<TransformWorkerOutputDto>(nestedJson);
-            Assert.That(nested.removedMembers.Length, Is.EqualTo(1));
-            Assert.That(nested.removedMembers[0].kind, Is.EqualTo("method"));
-            Assert.That(nested.removedMembers[0].name, Is.EqualTo("Gone"));
+            Assert.That(nested.files[0].removedMembers.Length, Is.EqualTo(1));
+            Assert.That(nested.files[0].removedMembers[0].kind, Is.EqualTo("method"));
+            Assert.That(nested.files[0].removedMembers[0].name, Is.EqualTo("Gone"));
             Assert.That(nested.entries[0].calledAddedMethodKeys, Is.EqualTo(new[] { "T::Added()" }));
+        }
+
+        /// <summary>
+        /// What: an omitted files array coalesces to empty, and every array and the sha256 string
+        /// omitted inside one files entry coalesces to non-null, so per-file readers never see null.
+        /// </summary>
+        [Test]
+        public void CoalesceOutput_OmittedFilesAndPerFileFields_BecomeNonNull()
+        {
+            TransformWorkerOutputDto withoutFiles =
+                JsonConvert.DeserializeObject<TransformWorkerOutputDto>("{\"shimSource\":\"\"}");
+            Assert.That(withoutFiles.files, Is.Null, "Omitted files must deserialize as null.");
+            TransformWorkerClient.CoalesceOutput(withoutFiles);
+            Assert.That(withoutFiles.files, Is.Not.Null);
+            Assert.That(withoutFiles.files, Is.Empty);
+
+            TransformWorkerOutputDto withBareFile = JsonConvert.DeserializeObject<TransformWorkerOutputDto>(
+                "{\"shimSource\":\"\",\"files\":[{\"projectRelativePath\":\"Assets/Edited.cs\"}]}");
+            Assert.That(withBareFile.files[0].sourceContentSha256, Is.Null);
+            TransformWorkerClient.CoalesceOutput(withBareFile);
+            TransformWorkerFileOutputDto coalesced = withBareFile.files[0];
+            Assert.That(coalesced.projectRelativePath, Is.EqualTo("Assets/Edited.cs"));
+            Assert.That(coalesced.sourceContentSha256, Is.EqualTo(string.Empty));
+            Assert.That(coalesced.parseErrors, Is.Not.Null);
+            Assert.That(coalesced.parseErrors, Is.Empty);
+            Assert.That(coalesced.declarationDriftWarnings, Is.Not.Null);
+            Assert.That(coalesced.declarationDriftWarnings, Is.Empty);
+            Assert.That(coalesced.removedMembers, Is.Not.Null);
+            Assert.That(coalesced.removedMembers, Is.Empty);
+            Assert.That(coalesced.removedMethodSignatures, Is.Not.Null);
+            Assert.That(coalesced.removedMethodSignatures, Is.Empty);
+            Assert.That(coalesced.addedFieldNames, Is.Not.Null);
+            Assert.That(coalesced.addedFieldNames, Is.Empty);
+            Assert.That(coalesced.addedConstNames, Is.Not.Null);
+            Assert.That(coalesced.addedConstNames, Is.Empty);
+            Assert.That(coalesced.baselineDisabledByDuplicateKeys, Is.False);
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -2293,7 +2293,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string projectRelativePath,
             string snapshotSource = null,
             string[] additionalAssemblySourcePaths = null,
-            string[] changedSiblingSourcePaths = null)
+            string[] changedSiblingSourcePaths = null,
+            string secondSourcePath = null,
+            string secondProjectRelativePath = null)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string targetDllPath = Path.Combine(
@@ -2335,17 +2337,27 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 assemblySourcePaths = merged.ToArray();
             }
 
+            List<TransformWorkerSourceDto> sources = new List<TransformWorkerSourceDto>
+            {
+                new TransformWorkerSourceDto
+                {
+                    sourcePath = sourcePath,
+                    projectRelativePath = projectRelativePath,
+                    snapshotSource = snapshotSource
+                }
+            };
+            if (secondSourcePath != null)
+            {
+                sources.Add(new TransformWorkerSourceDto
+                {
+                    sourcePath = secondSourcePath,
+                    projectRelativePath = secondProjectRelativePath
+                });
+            }
+
             TransformWorkerInputDto input = new TransformWorkerInputDto
             {
-                sources = new[]
-                {
-                    new TransformWorkerSourceDto
-                    {
-                        sourcePath = sourcePath,
-                        projectRelativePath = projectRelativePath,
-                        snapshotSource = snapshotSource
-                    }
-                },
+                sources = sources.ToArray(),
                 defines = compilationAssembly.defines ?? System.Array.Empty<string>(),
                 referencePaths = referencePaths,
                 targetTypesAssemblyPath = targetDllPath,
@@ -2592,6 +2604,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(nested.files[0].removedMembers[0].kind, Is.EqualTo("method"));
             Assert.That(nested.files[0].removedMembers[0].name, Is.EqualTo("Gone"));
             Assert.That(nested.entries[0].calledAddedMethodKeys, Is.EqualTo(new[] { "T::Added()" }));
+        }
+
+        /// <summary>
+        /// What: a run carrying more than one source is a run-level failure, so the client
+        /// reports it as a failed result instead of a success with no per-file rows.
+        /// </summary>
+        [Test]
+        public async Task BootstrapAndRun_MoreThanOneSource_FailsWithRunLevelError()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string fixtureProjectRelativePath = ResolveE2EFixtureProjectRelativePath();
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                fixturePath,
+                fixtureProjectRelativePath,
+                secondSourcePath: fixturePath,
+                secondProjectRelativePath: fixtureProjectRelativePath);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("exactly one source"));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerDisabledTextTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerDisabledTextTests.cs
@@ -104,12 +104,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             TransformWorkerInputDto input = new TransformWorkerInputDto
             {
-                sourcePath = sourcePath,
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = sourcePath,
+                        projectRelativePath = projectRelativePath,
+                        snapshotSource = snapshotSource
+                    }
+                },
                 defines = compilationAssembly.defines ?? Array.Empty<string>(),
                 referencePaths = referencePaths.ToArray(),
                 targetTypesAssemblyPath = targetDllPath,
-                snapshotSource = snapshotSource,
-                projectRelativePath = projectRelativePath,
                 assemblySourcePaths = assemblySourcePaths.ToArray()
             };
 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerEventAccessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerEventAccessorTests.cs
@@ -499,12 +499,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             TransformWorkerInputDto input = new TransformWorkerInputDto
             {
-                sourcePath = sourcePath,
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = sourcePath,
+                        projectRelativePath = projectRelativePath,
+                        snapshotSource = snapshotSource
+                    }
+                },
                 defines = compilationAssembly.defines ?? Array.Empty<string>(),
                 referencePaths = BuildAbsoluteReferencePaths(compilationAssembly.allReferences, targetDllPath),
                 targetTypesAssemblyPath = targetDllPath,
-                snapshotSource = snapshotSource,
-                projectRelativePath = projectRelativePath,
                 assemblySourcePaths = BuildAbsoluteAssemblySourcePaths(compilationAssembly.sourceFiles),
                 excludedMethodKeys = Array.Empty<string>(),
                 excludedAddedMethodKeys = Array.Empty<string>()

--- a/Assets/Tests/Editor/HotReload/TransformWorkerLineDirectiveTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerLineDirectiveTests.cs
@@ -227,12 +227,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             TransformWorkerInputDto input = new TransformWorkerInputDto
             {
-                sourcePath = sourcePath,
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = sourcePath,
+                        projectRelativePath = projectRelativePath,
+                        snapshotSource = snapshotSource
+                    }
+                },
                 defines = compilationAssembly.defines ?? Array.Empty<string>(),
                 referencePaths = referencePaths.ToArray(),
                 targetTypesAssemblyPath = targetDllPath,
-                snapshotSource = snapshotSource,
-                projectRelativePath = projectRelativePath,
                 assemblySourcePaths = assemblySourcePaths.ToArray()
             };
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyContext.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyContext.cs
@@ -27,6 +27,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string[] defines,
             TransformWorkerInputDto workerInput,
             TransformWorkerOutputDto workerOutput,
+            TransformWorkerFileOutputDto fileOutput,
             HashSet<string> snapshotLabels,
             HashSet<string> snapshotAddedLabels)
         {
@@ -39,6 +40,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(defines != null, "defines must not be null.");
             Debug.Assert(workerInput != null, "workerInput must not be null.");
             Debug.Assert(workerOutput != null, "workerOutput must not be null.");
+            Debug.Assert(fileOutput != null, "fileOutput must not be null.");
             Debug.Assert(snapshotLabels != null, "snapshotLabels must not be null.");
             Debug.Assert(snapshotAddedLabels != null, "snapshotAddedLabels must not be null.");
 
@@ -52,6 +54,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Defines = defines;
             WorkerInput = workerInput;
             WorkerOutput = workerOutput;
+            FileOutput = fileOutput;
             SnapshotLabels = snapshotLabels;
             SnapshotAddedLabels = snapshotAddedLabels;
         }
@@ -75,6 +78,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal TransformWorkerInputDto WorkerInput { get; }
 
         internal TransformWorkerOutputDto WorkerOutput { get; }
+
+        // The row set of ProjectRelativePath inside WorkerOutput.
+        internal TransformWorkerFileOutputDto FileOutput { get; }
 
         // Patch labels already active for this file when its apply started. Snapshotted because
         // a multi-file run mutates the ledgers between files.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
@@ -44,6 +44,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     context.SnapshotAddedLabels,
                     context.ProjectRelativePath,
                     context.WorkerOutput,
+                    context.FileOutput.sourceContentSha256,
                     sinks.SuppressedPausePointIds,
                     sinks.RetargetedPausePointIds,
                     unchangedMethodCount,
@@ -83,6 +84,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 context.SnapshotAddedLabels,
                 context.ProjectRelativePath,
                 context.WorkerOutput,
+                context.FileOutput.sourceContentSha256,
                 sinks.SuppressedPausePointIds,
                 sinks.RetargetedPausePointIds,
                 unchangedMethodCount,
@@ -100,6 +102,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HashSet<string> snapshotAddedLabels,
             string projectRelativePath,
             TransformWorkerOutputDto workerOutput,
+            string sourceContentSha256,
             List<string> suppressedPausePointIds,
             List<string> retargetedPausePointIds,
             int unchangedMethodCount,
@@ -127,7 +130,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 unchangedMethodCount,
                 retargetedPausePointIds,
                 addedFieldNames,
-                workerOutput.sourceContentSha256,
+                sourceContentSha256,
                 addedConstNames,
                 revertedUnchangedCount);
         }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -133,12 +133,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             TransformWorkerInputDto workerInput = new TransformWorkerInputDto
             {
-                sourcePath = Path.GetFullPath(workerSourcePath),
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = Path.GetFullPath(workerSourcePath),
+                        projectRelativePath = projectRelativePath,
+                        snapshotSource = snapshotSource
+                    }
+                },
                 defines = defines,
                 referencePaths = referencePaths,
                 targetTypesAssemblyPath = Path.GetFullPath(targetDllPath),
-                snapshotSource = snapshotSource,
-                projectRelativePath = projectRelativePath,
                 assemblySourcePaths = HotReloadPatchTargetSupport.BuildAssemblySourcePaths(projectRoot, compilationAssembly.sourceFiles),
                 changedSiblingSourcePaths = siblingScan.ChangedSiblingAbsolutePaths
             };
@@ -154,9 +160,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             TransformWorkerOutputDto workerOutput = workerResult.Output;
-            string[] addedFieldNames = workerOutput.addedFieldNames;
+            // One source in, one per-file row out. Assembly grouping widens this to the group size.
+            Debug.Assert(
+                workerOutput.files.Length == 1,
+                "A single-source worker run must return exactly one per-file output.");
+            TransformWorkerFileOutputDto fileOutput = workerOutput.files[0];
+            string[] addedFieldNames = fileOutput.addedFieldNames;
             HotReloadWorkerNoticeAppender.AppendWorkerNotices(
                 workerOutput,
+                fileOutput,
                 snapshotSource,
                 projectRelativePath,
                 assemblyName,
@@ -187,6 +199,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 defines,
                 workerInput,
                 workerOutput,
+                fileOutput,
                 snapshotLabels,
                 snapshotAddedLabels);
 
@@ -197,8 +210,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why after the gate: a gated replacement is not applied, so listing it under
             // "Removed members stay present... edited bodies no longer call them" is false.
             string removedMembersWarning = HotReloadRemovedMembersWarning.FormatRemovedMembersWarning(
-                workerOutput.removedMembers,
-                workerOutput.removedMethodSignatures,
+                fileOutput.removedMembers,
+                fileOutput.removedMethodSignatures,
                 gateResult.GatedReplacementMethodKeys);
             if (removedMembersWarning != null)
             {
@@ -208,6 +221,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadStalePatchOutcomes.Append(
                 sinks.Outcomes,
                 workerOutput,
+                fileOutput.removedMethodSignatures,
                 gateResult.GatedReplacementMethodKeys,
                 projectRelativePath,
                 assemblyResolvePath);
@@ -226,7 +240,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     sinks.Warnings,
                     0,
                     unchangedMethodCount: unchangedMethodCount,
-                    sourceContentSha256: workerOutput.sourceContentSha256,
+                    sourceContentSha256: fileOutput.sourceContentSha256,
                     revertedUnchangedCount: revertedUnchangedCount);
             }
 
@@ -275,7 +289,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         sinks.Warnings,
                         0,
                         unchangedMethodCount: unchangedMethodCount,
-                        sourceContentSha256: workerOutput.sourceContentSha256,
+                        sourceContentSha256: fileOutput.sourceContentSha256,
                         revertedUnchangedCount: revertedUnchangedCount);
                 }
 
@@ -303,6 +317,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             RecordSupersededSignaturesAfterApply(
                 applied,
                 workerOutput,
+                fileOutput.removedMethodSignatures,
                 gateResult.GatedReplacementMethodKeys);
             return applied;
         }
@@ -310,6 +325,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static void RecordSupersededSignaturesAfterApply(
             HotReloadFileProcessResult applied,
             TransformWorkerOutputDto workerOutput,
+            TransformWorkerRemovedMethodSignatureDto[] removedMethodSignatures,
             IReadOnlyCollection<string> gatedReplacementMethodKeys)
         {
             if (!HasAppliedChange(applied.Outcomes))
@@ -319,6 +335,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             HotReloadSupersededSignatureRecorder.RecordFromWorkerOutput(
                 workerOutput,
+                removedMethodSignatures,
                 gatedReplacementMethodKeys);
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimErrorAttribution.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimErrorAttribution.cs
@@ -11,20 +11,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <summary>
         /// Maps each shim compile error to the entry whose original-source [sourceStartLine,
         /// sourceEndLine] contains its #line-mapped location in the same user file. Returns null
-        /// if any error is unattributable (wrong/empty file, scaffold path, or outside every
+        /// if any error is unattributable (unknown/empty file, scaffold path, or outside every
         /// entry range) — method isolation cannot fix those.
         /// </summary>
         internal static ShimCompileErrorAttribution AttributeErrorsToEntries(
             TransformWorkerEntryDto[] entries,
-            IReadOnlyList<HotReloadShimCompileError> errors,
-            string projectRelativePath)
+            IReadOnlyList<HotReloadShimCompileError> errors)
         {
             Dictionary<TransformWorkerEntryDto, List<string>> errorMessagesByEntry =
                 new Dictionary<TransformWorkerEntryDto, List<string>>();
             foreach (HotReloadShimCompileError error in errors)
             {
-                TransformWorkerEntryDto matchedEntry =
-                    FindEntryForError(entries, error, projectRelativePath);
+                TransformWorkerEntryDto matchedEntry = FindEntryForError(entries, error);
                 if (matchedEntry == null)
                 {
                     return null;
@@ -47,18 +45,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static TransformWorkerEntryDto FindEntryForError(
             TransformWorkerEntryDto[] entries,
-            HotReloadShimCompileError error,
-            string projectRelativePath)
+            HotReloadShimCompileError error)
         {
-            if (string.IsNullOrEmpty(error.File) || string.IsNullOrEmpty(projectRelativePath))
-            {
-                return null;
-            }
-
-            // Why suffix-tolerant compare (not ordinal equality): the three shim-compile backends
-            // report file as #line literal, absolute path, or temp scaffold path depending on the
-            // fallback stage — HotReloadSourcePathNormalizer already encodes that contract.
-            if (!HotReloadSourcePathNormalizer.PathsReferToSameFile(error.File, projectRelativePath))
+            if (string.IsNullOrEmpty(error.File))
             {
                 return null;
             }
@@ -70,8 +59,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int matchCount = 0;
             foreach (TransformWorkerEntryDto entry in entries)
             {
+                // Why per entry (not once per error): one shim assembly can host several edited
+                // files, so the error's file decides which file's entries may match at all.
+                // Why suffix-tolerant compare (not ordinal equality): the three shim-compile
+                // backends report file as #line literal, absolute path, or temp scaffold path
+                // depending on the fallback stage — HotReloadSourcePathNormalizer encodes that.
+                bool sameFile = !string.IsNullOrEmpty(entry.sourceProjectRelativePath)
+                    && HotReloadSourcePathNormalizer.PathsReferToSameFile(
+                        error.File,
+                        entry.sourceProjectRelativePath);
                 bool hasKnownRange = entry.sourceStartLine > 0 && entry.sourceEndLine > 0;
-                if (hasKnownRange && error.Line >= entry.sourceStartLine && error.Line <= entry.sourceEndLine)
+                if (sameFile && hasKnownRange && error.Line >= entry.sourceStartLine && error.Line <= entry.sourceEndLine)
                 {
                     matchedEntry = entry;
                     matchCount++;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
@@ -36,7 +36,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(context != null, "context must not be null.");
             Debug.Assert(sinks != null, "sinks must not be null.");
-            string[] addedConstNames = context.WorkerOutput.addedConstNames;
+            string[] addedConstNames = context.FileOutput.addedConstNames;
             if (gateResult.UsedWorkerRetry)
             {
                 addedFieldNames = gateResult.Isolation.AddedFieldNames;
@@ -53,7 +53,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                             unchangedMethodCount,
                             sinks.RetargetedPausePointIds,
                             addedFieldNames: null,
-                            sourceContentSha256: context.WorkerOutput.sourceContentSha256,
+                            sourceContentSha256: context.FileOutput.sourceContentSha256,
                             revertedUnchangedCount: revertedUnchangedCount),
                         null,
                         null,
@@ -86,7 +86,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // side has stale rows to drop; starting a shim generation would need bytes that
                 // do not exist.
                 HotReloadAddedMemberRegistry.BeginFileGeneration(context.ProjectRelativePath);
-                HotReloadEntryApplier.CommitAddedFieldsForFile(context.ProjectRelativePath, context.WorkerOutput.addedFieldNames);
+                HotReloadEntryApplier.CommitAddedFieldsForFile(
+                    context.ProjectRelativePath,
+                    context.FileOutput.addedFieldNames);
                 // Why after the clear: a still-declared added method can be worker-skipped
                 // (virtual/generic), leaving entries empty while the registry drop is real.
                 HotReloadAppliedSourceLifecycle.AppendDeactivatedPatchesWarning(
@@ -102,7 +104,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         sinks.Warnings,
                         0,
                         unchangedMethodCount: unchangedMethodCount,
-                        sourceContentSha256: context.WorkerOutput.sourceContentSha256,
+                        sourceContentSha256: context.FileOutput.sourceContentSha256,
                         revertedUnchangedCount: revertedUnchangedCount),
                     null,
                     null,
@@ -134,7 +136,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         sinks.Warnings,
                         0,
                         unchangedMethodCount: unchangedMethodCount,
-                        sourceContentSha256: context.WorkerOutput.sourceContentSha256,
+                        sourceContentSha256: context.FileOutput.sourceContentSha256,
                         revertedUnchangedCount: revertedUnchangedCount),
                     null,
                     null,
@@ -155,7 +157,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         unchangedMethodCount,
                         sinks.RetargetedPausePointIds,
                         addedFieldNames: null,
-                        sourceContentSha256: context.WorkerOutput.sourceContentSha256,
+                        sourceContentSha256: context.FileOutput.sourceContentSha256,
                         revertedUnchangedCount: revertedUnchangedCount),
                     null,
                     null,
@@ -208,7 +210,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 workerOutput.shimSource,
                 shimReferences,
                 defines,
-                workerInput.projectRelativePath,
+                workerInput.sources[0].projectRelativePath,
                 ct).ConfigureAwait(false);
 
             TransformWorkerEntryDto[] entriesToPatch = workerOutput.entries;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
@@ -44,8 +44,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadShimErrorAttribution.ShimCompileErrorAttribution attribution =
                 HotReloadShimErrorAttribution.AttributeErrorsToEntries(
                 workerOutput.entries,
-                compileResult.Errors,
-                workerInput.projectRelativePath);
+                compileResult.Errors);
             if (attribution == null
                 || attribution.FailedEntries.Count == 0
                 || attribution.FailedEntries.Count == workerOutput.entries.Length)
@@ -97,16 +96,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             TransformWorkerInputDto retryInput = new TransformWorkerInputDto
             {
-                sourcePath = workerInput.sourcePath,
+                // Why share the array: the worker only reads it, and each source carries the
+                // snapshotSource the retry needs — omitting it would make the retry patch
+                // unedited methods again and diverge the retry entries from the first pass.
+                sources = workerInput.sources,
                 defines = workerInput.defines,
                 referencePaths = workerInput.referencePaths,
                 targetTypesAssemblyPath = workerInput.targetTypesAssemblyPath,
                 excludedMethodKeys = exclusions.ExcludedMethodKeys,
                 excludedAddedMethodKeys = exclusions.ExcludedAddedMethodKeys,
-                // Why copy: omitting snapshotSource would make the retry patch unedited methods
-                // again and diverge the retry entries set from the first-pass isolation baseline.
-                snapshotSource = workerInput.snapshotSource,
-                projectRelativePath = workerInput.projectRelativePath,
                 assemblySourcePaths = workerInput.assemblySourcePaths,
                 // Why copy: retry must still scan the same snapshot-mismatched siblings so
                 // siblingConstDriftWarnings stay populated on the retry worker output.
@@ -131,6 +129,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             TransformWorkerOutputDto retryOutput = retryWorkerResult.Output;
+            // One source in, one per-file row out. Assembly grouping widens this to the group size.
+            Debug.Assert(
+                retryOutput.files.Length == 1,
+                "A single-source retry worker run must return exactly one per-file output.");
+            TransformWorkerFileOutputDto retryFileOutput = retryOutput.files[0];
             // Why drop first-pass (Method, Reason) pairs: consuming them again would duplicate
             // every per-file skip. Retry-only pairs are new — typically transitive callers of
             // excluded added methods — and must surface or the edit is applied nowhere.
@@ -158,9 +161,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         skippedCallerOutcomes,
                         Array.Empty<TransformWorkerEntryDto>(),
                         null,
-                        retryOutput.addedFieldNames,
+                        retryFileOutput.addedFieldNames,
                         retryOutput.siblingConstDriftWarnings,
-                        retryOutput.addedConstNames));
+                        retryFileOutput.addedConstNames));
             }
 
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -184,7 +187,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 retryOutput.shimSource,
                 shimReferences,
                 defines,
-                workerInput.projectRelativePath,
+                workerInput.sources[0].projectRelativePath,
                 ct).ConfigureAwait(false);
             if (!retryCompileResult.Success)
             {
@@ -202,9 +205,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     skippedCallerOutcomes,
                     retryOutput.entries,
                     retryCompileResult,
-                    retryOutput.addedFieldNames,
+                    retryFileOutput.addedFieldNames,
                     retryOutput.siblingConstDriftWarnings,
-                    retryOutput.addedConstNames));
+                    retryFileOutput.addedConstNames));
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
@@ -23,7 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(context != null, "context must not be null.");
             TransformWorkerEntryDto[] entries = context.WorkerOutput.entries ?? Array.Empty<TransformWorkerEntryDto>();
             TransformWorkerRemovedMethodSignatureDto[] removedSignatures =
-                context.WorkerOutput.removedMethodSignatures
+                context.FileOutput.removedMethodSignatures
                 ?? Array.Empty<TransformWorkerRemovedMethodSignatureDto>();
             List<TransformWorkerEntryDto> replacementEntries = CollectReplacementEntries(entries);
             if (replacementEntries.Count == 0 && removedSignatures.Length == 0)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadStalePatchOutcomes.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadStalePatchOutcomes.cs
@@ -13,13 +13,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public static void Append(
             List<HotReloadMethodOutcome> outcomes,
             TransformWorkerOutputDto workerOutput,
+            TransformWorkerRemovedMethodSignatureDto[] removedMethodSignatures,
             IReadOnlyCollection<string> gatedReplacementMethodKeys,
             string projectRelativePath,
             string assemblyResolvePath)
         {
-            TransformWorkerRemovedMethodSignatureDto[] removedMethodSignatures =
-                workerOutput?.removedMethodSignatures;
-            if (removedMethodSignatures == null || removedMethodSignatures.Length == 0)
+            if (workerOutput == null
+                || removedMethodSignatures == null || removedMethodSignatures.Length == 0)
             {
                 return;
             }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSupersededSignatureRecorder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSupersededSignatureRecorder.cs
@@ -11,9 +11,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public static void RecordFromWorkerOutput(
             TransformWorkerOutputDto workerOutput,
+            TransformWorkerRemovedMethodSignatureDto[] removedMethodSignatures,
             IReadOnlyCollection<string> gatedReplacementMethodKeys)
         {
-            if (workerOutput?.removedMethodSignatures == null)
+            if (workerOutput == null || removedMethodSignatures == null)
             {
                 return;
             }
@@ -24,7 +25,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             IReadOnlyDictionary<string, TransformWorkerEntryDto> replacementsByWireKey =
                 HotReloadReplacedCompiledMethodEntries.IndexByReplacedWireKey(workerOutput.entries);
 
-            foreach (TransformWorkerRemovedMethodSignatureDto signature in workerOutput.removedMethodSignatures)
+            foreach (TransformWorkerRemovedMethodSignatureDto signature in removedMethodSignatures)
             {
                 if (signature == null || string.IsNullOrEmpty(signature.methodName))
                 {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerNoticeAppender.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerNoticeAppender.cs
@@ -17,6 +17,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // least one method or accessor row.
         internal static void AppendWorkerNotices(
             TransformWorkerOutputDto workerOutput,
+            TransformWorkerFileOutputDto fileOutput,
             string snapshotSource,
             string projectRelativePath,
             string assemblyName,
@@ -26,17 +27,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> siblingDerivedWarnings)
         {
             Debug.Assert(workerOutput != null, "workerOutput must not be null.");
+            Debug.Assert(fileOutput != null, "fileOutput must not be null.");
             Debug.Assert(outcomes != null, "outcomes must not be null.");
             Debug.Assert(warnings != null, "warnings must not be null.");
             Debug.Assert(siblingDerivedWarnings != null, "siblingDerivedWarnings must not be null.");
             AssertEntryRowsCameFromTheEditedFile(workerOutput, projectRelativePath);
 
-            AppendBaselineNotices(workerOutput, snapshotSource, projectRelativePath, assemblyName, warnings);
+            AppendBaselineNotices(
+                workerOutput,
+                fileOutput,
+                snapshotSource,
+                projectRelativePath,
+                assemblyName,
+                warnings);
+            // Run-level errors first: they describe the whole worker run, so they must not read
+            // as a consequence of this file's own parse errors.
             AppendAll(warnings, workerOutput.parseErrors);
+            AppendAll(warnings, fileOutput.parseErrors);
             AppendSkippedOutcomes(workerOutput.skipped, assemblyResolvePath, outcomes);
             // Surfaced before the empty-entries early return so const drift still reaches
             // the response when every method in the file is skipped or unchanged.
-            AppendAll(warnings, workerOutput.declarationDriftWarnings);
+            AppendAll(warnings, fileOutput.declarationDriftWarnings);
             AppendAll(siblingDerivedWarnings, workerOutput.siblingConstDriftWarnings);
         }
 
@@ -74,6 +85,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static void AppendBaselineNotices(
             TransformWorkerOutputDto workerOutput,
+            TransformWorkerFileOutputDto fileOutput,
             string snapshotSource,
             string projectRelativePath,
             string assemblyName,
@@ -88,7 +100,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         assemblyName));
             }
 
-            if (workerOutput.baselineDisabledByDuplicateKeys)
+            if (fileOutput.baselineDisabledByDuplicateKeys)
             {
                 warnings.Add(
                     string.Format(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerNoticeAppender.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerNoticeAppender.cs
@@ -40,9 +40,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 projectRelativePath,
                 assemblyName,
                 warnings);
-            // Run-level errors first: they describe the whole worker run, so they must not read
-            // as a consequence of this file's own parse errors.
-            AppendAll(warnings, workerOutput.parseErrors);
             AppendAll(warnings, fileOutput.parseErrors);
             AppendSkippedOutcomes(workerOutput.skipped, assemblyResolvePath, outcomes);
             // Surfaced before the empty-entries early return so const drift still reaches

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
@@ -26,7 +26,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             CancellationToken ct)
         {
             Debug.Assert(input != null, "input must not be null.");
-            Debug.Assert(!string.IsNullOrEmpty(input.sourcePath), "sourcePath must not be empty.");
+            Debug.Assert(input.sources != null, "sources must not be null.");
+            Debug.Assert(input.sources.Length > 0, "sources must not be empty.");
 
             TransformWorkerBootstrapResult bootstrapResult =
                 await TransformWorkerBootstrap.EnsureWorkerAsync(ct).ConfigureAwait(false);
@@ -107,15 +108,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             output.entries ??= Array.Empty<TransformWorkerEntryDto>();
             output.skipped ??= Array.Empty<TransformWorkerSkippedDto>();
+            output.files ??= Array.Empty<TransformWorkerFileOutputDto>();
             output.parseErrors ??= Array.Empty<string>();
-            output.declarationDriftWarnings ??= Array.Empty<string>();
             output.siblingConstDriftWarnings ??= Array.Empty<string>();
             output.unchangedMethods ??= Array.Empty<TransformWorkerUnchangedMethodDto>();
-            output.removedMembers ??= Array.Empty<TransformWorkerRemovedMemberDto>();
-            output.removedMethodSignatures ??= Array.Empty<TransformWorkerRemovedMethodSignatureDto>();
-            output.addedFieldNames ??= Array.Empty<string>();
-            output.addedConstNames ??= Array.Empty<string>();
             output.shimSource ??= string.Empty;
+            foreach (TransformWorkerFileOutputDto fileOutput in output.files)
+            {
+                if (fileOutput == null)
+                {
+                    continue;
+                }
+
+                fileOutput.sourceContentSha256 ??= string.Empty;
+                fileOutput.parseErrors ??= Array.Empty<string>();
+                fileOutput.declarationDriftWarnings ??= Array.Empty<string>();
+                fileOutput.removedMembers ??= Array.Empty<TransformWorkerRemovedMemberDto>();
+                fileOutput.removedMethodSignatures ??= Array.Empty<TransformWorkerRemovedMethodSignatureDto>();
+                fileOutput.addedFieldNames ??= Array.Empty<string>();
+                fileOutput.addedConstNames ??= Array.Empty<string>();
+            }
+
             foreach (TransformWorkerEntryDto entry in output.entries)
             {
                 if (entry == null)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
@@ -90,6 +90,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 CoalesceOutput(output);
+
+                // Why fail here: run-level parseErrors describe a failure that belongs to no
+                // single source, so there is no per-file row to carry it. Turning it into a
+                // client failure at the process boundary is what makes the per-file row count
+                // an invariant for every caller downstream.
+                if (output.parseErrors.Length > 0)
+                {
+                    return TransformWorkerClientResult.Failure(string.Join("\n", output.parseErrors));
+                }
+
+                Debug.Assert(
+                    output.files.Length == input.sources.Length,
+                    "A successful worker run must return one per-file output per source.");
                 return TransformWorkerClientResult.SuccessResult(output);
             }
             finally

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -8,7 +8,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     [Serializable]
     internal sealed class TransformWorkerInputDto
     {
-        public string sourcePath;
+        // Edited files this worker run must transform together. One or more; every source must
+        // belong to the same compilation assembly so a single shim assembly can host them all.
+        // Keep in sync with TransformWorker~/WorkerInput.cs.
+        public TransformWorkerSourceDto[] sources;
+
         public string[] defines;
         public string[] referencePaths;
         public string targetTypesAssemblyPath;
@@ -22,15 +26,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // (G1), while a broken added body can still be excluded together with its callers.
         public string[] excludedAddedMethodKeys;
 
-        // Verified snapshot text for edited-method detection. Null = no baseline, patch all methods.
-        // Why pass text (not a path): avoids an IO race between orchestrator verification and worker
-        // read that would crash the whole file under the no-try-catch policy.
-        public string snapshotSource;
-
-        // Project-relative forward-slash path baked into #line document names so shim compile
-        // diagnostics map back to the user's file (not the temp HotReloadShim.cs path).
-        public string projectRelativePath;
-
         // Absolute paths of every source file in the edited file's compilation assembly.
         // The worker scans these for global using directives. Null/omitted is treated as empty.
         public string[] assemblySourcePaths;
@@ -42,6 +37,64 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     }
 
     /// <summary>
+    /// One edited file inside a transform worker run.
+    /// </summary>
+    // Keep in sync with TransformWorker~/WorkerSourceInput.cs.
+    [Serializable]
+    internal sealed class TransformWorkerSourceDto
+    {
+        // Absolute path the worker reads the edited text from. May be a temp override copy.
+        public string sourcePath;
+
+        // Project-relative forward-slash path baked into #line document names so shim compile
+        // diagnostics map back to the user's file (not the temp HotReloadShim.cs path).
+        public string projectRelativePath;
+
+        // Verified snapshot text for edited-method detection. Null = no baseline, patch all methods.
+        // Why pass text (not a path): avoids an IO race between orchestrator verification and worker
+        // read that would crash the whole file under the no-try-catch policy.
+        public string snapshotSource;
+    }
+
+    /// <summary>
+    /// Per-file half of the transform worker output; one entry per input source, same order.
+    /// </summary>
+    // Keep in sync with TransformWorker~/WorkerFileOutput.cs.
+    [Serializable]
+    internal sealed class TransformWorkerFileOutputDto
+    {
+        // Echoes TransformWorkerSourceDto.projectRelativePath of the source this row set describes.
+        public string projectRelativePath;
+
+        // SHA-256 (lowercase hex) of the raw source bytes the worker actually read.
+        // Empty when the worker returned before reading the file.
+        public string sourceContentSha256;
+
+        public string[] parseErrors;
+        public string[] declarationDriftWarnings;
+
+        // True when snapshotSource was provided but a duplicate syntax-method key on either side
+        // disabled baseline comparison (silent patch-all fallback). False when snapshotSource is null.
+        public bool baselineDisabledByDuplicateKeys;
+
+        // Members present in the snapshot (or compiled assembly for fields) but absent from the
+        // edited source. Null/omitted deserializes as empty after client coalesce.
+        public TransformWorkerRemovedMemberDto[] removedMembers;
+
+        // Compiled identities of methods that left the edited file (or whose return type changed).
+        // Null/omitted deserializes as empty after client coalesce.
+        public TransformWorkerRemovedMethodSignatureDto[] removedMethodSignatures;
+
+        // Source-level names ("Ns.Type.field") of fields this reload added via store rewrite.
+        // Null/omitted deserializes as empty after client coalesce.
+        public string[] addedFieldNames;
+
+        // Source-level names of added consts folded into edited bodies as literals.
+        // Null/omitted deserializes as empty after client coalesce.
+        public string[] addedConstNames;
+    }
+
+    /// <summary>
     /// Output payload read from the out-of-process transform worker.
     /// </summary>
     [Serializable]
@@ -50,8 +103,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string shimSource;
         public TransformWorkerEntryDto[] entries;
         public TransformWorkerSkippedDto[] skipped;
+
+        // Per-file results, in the same order and count as TransformWorkerInputDto.sources.
+        // Null/omitted deserializes as empty after client coalesce.
+        public TransformWorkerFileOutputDto[] files;
+
+        // Run-level failures that cannot be attributed to any single source (for example a
+        // missing or empty sources array). Per-file failures belong in files[i].parseErrors.
         public string[] parseErrors;
-        public string[] declarationDriftWarnings;
 
         // Const-drift warnings collected from snapshot-mismatched sibling sources.
         // Kept separate from declarationDriftWarnings so the orchestrator can dedupe
@@ -62,14 +121,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Null/empty means none (or no baseline). UnchangedTotal is derived from Length.
         public TransformWorkerUnchangedMethodDto[] unchangedMethods;
 
-        // True when snapshotSource was provided but a duplicate syntax-method key on either side
-        // disabled baseline comparison (silent patch-all fallback). False when snapshotSource is null.
-        public bool baselineDisabledByDuplicateKeys;
-
-        // Members present in the snapshot (or compiled assembly for fields in later PRs) but
-        // absent from the edited source. Null/omitted deserializes as empty after client coalesce.
-        public TransformWorkerRemovedMemberDto[] removedMembers;
-
         // True when any emitted shim type contains Harmony accessor delegates. Drives Harmony
         // reference injection; patchKind "addedMethod" entries can also need accessors (B2).
         public bool hasAccessorDelegates;
@@ -77,22 +128,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // True when any emitted shim body rewrites an added-field access to HotReloadAddedFieldStore.
         // Drives ToolContracts assembly injection at both the first compile and isolation retry.
         public bool hasAddedFieldRewrites;
-
-        // Source-level names ("Ns.Type.field") of fields this reload added via store rewrite.
-        // Null/omitted deserializes as empty after client coalesce.
-        public string[] addedFieldNames;
-
-        // Source-level names of added consts folded into edited bodies as literals.
-        // Null/omitted deserializes as empty after client coalesce.
-        public string[] addedConstNames;
-
-        // Compiled identities of methods that left the edited file (or whose return type changed).
-        // Null/omitted deserializes as empty after client coalesce.
-        public TransformWorkerRemovedMethodSignatureDto[] removedMethodSignatures;
-
-        // SHA-256 (lowercase hex) of the raw source bytes the worker actually read.
-        // Null/omitted when the worker returned before reading the file.
-        public string sourceContentSha256;
     }
 
     [Serializable]
@@ -119,7 +154,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         // Project-relative forward-slash path of the file this row was produced from.
         // Why: once several edited files share one shim assembly, a row must say which file it
-        // came from; today it always equals TransformWorkerInputDto.projectRelativePath.
+        // came from; it is the projectRelativePath of the TransformWorkerSourceDto that produced it.
         public string sourceProjectRelativePath;
 
         public string typeMetadataName;
@@ -135,7 +170,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         // Project-relative forward-slash path of the file this row was produced from.
         // Why: once several edited files share one shim assembly, a row must say which file it
-        // came from; today it always equals TransformWorkerInputDto.projectRelativePath.
+        // came from; it is the projectRelativePath of the TransformWorkerSourceDto that produced it.
         public string sourceProjectRelativePath;
 
         public string typeMetadataName;
@@ -173,7 +208,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         // Project-relative forward-slash path of the file this row was produced from.
         // Why: once several edited files share one shim assembly, a row must say which file it
-        // came from; today it always equals TransformWorkerInputDto.projectRelativePath.
+        // came from; it is the projectRelativePath of the TransformWorkerSourceDto that produced it.
         public string sourceProjectRelativePath;
 
         public string method;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/BaselineSnapshotBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/BaselineSnapshotBuilder.cs
@@ -18,7 +18,7 @@ using Microsoft.CodeAnalysis.Text;
 internal static class BaselineSnapshotBuilder
 {
     internal static BaselineSnapshotState BuildBaselineSnapshotState(
-        WorkerInput input,
+        string snapshotSource,
         CSharpParseOptions parseOptions,
         CompilationUnitSyntax plainRoot)
     {
@@ -26,13 +26,13 @@ internal static class BaselineSnapshotBuilder
         // same-file old/new comparison only needs syntax keys to stay consistent with each other.
         BaselineSnapshotState baseline = new BaselineSnapshotState();
         // Null disables comparison; empty string is a real (empty) baseline text.
-        if (input.SnapshotSource == null)
+        if (snapshotSource == null)
         {
             return baseline;
         }
 
         baseline.SnapshotRoot = CSharpSyntaxTree.ParseText(
-                SourceText.From(input.SnapshotSource, Encoding.UTF8),
+                SourceText.From(snapshotSource, Encoding.UTF8),
                 parseOptions)
             .GetCompilationUnitRoot();
         Dictionary<string, MethodDeclarationSyntax> snapMethods =

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -81,9 +81,29 @@ public static class TransformWorkerProgram
     private static int RunTransform(string inputJsonPath, string outputJsonPath)
     {
         WorkerInput input = ReadInput(inputJsonPath);
-        WorkerOutput output = TransformFile(input);
+        WorkerOutput unsupportedSourceCount = TryCreateUnsupportedSourceCountOutput(input);
+        WorkerOutput output = unsupportedSourceCount ?? TransformFile(input);
         WriteOutput(outputJsonPath, output);
         return 0;
+    }
+
+    // Why a run-level failure output (not a throw): the source count crosses a process boundary
+    // via JSON, so it is untrusted input rather than a broken internal contract.
+    private static WorkerOutput TryCreateUnsupportedSourceCountOutput(WorkerInput input)
+    {
+        if (input.Sources.Length == 1)
+        {
+            return null;
+        }
+
+        return new WorkerOutput
+        {
+            ShimSource = string.Empty,
+            Entries = Array.Empty<WorkerEntry>(),
+            Skipped = Array.Empty<WorkerSkipped>(),
+            Files = Array.Empty<WorkerFileOutput>(),
+            ParseErrors = new[] { "This worker build accepts exactly one source." }
+        };
     }
 
     private static WorkerInput ReadInput(string inputJsonPath)
@@ -95,11 +115,7 @@ public static class TransformWorkerProgram
             throw new InvalidOperationException("Failed to deserialize worker input JSON.");
         }
 
-        if (string.IsNullOrEmpty(input.SourcePath))
-        {
-            throw new InvalidOperationException("sourcePath is required.");
-        }
-
+        input.Sources ??= Array.Empty<WorkerSourceInput>();
         input.Defines ??= Array.Empty<string>();
         input.ReferencePaths ??= Array.Empty<string>();
         input.ExcludedMethodKeys ??= Array.Empty<string>();
@@ -117,13 +133,14 @@ public static class TransformWorkerProgram
 
     private static WorkerOutput TransformFile(WorkerInput input)
     {
-        WorkerOutput invalidPath = TryCreateInvalidPathOutput(input);
+        WorkerSourceInput source = input.Sources[0];
+        WorkerOutput invalidPath = TryCreateInvalidPathOutput(source);
         if (invalidPath != null)
         {
             return invalidPath;
         }
 
-        (WorkerOutput readFailure, string sourceText, string sourceContentSha256) = TryReadSourceText(input);
+        (WorkerOutput readFailure, string sourceText, string sourceContentSha256) = TryReadSourceText(source);
         if (readFailure != null)
         {
             return readFailure;
@@ -136,7 +153,7 @@ public static class TransformWorkerProgram
         (SyntaxTree syntaxTree, CompilationUnitSyntax plainRoot) = WorkerSourceAnnotator.ParseAndAnnotateSource(
             sourceText,
             parseOptions,
-            input.SourcePath,
+            source.SourcePath,
             parseErrors);
 
         (List<MetadataReference> references, MetadataReference targetTypesReference) =
@@ -172,7 +189,8 @@ public static class TransformWorkerProgram
                 targetTypesAssemblySymbol,
                 declarationDriftWarnings);
 
-        BaselineSnapshotState baseline = BaselineSnapshotBuilder.BuildBaselineSnapshotState(input, parseOptions, plainRoot);
+        BaselineSnapshotState baseline =
+            BaselineSnapshotBuilder.BuildBaselineSnapshotState(source.SnapshotSource, parseOptions, plainRoot);
 
         List<WorkerEntry> entries = new List<WorkerEntry>();
         List<WorkerSkipped> skipped = new List<WorkerSkipped>();
@@ -249,7 +267,7 @@ public static class TransformWorkerProgram
             OutsideMethodBodyDriftChecker.AppendOutsideMethodBodyDriftWarningIfNeeded(
                 baseline.SnapshotRoot,
                 plainRoot,
-                Path.GetFileName(input.SourcePath),
+                Path.GetFileName(source.SourcePath),
                 declarationDriftWarnings,
                 addedMethodCatalog,
                 addedFieldCatalog,
@@ -259,7 +277,7 @@ public static class TransformWorkerProgram
 
         return BuildWorkerOutput(
             root,
-            input.ProjectRelativePath,
+            source.ProjectRelativePath,
             shimTypes,
             entries,
             skipped,
@@ -274,35 +292,54 @@ public static class TransformWorkerProgram
             sourceContentSha256);
     }
 
-    private static WorkerOutput TryCreateInvalidPathOutput(WorkerInput input)
+    private static WorkerOutput TryCreateInvalidPathOutput(WorkerSourceInput source)
     {
         // Why ParseErrors (not Debug.Assert): ProjectRelativePath crosses a process boundary via
         // JSON, and the worker is built without a DEBUG define so Conditional Asserts are stripped.
-        if (string.IsNullOrEmpty(input.ProjectRelativePath)
-            || input.ProjectRelativePath.IndexOf('\\') >= 0
-            || input.ProjectRelativePath.IndexOf('"') >= 0)
+        if (string.IsNullOrEmpty(source.ProjectRelativePath)
+            || source.ProjectRelativePath.IndexOf('\\') >= 0
+            || source.ProjectRelativePath.IndexOf('"') >= 0)
         {
-            return new WorkerOutput
-            {
-                ShimSource = string.Empty,
-                Entries = Array.Empty<WorkerEntry>(),
-                Skipped = Array.Empty<WorkerSkipped>(),
-                ParseErrors = new[]
-                {
-                    "Invalid projectRelativePath: must be a non-empty forward-slash path without quotes."
-                }
-            };
+            return CreateSourceFailureOutput(
+                source,
+                "Invalid projectRelativePath: must be a non-empty forward-slash path without quotes.");
         }
 
         return null;
     }
 
+    // A failure the run can attribute to one source: the row set is empty and the message
+    // travels on that source's per-file parse errors.
+    private static WorkerOutput CreateSourceFailureOutput(WorkerSourceInput source, string parseError)
+    {
+        return new WorkerOutput
+        {
+            ShimSource = string.Empty,
+            Entries = Array.Empty<WorkerEntry>(),
+            Skipped = Array.Empty<WorkerSkipped>(),
+            Files = new[]
+            {
+                new WorkerFileOutput
+                {
+                    ProjectRelativePath = source.ProjectRelativePath,
+                    SourceContentSha256 = string.Empty,
+                    ParseErrors = new[] { parseError },
+                    DeclarationDriftWarnings = Array.Empty<string>(),
+                    RemovedMembers = Array.Empty<WorkerRemovedMember>(),
+                    RemovedMethodSignatures = Array.Empty<WorkerRemovedMethodSignature>(),
+                    AddedFieldNames = Array.Empty<string>(),
+                    AddedConstNames = Array.Empty<string>()
+                }
+            }
+        };
+    }
+
     private static (WorkerOutput Failure, string SourceText, string SourceContentSha256) TryReadSourceText(
-        WorkerInput input)
+        WorkerSourceInput source)
     {
         try
         {
-            byte[] sourceBytes = File.ReadAllBytes(input.SourcePath);
+            byte[] sourceBytes = File.ReadAllBytes(source.SourcePath);
             string sourceContentSha256 = ComputeSourceContentSha256(sourceBytes);
             using MemoryStream memoryStream = new MemoryStream(sourceBytes, writable: false);
             using StreamReader reader = new StreamReader(
@@ -314,13 +351,7 @@ public static class TransformWorkerProgram
         catch (Exception exception)
         {
             return (
-                new WorkerOutput
-                {
-                    ShimSource = string.Empty,
-                    Entries = Array.Empty<WorkerEntry>(),
-                    Skipped = Array.Empty<WorkerSkipped>(),
-                    ParseErrors = new[] { "Failed to read sourcePath: " + exception.Message }
-                },
+                CreateSourceFailureOutput(source, "Failed to read sourcePath: " + exception.Message),
                 null,
                 null);
         }
@@ -416,23 +447,28 @@ public static class TransformWorkerProgram
         StampSourceProjectRelativePath(entries, skipped, unchangedMethods, projectRelativePath);
 
         string shimSource = ShimSourceEmitter.Emit(root, shimTypes, projectRelativePath);
+        WorkerFileOutput fileOutput = new WorkerFileOutput
+        {
+            ProjectRelativePath = projectRelativePath,
+            SourceContentSha256 = sourceContentSha256,
+            ParseErrors = parseErrors.ToArray(),
+            DeclarationDriftWarnings = declarationDriftWarnings.ToArray(),
+            BaselineDisabledByDuplicateKeys = baseline.BaselineDisabledByDuplicateKeys,
+            RemovedMembers = removedMembers.ToArray(),
+            RemovedMethodSignatures = removedMethodSignatures.ToArray(),
+            AddedFieldNames = addedFieldCatalog.ListRewrittenAddedFieldDisplayNames(),
+            AddedConstNames = addedFieldCatalog.ListFoldedConstDisplayNames()
+        };
         return new WorkerOutput
         {
             ShimSource = shimSource,
             Entries = entries.ToArray(),
             Skipped = skipped.ToArray(),
-            DeclarationDriftWarnings = declarationDriftWarnings.ToArray(),
+            Files = new[] { fileOutput },
             SiblingConstDriftWarnings = siblingConstDriftWarnings.ToArray(),
-            ParseErrors = parseErrors.ToArray(),
             UnchangedMethods = unchangedMethods.ToArray(),
-            BaselineDisabledByDuplicateKeys = baseline.BaselineDisabledByDuplicateKeys,
-            RemovedMembers = removedMembers.ToArray(),
-            RemovedMethodSignatures = removedMethodSignatures.ToArray(),
             HasAccessorDelegates = hasAccessorDelegates,
-            HasAddedFieldRewrites = addedFieldCatalog.HasStoreRewrites,
-            AddedFieldNames = addedFieldCatalog.ListRewrittenAddedFieldDisplayNames(),
-            AddedConstNames = addedFieldCatalog.ListFoldedConstDisplayNames(),
-            SourceContentSha256 = sourceContentSha256
+            HasAddedFieldRewrites = addedFieldCatalog.HasStoreRewrites
         };
     }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerFileOutput.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerFileOutput.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+// Keep in sync with TransformWorkerDtos.cs TransformWorkerFileOutputDto.
+internal sealed class WorkerFileOutput
+{
+    // Echoes WorkerSourceInput.ProjectRelativePath of the source this row set describes.
+    public string ProjectRelativePath { get; set; }
+
+    // SHA-256 (lowercase hex) of the raw source bytes the worker actually read.
+    // Empty when the worker returned before reading the file.
+    public string SourceContentSha256 { get; set; }
+
+    public string[] ParseErrors { get; set; }
+
+    public string[] DeclarationDriftWarnings { get; set; }
+
+    public bool BaselineDisabledByDuplicateKeys { get; set; }
+
+    public WorkerRemovedMember[] RemovedMembers { get; set; }
+
+    public WorkerRemovedMethodSignature[] RemovedMethodSignatures { get; set; }
+
+    public string[] AddedFieldNames { get; set; }
+
+    public string[] AddedConstNames { get; set; }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerInput.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerInput.cs
@@ -17,7 +17,9 @@ using Microsoft.CodeAnalysis.Text;
 
 internal sealed class WorkerInput
 {
-    public string SourcePath { get; set; }
+    // Edited files this run transforms together; all belong to the same compilation assembly.
+    // Keep in sync with TransformWorkerDtos.cs TransformWorkerInputDto.sources.
+    public WorkerSourceInput[] Sources { get; set; }
 
     public string[] Defines { get; set; }
 
@@ -33,14 +35,6 @@ internal sealed class WorkerInput
     // Added-method keys whose shim bodies failed the first compile. Distinct from
     // ExcludedMethodKeys so a healthy added shim is not dropped when an existing method fails.
     public string[] ExcludedAddedMethodKeys { get; set; }
-
-    // Verified snapshot text for edited-method detection. Null = no baseline, patch all methods.
-    // Why pass text (not a path): avoids an IO race between orchestrator verification and worker
-    // read that would crash the whole file under the no-try-catch policy.
-    public string SnapshotSource { get; set; }
-
-    // Project-relative forward-slash path embedded in #line document names.
-    public string ProjectRelativePath { get; set; }
 
     // Absolute paths of every source file in the edited file's compilation assembly.
     // Null/omitted is treated as empty (no sibling global usings collected).

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerOutput.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerOutput.cs
@@ -23,33 +23,22 @@ internal sealed class WorkerOutput
 
     public WorkerSkipped[] Skipped { get; set; }
 
-    public string[] DeclarationDriftWarnings { get; set; }
+    // Per-file results, same order and count as WorkerInput.Sources.
+    // Keep in sync with TransformWorkerOutputDto.files.
+    public WorkerFileOutput[] Files { get; set; }
+
+    // Run-level failures that cannot be attributed to any single source.
+    // Keep in sync with TransformWorkerOutputDto.parseErrors.
+    public string[] ParseErrors { get; set; }
 
     // Keep in sync with TransformWorkerOutputDto.siblingConstDriftWarnings.
     public string[] SiblingConstDriftWarnings { get; set; }
 
-    public string[] ParseErrors { get; set; }
-
     public WorkerUnchangedMethod[] UnchangedMethods { get; set; }
-
-    public bool BaselineDisabledByDuplicateKeys { get; set; }
-
-    public WorkerRemovedMember[] RemovedMembers { get; set; }
-
-    public WorkerRemovedMethodSignature[] RemovedMethodSignatures { get; set; }
 
     public bool HasAccessorDelegates { get; set; }
 
     // True when shim bodies rewrite added-field accesses to HotReloadAddedFieldStore.
     // Keep in sync with TransformWorkerOutputDto.hasAddedFieldRewrites.
     public bool HasAddedFieldRewrites { get; set; }
-
-    // Keep in sync with TransformWorkerOutputDto.addedFieldNames.
-    public string[] AddedFieldNames { get; set; }
-
-    // Keep in sync with TransformWorkerOutputDto.addedConstNames.
-    public string[] AddedConstNames { get; set; }
-
-    // Keep in sync with TransformWorkerOutputDto.sourceContentSha256.
-    public string SourceContentSha256 { get; set; }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceInput.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceInput.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+// Keep in sync with TransformWorkerDtos.cs TransformWorkerSourceDto.
+internal sealed class WorkerSourceInput
+{
+    // Absolute path the worker reads the edited text from. May be a temp override copy.
+    public string SourcePath { get; set; }
+
+    // Project-relative forward-slash path embedded in #line document names.
+    public string ProjectRelativePath { get; set; }
+
+    // Verified snapshot text for edited-method detection. Null = no baseline, patch all methods.
+    // Why pass text (not a path): avoids an IO race between orchestrator verification and worker
+    // read that would crash the whole file under the no-try-catch policy.
+    public string SnapshotSource { get; set; }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerUsingCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerUsingCollector.cs
@@ -78,8 +78,8 @@ internal static class WorkerUsingCollector
         return false;
     }
 
-    // Why skip SourcePath: the edited file's usings already come from the in-memory tree.
-    // Reading the on-disk copy would pick up the pre-edit source.
+    // Why skip the run's own sources: their usings already come from the in-memory trees.
+    // Reading the on-disk copies would pick up the pre-edit sources.
     internal static List<UsingDirectiveSyntax> CollectAssemblyGlobalUsings(
         WorkerInput input,
         CSharpParseOptions parseOptions)
@@ -88,7 +88,7 @@ internal static class WorkerUsingCollector
         foreach (string assemblySourcePath in input.AssemblySourcePaths)
         {
             if (string.IsNullOrEmpty(assemblySourcePath)
-                || PathsReferToSameSourceFile(assemblySourcePath, input.SourcePath)
+                || IsEditedSource(input, assemblySourcePath)
                 || !File.Exists(assemblySourcePath))
             {
                 continue;
@@ -106,6 +106,19 @@ internal static class WorkerUsingCollector
         }
 
         return collected;
+    }
+
+    private static bool IsEditedSource(WorkerInput input, string assemblySourcePath)
+    {
+        foreach (WorkerSourceInput source in input.Sources)
+        {
+            if (PathsReferToSameSourceFile(assemblySourcePath, source.SourcePath))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     internal static void AppendGlobalUsingsFromParsedText(


### PR DESCRIPTION
## Summary
- Prepares hot reload to apply edits that span several files of one assembly, by letting a single transform worker run name and report on many source files.
- No user-visible behavior change yet: a run still carries exactly one source, and the shim assembly is still built per file.

## User Impact
- Today, a method body edited in one file cannot call a method or field added in another file of the same assembly, because each file is transformed and shimmed alone.
- This change lays the wire groundwork for that: the worker protocol can now describe a group of edited files and return per-file findings. Behavior for a single edited file is unchanged.

## Changes
- Worker input carries `sources[]` of `(sourcePath, projectRelativePath, snapshotSource)` instead of a single source triple; the worker mirrors follow.
- Worker output splits per-file findings (content hash, parse errors, declaration drift warnings, baseline-disabled flag, removed/added members) into `files[]`, while `shimSource`, `entries`, `skipped` and `unchangedMethods` stay group-level. Top-level `parseErrors` remains the channel for failures that belong to no single source.
- Entry, skipped and unchanged-method rows carry `sourceProjectRelativePath` so each row states which file produced it.
- Shim compile error attribution compares the diagnostic's file against each entry's own `sourceProjectRelativePath` instead of one run-wide path, so overlapping original-source line ranges in different files no longer read as ambiguous.
- Guardrails for this stage: the worker rejects any source count other than one as a run-level failure, and both the orchestrator and the isolation retry assert that a single-source run returns exactly one per-file row.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <repo root>` → `ErrorCount: 0`, `Success: true`
- `dist/darwin-arm64/uloop run-tests --skip-compile --filter-type regex --filter-value 'HotReload'` → 684 tests, 684 passed, 0 failed, 0 skipped
- `dist/darwin-arm64/uloop run-tests --skip-compile --filter-type regex --filter-value 'HotReloadShimErrorAttributionTests|HotReloadOrchestratorTests'` → 154 tests, 154 passed, 0 failed
- `sh scripts/check-file-length.sh` → no files exceeded the 500 SLOC limit
- `sh scripts/check-code-complexity.sh` → Go cyclop 0 issues, C# CA1502 no findings above 15


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

