### PR TITLE
fix: Hot reload binds added methods reached through compiled types and explains unresolved types

### DIFF
--- a/.agents/skills/uloop-hot-reload/references/scope-and-limits.md
+++ b/.agents/skills/uloop-hot-reload/references/scope-and-limits.md
@@ -24,7 +24,11 @@ serialization. Referencing an added member from a file that is neither passed to
 already hot-reloaded, or from another assembly, fails that file's hot reload with
 the usual new-member hint; run `uloop compile` instead. Unchanged files of the same
 assembly that already hold active patches are re-applied automatically so they bind
-to the newest shim.
+to the newest shim. An edited body that reaches an added method through a
+compiled type still binds when the receiver's static type name, method name, and
+argument count uniquely match and the call is static only when the receiver is a
+type name; the lookup uses that static type itself (not a base type), requires an
+exact argument count, and does not cover `?.`.
 
 An added method reports its own row with Kind `Added`; the edited methods that call
 it report `Patched` as usual. Added `virtual`/`override`/`abstract` methods, explicit
@@ -215,6 +219,7 @@ stay `Skipped`.
 | Body contains a `base.` call | `base` cannot be expressed from outside the type |
 | Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
+| A declared return or parameter type cannot be resolved (an uncompiled new type, a missing using, or a typo) | Skipped; add the missing type, add the required `using`, or fix the typo, then run `uloop compile` |
 | Property setter, init, or indexer accessor with an explicit body | Accessor patching covers getters only; `uloop compile` applies setter/init/indexer edits |
 | Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Out of scope for v1; `uloop compile` applies these edits |
 | Method raises or reads a field-like event that has no reachable backing field | Custom `add`/`remove` accessors, an `abstract`/`extern`/interface event, a delegate type that is not visible outside the assembly, or an event added in this edit leave nothing for the shim's Harmony accessor to bind |

--- a/.claude/skills/uloop-hot-reload/references/scope-and-limits.md
+++ b/.claude/skills/uloop-hot-reload/references/scope-and-limits.md
@@ -24,7 +24,11 @@ serialization. Referencing an added member from a file that is neither passed to
 already hot-reloaded, or from another assembly, fails that file's hot reload with
 the usual new-member hint; run `uloop compile` instead. Unchanged files of the same
 assembly that already hold active patches are re-applied automatically so they bind
-to the newest shim.
+to the newest shim. An edited body that reaches an added method through a
+compiled type still binds when the receiver's static type name, method name, and
+argument count uniquely match and the call is static only when the receiver is a
+type name; the lookup uses that static type itself (not a base type), requires an
+exact argument count, and does not cover `?.`.
 
 An added method reports its own row with Kind `Added`; the edited methods that call
 it report `Patched` as usual. Added `virtual`/`override`/`abstract` methods, explicit
@@ -215,6 +219,7 @@ stay `Skipped`.
 | Body contains a `base.` call | `base` cannot be expressed from outside the type |
 | Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
+| A declared return or parameter type cannot be resolved (an uncompiled new type, a missing using, or a typo) | Skipped; add the missing type, add the required `using`, or fix the typo, then run `uloop compile` |
 | Property setter, init, or indexer accessor with an explicit body | Accessor patching covers getters only; `uloop compile` applies setter/init/indexer edits |
 | Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Out of scope for v1; `uloop compile` applies these edits |
 | Method raises or reads a field-like event that has no reachable backing field | Custom `add`/`remove` accessors, an `abstract`/`extern`/interface event, a delegate type that is not visible outside the assembly, or an event added in this edit leave nothing for the shim's Harmony accessor to bind |

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberCaller.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberCaller.cs
@@ -36,5 +36,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             return host.Gated(1);
         }
+
+        // Reaches the host through a compiled holder property so the receiver type is metadata.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int CallThroughHolder(HotReloadCrossFileAddedMemberHolder holder)
+        {
+            return holder.Host.Value();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Twice(int value)
+        {
+            return value * 2;
+        }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberHolder.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberHolder.cs
@@ -1,0 +1,9 @@
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// Compiled holder type that exposes the host through a property. It is never passed to a
+    /// reload, so a body reaching the host through it sees the compiled (metadata) host type.
+    internal sealed class HotReloadCrossFileAddedMemberHolder
+    {
+        public HotReloadCrossFileAddedMemberHost Host { get; } = new HotReloadCrossFileAddedMemberHost();
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberHolder.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberHolder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 857d3f716fdb64631a1d9e665a46d03b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
@@ -790,6 +790,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a caller that reaches an added host method through a compiled holder property
+        /// still patches and returns the added-method value, because the worker binds that call
+        /// from the metadata receiver type when GetSymbolInfo cannot.
+        /// </summary>
+        [Test]
+        public async Task Run_CallerReachesAddedMethodThroughCompiledHolderProperty_PatchesBehavior()
+        {
+            HotReloadOrchestratorResult result = await RunPairAsync(
+                "HolderReceiver",
+                InsertHostMember("        public int Added()\n        {\n            return 5;\n        }\n\n"),
+                ReplaceCallerBody("return holder.Host.Value();", "return Twice(holder.Host.Added());"));
+
+            AssertNoFailure(result);
+            Assert.That(
+                new HotReloadCrossFileAddedMemberCaller().CallThroughHolder(
+                    new HotReloadCrossFileAddedMemberHolder()),
+                Is.EqualTo(10));
+        }
+
+        /// <summary>
         /// What: changing a method's return type is applied when its only call site was edited in
         /// another file of the same reload, because the signature-change gate sees that caller
         /// covered by this run.

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -313,6 +313,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: an added method whose return type is a generic wrapping an unresolved type
+        /// still reports that the type could not be resolved, not condition c.
+        /// </summary>
+        [Test]
+        public async Task Run_AddedMethodReturningListOfUnresolvedType_ReportsUnresolvedTypeNotVisibility()
+        {
+            TransformWorkerClientResult result = await RunHostWithAddedMembersAsync(
+                "private System.Collections.Generic.List<MissingType> _missingList;\n"
+                + "        public System.Collections.Generic.List<MissingType> AddedUnresolvedList()\n        {\n"
+                + "            return _missingList;\n        }");
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            string reason = FindSkipReason(result, "AddedUnresolvedList");
+            Assert.That(reason, Is.Not.Null, "Expected a skip for AddedUnresolvedList.");
+            Assert.That(reason, Does.Contain("could not be resolved"));
+            Assert.That(reason, Does.Not.Contain("condition c"));
+        }
+
+        /// <summary>
         /// What: an added method whose private access has no accessor rewrite is Skipped
         /// with the added-method prefix plus the eligibility reason.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -295,6 +295,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: an added method whose return type cannot be resolved reports that the type
+        /// could not be resolved, not that it is invisible (condition c).
+        /// </summary>
+        [Test]
+        public async Task Run_AddedMethodReturningUnresolvedType_WithPrivateAccess_ReportsUnresolvedTypeNotVisibility()
+        {
+            TransformWorkerClientResult result = await RunHostWithAddedMembersAsync(
+                "private MissingReturnType _missingReturn;\n"
+                + "        public MissingReturnType AddedUnresolved()\n        {\n"
+                + "            return _missingReturn;\n        }");
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            string reason = FindSkipReason(result, "AddedUnresolved");
+            Assert.That(reason, Is.Not.Null, "Expected a skip for AddedUnresolved.");
+            Assert.That(reason, Does.Contain("could not be resolved"));
+            Assert.That(reason, Does.Not.Contain("condition c"));
+        }
+
+        /// <summary>
         /// What: an added method whose private access has no accessor rewrite is Skipped
         /// with the added-method prefix plus the eligibility reason.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -32,6 +32,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private static readonly string[] SelfSnapshotMethodlessTypeAllowList =
         {
             "HotReloadSiblingConstDefinitions.cs",
+            "HotReloadCrossFileAddedMemberHolder.cs",
         };
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerCrossFileTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerCrossFileTests.cs
@@ -254,6 +254,45 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a using-alias type-name receiver still binds an added static method, because
+        /// GetSymbolInfo on the alias identifier returns the target type, not IAliasSymbol.
+        /// </summary>
+        [Test]
+        public async Task Run_TypeAliasReceiverBindsAddedStaticMethod()
+        {
+            string editedCaller = ReplaceInSource(
+                ReadOnDisk(CallerFileName),
+                "using System.Runtime.CompilerServices;\n",
+                "using System.Runtime.CompilerServices;\n"
+                + "using HostAlias = io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadCrossFileAddedMemberHost;\n");
+            editedCaller = ReplaceInSource(
+                editedCaller,
+                "return holder.Host.Value();",
+                "return HostAlias.AddedStatic();");
+            CrossFileRun run = await RunEditedPairAsync(
+                AddHostStaticMethod(ReadOnDisk(HostFileName)),
+                editedCaller);
+
+            Assert.That(run.Result.Success, Is.True, run.Result.ErrorMessage);
+            TransformWorkerEntryDto addedEntry = FindEntry(run, HostTypeMetadataName, "AddedStatic");
+            Assert.That(addedEntry.patchKind, Is.EqualTo("addedMethod"));
+            TransformWorkerEntryDto callerEntry = FindEntry(run, CallerTypeMetadataName, "CallThroughHolder");
+            Assert.That(callerEntry.calledAddedMethodKeys, Is.Not.Null);
+            Assert.That(
+                callerEntry.calledAddedMethodKeys,
+                Has.Some.Contains("AddedStatic"),
+                "A type-alias receiver must record the added static method.");
+            Assert.That(
+                run.Result.Output.shimSource,
+                Does.Not.Contain("HostAlias.AddedStatic("),
+                "The type-alias static call must be rewritten off the added method.");
+            Assert.That(
+                run.Result.Output.shimSource,
+                Does.Contain("." + addedEntry.shimMethodName + "("),
+                "The added static shim must be invoked from the type-alias call.");
+        }
+
+        /// <summary>
         /// What: an unreadable source reports its failure on its own per-file row only, and the
         /// other file of the run still produces entries.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerCrossFileTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerCrossFileTests.cs
@@ -186,6 +186,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a caller that reaches an added host method through a compiled holder property
+        /// still records the added method and rewrites the invocation, because the receiver type
+        /// name plus method name plus argument count is enough to bind when GetSymbolInfo cannot.
+        /// </summary>
+        [Test]
+        public async Task Run_CallerReachesHostThroughCompiledHolder_BindsAddedMethodByReceiverType()
+        {
+            string editedCaller = ReplaceInSource(
+                ReadOnDisk(CallerFileName),
+                "return holder.Host.Value();",
+                "return Twice(holder.Host.Added());");
+            CrossFileRun run = await RunEditedPairAsync(
+                AddHostMethod(ReadOnDisk(HostFileName)),
+                editedCaller);
+
+            Assert.That(run.Result.Success, Is.True, run.Result.ErrorMessage);
+            TransformWorkerEntryDto callerEntry = FindEntry(run, CallerTypeMetadataName, "CallThroughHolder");
+            Assert.That(callerEntry.calledAddedMethodKeys, Is.Not.Null);
+            Assert.That(
+                callerEntry.calledAddedMethodKeys,
+                Has.Some.Contains("Added"),
+                "The edited caller body must record the added host method reached through the holder.");
+            AssertNoSkippedMethodNamed(run, "CallThroughHolder");
+            Assert.That(
+                run.Result.Output.shimSource,
+                Does.Not.Contain("holder.Host.Added("),
+                "The unbound metadata-receiver call must be rewritten off the added method.");
+            Assert.That(
+                run.Result.Output.shimSource,
+                Does.Contain("__uloopInstance.Twice("),
+                "The collateral unbound compiled call must be qualified onto the instance parameter.");
+        }
+
+        /// <summary>
         /// What: an unreadable source reports its failure on its own per-file row only, and the
         /// other file of the run still produces entries.
         /// </summary>
@@ -233,9 +267,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private static string ReplaceCallerBody(string callerSource, string bodyText)
         {
-            const string anchor = "return host.Value();";
-            Assert.That(callerSource, Does.Contain(anchor), "Precondition: caller anchor must exist.");
-            return callerSource.Replace(anchor, bodyText, StringComparison.Ordinal);
+            return ReplaceInSource(callerSource, "return host.Value();", bodyText);
+        }
+
+        private static string ReplaceInSource(string source, string anchor, string replacement)
+        {
+            Assert.That(source, Does.Contain(anchor), "Precondition: anchor must exist: " + anchor);
+            return source.Replace(anchor, replacement, StringComparison.Ordinal);
         }
 
         private static TransformWorkerEntryDto FindEntry(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerCrossFileTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerCrossFileTests.cs
@@ -220,6 +220,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a metadata value receiver does not bind an added static method, so the call
+        /// stays unbound instead of rewriting away the receiver evaluation (CS0176).
+        /// </summary>
+        [Test]
+        public async Task Run_ValueReceiverDoesNotBindAddedStaticMethod()
+        {
+            string editedCaller = ReplaceInSource(
+                ReadOnDisk(CallerFileName),
+                "return holder.Host.Value();",
+                "return holder.Host.AddedStatic();");
+            CrossFileRun run = await RunEditedPairAsync(
+                AddHostStaticMethod(ReadOnDisk(HostFileName)),
+                editedCaller);
+
+            Assert.That(run.Result.Success, Is.True, run.Result.ErrorMessage);
+            TransformWorkerEntryDto addedEntry = FindEntry(run, HostTypeMetadataName, "AddedStatic");
+            Assert.That(addedEntry.patchKind, Is.EqualTo("addedMethod"));
+            TransformWorkerEntryDto callerEntry = FindEntry(run, CallerTypeMetadataName, "CallThroughHolder");
+            Assert.That(
+                callerEntry.calledAddedMethodKeys == null
+                || !Array.Exists(callerEntry.calledAddedMethodKeys, key => key.Contains("AddedStatic")),
+                Is.True,
+                "A value-receiver call must not record the added static method.");
+            Assert.That(
+                run.Result.Output.shimSource,
+                Does.Contain("holder.Host.AddedStatic("),
+                "The mismatched static call must stay on the compiled receiver.");
+            Assert.That(
+                run.Result.Output.shimSource,
+                Does.Not.Contain("." + addedEntry.shimMethodName + "("),
+                "The added static shim must not be invoked from the value-receiver call.");
+        }
+
+        /// <summary>
         /// What: an unreadable source reports its failure on its own per-file row only, and the
         /// other file of the run still produces entries.
         /// </summary>
@@ -251,6 +285,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return InsertIntoHostBody(
                 hostSource,
                 "        public int Added()\n        {\n            return 41;\n        }\n\n");
+        }
+
+        private static string AddHostStaticMethod(string hostSource)
+        {
+            return InsertIntoHostBody(
+                hostSource,
+                "        public static int AddedStatic()\n        {\n            return 41;\n        }\n\n");
         }
 
         private static string InsertIntoHostBody(string hostSource, string memberText)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
@@ -215,6 +215,7 @@ stay `Skipped`.
 | Body contains a `base.` call | `base` cannot be expressed from outside the type |
 | Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
+| A declared return or parameter type cannot be resolved (an uncompiled new type, a missing using, or a typo) | Skipped; run `uloop compile` after the type exists |
 | Property setter, init, or indexer accessor with an explicit body | Accessor patching covers getters only; `uloop compile` applies setter/init/indexer edits |
 | Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Out of scope for v1; `uloop compile` applies these edits |
 | Method raises or reads a field-like event that has no reachable backing field | Custom `add`/`remove` accessors, an `abstract`/`extern`/interface event, a delegate type that is not visible outside the assembly, or an event added in this edit leave nothing for the shim's Harmony accessor to bind |

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
@@ -26,8 +26,9 @@ the usual new-member hint; run `uloop compile` instead. Unchanged files of the s
 assembly that already hold active patches are re-applied automatically so they bind
 to the newest shim. An edited body that reaches an added method through a
 compiled type still binds when the receiver's static type name, method name, and
-argument count uniquely match; the lookup uses that static type itself (not a base
-type), requires an exact argument count, and does not cover `?.`.
+argument count uniquely match and the call is static only when the receiver is a
+type name; the lookup uses that static type itself (not a base type), requires an
+exact argument count, and does not cover `?.`.
 
 An added method reports its own row with Kind `Added`; the edited methods that call
 it report `Patched` as usual. Added `virtual`/`override`/`abstract` methods, explicit

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
@@ -24,7 +24,10 @@ serialization. Referencing an added member from a file that is neither passed to
 already hot-reloaded, or from another assembly, fails that file's hot reload with
 the usual new-member hint; run `uloop compile` instead. Unchanged files of the same
 assembly that already hold active patches are re-applied automatically so they bind
-to the newest shim.
+to the newest shim. An edited body that reaches an added method through a
+compiled type still binds when the receiver's static type name, method name, and
+argument count uniquely match; the lookup uses that static type itself (not a base
+type), requires an exact argument count, and does not cover `?.`.
 
 An added method reports its own row with Kind `Added`; the edited methods that call
 it report `Patched` as usual. Added `virtual`/`override`/`abstract` methods, explicit
@@ -215,7 +218,7 @@ stay `Skipped`.
 | Body contains a `base.` call | `base` cannot be expressed from outside the type |
 | Private/internal access inside an async/iterator/closure body has no accessor-delegate shape | Conditional access (`?.`), `??=`, indexers, static field writes, initializer member assignments, compound writes whose receiver could be evaluated twice, assignments whose value is consumed, and calls with `ref`/`out`/`in`, named, optional, or `params` arguments (or to extension/generic/by-ref-returning methods) cannot be rewritten to accessor delegates |
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
-| A declared return or parameter type cannot be resolved (an uncompiled new type, a missing using, or a typo) | Skipped; run `uloop compile` after the type exists |
+| A declared return or parameter type cannot be resolved (an uncompiled new type, a missing using, or a typo) | Skipped; add the missing type, add the required `using`, or fix the typo, then run `uloop compile` |
 | Property setter, init, or indexer accessor with an explicit body | Accessor patching covers getters only; `uloop compile` applies setter/init/indexer edits |
 | Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Out of scope for v1; `uloop compile` applies these edits |
 | Method raises or reads a field-like event that has no reachable backing field | Custom `add`/`remove` accessors, an `abstract`/`extern`/interface event, a delegate type that is not visible outside the assembly, or an event added in this edit leave nothing for the shim's Harmony accessor to bind |

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AccessorEligibility.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AccessorEligibility.cs
@@ -120,8 +120,8 @@ internal static class AccessorEligibility
 
     // Why before visibility: TypeKind.Error is not "invisible"; treating it as condition c
     // tells the caller the type exists but cannot be seen, which hides missing usings/typos.
-    // Why recurse: List<MissingType> and MissingType[] have a resolved outer kind, so only
-    // the type argument or element is Error.
+    // Why recurse: List<MissingType>, MissingType[], and MissingType* have a resolved outer
+    // kind, so only the type argument, element, or pointed-at type is Error.
     private static bool TryDescribeUnresolvedType(ITypeSymbol typeSymbol, string role, out string reason)
     {
         if (typeSymbol == null)
@@ -137,6 +137,11 @@ internal static class AccessorEligibility
                 + typeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)
                 + "' could not be resolved (missing using directive, typo, or a type that is not compiled yet).";
             return true;
+        }
+
+        if (typeSymbol is IPointerTypeSymbol pointerType)
+        {
+            return TryDescribeUnresolvedType(pointerType.PointedAtType, role, out reason);
         }
 
         if (typeSymbol is IArrayTypeSymbol arrayType)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AccessorEligibility.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AccessorEligibility.cs
@@ -88,6 +88,11 @@ internal static class AccessorEligibility
 
     private static bool AreMethodSignatureTypesVisible(IMethodSymbol methodSymbol, out string rejectReason)
     {
+        if (TryDescribeUnresolvedType(methodSymbol.ReturnType, "method return type", out rejectReason))
+        {
+            return false;
+        }
+
         if (!AccessibilityRules.IsExternallyVisibleType(methodSymbol.ReturnType))
         {
             rejectReason = "method return type is not visible from an external assembly (condition c).";
@@ -96,6 +101,11 @@ internal static class AccessorEligibility
 
         foreach (IParameterSymbol parameter in methodSymbol.Parameters)
         {
+            if (TryDescribeUnresolvedType(parameter.Type, "method parameter type", out rejectReason))
+            {
+                return false;
+            }
+
             if (!AccessibilityRules.IsExternallyVisibleType(parameter.Type))
             {
                 rejectReason =
@@ -105,6 +115,23 @@ internal static class AccessorEligibility
         }
 
         rejectReason = null;
+        return true;
+    }
+
+    // Why before visibility: TypeKind.Error is not "invisible"; treating it as condition c
+    // tells the caller the type exists but cannot be seen, which hides missing usings/typos.
+    private static bool TryDescribeUnresolvedType(ITypeSymbol typeSymbol, string role, out string reason)
+    {
+        if (typeSymbol == null || typeSymbol.TypeKind != TypeKind.Error)
+        {
+            reason = null;
+            return false;
+        }
+
+        reason = role
+            + " '"
+            + typeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)
+            + "' could not be resolved (missing using directive, typo, or a type that is not compiled yet).";
         return true;
     }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AccessorEligibility.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AccessorEligibility.cs
@@ -120,19 +120,47 @@ internal static class AccessorEligibility
 
     // Why before visibility: TypeKind.Error is not "invisible"; treating it as condition c
     // tells the caller the type exists but cannot be seen, which hides missing usings/typos.
+    // Why recurse: List<MissingType> and MissingType[] have a resolved outer kind, so only
+    // the type argument or element is Error.
     private static bool TryDescribeUnresolvedType(ITypeSymbol typeSymbol, string role, out string reason)
     {
-        if (typeSymbol == null || typeSymbol.TypeKind != TypeKind.Error)
+        if (typeSymbol == null)
         {
             reason = null;
             return false;
         }
 
-        reason = role
-            + " '"
-            + typeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)
-            + "' could not be resolved (missing using directive, typo, or a type that is not compiled yet).";
-        return true;
+        if (typeSymbol.TypeKind == TypeKind.Error)
+        {
+            reason = role
+                + " '"
+                + typeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)
+                + "' could not be resolved (missing using directive, typo, or a type that is not compiled yet).";
+            return true;
+        }
+
+        if (typeSymbol is IArrayTypeSymbol arrayType)
+        {
+            return TryDescribeUnresolvedType(arrayType.ElementType, role, out reason);
+        }
+
+        INamedTypeSymbol namedType = typeSymbol as INamedTypeSymbol;
+        if (namedType == null)
+        {
+            reason = null;
+            return false;
+        }
+
+        foreach (ITypeSymbol typeArgument in namedType.TypeArguments)
+        {
+            if (TryDescribeUnresolvedType(typeArgument, role, out reason))
+            {
+                return true;
+            }
+        }
+
+        reason = null;
+        return false;
     }
 
     private static bool AreBodyTypeUsagesVisible(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedCallSiteGuard.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedCallSiteGuard.cs
@@ -273,22 +273,17 @@ internal static class AddedCallSiteGuard
                 continue;
             }
 
-            ISymbol symbol = semanticModel.GetSymbolInfo(invocation).Symbol;
-            if (symbol is not IMethodSymbol methodSymbol)
+            AddedMethodBinding binding = AddedMethodCallResolver.ResolveBindingOrNull(
+                invocation,
+                semanticModel,
+                addedMethodCatalog,
+                out _);
+            if (binding == null || binding.MethodKey == selfMethodKey)
             {
                 continue;
             }
 
-            string calledKey = WorkerMethodKeys.BuildMethodKeyFromSymbol(methodSymbol);
-            if (calledKey == selfMethodKey)
-            {
-                continue;
-            }
-
-            if (addedMethodCatalog.Contains(calledKey))
-            {
-                keys.Add(calledKey);
-            }
+            keys.Add(binding.MethodKey);
         }
 
         if (keys.Count == 0)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMethodBinding.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMethodBinding.cs
@@ -26,4 +26,6 @@ internal sealed class AddedMethodBinding
     public string NamespaceName { get; set; }
 
     public bool IsStatic { get; set; }
+
+    public int ParameterCount { get; set; }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMethodCallResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMethodCallResolver.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+// Resolves an invocation to an added-method catalog binding for rewrite and call-site collection.
+internal static class AddedMethodCallResolver
+{
+    // Why a fallback: added methods exist only on edited sources. A receiver reached through an
+    // unedited compiled type binds to the metadata type, so GetSymbolInfo stays unbound.
+    internal static AddedMethodBinding ResolveBindingOrNull(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        AddedMethodCatalog catalog,
+        out bool isStaticCall)
+    {
+        isStaticCall = false;
+        Debug.Assert(invocation != null, "invocation");
+        Debug.Assert(semanticModel != null, "semanticModel");
+        Debug.Assert(catalog != null, "catalog");
+
+        IMethodSymbol symbol = semanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol;
+        if (symbol != null)
+        {
+            if (symbol.MethodKind != MethodKind.Ordinary)
+            {
+                return null;
+            }
+
+            AddedMethodBinding bound = catalog.FindOrNull(WorkerMethodKeys.BuildMethodKeyFromSymbol(symbol));
+            isStaticCall = symbol.IsStatic;
+            return bound;
+        }
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return null;
+        }
+
+        ITypeSymbol receiverType = semanticModel.GetTypeInfo(memberAccess.Expression).Type;
+        if (receiverType == null)
+        {
+            receiverType = semanticModel.GetSymbolInfo(memberAccess.Expression).Symbol as INamedTypeSymbol;
+        }
+
+        if (receiverType is not INamedTypeSymbol named || named.TypeKind == TypeKind.Error)
+        {
+            return null;
+        }
+
+        AddedMethodBinding binding = catalog.FindUniqueByReceiverOrNull(
+            CecilTypeNames.ToMetadataName(named),
+            memberAccess.Name.Identifier.ValueText,
+            invocation.ArgumentList.Arguments.Count);
+        isStaticCall = binding != null && binding.IsStatic;
+        return binding;
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMethodCallResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMethodCallResolver.cs
@@ -64,7 +64,22 @@ internal static class AddedMethodCallResolver
             CecilTypeNames.ToMetadataName(named),
             memberAccess.Name.Identifier.ValueText,
             invocation.ArgumentList.Arguments.Count);
-        isStaticCall = binding != null && binding.IsStatic;
+        if (binding == null)
+        {
+            return null;
+        }
+
+        // Why match staticness: a value receiver plus a static added method is CS0176;
+        // rewriting it would drop receiver evaluation. A type-name receiver plus an
+        // instance method would pass the type name as the instance argument.
+        bool receiverIsTypeName =
+            semanticModel.GetSymbolInfo(memberAccess.Expression).Symbol is ITypeSymbol;
+        if (binding.IsStatic != receiverIsTypeName)
+        {
+            return null;
+        }
+
+        isStaticCall = binding.IsStatic;
         return binding;
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMethodCatalog.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMethodCatalog.cs
@@ -98,6 +98,39 @@ internal sealed class AddedMethodCatalog
         return _byKey.TryGetValue(methodKey, out AddedMethodBinding binding) ? binding : null;
     }
 
+    // A metadata receiver cannot bind to a source-only added method, so the rewriter
+    // matches on type name, method name, and argument count when GetSymbolInfo is unbound.
+    public AddedMethodBinding FindUniqueByReceiverOrNull(
+        string typeMetadataName,
+        string methodName,
+        int argumentCount)
+    {
+        Debug.Assert(typeMetadataName != null, "typeMetadataName");
+        Debug.Assert(methodName != null, "methodName");
+
+        string prefix = typeMetadataName + "::" + methodName + "(";
+        AddedMethodBinding unique = null;
+        int matches = 0;
+        foreach (AddedMethodBinding binding in _byKey.Values)
+        {
+            if (binding.MethodKey == null
+                || !binding.MethodKey.StartsWith(prefix, StringComparison.Ordinal)
+                || binding.ParameterCount != argumentCount)
+            {
+                continue;
+            }
+
+            matches++;
+            unique = binding;
+            if (matches > 1)
+            {
+                return null;
+            }
+        }
+
+        return matches == 1 ? unique : null;
+    }
+
     public void Unregister(string methodKey)
     {
         if (methodKey != null)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OrdinaryMethodQueue.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OrdinaryMethodQueue.cs
@@ -390,7 +390,8 @@ internal static class OrdinaryMethodQueue
                     ShimTypeName = shimType.ShimTypeName,
                     ShimMethodName = shimMethodName,
                     NamespaceName = shimType.NamespaceName,
-                    IsStatic = methodSymbol.IsStatic
+                    IsStatic = methodSymbol.IsStatic,
+                    ParameterCount = methodSymbol.Parameters.Length
                 });
             RemovedMemberCollector.RecordHandledAddedMethodSyntaxKey(
                 addedMethodCatalog,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimBodyRewriter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimBodyRewriter.cs
@@ -140,14 +140,14 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
             return base.VisitInvocationExpression(node);
         }
 
-        if (invokedSymbol is IMethodSymbol addedMethod
-            && addedMethod.MethodKind == MethodKind.Ordinary)
+        AddedMethodBinding binding = AddedMethodCallResolver.ResolveBindingOrNull(
+            node,
+            _semanticModel,
+            _addedMethodCatalog,
+            out bool isStaticCall);
+        if (binding != null)
         {
-            AddedMethodBinding binding = _addedMethodCatalog.FindOrNull(BuildAddedMethodKey(addedMethod));
-            if (binding != null)
-            {
-                return RewriteAddedMethodInvocation(node, addedMethod, binding);
-            }
+            return RewriteAddedMethodInvocation(node, isStaticCall, binding);
         }
 
         if (_accessorPlan == null)
@@ -234,7 +234,7 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
 
     private SyntaxNode RewriteAddedMethodInvocation(
         InvocationExpressionSyntax node,
-        IMethodSymbol addedMethod,
+        bool isStaticCall,
         AddedMethodBinding binding)
     {
         // Why the resolved namespace: a type from the global namespace gets a synthesized one,
@@ -250,7 +250,7 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
             SyntaxFactory.IdentifierName(binding.ShimMethodName));
 
         List<ArgumentSyntax> arguments = new List<ArgumentSyntax>();
-        if (!addedMethod.IsStatic)
+        if (!isStaticCall)
         {
             ExpressionSyntax receiver = ExtractReceiver(node.Expression);
             arguments.Add(SyntaxFactory.Argument(VisitReceiver(receiver)));
@@ -423,7 +423,8 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
             return original;
         }
 
-        ISymbol symbol = _semanticModel.GetSymbolInfo(node).Symbol;
+        ISymbol symbol = _semanticModel.GetSymbolInfo(node).Symbol
+            ?? UnboundOwnedCallQualifier.ResolveOwnedMethodOrNull(node, _semanticModel, _targetType);
         if (symbol == null)
         {
             return original;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/UnboundOwnedCallQualifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/UnboundOwnedCallQualifier.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+// Recovers an owned compiled method when GetSymbolInfo is unbound because an argument
+// failed to bind (error-typed), so VisitName can still qualify implicit this.
+internal static class UnboundOwnedCallQualifier
+{
+    // Why CandidateSymbols first: an error-typed argument yields OverloadResolutionFailure
+    // with the real methods, which is more precise than guessing by name and argument count.
+    internal static ISymbol ResolveOwnedMethodOrNull(
+        SimpleNameSyntax name,
+        SemanticModel semanticModel,
+        INamedTypeSymbol targetType)
+    {
+        Debug.Assert(name != null, "name");
+        Debug.Assert(semanticModel != null, "semanticModel");
+        Debug.Assert(targetType != null, "targetType");
+
+        ImmutableArray<ISymbol> candidates = CollectCandidateSymbols(name, semanticModel);
+        if (!candidates.IsDefaultOrEmpty)
+        {
+            return AdoptOwnedCandidatesOrNull(candidates, targetType);
+        }
+
+        return ResolveByNameAndArgumentCountOrNull(name, semanticModel, targetType);
+    }
+
+    private static ImmutableArray<ISymbol> CollectCandidateSymbols(
+        SimpleNameSyntax name,
+        SemanticModel semanticModel)
+    {
+        ImmutableArray<ISymbol> fromName = semanticModel.GetSymbolInfo(name).CandidateSymbols;
+        if (!fromName.IsDefaultOrEmpty)
+        {
+            return fromName;
+        }
+
+        if (name.Parent is InvocationExpressionSyntax invocation && invocation.Expression == name)
+        {
+            return semanticModel.GetSymbolInfo(invocation).CandidateSymbols;
+        }
+
+        return fromName;
+    }
+
+    private static ISymbol AdoptOwnedCandidatesOrNull(
+        ImmutableArray<ISymbol> candidates,
+        INamedTypeSymbol targetType)
+    {
+        IMethodSymbol adopted = null;
+        bool? expectedStatic = null;
+        foreach (ISymbol candidate in candidates)
+        {
+            IMethodSymbol method = AsOwnedOrdinaryMethodOrNull(candidate, targetType);
+            if (method == null)
+            {
+                return null;
+            }
+
+            if (expectedStatic == null)
+            {
+                expectedStatic = method.IsStatic;
+                adopted = method;
+                continue;
+            }
+
+            if (method.IsStatic != expectedStatic.Value)
+            {
+                return null;
+            }
+        }
+
+        return adopted;
+    }
+
+    private static IMethodSymbol AsOwnedOrdinaryMethodOrNull(
+        ISymbol candidate,
+        INamedTypeSymbol targetType)
+    {
+        IMethodSymbol method = candidate as IMethodSymbol;
+        if (method == null
+            || method.MethodKind != MethodKind.Ordinary
+            || method.ContainingType == null
+            || !HarmonyAccessorShimRewrite.IsInInheritanceHierarchy(targetType, method.ContainingType))
+        {
+            return null;
+        }
+
+        return method;
+    }
+
+    private static ISymbol ResolveByNameAndArgumentCountOrNull(
+        SimpleNameSyntax name,
+        SemanticModel semanticModel,
+        INamedTypeSymbol targetType)
+    {
+        if (name.Parent is not InvocationExpressionSyntax invocation || invocation.Expression != name)
+        {
+            return null;
+        }
+
+        string identifier = name.Identifier.ValueText;
+        if (HasLocalLikeSymbol(semanticModel, name.SpanStart, identifier))
+        {
+            return null;
+        }
+
+        return FindUniqueOwnedMethodOrNull(
+            targetType,
+            identifier,
+            invocation.ArgumentList.Arguments.Count);
+    }
+
+    private static bool HasLocalLikeSymbol(SemanticModel semanticModel, int position, string identifier)
+    {
+        foreach (ISymbol symbol in semanticModel.LookupSymbols(position, name: identifier))
+        {
+            if (symbol is ILocalSymbol || symbol is IParameterSymbol)
+            {
+                return true;
+            }
+
+            if (symbol is IMethodSymbol method && method.MethodKind == MethodKind.LocalFunction)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static ISymbol FindUniqueOwnedMethodOrNull(
+        INamedTypeSymbol targetType,
+        string methodName,
+        int argumentCount)
+    {
+        IMethodSymbol unique = null;
+        int matches = 0;
+        for (INamedTypeSymbol type = targetType; type != null; type = type.BaseType)
+        {
+            foreach (ISymbol member in type.GetMembers(methodName))
+            {
+                if (member is not IMethodSymbol method
+                    || method.MethodKind != MethodKind.Ordinary
+                    || method.Parameters.Length != argumentCount)
+                {
+                    continue;
+                }
+
+                matches++;
+                unique = method;
+                if (matches > 1)
+                {
+                    return null;
+                }
+            }
+        }
+
+        return matches == 1 ? unique : null;
+    }
+}


### PR DESCRIPTION
## Summary
- Hot reload now applies an added method even when the call reaches it through a compiled type that was not passed to this reload.
- When a declared return or parameter type cannot be resolved, the skip reason says so instead of calling the type invisible.

## User Impact
- Before: a call such as `holder.Host.Added()` failed with a missing-member compile error if `holder`'s type was not in the reload, even though `Added` was declared in another file of the same reload. Skip reasons for a missing type also said the type was not visible from an external assembly.
- After: that call binds and the patched method runs. An unresolved type is reported as unresolved (missing using, typo, or not compiled yet) and still needs `uloop compile`.

## Changes
- When `GetSymbolInfo` cannot bind an added-method call, look it up by receiver type name, method name, and argument count.
- Qualify a compiled outer call that stayed unbound for the same reason (error-typed argument).
- Treat `TypeKind.Error` on a method signature as unresolved, not as a visibility failure.

## Verification
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value 'TransformWorkerCrossFileTests|HotReloadCrossFileE2ETests' --project-path "$(git rev-parse --show-toplevel)"` → `"FailedCount": 0`, `"PassedCount": 16`
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value 'TransformWorker' --project-path "$(git rev-parse --show-toplevel)"` → `"FailedCount": 0`, `"PassedCount": 194`
- `dist/darwin-arm64/uloop run-tests --filter-type class --filter-value TransformWorkerAddedMemberTests --project-path "$(git rev-parse --show-toplevel)"` → `"FailedCount": 0`, `"PassedCount": 48`
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value 'HotReload|TransformWorker' --timeout-seconds 1200 --project-path "$(git rev-parse --show-toplevel)"` → `"FailedCount": 0`, `"PassedCount": 721`
- `scripts/check-file-length.sh` → no files exceeded the limit
- `scripts/check-code-complexity.sh` → 0 issues
- `cd cli/release-automation && go run ./cmd/check-skill-size --root "$(git rev-parse --show-toplevel)"` → exit 0
- Rebased onto `origin/main` (`66ab19c3a`, #2611) with no conflicts


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

