### PR TITLE
fix: Hot reload status no longer credits an unapplied method for replacing an old signature

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2844,6 +2844,98 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
         }
 
+        /// <summary>
+        /// What: when a Harmony apply-engine failure stops a file after an earlier entry patched,
+        /// only the patched entry is reported as applied, so the failed replacement's removed
+        /// signature is not recorded as superseded.
+        /// </summary>
+        [Test]
+        public void ApplyEntries_ReplacementFailsAfterPatchedEntry_RecordsNoSupersededSignature()
+        {
+            const string projectRelativePath = "Assets/Tests/Editor/HotReload/PartialApplyReplacement.cs";
+            string typeName = typeof(HotReloadCoreFixture).FullName;
+            string[] replacedParameterTypeFullNames = { typeof(int).FullName };
+            TransformWorkerEntryDto patchedEntry = CreateExistingMethodEntry(
+                typeName,
+                nameof(HotReloadCoreFixture.VoidBump),
+                Array.Empty<string>(),
+                nameof(HotReloadHandwrittenShims),
+                nameof(HotReloadHandwrittenShims.VoidBump__shim0));
+            TransformWorkerEntryDto failedReplacementEntry = CreateExistingMethodEntry(
+                typeName,
+                nameof(HotReloadCoreFixture.ReplaceableCompute),
+                replacedParameterTypeFullNames,
+                nameof(HotReloadOrchestratorTests),
+                nameof(ApplyEngineFailureExternShim));
+            failedReplacementEntry.replacesCompiledMethod = true;
+            TransformWorkerEntryDto[] entries = { patchedEntry, failedReplacementEntry };
+            TransformWorkerOutputDto workerOutput = new TransformWorkerOutputDto
+            {
+                entries = entries,
+                files = new[]
+                {
+                    new TransformWorkerFileOutputDto
+                    {
+                        projectRelativePath = projectRelativePath,
+                        addedFieldNames = Array.Empty<string>(),
+                        sourceContentSha256 = "partial-apply-replacement",
+                        removedMethodSignatures = new[]
+                        {
+                            new TransformWorkerRemovedMethodSignatureDto
+                            {
+                                typeMetadataName = typeName,
+                                methodName = nameof(HotReloadCoreFixture.ReplaceableCompute),
+                                parameterTypeFullNames = replacedParameterTypeFullNames,
+                                genericArity = 0
+                            }
+                        }
+                    }
+                }
+            };
+            string removedMethodLabel = HotReloadMethodKeys.FormatMethodLabelParts(
+                typeName,
+                nameof(HotReloadCoreFixture.ReplaceableCompute),
+                replacedParameterTypeFullNames,
+                genericArity: 0);
+            HotReloadApplyContext context = CreateApplyContext(
+                typeof(HotReloadCoreFixture).Assembly.GetName().Name,
+                projectRelativePath,
+                workerOutput,
+                entries,
+                Array.Empty<string>());
+            HotReloadSupersededSignatureRegistry.ClearAll();
+
+            try
+            {
+                IReadOnlyList<HotReloadFileProcessResult> results =
+                    HotReloadEntryApplier.ApplyGroupAndBuildResults(
+                        context,
+                        HotReloadShimCompileResult.SuccessResult(
+                            typeof(HotReloadOrchestratorTests).Assembly,
+                            new byte[] { 1 },
+                            Array.Empty<byte>()),
+                        entries);
+
+                Assert.That(results[0].Outcomes[0].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Patched));
+                Assert.That(results[0].Outcomes[1].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Failed));
+                Assert.That(context.Files[0].Sinks.AppliedEntries, Is.EqualTo(new[] { patchedEntry }));
+
+                HotReloadSupersededSignatureRecorder.RecordFromAppliedEntries(
+                    context.Files[0].Sinks.AppliedEntries,
+                    context.Files[0].FileOutput.removedMethodSignatures,
+                    Array.Empty<string>());
+
+                Assert.That(
+                    HotReloadSupersededSignatureRegistry.TryGetReplacement(removedMethodLabel, out string _),
+                    Is.False);
+            }
+            finally
+            {
+                HotReloadSupersededSignatureRegistry.ClearAll();
+                HotReloadPatcher.RevertAll();
+            }
+        }
+
         [DllImport("__Internal")]
         public static extern int ApplyEngineFailureExternShim(int value);
 

--- a/Assets/Tests/Editor/HotReload/HotReloadSupersededSignatureRecorderTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSupersededSignatureRecorderTests.cs
@@ -15,6 +15,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     {
         private const string TypeMetadataName = "Sample.Host";
         private const string RemovedMethodLabel = "Sample.Host.Scaled(System.Int32)";
+        private const string DecoyMethodLabel = "Sample.Host.Other(System.Int32)";
 
         [SetUp]
         public void SetUp()
@@ -30,13 +31,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: a removed signature whose replacement is among the applied entries is recorded
-        /// with that replacement's display name.
+        /// with that replacement's display name, chosen by signature rather than by taking the
+        /// first replacement entry of the list.
         /// </summary>
         [Test]
         public void RecordFromAppliedEntries_WhenReplacementWasApplied_RecordsTheSupersededSignature()
         {
             HotReloadSupersededSignatureRecorder.RecordFromAppliedEntries(
-                new[] { CreateReplacementEntry() },
+                new[] { CreateDecoyReplacementEntry(), CreateReplacementEntry() },
                 new[] { CreateRemovedSignature() },
                 Array.Empty<string>());
 
@@ -46,6 +48,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(found, Is.True);
             Assert.That(replacementDisplayName, Is.EqualTo(RemovedMethodLabel));
+            Assert.That(replacementDisplayName, Is.Not.EqualTo(DecoyMethodLabel));
         }
 
         /// <summary>
@@ -95,6 +98,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 sourceProjectRelativePath = "Assets/Scripts/Host.cs",
                 typeMetadataName = TypeMetadataName,
                 methodName = "Scaled",
+                parameterTypeFullNames = new[] { "System.Int32" },
+                genericArity = 0,
+                replacesCompiledMethod = true
+            };
+        }
+
+        // A replacement of another compiled signature, so a recorder that picked the first
+        // replacement entry instead of the matching one would report this label.
+        private static TransformWorkerEntryDto CreateDecoyReplacementEntry()
+        {
+            return new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = "Assets/Scripts/Host.cs",
+                typeMetadataName = TypeMetadataName,
+                methodName = "Other",
                 parameterTypeFullNames = new[] { "System.Int32" },
                 genericArity = 0,
                 replacesCompiledMethod = true

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedFileAggregator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadChangedFileAggregator.cs
@@ -76,7 +76,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(snapshotAssemblies != null, "snapshotAssemblies must not be null.");
 
             bool hasBaseline = false;
-            HashSet<string> changedPathSet = new HashSet<string>(GetProjectRelativePathComparer());
+            HashSet<string> changedPathSet = new HashSet<string>(HotReloadSourcePathNormalizer.ProjectRelativePathComparer());
             List<string> scanLimitWarnings = new List<string>();
             HashSet<string> warningSet = new HashSet<string>(StringComparer.Ordinal);
             for (int index = 0; index < snapshotAssemblies.Count; index++)
@@ -102,7 +102,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             List<string> changedProjectRelativePaths = new List<string>(changedPathSet);
-            changedProjectRelativePaths.Sort(GetProjectRelativePathComparer());
+            changedProjectRelativePaths.Sort(HotReloadSourcePathNormalizer.ProjectRelativePathComparer());
             scanLimitWarnings.Sort(StringComparer.Ordinal);
             return new HotReloadChangedFileAggregationResult(
                 hasBaseline,
@@ -142,13 +142,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return snapshotAssemblies;
-        }
-
-        private static StringComparer GetProjectRelativePathComparer()
-        {
-            return Path.DirectorySeparatorChar == '\\'
-                ? StringComparer.OrdinalIgnoreCase
-                : StringComparer.Ordinal;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
@@ -177,6 +177,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     || outcome.Kind == HotReloadMethodOutcomeKind.Added)
                 {
                     appliedThisRun++;
+                    sinks.AppliedEntries.Add(resolvedEntries[index].Entry);
                     if (outcome.Kind == HotReloadMethodOutcomeKind.Patched)
                     {
                         patchedCount++;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileSinks.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileSinks.cs
@@ -24,6 +24,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Warnings = new List<string>();
             SuppressedPausePointIds = new List<string>();
             RetargetedPausePointIds = new List<string>();
+            AppliedEntries = new List<TransformWorkerEntryDto>();
             SiblingDerivedWarnings = siblingDerivedWarnings;
             OneShotCallerNoteCandidates = oneShotCallerNoteCandidates;
         }
@@ -35,6 +36,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal List<string> SuppressedPausePointIds { get; }
 
         internal List<string> RetargetedPausePointIds { get; }
+
+        // The worker rows this file actually patched or added. Why recorded here instead of
+        // derived from the outcomes: a partly applied file reports Patched rows next to Failed
+        // and file-atomic Skipped rows, so only the apply loop knows which row reached Harmony.
+        internal List<TransformWorkerEntryDto> AppliedEntries { get; }
 
         // Shared across the whole run so sibling-derived text can be deduped once at the end.
         internal List<string> SiblingDerivedWarnings { get; }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -320,11 +320,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             for (int index = 0; index < context.Files.Count; index++)
             {
                 HotReloadGroupFile file = context.Files[index];
-                if (file.FileOutput == null)
-                {
-                    continue;
-                }
-
+                Debug.Assert(file.FileOutput != null, "Every file must carry its worker output row.");
                 HotReloadSupersededSignatureRecorder.RecordFromAppliedEntries(
                     file.Sinks.AppliedEntries,
                     file.FileOutput.removedMethodSignatures

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -141,11 +141,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why after apply: earlier returns (gate fail, shim compile, coverage loss)
             // never applied the replacement, so leftover Active rows must not claim they
             // were superseded.
-            RecordSupersededSignaturesAfterApply(
-                results,
-                context,
-                compile.EntriesToPatch,
-                gateResult.GatedReplacementMethodKeys);
+            RecordSupersededSignaturesAfterApply(context, gateResult.GatedReplacementMethodKeys);
             return results;
         }
 
@@ -314,48 +310,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        // Why per file: a group applies file by file, so only the files that actually patched
-        // something may claim their removed signatures were superseded, and only through the
-        // entries that reached Harmony.
+        // Why per file: a group applies file by file, so only the rows that actually reached
+        // Harmony may claim their removed signatures were superseded. A partly applied file
+        // patches some rows and leaves the rest failed or file-atomically skipped.
         private static void RecordSupersededSignaturesAfterApply(
-            IReadOnlyList<HotReloadFileProcessResult> results,
             HotReloadApplyContext context,
-            TransformWorkerEntryDto[] appliedEntries,
             IReadOnlyCollection<string> gatedReplacementMethodKeys)
         {
-            Debug.Assert(
-                results.Count == context.Files.Count,
-                "A group must report one result per edited file.");
-            Dictionary<string, List<TransformWorkerEntryDto>> appliedEntriesByFile =
-                HotReloadWorkerRowsByFile.GroupEntriesBySourceFile(appliedEntries, context.ProjectRelativePaths);
-            for (int index = 0; index < results.Count; index++)
+            for (int index = 0; index < context.Files.Count; index++)
             {
-                if (!HasAppliedChange(results[index].Outcomes))
+                HotReloadGroupFile file = context.Files[index];
+                if (file.FileOutput == null)
                 {
                     continue;
                 }
 
-                HotReloadGroupFile file = context.Files[index];
                 HotReloadSupersededSignatureRecorder.RecordFromAppliedEntries(
-                    appliedEntriesByFile[file.ProjectRelativePath],
-                    file.FileOutput.removedMethodSignatures ?? Array.Empty<TransformWorkerRemovedMethodSignatureDto>(),
+                    file.Sinks.AppliedEntries,
+                    file.FileOutput.removedMethodSignatures
+                        ?? Array.Empty<TransformWorkerRemovedMethodSignatureDto>(),
                     gatedReplacementMethodKeys);
             }
-        }
-
-        private static bool HasAppliedChange(IReadOnlyList<HotReloadMethodOutcome> outcomes)
-        {
-            for (int index = 0; index < outcomes.Count; index++)
-            {
-                HotReloadMethodOutcomeKind kind = outcomes[index].Kind;
-                if (kind == HotReloadMethodOutcomeKind.Patched
-                    || kind == HotReloadMethodOutcomeKind.Added)
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         private static List<string> CollectProjectRelativePaths(IReadOnlyList<HotReloadGroupFile> files)


### PR DESCRIPTION
## Summary
- `uloop hot-reload --status` no longer explains a leftover Active row with a replacement method that was never applied.

## User Impact
- Before: when a reload applied part of an edited file and then hit a patch-engine failure, the methods that never reached the patch engine were still treated as applied for status reporting. A return-type change that failed in that file made `--status` claim the old compiled signature had been superseded by the new one, even though the new one is not active.
- After: only the methods a file actually patched or added are treated as applied, so a failed or file-atomically skipped replacement leaves the old signature reported as-is.

## Changes
- The apply loop records each worker row it patched or added into the file's output buffers, and the group processor feeds exactly those rows to the superseded-signature recorder instead of every row attributed to a file with at least one applied outcome.
- The changed-file aggregator reuses the shared project-relative path comparer instead of repeating the platform separator check.
- New regression test: a patch-engine failure on a replacement after an earlier successful patch reports only the patched row as applied and records no superseded signature. Verified to fail when the pre-fix input (all of the file's rows) is passed instead.
- Strengthened the recorder unit test with a second replacement row for another signature, so an implementation that picked the first replacement instead of the matching one would fail.

## Notes for review
- One review point asked for the replacement in the recorder unit test to carry a method name distinct from the removed signature. That is not expressible: the recorder looks the replacement up *by* the removed signature's wire key, and the display label omits the return type, so a return-type replacement necessarily has the same name, parameters and label. The decoy row above covers the same weak-assertion concern instead.

## Verification
- `uloop compile` (development binary) — no errors (only pre-existing test-fixture warnings).
- `uloop run-tests --skip-compile --filter-type regex --filter-value 'HotReload'` — 716 tests, 716 passed, 0 failed.
- The new regression test alone — 1 test, 1 passed; the same test fails when fed every row of the file, confirming it covers the fix.
- `sh scripts/check-file-length.sh` — no files exceeded the 500 SLOC limit.
- `sh scripts/check-code-complexity.sh` — 0 Go issues, no CA1502 findings above 15.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

