### PR TITLE
feat: Hot reload now applies edits across several files of the same assembly in one run

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadChangedSiblingSourceDetectorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadChangedSiblingSourceDetectorTests.cs
@@ -38,13 +38,51 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         projectRoot,
                         "Asm-mvid",
                         new[] { editedRelative, siblingRelative },
-                        editedRelative);
+                        new[] { editedRelative });
 
                 Assert.That(result.ChangedSiblingAbsolutePaths, Has.Length.EqualTo(1));
                 Assert.That(
                     result.ChangedSiblingAbsolutePaths[0],
                     Is.EqualTo(AbsoluteProjectPath(projectRoot, siblingRelative)));
                 Assert.That(result.ScanLimitWarning, Is.EqualTo(string.Empty));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// What: every file edited in the same run is excluded, so a file transformed together
+        /// with its group is not also reported as a drifted sibling.
+        /// </summary>
+        [Test]
+        public void DetectFromSnapshotDirectory_WhenTwoFilesAreEdited_ExcludesBothOfThem()
+        {
+            string projectRoot = CreateTempProjectRoot();
+            try
+            {
+                string firstEditedRelative = "Assets/FirstEdited.cs";
+                string secondEditedRelative = "Assets/SecondEdited.cs";
+                string siblingRelative = "Assets/Sibling.cs";
+                WriteProjectFile(projectRoot, firstEditedRelative, "first-disk");
+                WriteProjectFile(projectRoot, secondEditedRelative, "second-disk");
+                WriteProjectFile(projectRoot, siblingRelative, "sibling-disk");
+                WriteSnapshot(projectRoot, "Asm-mvid", firstEditedRelative, "first-snapshot");
+                WriteSnapshot(projectRoot, "Asm-mvid", secondEditedRelative, "second-snapshot");
+                WriteSnapshot(projectRoot, "Asm-mvid", siblingRelative, "sibling-snapshot");
+
+                HotReloadChangedSiblingScanResult result =
+                    HotReloadChangedSiblingSourceDetector.DetectFromSnapshotDirectory(
+                        projectRoot,
+                        "Asm-mvid",
+                        new[] { firstEditedRelative, secondEditedRelative, siblingRelative },
+                        new[] { firstEditedRelative, secondEditedRelative });
+
+                Assert.That(result.ChangedSiblingAbsolutePaths, Has.Length.EqualTo(1));
+                Assert.That(
+                    result.ChangedSiblingAbsolutePaths[0],
+                    Is.EqualTo(AbsoluteProjectPath(projectRoot, siblingRelative)));
             }
             finally
             {
@@ -71,7 +109,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         projectRoot,
                         "Asm-mvid",
                         new[] { editedRelative, siblingRelative },
-                        editedRelative);
+                        new[] { editedRelative });
 
                 Assert.That(result.ChangedSiblingAbsolutePaths, Is.Empty);
                 Assert.That(result.ScanLimitWarning, Is.EqualTo(string.Empty));
@@ -96,7 +134,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     "Asm",
                     Path.Combine(projectRoot, "missing.dll"),
                     new[] { "Assets/Edited.cs", "Assets/Sibling.cs" },
-                    "Assets/Edited.cs");
+                    new[] { "Assets/Edited.cs" });
 
                 Assert.That(result.ChangedSiblingAbsolutePaths, Is.Empty);
                 Assert.That(result.ScanLimitWarning, Is.EqualTo(string.Empty));
@@ -131,7 +169,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         projectRoot,
                         "Asm-mvid",
                         new[] { editedRelative, changedRelative, identicalRelative },
-                        editedRelative);
+                        new[] { editedRelative });
 
                 Assert.That(result.ChangedSiblingAbsolutePaths, Has.Length.EqualTo(1));
                 Assert.That(
@@ -177,7 +215,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         projectRoot,
                         "Asm-mvid",
                         sourceFiles,
-                        editedRelative);
+                        new[] { editedRelative });
 
                 Assert.That(result.ChangedSiblingAbsolutePaths, Has.Length.EqualTo(50));
                 Assert.That(

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberCaller.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberCaller.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
     /// <summary>
@@ -6,9 +8,33 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     /// </summary>
     internal sealed class HotReloadCrossFileAddedMemberCaller
     {
+        // Why NoInlining on every member: end-to-end tests read patched bodies back through a
+        // direct call, which an inlined copy at the call site would not observe.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public int Call(HotReloadCrossFileAddedMemberHost host)
         {
             return host.Value();
+        }
+
+        // Second editable member of this file, so a file-atomic skip has something to report
+        // besides the method a compile error was attributed to.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Other()
+        {
+            return 7;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int CallScaled(HotReloadCrossFileAddedMemberHost host)
+        {
+            return host.Scaled(1);
+        }
+
+        // The only compiled call site of the host's gated member.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int CallGated(HotReloadCrossFileAddedMemberHost host)
+        {
+            return host.Gated(1);
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberHost.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
     /// <summary>
@@ -9,6 +11,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public int Value()
         {
             return 1;
+        }
+
+        // Why NoInlining: end-to-end tests edit this body and read the new value back through a
+        // direct call, which an inlined copy at the call site would not observe.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Scaled(int factor)
+        {
+            return factor;
+        }
+
+        // Why a member nothing else calls: the signature-change gate demands every compiled call
+        // site of a replaced method be patched in the same reload, so this one is called only
+        // from the sibling caller fixture.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Gated(int seed)
+        {
+            return seed;
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
@@ -160,10 +160,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// <summary>
         /// What: when the file that declares an added method fails to compile, the sibling file's
         /// body that calls it is skipped as an isolated added-method caller instead of being
-        /// reported as one more file-atomic skip.
+        /// reported as one more file-atomic skip, and nothing of the reload is applied because
+        /// the surviving file's only edited body was that caller.
         /// </summary>
         [Test]
-        public async Task Run_TwoFilesBrokenFileDeclaresAddedMethodUsedByOther_SkipsCallerBodyAndAppliesRest()
+        public async Task Run_TwoFilesBrokenFileDeclaresAddedMethodUsedByOther_SkipsCallerBodyAndAppliesNothing()
         {
             string hostSource = InsertHostMember(
                 "        public int Added()\n        {\n            return 41;\n        }\n\n");
@@ -184,6 +185,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadMethodOutcome callerSkip = FindOutcome(result, HotReloadMethodOutcomeKind.Skipped, "Call(");
             Assert.That(callerSkip.Reason, Is.EqualTo(HotReloadConstants.IsolatedAddedMethodCallerSkipReason));
             Assert.That(callerSkip.FilePath, Is.EqualTo(FixturePath(CallerFileName)));
+            AssertNothingApplied(result);
         }
 
         /// <summary>
@@ -357,6 +359,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     outcome.Kind,
                     Is.Not.EqualTo(HotReloadMethodOutcomeKind.Failed),
                     "Unexpected failure.\n" + FormatOutcomes(result));
+            }
+        }
+
+        private static void AssertNothingApplied(HotReloadOrchestratorResult result)
+        {
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                Assert.That(
+                    outcome.Kind,
+                    Is.Not.EqualTo(HotReloadMethodOutcomeKind.Patched),
+                    "Nothing may be applied here.\n" + FormatOutcomes(result));
+                Assert.That(
+                    outcome.Kind,
+                    Is.Not.EqualTo(HotReloadMethodOutcomeKind.Added),
+                    "Nothing may be applied here.\n" + FormatOutcomes(result));
             }
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
@@ -1,0 +1,453 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// End-to-end EditMode coverage for reloading several edited files of one compilation
+    /// assembly in a single worker run and a single shim assembly.
+    /// </summary>
+    public class HotReloadCrossFileE2ETests
+    {
+        private const string HostFileName = "HotReloadCrossFileAddedMemberHost.cs";
+        private const string CallerFileName = "HotReloadCrossFileAddedMemberCaller.cs";
+        private const string CrossAssemblyFileName = "HotReloadCallSiteCrossAssemblyCaller.cs";
+        // The registry keys added members by their display label, not by the worker wire key.
+        private const string HostAddedMethodLabel =
+            "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadCrossFileAddedMemberHost.Added()";
+
+        private const string HostValueAnchor = "        public int Value()";
+        private const string HostScaledBodyAnchor = "return factor;";
+        private const string CallerCallBodyAnchor = "return host.Value();";
+        private const string CallerOtherBodyAnchor = "return 7;";
+        private const string CallerGatedCallBodyAnchor = "return host.Gated(1);";
+        private const string CrossAssemblyBodyAnchor = "return 8;";
+
+        [SetUp]
+        public void SetUp()
+        {
+            HotReloadPatcher.RevertAll();
+            HotReloadAutoRefreshHold.Sync(HotReloadPatcher.ActiveChangeCount);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadPatcher.RevertAll();
+            HotReloadAutoRefreshHold.Sync(HotReloadPatcher.ActiveChangeCount);
+            VibeLogger.ClearMemoryLogs();
+        }
+
+        /// <summary>
+        /// What: a body edited in the caller file binds to a method added in the host file within
+        /// one reload, both files are applied, every outcome names the file that declares it, and
+        /// the patched caller returns the value the added method produces.
+        /// </summary>
+        [Test]
+        public async Task Run_CallerFileUsesMethodAddedInOtherFile_AppliesBothAndUpdatesRuntime()
+        {
+            HotReloadOrchestratorResult result = await RunPairAsync(
+                "CrossFileAddedMethod",
+                InsertHostMember("        public int Added()\n        {\n            return 41;\n        }\n\n"),
+                ReplaceCallerBody(CallerCallBodyAnchor, "return host.Added() + 1;"));
+
+            AssertNoFailure(result);
+            AssertKind(result, HotReloadMethodOutcomeKind.Added, "Added");
+            AssertKind(result, HotReloadMethodOutcomeKind.Patched, "Call");
+            AssertOutcomeFilePathsMatchDeclaringFile(result);
+            Assert.That(
+                new HotReloadCrossFileAddedMemberCaller().Call(new HotReloadCrossFileAddedMemberHost()),
+                Is.EqualTo(42));
+            Assert.That(HotReloadShimRegistry.HasGeneration(HostProjectRelativePath()), Is.True);
+            Assert.That(HotReloadShimRegistry.HasGeneration(CallerProjectRelativePath()), Is.True);
+            Assert.That(
+                HotReloadAddedMemberRegistry.IsActiveMember(HostProjectRelativePath(), HostAddedMethodLabel),
+                Is.True);
+            Assert.That(
+                HotReloadAddedMemberRegistry.IsActiveMember(CallerProjectRelativePath(), HostAddedMethodLabel),
+                Is.False);
+        }
+
+        /// <summary>
+        /// What: a field added in the host file is readable and writable from the caller file's
+        /// edited body within one reload, the field survives across calls, and the run reports
+        /// that one added field once.
+        /// </summary>
+        [Test]
+        public async Task Run_CallerFileUsesFieldAddedInOtherFile_AppliesBothAndUpdatesRuntime()
+        {
+            HotReloadOrchestratorResult result = await RunPairAsync(
+                "CrossFileAddedField",
+                InsertHostMember("        public int Counter;\n\n"),
+                ReplaceCallerBody(
+                    CallerCallBodyAnchor,
+                    "host.Counter += 1;\n            return host.Counter + 40;"));
+
+            AssertNoFailure(result);
+            AssertKind(result, HotReloadMethodOutcomeKind.Patched, "Call");
+            HotReloadCrossFileAddedMemberCaller caller = new HotReloadCrossFileAddedMemberCaller();
+            HotReloadCrossFileAddedMemberHost host = new HotReloadCrossFileAddedMemberHost();
+            Assert.That(caller.Call(host), Is.EqualTo(41));
+            Assert.That(caller.Call(host), Is.EqualTo(42));
+            Assert.That(
+                HotReloadAddedFieldRegistry.GetFieldsForType(
+                    typeof(HotReloadCrossFileAddedMemberHost).FullName),
+                Is.EqualTo(new[] { "Counter" }));
+            Assert.That(result.AddedFields, Has.Length.EqualTo(1));
+            Assert.That(result.AddedFields[0], Does.Contain("Counter"));
+            Assert.That(CountAddedFieldsLifetimeWarnings(result), Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// What: calling a method that only an unedited sibling file would declare still fails,
+        /// because a member the reload does not carry cannot be emitted into the shim.
+        /// </summary>
+        [Test]
+        public async Task Run_CallerFileOnly_WithoutHostFile_FailsWithNewMemberHint()
+        {
+            string callerPath = FixturePath(CallerFileName);
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { callerPath },
+                HotReloadTestSourceWriter.WriteEditedSource(
+                    "CrossFileCallerOnly.cs",
+                    ReplaceCallerBody(CallerCallBodyAnchor, "return host.Added() + 1;")),
+                CancellationToken.None);
+
+            HotReloadMethodOutcome failure = FindOutcome(result, HotReloadMethodOutcomeKind.Failed, "Call");
+            Assert.That(failure.Reason, Does.Contain(HotReloadConstants.NewMemberCompileHint));
+        }
+
+        /// <summary>
+        /// What: a compile error in one file of the group takes down only that file — its other
+        /// edited method reports the file-atomic skip and it starts no generation — while the
+        /// healthy sibling file is applied and its runtime is updated.
+        /// </summary>
+        [Test]
+        public async Task Run_TwoFilesOneHasCompileError_AppliesHealthyFileAndFailsOnlyBrokenFile()
+        {
+            string callerSource = ReplaceCallerBody(
+                CallerCallBodyAnchor,
+                "int broken = \"not an int\";\n            return broken;");
+            callerSource = ReplaceInSource(callerSource, CallerOtherBodyAnchor, "return 8;");
+
+            HotReloadOrchestratorResult result = await RunPairAsync(
+                "CrossFileBrokenCaller",
+                ReplaceHostBody(HostScaledBodyAnchor, "return factor + 100;"),
+                callerSource);
+
+            AssertKind(result, HotReloadMethodOutcomeKind.Patched, "Scaled");
+            HotReloadMethodOutcome failure = FindOutcome(result, HotReloadMethodOutcomeKind.Failed, "Call");
+            HotReloadMethodOutcome atomicSkip = FindOutcome(result, HotReloadMethodOutcomeKind.Skipped, "Other");
+            Assert.That(atomicSkip.Reason, Is.EqualTo(HotReloadConstants.AtomicFileSkipReason));
+            Assert.That(failure.FilePath, Is.EqualTo(FixturePath(CallerFileName)));
+            Assert.That(atomicSkip.FilePath, Is.EqualTo(FixturePath(CallerFileName)));
+            Assert.That(new HotReloadCrossFileAddedMemberHost().Scaled(1), Is.EqualTo(101));
+            Assert.That(HotReloadShimRegistry.HasGeneration(HostProjectRelativePath()), Is.True);
+            Assert.That(HotReloadShimRegistry.HasGeneration(CallerProjectRelativePath()), Is.False);
+        }
+
+        /// <summary>
+        /// What: when the file that declares an added method fails to compile, the sibling file's
+        /// body that calls it is skipped as an isolated added-method caller instead of being
+        /// reported as one more file-atomic skip.
+        /// </summary>
+        [Test]
+        public async Task Run_TwoFilesBrokenFileDeclaresAddedMethodUsedByOther_SkipsCallerBodyAndAppliesRest()
+        {
+            string hostSource = InsertHostMember(
+                "        public int Added()\n        {\n            return 41;\n        }\n\n");
+            hostSource = ReplaceInSource(
+                hostSource,
+                "return 1;",
+                "int broken = \"not an int\";\n            return broken;");
+            hostSource = ReplaceInSource(hostSource, HostScaledBodyAnchor, "return factor + 5;");
+
+            HotReloadOrchestratorResult result = await RunPairAsync(
+                "CrossFileBrokenHostAddedMethod",
+                hostSource,
+                ReplaceCallerBody(CallerCallBodyAnchor, "return host.Added() + 1;"));
+
+            FindOutcome(result, HotReloadMethodOutcomeKind.Failed, "Value");
+            HotReloadMethodOutcome hostSkip = FindOutcome(result, HotReloadMethodOutcomeKind.Skipped, "Scaled");
+            Assert.That(hostSkip.Reason, Is.EqualTo(HotReloadConstants.AtomicFileSkipReason));
+            HotReloadMethodOutcome callerSkip = FindOutcome(result, HotReloadMethodOutcomeKind.Skipped, "Call(");
+            Assert.That(callerSkip.Reason, Is.EqualTo(HotReloadConstants.IsolatedAddedMethodCallerSkipReason));
+            Assert.That(callerSkip.FilePath, Is.EqualTo(FixturePath(CallerFileName)));
+        }
+
+        /// <summary>
+        /// What: two edited files of different compilation assemblies are processed as separate
+        /// groups, so both are applied in one run and a compile error in one of them leaves the
+        /// other applied.
+        /// </summary>
+        [Test]
+        public async Task Run_TwoFilesDifferentAssemblies_ProcessedAsSeparateGroups()
+        {
+            string hostPath = FixturePath(HostFileName);
+            string crossAssemblyPath = CrossAssemblyFixturePath();
+            string crossAssemblyOnDisk = File.ReadAllText(crossAssemblyPath);
+
+            HotReloadOrchestratorResult applied = await HotReloadOrchestrator.RunAsync(
+                new[] { hostPath, crossAssemblyPath },
+                contentPathOverride: null,
+                CancellationToken.None,
+                new Dictionary<string, string>
+                {
+                    [hostPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                        "CrossAssemblyGroupHost.cs",
+                        ReplaceHostBody(HostScaledBodyAnchor, "return factor + 200;")),
+                    [crossAssemblyPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                        "CrossAssemblyGroupCaller.cs",
+                        ReplaceInSource(crossAssemblyOnDisk, CrossAssemblyBodyAnchor, "return 9;"))
+                });
+
+            AssertNoFailure(applied);
+            AssertKind(applied, HotReloadMethodOutcomeKind.Patched, "Scaled");
+            AssertKind(applied, HotReloadMethodOutcomeKind.Patched, "CalledFromCrossAssembly");
+
+            HotReloadPatcher.RevertAll();
+            HotReloadAutoRefreshHold.Sync(HotReloadPatcher.ActiveChangeCount);
+
+            HotReloadOrchestratorResult isolated = await HotReloadOrchestrator.RunAsync(
+                new[] { hostPath, crossAssemblyPath },
+                contentPathOverride: null,
+                CancellationToken.None,
+                new Dictionary<string, string>
+                {
+                    [hostPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                        "CrossAssemblyGroupHostHealthy.cs",
+                        ReplaceHostBody(HostScaledBodyAnchor, "return factor + 300;")),
+                    [crossAssemblyPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                        "CrossAssemblyGroupCallerBroken.cs",
+                        ReplaceInSource(
+                            crossAssemblyOnDisk,
+                            CrossAssemblyBodyAnchor,
+                            "int broken = \"not an int\";\n            return broken;"))
+                });
+
+            AssertKind(isolated, HotReloadMethodOutcomeKind.Patched, "Scaled");
+            HotReloadMethodOutcome failure =
+                FindOutcome(isolated, HotReloadMethodOutcomeKind.Failed, "CalledFromCrossAssembly");
+            Assert.That(failure.FilePath, Is.EqualTo(crossAssemblyPath));
+            Assert.That(new HotReloadCrossFileAddedMemberHost().Scaled(1), Is.EqualTo(301));
+        }
+
+        /// <summary>
+        /// What: changing a method's return type is applied when its only call site was edited in
+        /// another file of the same reload, because the signature-change gate sees that caller
+        /// covered by this run.
+        /// </summary>
+        [Test]
+        public async Task Run_ReturnTypeChange_CallerInOtherEditedFile_CoversGate()
+        {
+            HotReloadOrchestratorResult result = await RunPairAsync(
+                "CrossFileReturnTypeChange",
+                ReplaceInSource(
+                    ReadFixture(HostFileName),
+                    "public int Gated(int seed)",
+                    "public long Gated(int seed)"),
+                ReplaceCallerBody(CallerGatedCallBodyAnchor, "return (int)host.Gated(2);"));
+
+            AssertNoFailure(result);
+            AssertKind(result, HotReloadMethodOutcomeKind.Patched, "CallGated");
+            Assert.That(
+                FindReplacementOutcome(result, ".Gated(").Kind,
+                Is.Not.EqualTo(HotReloadMethodOutcomeKind.Skipped),
+                "The gate must treat a caller edited in the same reload as covered.\n"
+                + FormatOutcomes(result));
+        }
+
+        private static async Task<HotReloadOrchestratorResult> RunPairAsync(
+            string editedFileNamePrefix,
+            string editedHostSource,
+            string editedCallerSource)
+        {
+            string hostPath = FixturePath(HostFileName);
+            string callerPath = FixturePath(CallerFileName);
+            return await HotReloadOrchestrator.RunAsync(
+                new[] { hostPath, callerPath },
+                contentPathOverride: null,
+                CancellationToken.None,
+                new Dictionary<string, string>
+                {
+                    [hostPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                        editedFileNamePrefix + "Host.cs",
+                        editedHostSource),
+                    [callerPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                        editedFileNamePrefix + "Caller.cs",
+                        editedCallerSource)
+                });
+        }
+
+        private static string InsertHostMember(string memberText)
+        {
+            string source = ReadFixture(HostFileName);
+            Assert.That(source, Does.Contain(HostValueAnchor), "Precondition: host anchor must exist.");
+            return source.Replace(HostValueAnchor, memberText + HostValueAnchor, StringComparison.Ordinal);
+        }
+
+        private static string ReplaceHostBody(string bodyAnchor, string bodyText)
+        {
+            return ReplaceInSource(ReadFixture(HostFileName), bodyAnchor, bodyText);
+        }
+
+        private static string ReplaceCallerBody(string bodyAnchor, string bodyText)
+        {
+            return ReplaceInSource(ReadFixture(CallerFileName), bodyAnchor, bodyText);
+        }
+
+        private static string ReplaceInSource(string source, string anchor, string replacement)
+        {
+            Assert.That(source, Does.Contain(anchor), "Precondition: anchor must exist: " + anchor);
+            return source.Replace(anchor, replacement, StringComparison.Ordinal);
+        }
+
+        private static string ReadFixture(string fileName)
+        {
+            return File.ReadAllText(FixturePath(fileName));
+        }
+
+        private static string FixturePath(string fileName)
+        {
+            string path = Path.GetFullPath(
+                Path.Combine(Application.dataPath, "Tests", "Editor", "HotReload", fileName));
+            Assert.That(File.Exists(path), Is.True, "Fixture missing: " + path);
+            return path;
+        }
+
+        private static string CrossAssemblyFixturePath()
+        {
+            string path = Path.GetFullPath(
+                Path.Combine(
+                    Application.dataPath,
+                    "Tests",
+                    "Editor",
+                    "HotReloadCallSiteCrossAssembly",
+                    CrossAssemblyFileName));
+            Assert.That(File.Exists(path), Is.True, "Fixture missing: " + path);
+            return path;
+        }
+
+        private static string HostProjectRelativePath()
+        {
+            return "Assets/Tests/Editor/HotReload/" + HostFileName;
+        }
+
+        private static string CallerProjectRelativePath()
+        {
+            return "Assets/Tests/Editor/HotReload/" + CallerFileName;
+        }
+
+        private static void AssertNoFailure(HotReloadOrchestratorResult result)
+        {
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                Assert.That(
+                    outcome.Kind,
+                    Is.Not.EqualTo(HotReloadMethodOutcomeKind.Failed),
+                    "Unexpected failure.\n" + FormatOutcomes(result));
+            }
+        }
+
+        private static void AssertKind(
+            HotReloadOrchestratorResult result,
+            HotReloadMethodOutcomeKind kind,
+            string methodNamePart)
+        {
+            FindOutcome(result, kind, methodNamePart);
+        }
+
+        private static HotReloadMethodOutcome FindOutcome(
+            HotReloadOrchestratorResult result,
+            HotReloadMethodOutcomeKind kind,
+            string methodNamePart)
+        {
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == kind && outcome.Method != null && outcome.Method.Contains(methodNamePart))
+                {
+                    return outcome;
+                }
+            }
+
+            Assert.Fail("Expected " + kind + " for " + methodNamePart + ".\n" + FormatOutcomes(result));
+            return null;
+        }
+
+        // The outcome of the method whose signature the edit replaced, whatever kind the gate
+        // and the applier gave it.
+        private static HotReloadMethodOutcome FindReplacementOutcome(
+            HotReloadOrchestratorResult result,
+            string methodNamePart)
+        {
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Method != null && outcome.Method.Contains(methodNamePart))
+                {
+                    return outcome;
+                }
+            }
+
+            Assert.Fail("Expected an outcome for " + methodNamePart + ".\n" + FormatOutcomes(result));
+            return null;
+        }
+
+        // Every outcome must report the fixture file whose type declares the method, so a group
+        // run cannot attribute one file's rows to another.
+        private static void AssertOutcomeFilePathsMatchDeclaringFile(HotReloadOrchestratorResult result)
+        {
+            string hostPath = FixturePath(HostFileName);
+            string callerPath = FixturePath(CallerFileName);
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                string expected = outcome.Method != null
+                    && outcome.Method.Contains(nameof(HotReloadCrossFileAddedMemberCaller))
+                        ? callerPath
+                        : hostPath;
+                Assert.That(
+                    outcome.FilePath,
+                    Is.EqualTo(expected),
+                    "Outcome names the wrong file: " + outcome.Method);
+            }
+        }
+
+        private static int CountAddedFieldsLifetimeWarnings(HotReloadOrchestratorResult result)
+        {
+            string prefix = HotReloadConstants.AddedFieldsLifetimeWarningFormat.Substring(
+                0,
+                HotReloadConstants.AddedFieldsLifetimeWarningFormat.IndexOf("{0}", StringComparison.Ordinal));
+            int count = 0;
+            foreach (string warning in result.Warnings)
+            {
+                if (warning != null && warning.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        private static string FormatOutcomes(HotReloadOrchestratorResult result)
+        {
+            List<string> lines = new List<string>();
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                lines.Add(outcome.Kind + " " + outcome.Method + " @" + outcome.FilePath + " :: " + outcome.Reason);
+            }
+
+            return string.Join("\n", lines);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2595d0e7c3d8a40cfb52ff06e6192e95
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadFileAtomicIsolationPlanTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadFileAtomicIsolationPlanTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for the two exclusion branches a failed group shim compile chooses
+    /// between: keep the narrow method-and-caller exclusion when no file survives, and drop whole
+    /// files when at least one file can still be applied.
+    /// </summary>
+    public class HotReloadFileAtomicIsolationPlanTests
+    {
+        private const string FirstFile = "Assets/Scripts/First.cs";
+        private const string SecondFile = "Assets/Scripts/Second.cs";
+
+        /// <summary>
+        /// What: when every file of the group failed, the plan keeps the legacy exclusion set —
+        /// the failed added method plus the entries that call it — and leaves the file's other
+        /// entries in, instead of excluding the whole file.
+        /// </summary>
+        [Test]
+        public void Build_WhenEveryFileFailed_ExcludesOnlyTheFailedMethodAndItsCallers()
+        {
+            TransformWorkerEntryDto brokenAddedMethod = CreateEntry(
+                FirstFile,
+                "AddedHelper",
+                HotReloadConstants.PatchKindAddedMethod);
+            TransformWorkerEntryDto caller = CreateEntry(
+                FirstFile,
+                "CallsAddedHelper",
+                HotReloadConstants.PatchKindDelegation);
+            caller.calledAddedMethodKeys = new[] { HotReloadMethodKeys.BuildMethodKey(brokenAddedMethod) };
+            TransformWorkerEntryDto unrelated = CreateEntry(
+                FirstFile,
+                "Unrelated",
+                HotReloadConstants.PatchKindDelegation);
+            TransformWorkerEntryDto[] entries = new[] { brokenAddedMethod, caller, unrelated };
+
+            HotReloadFileAtomicIsolationPlan plan = HotReloadFileAtomicIsolationPlan.Build(
+                entries,
+                CreateAttribution(brokenAddedMethod),
+                Array.Empty<TransformWorkerSkippedDto>(),
+                CreateGroupFilePaths(FirstFile),
+                new[] { FirstFile });
+
+            Assert.That(plan.AllFilesFailed, Is.True);
+            Assert.That(plan.IsFailedFile(FirstFile), Is.True);
+            Assert.That(
+                plan.ExcludedAddedMethodKeys,
+                Is.EqualTo(new[] { HotReloadMethodKeys.BuildMethodKey(brokenAddedMethod) }));
+            Assert.That(
+                plan.ExcludedMethodKeys,
+                Is.EqualTo(new[] { HotReloadMethodKeys.BuildMethodKey(caller) }));
+            Assert.That(plan.CallerEntries, Is.EqualTo(new[] { caller }));
+            Assert.That(plan.AtomicSkipOutcomesByFile, Is.Empty);
+            Assert.That(
+                HotReloadFileAtomicIsolationPlan.CollectOutcomes(plan.FailedOutcomesByFile, new[] { FirstFile }),
+                Has.Count.EqualTo(1));
+        }
+
+        /// <summary>
+        /// What: when one file of the group survived, the plan excludes every entry of the failed
+        /// file (added methods through the added-method set), reports the failed file's remaining
+        /// entries as file-atomic skips, and touches nothing of the surviving file.
+        /// </summary>
+        [Test]
+        public void Build_WhenOneFileSurvived_ExcludesEveryEntryOfTheFailedFile()
+        {
+            TransformWorkerEntryDto brokenBody = CreateEntry(
+                FirstFile,
+                "BrokenBody",
+                HotReloadConstants.PatchKindDelegation);
+            TransformWorkerEntryDto sameFileAddedMethod = CreateEntry(
+                FirstFile,
+                "AddedHelper",
+                HotReloadConstants.PatchKindAddedMethod);
+            TransformWorkerEntryDto sameFileHealthy = CreateEntry(
+                FirstFile,
+                "Healthy",
+                HotReloadConstants.PatchKindDelegation);
+            TransformWorkerEntryDto survivingFileEntry = CreateEntry(
+                SecondFile,
+                "SurvivingBody",
+                HotReloadConstants.PatchKindDelegation);
+            TransformWorkerEntryDto[] entries =
+                new[] { brokenBody, sameFileAddedMethod, sameFileHealthy, survivingFileEntry };
+
+            HotReloadFileAtomicIsolationPlan plan = HotReloadFileAtomicIsolationPlan.Build(
+                entries,
+                CreateAttribution(brokenBody),
+                Array.Empty<TransformWorkerSkippedDto>(),
+                CreateGroupFilePaths(FirstFile, SecondFile),
+                new[] { FirstFile, SecondFile });
+
+            Assert.That(plan.AllFilesFailed, Is.False);
+            Assert.That(plan.IsFailedFile(FirstFile), Is.True);
+            Assert.That(plan.IsFailedFile(SecondFile), Is.False);
+            Assert.That(
+                plan.ExcludedMethodKeys,
+                Is.EquivalentTo(new[]
+                {
+                    HotReloadMethodKeys.BuildMethodKey(brokenBody),
+                    HotReloadMethodKeys.BuildMethodKey(sameFileHealthy)
+                }));
+            Assert.That(
+                plan.ExcludedAddedMethodKeys,
+                Is.EqualTo(new[] { HotReloadMethodKeys.BuildMethodKey(sameFileAddedMethod) }));
+            Assert.That(
+                plan.ExcludedMethodKeys,
+                Does.Not.Contain(HotReloadMethodKeys.BuildMethodKey(survivingFileEntry)));
+            Assert.That(plan.CallerEntries, Is.Empty);
+
+            List<HotReloadMethodOutcome> atomicSkips = HotReloadFileAtomicIsolationPlan.CollectOutcomes(
+                plan.AtomicSkipOutcomesByFile,
+                new[] { FirstFile, SecondFile });
+            Assert.That(atomicSkips, Has.Count.EqualTo(2));
+            foreach (HotReloadMethodOutcome outcome in atomicSkips)
+            {
+                Assert.That(outcome.Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Skipped));
+                Assert.That(outcome.Reason, Is.EqualTo(HotReloadConstants.AtomicFileSkipReason));
+                Assert.That(outcome.FilePath, Is.EqualTo(FirstFile));
+            }
+        }
+
+        private static TransformWorkerEntryDto CreateEntry(
+            string projectRelativePath,
+            string methodName,
+            string patchKind)
+        {
+            return new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = projectRelativePath,
+                typeMetadataName = "Sample.Host",
+                methodName = methodName,
+                parameterTypeFullNames = Array.Empty<string>(),
+                genericArity = 0,
+                patchKind = patchKind
+            };
+        }
+
+        private static HotReloadShimErrorAttribution.ShimCompileErrorAttribution CreateAttribution(
+            TransformWorkerEntryDto failedEntry)
+        {
+            Dictionary<TransformWorkerEntryDto, List<string>> errorMessagesByEntry =
+                new Dictionary<TransformWorkerEntryDto, List<string>>
+                {
+                    { failedEntry, new List<string> { "CS0103: name not found (line 12)" } }
+                };
+            return new HotReloadShimErrorAttribution.ShimCompileErrorAttribution(errorMessagesByEntry);
+        }
+
+        private static HotReloadGroupFilePaths CreateGroupFilePaths(params string[] projectRelativePaths)
+        {
+            List<(string ProjectRelativePath, string AssemblyResolvePath)> files =
+                new List<(string ProjectRelativePath, string AssemblyResolvePath)>();
+            foreach (string projectRelativePath in projectRelativePaths)
+            {
+                files.Add((projectRelativePath, projectRelativePath));
+            }
+
+            return new HotReloadGroupFilePaths(files);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadFileAtomicIsolationPlanTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadFileAtomicIsolationPlanTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ab7d7c819c9346828c0b1fe39879285
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadFileGroupPlannerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadFileGroupPlannerTests.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for grouping the edited files of one run by the assembly they resolved to.
+    /// </summary>
+    public class HotReloadFileGroupPlannerTests
+    {
+        /// <summary>
+        /// What: two files of the same assembly land in one group, in input order.
+        /// </summary>
+        [Test]
+        public void Plan_TwoFilesOfOneAssembly_FormsOneGroup()
+        {
+            IReadOnlyList<HotReloadFileGroupPlan> groups = HotReloadFileGroupPlanner.Plan(
+                new List<(int InputIndex, string AssemblyName, string ProjectRelativePath)>
+                {
+                    (0, "AssemblyA", "Assets/Scripts/First.cs"),
+                    (1, "AssemblyA", "Assets/Scripts/Second.cs")
+                });
+
+            Assert.That(groups.Count, Is.EqualTo(1));
+            Assert.That(groups[0].AssemblyName, Is.EqualTo("AssemblyA"));
+            Assert.That(groups[0].InputIndexes, Is.EqualTo(new[] { 0, 1 }));
+        }
+
+        /// <summary>
+        /// What: files of different assemblies form separate groups, ordered by the input index of
+        /// the file that opened each group.
+        /// </summary>
+        [Test]
+        public void Plan_FilesOfDifferentAssemblies_FormsGroupsInInputOrder()
+        {
+            IReadOnlyList<HotReloadFileGroupPlan> groups = HotReloadFileGroupPlanner.Plan(
+                new List<(int InputIndex, string AssemblyName, string ProjectRelativePath)>
+                {
+                    (0, "AssemblyB", "Assets/Scripts/First.cs"),
+                    (1, "AssemblyA", "Assets/Scripts/Second.cs"),
+                    (2, "AssemblyB", "Assets/Scripts/Third.cs")
+                });
+
+            Assert.That(groups.Count, Is.EqualTo(2));
+            Assert.That(groups[0].AssemblyName, Is.EqualTo("AssemblyB"));
+            Assert.That(groups[0].InputIndexes, Is.EqualTo(new[] { 0, 2 }));
+            Assert.That(groups[1].AssemblyName, Is.EqualTo("AssemblyA"));
+            Assert.That(groups[1].InputIndexes, Is.EqualTo(new[] { 1 }));
+        }
+
+        /// <summary>
+        /// What: the same file listed twice opens a second group of that assembly, because a
+        /// repeated input is applied twice and one worker run cannot carry a path twice.
+        /// </summary>
+        [Test]
+        public void Plan_RepeatedProjectRelativePath_OpensASecondGroup()
+        {
+            IReadOnlyList<HotReloadFileGroupPlan> groups = HotReloadFileGroupPlanner.Plan(
+                new List<(int InputIndex, string AssemblyName, string ProjectRelativePath)>
+                {
+                    (0, "AssemblyA", "Assets/Scripts/First.cs"),
+                    (1, "AssemblyA", "Assets/Scripts/Second.cs"),
+                    (2, "AssemblyA", "Assets/Scripts/First.cs")
+                });
+
+            Assert.That(groups.Count, Is.EqualTo(2));
+            Assert.That(groups[0].InputIndexes, Is.EqualTo(new[] { 0, 1 }));
+            Assert.That(groups[1].InputIndexes, Is.EqualTo(new[] { 2 }));
+        }
+
+        /// <summary>
+        /// What: a repeated file joins a new group even when another assembly's file sits between
+        /// the two occurrences, so the group order stays that of the opening files.
+        /// </summary>
+        [Test]
+        public void Plan_RepeatedPathAcrossAnotherAssembly_KeepsGroupOrder()
+        {
+            IReadOnlyList<HotReloadFileGroupPlan> groups = HotReloadFileGroupPlanner.Plan(
+                new List<(int InputIndex, string AssemblyName, string ProjectRelativePath)>
+                {
+                    (0, "AssemblyA", "Assets/Scripts/First.cs"),
+                    (1, "AssemblyA", "Assets/Scripts/Second.cs"),
+                    (2, "AssemblyB", "Assets/Scripts/Third.cs"),
+                    (3, "AssemblyA", "Assets/Scripts/First.cs")
+                });
+
+            Assert.That(groups.Count, Is.EqualTo(3));
+            Assert.That(groups[0].AssemblyName, Is.EqualTo("AssemblyA"));
+            Assert.That(groups[0].InputIndexes, Is.EqualTo(new[] { 0, 1 }));
+            Assert.That(groups[1].AssemblyName, Is.EqualTo("AssemblyB"));
+            Assert.That(groups[1].InputIndexes, Is.EqualTo(new[] { 2 }));
+            Assert.That(groups[2].AssemblyName, Is.EqualTo("AssemblyA"));
+            Assert.That(groups[2].InputIndexes, Is.EqualTo(new[] { 3 }));
+        }
+
+        /// <summary>
+        /// What: an empty run produces no groups.
+        /// </summary>
+        [Test]
+        public void Plan_NoFiles_ReturnsNoGroups()
+        {
+            IReadOnlyList<HotReloadFileGroupPlan> groups = HotReloadFileGroupPlanner.Plan(
+                new List<(int InputIndex, string AssemblyName, string ProjectRelativePath)>());
+
+            Assert.That(groups.Count, Is.EqualTo(0));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadFileGroupPlannerTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadFileGroupPlannerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea6943d2a59024eb58d1ac7c40c7c4cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadGroupFilePathsTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupFilePathsTests.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for resolving a worker row's file identity to the path outcomes report.
+    /// </summary>
+    public class HotReloadGroupFilePathsTests
+    {
+        /// <summary>
+        /// What: each file of a group resolves to its own assembly-resolve path, so an outcome of
+        /// one file is never reported under another file of the same group.
+        /// </summary>
+        [Test]
+        public void ResolveAssemblyResolvePath_TwoFiles_ResolvesEachToItsOwnPath()
+        {
+            HotReloadGroupFilePaths paths = new HotReloadGroupFilePaths(
+                new List<(string ProjectRelativePath, string AssemblyResolvePath)>
+                {
+                    ("Assets/Scripts/First.cs", "Assets/Scripts/First.cs"),
+                    ("Assets/Scripts/Second.cs", "Packages/dev.example/Second.cs")
+                });
+
+            Assert.That(
+                paths.ResolveAssemblyResolvePath("Assets/Scripts/First.cs"),
+                Is.EqualTo("Assets/Scripts/First.cs"));
+            Assert.That(
+                paths.ResolveAssemblyResolvePath("Assets/Scripts/Second.cs"),
+                Is.EqualTo("Packages/dev.example/Second.cs"));
+        }
+
+        /// <summary>
+        /// What: a single-file group resolves its one row set, which is what a run of one edited
+        /// file produces.
+        /// </summary>
+        [Test]
+        public void ForSingleFile_ResolvesThatFile()
+        {
+            HotReloadGroupFilePaths paths = HotReloadGroupFilePaths.ForSingleFile(
+                "Assets/Scripts/Only.cs",
+                "Assets/Scripts/Only.cs");
+
+            Assert.That(
+                paths.ResolveAssemblyResolvePath("Assets/Scripts/Only.cs"),
+                Is.EqualTo("Assets/Scripts/Only.cs"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadGroupFilePathsTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupFilePathsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25652348726a54e9d8fe8da47e31cf0c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -4787,6 +4787,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             {
                 new TransformWorkerSkippedDto
                 {
+                    sourceProjectRelativePath = "Assets/Scripts/Host.cs",
                     method = "Host.Mid()",
                     methodKey = "Host::Mid()",
                     reason = HotReloadConstants.UnavailableAddedCallSkipReason,
@@ -4794,6 +4795,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 },
                 new TransformWorkerSkippedDto
                 {
+                    sourceProjectRelativePath = "Assets/Scripts/Host.cs",
                     method = "Host.Outer()",
                     methodKey = "Host::Outer()",
                     reason = HotReloadConstants.UnavailableAddedCallSkipReason,
@@ -4804,7 +4806,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<HotReloadMethodOutcome> outcomes = HotReloadShimIsolation.CollectRetryOnlySkippedOutcomes(
                 Array.Empty<TransformWorkerSkippedDto>(),
                 retrySkipped,
-                "test.dll",
+                HotReloadGroupFilePaths.ForSingleFile("Assets/Scripts/Host.cs", "test.dll"),
                 HotReloadConstants.VibeLogIsolationTriggerShimCompileFailure,
                 new[] { "Host::Broken()" });
 
@@ -4824,6 +4826,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             {
                 new TransformWorkerSkippedDto
                 {
+                    sourceProjectRelativePath = "Assets/Scripts/Host.cs",
                     method = "Host.Mid()",
                     methodKey = "Host::Mid()",
                     reason = HotReloadConstants.UnavailableAddedCallSkipReason,
@@ -4831,6 +4834,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 },
                 new TransformWorkerSkippedDto
                 {
+                    sourceProjectRelativePath = "Assets/Scripts/Host.cs",
                     method = "Host.Outer()",
                     methodKey = "Host::Outer()",
                     reason = HotReloadConstants.UnavailableAddedCallSkipReason,
@@ -4841,7 +4845,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<HotReloadMethodOutcome> outcomes = HotReloadShimIsolation.CollectRetryOnlySkippedOutcomes(
                 Array.Empty<TransformWorkerSkippedDto>(),
                 retrySkipped,
-                "test.dll",
+                HotReloadGroupFilePaths.ForSingleFile("Assets/Scripts/Host.cs", "test.dll"),
                 HotReloadConstants.VibeLogIsolationTriggerSignatureChangeGate,
                 new[] { "Host::Broken()" });
 
@@ -4861,6 +4865,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             {
                 new TransformWorkerSkippedDto
                 {
+                    sourceProjectRelativePath = "Assets/Scripts/Host.cs",
                     method = "Host.Caller()",
                     methodKey = "Host::Caller()",
                     reason = HotReloadConstants.UnavailableAddedCallSkipReason,
@@ -4871,7 +4876,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<HotReloadMethodOutcome> outcomes = HotReloadShimIsolation.CollectRetryOnlySkippedOutcomes(
                 Array.Empty<TransformWorkerSkippedDto>(),
                 retrySkipped,
-                "test.dll",
+                HotReloadGroupFilePaths.ForSingleFile("Assets/Scripts/Host.cs", "test.dll"),
                 HotReloadConstants.VibeLogIsolationTriggerShimCompileFailure,
                 new[] { "Host::Broken()" });
 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2639,21 +2639,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             };
 
             HotReloadFileProcessResult fileResult =
-                HotReloadEntryApplier.ApplyEntriesAndBuildResult(
+                HotReloadEntryApplier.ApplyGroupAndBuildResults(
                     CreateApplyContext(
                         typeof(HotReloadE2EFixture).Assembly.GetName().Name,
                         projectRelativePath,
-                        workerOutput),
-                    new HotReloadFileSinks(new List<string>(), null),
+                        workerOutput,
+                        entries,
+                        addedFieldNames),
                     HotReloadShimCompileResult.SuccessResult(
                         typeof(HotReloadEntryApplier).Assembly,
                         new byte[] { 1 },
                         Array.Empty<byte>()),
-                    entries,
-                    addedFieldNames,
-                    Array.Empty<string>(),
-                    unchangedMethodCount: 0,
-                    revertedUnchangedCount: 0);
+                    entries)[0];
 
             HotReloadOrchestratorResult result = new HotReloadOrchestratorResult(
                 fileResult.Outcomes,
@@ -2904,32 +2901,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     }
                 }
             };
-            return HotReloadEntryApplier.ApplyEntriesAndBuildResult(
+            return HotReloadEntryApplier.ApplyGroupAndBuildResults(
                 CreateApplyContext(
                     typeof(HotReloadCoreFixture).Assembly.GetName().Name,
                     projectRelativePath,
-                    workerOutput),
-                new HotReloadFileSinks(new List<string>(), null),
+                    workerOutput,
+                    entries,
+                    Array.Empty<string>()),
                 HotReloadShimCompileResult.SuccessResult(
                     typeof(HotReloadOrchestratorTests).Assembly,
                     new byte[] { 1 },
                     Array.Empty<byte>()),
-                entries,
-                Array.Empty<string>(),
-                Array.Empty<string>(),
-                unchangedMethodCount: 0,
-                revertedUnchangedCount: 0);
+                entries)[0];
         }
 
         /// <summary>
-        /// What: builds the apply-pipeline context these direct-apply tests need. The applier
-        /// reads only the assembly name, the file path and the worker output; the remaining
-        /// fields exist to satisfy the context's own preconditions.
+        /// What: builds the one-file group context these direct-apply tests need, and stamps the
+        /// entries with that file so the apply stage can route them. The applier reads only the
+        /// assembly name, the group's single file and the worker output; the remaining fields
+        /// exist to satisfy the context's own preconditions.
         /// </summary>
         private static HotReloadApplyContext CreateApplyContext(
             string assemblyName,
             string projectRelativePath,
-            TransformWorkerOutputDto workerOutput)
+            TransformWorkerOutputDto workerOutput,
+            TransformWorkerEntryDto[] entries,
+            string[] addedFieldNames)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string targetDllPath = Path.Combine(
@@ -2947,11 +2944,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             Assert.That(compilationAssembly, Is.Not.Null, "Compilation assembly missing: " + assemblyName);
+            foreach (TransformWorkerEntryDto entry in entries)
+            {
+                entry.sourceProjectRelativePath = projectRelativePath;
+            }
+
+            HotReloadGroupFile file = new HotReloadGroupFile(
+                projectRelativePath,
+                projectRelativePath,
+                projectRelativePath,
+                assemblyName,
+                compilationAssembly,
+                targetDllPath,
+                projectRoot,
+                new HotReloadFileSinks(new List<string>(), null))
+            {
+                FileOutput = workerOutput.files[0],
+                SnapshotLabels = new HashSet<string>(),
+                SnapshotAddedLabels = new HashSet<string>(),
+                AddedFieldNames = addedFieldNames,
+                AddedConstNames = Array.Empty<string>()
+            };
             return new HotReloadApplyContext(
                 projectRoot,
                 assemblyName,
-                projectRelativePath,
-                projectRelativePath,
                 "direct-apply",
                 compilationAssembly,
                 targetDllPath,
@@ -2964,9 +2980,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     }
                 },
                 workerOutput,
-                workerOutput.files[0],
-                new HashSet<string>(),
-                new HashSet<string>());
+                new[] { file });
         }
 
         private static HotReloadOrchestratorResult ToOrchestratorResult(
@@ -7301,14 +7315,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private static string WriteEditedSource(string fileName, string contents)
         {
-            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
-            string directory = Path.Combine(
-                projectRoot,
-                HotReloadConstants.TestSourcesRelativeDirectory);
-            Directory.CreateDirectory(directory);
-            string path = Path.Combine(directory, fileName);
-            File.WriteAllText(path, contents);
-            return path;
+            return HotReloadTestSourceWriter.WriteEditedSource(fileName, contents);
         }
 
         private static string ResolveSiblingConstDefinitionsPath()

--- a/Assets/Tests/Editor/HotReload/HotReloadSupersededSignatureRecorderTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSupersededSignatureRecorderTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for recording superseded compiled signatures from the entries a file
+    /// actually applied, which a group run must not confuse with the whole run's output.
+    /// </summary>
+    public class HotReloadSupersededSignatureRecorderTests
+    {
+        private const string TypeMetadataName = "Sample.Host";
+        private const string RemovedMethodLabel = "Sample.Host.Scaled(System.Int32)";
+
+        [SetUp]
+        public void SetUp()
+        {
+            HotReloadSupersededSignatureRegistry.ClearAll();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadSupersededSignatureRegistry.ClearAll();
+        }
+
+        /// <summary>
+        /// What: a removed signature whose replacement is among the applied entries is recorded
+        /// with that replacement's display name.
+        /// </summary>
+        [Test]
+        public void RecordFromAppliedEntries_WhenReplacementWasApplied_RecordsTheSupersededSignature()
+        {
+            HotReloadSupersededSignatureRecorder.RecordFromAppliedEntries(
+                new[] { CreateReplacementEntry() },
+                new[] { CreateRemovedSignature() },
+                Array.Empty<string>());
+
+            bool found = HotReloadSupersededSignatureRegistry.TryGetReplacement(
+                RemovedMethodLabel,
+                out string replacementDisplayName);
+
+            Assert.That(found, Is.True);
+            Assert.That(replacementDisplayName, Is.EqualTo(RemovedMethodLabel));
+        }
+
+        /// <summary>
+        /// What: a removed signature is not recorded when its replacement never reached the apply
+        /// stage, which is what happens to a file that isolation dropped while a sibling applied.
+        /// </summary>
+        [Test]
+        public void RecordFromAppliedEntries_WhenReplacementWasNotApplied_RecordsNothing()
+        {
+            HotReloadSupersededSignatureRecorder.RecordFromAppliedEntries(
+                new List<TransformWorkerEntryDto>(),
+                new[] { CreateRemovedSignature() },
+                Array.Empty<string>());
+
+            bool found = HotReloadSupersededSignatureRegistry.TryGetReplacement(
+                RemovedMethodLabel,
+                out string _);
+
+            Assert.That(found, Is.False);
+        }
+
+        /// <summary>
+        /// What: a replacement the signature-change gate refused is not recorded even when the
+        /// entry list still carries it.
+        /// </summary>
+        [Test]
+        public void RecordFromAppliedEntries_WhenReplacementWasGated_RecordsNothing()
+        {
+            TransformWorkerEntryDto entry = CreateReplacementEntry();
+
+            HotReloadSupersededSignatureRecorder.RecordFromAppliedEntries(
+                new[] { entry },
+                new[] { CreateRemovedSignature() },
+                new[] { HotReloadMethodKeys.BuildMethodKey(entry) });
+
+            bool found = HotReloadSupersededSignatureRegistry.TryGetReplacement(
+                RemovedMethodLabel,
+                out string _);
+
+            Assert.That(found, Is.False);
+        }
+
+        private static TransformWorkerEntryDto CreateReplacementEntry()
+        {
+            return new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = "Assets/Scripts/Host.cs",
+                typeMetadataName = TypeMetadataName,
+                methodName = "Scaled",
+                parameterTypeFullNames = new[] { "System.Int32" },
+                genericArity = 0,
+                replacesCompiledMethod = true
+            };
+        }
+
+        private static TransformWorkerRemovedMethodSignatureDto CreateRemovedSignature()
+        {
+            return new TransformWorkerRemovedMethodSignatureDto
+            {
+                typeMetadataName = TypeMetadataName,
+                methodName = "Scaled",
+                parameterTypeFullNames = new[] { "System.Int32" },
+                genericArity = 0
+            };
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSupersededSignatureRecorderTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSupersededSignatureRecorderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ab86523507c94cae94fc89918ac3704
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadTestSourceWriter.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadTestSourceWriter.cs
@@ -1,0 +1,29 @@
+using System.IO;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Writes an edited copy of a fixture source under the hot-reload test-sources directory.
+    /// </summary>
+    /// <remarks>
+    /// Why outside Assets/: an edited copy inside the project would trigger AssetDatabase import
+    /// and a real compile in the middle of a test. Shared so the orchestrator tests and the
+    /// cross-file end-to-end tests write their copies to the same place.
+    /// </remarks>
+    internal static class HotReloadTestSourceWriter
+    {
+        internal static string WriteEditedSource(string fileName, string contents)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, HotReloadConstants.TestSourcesRelativeDirectory);
+            Directory.CreateDirectory(directory);
+            string path = Path.Combine(directory, fileName);
+            File.WriteAllText(path, contents);
+            return path;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadTestSourceWriter.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadTestSourceWriter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6c6343b579e04ffd87ec3da89afb265
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadWorkerRowsByFileTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadWorkerRowsByFileTests.cs
@@ -1,0 +1,151 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for splitting one group worker output into the rows of each edited file.
+    /// </summary>
+    public class HotReloadWorkerRowsByFileTests
+    {
+        private const string FirstPath = "Assets/Scripts/First.cs";
+        private const string SecondPath = "Assets/Scripts/Second.cs";
+
+        /// <summary>
+        /// What: entries, skips and unchanged methods are split by the file each row came from.
+        /// </summary>
+        [Test]
+        public void Build_RowsOfTwoFiles_SplitsEveryRowKindByItsFile()
+        {
+            HotReloadWorkerRowsByFile rows = HotReloadWorkerRowsByFile.Build(
+                CreateOutput(),
+                new List<string> { FirstPath, SecondPath });
+
+            Assert.That(rows.EntriesFor(FirstPath).Count, Is.EqualTo(2));
+            Assert.That(rows.EntriesFor(FirstPath)[0].methodName, Is.EqualTo("FirstA"));
+            Assert.That(rows.EntriesFor(FirstPath)[1].methodName, Is.EqualTo("FirstB"));
+            Assert.That(rows.EntriesFor(SecondPath).Count, Is.EqualTo(1));
+            Assert.That(rows.EntriesFor(SecondPath)[0].methodName, Is.EqualTo("SecondA"));
+
+            Assert.That(rows.SkippedFor(FirstPath).Count, Is.EqualTo(1));
+            Assert.That(rows.SkippedFor(FirstPath)[0].method, Is.EqualTo("First.Skipped"));
+            Assert.That(rows.SkippedFor(SecondPath).Count, Is.EqualTo(0));
+
+            Assert.That(rows.UnchangedFor(SecondPath).Count, Is.EqualTo(1));
+            Assert.That(rows.UnchangedFor(SecondPath)[0].methodName, Is.EqualTo("SecondUnchanged"));
+            Assert.That(rows.UnchangedFor(FirstPath).Count, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: the per-file output of each edited file is reachable by that file's path.
+        /// </summary>
+        [Test]
+        public void Build_FileOutputFor_ReturnsThePerFileRowOfThatFile()
+        {
+            HotReloadWorkerRowsByFile rows = HotReloadWorkerRowsByFile.Build(
+                CreateOutput(),
+                new List<string> { FirstPath, SecondPath });
+
+            Assert.That(rows.FileOutputFor(FirstPath).sourceContentSha256, Is.EqualTo("aaaa"));
+            Assert.That(rows.FileOutputFor(SecondPath).sourceContentSha256, Is.EqualTo("bbbb"));
+        }
+
+        /// <summary>
+        /// What: a file of the group that produced no rows reads back as empty rather than null,
+        /// so callers do not need a null check per row kind.
+        /// </summary>
+        [Test]
+        public void Build_GroupFileWithNoRows_ReturnsEmptyRowLists()
+        {
+            TransformWorkerOutputDto output = new TransformWorkerOutputDto
+            {
+                shimSource = string.Empty,
+                entries = new TransformWorkerEntryDto[0],
+                skipped = new TransformWorkerSkippedDto[0],
+                unchangedMethods = new TransformWorkerUnchangedMethodDto[0],
+                files = new[] { CreateFileOutput(FirstPath, "aaaa") },
+                parseErrors = new string[0],
+                siblingConstDriftWarnings = new string[0]
+            };
+
+            HotReloadWorkerRowsByFile rows = HotReloadWorkerRowsByFile.Build(
+                output,
+                new List<string> { FirstPath });
+
+            Assert.That(rows.EntriesFor(FirstPath), Is.Empty);
+            Assert.That(rows.SkippedFor(FirstPath), Is.Empty);
+            Assert.That(rows.UnchangedFor(FirstPath), Is.Empty);
+        }
+
+        private static TransformWorkerOutputDto CreateOutput()
+        {
+            return new TransformWorkerOutputDto
+            {
+                shimSource = "// shim",
+                entries = new[]
+                {
+                    CreateEntry(FirstPath, "FirstA"),
+                    CreateEntry(SecondPath, "SecondA"),
+                    CreateEntry(FirstPath, "FirstB")
+                },
+                skipped = new[]
+                {
+                    new TransformWorkerSkippedDto
+                    {
+                        sourceProjectRelativePath = FirstPath,
+                        method = "First.Skipped",
+                        reason = "reason"
+                    }
+                },
+                unchangedMethods = new[]
+                {
+                    new TransformWorkerUnchangedMethodDto
+                    {
+                        sourceProjectRelativePath = SecondPath,
+                        typeMetadataName = "SecondType",
+                        methodName = "SecondUnchanged",
+                        parameterTypeFullNames = new string[0]
+                    }
+                },
+                files = new[]
+                {
+                    CreateFileOutput(FirstPath, "aaaa"),
+                    CreateFileOutput(SecondPath, "bbbb")
+                },
+                parseErrors = new string[0],
+                siblingConstDriftWarnings = new string[0]
+            };
+        }
+
+        private static TransformWorkerEntryDto CreateEntry(string projectRelativePath, string methodName)
+        {
+            return new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = projectRelativePath,
+                typeMetadataName = "SomeType",
+                methodName = methodName,
+                parameterTypeFullNames = new string[0]
+            };
+        }
+
+        private static TransformWorkerFileOutputDto CreateFileOutput(
+            string projectRelativePath,
+            string sourceContentSha256)
+        {
+            return new TransformWorkerFileOutputDto
+            {
+                projectRelativePath = projectRelativePath,
+                sourceContentSha256 = sourceContentSha256,
+                parseErrors = new string[0],
+                declarationDriftWarnings = new string[0],
+                removedMembers = new TransformWorkerRemovedMemberDto[0],
+                removedMethodSignatures = new TransformWorkerRemovedMethodSignatureDto[0],
+                addedFieldNames = new string[0],
+                addedConstNames = new string[0]
+            };
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadWorkerRowsByFileTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadWorkerRowsByFileTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 05af7a94067e0486bb8b21c3974b9239
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyContext.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyContext.cs
@@ -7,66 +7,70 @@ using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// The read-only inputs of one file's apply pipeline, fixed once the worker has run.
+    /// The read-only inputs of one group's apply pipeline, fixed once the worker has run.
     /// </summary>
     /// <remarks>
     /// Why: the gate, the first shim compile and the entry applier each took the same dozen
     /// values as separate parameters, so every stage signature grew with the pipeline. Passing
     /// them as one object keeps a stage's parameter list to what that stage itself computes.
+    /// The file-specific half lives in HotReloadGroupFile, one per edited file of the group.
     /// </remarks>
     internal sealed class HotReloadApplyContext
     {
         internal HotReloadApplyContext(
             string projectRoot,
             string assemblyName,
-            string assemblyResolvePath,
-            string projectRelativePath,
             string correlationId,
             UnityCompilationAssembly compilationAssembly,
             string targetDllPath,
             string[] defines,
             TransformWorkerInputDto workerInput,
             TransformWorkerOutputDto workerOutput,
-            TransformWorkerFileOutputDto fileOutput,
-            HashSet<string> snapshotLabels,
-            HashSet<string> snapshotAddedLabels)
+            IReadOnlyList<HotReloadGroupFile> files)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be empty.");
             Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be empty.");
-            Debug.Assert(!string.IsNullOrEmpty(assemblyResolvePath), "assemblyResolvePath must not be empty.");
-            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
             Debug.Assert(!string.IsNullOrEmpty(targetDllPath), "targetDllPath must not be empty.");
             Debug.Assert(compilationAssembly != null, "compilationAssembly must not be null.");
             Debug.Assert(defines != null, "defines must not be null.");
             Debug.Assert(workerInput != null, "workerInput must not be null.");
             Debug.Assert(workerOutput != null, "workerOutput must not be null.");
-            Debug.Assert(fileOutput != null, "fileOutput must not be null.");
-            Debug.Assert(snapshotLabels != null, "snapshotLabels must not be null.");
-            Debug.Assert(snapshotAddedLabels != null, "snapshotAddedLabels must not be null.");
+            Debug.Assert(files != null && files.Count > 0, "A group must hold a file.");
 
             ProjectRoot = projectRoot;
             AssemblyName = assemblyName;
-            AssemblyResolvePath = assemblyResolvePath;
-            ProjectRelativePath = projectRelativePath;
             CorrelationId = correlationId;
             CompilationAssembly = compilationAssembly;
             TargetDllPath = targetDllPath;
             Defines = defines;
             WorkerInput = workerInput;
             WorkerOutput = workerOutput;
-            FileOutput = fileOutput;
-            SnapshotLabels = snapshotLabels;
-            SnapshotAddedLabels = snapshotAddedLabels;
-            GroupFilePaths = HotReloadGroupFilePaths.ForSingleFile(projectRelativePath, assemblyResolvePath);
+            Files = files;
+
+            List<(string ProjectRelativePath, string AssemblyResolvePath)> filePaths =
+                new List<(string ProjectRelativePath, string AssemblyResolvePath)>(files.Count);
+            List<string> projectRelativePaths = new List<string>(files.Count);
+            List<TransformWorkerRemovedMethodSignatureDto> removedMethodSignatures =
+                new List<TransformWorkerRemovedMethodSignatureDto>();
+            foreach (HotReloadGroupFile file in files)
+            {
+                Debug.Assert(file.FileOutput != null, "Every file must carry its worker output row.");
+                filePaths.Add((file.ProjectRelativePath, file.AssemblyResolvePath));
+                projectRelativePaths.Add(file.ProjectRelativePath);
+                if (file.FileOutput.removedMethodSignatures != null)
+                {
+                    removedMethodSignatures.AddRange(file.FileOutput.removedMethodSignatures);
+                }
+            }
+
+            GroupFilePaths = new HotReloadGroupFilePaths(filePaths);
+            ProjectRelativePaths = projectRelativePaths;
+            RemovedMethodSignatures = removedMethodSignatures.ToArray();
         }
 
         internal string ProjectRoot { get; }
 
         internal string AssemblyName { get; }
-
-        internal string AssemblyResolvePath { get; }
-
-        internal string ProjectRelativePath { get; }
 
         internal string CorrelationId { get; }
 
@@ -80,16 +84,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal TransformWorkerOutputDto WorkerOutput { get; }
 
-        // The row set of ProjectRelativePath inside WorkerOutput.
-        internal TransformWorkerFileOutputDto FileOutput { get; }
-
-        // Patch labels already active for this file when its apply started. Snapshotted because
-        // a multi-file run mutates the ledgers between files.
-        internal HashSet<string> SnapshotLabels { get; }
-
-        internal HashSet<string> SnapshotAddedLabels { get; }
+        // The edited files of this group, in the order they were sent to the worker.
+        internal IReadOnlyList<HotReloadGroupFile> Files { get; }
 
         // Resolves the file identity a worker row carries into the path its outcomes report.
         internal HotReloadGroupFilePaths GroupFilePaths { get; }
+
+        internal IReadOnlyList<string> ProjectRelativePaths { get; }
+
+        // Every signature the group's files removed. Why joined: the call-site scan that gates a
+        // replacement runs once for the group, so it must see what the whole edit took away.
+        internal TransformWorkerRemovedMethodSignatureDto[] RemovedMethodSignatures { get; }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyContext.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyContext.cs
@@ -57,6 +57,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             FileOutput = fileOutput;
             SnapshotLabels = snapshotLabels;
             SnapshotAddedLabels = snapshotAddedLabels;
+            GroupFilePaths = HotReloadGroupFilePaths.ForSingleFile(projectRelativePath, assemblyResolvePath);
         }
 
         internal string ProjectRoot { get; }
@@ -87,5 +88,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal HashSet<string> SnapshotLabels { get; }
 
         internal HashSet<string> SnapshotAddedLabels { get; }
+
+        // Resolves the file identity a worker row carries into the path its outcomes report.
+        internal HotReloadGroupFilePaths GroupFilePaths { get; }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSiblingSourceDetector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedSiblingSourceDetector.cs
@@ -14,21 +14,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         /// <summary>
         /// Returns changed sibling absolute paths for <paramref name="sourceFiles"/>, excluding
-        /// <paramref name="editedProjectRelativePath"/>. Missing snapshots or DLLs yield an empty
+        /// <paramref name="editedProjectRelativePaths"/>. Missing snapshots or DLLs yield an empty
         /// result with no extra warning — the existing missing-baseline path already covers that.
         /// </summary>
+        /// <remarks>
+        /// Why a collection of edited paths: one run transforms every edited file of an assembly
+        /// together, and a file edited in the same run is not a drifted sibling of its own group.
+        /// </remarks>
         internal static HotReloadChangedSiblingScanResult Detect(
             string projectRoot,
             string assemblyName,
             string targetDllPath,
             string[] sourceFiles,
-            string editedProjectRelativePath)
+            IReadOnlyCollection<string> editedProjectRelativePaths)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty.");
             Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
             Debug.Assert(
-                !string.IsNullOrEmpty(editedProjectRelativePath),
-                "editedProjectRelativePath must not be null or empty.");
+                editedProjectRelativePaths != null && editedProjectRelativePaths.Count > 0,
+                "editedProjectRelativePaths must not be empty.");
 
             if (string.IsNullOrEmpty(targetDllPath) || !File.Exists(targetDllPath))
             {
@@ -46,7 +50,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 projectRoot,
                 assemblyName + "-" + mvid,
                 sourceFiles,
-                editedProjectRelativePath);
+                editedProjectRelativePaths);
         }
 
         // Why a directory-name entry: EditMode tests plant a snapshot tree without a real DLL.
@@ -54,15 +58,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string projectRoot,
             string assemblySnapshotDirectoryName,
             string[] sourceFiles,
-            string editedProjectRelativePath)
+            IReadOnlyCollection<string> editedProjectRelativePaths)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty.");
             Debug.Assert(
                 !string.IsNullOrEmpty(assemblySnapshotDirectoryName),
                 "assemblySnapshotDirectoryName must not be null or empty.");
             Debug.Assert(
-                !string.IsNullOrEmpty(editedProjectRelativePath),
-                "editedProjectRelativePath must not be null or empty.");
+                editedProjectRelativePaths != null && editedProjectRelativePaths.Count > 0,
+                "editedProjectRelativePaths must not be empty.");
 
             if (sourceFiles == null || sourceFiles.Length == 0)
             {
@@ -73,7 +77,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 projectRoot,
                 assemblySnapshotDirectoryName,
                 sourceFiles,
-                editedProjectRelativePath);
+                editedProjectRelativePaths);
             List<string> changedSiblingAbsolutePaths = new List<string>(
                 sourceScan.ChangedProjectRelativePaths.Count);
             for (int index = 0; index < sourceScan.ChangedProjectRelativePaths.Count; index++)
@@ -104,14 +108,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 projectRoot,
                 assemblySnapshotDirectoryName,
                 sourceFiles,
-                excludedProjectRelativePath: null);
+                excludedProjectRelativePaths: null);
         }
 
         private static HotReloadChangedSourceScanResult DetectChangedFromSnapshotDirectory(
             string projectRoot,
             string assemblySnapshotDirectoryName,
             string[] sourceFiles,
-            string excludedProjectRelativePath)
+            IReadOnlyCollection<string> excludedProjectRelativePaths)
         {
             string snapshotDirectory = Path.Combine(
                 projectRoot,
@@ -134,7 +138,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     projectRoot,
                     snapshotDirectory,
                     sourceFiles[index],
-                    excludedProjectRelativePath);
+                    excludedProjectRelativePaths);
                 if (changedPath != null)
                 {
                     changedProjectRelativePaths.Add(changedPath);
@@ -148,7 +152,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string projectRoot,
             string snapshotDirectory,
             string projectRelativeSourcePath,
-            string excludedProjectRelativePath)
+            IReadOnlyCollection<string> excludedProjectRelativePaths)
         {
             if (string.IsNullOrEmpty(projectRelativeSourcePath))
             {
@@ -156,8 +160,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             string normalizedRelativePath = projectRelativeSourcePath.Replace('\\', '/');
-            if (!string.IsNullOrEmpty(excludedProjectRelativePath)
-                && IsSameProjectRelativePath(normalizedRelativePath, excludedProjectRelativePath))
+            if (IsExcludedProjectRelativePath(normalizedRelativePath, excludedProjectRelativePaths))
             {
                 return null;
             }
@@ -214,6 +217,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             return Path.GetFullPath(
                 Path.Combine(projectRoot, projectRelativePath.Replace('/', Path.DirectorySeparatorChar)));
+        }
+
+        private static bool IsExcludedProjectRelativePath(
+            string normalizedRelativePath,
+            IReadOnlyCollection<string> excludedProjectRelativePaths)
+        {
+            if (excludedProjectRelativePaths == null)
+            {
+                return false;
+            }
+
+            foreach (string excludedProjectRelativePath in excludedProjectRelativePaths)
+            {
+                if (!string.IsNullOrEmpty(excludedProjectRelativePath)
+                    && IsSameProjectRelativePath(normalizedRelativePath, excludedProjectRelativePath))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static bool IsSameProjectRelativePath(string left, string right)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
@@ -15,217 +15,57 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class HotReloadEntryApplier
     {
-        // Why preflight before BeginFileGeneration: a match/bind/CheckPatchable failure
-        // must not replace the file's shim or added-member generation.
-        internal static HotReloadFileProcessResult ApplyEntriesAndBuildResult(
+        /// <summary>
+        /// Applies the group's entries file by file against the one compiled shim assembly, and
+        /// returns one result per file in the order the files were sent to the worker.
+        /// </summary>
+        /// <remarks>
+        /// Why per file: the shim assembly is shared, but a generation, an added-field ledger and
+        /// an apply result all belong to a single file, and a file whose entries cannot be
+        /// resolved must not stop its siblings from being applied.
+        /// </remarks>
+        internal static IReadOnlyList<HotReloadFileProcessResult> ApplyGroupAndBuildResults(
             HotReloadApplyContext context,
-            HotReloadFileSinks sinks,
             HotReloadShimCompileResult compileResult,
-            TransformWorkerEntryDto[] entriesToPatch,
-            string[] addedFieldNames,
-            string[] addedConstNames,
-            int unchangedMethodCount,
-            int revertedUnchangedCount)
+            TransformWorkerEntryDto[] entriesToPatch)
         {
             Debug.Assert(context != null, "context must not be null.");
-            Debug.Assert(sinks != null, "sinks must not be null.");
-            HotReloadEntryResolution.Result resolution = HotReloadEntryResolution.ResolveEntries(
-                context.AssemblyName,
-                context.AssemblyResolvePath,
-                compileResult.Assembly,
-                entriesToPatch);
-            if (!resolution.AllResolved)
+            Debug.Assert(compileResult != null, "compileResult must not be null.");
+            Debug.Assert(entriesToPatch != null, "entriesToPatch must not be null.");
+
+            Dictionary<string, List<TransformWorkerEntryDto>> entriesByFile =
+                HotReloadWorkerRowsByFile.GroupEntriesBySourceFile(entriesToPatch, context.ProjectRelativePaths);
+            // Why once for the group: every shim type of the group lives in this one assembly, so
+            // binding per file would re-run the same binders and hide which file first failed.
+            Dictionary<string, string> bindFailures = BindShimAccessors(compileResult.Assembly);
+            List<HotReloadFileProcessResult> results =
+                new List<HotReloadFileProcessResult>(context.Files.Count);
+            foreach (HotReloadGroupFile file in context.Files)
             {
-                sinks.Outcomes.AddRange(resolution.FailureOutcomes);
-                return FinishFileResult(
-                    sinks.Outcomes,
-                    sinks.Warnings,
-                    context.SnapshotLabels,
-                    context.SnapshotAddedLabels,
-                    context.ProjectRelativePath,
-                    context.WorkerOutput,
-                    context.FileOutput.sourceContentSha256,
-                    sinks.SuppressedPausePointIds,
-                    sinks.RetargetedPausePointIds,
-                    unchangedMethodCount,
-                    patchedCount: 0,
-                    addedFieldNames: null,
-                    addedConstNames: null,
-                    revertedUnchangedCount: revertedUnchangedCount);
-            }
-
-            HotReloadFileGenerations.BeginFileGeneration(
-                context.ProjectRelativePath,
-                compileResult.AssemblyBytes,
-                compileResult.PdbBytes,
-                compileResult.Assembly);
-            CommitAddedFieldsForFile(context.ProjectRelativePath, addedFieldNames);
-            // Why bind again: phase 1 already bound to detect failures; phase 2 keeps the
-            // historical apply order so a successful preflight still runs Bind before Patch.
-            BindShimAccessors(compileResult.Assembly);
-            List<string> inlineRiskMethodLabels = new List<string>();
-            int patchedCount = ApplyResolvedEntries(
-                resolution.ResolvedEntries,
-                entriesToPatch,
-                context.AssemblyResolvePath,
-                context.ProjectRelativePath,
-                sinks.Outcomes,
-                sinks.Warnings,
-                inlineRiskMethodLabels,
-                sinks.SuppressedPausePointIds,
-                sinks.RetargetedPausePointIds,
-                context.AssemblyName,
-                sinks.OneShotCallerNoteCandidates);
-
-            return FinishFileResult(
-                sinks.Outcomes,
-                sinks.Warnings,
-                context.SnapshotLabels,
-                context.SnapshotAddedLabels,
-                context.ProjectRelativePath,
-                context.WorkerOutput,
-                context.FileOutput.sourceContentSha256,
-                sinks.SuppressedPausePointIds,
-                sinks.RetargetedPausePointIds,
-                unchangedMethodCount,
-                patchedCount,
-                addedFieldNames,
-                addedConstNames,
-                inlineRiskMethodLabels,
-                revertedUnchangedCount);
-        }
-
-        private static HotReloadFileProcessResult FinishFileResult(
-            List<HotReloadMethodOutcome> outcomes,
-            List<string> warnings,
-            HashSet<string> snapshotLabels,
-            HashSet<string> snapshotAddedLabels,
-            string projectRelativePath,
-            TransformWorkerOutputDto workerOutput,
-            string sourceContentSha256,
-            List<string> suppressedPausePointIds,
-            List<string> retargetedPausePointIds,
-            int unchangedMethodCount,
-            int patchedCount,
-            string[] addedFieldNames,
-            string[] addedConstNames = null,
-            List<string> inlineRiskMethodLabels = null,
-            int revertedUnchangedCount = 0)
-        {
-            // Why here as well as the empty-entries return: apply can drop a still-declared
-            // added member by not re-Registering it after BeginFileGeneration.
-            HotReloadAppliedSourceLifecycle.AppendDeactivatedPatchesWarning(
-                warnings,
-                snapshotLabels,
-                snapshotAddedLabels,
-                projectRelativePath,
-                workerOutput,
-                outcomes);
-            return new HotReloadFileProcessResult(
-                outcomes,
-                warnings,
-                patchedCount,
-                suppressedPausePointIds,
-                inlineRiskMethodLabels ?? new List<string>(),
-                unchangedMethodCount,
-                retargetedPausePointIds,
-                addedFieldNames,
-                sourceContentSha256,
-                addedConstNames,
-                revertedUnchangedCount);
-        }
-
-        private static int ApplyResolvedEntries(
-            IReadOnlyList<HotReloadEntryResolution.ResolvedEntry> resolvedEntries,
-            TransformWorkerEntryDto[] entriesToPatch,
-            string assemblyResolvePath,
-            string projectRelativePath,
-            List<HotReloadMethodOutcome> outcomes,
-            List<string> warnings,
-            List<string> inlineRiskMethodLabels,
-            List<string> suppressedPausePointIds,
-            List<string> retargetedPausePointIds,
-            string assemblyName,
-            List<HotReloadOneShotCallerNoteEnricher.Candidate> oneShotCallerNoteCandidates)
-        {
-            int patchedCount = 0;
-            int appliedThisRun = 0;
-            for (int index = 0; index < resolvedEntries.Count; index++)
-            {
-                HotReloadMethodOutcome outcome = ApplyResolvedEntry(
-                    resolvedEntries[index],
-                    projectRelativePath,
-                    inlineRiskMethodLabels,
-                    suppressedPausePointIds,
-                    retargetedPausePointIds);
-                outcomes.Add(outcome);
-                AppendOneShotCallerNoteCandidate(
-                    resolvedEntries[index],
-                    outcome,
-                    assemblyName,
-                    oneShotCallerNoteCandidates);
-                if (outcome.Kind == HotReloadMethodOutcomeKind.Patched
-                    || outcome.Kind == HotReloadMethodOutcomeKind.Added)
+                if (file.SkipApply)
                 {
-                    appliedThisRun++;
-                    if (outcome.Kind == HotReloadMethodOutcomeKind.Patched)
-                    {
-                        patchedCount++;
-                    }
-
+                    results.Add(HotReloadFileEntryApplier.BuildUnappliedResult(file));
                     continue;
                 }
 
-                if (outcome.Kind != HotReloadMethodOutcomeKind.Failed)
+                List<TransformWorkerEntryDto> fileEntries = entriesByFile[file.ProjectRelativePath];
+                if (fileEntries.Count == 0)
                 {
+                    HotReloadFileEntryApplier.ClearFileGeneration(context, file);
+                    results.Add(HotReloadFileEntryApplier.BuildUnappliedResult(file));
                     continue;
                 }
 
-                HotReloadEntryResolution.AppendAtomicSkipOutcomes(
-                    outcomes,
-                    entriesToPatch,
-                    index + 1,
-                    assemblyResolvePath);
-                if (appliedThisRun >= 1)
-                {
-                    warnings.Add(
-                        string.Format(
-                            HotReloadConstants.PartialApplyAfterPatchEngineFailureWarningFormat,
-                            appliedThisRun));
-                }
-
-                break;
+                results.Add(
+                    HotReloadFileEntryApplier.ApplyFileAndBuildResult(
+                        context,
+                        file,
+                        compileResult,
+                        fileEntries.ToArray(),
+                        bindFailures));
             }
 
-            return patchedCount;
-        }
-
-        private static void AppendOneShotCallerNoteCandidate(
-            HotReloadEntryResolution.ResolvedEntry resolved,
-            HotReloadMethodOutcome outcome,
-            string assemblyName,
-            List<HotReloadOneShotCallerNoteEnricher.Candidate> candidates)
-        {
-            if (candidates == null)
-            {
-                return;
-            }
-
-            if ((outcome.Kind != HotReloadMethodOutcomeKind.Patched
-                    && outcome.Kind != HotReloadMethodOutcomeKind.Added)
-                || !string.IsNullOrEmpty(outcome.LifecycleNote))
-            {
-                return;
-            }
-
-            HotReloadCallSiteScanner.CompiledMethodIdentity identity =
-                new HotReloadCallSiteScanner.CompiledMethodIdentity(
-                    assemblyName,
-                    resolved.Entry.typeMetadataName,
-                    resolved.Entry.methodName,
-                    resolved.Entry.parameterTypeFullNames ?? Array.Empty<string>(),
-                    resolved.Entry.genericArity);
-            candidates.Add(new HotReloadOneShotCallerNoteEnricher.Candidate(identity, outcome));
+            return results;
         }
 
         // Why only here and the empty-entries deactivation: a failed worker or shim compile
@@ -281,115 +121,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return revertedCount;
-        }
-
-        private static HotReloadMethodOutcome ApplyResolvedEntry(
-            HotReloadEntryResolution.ResolvedEntry resolved,
-            string projectRelativePath,
-            List<string> inlineRiskMethodLabels,
-            List<string> suppressedPausePointIds,
-            List<string> retargetedPausePointIds)
-        {
-            if (resolved.IsAddedMethod)
-            {
-                HotReloadAddedMemberRegistry.Register(
-                    projectRelativePath,
-                    resolved.MethodLabel,
-                    resolved.ShimMethod,
-                    resolved.FilePath);
-                return HotReloadMethodOutcome.Added(
-                    resolved.MethodLabel,
-                    resolved.FilePath,
-                    resolved.Entry.lifecycleNote);
-            }
-
-            // Why before Apply: Apply notifies OnHotReloadPatchStateChanged(true) after the
-            // ledger write; registration must already expose this method's shim for retarget.
-            HotReloadShimRegistry.RegisterMethod(
-                projectRelativePath,
-                resolved.OriginalMethod,
-                new HotReloadShimRegistry.MethodEntry(
-                    resolved.ShimMethod,
-                    resolved.PatchShape == HotReloadPatchShape.Delegation,
-                    resolved.Entry.sourceStartLine,
-                    resolved.Entry.sourceEndLine));
-            HotReloadPatchResult patchResult = HotReloadPatcher.Apply(
-                resolved.OriginalMethod,
-                resolved.ShimMethod,
-                resolved.PatchShape,
-                projectRelativePath);
-            if (!patchResult.Success)
-            {
-                HotReloadShimRegistry.RemoveMethod(resolved.OriginalMethod);
-                return HotReloadMethodOutcome.Failed(
-                    resolved.MethodLabel,
-                    patchResult.ErrorMessage,
-                    resolved.FilePath);
-            }
-
-            AppendPausePointTransitionIds(
-                resolved.OriginalMethod,
-                suppressedPausePointIds,
-                retargetedPausePointIds);
-
-            // Inline risk is flagged per method but reported as one aggregated warning so
-            // Warnings stay readable when many tiny methods are patched together.
-            if (patchResult.InlineRiskDetected)
-            {
-                inlineRiskMethodLabels.Add(resolved.MethodLabel);
-            }
-
-            return HotReloadMethodOutcome.Patched(
-                resolved.MethodLabel,
-                resolved.FilePath,
-                resolved.Entry.lifecycleNote);
-        }
-
-        // What: after Apply (+ retarget handler), splits armed markers into retargeted vs suppressed.
-        // Expired skips are recorded as a pending-drain event inside SourcePausePointPatcher and
-        // surfaced from HotReloadTools.BuildApplyResponse (same pattern as line-drift warnings).
-        private static void AppendPausePointTransitionIds(
-            MethodBase method,
-            List<string> suppressedPausePointIds,
-            List<string> retargetedPausePointIds)
-        {
-            IReadOnlyList<string> armedIds =
-                HotReloadPausePointCoordination.GetArmedMarkerIdsOnMethod?.Invoke(method);
-            if (armedIds == null || armedIds.Count == 0)
-            {
-                return;
-            }
-
-            IReadOnlyList<string> suppressedIds =
-                HotReloadPausePointCoordination.GetSuppressedMarkerIdsOnMethod?.Invoke(method)
-                ?? Array.Empty<string>();
-
-            // The same method can be patched twice in one run (duplicate file inputs,
-            // re-applied edits); the aggregated warning must list each marker id once.
-            foreach (string armedId in armedIds)
-            {
-                bool suppressed = false;
-                for (int index = 0; index < suppressedIds.Count; index++)
-                {
-                    if (suppressedIds[index] == armedId)
-                    {
-                        suppressed = true;
-                        break;
-                    }
-                }
-
-                if (suppressed)
-                {
-                    if (!suppressedPausePointIds.Contains(armedId))
-                    {
-                        suppressedPausePointIds.Add(armedId);
-                    }
-                }
-                else if (!retargetedPausePointIds.Contains(armedId))
-                {
-                    retargetedPausePointIds.Add(armedId);
-                }
-            }
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryResolution.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryResolution.cs
@@ -14,18 +14,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class HotReloadEntryResolution
     {
+        // Why bindFailures is passed in: one shim assembly serves every file of a group, so its
+        // accessor binders run once for the group instead of once per file.
         internal static Result ResolveEntries(
             string assemblyName,
             string filePath,
             Assembly shimAssembly,
-            TransformWorkerEntryDto[] entriesToPatch)
+            TransformWorkerEntryDto[] entriesToPatch,
+            Dictionary<string, string> bindFailures)
         {
             Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
             Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be empty.");
             Debug.Assert(shimAssembly != null, "shimAssembly must not be null.");
             Debug.Assert(entriesToPatch != null, "entriesToPatch must not be null.");
+            Debug.Assert(bindFailures != null, "bindFailures must not be null.");
 
-            Dictionary<string, string> bindFailures = HotReloadEntryApplier.BindShimAccessors(shimAssembly);
             List<ResolvedEntry> resolvedEntries = new List<ResolvedEntry>();
             for (int index = 0; index < entriesToPatch.Length; index++)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileAtomicIsolationPlan.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileAtomicIsolationPlan.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Decides which edited files of a group a failed shim compile takes down, what those files
+    /// report, and which method keys the isolation retry must leave out.
+    /// </summary>
+    /// <remarks>
+    /// Why whole files (not single methods): the group compiles one shim assembly, so a method
+    /// whose body does not compile is dropped together with everything else its file contributed.
+    /// Applying a file's remaining methods without the failed one would leave that file half
+    /// applied, which is the atomicity rule a single-file run already followed.
+    /// Why the two exclusion branches: dropping whole files is what lets the other files of the
+    /// group still be applied. When no file survives there is nothing to save, so the narrower
+    /// method-and-caller exclusion is kept — it is what makes the retry report a caller of a
+    /// broken added method as such instead of as one more file-atomic skip.
+    /// </remarks>
+    internal sealed class HotReloadFileAtomicIsolationPlan
+    {
+        private readonly HashSet<string> failedFiles;
+
+        private HotReloadFileAtomicIsolationPlan(
+            HashSet<string> failedFiles,
+            bool allFilesFailed,
+            string[] excludedMethodKeys,
+            string[] excludedAddedMethodKeys,
+            IReadOnlyList<TransformWorkerEntryDto> callerEntries,
+            Dictionary<string, List<HotReloadMethodOutcome>> failedOutcomesByFile,
+            Dictionary<string, List<HotReloadMethodOutcome>> atomicSkipOutcomesByFile)
+        {
+            this.failedFiles = failedFiles;
+            AllFilesFailed = allFilesFailed;
+            ExcludedMethodKeys = excludedMethodKeys;
+            ExcludedAddedMethodKeys = excludedAddedMethodKeys;
+            CallerEntries = callerEntries;
+            FailedOutcomesByFile = failedOutcomesByFile;
+            AtomicSkipOutcomesByFile = atomicSkipOutcomesByFile;
+        }
+
+        // The project-relative paths of the files a compile error was attributed to.
+        internal IReadOnlyCollection<string> FailedFiles => failedFiles;
+
+        internal bool AllFilesFailed { get; }
+
+        internal bool IsFailedFile(string projectRelativePath)
+        {
+            return failedFiles.Contains(projectRelativePath);
+        }
+
+        internal string[] ExcludedMethodKeys { get; }
+
+        internal string[] ExcludedAddedMethodKeys { get; }
+
+        // Entries that call a failed added method and are therefore excluded by name. Empty
+        // unless every file failed, because a file-wide exclusion already covers its callers.
+        internal IReadOnlyList<TransformWorkerEntryDto> CallerEntries { get; }
+
+        // Failed outcomes of the attributed methods, keyed by their file.
+        internal IReadOnlyDictionary<string, List<HotReloadMethodOutcome>> FailedOutcomesByFile { get; }
+
+        // Skipped outcomes of the remaining entries of a failed file, keyed by that file. Empty
+        // when every file failed: there the retry still runs, and only the entries it re-emitted
+        // are file-atomic skips — the ones it dropped report the reason the retry gave them.
+        internal IReadOnlyDictionary<string, List<HotReloadMethodOutcome>> AtomicSkipOutcomesByFile { get; }
+
+        internal static HotReloadFileAtomicIsolationPlan Build(
+            TransformWorkerEntryDto[] entries,
+            HotReloadShimErrorAttribution.ShimCompileErrorAttribution attribution,
+            TransformWorkerSkippedDto[] skipped,
+            HotReloadGroupFilePaths groupFilePaths,
+            IReadOnlyCollection<string> groupPaths)
+        {
+            Debug.Assert(entries != null, "entries must not be null.");
+            Debug.Assert(attribution != null, "attribution must not be null.");
+            Debug.Assert(groupFilePaths != null, "groupFilePaths must not be null.");
+            Debug.Assert(groupPaths != null && groupPaths.Count > 0, "A group must hold a file.");
+
+            HashSet<string> failedFiles = CollectFailedFiles(attribution.FailedEntries);
+            bool allFilesFailed = failedFiles.Count >= groupPaths.Count;
+            Dictionary<string, List<HotReloadMethodOutcome>> failedOutcomesByFile = BuildFailedOutcomesByFile(
+                attribution,
+                skipped,
+                groupFilePaths);
+            if (allFilesFailed)
+            {
+                HotReloadShimIsolation.IsolationExclusions exclusions =
+                    HotReloadShimIsolation.BuildIsolationExclusions(attribution.FailedEntries, entries);
+                return new HotReloadFileAtomicIsolationPlan(
+                    failedFiles,
+                    true,
+                    exclusions.ExcludedMethodKeys,
+                    exclusions.ExcludedAddedMethodKeys,
+                    exclusions.CallerEntries,
+                    failedOutcomesByFile,
+                    new Dictionary<string, List<HotReloadMethodOutcome>>(StringComparer.Ordinal));
+            }
+
+            HashSet<TransformWorkerEntryDto> failedEntries =
+                new HashSet<TransformWorkerEntryDto>(attribution.FailedEntries);
+            HashSet<string> excludedMethodKeys = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<string> excludedAddedMethodKeys = new HashSet<string>(StringComparer.Ordinal);
+            Dictionary<string, List<HotReloadMethodOutcome>> atomicSkipOutcomesByFile =
+                new Dictionary<string, List<HotReloadMethodOutcome>>(StringComparer.Ordinal);
+            foreach (TransformWorkerEntryDto entry in entries)
+            {
+                string sourceFile = entry.sourceProjectRelativePath;
+                if (!failedFiles.Contains(sourceFile))
+                {
+                    continue;
+                }
+
+                string methodKey = HotReloadMethodKeys.BuildMethodKey(entry);
+                if (entry.patchKind == HotReloadConstants.PatchKindAddedMethod)
+                {
+                    // Why a separate set: dropping a healthy added shim through excludedMethodKeys
+                    // leaves its callers with CS0103. The added-method set removes the declaration
+                    // as well, so the worker skips those callers instead of emitting broken bodies.
+                    excludedAddedMethodKeys.Add(methodKey);
+                }
+                else
+                {
+                    excludedMethodKeys.Add(methodKey);
+                }
+
+                if (failedEntries.Contains(entry))
+                {
+                    continue;
+                }
+
+                AppendOutcome(
+                    atomicSkipOutcomesByFile,
+                    sourceFile,
+                    HotReloadMethodOutcome.Skipped(
+                        HotReloadMethodKeys.FormatMethodLabelParts(
+                            entry.typeMetadataName,
+                            entry.methodName,
+                            entry.parameterTypeFullNames ?? Array.Empty<string>(),
+                            entry.genericArity),
+                        HotReloadConstants.AtomicFileSkipReason,
+                        groupFilePaths.ResolveAssemblyResolvePath(sourceFile)));
+            }
+
+            return new HotReloadFileAtomicIsolationPlan(
+                failedFiles,
+                false,
+                ToArray(excludedMethodKeys),
+                ToArray(excludedAddedMethodKeys),
+                Array.Empty<TransformWorkerEntryDto>(),
+                failedOutcomesByFile,
+                atomicSkipOutcomesByFile);
+        }
+
+        // Flattens per-file outcomes in the order of the group's files, for the stages that route
+        // outcomes by the file path each outcome already carries.
+        internal static List<HotReloadMethodOutcome> CollectOutcomes(
+            IReadOnlyDictionary<string, List<HotReloadMethodOutcome>> outcomesByFile,
+            IReadOnlyList<string> groupPaths)
+        {
+            Debug.Assert(outcomesByFile != null, "outcomesByFile must not be null.");
+            Debug.Assert(groupPaths != null, "groupPaths must not be null.");
+
+            List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
+            foreach (string groupPath in groupPaths)
+            {
+                if (outcomesByFile.TryGetValue(groupPath, out List<HotReloadMethodOutcome> fileOutcomes))
+                {
+                    outcomes.AddRange(fileOutcomes);
+                }
+            }
+
+            return outcomes;
+        }
+
+        private static Dictionary<string, List<HotReloadMethodOutcome>> BuildFailedOutcomesByFile(
+            HotReloadShimErrorAttribution.ShimCompileErrorAttribution attribution,
+            TransformWorkerSkippedDto[] skipped,
+            HotReloadGroupFilePaths groupFilePaths)
+        {
+            Dictionary<string, List<HotReloadMethodOutcome>> failedOutcomesByFile =
+                new Dictionary<string, List<HotReloadMethodOutcome>>(StringComparer.Ordinal);
+            foreach (TransformWorkerEntryDto failedEntry in attribution.FailedEntries)
+            {
+                List<string> entryErrorMessages = attribution.ErrorMessagesByEntry[failedEntry];
+                AppendOutcome(
+                    failedOutcomesByFile,
+                    failedEntry.sourceProjectRelativePath,
+                    HotReloadMethodOutcome.Failed(
+                        HotReloadMethodKeys.FormatMethodLabelParts(
+                            failedEntry.typeMetadataName,
+                            failedEntry.methodName,
+                            failedEntry.parameterTypeFullNames ?? Array.Empty<string>(),
+                            failedEntry.genericArity),
+                        HotReloadSkippedMemberCompileNote.AppendNotes(
+                            HotReloadShimCompiler.ComposeShimCompileFailureMessage(entryErrorMessages),
+                            entryErrorMessages,
+                            skipped),
+                        groupFilePaths.ResolveAssemblyResolvePath(failedEntry.sourceProjectRelativePath)));
+            }
+
+            return failedOutcomesByFile;
+        }
+
+        private static HashSet<string> CollectFailedFiles(
+            IReadOnlyList<TransformWorkerEntryDto> failedEntries)
+        {
+            HashSet<string> failedFiles = new HashSet<string>(StringComparer.Ordinal);
+            foreach (TransformWorkerEntryDto failedEntry in failedEntries)
+            {
+                Debug.Assert(
+                    !string.IsNullOrEmpty(failedEntry.sourceProjectRelativePath),
+                    "An attributed entry must name the source file it came from.");
+                failedFiles.Add(failedEntry.sourceProjectRelativePath);
+            }
+
+            return failedFiles;
+        }
+
+        private static void AppendOutcome(
+            Dictionary<string, List<HotReloadMethodOutcome>> outcomesByFile,
+            string sourceFile,
+            HotReloadMethodOutcome outcome)
+        {
+            if (!outcomesByFile.TryGetValue(sourceFile, out List<HotReloadMethodOutcome> outcomes))
+            {
+                outcomes = new List<HotReloadMethodOutcome>();
+                outcomesByFile[sourceFile] = outcomes;
+            }
+
+            outcomes.Add(outcome);
+        }
+
+        private static string[] ToArray(HashSet<string> keys)
+        {
+            string[] array = new string[keys.Count];
+            keys.CopyTo(array);
+            return array;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileAtomicIsolationPlan.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileAtomicIsolationPlan.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e69d96e811744bb2960fc661a19046f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
@@ -74,12 +74,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadFileGenerations.ListActiveAddedMethodKeys(file.ProjectRelativePath);
             HotReloadOrchestratorLog.LogHotReloadEmptyEntriesClear(addedLabelsAtClear, context.CorrelationId);
             HotReloadAddedMemberRegistry.BeginFileGeneration(file.ProjectRelativePath);
-            HotReloadEntryApplier.CommitAddedFieldsForFile(
-                file.ProjectRelativePath,
-                file.FileOutput.addedFieldNames);
+            // Why AddedFieldNames first: a retry (gate or isolation) replaces this file's added
+            // field names, and committing the first-pass names would resurrect a field the
+            // retry no longer emits. The worker row is the first-pass fallback.
+            string[] addedFieldNames = file.AddedFieldNames ?? file.FileOutput.addedFieldNames;
+            HotReloadEntryApplier.CommitAddedFieldsForFile(file.ProjectRelativePath, addedFieldNames);
             // Why recorded: a file that only declares an added member has no entry of its own,
             // yet a sibling file's applied body uses that field, so the run must report it.
-            file.ClearedAddedFieldNames = file.FileOutput.addedFieldNames;
+            file.ClearedAddedFieldNames = addedFieldNames;
             // Why after the clear: a still-declared added method can be worker-skipped
             // (virtual/generic), leaving entries empty while the registry drop is real.
             HotReloadAppliedSourceLifecycle.AppendDeactivatedPatchesWarning(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
@@ -1,0 +1,348 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Applies one file of a group: preflight resolution, generation start, added-field commit,
+    /// Harmony patch/register, and that file's result.
+    /// </summary>
+    internal static class HotReloadFileEntryApplier
+    {
+        // Why preflight before BeginFileGeneration: a match/bind/CheckPatchable failure
+        // must not replace this file's shim or added-member generation.
+        internal static HotReloadFileProcessResult ApplyFileAndBuildResult(
+            HotReloadApplyContext context,
+            HotReloadGroupFile file,
+            HotReloadShimCompileResult compileResult,
+            TransformWorkerEntryDto[] fileEntries,
+            Dictionary<string, string> bindFailures)
+        {
+            Debug.Assert(context != null, "context must not be null.");
+            Debug.Assert(file != null, "file must not be null.");
+            Debug.Assert(fileEntries.Length > 0, "An applied file must hold an entry.");
+
+            HotReloadFileSinks sinks = file.Sinks;
+            HotReloadEntryResolution.Result resolution = HotReloadEntryResolution.ResolveEntries(
+                context.AssemblyName,
+                file.AssemblyResolvePath,
+                compileResult.Assembly,
+                fileEntries,
+                bindFailures);
+            if (!resolution.AllResolved)
+            {
+                sinks.Outcomes.AddRange(resolution.FailureOutcomes);
+                return FinishFileResult(context, file, patchedCount: 0, applied: false);
+            }
+
+            HotReloadFileGenerations.BeginFileGeneration(
+                file.ProjectRelativePath,
+                compileResult.AssemblyBytes,
+                compileResult.PdbBytes,
+                compileResult.Assembly);
+            HotReloadEntryApplier.CommitAddedFieldsForFile(file.ProjectRelativePath, file.AddedFieldNames);
+            List<string> inlineRiskMethodLabels = new List<string>();
+            int patchedCount = ApplyResolvedEntries(
+                resolution.ResolvedEntries,
+                fileEntries,
+                file,
+                context.AssemblyName,
+                inlineRiskMethodLabels);
+
+            return FinishFileResult(context, file, patchedCount, applied: true, inlineRiskMethodLabels);
+        }
+
+        /// <summary>
+        /// Drops the file's stale added members when the run left it with no entry to patch.
+        /// </summary>
+        /// <remarks>
+        /// Why not HotReloadFileGenerations.BeginFileGeneration: this file contributed no body to
+        /// the shim assembly, so there are no bytes to register a shim generation with. Only the
+        /// added-member side has stale rows to drop.
+        /// </remarks>
+        internal static void ClearFileGeneration(HotReloadApplyContext context, HotReloadGroupFile file)
+        {
+            Debug.Assert(context != null, "context must not be null.");
+            Debug.Assert(file != null, "file must not be null.");
+
+            IReadOnlyList<string> addedLabelsAtClear =
+                HotReloadFileGenerations.ListActiveAddedMethodKeys(file.ProjectRelativePath);
+            HotReloadOrchestratorLog.LogHotReloadEmptyEntriesClear(addedLabelsAtClear, context.CorrelationId);
+            HotReloadAddedMemberRegistry.BeginFileGeneration(file.ProjectRelativePath);
+            HotReloadEntryApplier.CommitAddedFieldsForFile(
+                file.ProjectRelativePath,
+                file.FileOutput.addedFieldNames);
+            // Why recorded: a file that only declares an added member has no entry of its own,
+            // yet a sibling file's applied body uses that field, so the run must report it.
+            file.ClearedAddedFieldNames = file.FileOutput.addedFieldNames;
+            // Why after the clear: a still-declared added method can be worker-skipped
+            // (virtual/generic), leaving entries empty while the registry drop is real.
+            HotReloadAppliedSourceLifecycle.AppendDeactivatedPatchesWarning(
+                file.Sinks.Warnings,
+                file.SnapshotLabels,
+                file.SnapshotAddedLabels,
+                file.ProjectRelativePath,
+                context.WorkerOutput,
+                file.Sinks.Outcomes);
+        }
+
+        /// <summary>
+        /// The result of a file the group never applied: a group-level failure, a preflight
+        /// failure of another stage, or a file left with no entry to patch. It reports added
+        /// field names only when the clear path committed them.
+        /// </summary>
+        internal static HotReloadFileProcessResult BuildUnappliedResult(HotReloadGroupFile file)
+        {
+            Debug.Assert(file != null, "file must not be null.");
+
+            HotReloadFileSinks sinks = file.Sinks;
+            return new HotReloadFileProcessResult(
+                sinks.Outcomes,
+                sinks.Warnings,
+                0,
+                sinks.SuppressedPausePointIds,
+                new List<string>(),
+                file.UnchangedMethodCount,
+                sinks.RetargetedPausePointIds,
+                addedFieldNames: file.ClearedAddedFieldNames,
+                sourceContentSha256: file.FileOutput != null ? file.FileOutput.sourceContentSha256 : null,
+                revertedUnchangedCount: file.RevertedUnchangedCount);
+        }
+
+        private static HotReloadFileProcessResult FinishFileResult(
+            HotReloadApplyContext context,
+            HotReloadGroupFile file,
+            int patchedCount,
+            bool applied,
+            List<string> inlineRiskMethodLabels = null)
+        {
+            HotReloadFileSinks sinks = file.Sinks;
+            // Why here as well as the empty-entries return: apply can drop a still-declared
+            // added member by not re-Registering it after BeginFileGeneration.
+            HotReloadAppliedSourceLifecycle.AppendDeactivatedPatchesWarning(
+                sinks.Warnings,
+                file.SnapshotLabels,
+                file.SnapshotAddedLabels,
+                file.ProjectRelativePath,
+                context.WorkerOutput,
+                sinks.Outcomes);
+            return new HotReloadFileProcessResult(
+                sinks.Outcomes,
+                sinks.Warnings,
+                patchedCount,
+                sinks.SuppressedPausePointIds,
+                inlineRiskMethodLabels ?? new List<string>(),
+                file.UnchangedMethodCount,
+                sinks.RetargetedPausePointIds,
+                applied ? file.AddedFieldNames : null,
+                file.FileOutput.sourceContentSha256,
+                applied ? file.AddedConstNames : null,
+                file.RevertedUnchangedCount);
+        }
+
+        private static int ApplyResolvedEntries(
+            IReadOnlyList<HotReloadEntryResolution.ResolvedEntry> resolvedEntries,
+            TransformWorkerEntryDto[] entriesToPatch,
+            HotReloadGroupFile file,
+            string assemblyName,
+            List<string> inlineRiskMethodLabels)
+        {
+            HotReloadFileSinks sinks = file.Sinks;
+            List<HotReloadMethodOutcome> outcomes = sinks.Outcomes;
+            List<string> warnings = sinks.Warnings;
+            int patchedCount = 0;
+            int appliedThisRun = 0;
+            for (int index = 0; index < resolvedEntries.Count; index++)
+            {
+                HotReloadMethodOutcome outcome = ApplyResolvedEntry(
+                    resolvedEntries[index],
+                    file.ProjectRelativePath,
+                    inlineRiskMethodLabels,
+                    sinks.SuppressedPausePointIds,
+                    sinks.RetargetedPausePointIds);
+                outcomes.Add(outcome);
+                AppendOneShotCallerNoteCandidate(
+                    resolvedEntries[index],
+                    outcome,
+                    assemblyName,
+                    sinks.OneShotCallerNoteCandidates);
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Patched
+                    || outcome.Kind == HotReloadMethodOutcomeKind.Added)
+                {
+                    appliedThisRun++;
+                    if (outcome.Kind == HotReloadMethodOutcomeKind.Patched)
+                    {
+                        patchedCount++;
+                    }
+
+                    continue;
+                }
+
+                if (outcome.Kind != HotReloadMethodOutcomeKind.Failed)
+                {
+                    continue;
+                }
+
+                HotReloadEntryResolution.AppendAtomicSkipOutcomes(
+                    outcomes,
+                    entriesToPatch,
+                    index + 1,
+                    file.AssemblyResolvePath);
+                if (appliedThisRun >= 1)
+                {
+                    warnings.Add(
+                        string.Format(
+                            HotReloadConstants.PartialApplyAfterPatchEngineFailureWarningFormat,
+                            appliedThisRun));
+                }
+
+                break;
+            }
+
+            return patchedCount;
+        }
+
+        private static void AppendOneShotCallerNoteCandidate(
+            HotReloadEntryResolution.ResolvedEntry resolved,
+            HotReloadMethodOutcome outcome,
+            string assemblyName,
+            List<HotReloadOneShotCallerNoteEnricher.Candidate> candidates)
+        {
+            if (candidates == null)
+            {
+                return;
+            }
+
+            if ((outcome.Kind != HotReloadMethodOutcomeKind.Patched
+                    && outcome.Kind != HotReloadMethodOutcomeKind.Added)
+                || !string.IsNullOrEmpty(outcome.LifecycleNote))
+            {
+                return;
+            }
+
+            HotReloadCallSiteScanner.CompiledMethodIdentity identity =
+                new HotReloadCallSiteScanner.CompiledMethodIdentity(
+                    assemblyName,
+                    resolved.Entry.typeMetadataName,
+                    resolved.Entry.methodName,
+                    resolved.Entry.parameterTypeFullNames ?? Array.Empty<string>(),
+                    resolved.Entry.genericArity);
+            candidates.Add(new HotReloadOneShotCallerNoteEnricher.Candidate(identity, outcome));
+        }
+
+        private static HotReloadMethodOutcome ApplyResolvedEntry(
+            HotReloadEntryResolution.ResolvedEntry resolved,
+            string projectRelativePath,
+            List<string> inlineRiskMethodLabels,
+            List<string> suppressedPausePointIds,
+            List<string> retargetedPausePointIds)
+        {
+            if (resolved.IsAddedMethod)
+            {
+                HotReloadAddedMemberRegistry.Register(
+                    projectRelativePath,
+                    resolved.MethodLabel,
+                    resolved.ShimMethod,
+                    resolved.FilePath);
+                return HotReloadMethodOutcome.Added(
+                    resolved.MethodLabel,
+                    resolved.FilePath,
+                    resolved.Entry.lifecycleNote);
+            }
+
+            // Why before Apply: Apply notifies OnHotReloadPatchStateChanged(true) after the
+            // ledger write; registration must already expose this method's shim for retarget.
+            HotReloadShimRegistry.RegisterMethod(
+                projectRelativePath,
+                resolved.OriginalMethod,
+                new HotReloadShimRegistry.MethodEntry(
+                    resolved.ShimMethod,
+                    resolved.PatchShape == HotReloadPatchShape.Delegation,
+                    resolved.Entry.sourceStartLine,
+                    resolved.Entry.sourceEndLine));
+            HotReloadPatchResult patchResult = HotReloadPatcher.Apply(
+                resolved.OriginalMethod,
+                resolved.ShimMethod,
+                resolved.PatchShape,
+                projectRelativePath);
+            if (!patchResult.Success)
+            {
+                HotReloadShimRegistry.RemoveMethod(resolved.OriginalMethod);
+                return HotReloadMethodOutcome.Failed(
+                    resolved.MethodLabel,
+                    patchResult.ErrorMessage,
+                    resolved.FilePath);
+            }
+
+            AppendPausePointTransitionIds(
+                resolved.OriginalMethod,
+                suppressedPausePointIds,
+                retargetedPausePointIds);
+
+            // Inline risk is flagged per method but reported as one aggregated warning so
+            // Warnings stay readable when many tiny methods are patched together.
+            if (patchResult.InlineRiskDetected)
+            {
+                inlineRiskMethodLabels.Add(resolved.MethodLabel);
+            }
+
+            return HotReloadMethodOutcome.Patched(
+                resolved.MethodLabel,
+                resolved.FilePath,
+                resolved.Entry.lifecycleNote);
+        }
+
+        // What: after Apply (+ retarget handler), splits armed markers into retargeted vs suppressed.
+        // Expired skips are recorded as a pending-drain event inside SourcePausePointPatcher and
+        // surfaced from HotReloadTools.BuildApplyResponse (same pattern as line-drift warnings).
+        private static void AppendPausePointTransitionIds(
+            MethodBase method,
+            List<string> suppressedPausePointIds,
+            List<string> retargetedPausePointIds)
+        {
+            IReadOnlyList<string> armedIds =
+                HotReloadPausePointCoordination.GetArmedMarkerIdsOnMethod?.Invoke(method);
+            if (armedIds == null || armedIds.Count == 0)
+            {
+                return;
+            }
+
+            IReadOnlyList<string> suppressedIds =
+                HotReloadPausePointCoordination.GetSuppressedMarkerIdsOnMethod?.Invoke(method)
+                ?? Array.Empty<string>();
+
+            // The same method can be patched twice in one run (duplicate file inputs,
+            // re-applied edits); the aggregated warning must list each marker id once.
+            foreach (string armedId in armedIds)
+            {
+                bool suppressed = false;
+                for (int index = 0; index < suppressedIds.Count; index++)
+                {
+                    if (suppressedIds[index] == armedId)
+                    {
+                        suppressed = true;
+                        break;
+                    }
+                }
+
+                if (suppressed)
+                {
+                    if (!suppressedPausePointIds.Contains(armedId))
+                    {
+                        suppressedPausePointIds.Add(armedId);
+                    }
+                }
+                else if (!retargetedPausePointIds.Contains(armedId))
+                {
+                    retargetedPausePointIds.Add(armedId);
+                }
+            }
+        }
+
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94368447c97c547139f070a72bb51f79
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileGroupPlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileGroupPlanner.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// One group of edited files that a single worker run and a single shim assembly cover:
+    /// the files of a run that resolved to the same compilation assembly.
+    /// </summary>
+    internal sealed class HotReloadFileGroupPlan
+    {
+        public string AssemblyName { get; }
+
+        /// <summary>Indexes into the run's file list, in input order.</summary>
+        public IReadOnlyList<int> InputIndexes { get; }
+
+        public HotReloadFileGroupPlan(string assemblyName, IReadOnlyList<int> inputIndexes)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be empty.");
+            Debug.Assert(inputIndexes != null && inputIndexes.Count > 0, "A group must hold a file.");
+            AssemblyName = assemblyName;
+            InputIndexes = inputIndexes;
+        }
+    }
+
+    /// <summary>
+    /// Groups the edited files of one run by the assembly they resolved to, so each group can be
+    /// transformed in one worker run and hosted by one shim assembly.
+    /// </summary>
+    internal static class HotReloadFileGroupPlanner
+    {
+        public static IReadOnlyList<HotReloadFileGroupPlan> Plan(
+            IReadOnlyList<(int InputIndex, string AssemblyName, string ProjectRelativePath)> files)
+        {
+            Debug.Assert(files != null, "files must not be null.");
+
+            List<GroupBuilder> builders = new List<GroupBuilder>();
+            foreach ((int InputIndex, string AssemblyName, string ProjectRelativePath) file in files)
+            {
+                Debug.Assert(!string.IsNullOrEmpty(file.AssemblyName), "assemblyName must not be empty.");
+                Debug.Assert(
+                    !string.IsNullOrEmpty(file.ProjectRelativePath),
+                    "projectRelativePath must not be empty.");
+
+                GroupBuilder builder = FindOpenGroup(builders, file.AssemblyName, file.ProjectRelativePath);
+                if (builder == null)
+                {
+                    builder = new GroupBuilder(file.AssemblyName);
+                    builders.Add(builder);
+                }
+
+                builder.Add(file.InputIndex, file.ProjectRelativePath);
+            }
+
+            List<HotReloadFileGroupPlan> groups = new List<HotReloadFileGroupPlan>();
+            foreach (GroupBuilder builder in builders)
+            {
+                groups.Add(builder.Build());
+            }
+
+            return groups;
+        }
+
+        // The most recent group of this assembly that can still take the file. Why the most recent
+        // one only: a repeated input path is applied twice, and one worker run cannot carry the
+        // same path twice, so a repeat has to open a new group rather than join an earlier one.
+        private static GroupBuilder FindOpenGroup(
+            List<GroupBuilder> builders,
+            string assemblyName,
+            string projectRelativePath)
+        {
+            for (int index = builders.Count - 1; index >= 0; index--)
+            {
+                GroupBuilder builder = builders[index];
+                if (!string.Equals(builder.AssemblyName, assemblyName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                return builder.Contains(projectRelativePath) ? null : builder;
+            }
+
+            return null;
+        }
+
+        private sealed class GroupBuilder
+        {
+            private readonly List<int> inputIndexes = new List<int>();
+            private readonly HashSet<string> projectRelativePaths =
+                new HashSet<string>(StringComparer.Ordinal);
+
+            public string AssemblyName { get; }
+
+            public GroupBuilder(string assemblyName)
+            {
+                AssemblyName = assemblyName;
+            }
+
+            public bool Contains(string projectRelativePath)
+            {
+                return projectRelativePaths.Contains(projectRelativePath);
+            }
+
+            public void Add(int inputIndex, string projectRelativePath)
+            {
+                inputIndexes.Add(inputIndex);
+                projectRelativePaths.Add(projectRelativePath);
+            }
+
+            public HotReloadFileGroupPlan Build()
+            {
+                return new HotReloadFileGroupPlan(AssemblyName, inputIndexes);
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileGroupPlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileGroupPlanner.cs
@@ -87,8 +87,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private sealed class GroupBuilder
         {
             private readonly List<int> inputIndexes = new List<int>();
+            // Why platform-aware: on Windows two spellings that differ only in case name the
+            // same physical file, and one worker run cannot parse the same source twice.
             private readonly HashSet<string> projectRelativePaths =
-                new HashSet<string>(StringComparer.Ordinal);
+                new HashSet<string>(HotReloadSourcePathNormalizer.ProjectRelativePathComparer());
 
             public string AssemblyName { get; }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileGroupPlanner.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileGroupPlanner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f684e7ea9bbda42349957a37ca0e4818
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCompileResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCompileResult.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// What the group's shim compile left for the apply stage: the entries to patch against the
+    /// compiled shim assembly, or nothing at all when every file already reported its result.
+    /// </summary>
+    internal sealed class HotReloadGroupCompileResult
+    {
+        private HotReloadGroupCompileResult(
+            TransformWorkerEntryDto[] entriesToPatch,
+            HotReloadShimCompileResult compileResult)
+        {
+            EntriesToPatch = entriesToPatch;
+            CompileResult = compileResult;
+        }
+
+        // False when the outcomes of every file are already in their sinks: the group cleared
+        // its generations, failed, or produced no entry to patch.
+        internal bool HasEntriesToApply => EntriesToPatch != null;
+
+        internal TransformWorkerEntryDto[] EntriesToPatch { get; }
+
+        internal HotReloadShimCompileResult CompileResult { get; }
+
+        internal static HotReloadGroupCompileResult NothingToApply()
+        {
+            return new HotReloadGroupCompileResult(null, null);
+        }
+
+        internal static HotReloadGroupCompileResult Apply(
+            TransformWorkerEntryDto[] entriesToPatch,
+            HotReloadShimCompileResult compileResult)
+        {
+            Debug.Assert(entriesToPatch != null, "entriesToPatch must not be null.");
+            Debug.Assert(entriesToPatch.Length > 0, "An apply must hold an entry.");
+            Debug.Assert(compileResult != null, "compileResult must not be null.");
+            return new HotReloadGroupCompileResult(entriesToPatch, compileResult);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCompileResult.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCompileResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fbd74148ba51546f3b64a8a976a0a022
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupFile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupFile.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+
+using UnityEngine;
+
+using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// One edited file inside a group: what the run resolved for it, where its results go, and
+    /// the per-file findings the group pipeline fills in as it proceeds.
+    /// </summary>
+    /// <remarks>
+    /// Why per file (not per run): a group is transformed and compiled as a whole, but the unit
+    /// that gets applied and reported is still the single file, so every stage needs the file its
+    /// rows belong to. The assembly-level fields are repeated per file because assembly resolution
+    /// runs before the run knows which files group together.
+    /// </remarks>
+    internal sealed class HotReloadGroupFile
+    {
+        internal HotReloadGroupFile(
+            string assemblyResolvePath,
+            string workerSourcePath,
+            string projectRelativePath,
+            string assemblyName,
+            UnityCompilationAssembly compilationAssembly,
+            string targetDllPath,
+            string projectRoot,
+            HotReloadFileSinks sinks)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assemblyResolvePath), "assemblyResolvePath must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(workerSourcePath), "workerSourcePath must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be empty.");
+            Debug.Assert(compilationAssembly != null, "compilationAssembly must not be null.");
+            Debug.Assert(!string.IsNullOrEmpty(targetDllPath), "targetDllPath must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be empty.");
+            Debug.Assert(sinks != null, "sinks must not be null.");
+
+            AssemblyResolvePath = assemblyResolvePath;
+            WorkerSourcePath = workerSourcePath;
+            ProjectRelativePath = projectRelativePath;
+            AssemblyName = assemblyName;
+            CompilationAssembly = compilationAssembly;
+            TargetDllPath = targetDllPath;
+            ProjectRoot = projectRoot;
+            Sinks = sinks;
+        }
+
+        // The path the caller asked to reload, used as the outcome file path.
+        internal string AssemblyResolvePath { get; }
+
+        // The path the worker reads the edited text from; a test override copy may differ.
+        internal string WorkerSourcePath { get; }
+
+        internal string ProjectRelativePath { get; }
+
+        internal string AssemblyName { get; }
+
+        internal UnityCompilationAssembly CompilationAssembly { get; }
+
+        internal string TargetDllPath { get; }
+
+        internal string ProjectRoot { get; }
+
+        internal HotReloadFileSinks Sinks { get; }
+
+        // Verified snapshot text of this file, or null when it has no baseline.
+        internal string SnapshotSource { get; set; }
+
+        // Patch labels already active for this file when the group's apply started. Snapshotted
+        // because a run mutates the ledgers between files.
+        internal HashSet<string> SnapshotLabels { get; set; }
+
+        internal HashSet<string> SnapshotAddedLabels { get; set; }
+
+        // Set when a group-level stage already failed this file, so the apply loop must leave
+        // its generations alone and keep the patches of the previous run in place.
+        internal bool SkipApply { get; set; }
+
+        // This file's row set inside the group worker output.
+        internal TransformWorkerFileOutputDto FileOutput { get; set; }
+
+        internal int UnchangedMethodCount { get; set; }
+
+        internal int RevertedUnchangedCount { get; set; }
+
+        // Added field and const display names to commit for this file, as resolved by the stage
+        // that produced the entries actually applied (first pass, gate retry or isolation retry).
+        internal string[] AddedFieldNames { get; set; }
+
+        internal string[] AddedConstNames { get; set; }
+
+        // Added field names this file actually committed while its generation was cleared,
+        // so the run reports what the ledger now holds. Why only that path: a file the group
+        // never applied (a group-level failure, a preflight failure) committed nothing, and
+        // reporting names it did not write would make the response disagree with the ledger.
+        internal string[] ClearedAddedFieldNames { get; set; }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupFile.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupFile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a634eedd6d549466181e4b97c65b1d2a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupFilePaths.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupFilePaths.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Resolves the file identity a worker row carries into the path outcomes report for it.
+    /// </summary>
+    /// <remarks>
+    /// Why a resolver (not one path per stage): a group run returns rows of several files, so a
+    /// stage that stamps outcomes with one path would report every skip and failure under
+    /// whichever file happened to be handed to it.
+    /// </remarks>
+    internal sealed class HotReloadGroupFilePaths
+    {
+        private readonly Dictionary<string, string> assemblyResolvePathsByFile;
+        private readonly string firstAssemblyResolvePath;
+
+        internal HotReloadGroupFilePaths(
+            IReadOnlyList<(string ProjectRelativePath, string AssemblyResolvePath)> files)
+        {
+            Debug.Assert(files != null && files.Count > 0, "A group must hold a file.");
+
+            assemblyResolvePathsByFile = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach ((string ProjectRelativePath, string AssemblyResolvePath) file in files)
+            {
+                Debug.Assert(
+                    !string.IsNullOrEmpty(file.ProjectRelativePath),
+                    "projectRelativePath must not be empty.");
+                Debug.Assert(
+                    !string.IsNullOrEmpty(file.AssemblyResolvePath),
+                    "assemblyResolvePath must not be empty.");
+                assemblyResolvePathsByFile[file.ProjectRelativePath] = file.AssemblyResolvePath;
+            }
+
+            firstAssemblyResolvePath = files[0].AssemblyResolvePath;
+        }
+
+        internal static HotReloadGroupFilePaths ForSingleFile(
+            string projectRelativePath,
+            string assemblyResolvePath)
+        {
+            return new HotReloadGroupFilePaths(
+                new List<(string ProjectRelativePath, string AssemblyResolvePath)>
+                {
+                    (projectRelativePath, assemblyResolvePath)
+                });
+        }
+
+        internal string ResolveAssemblyResolvePath(string sourceProjectRelativePath)
+        {
+            if (sourceProjectRelativePath != null
+                && assemblyResolvePathsByFile.TryGetValue(
+                    sourceProjectRelativePath,
+                    out string assemblyResolvePath))
+            {
+                return assemblyResolvePath;
+            }
+
+            // Why fall back to the first file of the group: an outcome without a file path loses
+            // the only location the reader has. Every row of a group run names a file of that
+            // group, so reaching here means the row set and the group disagree.
+            Debug.Assert(false, "A worker row must name a file of the group: " + sourceProjectRelativePath);
+            return firstAssemblyResolvePath;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupFilePaths.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupFilePaths.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c0ea2c05b8334ed1b97e8b1693cf762
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupOutcomeRouter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupOutcomeRouter.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Delivers the outcomes a group-level stage produced to the sinks of the file each outcome
+    /// belongs to, and reports a group-wide failure once per file.
+    /// </summary>
+    /// <remarks>
+    /// Why by file path: the gate, the shim compile and the isolation retry all see the whole
+    /// group, so they return one flat list. The reported unit stays the single file, and the file
+    /// each outcome names is the path it already carries.
+    /// </remarks>
+    internal static class HotReloadGroupOutcomeRouter
+    {
+        internal static void AppendByFilePath(
+            IReadOnlyList<HotReloadGroupFile> files,
+            IReadOnlyList<HotReloadMethodOutcome> outcomes)
+        {
+            Debug.Assert(files != null && files.Count > 0, "A group must hold a file.");
+            if (outcomes == null || outcomes.Count == 0)
+            {
+                return;
+            }
+
+            Dictionary<string, HotReloadGroupFile> filesByAssemblyResolvePath =
+                new Dictionary<string, HotReloadGroupFile>(StringComparer.Ordinal);
+            foreach (HotReloadGroupFile file in files)
+            {
+                filesByAssemblyResolvePath[file.AssemblyResolvePath] = file;
+            }
+
+            foreach (HotReloadMethodOutcome outcome in outcomes)
+            {
+                if (outcome.FilePath != null
+                    && filesByAssemblyResolvePath.TryGetValue(
+                        outcome.FilePath,
+                        out HotReloadGroupFile owningFile))
+                {
+                    owningFile.Sinks.Outcomes.Add(outcome);
+                    continue;
+                }
+
+                // Why the first file rather than dropping the row: an outcome the reader never
+                // sees is worse than one filed under a sibling of the same group, and reaching
+                // here means a stage stamped a path the group does not contain.
+                Debug.Assert(false, "A group outcome must name a file of the group: " + outcome.FilePath);
+                files[0].Sinks.Outcomes.Add(outcome);
+            }
+        }
+
+        // Why one row per file: a stage that ran for the whole group cannot say which file broke,
+        // and a run response lists results per file, so a single row would leave the other files
+        // of the group looking untouched.
+        internal static void AppendGroupFailure(
+            IReadOnlyList<HotReloadGroupFile> files,
+            string methodLabel,
+            string reason)
+        {
+            Debug.Assert(files != null && files.Count > 0, "A group must hold a file.");
+
+            foreach (HotReloadGroupFile file in files)
+            {
+                file.Sinks.Outcomes.Add(
+                    HotReloadMethodOutcome.Failed(methodLabel, reason, file.AssemblyResolvePath));
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupOutcomeRouter.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupOutcomeRouter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aea7927326a754ad2876f33e972e7379
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -141,7 +141,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why after apply: earlier returns (gate fail, shim compile, coverage loss)
             // never applied the replacement, so leftover Active rows must not claim they
             // were superseded.
-            RecordSupersededSignaturesAfterApply(results, context, gateResult.GatedReplacementMethodKeys);
+            RecordSupersededSignaturesAfterApply(
+                results,
+                context,
+                compile.EntriesToPatch,
+                gateResult.GatedReplacementMethodKeys);
             return results;
         }
 
@@ -310,23 +314,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
+        // Why per file: a group applies file by file, so only the files that actually patched
+        // something may claim their removed signatures were superseded, and only through the
+        // entries that reached Harmony.
         private static void RecordSupersededSignaturesAfterApply(
             IReadOnlyList<HotReloadFileProcessResult> results,
             HotReloadApplyContext context,
+            TransformWorkerEntryDto[] appliedEntries,
             IReadOnlyCollection<string> gatedReplacementMethodKeys)
         {
-            foreach (HotReloadFileProcessResult result in results)
+            Debug.Assert(
+                results.Count == context.Files.Count,
+                "A group must report one result per edited file.");
+            Dictionary<string, List<TransformWorkerEntryDto>> appliedEntriesByFile =
+                HotReloadWorkerRowsByFile.GroupEntriesBySourceFile(appliedEntries, context.ProjectRelativePaths);
+            for (int index = 0; index < results.Count; index++)
             {
-                if (!HasAppliedChange(result.Outcomes))
+                if (!HasAppliedChange(results[index].Outcomes))
                 {
                     continue;
                 }
 
-                HotReloadSupersededSignatureRecorder.RecordFromWorkerOutput(
-                    context.WorkerOutput,
-                    context.RemovedMethodSignatures,
+                HotReloadGroupFile file = context.Files[index];
+                HotReloadSupersededSignatureRecorder.RecordFromAppliedEntries(
+                    appliedEntriesByFile[file.ProjectRelativePath],
+                    file.FileOutput.removedMethodSignatures ?? Array.Empty<TransformWorkerRemovedMethodSignatureDto>(),
                     gatedReplacementMethodKeys);
-                return;
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -1,0 +1,372 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Runs one assembly group through the pipeline: one worker run, one shim compile, and one
+    /// apply per edited file of the group.
+    /// </summary>
+    /// <remarks>
+    /// Why a group is the unit: the edited files of an assembly are transformed into a single
+    /// shim assembly, so a body in one file can call a method or field another file of the same
+    /// edit added. The reported and applied unit stays the single file.
+    /// </remarks>
+    internal static class HotReloadGroupProcessor
+    {
+        internal static async Task<IReadOnlyList<HotReloadFileProcessResult>> ProcessGroupAsync(
+            IReadOnlyList<HotReloadGroupFile> files,
+            string correlationId,
+            CancellationToken ct)
+        {
+            Debug.Assert(files != null && files.Count > 0, "A group must hold a file.");
+
+            HotReloadGroupFile firstFile = files[0];
+            // Application.dataPath and the ledgers require the Unity main thread.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+            SnapshotGroupState(files);
+
+            HotReloadChangedSiblingScanResult siblingScan = HotReloadChangedSiblingSourceDetector.Detect(
+                firstFile.ProjectRoot,
+                firstFile.AssemblyName,
+                firstFile.TargetDllPath,
+                firstFile.CompilationAssembly.sourceFiles,
+                CollectProjectRelativePaths(files));
+            if (!string.IsNullOrEmpty(siblingScan.ScanLimitWarning))
+            {
+                firstFile.Sinks.SiblingDerivedWarnings.Add(siblingScan.ScanLimitWarning);
+            }
+
+            TransformWorkerInputDto workerInput = BuildWorkerInput(files, siblingScan);
+            TransformWorkerClientResult workerResult =
+                await TransformWorkerClient.RunAsync(workerInput, ct).ConfigureAwait(false);
+            HotReloadOrchestratorLog.LogHotReloadWorkerResult(workerResult, correlationId);
+            if (!workerResult.Success)
+            {
+                HotReloadGroupOutcomeRouter.AppendGroupFailure(files, "(file)", workerResult.ErrorMessage);
+                return BuildUnappliedResults(files);
+            }
+
+            TransformWorkerOutputDto workerOutput = workerResult.Output;
+            Debug.Assert(
+                workerOutput.files.Length == files.Count,
+                "A group worker run must return one per-file output per edited file.");
+            HotReloadWorkerRowsByFile rows = HotReloadWorkerRowsByFile.Build(
+                workerOutput,
+                CollectProjectRelativePaths(files));
+            AppendPerFileWorkerNotices(files, rows);
+            // Why once for the group: the worker scans the assembly's unedited siblings for const
+            // drift as a whole, so flowing them per file would repeat the same texts.
+            if (workerOutput.siblingConstDriftWarnings != null)
+            {
+                firstFile.Sinks.SiblingDerivedWarnings.AddRange(workerOutput.siblingConstDriftWarnings);
+            }
+
+            // Why before the empty-entries return: all-unchanged runs exit there, and those are
+            // exactly the runs that must peel leftover patches so behavior converges to compiled IL.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+            RevertUnchangedPatchesPerFile(files, rows);
+
+            HotReloadApplyContext context = new HotReloadApplyContext(
+                firstFile.ProjectRoot,
+                firstFile.AssemblyName,
+                correlationId,
+                firstFile.CompilationAssembly,
+                firstFile.TargetDllPath,
+                firstFile.CompilationAssembly.defines ?? Array.Empty<string>(),
+                workerInput,
+                workerOutput,
+                files);
+            return await ApplyGroupAsync(context, firstFile, ct).ConfigureAwait(false);
+        }
+
+        private static async Task<IReadOnlyList<HotReloadFileProcessResult>> ApplyGroupAsync(
+            HotReloadApplyContext context,
+            HotReloadGroupFile gateWarningSink,
+            CancellationToken ct)
+        {
+            IReadOnlyList<HotReloadGroupFile> files = context.Files;
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult = await HotReloadSignatureChangeGate.TryApplySignatureChangeGateAsync(
+                context,
+                ct).ConfigureAwait(false);
+            HotReloadWorkerNoticeAppender.AppendRetrySiblingConstDriftWarnings(
+                gateWarningSink.Sinks.SiblingDerivedWarnings,
+                gateResult.Isolation);
+            AppendRemovedMemberNotices(context, gateResult);
+            if (gateResult.FileFailed)
+            {
+                // Why not apply first-pass entries: a gate retry null means the replacement was
+                // not isolated. Falling through would apply the unguarded return-type change.
+                // Why every file: the gate consumed the run's one worker retry for the group, so
+                // no file of it can be retried on its own.
+                HotReloadGroupOutcomeRouter.AppendGroupFailure(
+                    files,
+                    "(signature-change-gate)",
+                    gateResult.FailureMessage);
+                return BuildUnappliedResults(files);
+            }
+
+            HotReloadGroupOutcomeRouter.AppendByFilePath(files, gateResult.SkippedOutcomes);
+            // Why one file's warning list: gate warnings name compiled call sites across the
+            // assembly, not one edited file, and the run merges every file's warnings anyway.
+            gateWarningSink.Sinks.Warnings.AddRange(gateResult.Warnings);
+
+            HotReloadGroupCompileResult compile = await HotReloadShimFirstCompile.ResolveEntriesToPatchAsync(
+                context,
+                gateResult,
+                ct).ConfigureAwait(false);
+            if (!compile.HasEntriesToApply)
+            {
+                return BuildUnappliedResults(files);
+            }
+
+            if (gateResult.DidScan && !AppendSignatureChangeCoverageNotices(context, gateResult, compile))
+            {
+                return BuildUnappliedResults(files);
+            }
+
+            // Harmony Patch/Unpatch and method resolution against loaded modules require main thread.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+            IReadOnlyList<HotReloadFileProcessResult> results = HotReloadEntryApplier.ApplyGroupAndBuildResults(
+                context,
+                compile.CompileResult,
+                compile.EntriesToPatch);
+            // Why after apply: earlier returns (gate fail, shim compile, coverage loss)
+            // never applied the replacement, so leftover Active rows must not claim they
+            // were superseded.
+            RecordSupersededSignaturesAfterApply(results, context, gateResult.GatedReplacementMethodKeys);
+            return results;
+        }
+
+        // Returns false when a replacement lost its covering caller and the group must fail.
+        private static bool AppendSignatureChangeCoverageNotices(
+            HotReloadApplyContext context,
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult,
+            HotReloadGroupCompileResult compile)
+        {
+            // Why after entriesToPatch is final and before Harmony: isolation or a gate
+            // retry can drop a covering caller without dropping the replacement. A third
+            // worker run is not allowed (max two); fail the group instead of applying.
+            List<string> lostReplacementKeys = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                compile.EntriesToPatch,
+                gateResult.Hits,
+                gateResult.ScanTargetKeys);
+            if (lostReplacementKeys.Count > 0)
+            {
+                HotReloadGroupOutcomeRouter.AppendGroupFailure(
+                    context.Files,
+                    "(signature-change-gate)",
+                    string.Format(
+                        HotReloadConstants.SignatureChangeCoverageLostFailureFormat,
+                        string.Join(", ", lostReplacementKeys)));
+                return false;
+            }
+
+            foreach (HotReloadGroupFile file in context.Files)
+            {
+                // Why the group's entries with this file's labels: a caller in one file can cover
+                // a replacement in another, and the snapshot labels decide which file's response
+                // the warning belongs to.
+                HotReloadSignatureChangeCoverage.AppendSignatureChangeCallersRepatchedWarnings(
+                    file.Sinks.Warnings,
+                    compile.EntriesToPatch,
+                    gateResult.Hits,
+                    file.SnapshotLabels);
+            }
+
+            return true;
+        }
+
+        private static void AppendRemovedMemberNotices(
+            HotReloadApplyContext context,
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult)
+        {
+            foreach (HotReloadGroupFile file in context.Files)
+            {
+                // Why after the gate: a gated replacement is not applied, so listing it under
+                // "Removed members stay present... edited bodies no longer call them" is false.
+                string removedMembersWarning = HotReloadRemovedMembersWarning.FormatRemovedMembersWarning(
+                    file.FileOutput.removedMembers,
+                    file.FileOutput.removedMethodSignatures,
+                    gateResult.GatedReplacementMethodKeys);
+                if (removedMembersWarning != null)
+                {
+                    file.Sinks.Warnings.Add(removedMembersWarning);
+                }
+
+                HotReloadStalePatchOutcomes.Append(
+                    file.Sinks.Outcomes,
+                    context.WorkerOutput,
+                    file.FileOutput.removedMethodSignatures,
+                    gateResult.GatedReplacementMethodKeys,
+                    file.ProjectRelativePath,
+                    file.AssemblyResolvePath);
+            }
+        }
+
+        private static void SnapshotGroupState(IReadOnlyList<HotReloadGroupFile> files)
+        {
+            foreach (HotReloadGroupFile file in files)
+            {
+                // Why snapshot at the group's apply entry: runs process groups sequentially, and
+                // RevertUnchangedPatches / BeginFileGeneration mutate ledgers after the worker.
+                // The worker itself does not.
+                file.SnapshotLabels =
+                    HotReloadAppliedSourceLifecycle.CollectActiveLabelsForFile(file.ProjectRelativePath);
+                file.SnapshotAddedLabels = new HashSet<string>(
+                    HotReloadFileGenerations.ListActiveAddedMethodKeys(file.ProjectRelativePath),
+                    StringComparer.Ordinal);
+                // Why projectRelativePath (not workerSourcePath): contentPathOverride E2E copies
+                // live under Library/UloopHotReload/TestSources/ and are absent from the PDB
+                // document list. Assembly resolution already computed the on-disk path.
+                file.SnapshotSource = HotReloadSourceBaseline.LoadVerifiedSnapshotSource(
+                    file.ProjectRelativePath,
+                    file.TargetDllPath);
+            }
+        }
+
+        private static TransformWorkerInputDto BuildWorkerInput(
+            IReadOnlyList<HotReloadGroupFile> files,
+            HotReloadChangedSiblingScanResult siblingScan)
+        {
+            HotReloadGroupFile firstFile = files[0];
+            TransformWorkerSourceDto[] sources = new TransformWorkerSourceDto[files.Count];
+            for (int index = 0; index < files.Count; index++)
+            {
+                HotReloadGroupFile file = files[index];
+                sources[index] = new TransformWorkerSourceDto
+                {
+                    sourcePath = Path.GetFullPath(file.WorkerSourcePath),
+                    projectRelativePath = file.ProjectRelativePath,
+                    snapshotSource = file.SnapshotSource
+                };
+            }
+
+            return new TransformWorkerInputDto
+            {
+                sources = sources,
+                defines = firstFile.CompilationAssembly.defines ?? Array.Empty<string>(),
+                referencePaths = HotReloadShimReferenceBuilder.BuildWorkerReferencePaths(
+                    firstFile.CompilationAssembly,
+                    firstFile.TargetDllPath),
+                targetTypesAssemblyPath = Path.GetFullPath(firstFile.TargetDllPath),
+                assemblySourcePaths = HotReloadPatchTargetSupport.BuildAssemblySourcePaths(
+                    firstFile.ProjectRoot,
+                    firstFile.CompilationAssembly.sourceFiles),
+                changedSiblingSourcePaths = siblingScan.ChangedSiblingAbsolutePaths
+            };
+        }
+
+        private static void AppendPerFileWorkerNotices(
+            IReadOnlyList<HotReloadGroupFile> files,
+            HotReloadWorkerRowsByFile rows)
+        {
+            foreach (HotReloadGroupFile file in files)
+            {
+                IReadOnlyList<TransformWorkerSkippedDto> fileSkipped = rows.SkippedFor(file.ProjectRelativePath);
+                int patchCandidateRowCount = rows.EntriesFor(file.ProjectRelativePath).Count
+                    + fileSkipped.Count
+                    + rows.UnchangedFor(file.ProjectRelativePath).Count;
+                file.FileOutput = rows.FileOutputFor(file.ProjectRelativePath);
+                file.UnchangedMethodCount = rows.UnchangedFor(file.ProjectRelativePath).Count;
+                HotReloadWorkerNoticeAppender.AppendWorkerNotices(
+                    file.FileOutput,
+                    fileSkipped,
+                    patchCandidateRowCount,
+                    file.SnapshotSource,
+                    file.ProjectRelativePath,
+                    file.AssemblyName,
+                    file.AssemblyResolvePath,
+                    file.Sinks.Outcomes,
+                    file.Sinks.Warnings);
+            }
+        }
+
+        private static void RevertUnchangedPatchesPerFile(
+            IReadOnlyList<HotReloadGroupFile> files,
+            HotReloadWorkerRowsByFile rows)
+        {
+            foreach (HotReloadGroupFile file in files)
+            {
+                IReadOnlyList<TransformWorkerUnchangedMethodDto> fileUnchanged =
+                    rows.UnchangedFor(file.ProjectRelativePath);
+                TransformWorkerUnchangedMethodDto[] unchangedMethods =
+                    new TransformWorkerUnchangedMethodDto[fileUnchanged.Count];
+                for (int index = 0; index < fileUnchanged.Count; index++)
+                {
+                    unchangedMethods[index] = fileUnchanged[index];
+                }
+
+                file.RevertedUnchangedCount = HotReloadEntryApplier.RevertUnchangedPatches(
+                    file.AssemblyName,
+                    unchangedMethods);
+            }
+        }
+
+        private static void RecordSupersededSignaturesAfterApply(
+            IReadOnlyList<HotReloadFileProcessResult> results,
+            HotReloadApplyContext context,
+            IReadOnlyCollection<string> gatedReplacementMethodKeys)
+        {
+            foreach (HotReloadFileProcessResult result in results)
+            {
+                if (!HasAppliedChange(result.Outcomes))
+                {
+                    continue;
+                }
+
+                HotReloadSupersededSignatureRecorder.RecordFromWorkerOutput(
+                    context.WorkerOutput,
+                    context.RemovedMethodSignatures,
+                    gatedReplacementMethodKeys);
+                return;
+            }
+        }
+
+        private static bool HasAppliedChange(IReadOnlyList<HotReloadMethodOutcome> outcomes)
+        {
+            for (int index = 0; index < outcomes.Count; index++)
+            {
+                HotReloadMethodOutcomeKind kind = outcomes[index].Kind;
+                if (kind == HotReloadMethodOutcomeKind.Patched
+                    || kind == HotReloadMethodOutcomeKind.Added)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static List<string> CollectProjectRelativePaths(IReadOnlyList<HotReloadGroupFile> files)
+        {
+            List<string> projectRelativePaths = new List<string>(files.Count);
+            foreach (HotReloadGroupFile file in files)
+            {
+                projectRelativePaths.Add(file.ProjectRelativePath);
+            }
+
+            return projectRelativePaths;
+        }
+
+        private static List<HotReloadFileProcessResult> BuildUnappliedResults(
+            IReadOnlyList<HotReloadGroupFile> files)
+        {
+            List<HotReloadFileProcessResult> results =
+                new List<HotReloadFileProcessResult>(files.Count);
+            foreach (HotReloadGroupFile file in files)
+            {
+                results.Add(HotReloadFileEntryApplier.BuildUnappliedResult(file));
+            }
+
+            return results;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9725f046456654c98bead3909604154f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -13,7 +13,8 @@ using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// End-to-end hot-reload pipeline: resolve assembly → worker → shim compile → match → patch.
+    /// End-to-end hot-reload pipeline: resolve every file's assembly, group the files of one
+    /// assembly, run each group, and merge the per-file results in input order.
     /// </summary>
     internal static class HotReloadOrchestrator
     {
@@ -37,29 +38,41 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string correlationId = VibeLogger.GenerateCorrelationId();
             HotReloadRunAccumulator run = new HotReloadRunAccumulator();
 
+            // CompilationPipeline / Application.dataPath require the Unity main thread, and the
+            // groups cannot be planned before every file knows which assembly it compiles into.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+            HotReloadFileProcessResult[] resultSlots = new HotReloadFileProcessResult[files.Count];
+            string[] resultPaths = new string[files.Count];
+            HotReloadGroupFile[] groupFiles = new HotReloadGroupFile[files.Count];
+            List<(int InputIndex, string AssemblyName, string ProjectRelativePath)> plannerInput =
+                new List<(int InputIndex, string AssemblyName, string ProjectRelativePath)>();
             for (int index = 0; index < files.Count; index++)
             {
                 ct.ThrowIfCancellationRequested();
-                string filePath = files[index];
-                string workerSourcePath = ResolveWorkerSourcePath(
-                    filePath,
+                ResolveInputFile(
+                    files[index],
+                    index,
                     contentPathOverride,
-                    contentPathOverrideByFile);
-
-                // Why ConfigureAwait(false): UnityCliLoopTool forbids capturing Unity's
-                // SynchronizationContext across awaits — while Play Mode is paused that context
-                // does not run continuations, so a true resume would hang the tool forever.
-                // ProcessFileAsync switches back via MainThreadSwitcher (EditorApplication.update
-                // queue) before any main-thread-only editor API or Harmony patch.
-                HotReloadFileProcessResult fileResult = await ProcessFileAsync(
-                    filePath,
-                    workerSourcePath,
+                    contentPathOverrideByFile,
                     correlationId,
-                    run.SiblingDerivedWarnings,
-                    run.OneShotCallerNoteCandidates,
-                    ct).ConfigureAwait(false);
+                    run,
+                    resultSlots,
+                    resultPaths,
+                    groupFiles,
+                    plannerInput);
+            }
 
-                run.Add(HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(filePath), fileResult);
+            IReadOnlyList<HotReloadFileGroupPlan> plans = HotReloadFileGroupPlanner.Plan(plannerInput);
+            foreach (HotReloadFileGroupPlan plan in plans)
+            {
+                ct.ThrowIfCancellationRequested();
+                await ProcessPlannedGroupAsync(plan, groupFiles, resultSlots, correlationId, ct)
+                    .ConfigureAwait(false);
+            }
+
+            for (int index = 0; index < files.Count; index++)
+            {
+                run.Add(resultPaths[index], resultSlots[index]);
             }
 
             run.RecordAppliedSourceHashes();
@@ -72,19 +85,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return run.BuildResult(correlationId);
         }
 
-        private static async Task<HotReloadFileProcessResult> ProcessFileAsync(
-            string assemblyResolvePath,
-            string workerSourcePath,
+        // Resolves one input path's patch target and either records its early result or enrolls
+        // it in the group plan.
+        private static void ResolveInputFile(
+            string filePath,
+            int index,
+            string contentPathOverride,
+            IReadOnlyDictionary<string, string> contentPathOverrideByFile,
             string correlationId,
-            List<string> siblingDerivedWarnings,
-            List<HotReloadOneShotCallerNoteEnricher.Candidate> oneShotCallerNoteCandidates,
-            CancellationToken ct)
+            HotReloadRunAccumulator run,
+            HotReloadFileProcessResult[] resultSlots,
+            string[] resultPaths,
+            HotReloadGroupFile[] groupFiles,
+            List<(int InputIndex, string AssemblyName, string ProjectRelativePath)> plannerInput)
         {
-            Debug.Assert(siblingDerivedWarnings != null, "siblingDerivedWarnings must not be null.");
-            HotReloadFileSinks sinks = new HotReloadFileSinks(siblingDerivedWarnings, oneShotCallerNoteCandidates);
-
-            // CompilationPipeline / Application.dataPath require the Unity main thread.
-            await MainThreadSwitcher.SwitchToMainThread(ct);
+            string workerSourcePath = ResolveWorkerSourcePath(
+                filePath,
+                contentPathOverride,
+                contentPathOverrideByFile);
+            HotReloadFileSinks sinks = new HotReloadFileSinks(
+                run.SiblingDerivedWarnings,
+                run.OneShotCallerNoteCandidates);
 
             (HotReloadFileProcessResult earlyResolve,
                 string projectRelativePath,
@@ -92,266 +113,60 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 UnityCompilationAssembly compilationAssembly,
                 string targetDllPath,
                 string projectRoot) = HotReloadPatchTargetSupport.ResolvePatchTarget(
-                assemblyResolvePath,
+                filePath,
                 workerSourcePath,
                 sinks.Outcomes,
                 sinks.Warnings,
                 correlationId);
             if (earlyResolve != null)
             {
-                return earlyResolve;
-            }
-
-            // Why snapshot at this file's apply entry: multi-file runs process files
-            // sequentially, and RevertUnchangedPatches / BeginFileGeneration mutate ledgers
-            // after the worker. The worker itself does not.
-            HashSet<string> snapshotLabels = HotReloadAppliedSourceLifecycle.CollectActiveLabelsForFile(projectRelativePath);
-            HashSet<string> snapshotAddedLabels = new HashSet<string>(
-                HotReloadFileGenerations.ListActiveAddedMethodKeys(projectRelativePath),
-                StringComparer.Ordinal);
-
-            string[] defines = compilationAssembly.defines ?? Array.Empty<string>();
-            string[] referencePaths = HotReloadShimReferenceBuilder.BuildWorkerReferencePaths(compilationAssembly, targetDllPath);
-
-            // Why projectRelativePath (not workerSourcePath): contentPathOverride E2E copies live
-            // under Library/UloopHotReload/TestSources/ and are absent from the PDB document list.
-            // Assembly resolution already computed the on-disk Assets/Packages path above.
-            string snapshotSource = HotReloadSourceBaseline.LoadVerifiedSnapshotSource(
-                projectRelativePath,
-                targetDllPath);
-
-            HotReloadChangedSiblingScanResult siblingScan = HotReloadChangedSiblingSourceDetector.Detect(
-                projectRoot,
-                assemblyName,
-                targetDllPath,
-                compilationAssembly.sourceFiles,
-                projectRelativePath);
-            if (!string.IsNullOrEmpty(siblingScan.ScanLimitWarning))
-            {
-                sinks.SiblingDerivedWarnings.Add(siblingScan.ScanLimitWarning);
-            }
-
-            TransformWorkerInputDto workerInput = new TransformWorkerInputDto
-            {
-                sources = new[]
-                {
-                    new TransformWorkerSourceDto
-                    {
-                        sourcePath = Path.GetFullPath(workerSourcePath),
-                        projectRelativePath = projectRelativePath,
-                        snapshotSource = snapshotSource
-                    }
-                },
-                defines = defines,
-                referencePaths = referencePaths,
-                targetTypesAssemblyPath = Path.GetFullPath(targetDllPath),
-                assemblySourcePaths = HotReloadPatchTargetSupport.BuildAssemblySourcePaths(projectRoot, compilationAssembly.sourceFiles),
-                changedSiblingSourcePaths = siblingScan.ChangedSiblingAbsolutePaths
-            };
-
-            TransformWorkerClientResult workerResult =
-                await TransformWorkerClient.RunAsync(workerInput, ct).ConfigureAwait(false);
-            HotReloadOrchestratorLog.LogHotReloadWorkerResult(workerResult, correlationId);
-            if (!workerResult.Success)
-            {
-                sinks.Outcomes.Add(
-                    HotReloadMethodOutcome.Failed("(file)", workerResult.ErrorMessage, assemblyResolvePath));
-                return new HotReloadFileProcessResult(sinks.Outcomes, sinks.Warnings, 0);
-            }
-
-            TransformWorkerOutputDto workerOutput = workerResult.Output;
-            // One source in, one per-file row out. Assembly grouping widens this to the group size.
-            Debug.Assert(
-                workerOutput.files.Length == 1,
-                "A single-source worker run must return exactly one per-file output.");
-            TransformWorkerFileOutputDto fileOutput = workerOutput.files[0];
-            string[] addedFieldNames = fileOutput.addedFieldNames;
-            HotReloadWorkerNoticeAppender.AppendWorkerNotices(
-                workerOutput,
-                fileOutput,
-                snapshotSource,
-                projectRelativePath,
-                assemblyName,
-                assemblyResolvePath,
-                sinks.Outcomes,
-                sinks.Warnings,
-                sinks.SiblingDerivedWarnings);
-
-            TransformWorkerUnchangedMethodDto[] unchangedMethods =
-                workerOutput.unchangedMethods ?? Array.Empty<TransformWorkerUnchangedMethodDto>();
-            int unchangedMethodCount = unchangedMethods.Length;
-
-            // Why before the empty-entries return: all-unchanged runs exit there, and those are
-            // exactly the runs that must peel leftover patches so behavior converges to compiled IL.
-            await MainThreadSwitcher.SwitchToMainThread(ct);
-            int revertedUnchangedCount = HotReloadEntryApplier.RevertUnchangedPatches(
-                assemblyName,
-                unchangedMethods);
-
-            HotReloadApplyContext context = new HotReloadApplyContext(
-                projectRoot,
-                assemblyName,
-                assemblyResolvePath,
-                projectRelativePath,
-                correlationId,
-                compilationAssembly,
-                targetDllPath,
-                defines,
-                workerInput,
-                workerOutput,
-                fileOutput,
-                snapshotLabels,
-                snapshotAddedLabels);
-
-            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult = await HotReloadSignatureChangeGate.TryApplySignatureChangeGateAsync(
-                context,
-                ct).ConfigureAwait(false);
-            HotReloadWorkerNoticeAppender.AppendRetrySiblingConstDriftWarnings(sinks.SiblingDerivedWarnings, gateResult.Isolation);
-            // Why after the gate: a gated replacement is not applied, so listing it under
-            // "Removed members stay present... edited bodies no longer call them" is false.
-            string removedMembersWarning = HotReloadRemovedMembersWarning.FormatRemovedMembersWarning(
-                fileOutput.removedMembers,
-                fileOutput.removedMethodSignatures,
-                gateResult.GatedReplacementMethodKeys);
-            if (removedMembersWarning != null)
-            {
-                sinks.Warnings.Add(removedMembersWarning);
-            }
-
-            HotReloadStalePatchOutcomes.Append(
-                sinks.Outcomes,
-                workerOutput,
-                fileOutput.removedMethodSignatures,
-                gateResult.GatedReplacementMethodKeys,
-                projectRelativePath,
-                assemblyResolvePath);
-
-            if (gateResult.FileFailed)
-            {
-                // Why not apply first-pass entries: a gate retry null means the replacement was
-                // not isolated. Falling through would apply the unguarded return-type change.
-                sinks.Outcomes.Add(
-                    HotReloadMethodOutcome.Failed(
-                        "(signature-change-gate)",
-                        gateResult.FailureMessage,
-                        assemblyResolvePath));
-                return new HotReloadFileProcessResult(
-                    sinks.Outcomes,
-                    sinks.Warnings,
-                    0,
-                    unchangedMethodCount: unchangedMethodCount,
-                    sourceContentSha256: fileOutput.sourceContentSha256,
-                    revertedUnchangedCount: revertedUnchangedCount);
-            }
-
-            sinks.Outcomes.AddRange(gateResult.SkippedOutcomes);
-            sinks.Warnings.AddRange(gateResult.Warnings);
-
-            (HotReloadFileProcessResult earlyEntries,
-                TransformWorkerEntryDto[] entriesToPatch,
-                HotReloadShimCompileResult compileResult,
-                string[] resolvedAddedFieldNames,
-                string[] resolvedAddedConstNames) = await HotReloadShimFirstCompile.ResolveEntriesToPatchAsync(
-                context,
-                sinks,
-                gateResult,
-                addedFieldNames,
-                unchangedMethodCount,
-                revertedUnchangedCount,
-                ct).ConfigureAwait(false);
-            if (earlyEntries != null)
-            {
-                return earlyEntries;
-            }
-
-            addedFieldNames = resolvedAddedFieldNames;
-
-            if (gateResult.DidScan)
-            {
-                // Why after entriesToPatch is final and before Harmony: isolation or a gate
-                // retry can drop a covering caller without dropping the replacement. A third
-                // worker run is not allowed (max two); fail the file instead of applying.
-                List<string> lostReplacementKeys = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
-                    entriesToPatch,
-                    gateResult.Hits,
-                    gateResult.ScanTargetKeys);
-                if (lostReplacementKeys.Count > 0)
-                {
-                    sinks.Outcomes.Add(
-                        HotReloadMethodOutcome.Failed(
-                            "(signature-change-gate)",
-                            string.Format(
-                                HotReloadConstants.SignatureChangeCoverageLostFailureFormat,
-                                string.Join(", ", lostReplacementKeys)),
-                            assemblyResolvePath));
-                    return new HotReloadFileProcessResult(
-                        sinks.Outcomes,
-                        sinks.Warnings,
-                        0,
-                        unchangedMethodCount: unchangedMethodCount,
-                        sourceContentSha256: fileOutput.sourceContentSha256,
-                        revertedUnchangedCount: revertedUnchangedCount);
-                }
-
-                HotReloadSignatureChangeCoverage.AppendSignatureChangeCallersRepatchedWarnings(
-                    sinks.Warnings,
-                    entriesToPatch,
-                    gateResult.Hits,
-                    snapshotLabels);
-            }
-
-            // Harmony Patch/Unpatch and method resolution against loaded modules require main thread.
-            await MainThreadSwitcher.SwitchToMainThread(ct);
-            HotReloadFileProcessResult applied = HotReloadEntryApplier.ApplyEntriesAndBuildResult(
-                context,
-                sinks,
-                compileResult,
-                entriesToPatch,
-                addedFieldNames,
-                resolvedAddedConstNames,
-                unchangedMethodCount,
-                revertedUnchangedCount);
-            // Why after apply: earlier returns (gate fail, shim compile, coverage loss)
-            // never applied the replacement, so leftover Active rows must not claim they
-            // were superseded.
-            RecordSupersededSignaturesAfterApply(
-                applied,
-                workerOutput,
-                fileOutput.removedMethodSignatures,
-                gateResult.GatedReplacementMethodKeys);
-            return applied;
-        }
-
-        private static void RecordSupersededSignaturesAfterApply(
-            HotReloadFileProcessResult applied,
-            TransformWorkerOutputDto workerOutput,
-            TransformWorkerRemovedMethodSignatureDto[] removedMethodSignatures,
-            IReadOnlyCollection<string> gatedReplacementMethodKeys)
-        {
-            if (!HasAppliedChange(applied.Outcomes))
-            {
+                resultSlots[index] = earlyResolve;
+                resultPaths[index] = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(filePath);
                 return;
             }
 
-            HotReloadSupersededSignatureRecorder.RecordFromWorkerOutput(
-                workerOutput,
-                removedMethodSignatures,
-                gatedReplacementMethodKeys);
+            groupFiles[index] = new HotReloadGroupFile(
+                filePath,
+                workerSourcePath,
+                projectRelativePath,
+                assemblyName,
+                compilationAssembly,
+                targetDllPath,
+                projectRoot,
+                sinks);
+            resultPaths[index] = projectRelativePath;
+            plannerInput.Add((index, assemblyName, projectRelativePath));
         }
 
-        private static bool HasAppliedChange(IReadOnlyList<HotReloadMethodOutcome> outcomes)
+        private static async Task ProcessPlannedGroupAsync(
+            HotReloadFileGroupPlan plan,
+            HotReloadGroupFile[] groupFiles,
+            HotReloadFileProcessResult[] resultSlots,
+            string correlationId,
+            CancellationToken ct)
         {
-            for (int index = 0; index < outcomes.Count; index++)
+            IReadOnlyList<int> inputIndexes = plan.InputIndexes;
+            List<HotReloadGroupFile> filesOfGroup = new List<HotReloadGroupFile>(inputIndexes.Count);
+            foreach (int inputIndex in inputIndexes)
             {
-                HotReloadMethodOutcomeKind kind = outcomes[index].Kind;
-                if (kind == HotReloadMethodOutcomeKind.Patched
-                    || kind == HotReloadMethodOutcomeKind.Added)
-                {
-                    return true;
-                }
+                filesOfGroup.Add(groupFiles[inputIndex]);
             }
 
-            return false;
+            // Why ConfigureAwait(false): UnityCliLoopTool forbids capturing Unity's
+            // SynchronizationContext across awaits — while Play Mode is paused that context
+            // does not run continuations, so a true resume would hang the tool forever.
+            // ProcessGroupAsync switches back via MainThreadSwitcher (EditorApplication.update
+            // queue) before any main-thread-only editor API or Harmony patch.
+            IReadOnlyList<HotReloadFileProcessResult> groupResults =
+                await HotReloadGroupProcessor.ProcessGroupAsync(filesOfGroup, correlationId, ct)
+                    .ConfigureAwait(false);
+            Debug.Assert(
+                groupResults.Count == inputIndexes.Count,
+                "A group must report one result per edited file.");
+            for (int position = 0; position < inputIndexes.Count; position++)
+            {
+                resultSlots[inputIndexes[position]] = groupResults[position];
+            }
         }
 
         // Why keyed by path (not by index): one contentPathOverride cannot feed two edited

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadReplacedCompiledMethodEntries.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadReplacedCompiledMethodEntries.cs
@@ -13,7 +13,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Why first-wins: duplicate keys would mean two entries claim the same compiled signature,
         // and the recorder's original linear scan reported the first match.
         public static IReadOnlyDictionary<string, TransformWorkerEntryDto> IndexByReplacedWireKey(
-            TransformWorkerEntryDto[] entries)
+            IReadOnlyList<TransformWorkerEntryDto> entries)
         {
             Dictionary<string, TransformWorkerEntryDto> entriesByWireKey =
                 new Dictionary<string, TransformWorkerEntryDto>(StringComparer.Ordinal);
@@ -22,7 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return entriesByWireKey;
             }
 
-            for (int index = 0; index < entries.Length; index++)
+            for (int index = 0; index < entries.Count; index++)
             {
                 TransformWorkerEntryDto entry = entries[index];
                 if (entry == null || !entry.replacesCompiledMethod)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompiler.cs
@@ -30,13 +30,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string shimSource,
             IReadOnlyList<string> referencePaths,
             IReadOnlyList<string> defineSymbols,
-            string projectRelativePath,
+            IReadOnlyCollection<string> projectRelativePaths,
             CancellationToken ct)
         {
             Debug.Assert(!string.IsNullOrEmpty(shimSource), "shimSource must not be empty.");
             Debug.Assert(referencePaths != null, "referencePaths must not be null.");
             Debug.Assert(defineSymbols != null, "defineSymbols must not be null.");
-            Debug.Assert(projectRelativePath != null, "projectRelativePath must not be null.");
+            Debug.Assert(projectRelativePaths != null, "projectRelativePaths must not be null.");
 
             // Resolver and Application.dataPath (CreateWorkDirectory) need the Unity main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -87,7 +87,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     {
                         // Why only user-file mapped lines: scaffold diagnostics (temp HotReloadShim.cs)
                         // must not grow a fake "(line N)" that looks like the edited source.
-                        errorMessages.Add(FormatErrorMessageWithMappedLine(error, projectRelativePath));
+                        errorMessages.Add(FormatErrorMessageWithMappedLine(error, projectRelativePaths));
                     }
 
                     return HotReloadShimCompileResult.Failure(
@@ -148,13 +148,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         private static string FormatErrorMessageWithMappedLine(
             HotReloadShimCompileError error,
-            string projectRelativePath)
+            IReadOnlyCollection<string> projectRelativePaths)
         {
-            if (error.Line > 0
-                && !string.IsNullOrEmpty(error.File)
-                && HotReloadSourcePathNormalizer.PathsReferToSameFile(error.File, projectRelativePath))
+            if (error.Line <= 0 || string.IsNullOrEmpty(error.File))
             {
-                return error.Message + " (line " + error.Line + ")";
+                return error.Message;
+            }
+
+            // Why any file of the group: one shim assembly hosts the bodies of every edited file
+            // of the group, so a mapped line belongs to whichever of them the directive names.
+            foreach (string projectRelativePath in projectRelativePaths)
+            {
+                if (HotReloadSourcePathNormalizer.PathsReferToSameFile(error.File, projectRelativePath))
+                {
+                    return error.Message + " (line " + error.Line + ")";
+                }
             }
 
             return error.Message;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
@@ -119,6 +119,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 context.TargetDllPath,
                 context.Defines,
                 context.AssemblyResolvePath,
+                context.GroupFilePaths,
                 context.CorrelationId,
                 sinks.SiblingDerivedWarnings,
                 ct).ConfigureAwait(false);
@@ -179,6 +180,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string targetDllPath,
             string[] defines,
             string assemblyResolvePath,
+            HotReloadGroupFilePaths groupFilePaths,
             string correlationId,
             List<string> siblingDerivedWarnings,
             CancellationToken ct)
@@ -235,7 +237,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 compilationAssembly,
                 targetDllPath,
                 defines,
-                assemblyResolvePath,
+                groupFilePaths,
                 correlationId,
                 ct).ConfigureAwait(false);
             if (isolation == null)
@@ -282,7 +284,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             AppendAtomicFileSkipOutcomes(
                 isolationOutcomes,
                 isolation.RetryEntries,
-                assemblyResolvePath);
+                groupFilePaths);
             return ShimFirstCompileResult.Failed(isolationOutcomes);
         }
 
@@ -291,11 +293,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static void AppendAtomicFileSkipOutcomes(
             List<HotReloadMethodOutcome> outcomes,
             TransformWorkerEntryDto[] retryEntries,
-            string filePath)
+            HotReloadGroupFilePaths groupFilePaths)
         {
             Debug.Assert(outcomes != null, "outcomes must not be null.");
             Debug.Assert(retryEntries != null, "retryEntries must not be null.");
-            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be empty.");
+            Debug.Assert(groupFilePaths != null, "groupFilePaths must not be null.");
 
             foreach (TransformWorkerEntryDto entry in retryEntries)
             {
@@ -308,7 +310,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     HotReloadMethodOutcome.Skipped(
                         methodLabel,
                         HotReloadConstants.AtomicFileSkipReason,
-                        filePath));
+                        groupFilePaths.ResolveAssemblyResolvePath(entry.sourceProjectRelativePath)));
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
@@ -3,70 +3,39 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-using UnityEditor.Compilation;
-
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
-using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
-
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// Selects entries to patch: empty-entries clear, first shim compile, and compile-failure isolation.
+    /// Selects the entries a group applies: empty-entries clear, the one shim compile of the
+    /// group, and file-atomic isolation of a compile failure.
     /// </summary>
     internal static class HotReloadShimFirstCompile
     {
         // Why a helper: the gate-retry / empty-entries / first-pass compile fork is one
-        // entries-to-patch stage and kept ProcessFileAsync over CA1502.
-        internal static async Task<(
-            HotReloadFileProcessResult EarlyResult,
-            TransformWorkerEntryDto[] EntriesToPatch,
-            HotReloadShimCompileResult CompileResult,
-            string[] AddedFieldNames,
-            string[] AddedConstNames)> ResolveEntriesToPatchAsync(
+        // entries-to-patch stage and kept the group pipeline over CA1502.
+        internal static async Task<HotReloadGroupCompileResult> ResolveEntriesToPatchAsync(
             HotReloadApplyContext context,
-            HotReloadFileSinks sinks,
             HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult,
-            string[] addedFieldNames,
-            int unchangedMethodCount,
-            int revertedUnchangedCount,
             CancellationToken ct)
         {
             Debug.Assert(context != null, "context must not be null.");
-            Debug.Assert(sinks != null, "sinks must not be null.");
-            string[] addedConstNames = context.FileOutput.addedConstNames;
+            Debug.Assert(gateResult != null, "gateResult must not be null.");
+
             if (gateResult.UsedWorkerRetry)
             {
-                addedFieldNames = gateResult.Isolation.AddedFieldNames;
-                addedConstNames = gateResult.Isolation.AddedConstNames;
+                AdoptRetryAddedMemberNames(context.Files, gateResult.Isolation.RetryFiles);
                 if (gateResult.Isolation.RetryEntries.Length == 0)
                 {
-                    return (
-                        new HotReloadFileProcessResult(
-                            sinks.Outcomes,
-                            sinks.Warnings,
-                            0,
-                            sinks.SuppressedPausePointIds,
-                            new List<string>(),
-                            unchangedMethodCount,
-                            sinks.RetargetedPausePointIds,
-                            addedFieldNames: null,
-                            sourceContentSha256: context.FileOutput.sourceContentSha256,
-                            revertedUnchangedCount: revertedUnchangedCount),
-                        null,
-                        null,
-                        addedFieldNames,
-                        addedConstNames);
+                    return HotReloadGroupCompileResult.NothingToApply();
                 }
 
-                return (
-                    null,
+                return HotReloadGroupCompileResult.Apply(
                     gateResult.Isolation.RetryEntries,
-                    gateResult.Isolation.RetryCompileResult,
-                    addedFieldNames,
-                    addedConstNames);
+                    gateResult.Isolation.RetryCompileResult);
             }
 
             if (string.IsNullOrEmpty(context.WorkerOutput.shimSource)
@@ -78,285 +47,212 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Worker failure and shim-compile failure return earlier or later without
                 // clearing — same as leaving existing Harmony patches in place when apply does
                 // not succeed.
-                IReadOnlyList<string> addedLabelsAtClear =
-                    HotReloadFileGenerations.ListActiveAddedMethodKeys(context.ProjectRelativePath);
-                HotReloadOrchestratorLog.LogHotReloadEmptyEntriesClear(addedLabelsAtClear, context.CorrelationId);
-                // Why not HotReloadFileGenerations.BeginFileGeneration: there is no shim assembly
-                // on this path — entries are empty, so nothing was compiled. Only the added-member
-                // side has stale rows to drop; starting a shim generation would need bytes that
-                // do not exist.
-                HotReloadAddedMemberRegistry.BeginFileGeneration(context.ProjectRelativePath);
-                HotReloadEntryApplier.CommitAddedFieldsForFile(
-                    context.ProjectRelativePath,
-                    context.FileOutput.addedFieldNames);
-                // Why after the clear: a still-declared added method can be worker-skipped
-                // (virtual/generic), leaving entries empty while the registry drop is real.
-                HotReloadAppliedSourceLifecycle.AppendDeactivatedPatchesWarning(
-                    sinks.Warnings,
-                    context.SnapshotLabels,
-                    context.SnapshotAddedLabels,
-                    context.ProjectRelativePath,
-                    context.WorkerOutput,
-                    sinks.Outcomes);
-                return (
-                    new HotReloadFileProcessResult(
-                        sinks.Outcomes,
-                        sinks.Warnings,
-                        0,
-                        unchangedMethodCount: unchangedMethodCount,
-                        sourceContentSha256: context.FileOutput.sourceContentSha256,
-                        revertedUnchangedCount: revertedUnchangedCount),
-                    null,
-                    null,
-                    addedFieldNames,
-                    addedConstNames);
+                foreach (HotReloadGroupFile file in context.Files)
+                {
+                    HotReloadFileEntryApplier.ClearFileGeneration(context, file);
+                }
+
+                return HotReloadGroupCompileResult.NothingToApply();
             }
 
-            ShimFirstCompileResult firstCompile = await CompileShimFirstPassAsync(
-                context.WorkerInput,
-                context.WorkerOutput,
-                context.CompilationAssembly,
-                context.TargetDllPath,
-                context.Defines,
-                context.AssemblyResolvePath,
-                context.GroupFilePaths,
-                context.CorrelationId,
-                sinks.SiblingDerivedWarnings,
-                ct).ConfigureAwait(false);
-            if (firstCompile.AddedFieldNames != null)
-            {
-                addedFieldNames = firstCompile.AddedFieldNames;
-            }
-
-            if (firstCompile.FileFailed)
-            {
-                sinks.Outcomes.AddRange(firstCompile.Outcomes);
-                return (
-                    new HotReloadFileProcessResult(
-                        sinks.Outcomes,
-                        sinks.Warnings,
-                        0,
-                        unchangedMethodCount: unchangedMethodCount,
-                        sourceContentSha256: context.FileOutput.sourceContentSha256,
-                        revertedUnchangedCount: revertedUnchangedCount),
-                    null,
-                    null,
-                    addedFieldNames,
-                    addedConstNames);
-            }
-
-            sinks.Outcomes.AddRange(firstCompile.Outcomes);
-            if (firstCompile.EntriesToPatch.Length == 0)
-            {
-                return (
-                    new HotReloadFileProcessResult(
-                        sinks.Outcomes,
-                        sinks.Warnings,
-                        0,
-                        sinks.SuppressedPausePointIds,
-                        new List<string>(),
-                        unchangedMethodCount,
-                        sinks.RetargetedPausePointIds,
-                        addedFieldNames: null,
-                        sourceContentSha256: context.FileOutput.sourceContentSha256,
-                        revertedUnchangedCount: revertedUnchangedCount),
-                    null,
-                    null,
-                    addedFieldNames,
-                    addedConstNames);
-            }
-
-            return (null, firstCompile.EntriesToPatch, firstCompile.CompileResult, addedFieldNames, addedConstNames);
+            return await CompileShimForGroupAsync(context, ct).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// First shim compile plus optional compile-failure isolation. Signature-change gate
-        /// retries never call this — they already consumed the one worker retry.
+        /// Compiles the group's shim source once and, on failure, isolates the files whose
+        /// methods the compiler errors belong to. Signature-change gate retries never call this —
+        /// they already consumed the one worker retry.
         /// </summary>
-        private static async Task<ShimFirstCompileResult> CompileShimFirstPassAsync(
-            TransformWorkerInputDto workerInput,
-            TransformWorkerOutputDto workerOutput,
-            UnityCompilationAssembly compilationAssembly,
-            string targetDllPath,
-            string[] defines,
-            string assemblyResolvePath,
-            HotReloadGroupFilePaths groupFilePaths,
-            string correlationId,
-            List<string> siblingDerivedWarnings,
+        private static async Task<HotReloadGroupCompileResult> CompileShimForGroupAsync(
+            HotReloadApplyContext context,
             CancellationToken ct)
         {
-            Debug.Assert(siblingDerivedWarnings != null, "siblingDerivedWarnings must not be null.");
             // BuildShimReferencePaths reads Application.dataPath / platform; stay on main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
+            TransformWorkerOutputDto workerOutput = context.WorkerOutput;
             bool includeHarmonyReference = HotReloadShimReferenceBuilder.NeedsHarmonyReference(workerOutput);
-            bool includeAddedFieldStoreReference = HotReloadShimReferenceBuilder.NeedsAddedFieldStoreReference(workerOutput);
+            bool includeAddedFieldStoreReference =
+                HotReloadShimReferenceBuilder.NeedsAddedFieldStoreReference(workerOutput);
             HotReloadShimReferenceBuilder.ShimReferencePathsResult shimReferencePaths = HotReloadShimReferenceBuilder.TryBuildShimReferencePaths(
-                compilationAssembly,
-                targetDllPath,
+                context.CompilationAssembly,
+                context.TargetDllPath,
                 includeHarmonyReference,
                 includeAddedFieldStoreReference);
             if (shimReferencePaths.ErrorMessage != null)
             {
-                return ShimFirstCompileResult.Failed(
-                    new List<HotReloadMethodOutcome>
-                    {
-                        HotReloadMethodOutcome.Failed(
-                            "(file)",
-                            shimReferencePaths.ErrorMessage,
-                            assemblyResolvePath)
-                    });
+                HotReloadGroupOutcomeRouter.AppendGroupFailure(
+                    context.Files,
+                    "(file)",
+                    shimReferencePaths.ErrorMessage);
+                return HotReloadGroupCompileResult.NothingToApply();
             }
 
-            List<string> shimReferences = shimReferencePaths.References;
             HotReloadShimCompileResult compileResult = await HotReloadShimCompiler.CompileAndLoadAsync(
                 workerOutput.shimSource,
-                shimReferences,
-                defines,
-                workerInput.sources[0].projectRelativePath,
+                shimReferencePaths.References,
+                context.Defines,
+                context.ProjectRelativePaths,
                 ct).ConfigureAwait(false);
-
-            TransformWorkerEntryDto[] entriesToPatch = workerOutput.entries;
             if (compileResult.Success)
             {
-                return ShimFirstCompileResult.Succeeded(entriesToPatch, compileResult);
+                AdoptFirstPassAddedMemberNames(context.Files);
+                return HotReloadGroupCompileResult.Apply(workerOutput.entries, compileResult);
             }
 
             HotReloadOrchestratorLog.LogHotReloadShimCompileFailed(
                 compileResult,
                 HotReloadConstants.VibeLogShimCompileStageFirstPass,
-                correlationId);
+                context.CorrelationId);
 
             // Why isolate only here: a signature-change gate retry already used
             // RunIsolationRetryAsync (worker run #2). Calling isolation after that would be a
             // third worker run. Gate retry compile failures return Failed from the gate and
             // never reach this first-compile path.
             HotReloadShimIsolation.HotReloadShimIsolationResult isolation = await HotReloadShimIsolation.TryIsolateShimCompileFailureAsync(
-                workerInput,
+                context.WorkerInput,
                 workerOutput,
                 compileResult,
-                compilationAssembly,
-                targetDllPath,
-                defines,
-                groupFilePaths,
-                correlationId,
+                context.CompilationAssembly,
+                context.TargetDllPath,
+                context.Defines,
+                context.GroupFilePaths,
+                context.CorrelationId,
                 ct).ConfigureAwait(false);
             if (isolation == null)
             {
-                // Why: CompileAndLoadAsync appends "(line N)" only for diagnostics whose
-                // #line-mapped file matches projectRelativePath — scaffold-only errors stay
-                // bare. Single-entry failures skip isolation and always take this path.
-                // Why attribute single-entry failures: "(shim-compile)" hides which method
-                // body failed when the agent edited only one method.
-                string failureMethodLabel = "(shim-compile)";
-                if (entriesToPatch.Length == 1)
-                {
-                    TransformWorkerEntryDto soleEntry = entriesToPatch[0];
-                    failureMethodLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                        soleEntry.typeMetadataName,
-                        soleEntry.methodName,
-                        soleEntry.parameterTypeFullNames ?? Array.Empty<string>(),
-                        soleEntry.genericArity);
-                }
-
-                List<string> fallbackErrorMessages = new List<string>(compileResult.Errors.Count);
-                for (int errorIndex = 0; errorIndex < compileResult.Errors.Count; errorIndex++)
-                {
-                    fallbackErrorMessages.Add(compileResult.Errors[errorIndex].Message);
-                }
-
-                return ShimFirstCompileResult.Failed(
-                    new List<HotReloadMethodOutcome>
-                    {
-                        HotReloadMethodOutcome.Failed(
-                            failureMethodLabel,
-                            HotReloadSkippedMemberCompileNote.AppendNotes(
-                                compileResult.ErrorMessage,
-                                fallbackErrorMessages,
-                                workerOutput.skipped),
-                            assemblyResolvePath)
-                    });
+                AppendUnattributableCompileFailure(context, compileResult);
+                return HotReloadGroupCompileResult.NothingToApply();
             }
 
-            siblingDerivedWarnings.AddRange(isolation.SiblingConstDriftWarnings);
-            List<HotReloadMethodOutcome> isolationOutcomes = new List<HotReloadMethodOutcome>();
-            isolationOutcomes.AddRange(isolation.FailedMethodOutcomes);
-            isolationOutcomes.AddRange(isolation.SkippedCallerOutcomes);
-            AppendAtomicFileSkipOutcomes(
-                isolationOutcomes,
-                isolation.RetryEntries,
-                groupFilePaths);
-            return ShimFirstCompileResult.Failed(isolationOutcomes);
+            context.Files[0].Sinks.SiblingDerivedWarnings.AddRange(isolation.SiblingConstDriftWarnings);
+            HotReloadGroupOutcomeRouter.AppendByFilePath(context.Files, isolation.FailedMethodOutcomes);
+            HotReloadGroupOutcomeRouter.AppendByFilePath(context.Files, isolation.SkippedCallerOutcomes);
+            return ResolveIsolatedEntriesToPatch(context, isolation);
         }
 
-        // Why survivors stay Skipped: applying them after a sibling Failed would leave
-        // the file half-applied. Isolation still attributes the Failed methods.
-        private static void AppendAtomicFileSkipOutcomes(
-            List<HotReloadMethodOutcome> outcomes,
+        // Why one failure per file: the errors could not be tied to any edited method, so the
+        // group as a whole is what failed. A single-entry group still names its method, because
+        // "(shim-compile)" would hide the only body the agent edited.
+        private static void AppendUnattributableCompileFailure(
+            HotReloadApplyContext context,
+            HotReloadShimCompileResult compileResult)
+        {
+            TransformWorkerEntryDto[] entries = context.WorkerOutput.entries;
+            string failureMethodLabel = "(shim-compile)";
+            if (entries.Length == 1)
+            {
+                TransformWorkerEntryDto soleEntry = entries[0];
+                failureMethodLabel = HotReloadMethodKeys.FormatMethodLabelParts(
+                    soleEntry.typeMetadataName,
+                    soleEntry.methodName,
+                    soleEntry.parameterTypeFullNames ?? Array.Empty<string>(),
+                    soleEntry.genericArity);
+            }
+
+            // Why: CompileAndLoadAsync appends "(line N)" only for diagnostics whose
+            // #line-mapped file is one of the group's sources — scaffold-only errors stay bare.
+            List<string> fallbackErrorMessages = new List<string>(compileResult.Errors.Count);
+            for (int errorIndex = 0; errorIndex < compileResult.Errors.Count; errorIndex++)
+            {
+                fallbackErrorMessages.Add(compileResult.Errors[errorIndex].Message);
+            }
+
+            HotReloadGroupOutcomeRouter.AppendGroupFailure(
+                context.Files,
+                failureMethodLabel,
+                HotReloadSkippedMemberCompileNote.AppendNotes(
+                    compileResult.ErrorMessage,
+                    fallbackErrorMessages,
+                    context.WorkerOutput.skipped));
+        }
+
+        private static HotReloadGroupCompileResult ResolveIsolatedEntriesToPatch(
+            HotReloadApplyContext context,
+            HotReloadShimIsolation.HotReloadShimIsolationResult isolation)
+        {
+            if (isolation.Plan.AllFilesFailed)
+            {
+                // Why survivors stay Skipped: applying them after a sibling Failed would leave
+                // the file half-applied. Isolation still attributes the Failed methods, and the
+                // retry ran only to collect the skips its exclusions caused.
+                HotReloadGroupOutcomeRouter.AppendByFilePath(
+                    context.Files,
+                    BuildAtomicFileSkipOutcomes(isolation.RetryEntries, context.GroupFilePaths));
+                return HotReloadGroupCompileResult.NothingToApply();
+            }
+
+            HotReloadGroupOutcomeRouter.AppendByFilePath(
+                context.Files,
+                HotReloadFileAtomicIsolationPlan.CollectOutcomes(
+                    isolation.Plan.AtomicSkipOutcomesByFile,
+                    context.ProjectRelativePaths));
+            foreach (HotReloadGroupFile file in context.Files)
+            {
+                // Why not apply: the file's generations must keep the previous run's patches, so
+                // the apply loop skips it entirely instead of clearing it.
+                file.SkipApply = isolation.Plan.IsFailedFile(file.ProjectRelativePath);
+            }
+
+            AdoptRetryAddedMemberNames(context.Files, isolation.RetryFiles);
+            if (isolation.RetryEntries.Length == 0)
+            {
+                return HotReloadGroupCompileResult.NothingToApply();
+            }
+
+            return HotReloadGroupCompileResult.Apply(isolation.RetryEntries, isolation.RetryCompileResult);
+        }
+
+        private static List<HotReloadMethodOutcome> BuildAtomicFileSkipOutcomes(
             TransformWorkerEntryDto[] retryEntries,
             HotReloadGroupFilePaths groupFilePaths)
         {
-            Debug.Assert(outcomes != null, "outcomes must not be null.");
-            Debug.Assert(retryEntries != null, "retryEntries must not be null.");
-            Debug.Assert(groupFilePaths != null, "groupFilePaths must not be null.");
-
+            List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>(retryEntries.Length);
             foreach (TransformWorkerEntryDto entry in retryEntries)
             {
-                string methodLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                    entry.typeMetadataName,
-                    entry.methodName,
-                    entry.parameterTypeFullNames ?? Array.Empty<string>(),
-                    entry.genericArity);
                 outcomes.Add(
                     HotReloadMethodOutcome.Skipped(
-                        methodLabel,
+                        HotReloadMethodKeys.FormatMethodLabelParts(
+                            entry.typeMetadataName,
+                            entry.methodName,
+                            entry.parameterTypeFullNames ?? Array.Empty<string>(),
+                            entry.genericArity),
                         HotReloadConstants.AtomicFileSkipReason,
                         groupFilePaths.ResolveAssemblyResolvePath(entry.sourceProjectRelativePath)));
             }
+
+            return outcomes;
         }
 
-        private sealed class ShimFirstCompileResult
+        private static void AdoptFirstPassAddedMemberNames(IReadOnlyList<HotReloadGroupFile> files)
         {
-            public bool FileFailed { get; }
-            public List<HotReloadMethodOutcome> Outcomes { get; }
-            public TransformWorkerEntryDto[] EntriesToPatch { get; }
-            public HotReloadShimCompileResult CompileResult { get; }
-            public string[] AddedFieldNames { get; }
-
-            private ShimFirstCompileResult(
-                bool fileFailed,
-                List<HotReloadMethodOutcome> outcomes,
-                TransformWorkerEntryDto[] entriesToPatch,
-                HotReloadShimCompileResult compileResult,
-                string[] addedFieldNames = null)
+            foreach (HotReloadGroupFile file in files)
             {
-                FileFailed = fileFailed;
-                Outcomes = outcomes ?? new List<HotReloadMethodOutcome>();
-                EntriesToPatch = entriesToPatch ?? Array.Empty<TransformWorkerEntryDto>();
-                CompileResult = compileResult;
-                AddedFieldNames = addedFieldNames;
+                file.AddedFieldNames = file.FileOutput.addedFieldNames;
+                file.AddedConstNames = file.FileOutput.addedConstNames;
+            }
+        }
+
+        // Why the retry rows win: the retry re-classified every declaration with the exclusions
+        // in place, so its per-file added fields and consts are the ones the apply commits.
+        private static void AdoptRetryAddedMemberNames(
+            IReadOnlyList<HotReloadGroupFile> files,
+            TransformWorkerFileOutputDto[] retryFiles)
+        {
+            Dictionary<string, TransformWorkerFileOutputDto> retryFilesByPath =
+                new Dictionary<string, TransformWorkerFileOutputDto>(StringComparer.Ordinal);
+            foreach (TransformWorkerFileOutputDto retryFile in retryFiles)
+            {
+                retryFilesByPath[retryFile.projectRelativePath] = retryFile;
             }
 
-            public static ShimFirstCompileResult Failed(List<HotReloadMethodOutcome> outcomes)
+            foreach (HotReloadGroupFile file in files)
             {
-                return new ShimFirstCompileResult(
-                    true,
-                    outcomes,
-                    Array.Empty<TransformWorkerEntryDto>(),
-                    null);
-            }
-
-            public static ShimFirstCompileResult Succeeded(
-                TransformWorkerEntryDto[] entriesToPatch,
-                HotReloadShimCompileResult compileResult,
-                List<HotReloadMethodOutcome> outcomes = null,
-                string[] addedFieldNames = null)
-            {
-                return new ShimFirstCompileResult(
-                    false,
-                    outcomes,
-                    entriesToPatch,
-                    compileResult,
-                    addedFieldNames);
+                Debug.Assert(
+                    retryFilesByPath.ContainsKey(file.ProjectRelativePath),
+                    "A retry worker run must return one per-file output per edited file.");
+                TransformWorkerFileOutputDto retryFile = retryFilesByPath[file.ProjectRelativePath];
+                file.AddedFieldNames = retryFile.addedFieldNames;
+                file.AddedConstNames = retryFile.addedConstNames;
             }
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
@@ -32,7 +32,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             UnityCompilationAssembly compilationAssembly,
             string targetDllPath,
             string[] defines,
-            string assemblyResolvePath,
+            HotReloadGroupFilePaths groupFilePaths,
             string correlationId,
             CancellationToken ct)
         {
@@ -55,13 +55,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             List<HotReloadMethodOutcome> failedMethodOutcomes =
-                BuildFailedMethodOutcomes(attribution, assemblyResolvePath, workerOutput.skipped);
+                BuildFailedMethodOutcomes(attribution, groupFilePaths, workerOutput.skipped);
             IsolationExclusions exclusions = BuildIsolationExclusions(
                 attribution.FailedEntries,
                 workerOutput.entries);
             List<HotReloadMethodOutcome> skippedCallerOutcomes = BuildSkippedCallerOutcomes(
                 exclusions.CallerEntries,
-                assemblyResolvePath,
+                groupFilePaths,
                 HotReloadConstants.IsolatedAddedMethodCallerSkipReason);
 
             IsolationRetryRunResult retry = await RunIsolationRetryAsync(
@@ -73,7 +73,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 targetDllPath,
                 defines,
                 workerOutput.skipped,
-                assemblyResolvePath,
+                groupFilePaths,
                 HotReloadConstants.VibeLogIsolationTriggerShimCompileFailure,
                 correlationId,
                 ct).ConfigureAwait(false);
@@ -89,7 +89,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string targetDllPath,
             string[] defines,
             TransformWorkerSkippedDto[] firstPassSkipped,
-            string assemblyResolvePath,
+            HotReloadGroupFilePaths groupFilePaths,
             string trigger,
             string correlationId,
             CancellationToken ct)
@@ -140,7 +140,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<HotReloadMethodOutcome> retryOnlySkipped = CollectRetryOnlySkippedOutcomes(
                 firstPassSkipped,
                 retryOutput.skipped,
-                assemblyResolvePath,
+                groupFilePaths,
                 trigger,
                 exclusions.ExcludedAddedMethodKeys);
             skippedCallerOutcomes.AddRange(retryOnlySkipped);
@@ -219,7 +219,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal static List<HotReloadMethodOutcome> CollectRetryOnlySkippedOutcomes(
             TransformWorkerSkippedDto[] firstPassSkipped,
             TransformWorkerSkippedDto[] retrySkipped,
-            string assemblyResolvePath,
+            HotReloadGroupFilePaths groupFilePaths,
             string trigger,
             IReadOnlyCollection<string> excludedAddedMethodKeys)
         {
@@ -256,7 +256,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     HotReloadMethodOutcome.Skipped(
                         retryRow.method ?? "(unknown)",
                         retryRow.reason ?? string.Empty,
-                        assemblyResolvePath));
+                        groupFilePaths.ResolveAssemblyResolvePath(retryRow.sourceProjectRelativePath)));
             }
 
             return retryOnly;
@@ -330,7 +330,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static List<HotReloadMethodOutcome> BuildFailedMethodOutcomes(
             HotReloadShimErrorAttribution.ShimCompileErrorAttribution attribution,
-            string assemblyResolvePath,
+            HotReloadGroupFilePaths groupFilePaths,
             TransformWorkerSkippedDto[] skipped)
         {
             List<HotReloadMethodOutcome> failedMethodOutcomes = new List<HotReloadMethodOutcome>();
@@ -350,7 +350,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                             composedMessage,
                             entryErrorMessages,
                             skipped),
-                        assemblyResolvePath));
+                        groupFilePaths.ResolveAssemblyResolvePath(failedEntry.sourceProjectRelativePath)));
             }
 
             return failedMethodOutcomes;
@@ -461,7 +461,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal static List<HotReloadMethodOutcome> BuildSkippedCallerOutcomes(
             IReadOnlyList<TransformWorkerEntryDto> callerEntries,
-            string assemblyResolvePath,
+            HotReloadGroupFilePaths groupFilePaths,
             string skipReason)
         {
             List<HotReloadMethodOutcome> skippedCallerOutcomes = new List<HotReloadMethodOutcome>();
@@ -476,7 +476,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     HotReloadMethodOutcome.Skipped(
                         methodLabel,
                         skipReason,
-                        assemblyResolvePath));
+                        groupFilePaths.ResolveAssemblyResolvePath(caller.sourceProjectRelativePath)));
             }
 
             return skippedCallerOutcomes;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
@@ -14,16 +14,17 @@ using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// Retries shim compile once by excluding attributed failures and their added-method callers.
+    /// Retries shim compile once by excluding every entry of the files a compile error was
+    /// attributed to, so the remaining files of the group can still be applied.
     /// </summary>
     internal static class HotReloadShimIsolation
     {
         /// <summary>
-        /// Retries the failed shim compile once, excluding the method(s) whose compiler errors can
-        /// be attributed to them, so the rest of the file's methods can still patch. Returns null
-        /// when isolation is not possible (unattributable errors, all/none of the entries failing,
-        /// the retry worker run failing, or the retry compile failing) — the caller then falls back
-        /// to a single Failed outcome (method-attributed when only one entry remains).
+        /// Retries the failed shim compile once, excluding every entry of the files whose compiler
+        /// errors could be attributed to them, so the other files of the group can still patch.
+        /// Returns null when isolation is not possible (unattributable errors, every entry failing,
+        /// the retry worker run failing, or the retry compile failing) — the caller then falls back to one group-level
+        /// Failed outcome per file (method-attributed when the group holds a single entry).
         /// </summary>
         internal static async Task<HotReloadShimIsolationResult> TryIsolateShimCompileFailureAsync(
             TransformWorkerInputDto workerInput,
@@ -49,18 +50,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 || attribution.FailedEntries.Count == 0
                 || attribution.FailedEntries.Count == workerOutput.entries.Length)
             {
-                // Unattributable errors (header/binder/using-level / scaffold path), or isolating
-                // everyone / no one would not narrow the failure at all.
+                // Unattributable errors (header/binder/using-level or scaffold path): naming a
+                // file would be a guess, so the caller falls back to one group-level failure.
+                // Every entry failing is the same situation from the other side: excluding all
+                // of them would narrow nothing, and there is no file left to save.
                 return null;
             }
 
+            List<string> groupPaths = CollectSourceProjectRelativePaths(workerInput);
+            HotReloadFileAtomicIsolationPlan plan = HotReloadFileAtomicIsolationPlan.Build(
+                workerOutput.entries,
+                attribution,
+                workerOutput.skipped,
+                groupFilePaths,
+                groupPaths);
             List<HotReloadMethodOutcome> failedMethodOutcomes =
-                BuildFailedMethodOutcomes(attribution, groupFilePaths, workerOutput.skipped);
-            IsolationExclusions exclusions = BuildIsolationExclusions(
-                attribution.FailedEntries,
-                workerOutput.entries);
+                HotReloadFileAtomicIsolationPlan.CollectOutcomes(plan.FailedOutcomesByFile, groupPaths);
+            IsolationExclusions exclusions = new IsolationExclusions(
+                plan.ExcludedMethodKeys,
+                plan.ExcludedAddedMethodKeys,
+                plan.CallerEntries);
             List<HotReloadMethodOutcome> skippedCallerOutcomes = BuildSkippedCallerOutcomes(
-                exclusions.CallerEntries,
+                plan.CallerEntries,
                 groupFilePaths,
                 HotReloadConstants.IsolatedAddedMethodCallerSkipReason);
 
@@ -77,6 +88,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadConstants.VibeLogIsolationTriggerShimCompileFailure,
                 correlationId,
                 ct).ConfigureAwait(false);
+            retry.Isolation?.AttachPlan(plan);
             return retry.Isolation;
         }
 
@@ -129,11 +141,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             TransformWorkerOutputDto retryOutput = retryWorkerResult.Output;
-            // One source in, one per-file row out. Assembly grouping widens this to the group size.
             Debug.Assert(
-                retryOutput.files.Length == 1,
-                "A single-source retry worker run must return exactly one per-file output.");
-            TransformWorkerFileOutputDto retryFileOutput = retryOutput.files[0];
+                retryOutput.files.Length == workerInput.sources.Length,
+                "A retry worker run must return one per-file output per source.");
             // Why drop first-pass (Method, Reason) pairs: consuming them again would duplicate
             // every per-file skip. Retry-only pairs are new — typically transitive callers of
             // excluded added methods — and must surface or the edit is applied nowhere.
@@ -161,9 +171,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         skippedCallerOutcomes,
                         Array.Empty<TransformWorkerEntryDto>(),
                         null,
-                        retryFileOutput.addedFieldNames,
-                        retryOutput.siblingConstDriftWarnings,
-                        retryFileOutput.addedConstNames));
+                        retryOutput.files,
+                        retryOutput.siblingConstDriftWarnings));
             }
 
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -187,7 +196,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 retryOutput.shimSource,
                 shimReferences,
                 defines,
-                workerInput.sources[0].projectRelativePath,
+                CollectSourceProjectRelativePaths(workerInput),
                 ct).ConfigureAwait(false);
             if (!retryCompileResult.Success)
             {
@@ -205,9 +214,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     skippedCallerOutcomes,
                     retryOutput.entries,
                     retryCompileResult,
-                    retryFileOutput.addedFieldNames,
-                    retryOutput.siblingConstDriftWarnings,
-                    retryFileOutput.addedConstNames));
+                    retryOutput.files,
+                    retryOutput.siblingConstDriftWarnings));
         }
 
         /// <summary>
@@ -328,32 +336,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return false;
         }
 
-        private static List<HotReloadMethodOutcome> BuildFailedMethodOutcomes(
-            HotReloadShimErrorAttribution.ShimCompileErrorAttribution attribution,
-            HotReloadGroupFilePaths groupFilePaths,
-            TransformWorkerSkippedDto[] skipped)
+        // The project-relative paths of every source the run transformed, for shim-diagnostic
+        // line mapping.
+        internal static List<string> CollectSourceProjectRelativePaths(TransformWorkerInputDto workerInput)
         {
-            List<HotReloadMethodOutcome> failedMethodOutcomes = new List<HotReloadMethodOutcome>();
-            foreach (TransformWorkerEntryDto failedEntry in attribution.FailedEntries)
+            List<string> projectRelativePaths = new List<string>(workerInput.sources.Length);
+            foreach (TransformWorkerSourceDto source in workerInput.sources)
             {
-                string methodLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                    failedEntry.typeMetadataName,
-                    failedEntry.methodName,
-                    failedEntry.parameterTypeFullNames ?? Array.Empty<string>(),
-                    failedEntry.genericArity);
-                List<string> entryErrorMessages = attribution.ErrorMessagesByEntry[failedEntry];
-                string composedMessage = HotReloadShimCompiler.ComposeShimCompileFailureMessage(entryErrorMessages);
-                failedMethodOutcomes.Add(
-                    HotReloadMethodOutcome.Failed(
-                        methodLabel,
-                        HotReloadSkippedMemberCompileNote.AppendNotes(
-                            composedMessage,
-                            entryErrorMessages,
-                            skipped),
-                        groupFilePaths.ResolveAssemblyResolvePath(failedEntry.sourceProjectRelativePath)));
+                projectRelativePaths.Add(source.projectRelativePath);
             }
 
-            return failedMethodOutcomes;
+            return projectRelativePaths;
         }
 
         internal static IsolationExclusions BuildIsolationExclusions(
@@ -532,27 +525,39 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public List<HotReloadMethodOutcome> SkippedCallerOutcomes { get; }
             public TransformWorkerEntryDto[] RetryEntries { get; }
             public HotReloadShimCompileResult RetryCompileResult { get; }
-            public string[] AddedFieldNames { get; }
-            public string[] AddedConstNames { get; }
+
+            // Per-file rows of the retry worker run. Why the rows (not one added-name array): the
+            // retry covers the whole group, and added fields and consts are per-file results.
+            public TransformWorkerFileOutputDto[] RetryFiles { get; }
+
             public string[] SiblingConstDriftWarnings { get; }
+
+            // How the failed shim compile was split across the group's files. Null when the
+            // signature-change gate drove the retry: that retry isolates gated replacements,
+            // not compile failures, so no file was taken down by an error.
+            public HotReloadFileAtomicIsolationPlan Plan { get; private set; }
+
+            internal void AttachPlan(HotReloadFileAtomicIsolationPlan plan)
+            {
+                Debug.Assert(plan != null, "plan must not be null.");
+                Plan = plan;
+            }
 
             public HotReloadShimIsolationResult(
                 List<HotReloadMethodOutcome> failedMethodOutcomes,
                 List<HotReloadMethodOutcome> skippedCallerOutcomes,
                 TransformWorkerEntryDto[] retryEntries,
                 HotReloadShimCompileResult retryCompileResult,
-                string[] addedFieldNames = null,
-                string[] siblingConstDriftWarnings = null,
-                string[] addedConstNames = null)
+                TransformWorkerFileOutputDto[] retryFiles = null,
+                string[] siblingConstDriftWarnings = null)
             {
                 Debug.Assert(skippedCallerOutcomes != null, "skippedCallerOutcomes must not be null.");
                 FailedMethodOutcomes = failedMethodOutcomes;
                 SkippedCallerOutcomes = skippedCallerOutcomes;
                 RetryEntries = retryEntries;
                 RetryCompileResult = retryCompileResult;
-                AddedFieldNames = addedFieldNames ?? Array.Empty<string>();
+                RetryFiles = retryFiles ?? Array.Empty<TransformWorkerFileOutputDto>();
                 SiblingConstDriftWarnings = siblingConstDriftWarnings ?? Array.Empty<string>();
-                AddedConstNames = addedConstNames ?? Array.Empty<string>();
             }
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeCoverage.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeCoverage.cs
@@ -302,6 +302,64 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return methodKeys;
         }
 
+        /// <summary>
+        /// The edited-method keys of each file of the group, keyed by that file's project
+        /// relative path.
+        /// </summary>
+        /// <remarks>
+        /// Why per file: "every uncovered caller is in the edited file" is a statement about one
+        /// file. A group run transforms several files at once, so a set built from all of them
+        /// would call a caller in a sibling file a same-file caller.
+        /// </remarks>
+        internal static Dictionary<string, HashSet<string>> CollectEditedFileMethodKeysByFile(
+            TransformWorkerEntryDto[] entries,
+            TransformWorkerUnchangedMethodDto[] unchangedMethods)
+        {
+            Debug.Assert(entries != null, "entries must not be null.");
+            Debug.Assert(unchangedMethods != null, "unchangedMethods must not be null.");
+
+            Dictionary<string, HashSet<string>> methodKeysByFile =
+                new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+            foreach (TransformWorkerEntryDto entry in entries)
+            {
+                AddMethodKeyOfFile(
+                    methodKeysByFile,
+                    entry.sourceProjectRelativePath,
+                    HotReloadMethodKeys.BuildMethodKey(entry));
+            }
+
+            foreach (TransformWorkerUnchangedMethodDto unchanged in unchangedMethods)
+            {
+                AddMethodKeyOfFile(
+                    methodKeysByFile,
+                    unchanged.sourceProjectRelativePath,
+                    HotReloadMethodKeys.BuildMethodKeyParts(
+                        unchanged.typeMetadataName,
+                        unchanged.methodName,
+                        unchanged.parameterTypeFullNames,
+                        unchanged.genericArity));
+            }
+
+            return methodKeysByFile;
+        }
+
+        private static void AddMethodKeyOfFile(
+            Dictionary<string, HashSet<string>> methodKeysByFile,
+            string projectRelativePath,
+            string methodKey)
+        {
+            Debug.Assert(
+                !string.IsNullOrEmpty(projectRelativePath),
+                "A worker row must name the source file it came from.");
+            if (!methodKeysByFile.TryGetValue(projectRelativePath, out HashSet<string> methodKeys))
+            {
+                methodKeys = new HashSet<string>(StringComparer.Ordinal);
+                methodKeysByFile[projectRelativePath] = methodKeys;
+            }
+
+            methodKeys.Add(methodKey);
+        }
+
         internal static bool AreAllUncoveredCallersInEditedFile(
             IReadOnlyList<string> uncoveredCallerKeys,
             HashSet<string> editedFileMethodKeys)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
@@ -63,12 +63,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 gatedReplacements,
                 uncoveredCallersByTarget,
                 editedFileMethodKeys,
-                context.AssemblyResolvePath,
-                context.ProjectRelativePath);
+                context.GroupFilePaths);
             skippedOutcomes.AddRange(
                 HotReloadShimIsolation.BuildSkippedCallerOutcomes(
                     exclusions.CallerEntries,
-                    context.AssemblyResolvePath,
+                    context.GroupFilePaths,
                     HotReloadConstants.SignatureChangedGatedCallerSkipReason));
 
             HotReloadShimIsolation.IsolationRetryRunResult retry = await HotReloadShimIsolation.RunIsolationRetryAsync(
@@ -80,7 +79,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 context.TargetDllPath,
                 context.Defines,
                 context.WorkerOutput.skipped,
-                context.AssemblyResolvePath,
+                context.GroupFilePaths,
                 HotReloadConstants.VibeLogIsolationTriggerSignatureChangeGate,
                 context.CorrelationId,
                 ct).ConfigureAwait(false);
@@ -237,8 +236,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             IReadOnlyList<TransformWorkerEntryDto> gatedReplacements,
             Dictionary<string, List<string>> uncoveredCallersByTarget,
             HashSet<string> editedFileMethodKeys,
-            string assemblyResolvePath,
-            string projectRelativePath)
+            HotReloadGroupFilePaths groupFilePaths)
         {
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
             foreach (TransformWorkerEntryDto entry in gatedReplacements)
@@ -248,7 +246,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 string reason;
                 // Why live registry, not a run-start snapshot: BeginFileGeneration runs after
                 // this gate, so the previous apply's added members are still listed here.
-                if (HotReloadAddedMemberRegistry.IsActiveMember(projectRelativePath, methodLabel))
+                // Why the entry's own file: a group run gates the replacements of several files,
+                // and a member is active per file.
+                if (HotReloadAddedMemberRegistry.IsActiveMember(entry.sourceProjectRelativePath, methodLabel))
                 {
                     reason = string.Format(
                         HotReloadConstants.SignatureChangedGateSkipReasonAlreadyActiveFormat,
@@ -273,7 +273,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     HotReloadMethodOutcome.Skipped(
                         methodLabel,
                         reason,
-                        assemblyResolvePath));
+                        groupFilePaths.ResolveAssemblyResolvePath(entry.sourceProjectRelativePath)));
             }
 
             return outcomes;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
@@ -54,13 +54,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             HotReloadShimIsolation.IsolationExclusions exclusions = HotReloadShimIsolation.BuildIsolationExclusions(gatedReplacements, entries);
-            HashSet<string> editedFileMethodKeys = HotReloadSignatureChangeCoverage.CollectEditedFileMethodKeys(
-                entries,
-                context.WorkerOutput.unchangedMethods ?? Array.Empty<TransformWorkerUnchangedMethodDto>());
+            Dictionary<string, HashSet<string>> editedFileMethodKeysByFile =
+                HotReloadSignatureChangeCoverage.CollectEditedFileMethodKeysByFile(
+                    entries,
+                    context.WorkerOutput.unchangedMethods ?? Array.Empty<TransformWorkerUnchangedMethodDto>());
             List<HotReloadMethodOutcome> skippedOutcomes = BuildGatedReplacementSkipOutcomes(
                 gatedReplacements,
                 uncoveredCallersByTarget,
-                editedFileMethodKeys,
+                editedFileMethodKeysByFile,
                 context.GroupFilePaths);
             skippedOutcomes.AddRange(
                 HotReloadShimIsolation.BuildSkippedCallerOutcomes(
@@ -233,7 +234,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static List<HotReloadMethodOutcome> BuildGatedReplacementSkipOutcomes(
             IReadOnlyList<TransformWorkerEntryDto> gatedReplacements,
             Dictionary<string, List<string>> uncoveredCallersByTarget,
-            HashSet<string> editedFileMethodKeys,
+            Dictionary<string, HashSet<string>> editedFileMethodKeysByFile,
             HotReloadGroupFilePaths groupFilePaths)
         {
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
@@ -252,7 +253,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         HotReloadConstants.SignatureChangedGateSkipReasonAlreadyActiveFormat,
                         methodLabel);
                 }
+                // Why this entry's own file: a caller edited in a sibling file of the group is
+                // not a same-file caller, and telling the user otherwise points them at the
+                // wrong file.
                 else if (uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> uncoveredCallers)
+                    && editedFileMethodKeysByFile.TryGetValue(
+                        entry.sourceProjectRelativePath,
+                        out HashSet<string> editedFileMethodKeys)
                     && HotReloadSignatureChangeCoverage.AreAllUncoveredCallersInEditedFile(uncoveredCallers, editedFileMethodKeys))
                 {
                     reason = string.Format(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
@@ -22,9 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(context != null, "context must not be null.");
             TransformWorkerEntryDto[] entries = context.WorkerOutput.entries ?? Array.Empty<TransformWorkerEntryDto>();
-            TransformWorkerRemovedMethodSignatureDto[] removedSignatures =
-                context.FileOutput.removedMethodSignatures
-                ?? Array.Empty<TransformWorkerRemovedMethodSignatureDto>();
+            TransformWorkerRemovedMethodSignatureDto[] removedSignatures = context.RemovedMethodSignatures;
             List<TransformWorkerEntryDto> replacementEntries = CollectReplacementEntries(entries);
             if (replacementEntries.Count == 0 && removedSignatures.Length == 0)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourcePathNormalizer.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSourcePathNormalizer.cs
@@ -17,6 +17,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return path.Replace('\\', '/');
         }
 
+        /// <summary>
+        /// The comparer for project-relative script paths on this platform: two spellings that
+        /// differ only in case name the same file on Windows and different files elsewhere.
+        /// </summary>
+        public static StringComparer ProjectRelativePathComparer()
+        {
+            return Path.DirectorySeparatorChar == '\\'
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal;
+        }
+
         public static bool PathsReferToSameFile(string documentUrl, string projectRelativePath)
         {
             Debug.Assert(documentUrl != null, "documentUrl must not be null.");

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSupersededSignatureRecorder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSupersededSignatureRecorder.cs
@@ -4,17 +4,22 @@ using System.Collections.Generic;
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// Records superseded compiled signatures from a worker output so --status can explain
-    /// leftover Active rows after a return-type change.
+    /// Records superseded compiled signatures from the entries a file actually applied, so
+    /// --status can explain leftover Active rows after a return-type change.
     /// </summary>
     internal static class HotReloadSupersededSignatureRecorder
     {
-        public static void RecordFromWorkerOutput(
-            TransformWorkerOutputDto workerOutput,
-            TransformWorkerRemovedMethodSignatureDto[] removedMethodSignatures,
+        /// <remarks>
+        /// Why the applied entries (not the run's whole output): a group can apply one file while
+        /// isolation drops another, and a replacement that was never patched must not claim the
+        /// compiled signature it would have superseded.
+        /// </remarks>
+        public static void RecordFromAppliedEntries(
+            IReadOnlyList<TransformWorkerEntryDto> appliedEntries,
+            IReadOnlyList<TransformWorkerRemovedMethodSignatureDto> removedMethodSignatures,
             IReadOnlyCollection<string> gatedReplacementMethodKeys)
         {
-            if (workerOutput == null || removedMethodSignatures == null)
+            if (appliedEntries == null || removedMethodSignatures == null)
             {
                 return;
             }
@@ -23,7 +28,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 gatedReplacementMethodKeys ?? Array.Empty<string>(),
                 StringComparer.Ordinal);
             IReadOnlyDictionary<string, TransformWorkerEntryDto> replacementsByWireKey =
-                HotReloadReplacedCompiledMethodEntries.IndexByReplacedWireKey(workerOutput.entries);
+                HotReloadReplacedCompiledMethodEntries.IndexByReplacedWireKey(appliedEntries);
 
             foreach (TransformWorkerRemovedMethodSignatureDto signature in removedMethodSignatures)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerNoticeAppender.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerNoticeAppender.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -14,57 +13,36 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         // Why after the worker: const-only / empty files have no patch candidates, so the
         // missing-baseline warning was pure noise (FB E). Emit only when the worker saw at
-        // least one method or accessor row.
+        // least one method or accessor row for this file.
         internal static void AppendWorkerNotices(
-            TransformWorkerOutputDto workerOutput,
             TransformWorkerFileOutputDto fileOutput,
+            IReadOnlyList<TransformWorkerSkippedDto> fileSkipped,
+            int patchCandidateRowCountForFile,
             string snapshotSource,
             string projectRelativePath,
             string assemblyName,
             string assemblyResolvePath,
             List<HotReloadMethodOutcome> outcomes,
-            List<string> warnings,
-            List<string> siblingDerivedWarnings)
+            List<string> warnings)
         {
-            Debug.Assert(workerOutput != null, "workerOutput must not be null.");
             Debug.Assert(fileOutput != null, "fileOutput must not be null.");
+            Debug.Assert(fileSkipped != null, "fileSkipped must not be null.");
+            Debug.Assert(patchCandidateRowCountForFile >= 0, "patchCandidateRowCountForFile must not be negative.");
             Debug.Assert(outcomes != null, "outcomes must not be null.");
             Debug.Assert(warnings != null, "warnings must not be null.");
-            Debug.Assert(siblingDerivedWarnings != null, "siblingDerivedWarnings must not be null.");
-            AssertEntryRowsCameFromTheEditedFile(workerOutput, projectRelativePath);
 
             AppendBaselineNotices(
-                workerOutput,
                 fileOutput,
+                patchCandidateRowCountForFile,
                 snapshotSource,
                 projectRelativePath,
                 assemblyName,
                 warnings);
             AppendAll(warnings, fileOutput.parseErrors);
-            AppendSkippedOutcomes(workerOutput.skipped, assemblyResolvePath, outcomes);
+            AppendSkippedOutcomes(fileSkipped, assemblyResolvePath, outcomes);
             // Surfaced before the empty-entries early return so const drift still reaches
             // the response when every method in the file is skipped or unchanged.
             AppendAll(warnings, fileOutput.declarationDriftWarnings);
-            AppendAll(siblingDerivedWarnings, workerOutput.siblingConstDriftWarnings);
-        }
-
-        // States today's contract: one worker run covers one file, so every entry row it returns
-        // must name that file. Grouping several files into one shim assembly will relax this.
-        private static void AssertEntryRowsCameFromTheEditedFile(
-            TransformWorkerOutputDto workerOutput,
-            string projectRelativePath)
-        {
-            if (workerOutput.entries == null)
-            {
-                return;
-            }
-
-            foreach (TransformWorkerEntryDto entry in workerOutput.entries)
-            {
-                Debug.Assert(
-                    string.Equals(entry.sourceProjectRelativePath, projectRelativePath, StringComparison.Ordinal),
-                    "Worker entry row reports a different source file than the one this run edited.");
-            }
         }
 
         internal static void AppendRetrySiblingConstDriftWarnings(
@@ -81,14 +59,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         private static void AppendBaselineNotices(
-            TransformWorkerOutputDto workerOutput,
             TransformWorkerFileOutputDto fileOutput,
+            int patchCandidateRowCountForFile,
             string snapshotSource,
             string projectRelativePath,
             string assemblyName,
             List<string> warnings)
         {
-            if (snapshotSource == null && CountPatchCandidateRows(workerOutput) >= 1)
+            if (snapshotSource == null && patchCandidateRowCountForFile >= 1)
             {
                 warnings.Add(
                     string.Format(
@@ -108,15 +86,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         private static void AppendSkippedOutcomes(
-            TransformWorkerSkippedDto[] skippedRows,
+            IReadOnlyList<TransformWorkerSkippedDto> skippedRows,
             string assemblyResolvePath,
             List<HotReloadMethodOutcome> outcomes)
         {
-            if (skippedRows == null)
-            {
-                return;
-            }
-
             foreach (TransformWorkerSkippedDto skipped in skippedRows)
             {
                 outcomes.Add(
@@ -138,15 +111,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 target.Add(additions[index]);
             }
-        }
-
-        private static int CountPatchCandidateRows(TransformWorkerOutputDto workerOutput)
-        {
-            int entryCount = workerOutput.entries != null ? workerOutput.entries.Length : 0;
-            int skippedCount = workerOutput.skipped != null ? workerOutput.skipped.Length : 0;
-            int unchangedCount =
-                workerOutput.unchangedMethods != null ? workerOutput.unchangedMethods.Length : 0;
-            return entryCount + skippedCount + unchangedCount;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerRowsByFile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerRowsByFile.cs
@@ -84,6 +84,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 fileOutputsByFile);
         }
 
+        // Groups an entry list that did not come from the group output itself - the isolation
+        // retry produces its own entries - so the apply stage can walk one file at a time.
+        public static Dictionary<string, List<TransformWorkerEntryDto>> GroupEntriesBySourceFile(
+            IReadOnlyList<TransformWorkerEntryDto> entries,
+            IReadOnlyCollection<string> groupPaths)
+        {
+            Debug.Assert(entries != null, "entries must not be null.");
+            Debug.Assert(groupPaths != null && groupPaths.Count > 0, "A group must hold a file.");
+
+            Dictionary<string, List<TransformWorkerEntryDto>> entriesByFile =
+                new Dictionary<string, List<TransformWorkerEntryDto>>(StringComparer.Ordinal);
+            foreach (string groupPath in groupPaths)
+            {
+                entriesByFile[groupPath] = new List<TransformWorkerEntryDto>();
+            }
+
+            HashSet<string> groupPathSet = new HashSet<string>(groupPaths, StringComparer.Ordinal);
+            foreach (TransformWorkerEntryDto entry in entries)
+            {
+                AssertRowBelongsToGroup(groupPathSet, entry.sourceProjectRelativePath, "entry");
+                entriesByFile[entry.sourceProjectRelativePath].Add(entry);
+            }
+
+            return entriesByFile;
+        }
+
         public IReadOnlyList<TransformWorkerEntryDto> EntriesFor(string projectRelativePath)
         {
             Debug.Assert(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerRowsByFile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerRowsByFile.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Splits the output of one group worker run into the rows of each edited file, so per-file
+    /// notices, gates and apply steps read only what their own file produced.
+    /// </summary>
+    internal sealed class HotReloadWorkerRowsByFile
+    {
+        private readonly Dictionary<string, List<TransformWorkerEntryDto>> entriesByFile;
+        private readonly Dictionary<string, List<TransformWorkerSkippedDto>> skippedByFile;
+        private readonly Dictionary<string, List<TransformWorkerUnchangedMethodDto>> unchangedByFile;
+        private readonly Dictionary<string, TransformWorkerFileOutputDto> fileOutputsByFile;
+
+        private HotReloadWorkerRowsByFile(
+            Dictionary<string, List<TransformWorkerEntryDto>> entriesByFile,
+            Dictionary<string, List<TransformWorkerSkippedDto>> skippedByFile,
+            Dictionary<string, List<TransformWorkerUnchangedMethodDto>> unchangedByFile,
+            Dictionary<string, TransformWorkerFileOutputDto> fileOutputsByFile)
+        {
+            this.entriesByFile = entriesByFile;
+            this.skippedByFile = skippedByFile;
+            this.unchangedByFile = unchangedByFile;
+            this.fileOutputsByFile = fileOutputsByFile;
+        }
+
+        public static HotReloadWorkerRowsByFile Build(
+            TransformWorkerOutputDto output,
+            IReadOnlyCollection<string> groupPaths)
+        {
+            Debug.Assert(output != null, "output must not be null.");
+            Debug.Assert(groupPaths != null && groupPaths.Count > 0, "A group must hold a file.");
+
+            Dictionary<string, List<TransformWorkerEntryDto>> entriesByFile =
+                new Dictionary<string, List<TransformWorkerEntryDto>>(StringComparer.Ordinal);
+            Dictionary<string, List<TransformWorkerSkippedDto>> skippedByFile =
+                new Dictionary<string, List<TransformWorkerSkippedDto>>(StringComparer.Ordinal);
+            Dictionary<string, List<TransformWorkerUnchangedMethodDto>> unchangedByFile =
+                new Dictionary<string, List<TransformWorkerUnchangedMethodDto>>(StringComparer.Ordinal);
+            Dictionary<string, TransformWorkerFileOutputDto> fileOutputsByFile =
+                new Dictionary<string, TransformWorkerFileOutputDto>(StringComparer.Ordinal);
+            foreach (string groupPath in groupPaths)
+            {
+                entriesByFile[groupPath] = new List<TransformWorkerEntryDto>();
+                skippedByFile[groupPath] = new List<TransformWorkerSkippedDto>();
+                unchangedByFile[groupPath] = new List<TransformWorkerUnchangedMethodDto>();
+            }
+
+            HashSet<string> groupPathSet = new HashSet<string>(groupPaths, StringComparer.Ordinal);
+            foreach (TransformWorkerEntryDto entry in output.entries)
+            {
+                AssertRowBelongsToGroup(groupPathSet, entry.sourceProjectRelativePath, "entry");
+                entriesByFile[entry.sourceProjectRelativePath].Add(entry);
+            }
+
+            foreach (TransformWorkerSkippedDto skipped in output.skipped)
+            {
+                AssertRowBelongsToGroup(groupPathSet, skipped.sourceProjectRelativePath, "skipped");
+                skippedByFile[skipped.sourceProjectRelativePath].Add(skipped);
+            }
+
+            foreach (TransformWorkerUnchangedMethodDto unchanged in output.unchangedMethods)
+            {
+                AssertRowBelongsToGroup(
+                    groupPathSet,
+                    unchanged.sourceProjectRelativePath,
+                    "unchanged-method");
+                unchangedByFile[unchanged.sourceProjectRelativePath].Add(unchanged);
+            }
+
+            foreach (TransformWorkerFileOutputDto fileOutput in output.files)
+            {
+                AssertRowBelongsToGroup(groupPathSet, fileOutput.projectRelativePath, "per-file");
+                fileOutputsByFile[fileOutput.projectRelativePath] = fileOutput;
+            }
+
+            return new HotReloadWorkerRowsByFile(
+                entriesByFile,
+                skippedByFile,
+                unchangedByFile,
+                fileOutputsByFile);
+        }
+
+        public IReadOnlyList<TransformWorkerEntryDto> EntriesFor(string projectRelativePath)
+        {
+            Debug.Assert(
+                entriesByFile.ContainsKey(projectRelativePath),
+                "Entries can only be read for a file of the group.");
+            return entriesByFile[projectRelativePath];
+        }
+
+        public IReadOnlyList<TransformWorkerSkippedDto> SkippedFor(string projectRelativePath)
+        {
+            Debug.Assert(
+                skippedByFile.ContainsKey(projectRelativePath),
+                "Skipped rows can only be read for a file of the group.");
+            return skippedByFile[projectRelativePath];
+        }
+
+        public IReadOnlyList<TransformWorkerUnchangedMethodDto> UnchangedFor(string projectRelativePath)
+        {
+            Debug.Assert(
+                unchangedByFile.ContainsKey(projectRelativePath),
+                "Unchanged methods can only be read for a file of the group.");
+            return unchangedByFile[projectRelativePath];
+        }
+
+        public TransformWorkerFileOutputDto FileOutputFor(string projectRelativePath)
+        {
+            Debug.Assert(
+                fileOutputsByFile.ContainsKey(projectRelativePath),
+                "Every file of the group must have a per-file worker output.");
+            return fileOutputsByFile[projectRelativePath];
+        }
+
+        // Why assert (not tolerate): a row naming a file outside the group means the worker and
+        // the group disagree about what was sent, and silently dropping it would hide the edit.
+        private static void AssertRowBelongsToGroup(
+            HashSet<string> groupPathSet,
+            string sourceProjectRelativePath,
+            string rowKind)
+        {
+            Debug.Assert(
+                sourceProjectRelativePath != null
+                && groupPathSet.Contains(sourceProjectRelativePath),
+                "A worker " + rowKind + " row must name a file of the group.");
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerRowsByFile.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadWorkerRowsByFile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e16cb90e2d9ac411b9704b8994879f55
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Editing several files of the same assembly in one `uloop hot-reload` now works as one reload: a body edited in one file can call a method or read a field added in another file of that same reload.
- A file that fails to compile no longer takes the whole reload down — the other files of the group are still applied, and the failed file reports what it skipped.

## User Impact
- Before: hot reload processed one edited file at a time. A method added in `Host.cs` was invisible to a body edited in `Caller.cs` in the same command, so that edit failed with "run 'uloop compile'" even though both files were passed together.
- After: files that compile into the same assembly are reloaded together. Cross-file added methods, added fields and folded consts bind, and each method is still reported under the file that declares it.
- A compile error is contained to its own file. The healthy files of the reload are applied, the broken file's other methods are reported as skipped because hot reload applies a file all-or-nothing, and a body that calls an added method declared in the broken file is reported as such rather than silently dropped.
- Files of different assemblies passed in one command are reloaded independently, so a failure in one does not affect the other.

## Changes
- The apply pipeline is now group-shaped: one context per group of files with per-file state, a dedicated group processor that snapshots, runs the worker, gates and compiles once, and an orchestrator that only resolves patch targets, plans groups and merges per-file results in input order.
- Shim compile failures are isolated by file: whole failed files are excluded so the surviving files apply, and the narrower failed-method-and-callers exclusion is kept for the case where no file survives.
- Worker notices, the signature-change gate and the isolation retry resolve which file each row belongs to instead of assuming a single edited file, and the sibling const-drift scan excludes every file edited in the run.
- A file left with no entry of its own still reports the added field names it committed, so the response cannot disagree with the added-field ledger when only a sibling file's body uses that field.
- Apply is split into a group loop (accessor binding once per group) and a single-file applier, keeping every production file under the length and complexity limits.

## Verification
- `dist/darwin-arm64/uloop compile` — no errors (only pre-existing test-fixture warnings).
- `dist/darwin-arm64/uloop run-tests --skip-compile --filter-type class --filter-value HotReloadCrossFileE2ETests` — 7 tests, 7 passed, 0 failed.
- `dist/darwin-arm64/uloop run-tests --skip-compile --filter-type class --filter-value HotReloadFileAtomicIsolationPlanTests` — 2 tests, 2 passed, 0 failed.
- `dist/darwin-arm64/uloop run-tests --skip-compile --filter-type regex --filter-value 'HotReload'` — 712 tests, 712 passed, 0 failed.
- `sh scripts/check-file-length.sh` — no files exceeded the 500 SLOC limit.
- `sh scripts/check-code-complexity.sh` — 0 Go issues, no CA1502 findings above 15.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

