### PR TITLE
fix: Hot reload now warns that an added test method stays invisible to the Test Runner until compile

### DIFF
--- a/.agents/skills/uloop-hot-reload/references/scope-and-limits.md
+++ b/.agents/skills/uloop-hot-reload/references/scope-and-limits.md
@@ -19,7 +19,9 @@ one shim assembly, so a body edited in one of them can call a member added in an
 code cannot see it, and neither can anything that resolves members by name at
 runtime: reflection (`GetType().GetMethod("NewM")` returns `null`), Unity's message
 discovery (an added `Update` or `OnCollisionEnter` on a `MonoBehaviour` is never
-invoked — a `Warnings` entry names it), UnityEvent/inspector wiring, and
+invoked — a `Warnings` entry names it), the Unity Test Runner (an added `[Test]` /
+`[UnityTest]` method is not enumerated by `uloop run-tests --skip-compile` — a
+`Warnings` entry names it; run `uloop compile` first), UnityEvent/inspector wiring, and
 serialization. Referencing an added member from a file that is neither passed to this reload nor
 already hot-reloaded, or from another assembly, fails that file's hot reload with
 the usual new-member hint; run `uloop compile` instead. Unchanged files of the same

--- a/.claude/skills/uloop-hot-reload/references/scope-and-limits.md
+++ b/.claude/skills/uloop-hot-reload/references/scope-and-limits.md
@@ -19,7 +19,9 @@ one shim assembly, so a body edited in one of them can call a member added in an
 code cannot see it, and neither can anything that resolves members by name at
 runtime: reflection (`GetType().GetMethod("NewM")` returns `null`), Unity's message
 discovery (an added `Update` or `OnCollisionEnter` on a `MonoBehaviour` is never
-invoked — a `Warnings` entry names it), UnityEvent/inspector wiring, and
+invoked — a `Warnings` entry names it), the Unity Test Runner (an added `[Test]` /
+`[UnityTest]` method is not enumerated by `uloop run-tests --skip-compile` — a
+`Warnings` entry names it; run `uloop compile` first), UnityEvent/inspector wiring, and
 serialization. Referencing an added member from a file that is neither passed to this reload nor
 already hot-reloaded, or from another assembly, fails that file's hot reload with
 the usual new-member hint; run `uloop compile` instead. Unchanged files of the same

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -485,6 +485,133 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: an added [Test] method stays Success/addedMethod and emits exactly one
+        /// Unity Test Runner visibility warning naming that method.
+        /// </summary>
+        [Test]
+        public async Task Warn_AddedTestMethod_KeepsEntryAndEmitsWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "[Test]\n        public void AddedProbe()\n        {\n        }");
+            string sourcePath = WriteEdited("AddedTestMethod.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+
+            TransformWorkerEntryDto added = FindEntry(result, "AddedProbe");
+            Assert.That(added, Is.Not.Null, "AddedProbe must still be an entry.");
+            Assert.That(added.patchKind, Is.EqualTo(HotReloadConstants.PatchKindAddedMethod));
+            Assert.That(
+                CountWarningsContaining(result, "Unity Test Runner"),
+                Is.EqualTo(1),
+                FormatWarnings(result));
+            Assert.That(
+                result.Output.files[0].declarationDriftWarnings,
+                Has.Some.Contain("AddedProbe").And.Contain("Unity Test Runner"));
+        }
+
+        /// <summary>
+        /// What: added methods with a qualified [TestCase], [UnityTest], or [SetUp] each
+        /// produce a Unity Test Runner warning that names that method.
+        /// </summary>
+        [Test]
+        public async Task Warn_AddedTestAttributes_QualifiedUnityTestAndSetUp_EmitWarningPerMethod()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "[NUnit.Framework.TestCase(1)]\n        public void AddedCaseProbe(int value)\n        {\n        }\n\n"
+                + "        [UnityTest]\n        public System.Collections.IEnumerator AddedUnityProbe()\n        {\n"
+                + "            yield break;\n        }\n\n"
+                + "        [SetUp]\n        public void AddedSetUpProbe()\n        {\n        }");
+            string sourcePath = WriteEdited("AddedTestAttributeShapes.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                result.Output.files[0].declarationDriftWarnings,
+                Has.Some.Contain("AddedCaseProbe").And.Contain("Unity Test Runner"),
+                FormatWarnings(result));
+            Assert.That(
+                result.Output.files[0].declarationDriftWarnings,
+                Has.Some.Contain("AddedUnityProbe").And.Contain("Unity Test Runner"),
+                FormatWarnings(result));
+            Assert.That(
+                result.Output.files[0].declarationDriftWarnings,
+                Has.Some.Contain("AddedSetUpProbe").And.Contain("Unity Test Runner"),
+                FormatWarnings(result));
+        }
+
+        /// <summary>
+        /// What: an added method with no test attribute, or only [System.Obsolete], does not
+        /// emit a Unity Test Runner warning.
+        /// </summary>
+        [Test]
+        public async Task Warn_AddedMethodWithoutTestAttribute_DoesNotEmitTestRunnerWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public void AddedPlainProbe()\n        {\n        }\n\n"
+                + "        [System.Obsolete]\n        public void AddedObsoleteProbe()\n        {\n        }");
+            string sourcePath = WriteEdited("AddedNonTestMethod.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, "AddedPlainProbe"), Is.Not.Null);
+            Assert.That(FindEntry(result, "AddedObsoleteProbe"), Is.Not.Null);
+            Assert.That(
+                result.Output.files[0].declarationDriftWarnings,
+                Has.None.Contain("Unity Test Runner"),
+                FormatWarnings(result));
+        }
+
+        /// <summary>
+        /// What: editing only the body of a baseline [Test] method (Patched) does not emit
+        /// a Unity Test Runner warning.
+        /// </summary>
+        [Test]
+        public async Task Warn_PatchedExistingTestMethod_DoesNotEmitTestRunnerWarning()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            const string originalExistingValue =
+                "        public int ExistingValue()\n        {\n            return 1;\n        }";
+            string snapshot = onDisk.Replace(
+                originalExistingValue,
+                "        [Test]\n        public int ExistingValue()\n        {\n            return 1;\n        }",
+                StringComparison.Ordinal);
+            string edited = onDisk.Replace(
+                originalExistingValue,
+                "        [Test]\n        public int ExistingValue()\n        {\n            return 99;\n        }",
+                StringComparison.Ordinal);
+            string sourcePath = WriteEdited("PatchedExistingTestMethod.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: snapshot);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            TransformWorkerEntryDto entry = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingValue));
+            Assert.That(entry, Is.Not.Null);
+            Assert.That(entry.patchKind, Is.Not.EqualTo(HotReloadConstants.PatchKindAddedMethod));
+            Assert.That(
+                result.Output.files[0].declarationDriftWarnings,
+                Has.None.Contain("Unity Test Runner"),
+                FormatWarnings(result));
+        }
+
+        /// <summary>
         /// What: adding or removing a method does not emit the outside-method-body drift warning;
         /// a field-initializer change still does.
         /// </summary>
@@ -1715,6 +1842,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             return null;
+        }
+
+        private static int CountWarningsContaining(TransformWorkerClientResult result, string fragment)
+        {
+            string[] warnings = result.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>();
+            int count = 0;
+            foreach (string warning in warnings)
+            {
+                if (warning.Contains(fragment, StringComparison.Ordinal))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        private static string FormatWarnings(TransformWorkerClientResult result)
+        {
+            string[] warnings = result.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>();
+            if (warnings.Length == 0)
+            {
+                return "declarationDriftWarnings=(none)";
+            }
+
+            return "declarationDriftWarnings=\n" + string.Join("\n", warnings);
         }
 
         private static string FormatSkipped(TransformWorkerSkippedDto[] skipped)

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -516,8 +516,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: added methods with a qualified [TestCase], [UnityTest], or [SetUp] each
-        /// produce a Unity Test Runner warning that names that method.
+        /// What: added methods with a qualified [TestCase], [global::NUnit.Framework.Test],
+        /// [UnityTest], or [SetUp] each produce a Unity Test Runner warning that names that method.
         /// </summary>
         [Test]
         public async Task Warn_AddedTestAttributes_QualifiedUnityTestAndSetUp_EmitWarningPerMethod()
@@ -526,6 +526,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string edited = WithHostMembers(
                 onDisk,
                 "[NUnit.Framework.TestCase(1)]\n        public void AddedCaseProbe(int value)\n        {\n        }\n\n"
+                + "        [global::NUnit.Framework.Test]\n        public void AddedGlobalProbe()\n        {\n        }\n\n"
                 + "        [UnityTest]\n        public System.Collections.IEnumerator AddedUnityProbe()\n        {\n"
                 + "            yield break;\n        }\n\n"
                 + "        [SetUp]\n        public void AddedSetUpProbe()\n        {\n        }");
@@ -539,6 +540,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 result.Output.files[0].declarationDriftWarnings,
                 Has.Some.Contain("AddedCaseProbe").And.Contain("Unity Test Runner"),
+                FormatWarnings(result));
+            Assert.That(
+                result.Output.files[0].declarationDriftWarnings,
+                Has.Some.Contain("AddedGlobalProbe").And.Contain("Unity Test Runner"),
                 FormatWarnings(result));
             Assert.That(
                 result.Output.files[0].declarationDriftWarnings,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
@@ -19,7 +19,9 @@ one shim assembly, so a body edited in one of them can call a member added in an
 code cannot see it, and neither can anything that resolves members by name at
 runtime: reflection (`GetType().GetMethod("NewM")` returns `null`), Unity's message
 discovery (an added `Update` or `OnCollisionEnter` on a `MonoBehaviour` is never
-invoked — a `Warnings` entry names it), UnityEvent/inspector wiring, and
+invoked — a `Warnings` entry names it), the Unity Test Runner (an added `[Test]` /
+`[UnityTest]` method is not enumerated by `uloop run-tests --skip-compile` — a
+`Warnings` entry names it; run `uloop compile` first), UnityEvent/inspector wiring, and
 serialization. Referencing an added member from a file that is neither passed to this reload nor
 already hot-reloaded, or from another assembly, fails that file's hot reload with
 the usual new-member hint; run `uloop compile` instead. Unchanged files of the same

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OrdinaryMethodQueue.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OrdinaryMethodQueue.cs
@@ -403,6 +403,11 @@ internal static class OrdinaryMethodQueue
                 typeState.TypeSymbol,
                 methodSymbol,
                 declarationDriftWarnings);
+            TestAttributeNames.AppendAddedTestMethodWarningIfNeeded(
+                methodDeclaration,
+                typeState.TypeSymbol,
+                methodSymbol,
+                declarationDriftWarnings);
         }
 
         return (shimTypeCounter, globalShimMethodCounter);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TestAttributeNames.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TestAttributeNames.cs
@@ -83,14 +83,21 @@ internal static class TestAttributeNames
     private static string GetSimpleAttributeName(NameSyntax name)
     {
         NameSyntax current = name;
-        while (current is QualifiedNameSyntax qualified)
+        while (true)
         {
-            current = qualified.Right;
-        }
+            if (current is AliasQualifiedNameSyntax aliasQualified)
+            {
+                current = aliasQualified.Name;
+                continue;
+            }
 
-        if (current is AliasQualifiedNameSyntax aliasQualified)
-        {
-            current = aliasQualified.Name;
+            if (current is QualifiedNameSyntax qualified)
+            {
+                current = qualified.Right;
+                continue;
+            }
+
+            break;
         }
 
         string identifier = ReadIdentifier(current);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TestAttributeNames.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TestAttributeNames.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+internal static class TestAttributeNames
+{
+    public const string AddedTestMethodWarningFormat =
+        "Added test method '{0}' on {1} is not visible to the Unity Test Runner until 'uloop compile'; "
+        + "the Test Runner discovers tests by reflection on the compiled assembly, so "
+        + "'uloop run-tests --skip-compile' will not find or run it. "
+        + "Run 'uloop compile' (or 'uloop run-tests' without --skip-compile) first.";
+
+    private static readonly HashSet<string> Names = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "Test",
+        "TestCase",
+        "TestCaseSource",
+        "Theory",
+        "UnityTest",
+        "SetUp",
+        "TearDown",
+        "OneTimeSetUp",
+        "OneTimeTearDown",
+        "UnitySetUp",
+        "UnityTearDown"
+    };
+
+    public static bool HasTestAttribute(MethodDeclarationSyntax methodDeclaration)
+    {
+        Debug.Assert(methodDeclaration != null, "methodDeclaration must not be null.");
+        foreach (AttributeListSyntax attributeList in methodDeclaration.AttributeLists)
+        {
+            foreach (AttributeSyntax attribute in attributeList.Attributes)
+            {
+                if (Names.Contains(GetSimpleAttributeName(attribute.Name)))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public static void AppendAddedTestMethodWarningIfNeeded(
+        MethodDeclarationSyntax methodDeclaration,
+        INamedTypeSymbol typeSymbol,
+        IMethodSymbol methodSymbol,
+        List<string> declarationDriftWarnings)
+    {
+        Debug.Assert(methodDeclaration != null, "methodDeclaration must not be null.");
+        Debug.Assert(typeSymbol != null, "typeSymbol must not be null.");
+        Debug.Assert(methodSymbol != null, "methodSymbol must not be null.");
+        Debug.Assert(declarationDriftWarnings != null, "declarationDriftWarnings must not be null.");
+        if (!HasTestAttribute(methodDeclaration))
+        {
+            return;
+        }
+
+        declarationDriftWarnings.Add(
+            string.Format(
+                CultureInfo.InvariantCulture,
+                AddedTestMethodWarningFormat,
+                methodSymbol.Name,
+                typeSymbol.ToDisplayString()));
+    }
+
+    // Syntax only, not symbols: the worker compile may lack NUnit / UnityEngine.TestTools
+    // references, so attribute symbols become ErrorType and a semantic check would flicker.
+    private static string GetSimpleAttributeName(NameSyntax name)
+    {
+        NameSyntax current = name;
+        while (current is QualifiedNameSyntax qualified)
+        {
+            current = qualified.Right;
+        }
+
+        if (current is AliasQualifiedNameSyntax aliasQualified)
+        {
+            current = aliasQualified.Name;
+        }
+
+        string identifier = ReadIdentifier(current);
+        const string suffix = "Attribute";
+        if (identifier.Length > suffix.Length && identifier.EndsWith(suffix, StringComparison.Ordinal))
+        {
+            return identifier.Substring(0, identifier.Length - suffix.Length);
+        }
+
+        return identifier;
+    }
+
+    private static string ReadIdentifier(NameSyntax name)
+    {
+        if (name is IdentifierNameSyntax identifierName)
+        {
+            return identifierName.Identifier.ValueText;
+        }
+
+        if (name is GenericNameSyntax genericName)
+        {
+            return genericName.Identifier.ValueText;
+        }
+
+        return name.ToString();
+    }
+}


### PR DESCRIPTION
## Summary
- Hot reload now warns when a newly added test method will not appear in the Unity Test Runner until compile.
- Agents can tell `Success` apart from “the Test Runner can see this test.”

## User Impact
- Before: adding a `[Test]` / `[UnityTest]` method reported `Success` with an `Added` row and no warning, so `uloop run-tests --skip-compile` looked like the next step and found nothing.
- After: the response `Warnings` names the added test method and says to run `uloop compile` (or `uloop run-tests` without `--skip-compile`) first. Editing an already-compiled test method still stays silent.

## Changes
- Worker detects test attributes from method syntax (not resolved symbols) and appends a declaration-drift warning for added methods only.
- Skill scope notes mention the Test Runner gap next to the existing Unity-message invisibility note.

## Verification
- `dist/darwin-arm64/uloop run-tests --project-path <worktree> --filter-type class --filter-value TransformWorkerAddedMemberTests`: TestCount 55, PassedCount 55, FailedCount 0
- Mutation check: temporarily expected 99 Test Runner warnings; the new test failed with `Expected: 99 / But was: 1` and the exact warning text, then the assertion was restored
- `CODE_FILE_LENGTH_FAIL_ON_EXCEEDED=true scripts/check-file-length.sh`: exit 0
- `CODE_COMPLEXITY_FAIL_ON_EXCEEDED=true scripts/check-code-complexity.sh`: exit 0
- `go run ./cmd/check-skill-size --root <repo>`: no SKILL.md exceeded the byte limit


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

