### PR TITLE
fix: Hot reload now reports an added auto-property as out of scope instead of a generic outside-method-bodies warning

### DIFF
--- a/.agents/skills/uloop-hot-reload/references/scope-and-limits.md
+++ b/.agents/skills/uloop-hot-reload/references/scope-and-limits.md
@@ -70,7 +70,9 @@ Adding a type
 (`class`, `struct`, `enum`, `record`), a property, an event, or an indexer
 is still out of scope. Added properties are reported per member: the
 property's getter appears as a `Skipped` row that says to use a 'const' or
-a plain added field for the value, or to run 'uloop compile'. Types, events,
+a plain added field for the value, or to run 'uloop compile'. That includes
+auto-properties: the response shows `Skipped ... get_X: Added properties are
+out of scope` rather than a generic outside-method-bodies warning. Types, events,
 and indexers are not reported per member — no `Skipped` row names them; at
 most they surface as outside-body drift in `Warnings`. Treat their silence
 as "not applied" and land them with `uloop compile`.

--- a/.claude/skills/uloop-hot-reload/references/scope-and-limits.md
+++ b/.claude/skills/uloop-hot-reload/references/scope-and-limits.md
@@ -70,7 +70,9 @@ Adding a type
 (`class`, `struct`, `enum`, `record`), a property, an event, or an indexer
 is still out of scope. Added properties are reported per member: the
 property's getter appears as a `Skipped` row that says to use a 'const' or
-a plain added field for the value, or to run 'uloop compile'. Types, events,
+a plain added field for the value, or to run 'uloop compile'. That includes
+auto-properties: the response shows `Skipped ... get_X: Added properties are
+out of scope` rather than a generic outside-method-bodies warning. Types, events,
 and indexers are not reported per member — no `Skipped` row names them; at
 most they surface as outside-body drift in `Warnings`. Treat their silence
 as "not applied" and land them with `uloop compile`.

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
@@ -136,6 +136,28 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: referencing an auto-property added in another file of the same reload fails
+        /// the caller with the skipped-member compile note that names the property.
+        /// </summary>
+        [Test]
+        public async Task Run_CallerFileUsesAutoPropertyAddedInOtherFile_FailsWithSkippedPropertyNote()
+        {
+            HotReloadOrchestratorResult result = await RunPairAsync(
+                "CrossFileAddedAutoProperty",
+                InsertHostMember("        public bool HasTarget { get; private set; }\n\n"),
+                ReplaceCallerBody(CallerCallBodyAnchor, "return host.HasTarget ? 1 : 0;"));
+
+            HotReloadMethodOutcome failure = FindOutcome(result, HotReloadMethodOutcomeKind.Failed, "Call");
+            Assert.That(
+                failure.Reason,
+                Does.Contain(string.Format(
+                    HotReloadConstants.SkippedMemberCompileFailureNoteFormat,
+                    "HasTarget",
+                    "Added properties are out of scope")));
+            Assert.That(failure.Reason, Does.Contain("Added properties are out of scope"));
+        }
+
+        /// <summary>
         /// What: a compile error in one file of the group takes down only that file — its other
         /// edited method reports the file-atomic skip and it starts no generation — while the
         /// healthy sibling file is applied and its runtime is updated.

--- a/Assets/Tests/Editor/HotReload/HotReloadSkippedMemberCompileNoteTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSkippedMemberCompileNoteTests.cs
@@ -140,6 +140,63 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a skipped get_X or set_X label matches unresolved property name X.
+        /// </summary>
+        [Test]
+        public void FindSkippedMemberNote_WhenAccessorPrefixMatchesPropertyName_ReturnsReason()
+        {
+            const string reason = "Added properties are out of scope for hot reload.";
+            TransformWorkerSkippedDto[] getterSkipped =
+            {
+                new TransformWorkerSkippedDto
+                {
+                    method = "Ns.Type.get_HasTarget",
+                    reason = reason
+                }
+            };
+            TransformWorkerSkippedDto[] setterSkipped =
+            {
+                new TransformWorkerSkippedDto
+                {
+                    method = "Ns.Type.set_HasTarget",
+                    reason = reason
+                }
+            };
+
+            Assert.That(
+                HotReloadSkippedMemberCompileNote.FindSkippedMemberNote("HasTarget", getterSkipped),
+                Is.EqualTo(reason));
+            Assert.That(
+                HotReloadSkippedMemberCompileNote.FindSkippedMemberNote("HasTarget", setterSkipped),
+                Is.EqualTo(reason));
+        }
+
+        /// <summary>
+        /// What: Get_X and getX (not the get_/set_ accessor prefixes) do not match X.
+        /// </summary>
+        [Test]
+        public void FindSkippedMemberNote_WhenAccessorPrefixIsNotExact_ReturnsNull()
+        {
+            TransformWorkerSkippedDto[] skipped =
+            {
+                new TransformWorkerSkippedDto
+                {
+                    method = "Ns.Type.Get_HasTarget",
+                    reason = "wrong-case get_"
+                },
+                new TransformWorkerSkippedDto
+                {
+                    method = "Ns.Type.getHasTarget",
+                    reason = "missing underscore"
+                }
+            };
+
+            Assert.That(
+                HotReloadSkippedMemberCompileNote.FindSkippedMemberNote("HasTarget", skipped),
+                Is.Null);
+        }
+
+        /// <summary>
         /// What: a skipped label whose parameter type contains dots still matches the simple name.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -1612,11 +1612,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: adding a property does not emit the compiled property warning and does
-        /// not add an individual Skipped row for that property (SKILL discrepancy kept).
+        /// What: adding an auto-property does not emit the compiled property warning and
+        /// skips the getter with the added-property reason.
         /// </summary>
         [Test]
-        public async Task Classify_AddedProperty_DoesNotWarnOrSkipTheProperty()
+        public async Task Classify_AddedProperty_SkipsGetterWithAddedPropertyReason()
         {
             string onDisk = File.ReadAllText(ResolveHostPath());
             string edited = onDisk.Replace(
@@ -1629,7 +1629,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             AssertHasNoCompiledKindChangeWarningForMember(result, "ExtraHp");
-            AssertHasNoSkipContaining(result, "ExtraHp");
+            AssertHasSkip(result, "get_ExtraHp", "Added properties are out of scope");
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -105,6 +105,67 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: an auto-property present only in the edited source is skipped with the
+        /// added-property reason and does not fire the outside-body drift warning.
+        /// </summary>
+        [Test]
+        public async Task Classify_AddedAutoProperty_SkipsGetterWithAddedPropertyReason()
+        {
+            const string expectedReason =
+                "Added properties are out of scope for hot reload; the compiled assembly has no such member. "
+                + "For a computed value, add a same-file method instead (e.g. 'private T GetX()'), which applies "
+                + "through hot reload; for a constant, use a 'const' or a plain added field; otherwise run "
+                + "'uloop compile'.";
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public int AddedAuto { get; private set; }");
+            string sourcePath = WriteEdited("ClassifyAddedAutoProperty.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            Assert.That(
+                FindEntry(result, "get_AddedAuto"),
+                Is.Null,
+                "Added auto-property getter must not be an entry.");
+            Assert.That(FindSkipReason(result, "get_AddedAuto"), Is.EqualTo(expectedReason));
+            Assert.That(
+                result.Output.files[0].declarationDriftWarnings,
+                Has.None.Contain("Edits outside method bodies"),
+                "Added auto-property must not fire outside-body drift.\n"
+                + string.Join("\n", result.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>()));
+        }
+
+        /// <summary>
+        /// What: an auto-property already present in the baseline snapshot stays silent
+        /// (no Skipped row and no unchanged row) when the declaration is unchanged.
+        /// </summary>
+        [Test]
+        public async Task Classify_ExistingUnchangedAutoProperty_DoesNotSkip()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string withExistingAuto = WithHostMembers(
+                onDisk,
+                "public int ExistingAuto { get; private set; }");
+            string sourcePath = WriteEdited("ClassifyExistingAutoProperty.cs", withExistingAuto);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: withExistingAuto);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                FindSkipReason(result, "get_ExistingAuto"),
+                Is.Null,
+                "Unchanged baseline auto-property must not emit a Skipped row.");
+            Assert.That(FindEntry(result, "get_ExistingAuto"), Is.Null);
+        }
+
+        /// <summary>
         /// What: an added method entry is emitted as a public static shim method in shimSource.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -1078,11 +1078,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: adding an auto-property emits no skip row, so the outside-body drift warning
-        /// remains the only signal that the new member was not applied.
+        /// What: adding an auto-property plus a method-body edit skips the getter with the
+        /// added-property reason and does not emit the outside-body drift warning.
         /// </summary>
         [Test]
-        public async Task Run_AddedAutoPropertyPlusBodyEdit_EmitsOutsideBodyWarningWithoutSkipRow()
+        public async Task Run_AddedAutoPropertyPlusBodyEdit_SkipsGetterWithoutOutsideBodyWarning()
         {
             const string fileName = "AddedAutoPropertyDrift.cs";
             TransformWorkerClientResult result = await RunWorkerOnEditedE2ECopyAsync(
@@ -1099,8 +1099,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         StringComparison.Ordinal);
                 });
 
-            AssertSkippedDoesNotContain(result, "AddedAuto");
-            AssertContainsOutsideMethodBodyDriftWarning(result, fileName);
+            AssertSkippedContains(result, "get_AddedAuto", ExpectedAddedPropertySkipReason);
+            AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
             AssertPatchedComputeWithPrivate(result);
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSkippedMemberCompileNote.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSkippedMemberCompileNote.cs
@@ -60,7 +60,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 string simpleName = ExtractSimpleMethodName(row.method);
-                if (string.Equals(simpleName, unresolvedName, StringComparison.Ordinal))
+                if (MatchesUnresolvedName(simpleName, unresolvedName))
                 {
                     return row.reason;
                 }
@@ -128,6 +128,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return error.Substring(nameStart, nameEnd - nameStart);
+        }
+
+        private static bool MatchesUnresolvedName(string simpleName, string unresolvedName)
+        {
+            if (string.Equals(simpleName, unresolvedName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            // Why get_/set_ only: CS1061 names the property, while the skipped row labels
+            // the accessor (get_X / set_X). Get_X and getX are not accessors.
+            if (simpleName.StartsWith("get_", StringComparison.Ordinal)
+                || simpleName.StartsWith("set_", StringComparison.Ordinal))
+            {
+                return string.Equals(simpleName.Substring(4), unresolvedName, StringComparison.Ordinal);
+            }
+
+            return false;
         }
 
         private static string ExtractSimpleMethodName(string methodLabel)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
@@ -70,7 +70,9 @@ Adding a type
 (`class`, `struct`, `enum`, `record`), a property, an event, or an indexer
 is still out of scope. Added properties are reported per member: the
 property's getter appears as a `Skipped` row that says to use a 'const' or
-a plain added field for the value, or to run 'uloop compile'. Types, events,
+a plain added field for the value, or to run 'uloop compile'. That includes
+auto-properties: the response shows `Skipped ... get_X: Added properties are
+out of scope` rather than a generic outside-method-bodies warning. Types, events,
 and indexers are not reported per member — no `Skipped` row names them; at
 most they surface as outside-body drift in `Warnings`. Treat their silence
 as "not applied" and land them with `uloop compile`.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
@@ -114,7 +114,18 @@ internal static class PropertyGetterEmitter
             PropertyGetterClassifier.TryGetPropertyGetterBody(propertyDeclaration);
         if (!hasGetterBody)
         {
-            // Auto-property / setter-only: not a patch candidate (no Skipped row either).
+            // Why skip added auto-properties: Harmony looks up get_<Name> on the compiled type
+            // and fails when the member does not exist. An existing auto-property stays silent.
+            PropertyGetterClassifier.TrySkipAddedProperty(
+                sourceProjectRelativePath,
+                hasBaseline,
+                snapshotPropertyMap,
+                plainCurrentPropertyMap,
+                typeMetadataNameFromSyntax,
+                propertyDeclaration,
+                propertySymbol.GetMethod,
+                skipped,
+                addedMethodCatalog);
             return (currentShimType, shimTypeCounter, globalShimMethodCounter);
         }
 


### PR DESCRIPTION
## Summary
- Adding an auto-property now produces a `Skipped` row that says properties are out of scope, instead of a generic "edits outside method bodies" warning that never mentions properties.
- When another file in the same reload fails with CS1061 on that property name, the failure reason now points at the matching `Skipped` row.

## User Impact
- Before: adding `public bool HasTarget { get; private set; }` and using it from another file looked like a missing member / outside-body edit. Agents followed the generic hint and wasted turns.
- After: the added auto-property is reported the same way as an expression-bodied property (`Skipped ... get_X: Added properties are out of scope ...`). A CS1061 on `HasTarget` appends the existing skipped-member note after the usual compile hints.

## Changes
- The transform worker now classifies an added auto-property with the existing added-property skip path (existing unchanged auto-properties stay silent).
- Skipped accessor labels `get_X` / `set_X` now match CS1061's unresolved name `X`. No new constants and no shim-compiler changes.
- Skill scope notes mention auto-properties explicitly.

## Verification
- `uloop compile` on this worktree: ErrorCount 0, WarningCount 0
- `uloop run-tests --filter-type regex --filter-value "TransformWorkerAddedMemberTests|TransformWorkerClientTests|HotReloadCrossFileE2ETests|HotReloadSkippedMemberCompileNoteTests|TransformWorkerAddedFieldTests"`: Passed 197 / 197
- Targeted rerun of the 7 new/inverted tests: Passed 7 / 7
- `scripts/check-file-length.sh` and `scripts/check-code-complexity.sh`: no findings


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

