### PR TITLE
fix: Hot reload folds line-count warnings of auto re-applied files into the continuing summary

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
@@ -348,6 +348,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CallerProjectRelativePath(),
                 HotReloadMethodOutcomeKind.Patched,
                 "Call");
+            Assert.That(
+                second.ReappliedSiblingPaths,
+                Is.EquivalentTo(new[] { CallerProjectRelativePath() }));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilderTests.cs
@@ -335,6 +335,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a Failed sibling pulled in by auto re-apply still folds into the continuing
+        /// line-shift summary; outcome Kind does not restore the full per-file warning.
+        /// </summary>
+        [Test]
+        public void Append_WhenReappliedSiblingHasFailedOutcome_AddsOneContinuingWarning()
+        {
+            List<string> warnings = new List<string>();
+            List<HotReloadMethodOutcome> methods = new List<HotReloadMethodOutcome>
+            {
+                HotReloadMethodOutcome.Failed("Enemy.Idle", "shim compile failed", "Assets/Scripts/Enemy.cs")
+            };
+
+            HotReloadUnpatchedMethodLineShiftWarningBuilder.Append(
+                warnings,
+                methods,
+                file => "line1\nline2\nline3",
+                file => "line1\nline2",
+                new[] { "Assets/Scripts/Enemy.cs" });
+
+            Assert.That(warnings.Count, Is.EqualTo(1));
+            Assert.That(
+                warnings[0],
+                Is.EqualTo(
+                    string.Format(
+                        HotReloadConstants.ContinuingLineShiftWarningFormat,
+                        1,
+                        "Assets/Scripts/Enemy.cs")));
+            Assert.That(warnings[0], Does.Not.Contain("line count differs from the last compiled source"));
+        }
+
+        /// <summary>
         /// What: a Patched file passed in --files still gets the full per-file line-count
         /// warning when it is not an auto-reapplied sibling.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilderTests.cs
@@ -127,7 +127,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 warnings,
                 methods,
                 file => "line1\nline2\nline3",
-                file => "line1\nline2");
+                file => "line1\nline2",
+                Array.Empty<string>());
 
             Assert.That(warnings.Count, Is.EqualTo(1));
             Assert.That(
@@ -160,7 +161,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 warnings,
                 methods,
                 file => "line1\nline2\nline3",
-                file => "line1\nline2");
+                file => "line1\nline2",
+                Array.Empty<string>());
 
             Assert.That(warnings.Count, Is.EqualTo(1));
             Assert.That(
@@ -190,7 +192,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     : "same\ncount",
                 file => file.IndexOf("Player", StringComparison.Ordinal) >= 0
                     ? "line1\nline2"
-                    : "same\ncount");
+                    : "same\ncount",
+                Array.Empty<string>());
 
             Assert.That(warnings.Count, Is.EqualTo(1));
             Assert.That(
@@ -220,7 +223,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     : "a\nb\nc\nd",
                 file => file.IndexOf("Player", StringComparison.Ordinal) >= 0
                     ? "line1\nline2"
-                    : "a\nb");
+                    : "a\nb",
+                Array.Empty<string>());
 
             Assert.That(warnings.Count, Is.EqualTo(2));
             Assert.That(
@@ -251,7 +255,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 warnings,
                 methods,
                 file => "line1\nline2\nline3",
-                file => "line1\nline2");
+                file => "line1\nline2",
+                Array.Empty<string>());
 
             Assert.That(warnings.Count, Is.EqualTo(1));
             Assert.That(
@@ -281,7 +286,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 warnings,
                 methods,
                 file => "line1\nline2\nline3",
-                file => "line1\nline2");
+                file => "line1\nline2",
+                Array.Empty<string>());
 
             Assert.That(warnings.Count, Is.EqualTo(2));
             Assert.That(
@@ -295,6 +301,64 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         HotReloadConstants.ContinuingLineShiftWarningFormat,
                         1,
                         "Assets/Scripts/Enemy.cs")));
+        }
+
+        /// <summary>
+        /// What: a Patched sibling pulled in by auto re-apply folds into the continuing
+        /// line-shift summary instead of reprinting the full per-file warning.
+        /// </summary>
+        [Test]
+        public void Append_WhenReappliedSiblingHasPatchedOutcome_AddsOneContinuingWarning()
+        {
+            List<string> warnings = new List<string>();
+            List<HotReloadMethodOutcome> methods = new List<HotReloadMethodOutcome>
+            {
+                HotReloadMethodOutcome.Patched("Enemy.Idle", "Assets/Scripts/Enemy.cs")
+            };
+
+            HotReloadUnpatchedMethodLineShiftWarningBuilder.Append(
+                warnings,
+                methods,
+                file => "line1\nline2\nline3",
+                file => "line1\nline2",
+                new[] { "Assets/Scripts/Enemy.cs" });
+
+            Assert.That(warnings.Count, Is.EqualTo(1));
+            Assert.That(
+                warnings[0],
+                Is.EqualTo(
+                    string.Format(
+                        HotReloadConstants.ContinuingLineShiftWarningFormat,
+                        1,
+                        "Assets/Scripts/Enemy.cs")));
+            Assert.That(warnings[0], Does.Not.Contain("line count differs from the last compiled source"));
+        }
+
+        /// <summary>
+        /// What: a Patched file passed in --files still gets the full per-file line-count
+        /// warning when it is not an auto-reapplied sibling.
+        /// </summary>
+        [Test]
+        public void Append_WhenRequestedFileHasPatchedOutcome_AddsFullLineCountWarning()
+        {
+            List<string> warnings = new List<string>();
+            List<HotReloadMethodOutcome> methods = new List<HotReloadMethodOutcome>
+            {
+                HotReloadMethodOutcome.Patched("Player.Jump", "Assets/Scripts/Player.cs")
+            };
+
+            HotReloadUnpatchedMethodLineShiftWarningBuilder.Append(
+                warnings,
+                methods,
+                file => "line1\nline2\nline3",
+                file => "line1\nline2",
+                Array.Empty<string>());
+
+            Assert.That(warnings.Count, Is.EqualTo(1));
+            Assert.That(
+                warnings[0],
+                Is.EqualTo(
+                    "Assets/Scripts/Player.cs: line count differs from the last compiled source (edited 3 lines vs compiled 2). This matters for 'enable-pause-point --line' targeting: methods NOT patched in this run still resolve against the last compiled source; patched methods with debug symbols resolve against the edited file. To pin the target, pass --method together with --line."));
         }
 
         /// <summary>
@@ -339,6 +403,54 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         "Hot reload applied. PatchedTotal=1, ActivePatchTotal=1. "
                         + "2 warning(s). See Warnings. "
                         + "A single 'uloop compile' clears all of them at once."));
+            }
+            finally
+            {
+                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = previousLoader;
+                if (File.Exists(absolutePath))
+                {
+                    File.Delete(absolutePath);
+                }
+            }
+        }
+
+        /// <summary>
+        /// What: a Patched file listed in ReappliedSiblingPaths emits the continuing line-shift
+        /// summary on the apply response, not the full per-file "line count differs" warning.
+        /// </summary>
+        [Test]
+        public void BuildApplyResponse_WhenReappliedSiblingLineShift_AddsContinuingWarningWithoutFullText()
+        {
+            string relativePath = "Library/UloopHotReload/TestSources/sibling-line-shift-warning-probe.cs";
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string absolutePath = Path.Combine(
+                projectRoot,
+                relativePath.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(absolutePath));
+            File.WriteAllText(absolutePath, "line1\nline2\nline3");
+
+            Func<string, string> previousLoader =
+                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile;
+            HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = _ => "line1\nline2";
+            try
+            {
+                HotReloadResponse response = HotReloadTool.BuildApplyResponse(
+                    new HotReloadOrchestratorResult(
+                        new List<HotReloadMethodOutcome>
+                        {
+                            HotReloadMethodOutcome.Patched("Probe.M", relativePath)
+                        },
+                        new List<string>(),
+                        patchedTotal: 1,
+                        activePatchTotal: 1,
+                        reappliedSiblingPaths: new[] { relativePath }));
+
+                Assert.That(response.Warnings.Count, Is.EqualTo(1));
+                Assert.That(response.Warnings[0], Does.Contain("Continuing from earlier runs:"));
+                Assert.That(response.Warnings[0], Does.Contain(relativePath));
+                Assert.That(
+                    response.Warnings[0],
+                    Does.Not.Contain("line count differs from the last compiled source"));
             }
             finally
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyResponseBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyResponseBuilder.cs
@@ -58,7 +58,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 warnings,
                 result.Methods,
                 HotReloadUnpatchedMethodLineShiftWarningBuilder.ReadEditedSourceFromDisk,
-                HotReloadUnpatchedMethodLineShiftWarningBuilder.ReadCompiledSnapshot);
+                HotReloadUnpatchedMethodLineShiftWarningBuilder.ReadCompiledSnapshot,
+                result.ReappliedSiblingPaths);
 
             // Why before the count snapshot: a Skipped method is applied by 'uloop compile' like
             // the warnings above it, so it must count toward the single-compile resolution suffix.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -135,7 +135,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             for (int extraIndex = 0; extraIndex < extraResults.Count; extraIndex++)
             {
-                run.Add(extraResults[extraIndex].Path, extraResults[extraIndex].Result);
+                run.AddReappliedSibling(extraResults[extraIndex].Path, extraResults[extraIndex].Result);
             }
 
             run.RecordAppliedSourceHashes();

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorResult.cs
@@ -22,6 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool AutoRefreshHoldNewlyArmed { get; }
         public bool AutoRefreshHoldReleaseDeferred { get; }
         public string AutoRefreshHoldSceneRefreshWarning { get; }
+        public IReadOnlyList<string> ReappliedSiblingPaths { get; }
 
         public HotReloadOrchestratorResult(
             IReadOnlyList<HotReloadMethodOutcome> methods,
@@ -34,7 +35,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string[] addedFields = null,
             string[] addedConsts = null,
             int revertedUnchangedTotal = 0,
-            HotReloadAutoRefreshHoldSyncResult autoRefreshHold = null)
+            HotReloadAutoRefreshHoldSyncResult autoRefreshHold = null,
+            IReadOnlyList<string> reappliedSiblingPaths = null)
         {
             Methods = methods;
             Warnings = warnings;
@@ -51,6 +53,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             AutoRefreshHoldReleaseDeferred = autoRefreshHold != null && autoRefreshHold.ReleaseDeferred;
             AutoRefreshHoldSceneRefreshWarning =
                 autoRefreshHold != null ? autoRefreshHold.SceneRefreshWarning : null;
+            ReappliedSiblingPaths = reappliedSiblingPaths ?? Array.Empty<string>();
         }
     }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRunAccumulator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRunAccumulator.cs
@@ -22,6 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly List<string> _addedFields = new List<string>();
         private readonly List<string> _addedConsts = new List<string>();
         private readonly List<string> _siblingDerivedWarnings = new List<string>();
+        private readonly List<string> _reappliedSiblingPaths = new List<string>();
         private readonly List<HotReloadOneShotCallerNoteEnricher.Candidate> _oneShotCallerNoteCandidates =
             new List<HotReloadOneShotCallerNoteEnricher.Candidate>();
         // Why staged (not recorded per file): duplicate paths in one run must still apply
@@ -64,6 +65,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 projectRelativePath,
                 fileResult.SourceContentSha256,
                 fileResult.Outcomes);
+        }
+
+        /// <summary>
+        /// Merges one auto-reapplied sibling file and records its project-relative path.
+        /// </summary>
+        public void AddReappliedSibling(string projectRelativePath, HotReloadFileProcessResult fileResult)
+        {
+            // Overloads are forbidden, so this distinct name both Adds and records extraResults
+            // paths for continuing line-shift aggregation.
+            Add(projectRelativePath, fileResult);
+            _reappliedSiblingPaths.Add(projectRelativePath);
         }
 
         /// <summary>Writes the staged applied-source hashes to the ledger. Call once after every file was added.</summary>
@@ -112,7 +124,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 _addedFields.ToArray(),
                 _addedConsts.ToArray(),
                 _revertedUnchangedTotal,
-                autoRefreshHold);
+                autoRefreshHold,
+                _reappliedSiblingPaths.ToArray());
         }
 
         private void AppendInlineRiskWarning()

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilder.cs
@@ -48,17 +48,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> warnings,
             IReadOnlyList<HotReloadMethodOutcome> methods,
             Func<string, string> readEditedSource,
-            Func<string, string> readCompiledSource)
+            Func<string, string> readCompiledSource,
+            IReadOnlyCollection<string> reappliedSiblingPaths)
         {
             Debug.Assert(warnings != null, "warnings must not be null.");
             Debug.Assert(methods != null, "methods must not be null.");
             Debug.Assert(readEditedSource != null, "readEditedSource must not be null.");
             Debug.Assert(readCompiledSource != null, "readCompiledSource must not be null.");
+            Debug.Assert(reappliedSiblingPaths != null, "reappliedSiblingPaths must not be null.");
 
             StringComparer fileComparer = Application.platform == RuntimePlatform.WindowsEditor
                 ? StringComparer.OrdinalIgnoreCase
                 : StringComparer.Ordinal;
-            List<LineShiftFileBucket> buckets = CollectUniqueFileBuckets(methods, fileComparer);
+            List<LineShiftFileBucket> buckets = CollectUniqueFileBuckets(
+                methods,
+                reappliedSiblingPaths,
+                fileComparer);
             List<string> continuingFiles = new List<string>();
             for (int index = 0; index < buckets.Count; index++)
             {
@@ -92,10 +97,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static List<LineShiftFileBucket> CollectUniqueFileBuckets(
             IReadOnlyList<HotReloadMethodOutcome> methods,
+            IReadOnlyCollection<string> reappliedSiblingPaths,
             StringComparer fileComparer)
         {
             List<LineShiftFileBucket> buckets = new List<LineShiftFileBucket>();
             Dictionary<string, LineShiftFileBucket> byFile = new Dictionary<string, LineShiftFileBucket>(fileComparer);
+            HashSet<string> siblingKeys = BuildReappliedSiblingKeys(reappliedSiblingPaths, fileComparer);
             for (int index = 0; index < methods.Count; index++)
             {
                 string filePath = methods[index].FilePath;
@@ -112,13 +119,34 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     buckets.Add(bucket);
                 }
 
-                if (methods[index].Kind != HotReloadMethodOutcomeKind.AlreadyActive)
+                // Auto-reapplied siblings come back as Patched/Added, so Kind alone would
+                // reprint the full warning every run. extraResults paths are the only signal.
+                if (methods[index].Kind != HotReloadMethodOutcomeKind.AlreadyActive
+                    && !siblingKeys.Contains(canonicalFile))
                 {
                     bucket.TouchedThisRun = true;
                 }
             }
 
             return buckets;
+        }
+
+        private static HashSet<string> BuildReappliedSiblingKeys(
+            IReadOnlyCollection<string> reappliedSiblingPaths,
+            StringComparer fileComparer)
+        {
+            HashSet<string> keys = new HashSet<string>(fileComparer);
+            foreach (string path in reappliedSiblingPaths)
+            {
+                if (string.IsNullOrEmpty(path))
+                {
+                    continue;
+                }
+
+                keys.Add(HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(path));
+            }
+
+            return keys;
         }
 
         private static void AppendContinuingWarning(List<string> warnings, List<string> continuingFiles)


### PR DESCRIPTION
## Summary
- Hot reload no longer reprints the full line-count warning for files it auto-reapplied just to rebind existing patches.
- Those files now appear in the one-line continuing summary. Files you passed to `--files` still get the full warning.

## User Impact
- Before: every reload that pulled in an unchanged sibling with active patches repeated the long `line count differs` warning for that sibling, even though you did not edit it this run.
- After: auto-reapplied siblings fold into `Continuing from earlier runs: N file(s) still differ in line count...`. The full warning stays on files you actually asked to reload.

## Changes
- Track auto-reapplied sibling paths on the run result.
- Fold those paths into the continuing line-count summary instead of treating a `Patched` sibling as a newly touched file.

## Verification
- `scripts/check-file-length.sh` and `scripts/check-code-complexity.sh`: no findings above the limits.
- `uloop compile --project-path <worktree>`: Success, ErrorCount 0.
- `uloop run-tests --filter-type regex --filter-value "HotReloadUnpatchedMethodLineShiftWarningBuilderTests|HotReloadOrchestratorTests|HotReloadCrossFileE2ETests"`: 185 passed, 0 failed.
- `uloop run-tests --filter-type class --filter-value HotReloadUnpatchedMethodLineShiftWarningBuilderTests`: 16 passed (13 existing + 3 new).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

