### PR TITLE
fix: Preserve final signature caller coverage

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Tests the group processor boundary between final coverage validation and application.
+    /// </summary>
+    public class HotReloadGroupProcessorTests
+    {
+        private const string AssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+        private const string CallerKey = "Coverage.Host::Caller()";
+        private const string TargetKey = "Coverage.Host::Target()";
+
+        /// <summary>
+        /// A two-file coverage loss fails both files before the application continuation runs.
+        /// </summary>
+        [Test]
+        public async Task CompleteApplyAfterCoverageAsync_DroppedSourceLiveCaller_FailsEveryFileWithoutContinuation()
+        {
+            HotReloadApplyContext context = CreateContext();
+            TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult = CreateGateResult();
+            HotReloadGroupCompileResult compile = CreateCompile(target);
+            int continuationCalls = 0;
+
+            IReadOnlyList<HotReloadFileProcessResult> results =
+                await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                    context,
+                    gateResult,
+                    compile,
+                    () =>
+                    {
+                        continuationCalls++;
+                        return Task.FromResult<IReadOnlyList<HotReloadFileProcessResult>>(
+                            Array.Empty<HotReloadFileProcessResult>());
+                    });
+
+            Assert.That(continuationCalls, Is.EqualTo(0));
+            Assert.That(results, Has.Count.EqualTo(2));
+            foreach (HotReloadFileProcessResult result in results)
+            {
+                Assert.That(result.PatchedCount, Is.EqualTo(0));
+                Assert.That(result.Outcomes, Has.Count.EqualTo(1));
+                Assert.That(result.Outcomes[0].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Failed));
+                Assert.That(result.Outcomes[0].Method, Is.EqualTo("(signature-change-gate)"));
+                Assert.That(result.Outcomes[0].Reason, Does.Contain(TargetKey));
+            }
+        }
+
+        /// <summary>
+        /// A final source-live caller permits the continuation and preserves its returned results.
+        /// </summary>
+        [Test]
+        public async Task CompleteApplyAfterCoverageAsync_RetainedCaller_InvokesContinuationAndReturnsItsResults()
+        {
+            HotReloadApplyContext context = CreateContext();
+            TransformWorkerEntryDto caller = CreateCallerEntry("Assets/CoverageCaller.cs");
+            TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult = CreateGateResult();
+            HotReloadGroupCompileResult compile = CreateCompile(caller, target);
+            int continuationCalls = 0;
+            IReadOnlyList<HotReloadFileProcessResult> expected =
+                new[] { new HotReloadFileProcessResult(new List<HotReloadMethodOutcome>(), new List<string>(), 1) };
+
+            IReadOnlyList<HotReloadFileProcessResult> results =
+                await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                    context,
+                    gateResult,
+                    compile,
+                    () =>
+                    {
+                        continuationCalls++;
+                        return Task.FromResult(expected);
+                    });
+
+            Assert.That(continuationCalls, Is.EqualTo(1));
+            Assert.That(results, Is.SameAs(expected));
+        }
+
+        private static HotReloadSignatureChangeGate.SignatureChangeGateResult CreateGateResult()
+        {
+            return HotReloadSignatureChangeGate.SignatureChangeGateResult.WarningsOnly(
+                new List<string>(),
+                new List<HotReloadCallSiteScanner.CallSiteHit>
+                {
+                    new HotReloadCallSiteScanner.CallSiteHit
+                    {
+                        CallerAssemblyName = AssemblyName,
+                        CallerMethodKey = CallerKey,
+                        CallerTypeMetadataName = "Coverage.Host",
+                        CallerMethodName = "Caller",
+                        CallerParameterTypeFullNames = Array.Empty<string>(),
+                        TargetMethodKey = TargetKey
+                    }
+                },
+                new HashSet<HotReloadQualifiedMethodIdentity>());
+        }
+
+        private static HotReloadGroupCompileResult CreateCompile(params TransformWorkerEntryDto[] entries)
+        {
+            return HotReloadGroupCompileResult.Apply(
+                entries,
+                HotReloadShimCompileResult.SuccessResult(
+                    typeof(HotReloadGroupProcessorTests).Assembly,
+                    new byte[] { 1 },
+                    Array.Empty<byte>()));
+        }
+
+        private static HotReloadApplyContext CreateContext()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            Assembly compilationAssembly = FindCompilationAssembly();
+            HotReloadGroupFile callerFile = CreateFile(
+                "Assets/CoverageCaller.cs", projectRoot, compilationAssembly);
+            HotReloadGroupFile targetFile = CreateFile(
+                "Assets/CoverageTarget.cs", projectRoot, compilationAssembly);
+            TransformWorkerEntryDto caller = CreateCallerEntry(callerFile.ProjectRelativePath);
+            TransformWorkerEntryDto target = CreateTargetEntry(targetFile.ProjectRelativePath);
+            TransformWorkerOutputDto workerOutput = new TransformWorkerOutputDto
+            {
+                entries = new[] { caller, target },
+                skipped = Array.Empty<TransformWorkerSkippedDto>(),
+                unchangedMethods = Array.Empty<TransformWorkerUnchangedMethodDto>(),
+                files = new[] { callerFile.FileOutput, targetFile.FileOutput }
+            };
+            return new HotReloadApplyContext(
+                projectRoot, AssemblyName, "coverage-test", compilationAssembly,
+                callerFile.TargetDllPath, compilationAssembly.defines ?? Array.Empty<string>(),
+                new TransformWorkerInputDto
+                {
+                    sources = new[]
+                    {
+                        new TransformWorkerSourceDto { projectRelativePath = callerFile.ProjectRelativePath },
+                        new TransformWorkerSourceDto { projectRelativePath = targetFile.ProjectRelativePath }
+                    }
+                },
+                workerOutput,
+                new[] { callerFile, targetFile });
+        }
+
+        private static Assembly FindCompilationAssembly()
+        {
+            foreach (Assembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name == AssemblyName)
+                {
+                    return assembly;
+                }
+            }
+
+            Assert.Fail("Compilation assembly was not found.");
+            return null;
+        }
+
+        private static HotReloadGroupFile CreateFile(string path, string projectRoot, Assembly compilationAssembly)
+        {
+            HotReloadGroupFile file = new HotReloadGroupFile(
+                path, path, path, AssemblyName, compilationAssembly,
+                Path.Combine(projectRoot, "Library", "ScriptAssemblies", AssemblyName + ".dll"),
+                projectRoot, new HotReloadFileSinks(new List<string>(), null));
+            file.FileOutput = new TransformWorkerFileOutputDto
+            {
+                projectRelativePath = path,
+                removedMethodSignatures = Array.Empty<TransformWorkerRemovedMethodSignatureDto>()
+            };
+            file.SnapshotLabels = new HashSet<string>();
+            file.SnapshotAddedLabels = new HashSet<string>();
+            return file;
+        }
+
+        private static TransformWorkerEntryDto CreateCallerEntry(string path)
+        {
+            return new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = path,
+                typeMetadataName = "Coverage.Host",
+                methodName = "Caller",
+                parameterTypeFullNames = Array.Empty<string>(),
+                genericArity = 0,
+                replacesCompiledMethod = true
+            };
+        }
+
+        private static TransformWorkerEntryDto CreateTargetEntry(string path)
+        {
+            return new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = path,
+                typeMetadataName = "Coverage.Host",
+                methodName = "Target",
+                parameterTypeFullNames = Array.Empty<string>(),
+                genericArity = 0,
+                replacesCompiledMethod = true
+            };
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -29,7 +29,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             HotReloadApplyContext context = CreateContext();
             TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
-            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult = CreateGateResult();
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult = CreateGateResultWithoutExemptions();
             HotReloadGroupCompileResult compile = CreateCompile(target);
             int continuationCalls = 0;
 
@@ -47,13 +47,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(continuationCalls, Is.EqualTo(0));
             Assert.That(results, Has.Count.EqualTo(2));
-            foreach (HotReloadFileProcessResult result in results)
+            string[] expectedPaths = { "Assets/CoverageCaller.cs", "Assets/CoverageTarget.cs" };
+            for (int index = 0; index < results.Count; index++)
             {
+                HotReloadFileProcessResult result = results[index];
                 Assert.That(result.PatchedCount, Is.EqualTo(0));
                 Assert.That(result.Outcomes, Has.Count.EqualTo(1));
                 Assert.That(result.Outcomes[0].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Failed));
                 Assert.That(result.Outcomes[0].Method, Is.EqualTo("(signature-change-gate)"));
                 Assert.That(result.Outcomes[0].Reason, Does.Contain(TargetKey));
+                Assert.That(result.Outcomes[0].FilePath, Is.EqualTo(expectedPaths[index]));
             }
         }
 
@@ -66,7 +69,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadApplyContext context = CreateContext();
             TransformWorkerEntryDto caller = CreateCallerEntry("Assets/CoverageCaller.cs");
             TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
-            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult = CreateGateResult();
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult = CreateGateResultWithoutExemptions();
             HotReloadGroupCompileResult compile = CreateCompile(caller, target);
             int continuationCalls = 0;
             IReadOnlyList<HotReloadFileProcessResult> expected =
@@ -87,7 +90,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(results, Is.SameAs(expected));
         }
 
-        private static HotReloadSignatureChangeGate.SignatureChangeGateResult CreateGateResult()
+        /// <summary>
+        /// A deletion exemption carried by the gate covers a caller absent from final entries.
+        /// </summary>
+        [Test]
+        public async Task CompleteApplyAfterCoverageAsync_DeletedCallerExemption_InvokesContinuationAndReturnsItsResults()
+        {
+            HotReloadApplyContext context = CreateContext();
+            TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
+            HotReloadGroupCompileResult compile = CreateCompile(target);
+            int continuationCalls = 0;
+            IReadOnlyList<HotReloadFileProcessResult> expected =
+                new[] { new HotReloadFileProcessResult(new List<HotReloadMethodOutcome>(), new List<string>(), 1) };
+
+            IReadOnlyList<HotReloadFileProcessResult> results =
+                await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                    context,
+                    CreateGateResultWithDeletedCallerExemption(),
+                    compile,
+                    () =>
+                    {
+                        continuationCalls++;
+                        return Task.FromResult(expected);
+                    });
+
+            Assert.That(continuationCalls, Is.EqualTo(1));
+            Assert.That(results, Is.SameAs(expected));
+        }
+
+        private static HotReloadSignatureChangeGate.SignatureChangeGateResult CreateGateResultWithoutExemptions()
         {
             return HotReloadSignatureChangeGate.SignatureChangeGateResult.WarningsOnly(
                 new List<string>(),
@@ -104,6 +135,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     }
                 },
                 new HashSet<HotReloadQualifiedMethodIdentity>());
+        }
+
+        private static HotReloadSignatureChangeGate.SignatureChangeGateResult CreateGateResultWithDeletedCallerExemption()
+        {
+            HashSet<HotReloadQualifiedMethodIdentity> exemptions =
+                new HashSet<HotReloadQualifiedMethodIdentity>
+                {
+                    new HotReloadQualifiedMethodIdentity(AssemblyName, CallerKey)
+                };
+            return HotReloadSignatureChangeGate.SignatureChangeGateResult.WarningsOnly(
+                new List<string>(),
+                new List<HotReloadCallSiteScanner.CallSiteHit>
+                {
+                    new HotReloadCallSiteScanner.CallSiteHit
+                    {
+                        CallerAssemblyName = AssemblyName,
+                        CallerMethodKey = CallerKey,
+                        CallerTypeMetadataName = "Coverage.Host",
+                        CallerMethodName = "Caller",
+                        CallerParameterTypeFullNames = Array.Empty<string>(),
+                        TargetMethodKey = TargetKey
+                    }
+                },
+                exemptions);
         }
 
         private static HotReloadGroupCompileResult CreateCompile(params TransformWorkerEntryDto[] entries)

--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c04946f0d3b644518c747bda93d96fa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -4857,7 +4857,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "TestAssembly",
                 new[] { replacement, caller },
                 hits,
-                new[] { "Host::Target(System.Int32)" });
+                new HashSet<HotReloadQualifiedMethodIdentity>());
 
             Assert.That(lost, Is.Empty);
         }
@@ -4879,7 +4879,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "TestAssembly",
                 new[] { replacement },
                 hits,
-                new[] { "Host::Target(System.Int32)" });
+                new HashSet<HotReloadQualifiedMethodIdentity>());
 
             Assert.That(lost, Is.EqualTo(new[] { "Host::Target(System.Int32)" }));
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
@@ -30,8 +30,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HotReloadSignatureChangeGate.CollectInitialUncoveredCallers(
                     EditedAssemblyName,
                     new[] { localCaller },
-                    Array.Empty<HotReloadCallSiteScanner.CompiledMethodIdentity>(),
-                    new[] { hit });
+                    new[] { hit },
+                    new HashSet<HotReloadQualifiedMethodIdentity>());
 
             Assert.That(uncovered, Does.ContainKey(ReplacementKey));
             Assert.That(
@@ -52,8 +52,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HotReloadSignatureChangeGate.CollectInitialUncoveredCallers(
                     EditedAssemblyName,
                     new[] { localCaller },
-                    Array.Empty<HotReloadCallSiteScanner.CompiledMethodIdentity>(),
-                    new[] { hit });
+                    new[] { hit },
+                    new HashSet<HotReloadQualifiedMethodIdentity>());
 
             Assert.That(uncovered, Is.Empty);
         }
@@ -160,8 +160,152 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 EditedAssemblyName,
                 new[] { replacement, localCaller },
                 new[] { hit },
-                new[] { ReplacementKey });
+                new HashSet<HotReloadQualifiedMethodIdentity>());
 
+            Assert.That(losses, Is.EqualTo(new[] { ReplacementKey }));
+        }
+
+        /// <summary>
+        /// A caller replacement that disappears after the gate retry is not treated as a deletion.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_DroppedSourceLiveCaller_GatesRemainingReplacement()
+        {
+            TransformWorkerEntryDto callerReplacement = CreateOrdinaryEntry();
+            callerReplacement.replacesCompiledMethod = true;
+            TransformWorkerEntryDto targetReplacement = CreateReplacementEntry();
+            HashSet<HotReloadQualifiedMethodIdentity> exemptions = HotReloadDeletedCallerExemptions.Collect(
+                EditedAssemblyName,
+                new[] { callerReplacement, targetReplacement },
+                Array.Empty<TransformWorkerUnchangedMethodDto>(),
+                Array.Empty<TransformWorkerSkippedDto>(),
+                Array.Empty<TransformWorkerRemovedMethodSignatureDto>());
+
+            List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                new[] { CreateHit(EditedAssemblyName) },
+                exemptions);
+
+            Assert.That(losses, Is.EqualTo(new[] { ReplacementKey }));
+        }
+
+        /// <summary>
+        /// A caller replacement that remains in the final apply set covers its target.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_RetainedSourceLiveCaller_AllowsRemainingReplacement()
+        {
+            TransformWorkerEntryDto callerReplacement = CreateOrdinaryEntry();
+            callerReplacement.replacesCompiledMethod = true;
+            TransformWorkerEntryDto targetReplacement = CreateReplacementEntry();
+            HashSet<HotReloadQualifiedMethodIdentity> exemptions = HotReloadDeletedCallerExemptions.Collect(
+                EditedAssemblyName,
+                new[] { callerReplacement, targetReplacement },
+                Array.Empty<TransformWorkerUnchangedMethodDto>(),
+                Array.Empty<TransformWorkerSkippedDto>(),
+                Array.Empty<TransformWorkerRemovedMethodSignatureDto>());
+
+            List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                EditedAssemblyName,
+                new[] { callerReplacement, targetReplacement },
+                new[] { CreateHit(EditedAssemblyName) },
+                exemptions);
+
+            Assert.That(losses, Is.Empty);
+        }
+
+        /// <summary>
+        /// A caller absent from the initial source-live rows remains a deletion exemption.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_DeletedCaller_AllowsRemainingReplacement()
+        {
+            TransformWorkerEntryDto targetReplacement = CreateReplacementEntry();
+            HashSet<HotReloadQualifiedMethodIdentity> exemptions = HotReloadDeletedCallerExemptions.Collect(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                Array.Empty<TransformWorkerUnchangedMethodDto>(),
+                Array.Empty<TransformWorkerSkippedDto>(),
+                new[] { CreateCallerRemovedSignature() });
+
+            List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                new[] { CreateHit(EditedAssemblyName) },
+                exemptions);
+
+            Assert.That(losses, Is.Empty);
+        }
+
+        /// <summary>
+        /// A deleted local caller does not exempt a same-key caller from another assembly.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_ExternalSameKeyCaller_IsNotDeletionExempt()
+        {
+            TransformWorkerEntryDto targetReplacement = CreateReplacementEntry();
+            HashSet<HotReloadQualifiedMethodIdentity> exemptions = HotReloadDeletedCallerExemptions.Collect(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                Array.Empty<TransformWorkerUnchangedMethodDto>(),
+                Array.Empty<TransformWorkerSkippedDto>(),
+                new[] { CreateCallerRemovedSignature() });
+
+            List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                new[] { CreateHit(ExternalAssemblyName) },
+                exemptions);
+
+            Assert.That(losses, Is.EqualTo(new[] { ReplacementKey }));
+        }
+
+        /// <summary>
+        /// An unidentified initial skipped row removes every deletion exemption.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_UnknownSkippedMethodKey_GatesRemainingReplacement()
+        {
+            TransformWorkerEntryDto targetReplacement = CreateReplacementEntry();
+            HashSet<HotReloadQualifiedMethodIdentity> exemptions = HotReloadDeletedCallerExemptions.Collect(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                Array.Empty<TransformWorkerUnchangedMethodDto>(),
+                new[] { new TransformWorkerSkippedDto() },
+                new[] { CreateCallerRemovedSignature() });
+
+            List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                new[] { CreateHit(EditedAssemblyName) },
+                exemptions);
+
+            Assert.That(exemptions, Is.Empty);
+            Assert.That(losses, Is.EqualTo(new[] { ReplacementKey }));
+        }
+
+        /// <summary>
+        /// A keyed skipped caller remains source-live and is not a deletion exemption.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_KeyedSkippedCaller_GatesRemainingReplacement()
+        {
+            TransformWorkerEntryDto targetReplacement = CreateReplacementEntry();
+            HashSet<HotReloadQualifiedMethodIdentity> exemptions = HotReloadDeletedCallerExemptions.Collect(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                Array.Empty<TransformWorkerUnchangedMethodDto>(),
+                new[] { new TransformWorkerSkippedDto { methodKey = CallerKey } },
+                new[] { CreateCallerRemovedSignature() });
+
+            List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                new[] { CreateHit(EditedAssemblyName) },
+                exemptions);
+
+            Assert.That(exemptions, Is.Empty);
             Assert.That(losses, Is.EqualTo(new[] { ReplacementKey }));
         }
 
@@ -235,6 +379,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 parameterTypeFullNames = Array.Empty<string>(),
                 genericArity = 0,
                 replacesCompiledMethod = true
+            };
+        }
+
+        private static TransformWorkerRemovedMethodSignatureDto CreateCallerRemovedSignature()
+        {
+            return new TransformWorkerRemovedMethodSignatureDto
+            {
+                typeMetadataName = "Example.Caller",
+                methodName = "Call",
+                parameterTypeFullNames = Array.Empty<string>(),
+                genericArity = 0
             };
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
@@ -179,7 +179,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 new[] { callerReplacement, targetReplacement },
                 Array.Empty<TransformWorkerUnchangedMethodDto>(),
                 Array.Empty<TransformWorkerSkippedDto>(),
-                Array.Empty<TransformWorkerRemovedMethodSignatureDto>());
+                new[] { CreateCallerRemovedSignature() });
 
             List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
                 EditedAssemblyName,
@@ -204,7 +204,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 new[] { callerReplacement, targetReplacement },
                 Array.Empty<TransformWorkerUnchangedMethodDto>(),
                 Array.Empty<TransformWorkerSkippedDto>(),
-                Array.Empty<TransformWorkerRemovedMethodSignatureDto>());
+                new[] { CreateCallerRemovedSignature() });
 
             List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
                 EditedAssemblyName,
@@ -213,6 +213,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 exemptions);
 
             Assert.That(losses, Is.Empty);
+        }
+
+        /// <summary>
+        /// An unchanged initial caller is source-live and cannot become a deletion exemption.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_UnchangedSourceLiveCaller_GatesRemainingReplacement()
+        {
+            TransformWorkerEntryDto targetReplacement = CreateReplacementEntry();
+            HashSet<HotReloadQualifiedMethodIdentity> exemptions = HotReloadDeletedCallerExemptions.Collect(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                new[] { CreateCallerUnchangedMethod() },
+                Array.Empty<TransformWorkerSkippedDto>(),
+                new[] { CreateCallerRemovedSignature() });
+
+            List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                new[] { CreateHit(EditedAssemblyName) },
+                exemptions);
+
+            Assert.That(exemptions, Is.Empty);
+            Assert.That(losses, Is.EqualTo(new[] { ReplacementKey }));
         }
 
         /// <summary>
@@ -386,6 +410,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             return new TransformWorkerRemovedMethodSignatureDto
             {
+                typeMetadataName = "Example.Caller",
+                methodName = "Call",
+                parameterTypeFullNames = Array.Empty<string>(),
+                genericArity = 0
+            };
+        }
+
+        private static TransformWorkerUnchangedMethodDto CreateCallerUnchangedMethod()
+        {
+            return new TransformWorkerUnchangedMethodDto
+            {
+                sourceProjectRelativePath = "Assets/Fixture.cs",
                 typeMetadataName = "Example.Caller",
                 methodName = "Call",
                 parameterTypeFullNames = Array.Empty<string>(),

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -1560,6 +1560,51 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// A return-type replacement skipped by the added-call guard keeps its removed signature
+        /// and reports the replacement wire key.
+        /// </summary>
+        [Test]
+        public async Task Classify_ReturnTypeChangeSkippedByAddedCallGuard_ReportsRemovedSignatureAndMethodKey()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public virtual int AddedVirtual(int value)\n        {\n            return value;\n        }");
+            edited = edited.Replace(
+                "        public int ExistingValue()\n        {\n            return 1;\n        }",
+                "        public long ExistingValue()\n        {\n            return AddedVirtual(1);\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("ReturnTypeGuardSkip.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingValue)), Is.Null);
+            Assert.That(
+                HasRemovedSignature(
+                    result.Output.files[0],
+                    typeof(HotReloadAddedMemberHost).FullName,
+                    nameof(HotReloadAddedMemberHost.ExistingValue)),
+                Is.True);
+
+            TransformWorkerSkippedDto skippedReplacement = null;
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                if (skipped.method != null
+                    && skipped.method.Contains(nameof(HotReloadAddedMemberHost.ExistingValue)))
+                {
+                    skippedReplacement = skipped;
+                    break;
+                }
+            }
+
+            Assert.That(skippedReplacement, Is.Not.Null);
+            Assert.That(
+                skippedReplacement.methodKey,
+                Is.EqualTo(BuildHostMethodKey(nameof(HotReloadAddedMemberHost.ExistingValue))));
+        }
+
+        /// <summary>
         /// What: a return-type change that is also virtual is skipped with the existing
         /// added-method vtable reason.
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDeletedCallerExemptions.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDeletedCallerExemptions.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Identifies removed callers that cannot remain compiled after the initial worker output.
+    /// </summary>
+    internal static class HotReloadDeletedCallerExemptions
+    {
+        internal static HashSet<HotReloadQualifiedMethodIdentity> Collect(
+            string assemblyName,
+            TransformWorkerEntryDto[] entries,
+            TransformWorkerUnchangedMethodDto[] unchangedMethods,
+            TransformWorkerSkippedDto[] skipped,
+            TransformWorkerRemovedMethodSignatureDto[] removedSignatures)
+        {
+            if (ContainsUnknownSkippedMethodKey(skipped))
+            {
+                // A skipped row without an identity might be a live compiled caller. Do not
+                // exempt any deletion when that fact cannot be established from worker output.
+                return new HashSet<HotReloadQualifiedMethodIdentity>();
+            }
+
+            HashSet<HotReloadQualifiedMethodIdentity> sourceLiveIdentities =
+                CollectSourceLiveIdentities(assemblyName, entries, unchangedMethods, skipped);
+            HashSet<HotReloadQualifiedMethodIdentity> deletedCallerExemptions =
+                new HashSet<HotReloadQualifiedMethodIdentity>();
+            foreach (TransformWorkerRemovedMethodSignatureDto removedSignature in removedSignatures)
+            {
+                HotReloadQualifiedMethodIdentity identity = new HotReloadQualifiedMethodIdentity(
+                    assemblyName,
+                    HotReloadMethodKeys.BuildMethodKeyParts(
+                        removedSignature.typeMetadataName,
+                        removedSignature.methodName,
+                        removedSignature.parameterTypeFullNames,
+                        removedSignature.genericArity));
+                if (!sourceLiveIdentities.Contains(identity))
+                {
+                    deletedCallerExemptions.Add(identity);
+                }
+            }
+
+            return deletedCallerExemptions;
+        }
+
+        private static bool ContainsUnknownSkippedMethodKey(TransformWorkerSkippedDto[] skipped)
+        {
+            foreach (TransformWorkerSkippedDto skippedMethod in skipped)
+            {
+                if (string.IsNullOrEmpty(skippedMethod.methodKey))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static HashSet<HotReloadQualifiedMethodIdentity> CollectSourceLiveIdentities(
+            string assemblyName,
+            TransformWorkerEntryDto[] entries,
+            TransformWorkerUnchangedMethodDto[] unchangedMethods,
+            TransformWorkerSkippedDto[] skipped)
+        {
+            HashSet<HotReloadQualifiedMethodIdentity> identities =
+                new HashSet<HotReloadQualifiedMethodIdentity>();
+            foreach (TransformWorkerEntryDto entry in entries)
+            {
+                identities.Add(new HotReloadQualifiedMethodIdentity(
+                    assemblyName,
+                    HotReloadMethodKeys.BuildMethodKey(entry)));
+            }
+
+            foreach (TransformWorkerUnchangedMethodDto unchangedMethod in unchangedMethods)
+            {
+                identities.Add(new HotReloadQualifiedMethodIdentity(
+                    assemblyName,
+                    HotReloadMethodKeys.BuildMethodKeyParts(
+                        unchangedMethod.typeMetadataName,
+                        unchangedMethod.methodName,
+                        unchangedMethod.parameterTypeFullNames,
+                        unchangedMethod.genericArity)));
+            }
+
+            foreach (TransformWorkerSkippedDto skippedMethod in skipped)
+            {
+                identities.Add(new HotReloadQualifiedMethodIdentity(assemblyName, skippedMethod.methodKey));
+            }
+
+            return identities;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDeletedCallerExemptions.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDeletedCallerExemptions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c53f0e3b5feb4e3bbc36d3b8393f6f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -127,22 +127,36 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return BuildUnappliedResults(files);
             }
 
+            return await CompleteApplyAfterCoverageAsync(
+                context,
+                gateResult,
+                compile,
+                async () =>
+                {
+                    await MainThreadSwitcher.SwitchToMainThread(ct);
+                    IReadOnlyList<HotReloadFileProcessResult> results = HotReloadEntryApplier.ApplyGroupAndBuildResults(
+                        context,
+                        compile.CompileResult,
+                        compile.EntriesToPatch);
+                    RecordSupersededSignaturesAfterApply(context, gateResult.GatedReplacementMethodKeys);
+                    return results;
+                }).ConfigureAwait(false);
+        }
+
+        // Why inject only the post-coverage continuation: coverage failure must use the real
+        // group failure routing, while tests must not invoke Harmony or main-thread work.
+        internal static async Task<IReadOnlyList<HotReloadFileProcessResult>> CompleteApplyAfterCoverageAsync(
+            HotReloadApplyContext context,
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult,
+            HotReloadGroupCompileResult compile,
+            Func<Task<IReadOnlyList<HotReloadFileProcessResult>>> continueAfterCoverage)
+        {
             if (gateResult.DidScan && !AppendSignatureChangeCoverageNotices(context, gateResult, compile))
             {
-                return BuildUnappliedResults(files);
+                return BuildUnappliedResults(context.Files);
             }
 
-            // Harmony Patch/Unpatch and method resolution against loaded modules require main thread.
-            await MainThreadSwitcher.SwitchToMainThread(ct);
-            IReadOnlyList<HotReloadFileProcessResult> results = HotReloadEntryApplier.ApplyGroupAndBuildResults(
-                context,
-                compile.CompileResult,
-                compile.EntriesToPatch);
-            // Why after apply: earlier returns (gate fail, shim compile, coverage loss)
-            // never applied the replacement, so leftover Active rows must not claim they
-            // were superseded.
-            RecordSupersededSignaturesAfterApply(context, gateResult.GatedReplacementMethodKeys);
-            return results;
+            return await continueAfterCoverage().ConfigureAwait(false);
         }
 
         // Returns false when a replacement lost its covering caller and the group must fail.
@@ -158,7 +172,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 context.AssemblyName,
                 compile.EntriesToPatch,
                 gateResult.Hits,
-                gateResult.ScanTargetKeys);
+                gateResult.DeletedCallerExemptions);
             if (lostReplacementKeys.Count > 0)
             {
                 HotReloadGroupOutcomeRouter.AppendGroupFailure(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeCoverage.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeCoverage.cs
@@ -13,24 +13,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         internal static HashSet<HotReloadQualifiedMethodIdentity> CollectCoveredMethodIdentities(
             string assemblyName,
-            TransformWorkerEntryDto[] entries,
-            HotReloadCallSiteScanner.CompiledMethodIdentity[] targets)
+            TransformWorkerEntryDto[] entries)
         {
             HashSet<HotReloadQualifiedMethodIdentity> coveredIdentities =
                 new HashSet<HotReloadQualifiedMethodIdentity>();
             foreach (TransformWorkerEntryDto entry in entries)
             {
                 coveredIdentities.Add(CreateEntryIdentity(assemblyName, entry));
-            }
-
-            foreach (HotReloadCallSiteScanner.CompiledMethodIdentity target in targets)
-            {
-                // Why include removed-signature targets: a deleted helper that called the
-                // replaced method is already stale (removed-members warning). Treating that
-                // corpse as uncovered would gate a same-file helper-delete + return-type
-                // change, which is still a consistent old world. Fail-closed only for live
-                // compiled callers that will keep invoking the old method.
-                coveredIdentities.Add(CreateTargetIdentity(target));
             }
 
             return coveredIdentities;
@@ -230,11 +219,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string assemblyName,
             TransformWorkerEntryDto[] entriesToPatch,
             IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits,
-            IReadOnlyList<string> scanTargetKeys)
+            IReadOnlyCollection<HotReloadQualifiedMethodIdentity> deletedCallerExemptions)
         {
             Debug.Assert(entriesToPatch != null, "entriesToPatch must not be null.");
             Debug.Assert(hits != null, "hits must not be null.");
-            Debug.Assert(scanTargetKeys != null, "scanTargetKeys must not be null.");
+            Debug.Assert(deletedCallerExemptions != null, "deletedCallerExemptions must not be null.");
 
             HashSet<HotReloadQualifiedMethodIdentity> coveredIdentities =
                 new HashSet<HotReloadQualifiedMethodIdentity>();
@@ -243,9 +232,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 coveredIdentities.Add(CreateEntryIdentity(assemblyName, entry));
             }
 
-            foreach (string targetKey in scanTargetKeys)
+            foreach (HotReloadQualifiedMethodIdentity deletedCallerExemption in deletedCallerExemptions)
             {
-                coveredIdentities.Add(new HotReloadQualifiedMethodIdentity(assemblyName, targetKey));
+                coveredIdentities.Add(deletedCallerExemption);
             }
 
             Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget =
@@ -269,23 +258,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return lostReplacementKeys;
-        }
-
-        internal static List<string> CollectScanTargetKeys(
-            HotReloadCallSiteScanner.CompiledMethodIdentity[] targets)
-        {
-            List<string> keys = new List<string>(targets.Length);
-            foreach (HotReloadCallSiteScanner.CompiledMethodIdentity target in targets)
-            {
-                keys.Add(
-                    HotReloadMethodKeys.BuildMethodKeyParts(
-                        target.TypeMetadataName,
-                        target.MethodName,
-                        target.ParameterTypeFullNames,
-                        target.GenericArity));
-            }
-
-            return keys;
         }
 
         internal static HashSet<HotReloadQualifiedMethodIdentity> CollectEditedFileMethodIdentities(
@@ -446,17 +418,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 unchanged.parameterTypeFullNames,
                 unchanged.genericArity);
             return new HotReloadQualifiedMethodIdentity(assemblyName, methodKey);
-        }
-
-        private static HotReloadQualifiedMethodIdentity CreateTargetIdentity(
-            HotReloadCallSiteScanner.CompiledMethodIdentity target)
-        {
-            string methodKey = HotReloadMethodKeys.BuildMethodKeyParts(
-                target.TypeMetadataName,
-                target.MethodName,
-                target.ParameterTypeFullNames,
-                target.GenericArity);
-            return new HotReloadQualifiedMethodIdentity(target.AssemblyName, methodKey);
         }
 
         private static HotReloadQualifiedMethodIdentity CreateCallerIdentity(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
@@ -33,10 +33,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 context.AssemblyName,
                 replacementEntries,
                 removedSignatures);
+            HashSet<HotReloadQualifiedMethodIdentity> deletedCallerExemptions =
+                HotReloadDeletedCallerExemptions.Collect(
+                    context.AssemblyName,
+                    entries,
+                    context.WorkerOutput.unchangedMethods ?? Array.Empty<TransformWorkerUnchangedMethodDto>(),
+                    context.WorkerOutput.skipped ?? Array.Empty<TransformWorkerSkippedDto>(),
+                    removedSignatures);
             List<HotReloadCallSiteScanner.CallSiteHit> hits =
                 HotReloadCallSiteScanner.FindCallSites(context.ProjectRoot, targets).Hits;
             Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget =
-                CollectInitialUncoveredCallers(context.AssemblyName, entries, targets, hits);
+                CollectInitialUncoveredCallers(context.AssemblyName, entries, hits, deletedCallerExemptions);
 
             List<string> staleWarnings = HotReloadSignatureChangeCoverage.CollectStaleSignatureWarnings(
                 removedSignatures,
@@ -49,7 +56,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return SignatureChangeGateResult.WarningsOnly(
                     staleWarnings,
                     hits,
-                    HotReloadSignatureChangeCoverage.CollectScanTargetKeys(targets));
+                    deletedCallerExemptions);
             }
 
             HotReloadShimIsolation.IsolationExclusions exclusions = HotReloadShimIsolation.BuildIsolationExclusions(gatedReplacements, entries);
@@ -99,7 +106,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 skippedOutcomes,
                 staleWarnings,
                 hits,
-                HotReloadSignatureChangeCoverage.CollectScanTargetKeys(targets),
+                deletedCallerExemptions,
                 gatedReplacementMethodKeys);
         }
 
@@ -124,14 +131,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal static Dictionary<string, List<HotReloadQualifiedMethodIdentity>> CollectInitialUncoveredCallers(
             string assemblyName,
             TransformWorkerEntryDto[] entries,
-            HotReloadCallSiteScanner.CompiledMethodIdentity[] targets,
-            IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits)
+            IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits,
+            IReadOnlyCollection<HotReloadQualifiedMethodIdentity> deletedCallerExemptions)
         {
             HashSet<HotReloadQualifiedMethodIdentity> coveredIdentities =
                 HotReloadSignatureChangeCoverage.CollectCoveredMethodIdentities(
                     assemblyName,
-                    entries,
-                    targets);
+                    entries);
+            coveredIdentities.UnionWith(deletedCallerExemptions);
             return HotReloadSignatureChangeCoverage.CollectUncoveredCallersByTarget(
                 hits,
                 coveredIdentities);
@@ -319,7 +326,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public List<HotReloadMethodOutcome> SkippedOutcomes { get; }
             public List<string> Warnings { get; }
             public List<HotReloadCallSiteScanner.CallSiteHit> Hits { get; }
-            public List<string> ScanTargetKeys { get; }
+            public HashSet<HotReloadQualifiedMethodIdentity> DeletedCallerExemptions { get; }
             public List<string> GatedReplacementMethodKeys { get; }
 
             private SignatureChangeGateResult(
@@ -331,7 +338,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 List<HotReloadMethodOutcome> skippedOutcomes,
                 List<string> warnings,
                 List<HotReloadCallSiteScanner.CallSiteHit> hits,
-                List<string> scanTargetKeys,
+                HashSet<HotReloadQualifiedMethodIdentity> deletedCallerExemptions,
                 List<string> gatedReplacementMethodKeys)
             {
                 FileFailed = fileFailed;
@@ -342,7 +349,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 SkippedOutcomes = skippedOutcomes ?? new List<HotReloadMethodOutcome>();
                 Warnings = warnings ?? new List<string>();
                 Hits = hits ?? new List<HotReloadCallSiteScanner.CallSiteHit>();
-                ScanTargetKeys = scanTargetKeys ?? new List<string>();
+                DeletedCallerExemptions = deletedCallerExemptions
+                    ?? new HashSet<HotReloadQualifiedMethodIdentity>();
                 GatedReplacementMethodKeys = gatedReplacementMethodKeys ?? new List<string>();
             }
 
@@ -355,10 +363,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public static SignatureChangeGateResult WarningsOnly(
                 List<string> warnings,
                 List<HotReloadCallSiteScanner.CallSiteHit> hits,
-                List<string> scanTargetKeys)
+                HashSet<HotReloadQualifiedMethodIdentity> deletedCallerExemptions)
             {
                 return new SignatureChangeGateResult(
-                    false, null, false, true, null, null, warnings, hits, scanTargetKeys, null);
+                    false, null, false, true, null, null, warnings, hits, deletedCallerExemptions, null);
             }
 
             public static SignatureChangeGateResult Failed(
@@ -383,7 +391,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 List<HotReloadMethodOutcome> skippedOutcomes,
                 List<string> warnings,
                 List<HotReloadCallSiteScanner.CallSiteHit> hits,
-                List<string> scanTargetKeys,
+                HashSet<HotReloadQualifiedMethodIdentity> deletedCallerExemptions,
                 List<string> gatedReplacementMethodKeys)
             {
                 return new SignatureChangeGateResult(
@@ -395,7 +403,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     skippedOutcomes,
                     warnings,
                     hits,
-                    scanTargetKeys,
+                    deletedCallerExemptions,
                     gatedReplacementMethodKeys);
             }
         }


### PR DESCRIPTION
## Summary

Preserve final signature-change coverage after gate isolation by separating truly deleted callers from source-live callers.

## Changes

- Carry assembly-qualified deletion exemptions from the initial worker output through the final coverage check.
- Treat keyed skipped methods as source-live and disable all deletion exemptions when any skipped method has no key.
- Fail the full group before application when final coverage loses a caller.
- Add focused coverage, worker-output, and two-file group-boundary regressions.

## Verification

- `HotReloadSignatureChangeCoverageTests`: 13 passed
- `HotReloadCallSiteScannerTests`: 14 passed
- `HotReloadGroupProcessorTests`: 2 passed
- Compile: 0 errors (existing fixture warnings remain)
- File length, complexity, and asmdef policy checks passed.

`TransformWorkerAddedMemberTests` produced no completion JSON or result XML after Unity finished its run, so it remains unverified. Build and Test does not run for this PR base; local verification above is not a substitute for it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

