### PR TITLE
fix: Pause-point warning no longer suggests execute-dynamic-code for hot-reload added fields

### DIFF
--- a/.agents/skills/uloop-hot-reload/references/scope-and-limits.md
+++ b/.agents/skills/uloop-hot-reload/references/scope-and-limits.md
@@ -50,8 +50,9 @@ method instead; for a reference type, guard that with
 the method `Skipped`. Added `const` values are folded into edited bodies as literals,
 like `nameof`. Pause-point
 `CapturedVariables` never includes added fields; `enable-pause-point` warns when the
-resolved type has any — read them from a patched method body or
-`uloop execute-dynamic-code` instead.
+resolved type has any — their values live in the hot-reload shim and are not visible
+to `uloop execute-dynamic-code` (it compiles against the compiled assembly, so those
+names fail with CS1061). Read them from a patched method body instead.
 
 Added members are an Editor-session illusion. Any real compile or domain reload
 drops them all: added methods disappear from the ledger and added-field values are

--- a/.claude/skills/uloop-hot-reload/references/scope-and-limits.md
+++ b/.claude/skills/uloop-hot-reload/references/scope-and-limits.md
@@ -50,8 +50,9 @@ method instead; for a reference type, guard that with
 the method `Skipped`. Added `const` values are folded into edited bodies as literals,
 like `nameof`. Pause-point
 `CapturedVariables` never includes added fields; `enable-pause-point` warns when the
-resolved type has any — read them from a patched method body or
-`uloop execute-dynamic-code` instead.
+resolved type has any — their values live in the hot-reload shim and are not visible
+to `uloop execute-dynamic-code` (it compiles against the compiled assembly, so those
+names fail with CS1061). Read them from a patched method body instead.
 
 Added members are an Editor-session illusion. Any real compile or domain reload
 drops them all: added methods disappear from the ledger and added-field values are

--- a/Assets/Tests/Editor/PausePointAddedFieldWarningTests.cs
+++ b/Assets/Tests/Editor/PausePointAddedFieldWarningTests.cs
@@ -70,6 +70,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: the added-fields warning does not recommend execute-dynamic-code as a read
+        /// path and instead states that those names are invisible to it.
+        /// </summary>
+        [Test]
+        public void Enable_WhenDeclaringTypeHasAddedFields_WarningDoesNotRecommendExecuteDynamicCode()
+        {
+            string typeName = typeof(EnableBySourceLocationFixture).FullName;
+            HotReloadAddedFieldRegistry.ReplaceForFile(
+                FixtureFilePath,
+                new[] { typeName + ".beta", typeName + ".alpha" });
+
+            PausePointResponse response = new PausePointUseCase().Enable(new EnablePausePointSchema
+            {
+                File = FixtureFilePath,
+                Line = FixtureLine,
+                TimeoutSeconds = 30,
+                Mode = UloopPausePointCaptureMode.SingleShot
+            });
+
+            Assert.That(
+                response.Success,
+                Is.True,
+                response.ErrorCode + " / " + response.Message);
+            Assert.That(
+                response.Warning,
+                Does.Not.Contain(
+                    "Read them via a patched method body or 'uloop execute-dynamic-code' instead"));
+            Assert.That(
+                response.Warning,
+                Does.Contain("not visible to 'uloop execute-dynamic-code'"));
+            Assert.That(
+                response.Warning,
+                Does.Contain("Read them from a patched method body"));
+        }
+
+        /// <summary>
         /// What: enabling a pause point on a type with no added fields yields only the usual
         /// enable warnings, with an exact full-string match and no added-field sentence.
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
@@ -50,8 +50,9 @@ method instead; for a reference type, guard that with
 the method `Skipped`. Added `const` values are folded into edited bodies as literals,
 like `nameof`. Pause-point
 `CapturedVariables` never includes added fields; `enable-pause-point` warns when the
-resolved type has any — read them from a patched method body or
-`uloop execute-dynamic-code` instead.
+resolved type has any — their values live in the hot-reload shim and are not visible
+to `uloop execute-dynamic-code` (it compiles against the compiled assembly, so those
+names fail with CS1061). Read them from a patched method body instead.
 
 Added members are an Editor-session illusion. Any real compile or domain reload
 drops them all: added methods disappear from the ledger and added-field values are

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -420,11 +420,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             + "resolve against the last compiled source instead. If you meant a different method, "
             + "verify ResolvedMethod, or pass a line outside patched methods' edited spans.";
 
+        // Why this wording: agents that followed the old "read via execute-dynamic-code"
+        // guidance wasted two round-trips; that command compiles against the compiled
+        // assembly and cannot see shim-only added fields (CS1061).
         // Format: declaring type name, added-field count, comma-separated simple field names.
         public const string HotReloadAddedFieldsNotCapturedWarningFormat =
-            "Hot reload added {1} field(s) to '{0}' ({2}); their values live outside the compiled "
-            + "assembly and never appear in CapturedVariables. Read them via a patched method body "
-            + "or 'uloop execute-dynamic-code' instead.";
+            "Hot reload added {1} field(s) to '{0}' ({2}); their values live in the hot-reload "
+            + "shim, never appear in CapturedVariables, and are not visible to 'uloop "
+            + "execute-dynamic-code' (it compiles against the compiled assembly, so those names "
+            + "fail with CS1061). Read them from a patched method body instead, e.g. log them or "
+            + "surface them in a patched OnGUI/Update.";
 
         // Why fill on success: a successful enable currently leaves RecommendedNextAction empty,
         // so agents arm a marker and then stall instead of running the path or using --await.


### PR DESCRIPTION
## Summary
- Pause-point enable warnings no longer tell agents to read hot-reload added fields through `uloop execute-dynamic-code`.
- The warning now states that those names live in the hot-reload shim and fail with CS1061 under execute-dynamic-code, and to read them from a patched method body instead.

## User Impact
- Before: `enable-pause-point` suggested `uloop execute-dynamic-code` as a way to read added fields. That command compiles against the compiled assembly, so the names do not resolve and agents wasted extra round-trips.
- After: the warning says those values are not visible to execute-dynamic-code and points only at a patched method body (for example logging or surfacing them in a patched OnGUI/Update).

## Changes
- Rewrite `HotReloadAddedFieldsNotCapturedWarningFormat` and add a Why comment for the old-guidance waste.
- Add a literal Contain / Not.Contain test that does not read the constant, so a wording regression fails even if the constant is reused.
- Update the hot-reload skill note that repeated the old "read via execute-dynamic-code" guidance.

## Verification
- Red: `uloop run-tests --filter-type class --filter-value PausePointAddedFieldWarningTests` failed the new test on the old wording (`FailedCount: 1`, `PassedCount: 2`).
- Green: the same filter passed (`TestCount: 3`, `PassedCount: 3`, `FailedCount: 0`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

