### PR TITLE
feat: Hot reload can now use members added in another file of the same assembly

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberCaller.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberCaller.cs
@@ -1,0 +1,14 @@
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled caller type for cross-file worker tests. Tests edit a copy of this body so it
+    /// calls a member added in the sibling host file within the same worker run.
+    /// </summary>
+    internal sealed class HotReloadCrossFileAddedMemberCaller
+    {
+        public int Call(HotReloadCrossFileAddedMemberHost host)
+        {
+            return host.Value();
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberCaller.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberCaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa26fd4af0f1b467ab6aead988acf1b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberHost.cs
@@ -1,0 +1,14 @@
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Compiled host type for cross-file worker tests. Tests copy this source, add members to the
+    /// copy, and expect a body edited in the sibling caller file to bind against them.
+    /// </summary>
+    internal sealed class HotReloadCrossFileAddedMemberHost
+    {
+        public int Value()
+        {
+            return 1;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberHost.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberHost.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9abef014092f84deab018d37a7790bd6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -2607,11 +2607,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a run carrying more than one source is a run-level failure, so the client
-        /// reports it as a failed result instead of a success with no per-file rows.
+        /// What: a run whose sources repeat one projectRelativePath is a run-level failure, so
+        /// the client reports it as a failed result instead of a success with ambiguous rows.
         /// </summary>
         [Test]
-        public async Task BootstrapAndRun_MoreThanOneSource_FailsWithRunLevelError()
+        public async Task BootstrapAndRun_TwoSourcesOfTheSameFile_FailsWithRunLevelError()
         {
             string fixturePath = ResolveE2EFixturePath();
             string fixtureProjectRelativePath = ResolveE2EFixtureProjectRelativePath();
@@ -2623,7 +2623,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 secondProjectRelativePath: fixtureProjectRelativePath);
 
             Assert.That(result.Success, Is.False);
-            Assert.That(result.ErrorMessage, Does.Contain("exactly one source"));
+            Assert.That(result.ErrorMessage, Does.Contain("repeat a projectRelativePath"));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerCrossFileTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerCrossFileTests.cs
@@ -1,0 +1,424 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for transforming two edited files of one assembly in a single worker
+    /// run, where a body edited in one file uses a member added in the other.
+    /// </summary>
+    public class TransformWorkerCrossFileTests
+    {
+        private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+        private const string HostFileName = "HotReloadCrossFileAddedMemberHost.cs";
+        private const string CallerFileName = "HotReloadCrossFileAddedMemberCaller.cs";
+        private const string HostTypeMetadataName =
+            "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadCrossFileAddedMemberHost";
+        private const string CallerTypeMetadataName =
+            "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadCrossFileAddedMemberCaller";
+
+        /// <summary>
+        /// What: a body edited in the caller file binds to a method added in the host file within
+        /// the same run, every row names the file that declared its type, the shim source carries
+        /// both documents, and files[] follows the sources order.
+        /// </summary>
+        [Test]
+        public async Task Run_TwoSources_CallerBindsToAddedMethodInOtherSource()
+        {
+            CrossFileRun run = await RunEditedPairAsync(
+                AddHostMethod(ReadOnDisk(HostFileName)),
+                CallAddedHostMethod(ReadOnDisk(CallerFileName)));
+
+            Assert.That(run.Result.Success, Is.True, run.Result.ErrorMessage);
+            TransformWorkerEntryDto addedEntry = FindEntry(run, HostTypeMetadataName, "Added");
+            TransformWorkerEntryDto callerEntry = FindEntry(run, CallerTypeMetadataName, "Call");
+            Assert.That(addedEntry.patchKind, Is.EqualTo("addedMethod"));
+            Assert.That(callerEntry.calledAddedMethodKeys, Is.Not.Null);
+            Assert.That(
+                callerEntry.calledAddedMethodKeys,
+                Has.Some.Contains("Added"),
+                "The edited caller body must record the added host method it calls.");
+            AssertNoSkippedMethodNamed(run, "Added");
+            AssertNoSkippedMethodNamed(run, "Call");
+            AssertEveryRowNamesItsDeclaringFile(run);
+
+            Assert.That(run.Result.Output.shimSource, Does.Contain("\"" + run.HostProjectRelativePath + "\""));
+            Assert.That(run.Result.Output.shimSource, Does.Contain("\"" + run.CallerProjectRelativePath + "\""));
+
+            Assert.That(run.Result.Output.files.Length, Is.EqualTo(2));
+            Assert.That(run.Result.Output.files[0].projectRelativePath, Is.EqualTo(run.HostProjectRelativePath));
+            Assert.That(run.Result.Output.files[1].projectRelativePath, Is.EqualTo(run.CallerProjectRelativePath));
+            Assert.That(run.Result.Output.files[0].sourceContentSha256, Is.Not.Empty);
+            Assert.That(run.Result.Output.files[1].sourceContentSha256, Is.Not.Empty);
+            Assert.That(
+                run.Result.Output.files[0].sourceContentSha256,
+                Is.Not.EqualTo(run.Result.Output.files[1].sourceContentSha256));
+        }
+
+        /// <summary>
+        /// What: a field added in the host file is readable and writable from the caller file's
+        /// edited body, and only the host's per-file row lists the added field name.
+        /// </summary>
+        [Test]
+        public async Task Run_TwoSources_CallerReadsAndWritesFieldAddedInOtherSource()
+        {
+            CrossFileRun run = await RunEditedPairAsync(
+                InsertIntoHostBody(ReadOnDisk(HostFileName), "        public int Counter;\n"),
+                ReplaceCallerBody(ReadOnDisk(CallerFileName), "host.Counter += 1;\n            return host.Counter;"));
+
+            Assert.That(run.Result.Success, Is.True, run.Result.ErrorMessage);
+            Assert.That(run.Result.Output.files[0].addedFieldNames, Has.Some.Contains("Counter"));
+            Assert.That(run.Result.Output.files[1].addedFieldNames, Is.Empty);
+            Assert.That(run.Result.Output.hasAddedFieldRewrites, Is.True);
+            FindEntry(run, CallerTypeMetadataName, "Call");
+            AssertNoSkippedMethodNamed(run, "Call");
+        }
+
+        /// <summary>
+        /// What: a const added in the host file folds into the caller file's edited body, and only
+        /// the host's per-file row lists the folded const name.
+        /// </summary>
+        [Test]
+        public async Task Run_TwoSources_CallerFoldsConstAddedInOtherSource()
+        {
+            CrossFileRun run = await RunEditedPairAsync(
+                InsertIntoHostBody(ReadOnDisk(HostFileName), "        public const int Limit = 7;\n"),
+                ReplaceCallerBody(
+                    ReadOnDisk(CallerFileName),
+                    "return HotReloadCrossFileAddedMemberHost.Limit;"));
+
+            Assert.That(run.Result.Success, Is.True, run.Result.ErrorMessage);
+            Assert.That(run.Result.Output.files[0].addedConstNames, Has.Some.Contains("Limit"));
+            Assert.That(run.Result.Output.files[1].addedConstNames, Is.Empty);
+            FindEntry(run, CallerTypeMetadataName, "Call");
+        }
+
+        /// <summary>
+        /// What: shim type and method names stay unique across the files of one run, so the single
+        /// shim assembly cannot host two members under the same name.
+        /// </summary>
+        [Test]
+        public async Task Run_TwoSources_ShimTypeNamesAreUnique()
+        {
+            CrossFileRun run = await RunEditedPairAsync(
+                AddHostMethod(ReadOnDisk(HostFileName)),
+                CallAddedHostMethod(ReadOnDisk(CallerFileName)));
+
+            Assert.That(run.Result.Success, Is.True, run.Result.ErrorMessage);
+            HashSet<string> shimMembers = new HashSet<string>(StringComparer.Ordinal);
+            foreach (TransformWorkerEntryDto entry in run.Result.Output.entries)
+            {
+                Assert.That(
+                    shimMembers.Add(entry.shimTypeName + "::" + entry.shimMethodName),
+                    Is.True,
+                    "Duplicate shim member: " + entry.shimTypeName + "::" + entry.shimMethodName);
+            }
+        }
+
+        /// <summary>
+        /// What: excluding the host file's added method skips the caller file's edited body in the
+        /// other source, because the caller can no longer bind to it.
+        /// </summary>
+        [Test]
+        public async Task Run_TwoSources_WhenAddedMethodIsExcluded_SkipsOtherSourceCaller()
+        {
+            CrossFileRun probe = await RunEditedPairAsync(
+                AddHostMethod(ReadOnDisk(HostFileName)),
+                CallAddedHostMethod(ReadOnDisk(CallerFileName)));
+            Assert.That(probe.Result.Success, Is.True, probe.Result.ErrorMessage);
+            TransformWorkerEntryDto callerEntry = FindEntry(probe, CallerTypeMetadataName, "Call");
+            Assert.That(callerEntry.calledAddedMethodKeys.Length, Is.EqualTo(1));
+            string addedMethodKey = callerEntry.calledAddedMethodKeys[0];
+
+            CrossFileRun run = await RunEditedPairAsync(
+                AddHostMethod(ReadOnDisk(HostFileName)),
+                CallAddedHostMethod(ReadOnDisk(CallerFileName)),
+                excludedAddedMethodKeys: new[] { addedMethodKey });
+
+            Assert.That(run.Result.Success, Is.True, run.Result.ErrorMessage);
+            TransformWorkerSkippedDto callerSkip = FindSkipped(run, "Call");
+            Assert.That(callerSkip.calledAddedMethodKey, Is.EqualTo(addedMethodKey));
+            Assert.That(
+                TryFindEntry(run, CallerTypeMetadataName, "Call"),
+                Is.Null,
+                "An excluded added method must not leave its caller patched.");
+        }
+
+        /// <summary>
+        /// What: an unreadable source reports its failure on its own per-file row only, and the
+        /// other file of the run still produces entries.
+        /// </summary>
+        [Test]
+        public async Task Run_TwoSources_WhenOneSourceIsUnreadable_ReportsParseErrorOnlyForThatFile()
+        {
+            CrossFileRun run = await RunEditedPairAsync(
+                AddHostMethod(ReadOnDisk(HostFileName)),
+                CallAddedHostMethod(ReadOnDisk(CallerFileName)),
+                missingHostSourcePath: true);
+
+            Assert.That(run.Result.Success, Is.True, run.Result.ErrorMessage);
+            Assert.That(run.Result.Output.files[0].parseErrors, Is.Not.Empty);
+            Assert.That(run.Result.Output.files[1].parseErrors, Is.Empty);
+            Assert.That(run.Result.Output.entries, Is.Not.Empty);
+            foreach (TransformWorkerEntryDto entry in run.Result.Output.entries)
+            {
+                Assert.That(entry.sourceProjectRelativePath, Is.EqualTo(run.CallerProjectRelativePath));
+            }
+        }
+
+        private static string ReadOnDisk(string fileName)
+        {
+            return File.ReadAllText(Path.Combine(Application.dataPath, "Tests", "Editor", "HotReload", fileName));
+        }
+
+        private static string AddHostMethod(string hostSource)
+        {
+            return InsertIntoHostBody(
+                hostSource,
+                "        public int Added()\n        {\n            return 41;\n        }\n\n");
+        }
+
+        private static string InsertIntoHostBody(string hostSource, string memberText)
+        {
+            const string anchor = "        public int Value()";
+            Assert.That(hostSource, Does.Contain(anchor), "Precondition: host anchor must exist.");
+            return hostSource.Replace(anchor, memberText + anchor, StringComparison.Ordinal);
+        }
+
+        private static string CallAddedHostMethod(string callerSource)
+        {
+            return ReplaceCallerBody(callerSource, "return host.Added() + 1;");
+        }
+
+        private static string ReplaceCallerBody(string callerSource, string bodyText)
+        {
+            const string anchor = "return host.Value();";
+            Assert.That(callerSource, Does.Contain(anchor), "Precondition: caller anchor must exist.");
+            return callerSource.Replace(anchor, bodyText, StringComparison.Ordinal);
+        }
+
+        private static TransformWorkerEntryDto FindEntry(
+            CrossFileRun run,
+            string typeMetadataName,
+            string methodName)
+        {
+            TransformWorkerEntryDto entry = TryFindEntry(run, typeMetadataName, methodName);
+            Assert.That(entry, Is.Not.Null, "Missing entry: " + typeMetadataName + "." + methodName);
+            return entry;
+        }
+
+        private static TransformWorkerEntryDto TryFindEntry(
+            CrossFileRun run,
+            string typeMetadataName,
+            string methodName)
+        {
+            foreach (TransformWorkerEntryDto entry in run.Result.Output.entries)
+            {
+                if (entry.typeMetadataName == typeMetadataName && entry.methodName == methodName)
+                {
+                    return entry;
+                }
+            }
+
+            return null;
+        }
+
+        private static TransformWorkerSkippedDto FindSkipped(CrossFileRun run, string methodName)
+        {
+            foreach (TransformWorkerSkippedDto skipped in run.Result.Output.skipped)
+            {
+                if (skipped.method != null && skipped.method.Contains("." + methodName + "("))
+                {
+                    return skipped;
+                }
+            }
+
+            Assert.Fail("Missing skipped row for " + methodName);
+            return null;
+        }
+
+        private static void AssertNoSkippedMethodNamed(CrossFileRun run, string methodName)
+        {
+            foreach (TransformWorkerSkippedDto skipped in run.Result.Output.skipped)
+            {
+                Assert.That(
+                    skipped.method,
+                    Does.Not.Contain("." + methodName + "("),
+                    "Unexpected skip: " + skipped.method + " (" + skipped.reason + ")");
+            }
+        }
+
+        private static void AssertEveryRowNamesItsDeclaringFile(CrossFileRun run)
+        {
+            foreach (TransformWorkerEntryDto entry in run.Result.Output.entries)
+            {
+                Assert.That(
+                    entry.sourceProjectRelativePath,
+                    Is.EqualTo(ExpectedPathOfType(run, entry.typeMetadataName)),
+                    "Entry row names the wrong file: " + entry.methodName);
+            }
+
+            foreach (TransformWorkerSkippedDto skipped in run.Result.Output.skipped)
+            {
+                Assert.That(
+                    skipped.sourceProjectRelativePath == run.HostProjectRelativePath
+                    || skipped.sourceProjectRelativePath == run.CallerProjectRelativePath,
+                    Is.True,
+                    "Skipped row names a file outside the run: " + skipped.method);
+            }
+
+            foreach (TransformWorkerUnchangedMethodDto unchanged in run.Result.Output.unchangedMethods)
+            {
+                Assert.That(
+                    unchanged.sourceProjectRelativePath,
+                    Is.EqualTo(ExpectedPathOfType(run, unchanged.typeMetadataName)),
+                    "Unchanged row names the wrong file: " + unchanged.methodName);
+            }
+        }
+
+        private static string ExpectedPathOfType(CrossFileRun run, string typeMetadataName)
+        {
+            return typeMetadataName == HostTypeMetadataName
+                ? run.HostProjectRelativePath
+                : run.CallerProjectRelativePath;
+        }
+
+        private static async Task<CrossFileRun> RunEditedPairAsync(
+            string editedHostSource,
+            string editedCallerSource,
+            string[] excludedAddedMethodKeys = null,
+            bool missingHostSourcePath = false)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string targetDllPath = Path.Combine(
+                projectRoot,
+                "Library",
+                "ScriptAssemblies",
+                TestAssemblyName + ".dll");
+            Assert.That(File.Exists(targetDllPath), Is.True, "Test assembly dll missing: " + targetDllPath);
+
+            UnityEditor.Compilation.Assembly compilationAssembly = null;
+            foreach (UnityEditor.Compilation.Assembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name == TestAssemblyName)
+                {
+                    compilationAssembly = assembly;
+                    break;
+                }
+            }
+
+            Assert.That(compilationAssembly, Is.Not.Null, "CompilationPipeline assembly not found.");
+
+            string temporaryDirectory = Path.Combine(
+                projectRoot,
+                "Library",
+                "UloopHotReload",
+                "TestSources",
+                "CrossFile");
+            Directory.CreateDirectory(temporaryDirectory);
+            string hostSourcePath = Path.Combine(temporaryDirectory, HostFileName);
+            string callerSourcePath = Path.Combine(temporaryDirectory, CallerFileName);
+            File.WriteAllText(hostSourcePath, editedHostSource);
+            File.WriteAllText(callerSourcePath, editedCallerSource);
+
+            CrossFileRun run = new CrossFileRun
+            {
+                HostProjectRelativePath = "Assets/Tests/Editor/HotReload/" + HostFileName,
+                CallerProjectRelativePath = "Assets/Tests/Editor/HotReload/" + CallerFileName
+            };
+            TransformWorkerInputDto input = new TransformWorkerInputDto
+            {
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = missingHostSourcePath
+                            ? Path.Combine(temporaryDirectory, "MissingCrossFileHost.cs")
+                            : hostSourcePath,
+                        projectRelativePath = run.HostProjectRelativePath,
+                        snapshotSource = ReadOnDisk(HostFileName)
+                    },
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = callerSourcePath,
+                        projectRelativePath = run.CallerProjectRelativePath,
+                        snapshotSource = ReadOnDisk(CallerFileName)
+                    }
+                },
+                defines = compilationAssembly.defines ?? Array.Empty<string>(),
+                referencePaths = BuildAbsoluteReferencePaths(compilationAssembly.allReferences, targetDllPath),
+                targetTypesAssemblyPath = targetDllPath,
+                assemblySourcePaths = BuildAbsoluteAssemblySourcePaths(compilationAssembly.sourceFiles),
+                excludedAddedMethodKeys = excludedAddedMethodKeys
+            };
+
+            run.Result = await TransformWorkerClient.RunAsync(input, CancellationToken.None);
+            return run;
+        }
+
+        private static string[] BuildAbsoluteReferencePaths(string[] allReferences, string targetDllPath)
+        {
+            List<string> paths = new List<string>();
+            if (allReferences != null)
+            {
+                foreach (string reference in allReferences)
+                {
+                    if (string.IsNullOrEmpty(reference) || !File.Exists(reference))
+                    {
+                        continue;
+                    }
+
+                    paths.Add(Path.GetFullPath(reference));
+                }
+            }
+
+            string fullTarget = Path.GetFullPath(targetDllPath);
+            if (!paths.Contains(fullTarget))
+            {
+                paths.Add(fullTarget);
+            }
+
+            return paths.ToArray();
+        }
+
+        private static string[] BuildAbsoluteAssemblySourcePaths(string[] sourceFiles)
+        {
+            if (sourceFiles == null || sourceFiles.Length == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string[] paths = new string[sourceFiles.Length];
+            for (int index = 0; index < sourceFiles.Length; index++)
+            {
+                string normalizedRelativePath = sourceFiles[index].Replace('\\', '/');
+                paths[index] = Path.GetFullPath(
+                    Path.Combine(projectRoot, normalizedRelativePath.Replace('/', Path.DirectorySeparatorChar)));
+            }
+
+            return paths;
+        }
+
+        // One cross-file worker run: the paths the sources were sent under and the run's result.
+        private sealed class CrossFileRun
+        {
+            public string HostProjectRelativePath { get; set; }
+
+            public string CallerProjectRelativePath { get; set; }
+
+            public TransformWorkerClientResult Result { get; set; }
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerCrossFileTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerCrossFileTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d71de9e1ec6c44afa00f4357e1514e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedCallSiteGuard.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedCallSiteGuard.cs
@@ -19,7 +19,6 @@ internal static class AddedCallSiteGuard
 {
     internal static void SkipBodiesThatCannotUseAddedMethods(
         List<TypeEmitState> typeEmitStates,
-        SemanticModel semanticModel,
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog,
         List<WorkerSkipped> skipped)
@@ -30,6 +29,9 @@ internal static class AddedCallSiteGuard
             progressed = false;
             foreach (TypeEmitState typeState in typeEmitStates)
             {
+                // Why per state (not one model for the run): the states of a group run come from
+                // several trees, and a SemanticModel only answers for the tree it was built from.
+                SemanticModel semanticModel = typeState.SourceUnit.SemanticModel;
                 List<QueuedShimMethod> remaining = new List<QueuedShimMethod>();
                 foreach (QueuedShimMethod queued in typeState.QueuedMethods)
                 {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedCallSiteGuard.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedCallSiteGuard.cs
@@ -48,6 +48,7 @@ internal static class AddedCallSiteGuard
                     {
                         skipped.Add(new WorkerSkipped
                         {
+                            SourceProjectRelativePath = typeState.SourceUnit.Input.ProjectRelativePath,
                             Method = WorkerMethodKeys.FormatMethodLabel(queued.MethodSymbol),
                             Reason = skipReason,
                             CalledAddedMethodKey = calledAddedMethodKey,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldBinding.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldBinding.cs
@@ -20,6 +20,10 @@ using Microsoft.CodeAnalysis.Text;
 /// </summary>
 internal sealed class AddedFieldBinding
 {
+    // The edited file that declared this field. A group run classifies fields from several
+    // files into one catalog, and each file reports only its own added names.
+    public string SourceProjectRelativePath { get; set; }
+
     public string FieldKey { get; set; }
 
     public string SyntaxKey { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldCatalog.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldCatalog.cs
@@ -71,23 +71,29 @@ internal sealed class AddedFieldCatalog
     // classification, so unused fields and isolation-excluded bodies would still list.
     // Excluded methods are dropped in TypeEmitPlanner.QueueTypeMethods before rewrite, so a file-wide
     // rewrite set matches emitted entries without per-entry tracking.
-    public string[] ListRewrittenAddedFieldDisplayNames()
+    public string[] ListRewrittenAddedFieldDisplayNames(string projectRelativePath)
     {
-        List<string> names = new List<string>(_rewrittenAddedFieldKeys.Count);
-        foreach (string fieldKey in _rewrittenAddedFieldKeys)
-        {
-            names.Add(FormatAddedFieldDisplayName(fieldKey));
-        }
-
-        names.Sort(StringComparer.Ordinal);
-        return names.ToArray();
+        return ListDisplayNamesOfFile(_rewrittenAddedFieldKeys, projectRelativePath);
     }
 
-    public string[] ListFoldedConstDisplayNames()
+    public string[] ListFoldedConstDisplayNames(string projectRelativePath)
     {
-        List<string> names = new List<string>(_foldedConstKeys.Count);
-        foreach (string fieldKey in _foldedConstKeys)
+        return ListDisplayNamesOfFile(_foldedConstKeys, projectRelativePath);
+    }
+
+    // Why filter by the binding's file: the catalog spans a whole group, while addedFieldNames
+    // and addedConstNames are per-file rows in the worker output.
+    private string[] ListDisplayNamesOfFile(HashSet<string> fieldKeys, string projectRelativePath)
+    {
+        List<string> names = new List<string>(fieldKeys.Count);
+        foreach (string fieldKey in fieldKeys)
         {
+            AddedFieldBinding binding = _byKey[fieldKey];
+            if (!string.Equals(binding.SourceProjectRelativePath, projectRelativePath, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
             names.Add(FormatAddedFieldDisplayName(fieldKey));
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
@@ -90,6 +90,7 @@ internal static class AddedFieldClassifier
 
         AddedFieldBinding binding = new AddedFieldBinding
         {
+            SourceProjectRelativePath = typeState.SourceUnit.Input.ProjectRelativePath,
             FieldKey = fieldKey,
             SyntaxKey = syntaxKey,
             FieldName = fieldSymbol.Name,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OrdinaryMethodQueue.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OrdinaryMethodQueue.cs
@@ -425,7 +425,8 @@ internal static class OrdinaryMethodQueue
         typeState.CurrentShimType = new ShimTypeBuilder(
             shimTypeName,
             namespaceName,
-            WorkerUsingCollector.CollectUsingsForType(root, typeState.TypeDeclaration, assemblyGlobalUsings));
+            WorkerUsingCollector.CollectUsingsForType(root, typeState.TypeDeclaration, assemblyGlobalUsings),
+            typeState.SourceUnit.Input.ProjectRelativePath);
         shimTypes.Add(typeState.CurrentShimType);
         return (typeState.CurrentShimType, shimTypeCounter);
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OrdinaryMethodQueue.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OrdinaryMethodQueue.cs
@@ -112,6 +112,7 @@ internal static class OrdinaryMethodQueue
         {
             skipped.Add(new WorkerSkipped
             {
+                SourceProjectRelativePath = typeState.SourceUnit.Input.ProjectRelativePath,
                 Method = WorkerMethodKeys.FormatMethodLabel(methodSymbol),
                 Reason = decision.SkipReason
             });
@@ -232,6 +233,7 @@ internal static class OrdinaryMethodQueue
 
         skipped.Add(new WorkerSkipped
         {
+            SourceProjectRelativePath = typeState.SourceUnit.Input.ProjectRelativePath,
             Method = WorkerMethodKeys.FormatMethodLabel(methodSymbol),
             Reason = AddedMethodSkipReasons.InterfaceMember
         });
@@ -272,6 +274,7 @@ internal static class OrdinaryMethodQueue
         {
             unchangedMethods.Add(new WorkerUnchangedMethod
             {
+                SourceProjectRelativePath = typeState.SourceUnit.Input.ProjectRelativePath,
                 TypeMetadataName = CecilTypeNames.ToMetadataName(typeState.TypeSymbol),
                 MethodName = methodSymbol.Name,
                 ParameterTypeFullNames = parameterTypeFullNames,
@@ -450,6 +453,7 @@ internal static class OrdinaryMethodQueue
 
             skipped.Add(new WorkerSkipped
             {
+                SourceProjectRelativePath = typeState.SourceUnit.Input.ProjectRelativePath,
                 Method = WorkerMethodKeys.FormatMethodLabel(methodSymbol),
                 Reason = AddedMethodSkipReasons.NewTypeOutOfScope
             });

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterClassifier.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis.Text;
 internal static class PropertyGetterClassifier
 {
     internal static bool TryRecordUnchangedPropertyGetter(
+        string sourceProjectRelativePath,
         bool hasBaseline,
         Dictionary<string, PropertyDeclarationSyntax> snapshotPropertyMap,
         Dictionary<string, PropertyDeclarationSyntax> plainCurrentPropertyMap,
@@ -42,6 +43,7 @@ internal static class PropertyGetterClassifier
         {
             unchangedMethods.Add(new WorkerUnchangedMethod
             {
+                SourceProjectRelativePath = sourceProjectRelativePath,
                 TypeMetadataName = CecilTypeNames.ToMetadataName(typeSymbol),
                 MethodName = getterSymbol.Name,
                 ParameterTypeFullNames = parameterTypeFullNames,
@@ -54,6 +56,7 @@ internal static class PropertyGetterClassifier
     }
 
     internal static bool TrySkipAddedProperty(
+        string sourceProjectRelativePath,
         bool hasBaseline,
         Dictionary<string, PropertyDeclarationSyntax> snapshotPropertyMap,
         Dictionary<string, PropertyDeclarationSyntax> plainCurrentPropertyMap,
@@ -78,6 +81,7 @@ internal static class PropertyGetterClassifier
 
         skipped.Add(new WorkerSkipped
         {
+            SourceProjectRelativePath = sourceProjectRelativePath,
             Method = WorkerMethodKeys.FormatMethodLabel(getterSymbol),
             Reason = AddedMethodSkipReasons.AddedProperty
         });
@@ -86,6 +90,7 @@ internal static class PropertyGetterClassifier
     }
 
     internal static (bool SkipGetter, MethodTransformDecision Decision) TrySkipPropertyGetterByDecision(
+        string sourceProjectRelativePath,
         TypeDeclarationSyntax typeDeclaration,
         INamedTypeSymbol typeSymbol,
         IMethodSymbol getterSymbol,
@@ -108,6 +113,7 @@ internal static class PropertyGetterClassifier
         {
             skipped.Add(new WorkerSkipped
             {
+                SourceProjectRelativePath = sourceProjectRelativePath,
                 Method = WorkerMethodKeys.FormatMethodLabel(getterSymbol),
                 Reason = decision.SkipReason
             });
@@ -126,6 +132,7 @@ internal static class PropertyGetterClassifier
 
         skipped.Add(new WorkerSkipped
         {
+            SourceProjectRelativePath = sourceProjectRelativePath,
             Method = WorkerMethodKeys.FormatMethodLabel(getterSymbol),
             Reason = addedCallSiteSkip,
             CalledAddedMethodKey = calledAddedMethodKey,
@@ -206,6 +213,7 @@ internal static class PropertyGetterClassifier
     }
 
     internal static void SkipPropertyGetterOnUncompiledType(
+        string sourceProjectRelativePath,
         PropertyDeclarationSyntax propertyDeclaration,
         SemanticModel semanticModel,
         List<WorkerSkipped> skipped)
@@ -225,6 +233,7 @@ internal static class PropertyGetterClassifier
 
         skipped.Add(new WorkerSkipped
         {
+            SourceProjectRelativePath = sourceProjectRelativePath,
             Method = WorkerMethodKeys.FormatMethodLabel(propertySymbol.GetMethod),
             Reason = AddedMethodSkipReasons.NewTypeOutOfScope
         });

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
@@ -54,6 +54,7 @@ internal static class PropertyGetterEmitter
                     typeState.TypeMetadataNameFromSyntax,
                     semanticModel,
                     root,
+                    typeState.SourceUnit.Input.ProjectRelativePath,
                     input,
                     baseline.HasBaseline,
                     baseline.SnapshotPropertyMap,
@@ -86,6 +87,7 @@ internal static class PropertyGetterEmitter
             string typeMetadataNameFromSyntax,
             SemanticModel semanticModel,
             CompilationUnitSyntax root,
+            string sourceProjectRelativePath,
             WorkerInput input,
             bool hasBaseline,
             Dictionary<string, PropertyDeclarationSyntax> snapshotPropertyMap,
@@ -197,6 +199,7 @@ internal static class PropertyGetterEmitter
             parameterTypeFullNames,
             semanticModel,
             root,
+            sourceProjectRelativePath,
             entries,
             shimTypes,
             shimTypeCounter,
@@ -219,6 +222,7 @@ internal static class PropertyGetterEmitter
             string[] parameterTypeFullNames,
             SemanticModel semanticModel,
             CompilationUnitSyntax root,
+            string sourceProjectRelativePath,
             List<WorkerEntry> entries,
             List<ShimTypeBuilder> shimTypes,
             int shimTypeCounter,
@@ -239,7 +243,8 @@ internal static class PropertyGetterEmitter
             currentShimType = new ShimTypeBuilder(
                 shimTypeName,
                 namespaceName,
-                WorkerUsingCollector.CollectUsingsForType(root, typeDeclaration, assemblyGlobalUsings));
+                WorkerUsingCollector.CollectUsingsForType(root, typeDeclaration, assemblyGlobalUsings),
+                sourceProjectRelativePath);
             shimTypes.Add(currentShimType);
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
@@ -39,6 +39,7 @@ internal static class PropertyGetterEmitter
             if (typeState.TypeIsAbsentFromCompiledAssembly)
             {
                 PropertyGetterClassifier.SkipPropertyGetterOnUncompiledType(
+                    typeState.SourceUnit.Input.ProjectRelativePath,
                     propertyDeclaration,
                     semanticModel,
                     skipped);
@@ -130,6 +131,7 @@ internal static class PropertyGetterEmitter
         }
 
         if (PropertyGetterClassifier.TryRecordUnchangedPropertyGetter(
+            sourceProjectRelativePath,
             hasBaseline,
             snapshotPropertyMap,
             plainCurrentPropertyMap,
@@ -146,6 +148,7 @@ internal static class PropertyGetterEmitter
         // Why skip newly added properties: Harmony looks up get_<Name> on the compiled type
         // and fails with "No method 'get_X' ... was found" when the member does not exist.
         if (PropertyGetterClassifier.TrySkipAddedProperty(
+            sourceProjectRelativePath,
             hasBaseline,
             snapshotPropertyMap,
             plainCurrentPropertyMap,
@@ -162,6 +165,7 @@ internal static class PropertyGetterEmitter
         {
             skipped.Add(new WorkerSkipped
             {
+                SourceProjectRelativePath = sourceProjectRelativePath,
                 Method = WorkerMethodKeys.FormatMethodLabel(getterSymbol),
                 Reason = "Explicit interface implementations are skipped in v1."
             });
@@ -174,6 +178,7 @@ internal static class PropertyGetterEmitter
             ?? (SyntaxNode)getAccessor.Body
             ?? getAccessor.ExpressionBody;
         (bool skipGetter, MethodTransformDecision decision) = PropertyGetterClassifier.TrySkipPropertyGetterByDecision(
+            sourceProjectRelativePath,
             typeDeclaration,
             typeSymbol,
             getterSymbol,
@@ -271,6 +276,7 @@ internal static class PropertyGetterEmitter
 
         entries.Add(new WorkerEntry
         {
+            SourceProjectRelativePath = sourceProjectRelativePath,
             TypeMetadataName = CecilTypeNames.ToMetadataName(typeSymbol),
             MethodName = getterSymbol.Name,
             ParameterTypeFullNames = parameterTypeFullNames,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
@@ -19,12 +19,9 @@ internal static class PropertyGetterEmitter
 {
     internal static (int ShimTypeCounter, int GlobalShimMethodCounter) EmitPropertyGettersForType(
         TypeEmitState typeState,
-        SemanticModel semanticModel,
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog,
-        CompilationUnitSyntax root,
         WorkerInput input,
-        BaselineSnapshotState baseline,
         List<WorkerEntry> entries,
         List<WorkerSkipped> skipped,
         List<WorkerUnchangedMethod> unchangedMethods,
@@ -33,6 +30,9 @@ internal static class PropertyGetterEmitter
         int shimTypeCounter,
         int globalShimMethodCounter)
     {
+        SemanticModel semanticModel = typeState.SourceUnit.SemanticModel;
+        CompilationUnitSyntax root = typeState.SourceUnit.Root;
+        BaselineSnapshotState baseline = typeState.SourceUnit.Baseline;
         foreach (PropertyDeclarationSyntax propertyDeclaration in typeState.TypeDeclaration.Members
             .OfType<PropertyDeclarationSyntax>())
         {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimMethodEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimMethodEmitter.cs
@@ -86,6 +86,7 @@ internal static class ShimMethodEmitter
 
             entries.Add(new WorkerEntry
             {
+                SourceProjectRelativePath = typeState.SourceUnit.Input.ProjectRelativePath,
                 TypeMetadataName = CecilTypeNames.ToMetadataName(typeState.TypeSymbol),
                 MethodName = queued.MethodSymbol.Name,
                 ParameterTypeFullNames = queued.ParameterTypeFullNames,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimMethodEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimMethodEmitter.cs
@@ -19,12 +19,9 @@ internal static class ShimMethodEmitter
 {
     internal static (int ShimTypeCounter, int GlobalShimMethodCounter) EmitQueuedMethodsAndPropertyGetters(
         List<TypeEmitState> typeEmitStates,
-        SemanticModel semanticModel,
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog,
-        CompilationUnitSyntax root,
         WorkerInput input,
-        BaselineSnapshotState baseline,
         List<WorkerEntry> entries,
         List<WorkerSkipped> skipped,
         List<WorkerUnchangedMethod> unchangedMethods,
@@ -37,18 +34,14 @@ internal static class ShimMethodEmitter
         {
             EmitQueuedMethods(
                 typeState,
-                semanticModel,
                 addedMethodCatalog,
                 addedFieldCatalog,
                 entries);
             (shimTypeCounter, globalShimMethodCounter) = PropertyGetterEmitter.EmitPropertyGettersForType(
                 typeState,
-                semanticModel,
                 addedMethodCatalog,
                 addedFieldCatalog,
-                root,
                 input,
-                baseline,
                 entries,
                 skipped,
                 unchangedMethods,
@@ -63,11 +56,11 @@ internal static class ShimMethodEmitter
 
     internal static void EmitQueuedMethods(
         TypeEmitState typeState,
-        SemanticModel semanticModel,
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog,
         List<WorkerEntry> entries)
     {
+        SemanticModel semanticModel = typeState.SourceUnit.SemanticModel;
         foreach (QueuedShimMethod queued in typeState.QueuedMethods)
         {
             AccessorPlan rewritePlan = queued.Decision.UsesDelegation

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimSourceEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimSourceEmitter.cs
@@ -17,6 +17,10 @@ using Microsoft.CodeAnalysis.Text;
 
 internal static class ShimSourceEmitter
 {
+    // Host namespace for shim types whose original type lives in the global namespace. The
+    // orchestrator resolves shim types by short name, so the namespace stays invisible to it.
+    private const string GlobalNamespaceShimNamespaceName = "UloopHotReloadGlobalShim";
+
     public static string Emit(List<ShimTypeBuilder> shimTypes)
     {
         if (shimTypes.Count == 0)
@@ -28,12 +32,10 @@ internal static class ShimSourceEmitter
 
         // Emit each shim type in the original type's namespace (and with that type's usings) so
         // unqualified sibling-type references in transplanted bodies still resolve. Manifest
-        // shimTypeName stays the short name; orchestrator resolves by Type.Name.
+        // shimTypeName stays the short name; orchestrator resolves by Type.Name. A type from the
+        // global namespace gets a synthesized namespace for the same reason (see below).
         CompilationUnitSyntax unit = SyntaxFactory.CompilationUnit();
         Dictionary<string, string> projectRelativePathsByShimTypeName = new Dictionary<string, string>();
-        // Why dedupe by normalized text: the shim types of a group can come from several files
-        // whose global-namespace usings overlap, and compilation-unit usings are one flat list.
-        HashSet<string> emittedCompilationUnitUsings = new HashSet<string>();
         foreach (ShimTypeBuilder shimType in shimTypes)
         {
             projectRelativePathsByShimTypeName[shimType.ShimTypeName] = shimType.SourceProjectRelativePath;
@@ -44,29 +46,22 @@ internal static class ShimSourceEmitter
                         SyntaxFactory.Token(SyntaxKind.StaticKeyword)))
                 .WithMembers(SyntaxFactory.List(shimType.EmitMembers()));
 
-            if (string.IsNullOrEmpty(shimType.NamespaceName))
-            {
-                foreach (UsingDirectiveSyntax usingDirective in shimType.Usings)
-                {
-                    if (!emittedCompilationUnitUsings.Add(usingDirective.ToFullString().Trim()))
-                    {
-                        continue;
-                    }
-
-                    unit = unit.AddUsings(usingDirective);
-                }
-
-                unit = unit.AddMembers(classDeclaration);
-            }
-            else
-            {
-                NamespaceDeclarationSyntax namespaceDeclaration = SyntaxFactory.NamespaceDeclaration(
-                        SyntaxFactory.ParseName(shimType.NamespaceName))
-                    .WithUsings(SyntaxFactory.List(shimType.Usings))
-                    .WithMembers(
-                        SyntaxFactory.SingletonList<MemberDeclarationSyntax>(classDeclaration));
-                unit = unit.AddMembers(namespaceDeclaration);
-            }
+            // Why every shim type gets a namespace declaration: a using belongs to the file it was
+            // written in, and the shim types of a group come from several files. Compilation-unit
+            // usings are one flat list shared by all of them, so two files whose usings conflict
+            // (the same alias bound differently, or two namespaces exporting the same type name)
+            // would break the whole shim assembly. A namespace declaration scopes each file's
+            // usings to its own shim type. Unqualified references to global-namespace types still
+            // resolve, because name lookup from inside a namespace walks outward to global.
+            string namespaceName = string.IsNullOrEmpty(shimType.NamespaceName)
+                ? GlobalNamespaceShimNamespaceName
+                : shimType.NamespaceName;
+            NamespaceDeclarationSyntax namespaceDeclaration = SyntaxFactory.NamespaceDeclaration(
+                    SyntaxFactory.ParseName(namespaceName))
+                .WithUsings(SyntaxFactory.List(shimType.Usings))
+                .WithMembers(
+                    SyntaxFactory.SingletonList<MemberDeclarationSyntax>(classDeclaration));
+            unit = unit.AddMembers(namespaceDeclaration);
         }
 
         // Why after NormalizeWhitespace: formatting would otherwise shift #line relative to

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimSourceEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimSourceEmitter.cs
@@ -17,24 +17,26 @@ using Microsoft.CodeAnalysis.Text;
 
 internal static class ShimSourceEmitter
 {
-    public static string Emit(
-        CompilationUnitSyntax originalRoot,
-        List<ShimTypeBuilder> shimTypes,
-        string projectRelativePath)
+    public static string Emit(List<ShimTypeBuilder> shimTypes)
     {
         if (shimTypes.Count == 0)
         {
             return string.Empty;
         }
 
-        // projectRelativePath shape is validated at TransformFile's input boundary (ParseErrors).
+        // Each source's projectRelativePath shape is validated at the input boundary (ParseErrors).
 
         // Emit each shim type in the original type's namespace (and with that type's usings) so
         // unqualified sibling-type references in transplanted bodies still resolve. Manifest
         // shimTypeName stays the short name; orchestrator resolves by Type.Name.
         CompilationUnitSyntax unit = SyntaxFactory.CompilationUnit();
+        Dictionary<string, string> projectRelativePathsByShimTypeName = new Dictionary<string, string>();
+        // Why dedupe by normalized text: the shim types of a group can come from several files
+        // whose global-namespace usings overlap, and compilation-unit usings are one flat list.
+        HashSet<string> emittedCompilationUnitUsings = new HashSet<string>();
         foreach (ShimTypeBuilder shimType in shimTypes)
         {
+            projectRelativePathsByShimTypeName[shimType.ShimTypeName] = shimType.SourceProjectRelativePath;
             ClassDeclarationSyntax classDeclaration = SyntaxFactory.ClassDeclaration(shimType.ShimTypeName)
                 .WithModifiers(
                     SyntaxFactory.TokenList(
@@ -46,6 +48,11 @@ internal static class ShimSourceEmitter
             {
                 foreach (UsingDirectiveSyntax usingDirective in shimType.Usings)
                 {
+                    if (!emittedCompilationUnitUsings.Add(usingDirective.ToFullString().Trim()))
+                    {
+                        continue;
+                    }
+
                     unit = unit.AddUsings(usingDirective);
                 }
 
@@ -65,7 +72,7 @@ internal static class ShimSourceEmitter
         // Why after NormalizeWhitespace: formatting would otherwise shift #line relative to
         // statements; annotations survive formatting so we inject directives on the final tree.
         unit = unit.NormalizeWhitespace();
-        unit = InjectLineDirectives(unit, projectRelativePath);
+        unit = InjectLineDirectives(unit, projectRelativePathsByShimTypeName);
 
         StringBuilder builder = new StringBuilder();
         builder.AppendLine(
@@ -76,10 +83,20 @@ internal static class ShimSourceEmitter
 
     private static CompilationUnitSyntax InjectLineDirectives(
         CompilationUnitSyntax unit,
-        string projectRelativePath)
+        Dictionary<string, string> projectRelativePathsByShimTypeName)
     {
         List<SyntaxNode> annotatedNodes = unit.GetAnnotatedNodes(TransformWorkerProgram.UloopLineAnnotationKind)
             .ToList();
+        // Why resolve the document before replacing: ReplaceNodes hands back rewritten nodes that
+        // are detached from the unit, so the enclosing shim class is only reachable up front.
+        Dictionary<SyntaxNode, string> projectRelativePathsByNode = new Dictionary<SyntaxNode, string>();
+        foreach (SyntaxNode annotatedNode in annotatedNodes)
+        {
+            projectRelativePathsByNode[annotatedNode] = ResolveProjectRelativePath(
+                annotatedNode,
+                projectRelativePathsByShimTypeName);
+        }
+
         if (annotatedNodes.Count > 0)
         {
             unit = unit.ReplaceNodes(
@@ -93,7 +110,7 @@ internal static class ShimSourceEmitter
                     // Why after comments/regions: those trivia consume mapped lines if they sit
                     // under the directive, so a later statement inherits the earlier line number.
                     string directiveText =
-                        "\n#line " + annotation.Data + " \"" + projectRelativePath + "\"\n";
+                        "\n#line " + annotation.Data + " \"" + projectRelativePathsByNode[original] + "\"\n";
                     return LineDirectiveTriviaInjector.Attach(rewritten, directiveText);
                 });
         }
@@ -119,5 +136,21 @@ internal static class ShimSourceEmitter
                 return rewritten.WithTrailingTrivia(
                     rewritten.GetTrailingTrivia().AddRange(defaultDirective));
             });
+    }
+
+    // The edited file a shim body came from, taken from the shim class that hosts it.
+    private static string ResolveProjectRelativePath(
+        SyntaxNode annotatedNode,
+        Dictionary<string, string> projectRelativePathsByShimTypeName)
+    {
+        ClassDeclarationSyntax shimClass = annotatedNode.Ancestors()
+            .OfType<ClassDeclarationSyntax>()
+            .LastOrDefault();
+        Debug.Assert(shimClass != null, "An annotated shim node must live inside a shim class.");
+        string shimTypeName = shimClass.Identifier.ValueText;
+        Debug.Assert(
+            projectRelativePathsByShimTypeName.ContainsKey(shimTypeName),
+            "Every emitted shim class must come from a known shim type.");
+        return projectRelativePathsByShimTypeName[shimTypeName];
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimTypeBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimTypeBuilder.cs
@@ -22,15 +22,21 @@ internal sealed class ShimTypeBuilder
     public ShimTypeBuilder(
         string shimTypeName,
         string namespaceName,
-        List<UsingDirectiveSyntax> usings)
+        List<UsingDirectiveSyntax> usings,
+        string sourceProjectRelativePath)
     {
         ShimTypeName = shimTypeName;
         NamespaceName = namespaceName ?? string.Empty;
         Usings = usings ?? new List<UsingDirectiveSyntax>();
+        SourceProjectRelativePath = sourceProjectRelativePath;
         AccessorPlan = new AccessorPlan();
     }
 
     public string ShimTypeName { get; }
+
+    // The edited file whose methods this shim type hosts. Emit names it in the #line directives
+    // so a shim compile error maps back to the file the body was written in.
+    public string SourceProjectRelativePath { get; }
 
     public string NamespaceName { get; }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -264,7 +264,6 @@ public static class TransformWorkerProgram
         }
 
         return BuildWorkerOutput(
-            root,
             source.ProjectRelativePath,
             shimTypes,
             entries,
@@ -366,7 +365,6 @@ public static class TransformWorkerProgram
     }
 
     private static WorkerOutput BuildWorkerOutput(
-        CompilationUnitSyntax root,
         string projectRelativePath,
         List<ShimTypeBuilder> shimTypes,
         List<WorkerEntry> entries,
@@ -395,7 +393,7 @@ public static class TransformWorkerProgram
         // rows, and stamping at the single output point cannot leave one of them behind.
         StampSourceProjectRelativePath(entries, skipped, unchangedMethods, projectRelativePath);
 
-        string shimSource = ShimSourceEmitter.Emit(root, shimTypes, projectRelativePath);
+        string shimSource = ShimSourceEmitter.Emit(shimTypes);
         WorkerFileOutput fileOutput = new WorkerFileOutput
         {
             ProjectRelativePath = projectRelativePath,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -403,8 +403,8 @@ public static class TransformWorkerProgram
             BaselineDisabledByDuplicateKeys = baseline.BaselineDisabledByDuplicateKeys,
             RemovedMembers = removedMembers.ToArray(),
             RemovedMethodSignatures = removedMethodSignatures.ToArray(),
-            AddedFieldNames = addedFieldCatalog.ListRewrittenAddedFieldDisplayNames(),
-            AddedConstNames = addedFieldCatalog.ListFoldedConstDisplayNames()
+            AddedFieldNames = addedFieldCatalog.ListRewrittenAddedFieldDisplayNames(projectRelativePath),
+            AddedConstNames = addedFieldCatalog.ListFoldedConstDisplayNames(projectRelativePath)
         };
         return new WorkerOutput
         {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -1,5 +1,6 @@
-// Hot-reload transform worker: parse + semantic analysis of one edited C# file, emit static
-// shim method sources (no Prefix wrappers) plus a per-method manifest / skip list.
+// Hot-reload transform worker: parse + semantic analysis of the edited C# files of one
+// compilation assembly, emit static shim method sources (no Prefix wrappers) plus a per-method
+// manifest / skip list.
 // Runs out-of-process on the Unity-bundled .NET host against the Unity-bundled Roslyn.
 // Generated shims mirror user method signatures verbatim; repo style rules apply to
 // hand-written code only.
@@ -81,28 +82,49 @@ public static class TransformWorkerProgram
     private static int RunTransform(string inputJsonPath, string outputJsonPath)
     {
         WorkerInput input = ReadInput(inputJsonPath);
-        WorkerOutput unsupportedSourceCount = TryCreateUnsupportedSourceCountOutput(input);
-        WorkerOutput output = unsupportedSourceCount ?? TransformFile(input);
+        WorkerOutput invalidSources = TryCreateInvalidSourcesOutput(input);
+        WorkerOutput output = invalidSources ?? WorkerGroupPipeline.Transform(input);
         WriteOutput(outputJsonPath, output);
         return 0;
     }
 
-    // Why a run-level failure output (not a throw): the source count crosses a process boundary
-    // via JSON, so it is untrusted input rather than a broken internal contract.
-    private static WorkerOutput TryCreateUnsupportedSourceCountOutput(WorkerInput input)
+    // Why a run-level failure output (not a throw): the sources array crosses a process boundary
+    // via JSON, so it is untrusted input rather than a broken internal contract. Both failures
+    // below belong to no single source, which is what the run-level ParseErrors channel is for.
+    private static WorkerOutput TryCreateInvalidSourcesOutput(WorkerInput input)
     {
-        if (input.Sources.Length == 1)
+        if (input.Sources.Length == 0)
         {
-            return null;
+            return CreateRunFailureOutput("sources must contain at least one edited source.");
         }
 
+        HashSet<string> projectRelativePaths = new HashSet<string>(StringComparer.Ordinal);
+        foreach (WorkerSourceInput source in input.Sources)
+        {
+            if (source == null)
+            {
+                return CreateRunFailureOutput("sources must not contain a null entry.");
+            }
+
+            if (!projectRelativePaths.Add(source.ProjectRelativePath ?? string.Empty))
+            {
+                return CreateRunFailureOutput(
+                    "sources must not repeat a projectRelativePath within one run.");
+            }
+        }
+
+        return null;
+    }
+
+    private static WorkerOutput CreateRunFailureOutput(string parseError)
+    {
         return new WorkerOutput
         {
             ShimSource = string.Empty,
             Entries = Array.Empty<WorkerEntry>(),
             Skipped = Array.Empty<WorkerSkipped>(),
             Files = Array.Empty<WorkerFileOutput>(),
-            ParseErrors = new[] { "This worker build accepts exactly one source." }
+            ParseErrors = new[] { parseError }
         };
     }
 
@@ -129,317 +151,6 @@ public static class TransformWorkerProgram
     {
         byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(output, JsonOptions);
         File.WriteAllBytes(outputJsonPath, bytes);
-    }
-
-    private static WorkerOutput TransformFile(WorkerInput input)
-    {
-        WorkerSourceInput source = input.Sources[0];
-        CSharpParseOptions parseOptions = new CSharpParseOptions(
-            languageVersion: LanguageVersion.Latest,
-            preprocessorSymbols: input.Defines);
-        WorkerSourceUnit unit = WorkerSourceLoader.Load(source, parseOptions);
-        if (unit.SyntaxTree == null)
-        {
-            return CreateSourceFailureOutput(source, unit.ParseErrors.ToArray());
-        }
-
-        List<string> parseErrors = unit.ParseErrors;
-        string sourceContentSha256 = unit.SourceContentSha256;
-        SyntaxTree syntaxTree = unit.SyntaxTree;
-        CompilationUnitSyntax plainRoot = unit.PlainRoot;
-
-        (List<MetadataReference> references, MetadataReference targetTypesReference) =
-            CollectMetadataReferences(input, parseErrors);
-
-        CSharpCompilation compilation = CSharpCompilation.Create(
-            assemblyName: "UloopHotReloadTransformWorkerCompilation",
-            syntaxTrees: new[] { syntaxTree },
-            references: references,
-            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
-
-        SemanticModel semanticModel = compilation.GetSemanticModel(syntaxTree, ignoreAccessibility: true);
-        unit.SemanticModel = semanticModel;
-        CompilationUnitSyntax root = unit.Root;
-
-        IAssemblySymbol targetTypesAssemblySymbol = ResolveTargetTypesAssemblySymbol(
-            compilation,
-            targetTypesReference);
-        List<string> declarationDriftWarnings = ConstDriftCollector.CollectConstDriftWarnings(
-            root,
-            semanticModel,
-            targetTypesAssemblySymbol);
-        List<string> siblingConstDriftWarnings = SiblingConstDriftCollector.CollectConstDriftWarnings(
-            input.ChangedSiblingSourcePaths,
-            parseOptions,
-            references,
-            targetTypesAssemblySymbol);
-        // Why here: a compiled property/event can disappear or change kind with no
-        // touched body, so the generic outside-body warning would bury the name.
-        CompiledMemberKindChangeWarnings.SyntaxKeys kindChangeSyntaxKeys =
-            CompiledMemberKindChangeWarnings.AppendCompiledPropertyOrEventKindChangeWarnings(
-                root,
-                semanticModel,
-                targetTypesAssemblySymbol,
-                declarationDriftWarnings);
-
-        BaselineSnapshotState baseline =
-            BaselineSnapshotBuilder.BuildBaselineSnapshotState(source.SnapshotSource, parseOptions, plainRoot);
-        unit.Baseline = baseline;
-
-        List<WorkerEntry> entries = new List<WorkerEntry>();
-        List<WorkerSkipped> skipped = new List<WorkerSkipped>();
-        List<WorkerUnchangedMethod> unchangedMethods = new List<WorkerUnchangedMethod>();
-        List<WorkerRemovedMember> removedMembers = new List<WorkerRemovedMember>();
-        List<WorkerRemovedMethodSignature> removedMethodSignatures = new List<WorkerRemovedMethodSignature>();
-        List<ShimTypeBuilder> shimTypes = new List<ShimTypeBuilder>();
-        int globalShimMethodCounter = 0;
-        int shimTypeCounter = 0;
-        List<UsingDirectiveSyntax> assemblyGlobalUsings =
-            WorkerUsingCollector.CollectAssemblyGlobalUsings(input, parseOptions);
-        AddedMethodCatalog addedMethodCatalog = new AddedMethodCatalog();
-        AddedFieldCatalog addedFieldCatalog = new AddedFieldCatalog();
-        (List<TypeEmitState> typeEmitStates, int nextShimTypeCounter, int nextGlobalShimMethodCounter) =
-            TypeEmitPlanner.QueueAllTypeEmitStates(
-                unit,
-                targetTypesAssemblySymbol,
-                input,
-                assemblyGlobalUsings,
-                shimTypes,
-                addedMethodCatalog,
-                addedFieldCatalog,
-                skipped,
-                unchangedMethods,
-                declarationDriftWarnings,
-                removedMembers,
-                removedMethodSignatures,
-                shimTypeCounter,
-                globalShimMethodCounter);
-        shimTypeCounter = nextShimTypeCounter;
-        globalShimMethodCounter = nextGlobalShimMethodCounter;
-
-        RemovedMemberCollector.CollectRemovedMembersIfBaseline(
-            baseline,
-            plainRoot,
-            typeEmitStates,
-            semanticModel,
-            targetTypesAssemblySymbol,
-            addedMethodCatalog,
-            addedFieldCatalog,
-            removedMembers,
-            removedMethodSignatures);
-
-        AddedCallSiteGuard.SkipBodiesThatCannotUseAddedMethods(
-            typeEmitStates,
-            addedMethodCatalog,
-            addedFieldCatalog,
-            skipped);
-
-        ShimMethodEmitter.EmitQueuedMethodsAndPropertyGetters(
-            typeEmitStates,
-            addedMethodCatalog,
-            addedFieldCatalog,
-            input,
-            entries,
-            skipped,
-            unchangedMethods,
-            shimTypes,
-            assemblyGlobalUsings,
-            shimTypeCounter,
-            globalShimMethodCounter);
-
-        if (baseline.HasBaseline && baseline.SnapshotRoot != null)
-        {
-            // Why after property emit: added-property syntax keys are registered when a skip
-            // row is written. Running the drift check first would miss those keys and keep
-            // the false outside-body warning for added properties that already have a row.
-            OutsideMethodBodyDriftChecker.AppendOutsideMethodBodyDriftWarningIfNeeded(
-                baseline.SnapshotRoot,
-                plainRoot,
-                Path.GetFileName(source.SourcePath),
-                declarationDriftWarnings,
-                addedMethodCatalog,
-                addedFieldCatalog,
-                kindChangeSyntaxKeys.PropertySyntaxKeys,
-                kindChangeSyntaxKeys.EventSyntaxKeys);
-        }
-
-        return BuildWorkerOutput(
-            source.ProjectRelativePath,
-            shimTypes,
-            entries,
-            skipped,
-            declarationDriftWarnings,
-            siblingConstDriftWarnings,
-            parseErrors,
-            unchangedMethods,
-            baseline,
-            removedMembers,
-            removedMethodSignatures,
-            addedFieldCatalog,
-            sourceContentSha256);
-    }
-
-    // A failure the run can attribute to one source: the row set is empty and the messages
-    // travel on that source's per-file parse errors.
-    private static WorkerOutput CreateSourceFailureOutput(WorkerSourceInput source, string[] parseErrors)
-    {
-        return new WorkerOutput
-        {
-            ShimSource = string.Empty,
-            Entries = Array.Empty<WorkerEntry>(),
-            Skipped = Array.Empty<WorkerSkipped>(),
-            Files = new[]
-            {
-                new WorkerFileOutput
-                {
-                    ProjectRelativePath = source.ProjectRelativePath,
-                    SourceContentSha256 = string.Empty,
-                    ParseErrors = parseErrors,
-                    DeclarationDriftWarnings = Array.Empty<string>(),
-                    RemovedMembers = Array.Empty<WorkerRemovedMember>(),
-                    RemovedMethodSignatures = Array.Empty<WorkerRemovedMethodSignature>(),
-                    AddedFieldNames = Array.Empty<string>(),
-                    AddedConstNames = Array.Empty<string>()
-                }
-            }
-        };
-    }
-
-    private static (List<MetadataReference> References, MetadataReference TargetTypesReference)
-        CollectMetadataReferences(WorkerInput input, List<string> parseErrors)
-    {
-        string targetTypesFullPath =
-            !string.IsNullOrEmpty(input.TargetTypesAssemblyPath) && File.Exists(input.TargetTypesAssemblyPath)
-                ? Path.GetFullPath(input.TargetTypesAssemblyPath)
-                : null;
-        MetadataReference targetTypesReference = null;
-
-        List<MetadataReference> references = new List<MetadataReference>();
-        foreach (string referencePath in input.ReferencePaths)
-        {
-            if (File.Exists(referencePath))
-            {
-                MetadataReference reference = MetadataReference.CreateFromFile(referencePath);
-                references.Add(reference);
-                if (targetTypesFullPath != null
-                    && string.Equals(
-                        Path.GetFullPath(referencePath),
-                        targetTypesFullPath,
-                        StringComparison.OrdinalIgnoreCase))
-                {
-                    targetTypesReference = reference;
-                }
-            }
-            else
-            {
-                parseErrors.Add("Reference not found: " + referencePath);
-            }
-        }
-
-        if (targetTypesFullPath != null && targetTypesReference == null)
-        {
-            targetTypesReference = MetadataReference.CreateFromFile(input.TargetTypesAssemblyPath);
-            references.Add(targetTypesReference);
-        }
-
-        return (references, targetTypesReference);
-    }
-
-    private static IAssemblySymbol ResolveTargetTypesAssemblySymbol(
-        CSharpCompilation compilation,
-        MetadataReference targetTypesReference)
-    {
-        // The drift comparison must see private and internal consts in the compiled target
-        // assembly, which the default MetadataImportOptions (Public) hides. Widening the main
-        // compilation would also widen what every classification query can bind to, so the
-        // wider import is confined to a throwaway compilation used only for this lookup.
-        if (targetTypesReference == null)
-        {
-            return null;
-        }
-
-        CSharpCompilation driftCompilation = compilation.WithOptions(
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-                .WithMetadataImportOptions(MetadataImportOptions.All));
-        return driftCompilation.GetAssemblyOrModuleSymbol(targetTypesReference) as IAssemblySymbol;
-    }
-
-    private static WorkerOutput BuildWorkerOutput(
-        string projectRelativePath,
-        List<ShimTypeBuilder> shimTypes,
-        List<WorkerEntry> entries,
-        List<WorkerSkipped> skipped,
-        List<string> declarationDriftWarnings,
-        List<string> siblingConstDriftWarnings,
-        List<string> parseErrors,
-        List<WorkerUnchangedMethod> unchangedMethods,
-        BaselineSnapshotState baseline,
-        List<WorkerRemovedMember> removedMembers,
-        List<WorkerRemovedMethodSignature> removedMethodSignatures,
-        AddedFieldCatalog addedFieldCatalog,
-        string sourceContentSha256)
-    {
-        bool hasAccessorDelegates = false;
-        foreach (ShimTypeBuilder shimType in shimTypes)
-        {
-            if (shimType.AccessorPlan.Entries.Count > 0)
-            {
-                hasAccessorDelegates = true;
-                break;
-            }
-        }
-
-        // Why stamp here instead of at each row's producer: six separate producers emit these
-        // rows, and stamping at the single output point cannot leave one of them behind.
-        StampSourceProjectRelativePath(entries, skipped, unchangedMethods, projectRelativePath);
-
-        string shimSource = ShimSourceEmitter.Emit(shimTypes);
-        WorkerFileOutput fileOutput = new WorkerFileOutput
-        {
-            ProjectRelativePath = projectRelativePath,
-            SourceContentSha256 = sourceContentSha256,
-            ParseErrors = parseErrors.ToArray(),
-            DeclarationDriftWarnings = declarationDriftWarnings.ToArray(),
-            BaselineDisabledByDuplicateKeys = baseline.BaselineDisabledByDuplicateKeys,
-            RemovedMembers = removedMembers.ToArray(),
-            RemovedMethodSignatures = removedMethodSignatures.ToArray(),
-            AddedFieldNames = addedFieldCatalog.ListRewrittenAddedFieldDisplayNames(projectRelativePath),
-            AddedConstNames = addedFieldCatalog.ListFoldedConstDisplayNames(projectRelativePath)
-        };
-        return new WorkerOutput
-        {
-            ShimSource = shimSource,
-            Entries = entries.ToArray(),
-            Skipped = skipped.ToArray(),
-            Files = new[] { fileOutput },
-            SiblingConstDriftWarnings = siblingConstDriftWarnings.ToArray(),
-            UnchangedMethods = unchangedMethods.ToArray(),
-            HasAccessorDelegates = hasAccessorDelegates,
-            HasAddedFieldRewrites = addedFieldCatalog.HasStoreRewrites
-        };
-    }
-
-    // Records which edited file every worker row came from, right before the rows leave the worker.
-    private static void StampSourceProjectRelativePath(
-        List<WorkerEntry> entries,
-        List<WorkerSkipped> skipped,
-        List<WorkerUnchangedMethod> unchangedMethods,
-        string projectRelativePath)
-    {
-        foreach (WorkerEntry entry in entries)
-        {
-            entry.SourceProjectRelativePath = projectRelativePath;
-        }
-
-        foreach (WorkerSkipped skippedRow in skipped)
-        {
-            skippedRow.SourceProjectRelativePath = projectRelativePath;
-        }
-
-        foreach (WorkerUnchangedMethod unchangedMethod in unchangedMethods)
-        {
-            unchangedMethod.SourceProjectRelativePath = projectRelativePath;
-        }
     }
 
     internal static IEnumerable<TypeDeclarationSyntax> EnumerateTypeDeclarations(CompilationUnitSyntax root)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -134,27 +134,19 @@ public static class TransformWorkerProgram
     private static WorkerOutput TransformFile(WorkerInput input)
     {
         WorkerSourceInput source = input.Sources[0];
-        WorkerOutput invalidPath = TryCreateInvalidPathOutput(source);
-        if (invalidPath != null)
-        {
-            return invalidPath;
-        }
-
-        (WorkerOutput readFailure, string sourceText, string sourceContentSha256) = TryReadSourceText(source);
-        if (readFailure != null)
-        {
-            return readFailure;
-        }
-
-        List<string> parseErrors = new List<string>();
         CSharpParseOptions parseOptions = new CSharpParseOptions(
             languageVersion: LanguageVersion.Latest,
             preprocessorSymbols: input.Defines);
-        (SyntaxTree syntaxTree, CompilationUnitSyntax plainRoot) = WorkerSourceAnnotator.ParseAndAnnotateSource(
-            sourceText,
-            parseOptions,
-            source.SourcePath,
-            parseErrors);
+        WorkerSourceUnit unit = WorkerSourceLoader.Load(source, parseOptions);
+        if (unit.SyntaxTree == null)
+        {
+            return CreateSourceFailureOutput(source, unit.ParseErrors.ToArray());
+        }
+
+        List<string> parseErrors = unit.ParseErrors;
+        string sourceContentSha256 = unit.SourceContentSha256;
+        SyntaxTree syntaxTree = unit.SyntaxTree;
+        CompilationUnitSyntax plainRoot = unit.PlainRoot;
 
         (List<MetadataReference> references, MetadataReference targetTypesReference) =
             CollectMetadataReferences(input, parseErrors);
@@ -292,25 +284,9 @@ public static class TransformWorkerProgram
             sourceContentSha256);
     }
 
-    private static WorkerOutput TryCreateInvalidPathOutput(WorkerSourceInput source)
-    {
-        // Why ParseErrors (not Debug.Assert): ProjectRelativePath crosses a process boundary via
-        // JSON, and the worker is built without a DEBUG define so Conditional Asserts are stripped.
-        if (string.IsNullOrEmpty(source.ProjectRelativePath)
-            || source.ProjectRelativePath.IndexOf('\\') >= 0
-            || source.ProjectRelativePath.IndexOf('"') >= 0)
-        {
-            return CreateSourceFailureOutput(
-                source,
-                "Invalid projectRelativePath: must be a non-empty forward-slash path without quotes.");
-        }
-
-        return null;
-    }
-
-    // A failure the run can attribute to one source: the row set is empty and the message
-    // travels on that source's per-file parse errors.
-    private static WorkerOutput CreateSourceFailureOutput(WorkerSourceInput source, string parseError)
+    // A failure the run can attribute to one source: the row set is empty and the messages
+    // travel on that source's per-file parse errors.
+    private static WorkerOutput CreateSourceFailureOutput(WorkerSourceInput source, string[] parseErrors)
     {
         return new WorkerOutput
         {
@@ -323,7 +299,7 @@ public static class TransformWorkerProgram
                 {
                     ProjectRelativePath = source.ProjectRelativePath,
                     SourceContentSha256 = string.Empty,
-                    ParseErrors = new[] { parseError },
+                    ParseErrors = parseErrors,
                     DeclarationDriftWarnings = Array.Empty<string>(),
                     RemovedMembers = Array.Empty<WorkerRemovedMember>(),
                     RemovedMethodSignatures = Array.Empty<WorkerRemovedMethodSignature>(),
@@ -332,29 +308,6 @@ public static class TransformWorkerProgram
                 }
             }
         };
-    }
-
-    private static (WorkerOutput Failure, string SourceText, string SourceContentSha256) TryReadSourceText(
-        WorkerSourceInput source)
-    {
-        try
-        {
-            byte[] sourceBytes = File.ReadAllBytes(source.SourcePath);
-            string sourceContentSha256 = ComputeSourceContentSha256(sourceBytes);
-            using MemoryStream memoryStream = new MemoryStream(sourceBytes, writable: false);
-            using StreamReader reader = new StreamReader(
-                memoryStream,
-                Encoding.UTF8,
-                detectEncodingFromByteOrderMarks: true);
-            return (null, reader.ReadToEnd(), sourceContentSha256);
-        }
-        catch (Exception exception)
-        {
-            return (
-                CreateSourceFailureOutput(source, "Failed to read sourcePath: " + exception.Message),
-                null,
-                null);
-        }
     }
 
     private static (List<MetadataReference> References, MetadataReference TargetTypesReference)
@@ -493,20 +446,6 @@ public static class TransformWorkerProgram
         {
             unchangedMethod.SourceProjectRelativePath = projectRelativePath;
         }
-    }
-
-    // Keep in sync with HotReloadAppliedSourceLedger.ComputeContentHash (lowercase hex SHA-256).
-    private static string ComputeSourceContentSha256(byte[] bytes)
-    {
-        using SHA256 sha256 = SHA256.Create();
-        byte[] hash = sha256.ComputeHash(bytes);
-        StringBuilder builder = new StringBuilder(hash.Length * 2);
-        for (int index = 0; index < hash.Length; index++)
-        {
-            builder.Append(hash[index].ToString("x2"));
-        }
-
-        return builder.ToString();
     }
 
     internal static IEnumerable<TypeDeclarationSyntax> EnumerateTypeDeclarations(CompilationUnitSyntax root)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -158,7 +158,8 @@ public static class TransformWorkerProgram
             options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
         SemanticModel semanticModel = compilation.GetSemanticModel(syntaxTree, ignoreAccessibility: true);
-        CompilationUnitSyntax root = syntaxTree.GetCompilationUnitRoot();
+        unit.SemanticModel = semanticModel;
+        CompilationUnitSyntax root = unit.Root;
 
         IAssemblySymbol targetTypesAssemblySymbol = ResolveTargetTypesAssemblySymbol(
             compilation,
@@ -183,6 +184,7 @@ public static class TransformWorkerProgram
 
         BaselineSnapshotState baseline =
             BaselineSnapshotBuilder.BuildBaselineSnapshotState(source.SnapshotSource, parseOptions, plainRoot);
+        unit.Baseline = baseline;
 
         List<WorkerEntry> entries = new List<WorkerEntry>();
         List<WorkerSkipped> skipped = new List<WorkerSkipped>();
@@ -198,11 +200,9 @@ public static class TransformWorkerProgram
         AddedFieldCatalog addedFieldCatalog = new AddedFieldCatalog();
         (List<TypeEmitState> typeEmitStates, int nextShimTypeCounter, int nextGlobalShimMethodCounter) =
             TypeEmitPlanner.QueueAllTypeEmitStates(
-                root,
-                semanticModel,
+                unit,
                 targetTypesAssemblySymbol,
                 input,
-                baseline,
                 assemblyGlobalUsings,
                 shimTypes,
                 addedMethodCatalog,
@@ -230,19 +230,15 @@ public static class TransformWorkerProgram
 
         AddedCallSiteGuard.SkipBodiesThatCannotUseAddedMethods(
             typeEmitStates,
-            semanticModel,
             addedMethodCatalog,
             addedFieldCatalog,
             skipped);
 
         ShimMethodEmitter.EmitQueuedMethodsAndPropertyGetters(
             typeEmitStates,
-            semanticModel,
             addedMethodCatalog,
             addedFieldCatalog,
-            root,
             input,
-            baseline,
             entries,
             skipped,
             unchangedMethods,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitPlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitPlanner.cs
@@ -19,11 +19,9 @@ internal static class TypeEmitPlanner
 {
     internal static (List<TypeEmitState> TypeEmitStates, int ShimTypeCounter, int GlobalShimMethodCounter)
         QueueAllTypeEmitStates(
-            CompilationUnitSyntax root,
-            SemanticModel semanticModel,
+            WorkerSourceUnit sourceUnit,
             IAssemblySymbol targetTypesAssemblySymbol,
             WorkerInput input,
-            BaselineSnapshotState baseline,
             List<UsingDirectiveSyntax> assemblyGlobalUsings,
             List<ShimTypeBuilder> shimTypes,
             AddedMethodCatalog addedMethodCatalog,
@@ -36,6 +34,9 @@ internal static class TypeEmitPlanner
             int shimTypeCounter,
             int globalShimMethodCounter)
     {
+        CompilationUnitSyntax root = sourceUnit.Root;
+        SemanticModel semanticModel = sourceUnit.SemanticModel;
+        BaselineSnapshotState baseline = sourceUnit.Baseline;
         List<TypeEmitState> typeEmitStates = new List<TypeEmitState>();
         foreach (TypeDeclarationSyntax typeDeclaration in TransformWorkerProgram.EnumerateTypeDeclarations(root))
         {
@@ -85,6 +86,7 @@ internal static class TypeEmitPlanner
 
             TypeEmitState typeState = new TypeEmitState
             {
+                SourceUnit = sourceUnit,
                 TypeDeclaration = typeDeclaration,
                 TypeSymbol = typeSymbol,
                 TypeMetadataNameFromSyntax = typeMetadataNameFromSyntax

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitPlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitPlanner.cs
@@ -56,6 +56,7 @@ internal static class TypeEmitPlanner
                 Dictionary<string, IndexerDeclarationSyntax> plainCurrentIndexerMap) =
                 baseline.GetAccessorBaselineMaps();
             UnsupportedMemberSkipCollector.AppendExplicitAccessorSkips(
+                sourceUnit.Input.ProjectRelativePath,
                 typeDeclaration,
                 typeMetadataNameFromSyntax,
                 semanticModel,
@@ -73,6 +74,7 @@ internal static class TypeEmitPlanner
                 Dictionary<string, EventDeclarationSyntax> plainCurrentEventMap) =
                 baseline.GetUnsupportedMemberBaselineMaps();
             UnsupportedMemberSkipCollector.AppendUnsupportedMemberKindSkips(
+                sourceUnit.Input.ProjectRelativePath,
                 typeDeclaration,
                 typeMetadataNameFromSyntax,
                 semanticModel,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitState.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitState.cs
@@ -17,6 +17,10 @@ using Microsoft.CodeAnalysis.Text;
 
 internal sealed class TypeEmitState
 {
+    // The edited file this type was declared in. Emit reads its SemanticModel, root and
+    // baseline from here so a group run never binds a type against another file's tree.
+    public WorkerSourceUnit SourceUnit { get; set; }
+
     public TypeDeclarationSyntax TypeDeclaration { get; set; }
 
     public INamedTypeSymbol TypeSymbol { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/UnsupportedMemberSkipCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/UnsupportedMemberSkipCollector.cs
@@ -30,6 +30,7 @@ internal static class UnsupportedMemberSkipCollector
     // When a verified snapshot declares an equivalent property/indexer, skip rows are omitted
     // (unchanged accessors must not appear as Skipped noise).
     internal static void AppendExplicitAccessorSkips(
+        string sourceProjectRelativePath,
         TypeDeclarationSyntax typeDeclaration,
         string typeMetadataNameFromSyntax,
         SemanticModel semanticModel,
@@ -40,6 +41,7 @@ internal static class UnsupportedMemberSkipCollector
         Dictionary<string, IndexerDeclarationSyntax> plainCurrentIndexerMap,
         AddedMethodCatalog addedMethodCatalog)
     {
+        int firstAppendedIndex = skipped.Count;
         foreach (MemberDeclarationSyntax member in typeDeclaration.Members)
         {
             if (member is PropertyDeclarationSyntax propertyDeclaration)
@@ -95,6 +97,8 @@ internal static class UnsupportedMemberSkipCollector
                     addedMethodCatalog);
             }
         }
+
+        StampSourceProjectRelativePath(skipped, firstAppendedIndex, sourceProjectRelativePath);
     }
 
     internal static void AppendExplicitAccessorSkipsForProperty(
@@ -234,6 +238,7 @@ internal static class UnsupportedMemberSkipCollector
     // explicit event accessors as Skipped. Unchanged members matching a verified snapshot
     // are omitted. Field-like events and finalizers are not listed.
     internal static void AppendUnsupportedMemberKindSkips(
+        string sourceProjectRelativePath,
         TypeDeclarationSyntax typeDeclaration,
         string typeMetadataNameFromSyntax,
         SemanticModel semanticModel,
@@ -245,6 +250,7 @@ internal static class UnsupportedMemberSkipCollector
         Dictionary<string, MemberDeclarationSyntax> plainCurrentOperatorMap,
         Dictionary<string, EventDeclarationSyntax> plainCurrentEventMap)
     {
+        int firstAppendedIndex = skipped.Count;
         AppendConstructorSkips(
             typeDeclaration,
             typeMetadataNameFromSyntax,
@@ -266,6 +272,21 @@ internal static class UnsupportedMemberSkipCollector
             skipped,
             snapshotEventMap,
             plainCurrentEventMap);
+        StampSourceProjectRelativePath(skipped, firstAppendedIndex, sourceProjectRelativePath);
+    }
+
+    // Why stamp the appended range (not each producer): every row below belongs to the one type
+    // this call was made for, so the rows a call appends all came from that type's file. The
+    // group-wide rows of other files sit before firstAppendedIndex and are left alone.
+    private static void StampSourceProjectRelativePath(
+        List<WorkerSkipped> skipped,
+        int firstAppendedIndex,
+        string sourceProjectRelativePath)
+    {
+        for (int index = firstAppendedIndex; index < skipped.Count; index++)
+        {
+            skipped[index].SourceProjectRelativePath = sourceProjectRelativePath;
+        }
     }
 
     internal static void AppendConstructorSkips(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
@@ -45,13 +45,17 @@ internal static class WorkerGroupPipeline
             syntaxTrees.Add(unit.SyntaxTree);
         }
 
-        // Why the first loaded unit's parse errors: reference resolution is assembly-wide, and a
-        // group with no loadable source has nowhere to report it — such a run emits no rows anyway.
-        List<string> referenceParseErrors = loadedUnits.Count > 0
-            ? loadedUnits[0].ParseErrors
-            : new List<string>();
+        // Why every loaded unit reports it: a missing reference is a problem of the whole assembly,
+        // not of one source, so each file's own result has to state it — reporting it on one unit
+        // would make the failure move as the input order changes. A run with no loadable source
+        // drops it, because such a run reports no per-file findings at all.
+        List<string> referenceParseErrors = new List<string>();
         (List<MetadataReference> references, MetadataReference targetTypesReference) =
             CollectMetadataReferences(input, referenceParseErrors);
+        foreach (WorkerSourceUnit loadedUnit in loadedUnits)
+        {
+            loadedUnit.ParseErrors.AddRange(referenceParseErrors);
+        }
 
         CSharpCompilation compilation = CSharpCompilation.Create(
             assemblyName: "UloopHotReloadTransformWorkerCompilation",

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
@@ -1,0 +1,354 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+// Transforms every edited source of one compilation assembly in a single pass: all trees enter
+// one compilation, added members are registered for the whole group before any body is guarded
+// or emitted, and the emitted shim source covers the group. That order is what lets a body
+// edited in one file call a member added in another.
+internal static class WorkerGroupPipeline
+{
+    internal static WorkerOutput Transform(WorkerInput input)
+    {
+        CSharpParseOptions parseOptions = new CSharpParseOptions(
+            languageVersion: LanguageVersion.Latest,
+            preprocessorSymbols: input.Defines);
+        List<WorkerSourceUnit> units = new List<WorkerSourceUnit>(input.Sources.Length);
+        foreach (WorkerSourceInput source in input.Sources)
+        {
+            units.Add(WorkerSourceLoader.Load(source, parseOptions));
+        }
+
+        List<WorkerSourceUnit> loadedUnits = new List<WorkerSourceUnit>(units.Count);
+        List<SyntaxTree> syntaxTrees = new List<SyntaxTree>(units.Count);
+        foreach (WorkerSourceUnit unit in units)
+        {
+            if (unit.SyntaxTree == null)
+            {
+                continue;
+            }
+
+            loadedUnits.Add(unit);
+            syntaxTrees.Add(unit.SyntaxTree);
+        }
+
+        // Why the first loaded unit's parse errors: reference resolution is assembly-wide, and a
+        // group with no loadable source has nowhere to report it — such a run emits no rows anyway.
+        List<string> referenceParseErrors = loadedUnits.Count > 0
+            ? loadedUnits[0].ParseErrors
+            : new List<string>();
+        (List<MetadataReference> references, MetadataReference targetTypesReference) =
+            CollectMetadataReferences(input, referenceParseErrors);
+
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName: "UloopHotReloadTransformWorkerCompilation",
+            syntaxTrees: syntaxTrees,
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        foreach (WorkerSourceUnit unit in loadedUnits)
+        {
+            unit.SemanticModel = compilation.GetSemanticModel(unit.SyntaxTree, ignoreAccessibility: true);
+        }
+
+        IAssemblySymbol targetTypesAssemblySymbol = ResolveTargetTypesAssemblySymbol(
+            compilation,
+            targetTypesReference);
+        List<UsingDirectiveSyntax> assemblyGlobalUsings =
+            WorkerUsingCollector.CollectAssemblyGlobalUsings(input, parseOptions);
+        List<string> siblingConstDriftWarnings = SiblingConstDriftCollector.CollectConstDriftWarnings(
+            input.ChangedSiblingSourcePaths,
+            parseOptions,
+            references,
+            targetTypesAssemblySymbol);
+
+        List<WorkerEntry> entries = new List<WorkerEntry>();
+        List<WorkerSkipped> skipped = new List<WorkerSkipped>();
+        List<WorkerUnchangedMethod> unchangedMethods = new List<WorkerUnchangedMethod>();
+        List<ShimTypeBuilder> shimTypes = new List<ShimTypeBuilder>();
+        AddedMethodCatalog addedMethodCatalog = new AddedMethodCatalog();
+        AddedFieldCatalog addedFieldCatalog = new AddedFieldCatalog();
+        // Why counters run across units: shim type and method names must stay unique when two
+        // files of the group declare types of the same name.
+        int shimTypeCounter = 0;
+        int globalShimMethodCounter = 0;
+        foreach (WorkerSourceUnit unit in loadedUnits)
+        {
+            (shimTypeCounter, globalShimMethodCounter) = QueueUnit(
+                unit,
+                input,
+                parseOptions,
+                targetTypesAssemblySymbol,
+                assemblyGlobalUsings,
+                shimTypes,
+                addedMethodCatalog,
+                addedFieldCatalog,
+                skipped,
+                unchangedMethods,
+                shimTypeCounter,
+                globalShimMethodCounter);
+        }
+
+        foreach (WorkerSourceUnit unit in loadedUnits)
+        {
+            RemovedMemberCollector.CollectRemovedMembersIfBaseline(
+                unit.Baseline,
+                unit.PlainRoot,
+                unit.TypeEmitStates,
+                unit.SemanticModel,
+                targetTypesAssemblySymbol,
+                addedMethodCatalog,
+                addedFieldCatalog,
+                unit.RemovedMembers,
+                unit.RemovedMethodSignatures);
+        }
+
+        // Why one concatenated list: the guard runs to a fixed point, so a body that calls an
+        // added method of another file must be able to lose its shim in the same iteration.
+        List<TypeEmitState> allTypeEmitStates = new List<TypeEmitState>();
+        foreach (WorkerSourceUnit unit in loadedUnits)
+        {
+            allTypeEmitStates.AddRange(unit.TypeEmitStates);
+        }
+
+        AddedCallSiteGuard.SkipBodiesThatCannotUseAddedMethods(
+            allTypeEmitStates,
+            addedMethodCatalog,
+            addedFieldCatalog,
+            skipped);
+
+        ShimMethodEmitter.EmitQueuedMethodsAndPropertyGetters(
+            allTypeEmitStates,
+            addedMethodCatalog,
+            addedFieldCatalog,
+            input,
+            entries,
+            skipped,
+            unchangedMethods,
+            shimTypes,
+            assemblyGlobalUsings,
+            shimTypeCounter,
+            globalShimMethodCounter);
+
+        foreach (WorkerSourceUnit unit in loadedUnits)
+        {
+            AppendOutsideMethodBodyDriftWarnings(unit, addedMethodCatalog, addedFieldCatalog);
+        }
+
+        return BuildWorkerOutput(
+            units,
+            shimTypes,
+            entries,
+            skipped,
+            unchangedMethods,
+            siblingConstDriftWarnings,
+            addedFieldCatalog);
+    }
+
+    // Everything one unit contributes before the group-wide guard and emit: its drift warnings,
+    // its baseline, and the queued shim methods of its types.
+    private static (int ShimTypeCounter, int GlobalShimMethodCounter) QueueUnit(
+        WorkerSourceUnit unit,
+        WorkerInput input,
+        CSharpParseOptions parseOptions,
+        IAssemblySymbol targetTypesAssemblySymbol,
+        List<UsingDirectiveSyntax> assemblyGlobalUsings,
+        List<ShimTypeBuilder> shimTypes,
+        AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog,
+        List<WorkerSkipped> skipped,
+        List<WorkerUnchangedMethod> unchangedMethods,
+        int shimTypeCounter,
+        int globalShimMethodCounter)
+    {
+        unit.DeclarationDriftWarnings.AddRange(
+            ConstDriftCollector.CollectConstDriftWarnings(
+                unit.Root,
+                unit.SemanticModel,
+                targetTypesAssemblySymbol));
+        // Why here: a compiled property/event can disappear or change kind with no
+        // touched body, so the generic outside-body warning would bury the name.
+        unit.KindChangeSyntaxKeys =
+            CompiledMemberKindChangeWarnings.AppendCompiledPropertyOrEventKindChangeWarnings(
+                unit.Root,
+                unit.SemanticModel,
+                targetTypesAssemblySymbol,
+                unit.DeclarationDriftWarnings);
+        unit.Baseline = BaselineSnapshotBuilder.BuildBaselineSnapshotState(
+            unit.Input.SnapshotSource,
+            parseOptions,
+            unit.PlainRoot);
+
+        (List<TypeEmitState> typeEmitStates, int nextShimTypeCounter, int nextGlobalShimMethodCounter) =
+            TypeEmitPlanner.QueueAllTypeEmitStates(
+                unit,
+                targetTypesAssemblySymbol,
+                input,
+                assemblyGlobalUsings,
+                shimTypes,
+                addedMethodCatalog,
+                addedFieldCatalog,
+                skipped,
+                unchangedMethods,
+                unit.DeclarationDriftWarnings,
+                unit.RemovedMembers,
+                unit.RemovedMethodSignatures,
+                shimTypeCounter,
+                globalShimMethodCounter);
+        unit.TypeEmitStates = typeEmitStates;
+        return (nextShimTypeCounter, nextGlobalShimMethodCounter);
+    }
+
+    private static void AppendOutsideMethodBodyDriftWarnings(
+        WorkerSourceUnit unit,
+        AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        if (!unit.Baseline.HasBaseline || unit.Baseline.SnapshotRoot == null)
+        {
+            return;
+        }
+
+        // Why after property emit: added-property syntax keys are registered when a skip
+        // row is written. Running the drift check first would miss those keys and keep
+        // the false outside-body warning for added properties that already have a row.
+        OutsideMethodBodyDriftChecker.AppendOutsideMethodBodyDriftWarningIfNeeded(
+            unit.Baseline.SnapshotRoot,
+            unit.PlainRoot,
+            Path.GetFileName(unit.Input.SourcePath),
+            unit.DeclarationDriftWarnings,
+            addedMethodCatalog,
+            addedFieldCatalog,
+            unit.KindChangeSyntaxKeys.PropertySyntaxKeys,
+            unit.KindChangeSyntaxKeys.EventSyntaxKeys);
+    }
+
+    private static (List<MetadataReference> References, MetadataReference TargetTypesReference)
+        CollectMetadataReferences(WorkerInput input, List<string> parseErrors)
+    {
+        string targetTypesFullPath =
+            !string.IsNullOrEmpty(input.TargetTypesAssemblyPath) && File.Exists(input.TargetTypesAssemblyPath)
+                ? Path.GetFullPath(input.TargetTypesAssemblyPath)
+                : null;
+        MetadataReference targetTypesReference = null;
+
+        List<MetadataReference> references = new List<MetadataReference>();
+        foreach (string referencePath in input.ReferencePaths)
+        {
+            if (File.Exists(referencePath))
+            {
+                MetadataReference reference = MetadataReference.CreateFromFile(referencePath);
+                references.Add(reference);
+                if (targetTypesFullPath != null
+                    && string.Equals(
+                        Path.GetFullPath(referencePath),
+                        targetTypesFullPath,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    targetTypesReference = reference;
+                }
+            }
+            else
+            {
+                parseErrors.Add("Reference not found: " + referencePath);
+            }
+        }
+
+        if (targetTypesFullPath != null && targetTypesReference == null)
+        {
+            targetTypesReference = MetadataReference.CreateFromFile(input.TargetTypesAssemblyPath);
+            references.Add(targetTypesReference);
+        }
+
+        return (references, targetTypesReference);
+    }
+
+    private static IAssemblySymbol ResolveTargetTypesAssemblySymbol(
+        CSharpCompilation compilation,
+        MetadataReference targetTypesReference)
+    {
+        // The drift comparison must see private and internal consts in the compiled target
+        // assembly, which the default MetadataImportOptions (Public) hides. Widening the main
+        // compilation would also widen what every classification query can bind to, so the
+        // wider import is confined to a throwaway compilation used only for this lookup.
+        if (targetTypesReference == null)
+        {
+            return null;
+        }
+
+        CSharpCompilation driftCompilation = compilation.WithOptions(
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithMetadataImportOptions(MetadataImportOptions.All));
+        return driftCompilation.GetAssemblyOrModuleSymbol(targetTypesReference) as IAssemblySymbol;
+    }
+
+    private static WorkerOutput BuildWorkerOutput(
+        List<WorkerSourceUnit> units,
+        List<ShimTypeBuilder> shimTypes,
+        List<WorkerEntry> entries,
+        List<WorkerSkipped> skipped,
+        List<WorkerUnchangedMethod> unchangedMethods,
+        List<string> siblingConstDriftWarnings,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        bool hasAccessorDelegates = false;
+        foreach (ShimTypeBuilder shimType in shimTypes)
+        {
+            if (shimType.AccessorPlan.Entries.Count > 0)
+            {
+                hasAccessorDelegates = true;
+                break;
+            }
+        }
+
+        // Why the input order: the orchestrator pairs files[i] with the source it sent.
+        WorkerFileOutput[] files = new WorkerFileOutput[units.Count];
+        for (int index = 0; index < units.Count; index++)
+        {
+            files[index] = BuildFileOutput(units[index], addedFieldCatalog);
+        }
+
+        return new WorkerOutput
+        {
+            ShimSource = ShimSourceEmitter.Emit(shimTypes),
+            Entries = entries.ToArray(),
+            Skipped = skipped.ToArray(),
+            Files = files,
+            SiblingConstDriftWarnings = siblingConstDriftWarnings.ToArray(),
+            UnchangedMethods = unchangedMethods.ToArray(),
+            HasAccessorDelegates = hasAccessorDelegates,
+            HasAddedFieldRewrites = addedFieldCatalog.HasStoreRewrites
+        };
+    }
+
+    private static WorkerFileOutput BuildFileOutput(WorkerSourceUnit unit, AddedFieldCatalog addedFieldCatalog)
+    {
+        string projectRelativePath = unit.Input.ProjectRelativePath;
+        return new WorkerFileOutput
+        {
+            ProjectRelativePath = projectRelativePath,
+            SourceContentSha256 = unit.SourceContentSha256,
+            ParseErrors = unit.ParseErrors.ToArray(),
+            DeclarationDriftWarnings = unit.DeclarationDriftWarnings.ToArray(),
+            // A unit that failed to load has no baseline, so duplicate keys never disabled one.
+            BaselineDisabledByDuplicateKeys =
+                unit.Baseline != null && unit.Baseline.BaselineDisabledByDuplicateKeys,
+            RemovedMembers = unit.RemovedMembers.ToArray(),
+            RemovedMethodSignatures = unit.RemovedMethodSignatures.ToArray(),
+            AddedFieldNames = addedFieldCatalog.ListRewrittenAddedFieldDisplayNames(projectRelativePath),
+            AddedConstNames = addedFieldCatalog.ListFoldedConstDisplayNames(projectRelativePath)
+        };
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceLoader.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceLoader.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+// Turns one wire source into a WorkerSourceUnit: validates the path, reads the text, hashes it,
+// then parses and annotates it. Failures land in the unit's ParseErrors with a null SyntaxTree
+// so the group run can keep going for the other sources.
+internal static class WorkerSourceLoader
+{
+    internal static WorkerSourceUnit Load(WorkerSourceInput source, CSharpParseOptions parseOptions)
+    {
+        WorkerSourceUnit unit = new WorkerSourceUnit { Input = source, SourceContentSha256 = string.Empty };
+        // Why ParseErrors (not Debug.Assert): ProjectRelativePath crosses a process boundary via
+        // JSON, and the worker is built without a DEBUG define so Conditional Asserts are stripped.
+        if (string.IsNullOrEmpty(source.ProjectRelativePath)
+            || source.ProjectRelativePath.IndexOf('\\') >= 0
+            || source.ProjectRelativePath.IndexOf('"') >= 0)
+        {
+            unit.ParseErrors.Add(
+                "Invalid projectRelativePath: must be a non-empty forward-slash path without quotes.");
+            return unit;
+        }
+
+        (string sourceText, string sourceContentSha256, string readError) = TryReadSourceText(source.SourcePath);
+        if (readError != null)
+        {
+            unit.ParseErrors.Add(readError);
+            return unit;
+        }
+
+        unit.SourceContentSha256 = sourceContentSha256;
+        (SyntaxTree syntaxTree, CompilationUnitSyntax plainRoot) = WorkerSourceAnnotator.ParseAndAnnotateSource(
+            sourceText,
+            parseOptions,
+            source.SourcePath,
+            unit.ParseErrors);
+        unit.SyntaxTree = syntaxTree;
+        unit.Root = syntaxTree.GetCompilationUnitRoot();
+        unit.PlainRoot = plainRoot;
+        return unit;
+    }
+
+    private static (string SourceText, string SourceContentSha256, string ReadError) TryReadSourceText(
+        string sourcePath)
+    {
+        try
+        {
+            byte[] sourceBytes = File.ReadAllBytes(sourcePath);
+            string sourceContentSha256 = ComputeSourceContentSha256(sourceBytes);
+            using MemoryStream memoryStream = new MemoryStream(sourceBytes, writable: false);
+            using StreamReader reader = new StreamReader(
+                memoryStream,
+                Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: true);
+            return (reader.ReadToEnd(), sourceContentSha256, null);
+        }
+        catch (Exception exception)
+        {
+            return (null, null, "Failed to read sourcePath: " + exception.Message);
+        }
+    }
+
+    // Keep in sync with HotReloadAppliedSourceLedger.ComputeContentHash (lowercase hex SHA-256).
+    private static string ComputeSourceContentSha256(byte[] bytes)
+    {
+        using SHA256 sha256 = SHA256.Create();
+        byte[] hash = sha256.ComputeHash(bytes);
+        StringBuilder builder = new StringBuilder(hash.Length * 2);
+        for (int index = 0; index < hash.Length; index++)
+        {
+            builder.Append(hash[index].ToString("x2"));
+        }
+
+        return builder.ToString();
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceUnit.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceUnit.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+// Everything one edited source file contributes to a group run: its parse products, its
+// baseline, and the rows and warnings that belong to that file alone. A group run holds one
+// unit per source so per-file state never has to be threaded through the emit pipeline.
+internal sealed class WorkerSourceUnit
+{
+    public WorkerSourceInput Input { get; set; }
+
+    // Null when the source could not be read or its path is invalid; such a unit stays out of
+    // the compilation and every later per-unit step skips it.
+    public SyntaxTree SyntaxTree { get; set; }
+
+    // Annotated root, bound to SyntaxTree. Emit needs the uloop-line annotations.
+    public CompilationUnitSyntax Root { get; set; }
+
+    // Unannotated root. Baseline comparison must use it on both sides.
+    public CompilationUnitSyntax PlainRoot { get; set; }
+
+    public SemanticModel SemanticModel { get; set; }
+
+    public BaselineSnapshotState Baseline { get; set; }
+
+    public string SourceContentSha256 { get; set; }
+
+    public List<string> ParseErrors { get; } = new List<string>();
+
+    public List<string> DeclarationDriftWarnings { get; } = new List<string>();
+
+    public List<WorkerRemovedMember> RemovedMembers { get; } = new List<WorkerRemovedMember>();
+
+    public List<WorkerRemovedMethodSignature> RemovedMethodSignatures { get; } =
+        new List<WorkerRemovedMethodSignature>();
+
+    public CompiledMemberKindChangeWarnings.SyntaxKeys KindChangeSyntaxKeys { get; set; }
+
+    public List<TypeEmitState> TypeEmitStates { get; set; } = new List<TypeEmitState>();
+}


### PR DESCRIPTION
## Summary
- Hot reload now analyzes every edited file of one compilation assembly in a single worker pass, so a body edited in one file can use a method, field or const added in another file of the same assembly.
- Each shim, entry and skip row states which edited file it came from, so shim compile errors and skip reasons still point at the right source.

## User Impact
- Before: each edited file was analyzed alone. Adding a method in one file and calling it from an edited body in another file could not work — the call site had nothing to bind to, so the edited body was skipped.
- After: the files of one assembly are analyzed together against one compilation, so cross-file additions bind. The unit that gets applied is still the single file, and single-file edits behave exactly as before.

## Changes
- New per-file unit type carrying that file's syntax tree, semantic model, baseline and findings; a loader builds one per source, recording read/parse failures on that file's own row instead of failing the run.
- New group pipeline: all sources load into one compilation, each unit gets a semantic model bound to its own tree, and shared work (references, target assembly symbol, global usings, sibling const drift) happens once. Shim type and method counters run across the whole group so names stay unique when two files declare same-named types.
- Emit state is bound to the unit it came from, so every consumer reads the semantic model, root and baseline of the file that declared the type rather than another file's tree.
- The added-call-site guard runs to a fixed point over the concatenated states of the group, which is what lets a call in one file see a member added in another.
- Emitted `#line` directives name the file each shim type came from, and compilation-unit usings are deduplicated across the group.
- Added field and const names are reported per edited file, filtered from the group-wide catalog by the binding's file.
- Run-level validation rejects an empty sources array, a null entry, and a repeated project-relative path as a run-level failure.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <repo root>` → `ErrorCount: 0`, `Success: true`
- `dist/darwin-arm64/uloop run-tests --skip-compile --filter-type class --filter-value <cross-file worker test class>` → 6 tests, 6 passed, 0 failed
- `dist/darwin-arm64/uloop run-tests --skip-compile --filter-type regex --filter-value 'HotReload'` → 692 tests, 692 passed, 0 failed, 0 skipped
- `sh scripts/check-file-length.sh` → no files exceeded the 500 SLOC limit
- `sh scripts/check-code-complexity.sh` → Go cyclop 0 issues, C# CA1502 no findings above 15


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

