### PR TITLE
fix: Hot reload applies edits in global-namespace files and files sharing a global using

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadGlobalNamespaceCaller.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGlobalNamespaceCaller.cs
@@ -1,0 +1,16 @@
+using System.Runtime.CompilerServices;
+
+/// <summary>
+/// Compiled caller type declared in the global namespace. Tests edit a copy of this body so it
+/// calls a member added in the sibling global-namespace host file within the same reload.
+/// </summary>
+internal sealed class HotReloadGlobalNamespaceCaller
+{
+    // Why NoInlining: end-to-end tests read the patched body back through a direct call, which
+    // an inlined copy at the call site would not observe.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public int Call(HotReloadGlobalNamespaceHost host)
+    {
+        return host.Value();
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadGlobalNamespaceCaller.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadGlobalNamespaceCaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a4602b3f335344c29341f1f52419599
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadGlobalNamespaceHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGlobalNamespaceHost.cs
@@ -1,0 +1,18 @@
+using System.Runtime.CompilerServices;
+
+/// <summary>
+/// Compiled host type declared in the global namespace. Tests add a member to a copy of this
+/// source and expect the sibling caller's edited body to bind against it, which only works when
+/// the shim emitter and the body rewriter agree on the namespace a global-namespace shim type
+/// is synthesized into.
+/// </summary>
+internal sealed class HotReloadGlobalNamespaceHost
+{
+    // Why NoInlining: end-to-end tests edit this body and read the new value back through a
+    // direct call, which an inlined copy at the call site would not observe.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public int Value()
+    {
+        return 1;
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadGlobalNamespaceHost.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadGlobalNamespaceHost.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2fc73073267d142259ab70616cb9b316
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadGlobalNamespaceShimE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGlobalNamespaceShimE2ETests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// End-to-end EditMode coverage for reloading files whose types live in the global namespace,
+    /// where the shim assembly has to host them under a synthesized namespace.
+    /// </summary>
+    public class HotReloadGlobalNamespaceShimE2ETests
+    {
+        private const string HostFileName = "HotReloadGlobalNamespaceHost.cs";
+        private const string CallerFileName = "HotReloadGlobalNamespaceCaller.cs";
+        private const string HostValueAnchor = "    public int Value()";
+        private const string CallerCallBodyAnchor = "return host.Value();";
+
+        [SetUp]
+        public void SetUp()
+        {
+            HotReloadPatcher.RevertAll();
+            HotReloadAutoRefreshHold.Sync(HotReloadPatcher.ActiveChangeCount);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadPatcher.RevertAll();
+            HotReloadAutoRefreshHold.Sync(HotReloadPatcher.ActiveChangeCount);
+            VibeLogger.ClearMemoryLogs();
+        }
+
+        /// <summary>
+        /// What: a body edited in a global-namespace file binds to a method added in another
+        /// global-namespace file of the same reload, both files are applied, and the patched
+        /// caller returns the value the added method produces.
+        /// </summary>
+        [Test]
+        public async Task Run_GlobalNamespaceCallerUsesMethodAddedInOtherFile_AppliesBothAndUpdatesRuntime()
+        {
+            string hostPath = FixturePath(HostFileName);
+            string callerPath = FixturePath(CallerFileName);
+            string editedHost = InsertHostMember(
+                "    public int Added()\n    {\n        return 41;\n    }\n\n");
+            string editedCaller = ReplaceInSource(
+                ReadFixture(CallerFileName),
+                CallerCallBodyAnchor,
+                "return host.Added() + 1;");
+
+            HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                new[] { hostPath, callerPath },
+                contentPathOverride: null,
+                CancellationToken.None,
+                new Dictionary<string, string>
+                {
+                    [hostPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                        "GlobalNamespaceShimHost.cs",
+                        editedHost),
+                    [callerPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                        "GlobalNamespaceShimCaller.cs",
+                        editedCaller)
+                });
+
+            AssertNoFailure(result);
+            FindOutcome(result, HotReloadMethodOutcomeKind.Added, "Added");
+            FindOutcome(result, HotReloadMethodOutcomeKind.Patched, "Call");
+            Assert.That(
+                new HotReloadGlobalNamespaceCaller().Call(new HotReloadGlobalNamespaceHost()),
+                Is.EqualTo(42));
+        }
+
+        private static string InsertHostMember(string memberText)
+        {
+            string source = ReadFixture(HostFileName);
+            Assert.That(source, Does.Contain(HostValueAnchor), "Precondition: host anchor must exist.");
+            return source.Replace(HostValueAnchor, memberText + HostValueAnchor, StringComparison.Ordinal);
+        }
+
+        private static string ReplaceInSource(string source, string anchor, string replacement)
+        {
+            Assert.That(source, Does.Contain(anchor), "Precondition: anchor must exist: " + anchor);
+            return source.Replace(anchor, replacement, StringComparison.Ordinal);
+        }
+
+        private static string ReadFixture(string fileName)
+        {
+            return File.ReadAllText(FixturePath(fileName));
+        }
+
+        private static string FixturePath(string fileName)
+        {
+            string path = Path.GetFullPath(
+                Path.Combine(Application.dataPath, "Tests", "Editor", "HotReload", fileName));
+            Assert.That(File.Exists(path), Is.True, "Fixture missing: " + path);
+            return path;
+        }
+
+        private static void AssertNoFailure(HotReloadOrchestratorResult result)
+        {
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                Assert.That(
+                    outcome.Kind,
+                    Is.Not.EqualTo(HotReloadMethodOutcomeKind.Failed),
+                    "Unexpected failure.\n" + FormatOutcomes(result));
+            }
+        }
+
+        private static HotReloadMethodOutcome FindOutcome(
+            HotReloadOrchestratorResult result,
+            HotReloadMethodOutcomeKind kind,
+            string methodNamePart)
+        {
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == kind && outcome.Method != null && outcome.Method.Contains(methodNamePart))
+                {
+                    return outcome;
+                }
+            }
+
+            Assert.Fail("Expected " + kind + " for " + methodNamePart + ".\n" + FormatOutcomes(result));
+            return null;
+        }
+
+        private static string FormatOutcomes(HotReloadOrchestratorResult result)
+        {
+            List<string> lines = new List<string>();
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                lines.Add(outcome.Kind + " " + outcome.Method + " @" + outcome.FilePath + " :: " + outcome.Reason);
+            }
+
+            return string.Join("\n", lines);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadGlobalNamespaceShimE2ETests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadGlobalNamespaceShimE2ETests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee34934f8031c4279a036d110fa47d6c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerCrossFileTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerCrossFileTests.cs
@@ -116,7 +116,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public async Task Run_TwoSources_GlobalUsingDeclaredInEditedFile_ReachesShimSource()
         {
             CrossFileRun run = await RunEditedPairAsync(
-                EditedGlobalUsingLine + ReadOnDisk(HostFileName),
+                EditedGlobalUsingLine + AddHostMethod(ReadOnDisk(HostFileName)),
                 ReplaceCallerBody(
                     ReadOnDisk(CallerFileName),
                     "return new HotReloadEditedFileGlobalAlias().Length;"));
@@ -128,6 +128,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 run.Result.Output.shimSource,
                 Does.Contain("using HotReloadEditedFileGlobalAlias"),
                 "The shim source must carry the global using the edited sibling file declares.");
+            Assert.That(
+                run.Result.Output.shimSource,
+                Does.Not.Contain("global using"),
+                "A global using is not allowed inside the shim type's namespace declaration.");
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerCrossFileTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerCrossFileTests.cs
@@ -27,6 +27,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadCrossFileAddedMemberHost";
         private const string CallerTypeMetadataName =
             "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadCrossFileAddedMemberCaller";
+        // Declared by an edited source only, so the collector cannot find it on disk.
+        private const string EditedGlobalUsingLine =
+            "global using HotReloadEditedFileGlobalAlias = System.Text.StringBuilder;\n";
 
         /// <summary>
         /// What: a body edited in the caller file binds to a method added in the host file within
@@ -102,6 +105,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(run.Result.Output.files[0].addedConstNames, Has.Some.Contains("Limit"));
             Assert.That(run.Result.Output.files[1].addedConstNames, Is.Empty);
             FindEntry(run, CallerTypeMetadataName, "Call");
+        }
+
+        /// <summary>
+        /// What: a global using declared in one edited file reaches the shim source, because the
+        /// collector takes the edited sources from the in-memory trees instead of their pre-edit
+        /// copies on disk.
+        /// </summary>
+        [Test]
+        public async Task Run_TwoSources_GlobalUsingDeclaredInEditedFile_ReachesShimSource()
+        {
+            CrossFileRun run = await RunEditedPairAsync(
+                EditedGlobalUsingLine + ReadOnDisk(HostFileName),
+                ReplaceCallerBody(
+                    ReadOnDisk(CallerFileName),
+                    "return new HotReloadEditedFileGlobalAlias().Length;"));
+
+            Assert.That(run.Result.Success, Is.True, run.Result.ErrorMessage);
+            FindEntry(run, CallerTypeMetadataName, "Call");
+            AssertNoSkippedMethodNamed(run, "Call");
+            Assert.That(
+                run.Result.Output.shimSource,
+                Does.Contain("using HotReloadEditedFileGlobalAlias"),
+                "The shim source must carry the global using the edited sibling file declares.");
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimBodyRewriter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimBodyRewriter.cs
@@ -237,9 +237,12 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
         IMethodSymbol addedMethod,
         AddedMethodBinding binding)
     {
-        string qualifiedShimType = string.IsNullOrEmpty(binding.NamespaceName)
-            ? "global::" + binding.ShimTypeName
-            : "global::" + binding.NamespaceName + "." + binding.ShimTypeName;
+        // Why the resolved namespace: a type from the global namespace gets a synthesized one,
+        // so naming the shim without it would not compile.
+        string qualifiedShimType = "global::"
+            + ShimNamespaceNames.ResolveShimNamespaceName(binding.NamespaceName)
+            + "."
+            + binding.ShimTypeName;
         ExpressionSyntax shimTypeExpression = SyntaxFactory.ParseTypeName(qualifiedShimType);
         ExpressionSyntax shimAccess = SyntaxFactory.MemberAccessExpression(
             SyntaxKind.SimpleMemberAccessExpression,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimNamespaceNames.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimNamespaceNames.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+// The namespace a shim type is emitted in. Shared by the emitter that declares the type and
+// by every rewrite that references it by name: a rewrite that guessed the global namespace
+// while the emitter synthesized one would emit a call that fails shim compilation with CS0246.
+internal static class ShimNamespaceNames
+{
+    // Host namespace for shim types whose original type lives in the global namespace. The
+    // orchestrator resolves shim types by short name, so the namespace stays invisible to it.
+    internal const string GlobalNamespaceShimNamespaceName = "UloopHotReloadGlobalShim";
+
+    internal static string ResolveShimNamespaceName(string originalNamespaceName)
+    {
+        return string.IsNullOrEmpty(originalNamespaceName)
+            ? GlobalNamespaceShimNamespaceName
+            : originalNamespaceName;
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimSourceEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimSourceEmitter.cs
@@ -17,10 +17,6 @@ using Microsoft.CodeAnalysis.Text;
 
 internal static class ShimSourceEmitter
 {
-    // Host namespace for shim types whose original type lives in the global namespace. The
-    // orchestrator resolves shim types by short name, so the namespace stays invisible to it.
-    private const string GlobalNamespaceShimNamespaceName = "UloopHotReloadGlobalShim";
-
     public static string Emit(List<ShimTypeBuilder> shimTypes)
     {
         if (shimTypes.Count == 0)
@@ -53,9 +49,7 @@ internal static class ShimSourceEmitter
             // would break the whole shim assembly. A namespace declaration scopes each file's
             // usings to its own shim type. Unqualified references to global-namespace types still
             // resolve, because name lookup from inside a namespace walks outward to global.
-            string namespaceName = string.IsNullOrEmpty(shimType.NamespaceName)
-                ? GlobalNamespaceShimNamespaceName
-                : shimType.NamespaceName;
+            string namespaceName = ShimNamespaceNames.ResolveShimNamespaceName(shimType.NamespaceName);
             NamespaceDeclarationSyntax namespaceDeclaration = SyntaxFactory.NamespaceDeclaration(
                     SyntaxFactory.ParseName(namespaceName))
                 .WithUsings(SyntaxFactory.List(shimType.Usings))

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
@@ -70,8 +70,14 @@ internal static class WorkerGroupPipeline
         IAssemblySymbol targetTypesAssemblySymbol = ResolveTargetTypesAssemblySymbol(
             compilation,
             targetTypesReference);
+        List<CompilationUnitSyntax> editedRoots = new List<CompilationUnitSyntax>(loadedUnits.Count);
+        foreach (WorkerSourceUnit loadedUnit in loadedUnits)
+        {
+            editedRoots.Add(loadedUnit.Root);
+        }
+
         List<UsingDirectiveSyntax> assemblyGlobalUsings =
-            WorkerUsingCollector.CollectAssemblyGlobalUsings(input, parseOptions);
+            WorkerUsingCollector.CollectAssemblyGlobalUsings(input, parseOptions, editedRoots);
         List<string> siblingConstDriftWarnings = SiblingConstDriftCollector.CollectConstDriftWarnings(
             input.ChangedSiblingSourcePaths,
             parseOptions,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerUsingCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerUsingCollector.cs
@@ -25,7 +25,10 @@ internal static class WorkerUsingCollector
         List<UsingDirectiveSyntax> usings = new List<UsingDirectiveSyntax>();
         foreach (UsingDirectiveSyntax usingDirective in root.Usings)
         {
-            usings.Add(usingDirective.WithoutTrivia());
+            // Why the global keyword is dropped: a file may declare a global using next to a
+            // type that emits a shim, and the emitter puts these usings inside the shim type's
+            // namespace declaration, where a global using does not compile.
+            usings.Add(usingDirective.WithGlobalKeyword(default).WithoutTrivia());
         }
 
         for (SyntaxNode node = typeDeclaration.Parent; node != null; node = node.Parent)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerUsingCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerUsingCollector.cs
@@ -78,13 +78,20 @@ internal static class WorkerUsingCollector
         return false;
     }
 
-    // Why skip the run's own sources: their usings already come from the in-memory trees.
-    // Reading the on-disk copies would pick up the pre-edit sources.
+    // Why the edited roots are passed in: reading their on-disk copies would pick up the
+    // pre-edit sources, yet a global using one edited file declares still has to reach the
+    // shims of its siblings, so those come from the in-memory trees instead.
     internal static List<UsingDirectiveSyntax> CollectAssemblyGlobalUsings(
         WorkerInput input,
-        CSharpParseOptions parseOptions)
+        CSharpParseOptions parseOptions,
+        IReadOnlyList<CompilationUnitSyntax> editedRoots)
     {
         List<UsingDirectiveSyntax> collected = new List<UsingDirectiveSyntax>();
+        for (int index = 0; index < editedRoots.Count; index++)
+        {
+            AppendGlobalUsings(collected, editedRoots[index]);
+        }
+
         foreach (string assemblySourcePath in input.AssemblySourcePaths)
         {
             if (string.IsNullOrEmpty(assemblySourcePath)
@@ -131,7 +138,15 @@ internal static class WorkerUsingCollector
             SourceText.From(text, Encoding.UTF8),
             parseOptions,
             path: assemblySourcePath);
-        CompilationUnitSyntax unit = tree.GetCompilationUnitRoot();
+        AppendGlobalUsings(collected, tree.GetCompilationUnitRoot());
+    }
+
+    // Why stripped of the global keyword: the emitter puts these usings inside the shim type's
+    // namespace declaration, where a global using is not allowed.
+    internal static void AppendGlobalUsings(
+        List<UsingDirectiveSyntax> collected,
+        CompilationUnitSyntax unit)
+    {
         foreach (UsingDirectiveSyntax usingDirective in unit.Usings)
         {
             if (!usingDirective.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword))

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -211,11 +211,13 @@ Wire details:
 
 ## Known Limits (documented, not worked around)
 
-- Adding fields, types, or methods; changing signatures; changing field initializers or
-  `const` values — all require `uloop compile`. Shim compile errors caused by references to
-  newly added members are reported with that hint, and changed `const` values (including
-  enum members) are compared against the compiled target assembly and reported as a
-  response warning; other outside-body edits stay silent.
+- New types; added members referenced from another assembly or from a file this reload did
+  not receive; changed field initializers or `const` values — all require `uloop compile`.
+  Added fields and methods themselves apply, and are visible to the bodies edited in any file
+  of the same assembly passed to the same reload. Shim compile errors caused by references to
+  members that are still missing are reported with that hint, and changed `const` values
+  (including enum members) are compared against the compiled target assembly and reported as
+  a response warning; other outside-body edits stay silent.
 - In-flight async methods and coroutines keep running the old code until re-entered.
 - Callers whose call sites were JIT-inlined may not observe the detour (`IsLikelyJitInlined`
   heuristic produces a warning, as with pause points).


### PR DESCRIPTION
## Summary
- Hot reload no longer fails on files whose types live in the global namespace when an edited body calls a method added in the same reload.
- A `global using` declared in one edited file now reaches the shim sources of the other edited files of the same reload.

## User Impact
- Before: editing a global-namespace type so that one file's body calls a method added in another file of the same reload made that body report a shim compile error (`could not be found in the global namespace`), because the shim type was emitted under a synthesized namespace while the call site still named the global one.
- Before: if one edited file declared a `global using` and a sibling edited file's body relied on it, the reload failed on the sibling with an unresolved-name error even though the code compiles normally.
- After: both cases apply like any other reload.
- Also: the "Known Limits" entry for added members is corrected — added fields and methods do apply, and are visible to the bodies edited in any file of the same assembly passed to the same reload. The limit is new types, and added members referenced from another assembly or from a file the reload did not receive.

## Changes
- New shared constant for the namespace a global-namespace shim type is synthesized into, used by both the shim emitter and the added-method call rewrite.
- The global-using collector takes the edited sources from the in-memory syntax trees instead of skipping them and reading only the untouched files from disk.
- Corrected the first Known Limits bullet in the hot-reload doc.

## Verification
- Development-binary `uloop compile` — success (only pre-existing test-fixture warnings).
- Development-binary `uloop run-tests --skip-compile --filter-type regex --filter-value HotReload` — 718 tests, 718 passed, 0 failed.
- Both new tests were confirmed to fail against the pre-fix code (a shim compile error naming the global namespace, and a shim source missing the using) and to pass after it.
- File-length check — no findings. Complexity check — 0 Go issues, no CA1502 findings above 15.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

