### PR TITLE
fix: Prevent unsafe signature changes across assemblies

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerFixture.cs
@@ -123,6 +123,28 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     }
 
     /// <summary>
+    /// Supplies a public target with same-key callers compiled into two different assemblies.
+    /// </summary>
+    public static class HotReloadQualifiedCallerIdentityTarget
+    {
+        public static int Called()
+        {
+            return 9;
+        }
+    }
+
+    /// <summary>
+    /// Supplies the main-assembly side of a same-metadata-name internal caller pair.
+    /// </summary>
+    internal static class HotReloadQualifiedCallerIdentityCaller
+    {
+        internal static int Call()
+        {
+            return HotReloadQualifiedCallerIdentityTarget.Called();
+        }
+    }
+
+    /// <summary>
     /// Open generic host so call sites go through a constructed <c>GenericHost&lt;int&gt;</c>.
     /// </summary>
     public class GenericHost<T>

--- a/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs
@@ -28,6 +28,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string CrossAssemblyTargetTypeMetadataName =
             "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadCallSiteScannerCrossAssemblyTarget";
 
+        private const string QualifiedCallerIdentityTargetTypeMetadataName =
+            "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadQualifiedCallerIdentityTarget";
+
         /// <summary>
         /// What: a method called from an ordinary method is reported with that caller's method key.
         /// </summary>
@@ -257,6 +260,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.EqualTo(
                     "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
                     + ".HotReloadCallSiteCrossAssemblyCaller::Call()"));
+        }
+
+        /// <summary>
+        /// What: callers with the same metadata name and wire key are reported with their distinct assemblies.
+        /// </summary>
+        [Test]
+        public void FindCallSites_SameKeyCallersAcrossAssemblies_ReportsBothCallerAssemblies()
+        {
+            List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
+                QualifiedCallerIdentityTargetTypeMetadataName,
+                nameof(HotReloadQualifiedCallerIdentityTarget.Called),
+                Array.Empty<string>(),
+                0);
+            List<string> callerAssemblyNames = new List<string>();
+            foreach (HotReloadCallSiteScanner.CallSiteHit hit in hits)
+            {
+                callerAssemblyNames.Add(hit.CallerAssemblyName);
+                Assert.That(
+                    hit.CallerMethodKey,
+                    Is.EqualTo(
+                        "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                        + ".HotReloadQualifiedCallerIdentityCaller::Call()"));
+            }
+
+            Assert.That(hits, Has.Count.EqualTo(2));
+            Assert.That(
+                callerAssemblyNames,
+                Does.Contain("UnityCLILoop.Tests.Editor.HotReload"));
+            Assert.That(
+                callerAssemblyNames,
+                Does.Contain("UnityCLILoop.Tests.Editor.HotReload.CallSiteCrossAssembly"));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -4854,6 +4854,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             };
 
             List<string> lost = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                "TestAssembly",
                 new[] { replacement, caller },
                 hits,
                 new[] { "Host::Target(System.Int32)" });
@@ -4875,6 +4876,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             };
 
             List<string> lost = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                "TestAssembly",
                 new[] { replacement },
                 hits,
                 new[] { "Host::Target(System.Int32)" });
@@ -5000,8 +5002,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string names = HotReloadSignatureChangeCoverage.FormatUncoveredCallerShortNames(
                 new[]
                 {
-                    "Ns.Host::AlphaCaller(System.Int32)",
-                    "Ns.Outer/Inner::BetaCaller(System.Int32)"
+                    new HotReloadQualifiedMethodIdentity(
+                        "TestAssembly",
+                        "Ns.Host::AlphaCaller(System.Int32)"),
+                    new HotReloadQualifiedMethodIdentity(
+                        "TestAssembly",
+                        "Ns.Outer/Inner::BetaCaller(System.Int32)")
                 });
 
             Assert.That(names, Is.EqualTo("Host.AlphaCaller, Inner.BetaCaller"));
@@ -5316,7 +5322,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             TransformWorkerEntryDto replacement = CreateReplacementEntry("Host", "Target");
             bool sameFile = HotReloadSignatureChangeCoverage.AreUncoveredCallersInEditedFile(
-                new[] { "Host::OtherFileCaller(System.Int32)" },
+                "TestAssembly",
+                new[]
+                {
+                    new HotReloadQualifiedMethodIdentity(
+                        "TestAssembly",
+                        "Host::OtherFileCaller(System.Int32)")
+                },
                 new[] { replacement },
                 Array.Empty<TransformWorkerUnchangedMethodDto>());
 
@@ -6892,6 +6904,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             return new HotReloadCallSiteScanner.CallSiteHit
             {
+                CallerAssemblyName = "TestAssembly",
                 CallerMethodKey = callerMethodKey,
                 CallerGenericArity = 0,
                 TargetMethodKey = targetMethodKey

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Pure coverage tests for signature-change caller identity and gate classification.
+    /// </summary>
+    public class HotReloadSignatureChangeCoverageTests
+    {
+        private const string EditedAssemblyName = "EditedAssembly";
+        private const string ExternalAssemblyName = "ExternalAssembly";
+        private const string CallerKey = "Example.Caller::Call()";
+        private const string ReplacementKey = "Example.Target::Call()";
+
+        /// <summary>
+        /// What: a caller from another assembly with the same wire key as an edited caller stays uncovered.
+        /// </summary>
+        [Test]
+        public void CollectUncoveredCallersByTarget_ExternalSameKeyCaller_StaysUncovered()
+        {
+            TransformWorkerEntryDto localCaller = CreateOrdinaryEntry();
+            HotReloadCallSiteScanner.CallSiteHit hit = CreateHit(ExternalAssemblyName);
+
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncovered =
+                HotReloadSignatureChangeGate.CollectInitialUncoveredCallers(
+                    EditedAssemblyName,
+                    new[] { localCaller },
+                    Array.Empty<HotReloadCallSiteScanner.CompiledMethodIdentity>(),
+                    new[] { hit });
+
+            Assert.That(uncovered, Does.ContainKey(ReplacementKey));
+            Assert.That(
+                uncovered[ReplacementKey],
+                Does.Contain(new HotReloadQualifiedMethodIdentity(ExternalAssemblyName, CallerKey)));
+        }
+
+        /// <summary>
+        /// What: a caller with the same key in the edited assembly is covered by its worker entry.
+        /// </summary>
+        [Test]
+        public void CollectInitialUncoveredCallers_SameAssemblySameKeyCaller_IsCovered()
+        {
+            TransformWorkerEntryDto localCaller = CreateOrdinaryEntry();
+            HotReloadCallSiteScanner.CallSiteHit hit = CreateHit(EditedAssemblyName);
+
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncovered =
+                HotReloadSignatureChangeGate.CollectInitialUncoveredCallers(
+                    EditedAssemblyName,
+                    new[] { localCaller },
+                    Array.Empty<HotReloadCallSiteScanner.CompiledMethodIdentity>(),
+                    new[] { hit });
+
+            Assert.That(uncovered, Is.Empty);
+        }
+
+        /// <summary>
+        /// What: an external caller sharing an edited-file method key receives the generic gate reason.
+        /// </summary>
+        [Test]
+        public void BuildGatedReplacementSkipOutcomes_ExternalSameKeyCaller_UsesGenericReason()
+        {
+            TransformWorkerEntryDto replacement = CreateReplacementEntry();
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredByTarget =
+                new Dictionary<string, List<HotReloadQualifiedMethodIdentity>>(StringComparer.Ordinal)
+                {
+                    {
+                        ReplacementKey,
+                        new List<HotReloadQualifiedMethodIdentity>
+                        {
+                            new HotReloadQualifiedMethodIdentity(ExternalAssemblyName, CallerKey)
+                        }
+                    }
+                };
+            Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>> editedFileIdentities =
+                new Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>>(StringComparer.Ordinal)
+                {
+                    {
+                        replacement.sourceProjectRelativePath,
+                        new HashSet<HotReloadQualifiedMethodIdentity>
+                        {
+                            new HotReloadQualifiedMethodIdentity(EditedAssemblyName, CallerKey)
+                        }
+                    }
+                };
+            HotReloadGroupFilePaths paths = HotReloadGroupFilePaths.ForSingleFile(
+                replacement.sourceProjectRelativePath,
+                "Assembly.dll");
+
+            List<HotReloadMethodOutcome> outcomes =
+                HotReloadSignatureChangeGate.BuildGatedReplacementSkipOutcomes(
+                    new[] { replacement },
+                    uncoveredByTarget,
+                    editedFileIdentities,
+                    paths);
+
+            string expectedReason = string.Format(
+                HotReloadConstants.SignatureChangedGateSkipReasonFormat,
+                HotReloadSignatureChangeGate.FormatGatedReplacementRegistryKey(replacement));
+            Assert.That(outcomes, Has.Count.EqualTo(1));
+            Assert.That(outcomes[0].Reason, Is.EqualTo(expectedReason));
+        }
+
+        /// <summary>
+        /// What: a same-assembly caller listed by the edited file receives the same-file gate reason.
+        /// </summary>
+        [Test]
+        public void BuildGatedReplacementSkipOutcomes_SameAssemblySameKeyCaller_UsesSameFileReason()
+        {
+            TransformWorkerEntryDto replacement = CreateReplacementEntry();
+            HotReloadQualifiedMethodIdentity localCallerIdentity =
+                new HotReloadQualifiedMethodIdentity(EditedAssemblyName, CallerKey);
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredByTarget =
+                new Dictionary<string, List<HotReloadQualifiedMethodIdentity>>(StringComparer.Ordinal)
+                {
+                    { ReplacementKey, new List<HotReloadQualifiedMethodIdentity> { localCallerIdentity } }
+                };
+            Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>> editedFileIdentities =
+                new Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>>(StringComparer.Ordinal)
+                {
+                    {
+                        replacement.sourceProjectRelativePath,
+                        new HashSet<HotReloadQualifiedMethodIdentity> { localCallerIdentity }
+                    }
+                };
+            HotReloadGroupFilePaths paths = HotReloadGroupFilePaths.ForSingleFile(
+                replacement.sourceProjectRelativePath,
+                "Assembly.dll");
+
+            List<HotReloadMethodOutcome> outcomes =
+                HotReloadSignatureChangeGate.BuildGatedReplacementSkipOutcomes(
+                    new[] { replacement },
+                    uncoveredByTarget,
+                    editedFileIdentities,
+                    paths);
+
+            string expectedReason = string.Format(
+                HotReloadConstants.SignatureChangedGateSkipReasonSameFileCallersFormat,
+                HotReloadSignatureChangeGate.FormatGatedReplacementRegistryKey(replacement),
+                "Caller.Call");
+            Assert.That(outcomes, Has.Count.EqualTo(1));
+            Assert.That(outcomes[0].Reason, Is.EqualTo(expectedReason));
+        }
+
+        /// <summary>
+        /// What: final coverage rejects a replacement when only a same-key caller from another assembly was kept.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_ExternalSameKeyCallerRemains_ReturnsReplacementKey()
+        {
+            TransformWorkerEntryDto replacement = CreateReplacementEntry();
+            TransformWorkerEntryDto localCaller = CreateOrdinaryEntry();
+            HotReloadCallSiteScanner.CallSiteHit hit = CreateHit(ExternalAssemblyName);
+
+            List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                EditedAssemblyName,
+                new[] { replacement, localCaller },
+                new[] { hit },
+                new[] { ReplacementKey });
+
+            Assert.That(losses, Is.EqualTo(new[] { ReplacementKey }));
+        }
+
+        /// <summary>
+        /// What: a foreign same-key caller does not produce an already-patched caller notice.
+        /// </summary>
+        [Test]
+        public void AppendSignatureChangeCallersRepatchedWarnings_ExternalSameKeyCaller_OmitsNotice()
+        {
+            TransformWorkerEntryDto replacement = CreateReplacementEntry();
+            TransformWorkerEntryDto localCaller = CreateOrdinaryEntry();
+            HotReloadCallSiteScanner.CallSiteHit hit = CreateHit(ExternalAssemblyName);
+            List<string> warnings = new List<string>();
+            HashSet<string> snapshotLabels = new HashSet<string>(StringComparer.Ordinal)
+            {
+                HotReloadMethodKeys.FormatMethodLabelParts(
+                    "Example.Caller",
+                    "Call",
+                    Array.Empty<string>(),
+                    0)
+            };
+
+            HotReloadSignatureChangeCoverage.AppendSignatureChangeCallersRepatchedWarnings(
+                warnings,
+                EditedAssemblyName,
+                new[] { replacement, localCaller },
+                new[] { hit },
+                snapshotLabels);
+
+            Assert.That(warnings, Is.Empty);
+        }
+
+        private static TransformWorkerEntryDto CreateReplacementEntry()
+        {
+            return new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = "Assets/Fixture.cs",
+                typeMetadataName = "Example.Target",
+                methodName = "Call",
+                parameterTypeFullNames = Array.Empty<string>(),
+                genericArity = 0,
+                replacesCompiledMethod = true
+            };
+        }
+
+        private static TransformWorkerEntryDto CreateOrdinaryEntry()
+        {
+            return new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = "Assets/Fixture.cs",
+                typeMetadataName = "Example.Caller",
+                methodName = "Call",
+                parameterTypeFullNames = Array.Empty<string>(),
+                genericArity = 0
+            };
+        }
+
+        private static HotReloadCallSiteScanner.CallSiteHit CreateHit(string callerAssemblyName)
+        {
+            return new HotReloadCallSiteScanner.CallSiteHit
+            {
+                CallerAssemblyName = callerAssemblyName,
+                CallerTypeMetadataName = "Example.Caller",
+                CallerMethodName = "Call",
+                CallerParameterTypeFullNames = Array.Empty<string>(),
+                CallerMethodKey = CallerKey,
+                CallerGenericArity = 0,
+                TargetMethodKey = ReplacementKey
+            };
+        }
+
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
@@ -194,6 +194,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(warnings, Is.Empty);
         }
 
+        /// <summary>
+        /// What: stale warnings de-duplicate only their displayed caller keys, preserving distinct
+        /// cross-assembly caller identities for coverage decisions.
+        /// </summary>
+        [Test]
+        public void FormatUncoveredCallerMethodKeys_CrossAssemblySameKey_DeduplicatesDisplayOnly()
+        {
+            List<HotReloadQualifiedMethodIdentity> sameKeyCallers =
+                new List<HotReloadQualifiedMethodIdentity>
+                {
+                    new HotReloadQualifiedMethodIdentity(EditedAssemblyName, CallerKey),
+                    new HotReloadQualifiedMethodIdentity(ExternalAssemblyName, CallerKey)
+                };
+            List<HotReloadQualifiedMethodIdentity> differentKeyCallers =
+                new List<HotReloadQualifiedMethodIdentity>
+                {
+                    new HotReloadQualifiedMethodIdentity(EditedAssemblyName, CallerKey),
+                    new HotReloadQualifiedMethodIdentity(
+                        ExternalAssemblyName,
+                        "Example.OtherCaller::Call()")
+                };
+
+            Assert.That(sameKeyCallers, Has.Count.EqualTo(2));
+            Assert.That(
+                CountOccurrences(CollectStaleWarning(sameKeyCallers), CallerKey),
+                Is.EqualTo(1));
+            Assert.That(
+                CollectStaleWarning(differentKeyCallers),
+                Does.Contain("Example.Caller::Call(), Example.OtherCaller::Call()"));
+        }
+
         private static TransformWorkerEntryDto CreateReplacementEntry()
         {
             return new TransformWorkerEntryDto
@@ -205,6 +236,47 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 genericArity = 0,
                 replacesCompiledMethod = true
             };
+        }
+
+        private static string CollectStaleWarning(
+            List<HotReloadQualifiedMethodIdentity> callers)
+        {
+            TransformWorkerRemovedMethodSignatureDto removedSignature =
+                new TransformWorkerRemovedMethodSignatureDto
+                {
+                    typeMetadataName = "Example.Target",
+                    methodName = "Call",
+                    parameterTypeFullNames = Array.Empty<string>(),
+                    genericArity = 0
+                };
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> callersByTarget =
+                new Dictionary<string, List<HotReloadQualifiedMethodIdentity>>(StringComparer.Ordinal)
+                {
+                    { ReplacementKey, callers }
+                };
+
+            List<string> warnings = HotReloadSignatureChangeCoverage.CollectStaleSignatureWarnings(
+                new[] { removedSignature },
+                callersByTarget);
+
+            return warnings[0];
+        }
+
+        private static int CountOccurrences(string text, string value)
+        {
+            int count = 0;
+            int startIndex = 0;
+            while (true)
+            {
+                int occurrenceIndex = text.IndexOf(value, startIndex, StringComparison.Ordinal);
+                if (occurrenceIndex < 0)
+                {
+                    return count;
+                }
+
+                count++;
+                startIndex = occurrenceIndex + value.Length;
+            }
         }
 
         private static TransformWorkerEntryDto CreateOrdinaryEntry()

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e6e965b93aad45d2ba83df0510b5f49
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReloadCallSiteCrossAssembly/HotReloadCallSiteCrossAssemblyCaller.cs
+++ b/Assets/Tests/Editor/HotReloadCallSiteCrossAssembly/HotReloadCallSiteCrossAssemblyCaller.cs
@@ -27,4 +27,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return 8;
         }
     }
+
+    /// <summary>
+    /// Supplies the foreign-assembly side of the same-metadata-name internal caller pair.
+    /// </summary>
+    internal static class HotReloadQualifiedCallerIdentityCaller
+    {
+        internal static int Call()
+        {
+            return HotReloadQualifiedCallerIdentityTarget.Called();
+        }
+    }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -155,6 +155,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // retry can drop a covering caller without dropping the replacement. A third
             // worker run is not allowed (max two); fail the group instead of applying.
             List<string> lostReplacementKeys = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                context.AssemblyName,
                 compile.EntriesToPatch,
                 gateResult.Hits,
                 gateResult.ScanTargetKeys);
@@ -176,6 +177,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // the warning belongs to.
                 HotReloadSignatureChangeCoverage.AppendSignatureChangeCallersRepatchedWarnings(
                     file.Sinks.Warnings,
+                    context.AssemblyName,
                     compile.EntriesToPatch,
                     gateResult.Hits,
                     file.SnapshotLabels);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadQualifiedMethodIdentity.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadQualifiedMethodIdentity.cs
@@ -20,15 +20,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             MethodKey = methodKey;
         }
 
-        public bool Equals(HotReloadQualifiedMethodIdentity other)
+        bool IEquatable<HotReloadQualifiedMethodIdentity>.Equals(HotReloadQualifiedMethodIdentity other)
         {
-            return string.Equals(AssemblyName, other.AssemblyName, StringComparison.Ordinal)
-                && string.Equals(MethodKey, other.MethodKey, StringComparison.Ordinal);
+            return HasSameValue(other);
         }
 
         public override bool Equals(object obj)
         {
-            return obj is HotReloadQualifiedMethodIdentity other && Equals(other);
+            return obj is HotReloadQualifiedMethodIdentity other && HasSameValue(other);
         }
 
         public override int GetHashCode()
@@ -36,6 +35,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int assemblyHashCode = StringComparer.Ordinal.GetHashCode(AssemblyName);
             int methodKeyHashCode = StringComparer.Ordinal.GetHashCode(MethodKey);
             return (assemblyHashCode * 397) ^ methodKeyHashCode;
+        }
+
+        private bool HasSameValue(HotReloadQualifiedMethodIdentity other)
+        {
+            return string.Equals(AssemblyName, other.AssemblyName, StringComparison.Ordinal)
+                && string.Equals(MethodKey, other.MethodKey, StringComparison.Ordinal);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadQualifiedMethodIdentity.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadQualifiedMethodIdentity.cs
@@ -1,0 +1,41 @@
+using System;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Identifies a compiled method without conflating identical wire keys from different assemblies.
+    /// </summary>
+    internal readonly struct HotReloadQualifiedMethodIdentity : IEquatable<HotReloadQualifiedMethodIdentity>
+    {
+        internal string AssemblyName { get; }
+        internal string MethodKey { get; }
+
+        internal HotReloadQualifiedMethodIdentity(string assemblyName, string methodKey)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
+            Debug.Assert(!string.IsNullOrEmpty(methodKey), "methodKey must not be null or empty.");
+            AssemblyName = assemblyName;
+            MethodKey = methodKey;
+        }
+
+        public bool Equals(HotReloadQualifiedMethodIdentity other)
+        {
+            return string.Equals(AssemblyName, other.AssemblyName, StringComparison.Ordinal)
+                && string.Equals(MethodKey, other.MethodKey, StringComparison.Ordinal);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is HotReloadQualifiedMethodIdentity other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            int assemblyHashCode = StringComparer.Ordinal.GetHashCode(AssemblyName);
+            int methodKeyHashCode = StringComparer.Ordinal.GetHashCode(MethodKey);
+            return (assemblyHashCode * 397) ^ methodKeyHashCode;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadQualifiedMethodIdentity.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadQualifiedMethodIdentity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c84a11be8bc2470499827821e11b509
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeCoverage.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeCoverage.cs
@@ -11,14 +11,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class HotReloadSignatureChangeCoverage
     {
-        internal static HashSet<string> CollectCoveredMethodKeys(
+        internal static HashSet<HotReloadQualifiedMethodIdentity> CollectCoveredMethodIdentities(
+            string assemblyName,
             TransformWorkerEntryDto[] entries,
             HotReloadCallSiteScanner.CompiledMethodIdentity[] targets)
         {
-            HashSet<string> coveredKeys = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<HotReloadQualifiedMethodIdentity> coveredIdentities =
+                new HashSet<HotReloadQualifiedMethodIdentity>();
             foreach (TransformWorkerEntryDto entry in entries)
             {
-                coveredKeys.Add(HotReloadMethodKeys.BuildMethodKey(entry));
+                coveredIdentities.Add(CreateIdentity(assemblyName, entry));
             }
 
             foreach (HotReloadCallSiteScanner.CompiledMethodIdentity target in targets)
@@ -28,39 +30,37 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // corpse as uncovered would gate a same-file helper-delete + return-type
                 // change, which is still a consistent old world. Fail-closed only for live
                 // compiled callers that will keep invoking the old method.
-                coveredKeys.Add(
-                    HotReloadMethodKeys.BuildMethodKeyParts(
-                        target.TypeMetadataName,
-                        target.MethodName,
-                        target.ParameterTypeFullNames,
-                        target.GenericArity));
+                coveredIdentities.Add(CreateIdentity(target));
             }
 
-            return coveredKeys;
+            return coveredIdentities;
         }
 
-        internal static Dictionary<string, List<string>> CollectUncoveredCallersByTarget(
+        internal static Dictionary<string, List<HotReloadQualifiedMethodIdentity>> CollectUncoveredCallersByTarget(
             IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits,
-            HashSet<string> coveredKeys)
+            HashSet<HotReloadQualifiedMethodIdentity> coveredIdentities)
         {
-            Dictionary<string, List<string>> uncoveredCallersByTarget =
-                new Dictionary<string, List<string>>(StringComparer.Ordinal);
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget =
+                new Dictionary<string, List<HotReloadQualifiedMethodIdentity>>(StringComparer.Ordinal);
             foreach (HotReloadCallSiteScanner.CallSiteHit hit in hits)
             {
-                if (coveredKeys.Contains(hit.CallerMethodKey))
+                HotReloadQualifiedMethodIdentity callerIdentity = CreateIdentity(hit);
+                if (coveredIdentities.Contains(callerIdentity))
                 {
                     continue;
                 }
 
-                if (!uncoveredCallersByTarget.TryGetValue(hit.TargetMethodKey, out List<string> callers))
+                if (!uncoveredCallersByTarget.TryGetValue(
+                        hit.TargetMethodKey,
+                        out List<HotReloadQualifiedMethodIdentity> callers))
                 {
-                    callers = new List<string>();
+                    callers = new List<HotReloadQualifiedMethodIdentity>();
                     uncoveredCallersByTarget.Add(hit.TargetMethodKey, callers);
                 }
 
-                if (!callers.Contains(hit.CallerMethodKey))
+                if (!callers.Contains(callerIdentity))
                 {
-                    callers.Add(hit.CallerMethodKey);
+                    callers.Add(callerIdentity);
                 }
             }
 
@@ -69,7 +69,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal static List<string> CollectStaleSignatureWarnings(
             TransformWorkerRemovedMethodSignatureDto[] removedSignatures,
-            Dictionary<string, List<string>> uncoveredCallersByTarget)
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget)
         {
             List<string> warnings = new List<string>();
             foreach (TransformWorkerRemovedMethodSignatureDto signature in removedSignatures)
@@ -79,7 +79,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     signature.methodName,
                     signature.parameterTypeFullNames,
                     signature.genericArity);
-                if (!uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> callers)
+                if (!uncoveredCallersByTarget.TryGetValue(
+                        methodKey,
+                        out List<HotReloadQualifiedMethodIdentity> callers)
                     || callers.Count == 0)
                 {
                     continue;
@@ -89,7 +91,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     string.Format(
                         HotReloadConstants.StaleSignatureCallersWarningFormat,
                         methodKey,
-                        string.Join(", ", callers)));
+                        FormatUncoveredCallerMethodKeys(callers)));
             }
 
             return warnings;
@@ -106,6 +108,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // from the wire key (same constraint as IsActiveMember).
         internal static void AppendSignatureChangeCallersRepatchedWarnings(
             List<string> warnings,
+            string assemblyName,
             TransformWorkerEntryDto[] entriesToPatch,
             IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits,
             HashSet<string> snapshotLabels)
@@ -115,12 +118,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(hits != null, "hits must not be null.");
             Debug.Assert(snapshotLabels != null, "snapshotLabels must not be null.");
 
-            HashSet<string> entryKeys = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<HotReloadQualifiedMethodIdentity> entryIdentities =
+                new HashSet<HotReloadQualifiedMethodIdentity>();
             HashSet<string> appliedReplacementKeys = new HashSet<string>(StringComparer.Ordinal);
             foreach (TransformWorkerEntryDto entry in entriesToPatch)
             {
                 string methodKey = HotReloadMethodKeys.BuildMethodKey(entry);
-                entryKeys.Add(methodKey);
+                entryIdentities.Add(CreateIdentity(assemblyName, methodKey));
                 if (entry.replacesCompiledMethod)
                 {
                     appliedReplacementKeys.Add(methodKey);
@@ -133,7 +137,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 if (hit == null
                     || !appliedReplacementKeys.Contains(hit.TargetMethodKey)
-                    || !entryKeys.Contains(hit.CallerMethodKey))
+                    || !entryIdentities.Contains(CreateIdentity(hit)))
                 {
                     continue;
                 }
@@ -204,17 +208,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// ctor, or another assembly) must return false so the compile-only wording is used.
         /// </summary>
         internal static bool AreUncoveredCallersInEditedFile(
-            IReadOnlyList<string> uncoveredCallerKeys,
+            string assemblyName,
+            IReadOnlyList<HotReloadQualifiedMethodIdentity> uncoveredCallerIdentities,
             TransformWorkerEntryDto[] entries,
             TransformWorkerUnchangedMethodDto[] unchangedMethods)
         {
-            Debug.Assert(uncoveredCallerKeys != null, "uncoveredCallerKeys must not be null.");
+            Debug.Assert(uncoveredCallerIdentities != null, "uncoveredCallerIdentities must not be null.");
             Debug.Assert(entries != null, "entries must not be null.");
             Debug.Assert(unchangedMethods != null, "unchangedMethods must not be null.");
 
             return AreAllUncoveredCallersInEditedFile(
-                uncoveredCallerKeys,
-                CollectEditedFileMethodKeys(entries, unchangedMethods));
+                uncoveredCallerIdentities,
+                CollectEditedFileMethodIdentities(assemblyName, entries, unchangedMethods));
         }
 
         /// <summary>
@@ -222,6 +227,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// still have uncovered compiled callers after isolation or a gate retry shrank entries.
         /// </summary>
         internal static List<string> FindSignatureChangeCoverageLosses(
+            string assemblyName,
             TransformWorkerEntryDto[] entriesToPatch,
             IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits,
             IReadOnlyList<string> scanTargetKeys)
@@ -230,19 +236,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(hits != null, "hits must not be null.");
             Debug.Assert(scanTargetKeys != null, "scanTargetKeys must not be null.");
 
-            HashSet<string> coveredKeys = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<HotReloadQualifiedMethodIdentity> coveredIdentities =
+                new HashSet<HotReloadQualifiedMethodIdentity>();
             foreach (TransformWorkerEntryDto entry in entriesToPatch)
             {
-                coveredKeys.Add(HotReloadMethodKeys.BuildMethodKey(entry));
+                coveredIdentities.Add(CreateIdentity(assemblyName, entry));
             }
 
             foreach (string targetKey in scanTargetKeys)
             {
-                coveredKeys.Add(targetKey);
+                coveredIdentities.Add(CreateIdentity(assemblyName, targetKey));
             }
 
-            Dictionary<string, List<string>> uncoveredCallersByTarget =
-                CollectUncoveredCallersByTarget(hits, coveredKeys);
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget =
+                CollectUncoveredCallersByTarget(hits, coveredIdentities);
             List<string> lostReplacementKeys = new List<string>();
             foreach (TransformWorkerEntryDto entry in entriesToPatch)
             {
@@ -252,7 +259,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 string methodKey = HotReloadMethodKeys.BuildMethodKey(entry);
-                if (uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> callers)
+                if (uncoveredCallersByTarget.TryGetValue(
+                        methodKey,
+                        out List<HotReloadQualifiedMethodIdentity> callers)
                     && callers.Count > 0)
                 {
                     lostReplacementKeys.Add(methodKey);
@@ -279,27 +288,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return keys;
         }
 
-        internal static HashSet<string> CollectEditedFileMethodKeys(
+        internal static HashSet<HotReloadQualifiedMethodIdentity> CollectEditedFileMethodIdentities(
+            string assemblyName,
             TransformWorkerEntryDto[] entries,
             TransformWorkerUnchangedMethodDto[] unchangedMethods)
         {
-            HashSet<string> methodKeys = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<HotReloadQualifiedMethodIdentity> methodIdentities =
+                new HashSet<HotReloadQualifiedMethodIdentity>();
             foreach (TransformWorkerEntryDto entry in entries)
             {
-                methodKeys.Add(HotReloadMethodKeys.BuildMethodKey(entry));
+                methodIdentities.Add(CreateIdentity(assemblyName, entry));
             }
 
             foreach (TransformWorkerUnchangedMethodDto unchanged in unchangedMethods)
             {
-                methodKeys.Add(
-                    HotReloadMethodKeys.BuildMethodKeyParts(
-                        unchanged.typeMetadataName,
-                        unchanged.methodName,
-                        unchanged.parameterTypeFullNames,
-                        unchanged.genericArity));
+                methodIdentities.Add(CreateIdentity(assemblyName, unchanged));
             }
 
-            return methodKeys;
+            return methodIdentities;
         }
 
         /// <summary>
@@ -311,62 +317,61 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// file. A group run transforms several files at once, so a set built from all of them
         /// would call a caller in a sibling file a same-file caller.
         /// </remarks>
-        internal static Dictionary<string, HashSet<string>> CollectEditedFileMethodKeysByFile(
+        internal static Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>> CollectEditedFileMethodIdentitiesByFile(
+            string assemblyName,
             TransformWorkerEntryDto[] entries,
             TransformWorkerUnchangedMethodDto[] unchangedMethods)
         {
             Debug.Assert(entries != null, "entries must not be null.");
             Debug.Assert(unchangedMethods != null, "unchangedMethods must not be null.");
 
-            Dictionary<string, HashSet<string>> methodKeysByFile =
-                new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+            Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>> methodIdentitiesByFile =
+                new Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>>(StringComparer.Ordinal);
             foreach (TransformWorkerEntryDto entry in entries)
             {
-                AddMethodKeyOfFile(
-                    methodKeysByFile,
+                AddMethodIdentityOfFile(
+                    methodIdentitiesByFile,
                     entry.sourceProjectRelativePath,
-                    HotReloadMethodKeys.BuildMethodKey(entry));
+                    CreateIdentity(assemblyName, entry));
             }
 
             foreach (TransformWorkerUnchangedMethodDto unchanged in unchangedMethods)
             {
-                AddMethodKeyOfFile(
-                    methodKeysByFile,
+                AddMethodIdentityOfFile(
+                    methodIdentitiesByFile,
                     unchanged.sourceProjectRelativePath,
-                    HotReloadMethodKeys.BuildMethodKeyParts(
-                        unchanged.typeMetadataName,
-                        unchanged.methodName,
-                        unchanged.parameterTypeFullNames,
-                        unchanged.genericArity));
+                    CreateIdentity(assemblyName, unchanged));
             }
 
-            return methodKeysByFile;
+            return methodIdentitiesByFile;
         }
 
-        private static void AddMethodKeyOfFile(
-            Dictionary<string, HashSet<string>> methodKeysByFile,
+        private static void AddMethodIdentityOfFile(
+            Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>> methodIdentitiesByFile,
             string projectRelativePath,
-            string methodKey)
+            HotReloadQualifiedMethodIdentity methodIdentity)
         {
             Debug.Assert(
                 !string.IsNullOrEmpty(projectRelativePath),
                 "A worker row must name the source file it came from.");
-            if (!methodKeysByFile.TryGetValue(projectRelativePath, out HashSet<string> methodKeys))
+            if (!methodIdentitiesByFile.TryGetValue(
+                    projectRelativePath,
+                    out HashSet<HotReloadQualifiedMethodIdentity> methodIdentities))
             {
-                methodKeys = new HashSet<string>(StringComparer.Ordinal);
-                methodKeysByFile[projectRelativePath] = methodKeys;
+                methodIdentities = new HashSet<HotReloadQualifiedMethodIdentity>();
+                methodIdentitiesByFile[projectRelativePath] = methodIdentities;
             }
 
-            methodKeys.Add(methodKey);
+            methodIdentities.Add(methodIdentity);
         }
 
         internal static bool AreAllUncoveredCallersInEditedFile(
-            IReadOnlyList<string> uncoveredCallerKeys,
-            HashSet<string> editedFileMethodKeys)
+            IReadOnlyList<HotReloadQualifiedMethodIdentity> uncoveredCallerIdentities,
+            HashSet<HotReloadQualifiedMethodIdentity> editedFileMethodIdentities)
         {
-            foreach (string callerKey in uncoveredCallerKeys)
+            foreach (HotReloadQualifiedMethodIdentity callerIdentity in uncoveredCallerIdentities)
             {
-                if (!editedFileMethodKeys.Contains(callerKey))
+                if (!editedFileMethodIdentities.Contains(callerIdentity))
                 {
                     return false;
                 }
@@ -380,7 +385,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// order, de-duplicated. Nested type '/' is normalized to '.' and only the last type
         /// segment is kept.
         /// </summary>
-        internal static string FormatUncoveredCallerShortNames(IReadOnlyList<string> uncoveredCallers)
+        internal static string FormatUncoveredCallerShortNames(
+            IReadOnlyList<HotReloadQualifiedMethodIdentity> uncoveredCallers)
         {
             if (uncoveredCallers == null || uncoveredCallers.Count == 0)
             {
@@ -389,9 +395,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             List<string> names = new List<string>();
             HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
-            foreach (string wireKey in uncoveredCallers)
+            foreach (HotReloadQualifiedMethodIdentity caller in uncoveredCallers)
             {
-                string shortName = FormatCallerShortName(wireKey);
+                string shortName = FormatCallerShortName(caller.MethodKey);
                 if (string.IsNullOrEmpty(shortName) || !seen.Add(shortName))
                 {
                     continue;
@@ -401,6 +407,62 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return string.Join(", ", names);
+        }
+
+        private static string FormatUncoveredCallerMethodKeys(
+            IReadOnlyList<HotReloadQualifiedMethodIdentity> callers)
+        {
+            List<string> methodKeys = new List<string>(callers.Count);
+            foreach (HotReloadQualifiedMethodIdentity caller in callers)
+            {
+                methodKeys.Add(caller.MethodKey);
+            }
+
+            return string.Join(", ", methodKeys);
+        }
+
+        private static HotReloadQualifiedMethodIdentity CreateIdentity(
+            string assemblyName,
+            TransformWorkerEntryDto entry)
+        {
+            return CreateIdentity(assemblyName, HotReloadMethodKeys.BuildMethodKey(entry));
+        }
+
+        private static HotReloadQualifiedMethodIdentity CreateIdentity(
+            string assemblyName,
+            TransformWorkerUnchangedMethodDto unchanged)
+        {
+            string methodKey = HotReloadMethodKeys.BuildMethodKeyParts(
+                unchanged.typeMetadataName,
+                unchanged.methodName,
+                unchanged.parameterTypeFullNames,
+                unchanged.genericArity);
+            return CreateIdentity(assemblyName, methodKey);
+        }
+
+        private static HotReloadQualifiedMethodIdentity CreateIdentity(
+            HotReloadCallSiteScanner.CompiledMethodIdentity target)
+        {
+            string methodKey = HotReloadMethodKeys.BuildMethodKeyParts(
+                target.TypeMetadataName,
+                target.MethodName,
+                target.ParameterTypeFullNames,
+                target.GenericArity);
+            return CreateIdentity(target.AssemblyName, methodKey);
+        }
+
+        private static HotReloadQualifiedMethodIdentity CreateIdentity(
+            HotReloadCallSiteScanner.CallSiteHit hit)
+        {
+            Debug.Assert(hit != null, "hit must not be null.");
+            return CreateIdentity(hit.CallerAssemblyName, hit.CallerMethodKey);
+        }
+
+        private static HotReloadQualifiedMethodIdentity CreateIdentity(
+            string assemblyName,
+            string methodKey)
+        {
+            return new HotReloadQualifiedMethodIdentity(assemblyName, methodKey);
         }
 
         internal static string FormatCallerShortName(string wireKey)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeCoverage.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeCoverage.cs
@@ -20,7 +20,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 new HashSet<HotReloadQualifiedMethodIdentity>();
             foreach (TransformWorkerEntryDto entry in entries)
             {
-                coveredIdentities.Add(CreateIdentity(assemblyName, entry));
+                coveredIdentities.Add(CreateEntryIdentity(assemblyName, entry));
             }
 
             foreach (HotReloadCallSiteScanner.CompiledMethodIdentity target in targets)
@@ -30,7 +30,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // corpse as uncovered would gate a same-file helper-delete + return-type
                 // change, which is still a consistent old world. Fail-closed only for live
                 // compiled callers that will keep invoking the old method.
-                coveredIdentities.Add(CreateIdentity(target));
+                coveredIdentities.Add(CreateTargetIdentity(target));
             }
 
             return coveredIdentities;
@@ -44,7 +44,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 new Dictionary<string, List<HotReloadQualifiedMethodIdentity>>(StringComparer.Ordinal);
             foreach (HotReloadCallSiteScanner.CallSiteHit hit in hits)
             {
-                HotReloadQualifiedMethodIdentity callerIdentity = CreateIdentity(hit);
+                HotReloadQualifiedMethodIdentity callerIdentity = CreateCallerIdentity(hit);
                 if (coveredIdentities.Contains(callerIdentity))
                 {
                     continue;
@@ -124,7 +124,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             foreach (TransformWorkerEntryDto entry in entriesToPatch)
             {
                 string methodKey = HotReloadMethodKeys.BuildMethodKey(entry);
-                entryIdentities.Add(CreateIdentity(assemblyName, methodKey));
+                entryIdentities.Add(new HotReloadQualifiedMethodIdentity(assemblyName, methodKey));
                 if (entry.replacesCompiledMethod)
                 {
                     appliedReplacementKeys.Add(methodKey);
@@ -137,7 +137,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 if (hit == null
                     || !appliedReplacementKeys.Contains(hit.TargetMethodKey)
-                    || !entryIdentities.Contains(CreateIdentity(hit)))
+                    || !entryIdentities.Contains(CreateCallerIdentity(hit)))
                 {
                     continue;
                 }
@@ -240,12 +240,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 new HashSet<HotReloadQualifiedMethodIdentity>();
             foreach (TransformWorkerEntryDto entry in entriesToPatch)
             {
-                coveredIdentities.Add(CreateIdentity(assemblyName, entry));
+                coveredIdentities.Add(CreateEntryIdentity(assemblyName, entry));
             }
 
             foreach (string targetKey in scanTargetKeys)
             {
-                coveredIdentities.Add(CreateIdentity(assemblyName, targetKey));
+                coveredIdentities.Add(new HotReloadQualifiedMethodIdentity(assemblyName, targetKey));
             }
 
             Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget =
@@ -297,12 +297,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 new HashSet<HotReloadQualifiedMethodIdentity>();
             foreach (TransformWorkerEntryDto entry in entries)
             {
-                methodIdentities.Add(CreateIdentity(assemblyName, entry));
+                methodIdentities.Add(CreateEntryIdentity(assemblyName, entry));
             }
 
             foreach (TransformWorkerUnchangedMethodDto unchanged in unchangedMethods)
             {
-                methodIdentities.Add(CreateIdentity(assemblyName, unchanged));
+                methodIdentities.Add(CreateUnchangedMethodIdentity(assemblyName, unchanged));
             }
 
             return methodIdentities;
@@ -332,7 +332,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 AddMethodIdentityOfFile(
                     methodIdentitiesByFile,
                     entry.sourceProjectRelativePath,
-                    CreateIdentity(assemblyName, entry));
+                    CreateEntryIdentity(assemblyName, entry));
             }
 
             foreach (TransformWorkerUnchangedMethodDto unchanged in unchangedMethods)
@@ -340,7 +340,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 AddMethodIdentityOfFile(
                     methodIdentitiesByFile,
                     unchanged.sourceProjectRelativePath,
-                    CreateIdentity(assemblyName, unchanged));
+                    CreateUnchangedMethodIdentity(assemblyName, unchanged));
             }
 
             return methodIdentitiesByFile;
@@ -413,22 +413,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             IReadOnlyList<HotReloadQualifiedMethodIdentity> callers)
         {
             List<string> methodKeys = new List<string>(callers.Count);
+            HashSet<string> seenMethodKeys = new HashSet<string>(StringComparer.Ordinal);
             foreach (HotReloadQualifiedMethodIdentity caller in callers)
             {
+                if (!seenMethodKeys.Add(caller.MethodKey))
+                {
+                    continue;
+                }
+
                 methodKeys.Add(caller.MethodKey);
             }
 
             return string.Join(", ", methodKeys);
         }
 
-        private static HotReloadQualifiedMethodIdentity CreateIdentity(
+        private static HotReloadQualifiedMethodIdentity CreateEntryIdentity(
             string assemblyName,
             TransformWorkerEntryDto entry)
         {
-            return CreateIdentity(assemblyName, HotReloadMethodKeys.BuildMethodKey(entry));
+            return new HotReloadQualifiedMethodIdentity(
+                assemblyName,
+                HotReloadMethodKeys.BuildMethodKey(entry));
         }
 
-        private static HotReloadQualifiedMethodIdentity CreateIdentity(
+        private static HotReloadQualifiedMethodIdentity CreateUnchangedMethodIdentity(
             string assemblyName,
             TransformWorkerUnchangedMethodDto unchanged)
         {
@@ -437,10 +445,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 unchanged.methodName,
                 unchanged.parameterTypeFullNames,
                 unchanged.genericArity);
-            return CreateIdentity(assemblyName, methodKey);
+            return new HotReloadQualifiedMethodIdentity(assemblyName, methodKey);
         }
 
-        private static HotReloadQualifiedMethodIdentity CreateIdentity(
+        private static HotReloadQualifiedMethodIdentity CreateTargetIdentity(
             HotReloadCallSiteScanner.CompiledMethodIdentity target)
         {
             string methodKey = HotReloadMethodKeys.BuildMethodKeyParts(
@@ -448,21 +456,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 target.MethodName,
                 target.ParameterTypeFullNames,
                 target.GenericArity);
-            return CreateIdentity(target.AssemblyName, methodKey);
+            return new HotReloadQualifiedMethodIdentity(target.AssemblyName, methodKey);
         }
 
-        private static HotReloadQualifiedMethodIdentity CreateIdentity(
+        private static HotReloadQualifiedMethodIdentity CreateCallerIdentity(
             HotReloadCallSiteScanner.CallSiteHit hit)
         {
             Debug.Assert(hit != null, "hit must not be null.");
-            return CreateIdentity(hit.CallerAssemblyName, hit.CallerMethodKey);
-        }
-
-        private static HotReloadQualifiedMethodIdentity CreateIdentity(
-            string assemblyName,
-            string methodKey)
-        {
-            return new HotReloadQualifiedMethodIdentity(assemblyName, methodKey);
+            return new HotReloadQualifiedMethodIdentity(hit.CallerAssemblyName, hit.CallerMethodKey);
         }
 
         internal static string FormatCallerShortName(string wireKey)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
@@ -35,9 +35,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 removedSignatures);
             List<HotReloadCallSiteScanner.CallSiteHit> hits =
                 HotReloadCallSiteScanner.FindCallSites(context.ProjectRoot, targets).Hits;
-            HashSet<string> coveredKeys = HotReloadSignatureChangeCoverage.CollectCoveredMethodKeys(entries, targets);
-            Dictionary<string, List<string>> uncoveredCallersByTarget =
-                HotReloadSignatureChangeCoverage.CollectUncoveredCallersByTarget(hits, coveredKeys);
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget =
+                CollectInitialUncoveredCallers(context.AssemblyName, entries, targets, hits);
 
             List<string> staleWarnings = HotReloadSignatureChangeCoverage.CollectStaleSignatureWarnings(
                 removedSignatures,
@@ -54,14 +53,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             HotReloadShimIsolation.IsolationExclusions exclusions = HotReloadShimIsolation.BuildIsolationExclusions(gatedReplacements, entries);
-            Dictionary<string, HashSet<string>> editedFileMethodKeysByFile =
-                HotReloadSignatureChangeCoverage.CollectEditedFileMethodKeysByFile(
+            Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>> editedFileMethodIdentitiesByFile =
+                HotReloadSignatureChangeCoverage.CollectEditedFileMethodIdentitiesByFile(
+                    context.AssemblyName,
                     entries,
                     context.WorkerOutput.unchangedMethods ?? Array.Empty<TransformWorkerUnchangedMethodDto>());
             List<HotReloadMethodOutcome> skippedOutcomes = BuildGatedReplacementSkipOutcomes(
                 gatedReplacements,
                 uncoveredCallersByTarget,
-                editedFileMethodKeysByFile,
+                editedFileMethodIdentitiesByFile,
                 context.GroupFilePaths);
             skippedOutcomes.AddRange(
                 HotReloadShimIsolation.BuildSkippedCallerOutcomes(
@@ -116,6 +116,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return replacements;
+        }
+
+        /// <summary>
+        /// Classifies scanned callers against the first worker output using the edited assembly.
+        /// </summary>
+        internal static Dictionary<string, List<HotReloadQualifiedMethodIdentity>> CollectInitialUncoveredCallers(
+            string assemblyName,
+            TransformWorkerEntryDto[] entries,
+            HotReloadCallSiteScanner.CompiledMethodIdentity[] targets,
+            IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits)
+        {
+            HashSet<HotReloadQualifiedMethodIdentity> coveredIdentities =
+                HotReloadSignatureChangeCoverage.CollectCoveredMethodIdentities(
+                    assemblyName,
+                    entries,
+                    targets);
+            return HotReloadSignatureChangeCoverage.CollectUncoveredCallersByTarget(
+                hits,
+                coveredIdentities);
         }
 
         private static HotReloadCallSiteScanner.CompiledMethodIdentity[] CollectScanTargets(
@@ -183,13 +202,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static List<TransformWorkerEntryDto> CollectGatedReplacementEntries(
             IReadOnlyList<TransformWorkerEntryDto> replacementEntries,
-            Dictionary<string, List<string>> uncoveredCallersByTarget)
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget)
         {
             List<TransformWorkerEntryDto> gated = new List<TransformWorkerEntryDto>();
             foreach (TransformWorkerEntryDto entry in replacementEntries)
             {
                 string methodKey = HotReloadMethodKeys.BuildMethodKey(entry);
-                if (uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> callers)
+                if (uncoveredCallersByTarget.TryGetValue(
+                        methodKey,
+                        out List<HotReloadQualifiedMethodIdentity> callers)
                     && callers.Count > 0)
                 {
                     gated.Add(entry);
@@ -231,10 +252,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 entry.genericArity);
         }
 
-        private static List<HotReloadMethodOutcome> BuildGatedReplacementSkipOutcomes(
+        internal static List<HotReloadMethodOutcome> BuildGatedReplacementSkipOutcomes(
             IReadOnlyList<TransformWorkerEntryDto> gatedReplacements,
-            Dictionary<string, List<string>> uncoveredCallersByTarget,
-            Dictionary<string, HashSet<string>> editedFileMethodKeysByFile,
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget,
+            Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>> editedFileMethodIdentitiesByFile,
             HotReloadGroupFilePaths groupFilePaths)
         {
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
@@ -256,11 +277,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Why this entry's own file: a caller edited in a sibling file of the group is
                 // not a same-file caller, and telling the user otherwise points them at the
                 // wrong file.
-                else if (uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> uncoveredCallers)
-                    && editedFileMethodKeysByFile.TryGetValue(
+                else if (uncoveredCallersByTarget.TryGetValue(
+                             methodKey,
+                             out List<HotReloadQualifiedMethodIdentity> uncoveredCallers)
+                    && editedFileMethodIdentitiesByFile.TryGetValue(
                         entry.sourceProjectRelativePath,
-                        out HashSet<string> editedFileMethodKeys)
-                    && HotReloadSignatureChangeCoverage.AreAllUncoveredCallersInEditedFile(uncoveredCallers, editedFileMethodKeys))
+                        out HashSet<HotReloadQualifiedMethodIdentity> editedFileMethodIdentities)
+                    && HotReloadSignatureChangeCoverage.AreAllUncoveredCallersInEditedFile(
+                        uncoveredCallers,
+                        editedFileMethodIdentities))
                 {
                     reason = string.Format(
                         HotReloadConstants.SignatureChangedGateSkipReasonSameFileCallersFormat,


### PR DESCRIPTION
## Summary

- Prevent unsafe hot-reload signature changes when callers in different assemblies share the same method key.

## User Impact

- A changed return type is no longer treated as safe merely because an unrelated assembly contains a caller with the same metadata name.
- Unsafe replacements now retain the generic compile guidance instead of being described as same-file callers.

## Changes

- Keep assembly identity together with method keys throughout initial and final coverage checks, gate classification, and re-patched notices.
- Add compiled two-assembly scanner fixtures plus focused coverage regressions.

## Verification

- `scripts/build-go-cli.sh`
- `dist/darwin-arm64/uloop compile --project-path "$PWD"` (Success=true, ErrorCount=0)
- `dist/darwin-arm64/uloop run-tests --project-path "$PWD" --test-mode EditMode --filter-type class --filter-value HotReloadSignatureChangeCoverageTests --unsaved-changes fail` (6 passed)
- `dist/darwin-arm64/uloop run-tests --project-path "$PWD" --test-mode EditMode --filter-type class --filter-value HotReloadCallSiteScannerTests --unsaved-changes fail` (14 passed)
- `CODE_FILE_LENGTH_FAIL_ON_EXCEEDED=true scripts/check-file-length.sh`
- `dotnet run --project tools/UnityCliLoop.CodeComplexity -- --root . --max-complexity 15 --fail-on-exceeded true`
- `(cd cli/release-automation && go run ./cmd/check-asmdef-policy --root ../..)`

Build and Test does not run for this pull request base branch; the focused local checks above are the verification for this change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

