### PR TITLE
fix: compile and run-tests now say how many hot-reload changes the domain reload dropped

### DIFF
--- a/.agents/skills/uloop-compile/SKILL.md
+++ b/.agents/skills/uloop-compile/SKILL.md
@@ -47,6 +47,7 @@ Returns JSON:
 - `Success`: boolean or null
 - `ErrorCount`: number or null
 - `WarningCount`: number or null
+- `Warning` (string, optional): set when compile was requested during Play Mode (Play session and pause points are discarded) or while hot-reload changes were active (a successful compile drops every patch; the edited sources are compiled in).
 - `Message`: string
 - `ErrorCode`: string or null. `COMPILE_ALREADY_IN_PROGRESS` when Unity is already compiling, `COMPILE_EDITOR_UPDATING` when the editor is updating, `COMPILE_RESULT_UNKNOWN` after a forced recompile that did not return a definitive result.
 - `NextActions`: string array or null. Corrective steps derived from the errors, e.g. the assembly that declares an unresolved namespace (CS0234), or, for CS0246 in a script under an asmdef, a reminder to check that asmdef's references (the type may instead be a typo — decide from the error).

--- a/.agents/skills/uloop-hot-reload/SKILL.md
+++ b/.agents/skills/uloop-hot-reload/SKILL.md
@@ -94,7 +94,7 @@ Full rules and the `Skipped`/`Failed` condition tables: `references/scope-and-li
 
 Treat hot reload as the exploration phase and `uloop compile` as the landing phase:
 keep edits inside the edited files, collect structural changes, and compile once —
-every compile drops all patches and pause points and resets the PlayMode session.
+every compile drops all patches and pause points and resets the PlayMode session (the compile response's Warning states how many were live).
 While patches are active, `AutoRefreshHeld` is true so returning focus does not
 recompile; `uloop compile` or `--revert-all` releases the hold.
 One-shot methods (`Awake`, `Start`, initialization helpers) patch successfully but show

--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -60,7 +60,7 @@ Returns JSON with:
 - `FailedTests` (array, optional): Up to 10 failed leaf tests with `FullName`, `Message`, and when the stack trace contains a path:line location, `File` and `Line`. Omitted when no tests failed. When `FailedCount` is greater than 10, `Message` ends with `first 10 of N failures listed; see XmlPath for full results.`
 - `SkippedTests` (string[], optional): Up to 10 full names of skipped leaf tests. Omitted when no tests were skipped. When `SkippedCount` is greater than 10, only the first 10 names are listed.
 - `ProposedTestAsmdef` (object, optional): `AssetPath` and `Content` of a ready-to-write test `.asmdef` (test-assembly wiring plus references to the project's assemblies under test). Present only when an unfiltered run found no tests and no test assembly exists for the TestMode.
-- `CompileNote` (string, optional): States that the automatic compile ran and succeeded before the tests and names `--skip-compile` as the opt-out. Omitted when `--skip-compile` was passed; a failed compile returns the compile error response instead.
+- `CompileNote` (string, optional): States that the automatic compile ran and succeeded before the tests and names `--skip-compile` as the opt-out. When the compile response carried a Warning (for example active hot-reload changes dropped by the domain reload), the note repeats it. Omitted when `--skip-compile` was passed; a failed compile returns the compile error response instead.
 
 ### XML Result File
 

--- a/.claude/skills/uloop-compile/SKILL.md
+++ b/.claude/skills/uloop-compile/SKILL.md
@@ -47,6 +47,7 @@ Returns JSON:
 - `Success`: boolean or null
 - `ErrorCount`: number or null
 - `WarningCount`: number or null
+- `Warning` (string, optional): set when compile was requested during Play Mode (Play session and pause points are discarded) or while hot-reload changes were active (a successful compile drops every patch; the edited sources are compiled in).
 - `Message`: string
 - `ErrorCode`: string or null. `COMPILE_ALREADY_IN_PROGRESS` when Unity is already compiling, `COMPILE_EDITOR_UPDATING` when the editor is updating, `COMPILE_RESULT_UNKNOWN` after a forced recompile that did not return a definitive result.
 - `NextActions`: string array or null. Corrective steps derived from the errors, e.g. the assembly that declares an unresolved namespace (CS0234), or, for CS0246 in a script under an asmdef, a reminder to check that asmdef's references (the type may instead be a typo — decide from the error).

--- a/.claude/skills/uloop-hot-reload/SKILL.md
+++ b/.claude/skills/uloop-hot-reload/SKILL.md
@@ -94,7 +94,7 @@ Full rules and the `Skipped`/`Failed` condition tables: `references/scope-and-li
 
 Treat hot reload as the exploration phase and `uloop compile` as the landing phase:
 keep edits inside the edited files, collect structural changes, and compile once —
-every compile drops all patches and pause points and resets the PlayMode session.
+every compile drops all patches and pause points and resets the PlayMode session (the compile response's Warning states how many were live).
 While patches are active, `AutoRefreshHeld` is true so returning focus does not
 recompile; `uloop compile` or `--revert-all` releases the hold.
 One-shot methods (`Awake`, `Start`, initialization helpers) patch successfully but show

--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -60,7 +60,7 @@ Returns JSON with:
 - `FailedTests` (array, optional): Up to 10 failed leaf tests with `FullName`, `Message`, and when the stack trace contains a path:line location, `File` and `Line`. Omitted when no tests failed. When `FailedCount` is greater than 10, `Message` ends with `first 10 of N failures listed; see XmlPath for full results.`
 - `SkippedTests` (string[], optional): Up to 10 full names of skipped leaf tests. Omitted when no tests were skipped. When `SkippedCount` is greater than 10, only the first 10 names are listed.
 - `ProposedTestAsmdef` (object, optional): `AssetPath` and `Content` of a ready-to-write test `.asmdef` (test-assembly wiring plus references to the project's assemblies under test). Present only when an unfiltered run found no tests and no test assembly exists for the TestMode.
-- `CompileNote` (string, optional): States that the automatic compile ran and succeeded before the tests and names `--skip-compile` as the opt-out. Omitted when `--skip-compile` was passed; a failed compile returns the compile error response instead.
+- `CompileNote` (string, optional): States that the automatic compile ran and succeeded before the tests and names `--skip-compile` as the opt-out. When the compile response carried a Warning (for example active hot-reload changes dropped by the domain reload), the note repeats it. Omitted when `--skip-compile` was passed; a failed compile returns the compile error response instead.
 
 ### XML Result File
 

--- a/Assets/Tests/Editor/CompilePlayModeStopWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/CompilePlayModeStopWarningBuilderTests.cs
@@ -19,7 +19,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             string warning = CompilePlayModeStopWarningBuilder.BuildWarning(
                 wasPlayingAtRequestStart: false,
-                activePausePointCount: 3);
+                activePausePointCount: 3,
+                activeHotReloadChangeCount: 0);
 
             Assert.That(warning, Is.Null);
         }
@@ -32,7 +33,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             string warning = CompilePlayModeStopWarningBuilder.BuildWarning(
                 wasPlayingAtRequestStart: true,
-                activePausePointCount: 0);
+                activePausePointCount: 0,
+                activeHotReloadChangeCount: 0);
 
             Assert.That(
                 warning,
@@ -48,12 +50,57 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             string warning = CompilePlayModeStopWarningBuilder.BuildWarning(
                 wasPlayingAtRequestStart: true,
-                activePausePointCount: 2);
+                activePausePointCount: 2,
+                activeHotReloadChangeCount: 0);
 
             Assert.That(
                 warning,
                 Is.EqualTo(
                     "Play Mode was active with 2 enabled pause point(s). The compile stops Play Mode and the domain reload discards the Play session state and all pause point patches — re-enable pause points after the compile completes."));
+        }
+
+        /// <summary>
+        /// What: not playing with active hot-reload changes warns only about the domain reload dropping those patches.
+        /// </summary>
+        [Test]
+        public void BuildWarning_WhenNotPlayingAndHotReloadChangesActive_ReturnsHotReloadDropWarning()
+        {
+            string warning = CompilePlayModeStopWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart: false,
+                activePausePointCount: 0,
+                activeHotReloadChangeCount: 3);
+
+            Assert.That(warning, Does.Contain("3 active hot-reload change(s)"));
+            Assert.That(warning, Does.Not.Contain("Play Mode"));
+        }
+
+        /// <summary>
+        /// What: Play plus active hot-reload changes keeps the Play sentence and appends the drop sentence.
+        /// </summary>
+        [Test]
+        public void BuildWarning_WhenPlayingAndHotReloadChangesActive_ReturnsBothSentences()
+        {
+            string warning = CompilePlayModeStopWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart: true,
+                activePausePointCount: 0,
+                activeHotReloadChangeCount: 2);
+
+            Assert.That(warning, Does.Contain("Play Mode was active"));
+            Assert.That(warning, Does.Contain("2 active hot-reload change(s)"));
+        }
+
+        /// <summary>
+        /// What: no Play and no hot-reload changes produces no Warning.
+        /// </summary>
+        [Test]
+        public void BuildWarning_WhenNothingActive_ReturnsNull()
+        {
+            string warning = CompilePlayModeStopWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart: false,
+                activePausePointCount: 0,
+                activeHotReloadChangeCount: 0);
+
+            Assert.That(warning, Is.Null);
         }
     }
 }

--- a/Assets/Tests/Editor/CompileUseCaseTests.cs
+++ b/Assets/Tests/Editor/CompileUseCaseTests.cs
@@ -165,7 +165,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     pendingCompileSessionRepository);
                 useCase.SetPlayModeStopWarningInputsForTesting(
                     wasPlayingAtRequestStart: true,
-                    activePausePointCount: 0);
+                    activePausePointCount: 0,
+                    activeHotReloadChangeCount: 0);
                 useCase.SetCompilationStateValidationForTesting(() =>
                     ValidationResult.FailureWithErrorCode(
                         "Compilation is already in progress. Please wait for the current compilation to finish.",
@@ -194,6 +195,70 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Assert.That(response.Warning, Is.EqualTo(expectedWarning));
                 Assert.That(storedResult.HasResult, Is.True);
                 Assert.That(storedResponse.Warning, Is.EqualTo(expectedWarning));
+            }
+            finally
+            {
+                originalSnapshot.Restore();
+            }
+        }
+
+        /// <summary>
+        /// What: a validation failure with active hot-reload changes returns and stores the drop Warning.
+        /// </summary>
+        [Test]
+        public async Task CompileAsync_WhenValidationFailsWithActiveHotReloadChanges_SetsHotReloadDropWarningOnImmediateAndStoredResponses()
+        {
+            UnityCliLoopCompileResultSessionRepository compileResultSessionRepository =
+                UnityCliLoopEditorSessionStateTestFactory.CreateCompileResultSessionRepository();
+            UnityCliLoopPendingCompileSessionRepository pendingCompileSessionRepository =
+                UnityCliLoopEditorSessionStateTestFactory.CreatePendingCompileSessionRepository();
+            UnityCliLoopCompileSessionLifecycleService compileSessionLifecycleService =
+                new(
+                    UnityCliLoopEditorSessionStateTestFactory.CreateSessionFlagsRepository(),
+                    compileResultSessionRepository,
+                    pendingCompileSessionRepository);
+            UnityCliLoopEditorSessionStateSnapshot originalSnapshot =
+                UnityCliLoopEditorSessionStateTestFactory.CaptureSnapshot();
+            UnityCliLoopEditorSessionStateTestFactory.ClearAll();
+
+            try
+            {
+                CompileUseCase useCase = new(
+                    compileSessionLifecycleService,
+                    compileResultSessionRepository,
+                    pendingCompileSessionRepository);
+                useCase.SetPlayModeStopWarningInputsForTesting(
+                    wasPlayingAtRequestStart: false,
+                    activePausePointCount: 0,
+                    activeHotReloadChangeCount: 4);
+                useCase.SetCompilationStateValidationForTesting(() =>
+                    ValidationResult.FailureWithErrorCode(
+                        "Compilation is already in progress. Please wait for the current compilation to finish.",
+                        CompileStateValidationErrorCodes.AlreadyInProgressErrorCodeText));
+                useCase.SetCompilationExecutionForTesting((compileRequest, playModeStopWarning, ct) =>
+                {
+                    throw new InvalidOperationException("validation failure must not start compilation");
+                });
+
+                CompileResponse response = await useCase.CompileAsync(
+                    new CompileSchema
+                    {
+                        WaitForDomainReload = true,
+                        RequestId = "compile_validation_hot_reload_drop_warning",
+                        ForceRecompile = false,
+                        ReloadExternalSceneChanges = true
+                    },
+                    CancellationToken.None);
+
+                UnityCliLoopStoredCompileResult storedResult =
+                    compileResultSessionRepository.GetCompileResult("compile_validation_hot_reload_drop_warning");
+                CompileResponse storedResponse = JsonConvert.DeserializeObject<CompileResponse>(
+                    storedResult.ResultJson,
+                    UnityCliLoopJsonResponseSerializerSettings.Settings);
+
+                Assert.That(response.Warning, Does.Contain("4 active hot-reload change(s)"));
+                Assert.That(storedResult.HasResult, Is.True);
+                Assert.That(storedResponse.Warning, Does.Contain("4 active hot-reload change(s)"));
             }
             finally
             {

--- a/Assets/Tests/Editor/CompileUseCaseTests.cs
+++ b/Assets/Tests/Editor/CompileUseCaseTests.cs
@@ -266,6 +266,70 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
         }
 
+        /// <summary>
+        /// What: a successful compile with live hot-reload changes passes the drop Warning into compilation execution.
+        /// </summary>
+        [Test]
+        public async Task CompileAsync_WhenHotReloadChangesActive_PassesDropWarningToCompilationExecution()
+        {
+            UnityCliLoopCompileResultSessionRepository innerCompileResultSessionRepository =
+                UnityCliLoopEditorSessionStateTestFactory.CreateCompileResultSessionRepository();
+            CountingCompileResultSessionRepository compileResultSessionRepository =
+                new(innerCompileResultSessionRepository);
+            UnityCliLoopPendingCompileSessionRepository pendingCompileSessionRepository =
+                UnityCliLoopEditorSessionStateTestFactory.CreatePendingCompileSessionRepository();
+            UnityCliLoopCompileSessionLifecycleService compileSessionLifecycleService =
+                new(
+                    UnityCliLoopEditorSessionStateTestFactory.CreateSessionFlagsRepository(),
+                    compileResultSessionRepository,
+                    pendingCompileSessionRepository);
+            UnityCliLoopEditorSessionStateSnapshot originalSnapshot =
+                UnityCliLoopEditorSessionStateTestFactory.CaptureSnapshot();
+            UnityCliLoopEditorSessionStateTestFactory.ClearAll();
+
+            try
+            {
+                CompileSchema request = new()
+                {
+                    WaitForDomainReload = true,
+                    RequestId = "compile_success_hot_reload_drop_warning",
+                    ForceRecompile = false,
+                    ReloadExternalSceneChanges = true
+                };
+                CompileResult executionResult = CreateSuccessfulCompileResult();
+                CompileUseCase useCase = new(
+                    compileSessionLifecycleService,
+                    compileResultSessionRepository,
+                    pendingCompileSessionRepository);
+                useCase.SetPlayModeStopWarningInputsForTesting(
+                    wasPlayingAtRequestStart: false,
+                    activePausePointCount: 0,
+                    activeHotReloadChangeCount: 2);
+                string capturedPlayModeStopWarning = null;
+                useCase.SetCompilationExecutionForTesting((compileRequest, playModeStopWarning, ct) =>
+                {
+                    capturedPlayModeStopWarning = playModeStopWarning;
+                    ct.ThrowIfCancellationRequested();
+                    CompileResultSessionRecorder.RecordCompileResult(
+                        compileResultSessionRepository,
+                        pendingCompileSessionRepository,
+                        compileRequest.RequestId,
+                        compileRequest.ForceRecompile,
+                        executionResult,
+                        compileRequest.RequestId);
+                    return Task.FromResult(executionResult);
+                });
+
+                await useCase.CompileAsync(request, CancellationToken.None);
+
+                Assert.That(capturedPlayModeStopWarning, Does.Contain("2 active hot-reload change(s)"));
+            }
+            finally
+            {
+                originalSnapshot.Restore();
+            }
+        }
+
         private static CompileResult CreateSuccessfulCompileResult()
         {
             CompilerMessage warning = new()

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompilePlayModeStopWarningBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompilePlayModeStopWarningBuilder.cs
@@ -1,13 +1,34 @@
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// Builds the compile Warning text when Play Mode was active at the moment compile was
-    /// requested: the compile stops Play Mode and the following domain reload discards the
-    /// Play session state, and also every pause-point Harmony patch when any are enabled.
+    /// Builds the compile Warning text when Play Mode was active or hot-reload changes were live
+    /// at the moment compile was requested: the compile stops Play Mode and the following
+    /// domain reload discards the Play session state, every pause-point Harmony patch when any
+    /// are enabled, and every active hot-reload patch.
     /// </summary>
     internal static class CompilePlayModeStopWarningBuilder
     {
-        public static string BuildWarning(bool wasPlayingAtRequestStart, int activePausePointCount)
+        public static string BuildWarning(
+            bool wasPlayingAtRequestStart,
+            int activePausePointCount,
+            int activeHotReloadChangeCount)
+        {
+            string playWarning = BuildPlayModeStopWarning(wasPlayingAtRequestStart, activePausePointCount);
+            string hotReloadWarning = BuildHotReloadDropWarning(activeHotReloadChangeCount);
+            if (playWarning == null)
+            {
+                return hotReloadWarning;
+            }
+
+            if (hotReloadWarning == null)
+            {
+                return playWarning;
+            }
+
+            return playWarning + " " + hotReloadWarning;
+        }
+
+        private static string BuildPlayModeStopWarning(bool wasPlayingAtRequestStart, int activePausePointCount)
         {
             if (!wasPlayingAtRequestStart)
             {
@@ -22,6 +43,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return "Play Mode was active when this compile was requested. The compile stops Play Mode and the domain reload discards the Play session state — re-establish your runtime state before continuing verification.";
+        }
+
+        private static string BuildHotReloadDropWarning(int activeHotReloadChangeCount)
+        {
+            if (activeHotReloadChangeCount <= 0)
+            {
+                return null;
+            }
+
+            return activeHotReloadChangeCount
+                + " active hot-reload change(s) were live when this compile was requested. "
+                + "A successful compile reloads the domain and drops every hot-reload patch; "
+                + "the edited source files are compiled in, so the behavior stays without re-applying them.";
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
@@ -24,7 +24,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly IPendingCompileSessionRepository _pendingCompileSessionRepository;
         private Func<CompileSchema, string, CancellationToken, Task<CompileResult>> _executeCompilationAsync;
         private Func<ValidationResult> _validateCompilationState;
-        private Func<(bool WasPlayingAtRequestStart, int ActivePausePointCount)> _capturePlayModeStopWarningInputs;
+        private Func<(bool WasPlayingAtRequestStart, int ActivePausePointCount, int ActiveHotReloadChangeCount)> _capturePlayModeStopWarningInputs;
 
         public CompileUseCase(
             UnityCliLoopCompileSessionLifecycleService compileSessionLifecycleService,
@@ -69,9 +69,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Replaces Play-at-request-start capture so tests can exercise the Play-stop Warning
         /// without entering Play Mode.
         /// </summary>
-        internal void SetPlayModeStopWarningInputsForTesting(bool wasPlayingAtRequestStart, int activePausePointCount)
+        internal void SetPlayModeStopWarningInputsForTesting(
+            bool wasPlayingAtRequestStart,
+            int activePausePointCount,
+            int activeHotReloadChangeCount)
         {
-            _capturePlayModeStopWarningInputs = () => (wasPlayingAtRequestStart, activePausePointCount);
+            _capturePlayModeStopWarningInputs = () =>
+                (wasPlayingAtRequestStart, activePausePointCount, activeHotReloadChangeCount);
         }
 
         /// <summary>
@@ -93,10 +97,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // Captured before PlayMode preparation can stop Play Mode, so the warning reflects
             // the state compile was actually requested in, not the state after this method mutates it.
-            (bool WasPlayingAtRequestStart, int ActivePausePointCount) playModeStopWarningInputs =
-                _capturePlayModeStopWarningInputs();
+            (bool WasPlayingAtRequestStart, int ActivePausePointCount, int ActiveHotReloadChangeCount)
+                playModeStopWarningInputs = _capturePlayModeStopWarningInputs();
             bool wasPlayingAtRequestStart = playModeStopWarningInputs.WasPlayingAtRequestStart;
             int activePausePointCountAtRequestStart = playModeStopWarningInputs.ActivePausePointCount;
+            int activeHotReloadChangeCountAtRequestStart = playModeStopWarningInputs.ActiveHotReloadChangeCount;
 
             DateTime utcNow = DateTime.UtcNow;
             _compileSessionLifecycleService.ClearExpiredCompileResult(utcNow);
@@ -164,7 +169,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // path above must not carry this Warning: Play is still running, so "discarded" would be false.
             string playModeStopWarning = CompilePlayModeStopWarningBuilder.BuildWarning(
                 wasPlayingAtRequestStart,
-                activePausePointCountAtRequestStart);
+                activePausePointCountAtRequestStart,
+                activeHotReloadChangeCountAtRequestStart);
 
             // 2. Compilation state validation
             ValidationResult validation = _validateCompilationState();
@@ -355,9 +361,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 correlationId);
         }
 
-        private static (bool WasPlayingAtRequestStart, int ActivePausePointCount) CaptureLivePlayModeStopWarningInputs()
+        private static (bool WasPlayingAtRequestStart, int ActivePausePointCount, int ActiveHotReloadChangeCount)
+            CaptureLivePlayModeStopWarningInputs()
         {
-            return (EditorApplication.isPlaying, UloopPausePointRegistry.GetActiveCount());
+            Func<int> getter = HotReloadPausePointCoordination.GetActiveHotReloadPatchCount;
+            int count = getter == null ? 0 : getter();
+            return (EditorApplication.isPlaying, UloopPausePointRegistry.GetActiveCount(), count);
         }
 
         private static string ResolveCorrelationId(CompileSchema request)

--- a/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
@@ -47,6 +47,7 @@ Returns JSON:
 - `Success`: boolean or null
 - `ErrorCount`: number or null
 - `WarningCount`: number or null
+- `Warning` (string, optional): set when compile was requested during Play Mode (Play session and pause points are discarded) or while hot-reload changes were active (a successful compile drops every patch; the edited sources are compiled in).
 - `Message`: string
 - `ErrorCode`: string or null. `COMPILE_ALREADY_IN_PROGRESS` when Unity is already compiling, `COMPILE_EDITOR_UPDATING` when the editor is updating, `COMPILE_RESULT_UNKNOWN` after a forced recompile that did not return a definitive result.
 - `NextActions`: string array or null. Corrective steps derived from the errors, e.g. the assembly that declares an unresolved namespace (CS0234), or, for CS0246 in a script under an asmdef, a reminder to check that asmdef's references (the type may instead be a typo — decide from the error).

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/SKILL.md
@@ -94,7 +94,7 @@ Full rules and the `Skipped`/`Failed` condition tables: `references/scope-and-li
 
 Treat hot reload as the exploration phase and `uloop compile` as the landing phase:
 keep edits inside the edited files, collect structural changes, and compile once —
-every compile drops all patches and pause points and resets the PlayMode session.
+every compile drops all patches and pause points and resets the PlayMode session (the compile response's Warning states how many were live).
 While patches are active, `AutoRefreshHeld` is true so returning focus does not
 recompile; `uloop compile` or `--revert-all` releases the hold.
 One-shot methods (`Awake`, `Start`, initialization helpers) patch successfully but show

--- a/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
@@ -60,7 +60,7 @@ Returns JSON with:
 - `FailedTests` (array, optional): Up to 10 failed leaf tests with `FullName`, `Message`, and when the stack trace contains a path:line location, `File` and `Line`. Omitted when no tests failed. When `FailedCount` is greater than 10, `Message` ends with `first 10 of N failures listed; see XmlPath for full results.`
 - `SkippedTests` (string[], optional): Up to 10 full names of skipped leaf tests. Omitted when no tests were skipped. When `SkippedCount` is greater than 10, only the first 10 names are listed.
 - `ProposedTestAsmdef` (object, optional): `AssetPath` and `Content` of a ready-to-write test `.asmdef` (test-assembly wiring plus references to the project's assemblies under test). Present only when an unfiltered run found no tests and no test assembly exists for the TestMode.
-- `CompileNote` (string, optional): States that the automatic compile ran and succeeded before the tests and names `--skip-compile` as the opt-out. Omitted when `--skip-compile` was passed; a failed compile returns the compile error response instead.
+- `CompileNote` (string, optional): States that the automatic compile ran and succeeded before the tests and names `--skip-compile` as the opt-out. When the compile response carried a Warning (for example active hot-reload changes dropped by the domain reload), the note repeats it. Omitted when `--skip-compile` was passed; a failed compile returns the compile error response instead.
 
 ### XML Result File
 

--- a/cli/project-runner/internal/projectrunner/run_tests_implicit_compile.go
+++ b/cli/project-runner/internal/projectrunner/run_tests_implicit_compile.go
@@ -29,7 +29,7 @@ func runTestsWithImplicitCompile(
 ) int {
 	remainingArgs, skipCompile := extractRunTestsSkipCompileFlag(commandArgs)
 	if skipCompile {
-		return runDynamicProjectToolWithCompileNote(ctx, connection, clicore.RunTestsCommandName, remainingArgs, startPath, stdout, stderr, false)
+		return runDynamicProjectToolWithCompileNote(ctx, connection, clicore.RunTestsCommandName, remainingArgs, startPath, stdout, stderr, false, "")
 	}
 
 	compileResult := runTestsImplicitCompile(ctx, connection, stderr)
@@ -37,7 +37,16 @@ func runTestsWithImplicitCompile(
 		return writeCompileExecutionResult(stdout, compileResult)
 	}
 
-	return runDynamicProjectToolWithCompileNote(ctx, connection, clicore.RunTestsCommandName, remainingArgs, startPath, stdout, stderr, true)
+	return runDynamicProjectToolWithCompileNote(
+		ctx,
+		connection,
+		clicore.RunTestsCommandName,
+		remainingArgs,
+		startPath,
+		stdout,
+		stderr,
+		true,
+		extractCompileWarning(compileResult.result))
 }
 
 func runTestsImplicitCompileDefault(
@@ -66,7 +75,23 @@ func extractRunTestsSkipCompileFlag(args []string) ([]string, bool) {
 	return remaining, skipCompile
 }
 
-func injectRunTestsCompileNote(raw []byte) ([]byte, error) {
+func extractCompileWarning(raw json.RawMessage) string {
+	fields := map[string]json.RawMessage{}
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return ""
+	}
+	warningRaw, ok := fields["Warning"]
+	if !ok {
+		return ""
+	}
+	warning := ""
+	if err := json.Unmarshal(warningRaw, &warning); err != nil {
+		return ""
+	}
+	return warning
+}
+
+func injectRunTestsCompileNote(raw []byte, compileWarning string) ([]byte, error) {
 	fields := map[string]json.RawMessage{}
 	if err := json.Unmarshal(raw, &fields); err != nil {
 		return nil, err
@@ -74,7 +99,11 @@ func injectRunTestsCompileNote(raw []byte) ([]byte, error) {
 	if fields == nil {
 		return nil, errors.New("run-tests response must be a JSON object")
 	}
-	note, err := json.Marshal(runTestsCompileNote)
+	noteText := runTestsCompileNote
+	if compileWarning != "" {
+		noteText = runTestsCompileNote + " " + compileWarning
+	}
+	note, err := json.Marshal(noteText)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/project-runner/internal/projectrunner/run_tests_implicit_compile_test.go
+++ b/cli/project-runner/internal/projectrunner/run_tests_implicit_compile_test.go
@@ -228,6 +228,89 @@ func TestRunTestsWithImplicitCompileFailsFastWithCompileResponse(t *testing.T) {
 	assertServerDidNotFail(t, serverErr)
 }
 
+// Verifies CompileNote starts with the fixed sentence and then repeats the compile Warning.
+func TestRunTestsWithImplicitCompileAppendsCompileWarningToCompileNote(t *testing.T) {
+	projectRoot := t.TempDir()
+	writeRunTestsCompileToolCache(t, projectRoot)
+	listener := newLoopbackIpcListener(t)
+	requests := make(chan map[string]any, 1)
+	serverErr := make(chan error, 1)
+	go serveSingleIPCResponse(listener, clicore.RunTestsCommandName, requests, serverErr, `{"Success":true,"Status":"Passed","Message":"Test execution completed with status: Passed"}`)
+
+	original := runTestsImplicitCompile
+	runTestsImplicitCompile = func(context.Context, unityipc.Connection, io.Writer) compileExecutionResult {
+		return compileExecutionResult{
+			result:   json.RawMessage(`{"Success":true,"Warning":"2 active hot-reload change(s) were live when this compile was requested."}`),
+			exitCode: 0,
+		}
+	}
+	t.Cleanup(func() {
+		runTestsImplicitCompile = original
+	})
+
+	connection := unityipc.Connection{
+		Endpoint:    unityipc.Endpoint{Network: listener.Addr().Network(), Address: listener.Addr().String()},
+		ProjectRoot: projectRoot,
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := runTestsWithImplicitCompile(context.Background(), connection, nil, projectRoot, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run-tests failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	readIPCRequest(t, requests)
+	note := decodeRunTestsCompileNote(t, stdout.Bytes())
+	if !bytes.HasPrefix([]byte(note), []byte(runTestsCompileNote)) {
+		t.Fatalf("CompileNote must start with the fixed sentence: %q", note)
+	}
+	if !bytes.Contains([]byte(note), []byte(" 2 active hot-reload change(s)")) {
+		t.Fatalf("CompileNote must append the compile Warning: %q", note)
+	}
+	assertServerDidNotFail(t, serverErr)
+}
+
+// Verifies CompileNote stays the fixed sentence when compile Warning is missing or null.
+func TestRunTestsWithImplicitCompileWithoutWarningKeepsPlainCompileNote(t *testing.T) {
+	compileResults := []json.RawMessage{
+		json.RawMessage(`{"Success":true}`),
+		json.RawMessage(`{"Success":true,"Warning":null}`),
+	}
+	for _, compileJSON := range compileResults {
+		func(compileJSON json.RawMessage) {
+			projectRoot := t.TempDir()
+			writeRunTestsCompileToolCache(t, projectRoot)
+			listener := newLoopbackIpcListener(t)
+			requests := make(chan map[string]any, 1)
+			serverErr := make(chan error, 1)
+			go serveSingleIPCResponse(listener, clicore.RunTestsCommandName, requests, serverErr, `{"Success":true,"Status":"Passed","Message":"Test execution completed with status: Passed"}`)
+
+			original := runTestsImplicitCompile
+			runTestsImplicitCompile = func(context.Context, unityipc.Connection, io.Writer) compileExecutionResult {
+				return compileExecutionResult{result: compileJSON, exitCode: 0}
+			}
+			t.Cleanup(func() {
+				runTestsImplicitCompile = original
+			})
+
+			connection := unityipc.Connection{
+				Endpoint:    unityipc.Endpoint{Network: listener.Addr().Network(), Address: listener.Addr().String()},
+				ProjectRoot: projectRoot,
+			}
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			code := runTestsWithImplicitCompile(context.Background(), connection, nil, projectRoot, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("run-tests failed: code=%d stdout=%s stderr=%s compile=%s", code, stdout.String(), stderr.String(), compileJSON)
+			}
+			readIPCRequest(t, requests)
+			assertSingleRunTestsJSON(t, stdout.Bytes(), true)
+			assertServerDidNotFail(t, serverErr)
+		}(compileJSON)
+	}
+}
+
 func writeRunTestsCompileToolCache(t *testing.T, projectRoot string) {
 	t.Helper()
 	clitest.WriteProjectFile(t, projectRoot, filepath.Join(clicore.CacheDirectoryName, clicore.CacheFileName), `{
@@ -260,6 +343,23 @@ func writeRunTestsCompileToolCacheWithTestMode(t *testing.T, projectRoot string)
     }
   ]
 }`)
+}
+
+func decodeRunTestsCompileNote(t *testing.T, output []byte) string {
+	t.Helper()
+	fields := map[string]json.RawMessage{}
+	if err := json.Unmarshal(output, &fields); err != nil {
+		t.Fatalf("stdout must contain JSON: %v\n%s", err, output)
+	}
+	compileNote, present := fields["CompileNote"]
+	if !present {
+		t.Fatalf("CompileNote missing: %s", output)
+	}
+	var note string
+	if err := json.Unmarshal(compileNote, &note); err != nil {
+		t.Fatalf("CompileNote must be a string: %v", err)
+	}
+	return note
 }
 
 func assertSingleRunTestsJSON(t *testing.T, output []byte, expectCompileNote bool) {

--- a/cli/project-runner/internal/projectrunner/run_tests_implicit_compile_test.go
+++ b/cli/project-runner/internal/projectrunner/run_tests_implicit_compile_test.go
@@ -270,11 +270,13 @@ func TestRunTestsWithImplicitCompileAppendsCompileWarningToCompileNote(t *testin
 	assertServerDidNotFail(t, serverErr)
 }
 
-// Verifies CompileNote stays the fixed sentence when compile Warning is missing or null.
+// Verifies CompileNote stays the fixed sentence when compile Warning is missing, null, or not a string.
 func TestRunTestsWithImplicitCompileWithoutWarningKeepsPlainCompileNote(t *testing.T) {
 	compileResults := []json.RawMessage{
 		json.RawMessage(`{"Success":true}`),
 		json.RawMessage(`{"Success":true,"Warning":null}`),
+		json.RawMessage(`{"Success":true,"Warning":7}`),
+		json.RawMessage(`{"Success":true,"Warning":{"x":1}}`),
 	}
 	for _, compileJSON := range compileResults {
 		func(compileJSON json.RawMessage) {

--- a/cli/project-runner/internal/projectrunner/runner_commands.go
+++ b/cli/project-runner/internal/projectrunner/runner_commands.go
@@ -57,7 +57,7 @@ func runDynamicProjectTool(
 	if command == clicore.RunTestsCommandName {
 		return runTestsWithImplicitCompile(ctx, connection, commandArgs, startPath, stdout, stderr)
 	}
-	return runDynamicProjectToolWithCompileNote(ctx, connection, command, commandArgs, startPath, stdout, stderr, false)
+	return runDynamicProjectToolWithCompileNote(ctx, connection, command, commandArgs, startPath, stdout, stderr, false, "")
 }
 
 func runDynamicProjectToolWithCompileNote(
@@ -69,6 +69,7 @@ func runDynamicProjectToolWithCompileNote(
 	stdout io.Writer,
 	stderr io.Writer,
 	includeCompileNote bool,
+	compileWarning string,
 ) int {
 	tool, cache, ok, err := clicore.FindToolForCommand(connection.ProjectRoot, command)
 	if err != nil {
@@ -112,7 +113,7 @@ func runDynamicProjectToolWithCompileNote(
 	if len(result.result) == 0 {
 		return result.exitCode
 	}
-	withCompileNote, err := injectRunTestsCompileNote(result.result)
+	withCompileNote, err := injectRunTestsCompileNote(result.result, compileWarning)
 	if err != nil {
 		writeRunTestsCompileNoteError(stderr, connection, err)
 		return 1


### PR DESCRIPTION
## Summary
- `uloop compile` now tells you how many active hot-reload changes were live when the compile was requested, and that a successful compile drops every patch.
- `uloop run-tests` repeats that compile Warning on `CompileNote`, so the implicit compile no longer hides the discarded work.

## User Impact
- Before: a successful compile (including the one run-tests does by default) reloaded the domain and dropped every hot-reload patch, but neither response mentioned it. Agents kept treating those patches as still live.
- After: compile `Warning` states the live count and that the domain reload drops every patch (the edited sources are compiled in). When run-tests ran that compile, `CompileNote` starts with the usual sentence and then repeats the Warning.

## Changes
- compile captures the live hot-reload patch count at request start and appends it to the existing Play-stop Warning text (Play wording is unchanged).
- run-tests reads the compile response `Warning` and appends it to `CompileNote` when present; missing or null Warning keeps the fixed sentence.
- Skill output tables document `Warning` and the repeated `CompileNote`.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` → `"Success": true`
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value 'CompilePlayModeStopWarningBuilderTests|CompileUseCaseTests' --project-path "$(git rev-parse --show-toplevel)"` → `"FailedCount": 0`, `"PassedCount": 10`
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value 'Compile' --project-path "$(git rev-parse --show-toplevel)"` → `"FailedCount": 0`, `"PassedCount": 440`
- `scripts/check-go-cli.sh` → exit 0 (fmt / vet / lint / test / dist rebuild)
- Live check: one hot-reload `Patched` on a fixture, then `uloop run-tests --filter-type class --filter-value CompilePlayModeStopWarningBuilderTests` → `CompileNote` contained `1 active hot-reload change(s) were live`
- `scripts/check-file-length.sh` → no files exceeded the limit
- `scripts/check-code-complexity.sh` → 0 issues
- `go run ./cmd/check-skill-size --root "$(git rev-parse --show-toplevel)"` → no SKILL.md exceeded 8000 bytes
- `go run ./cmd/sync-tool-docs --repository-root "$(git rev-parse --show-toplevel)" --check` → catalog matches


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

