### PR TITLE
fix: Prevent unsafe hot reload signature replacements

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerFixture.cs
@@ -123,6 +123,28 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     }
 
     /// <summary>
+    /// Supplies a public target with same-key callers compiled into two different assemblies.
+    /// </summary>
+    public static class HotReloadQualifiedCallerIdentityTarget
+    {
+        public static int Called()
+        {
+            return 9;
+        }
+    }
+
+    /// <summary>
+    /// Supplies the main-assembly side of a same-metadata-name internal caller pair.
+    /// </summary>
+    internal static class HotReloadQualifiedCallerIdentityCaller
+    {
+        internal static int Call()
+        {
+            return HotReloadQualifiedCallerIdentityTarget.Called();
+        }
+    }
+
+    /// <summary>
     /// Open generic host so call sites go through a constructed <c>GenericHost&lt;int&gt;</c>.
     /// </summary>
     public class GenericHost<T>

--- a/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs
@@ -28,6 +28,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string CrossAssemblyTargetTypeMetadataName =
             "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadCallSiteScannerCrossAssemblyTarget";
 
+        private const string QualifiedCallerIdentityTargetTypeMetadataName =
+            "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadQualifiedCallerIdentityTarget";
+
         /// <summary>
         /// What: a method called from an ordinary method is reported with that caller's method key.
         /// </summary>
@@ -257,6 +260,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.EqualTo(
                     "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
                     + ".HotReloadCallSiteCrossAssemblyCaller::Call()"));
+        }
+
+        /// <summary>
+        /// What: callers with the same metadata name and wire key are reported with their distinct assemblies.
+        /// </summary>
+        [Test]
+        public void FindCallSites_SameKeyCallersAcrossAssemblies_ReportsBothCallerAssemblies()
+        {
+            List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
+                QualifiedCallerIdentityTargetTypeMetadataName,
+                nameof(HotReloadQualifiedCallerIdentityTarget.Called),
+                Array.Empty<string>(),
+                0);
+            List<string> callerAssemblyNames = new List<string>();
+            foreach (HotReloadCallSiteScanner.CallSiteHit hit in hits)
+            {
+                callerAssemblyNames.Add(hit.CallerAssemblyName);
+                Assert.That(
+                    hit.CallerMethodKey,
+                    Is.EqualTo(
+                        "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                        + ".HotReloadQualifiedCallerIdentityCaller::Call()"));
+            }
+
+            Assert.That(hits, Has.Count.EqualTo(2));
+            Assert.That(
+                callerAssemblyNames,
+                Does.Contain("UnityCLILoop.Tests.Editor.HotReload"));
+            Assert.That(
+                callerAssemblyNames,
+                Does.Contain("UnityCLILoop.Tests.Editor.HotReload.CallSiteCrossAssembly"));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Tests the group processor boundary between final coverage validation and application.
+    /// </summary>
+    public class HotReloadGroupProcessorTests
+    {
+        private const string AssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+        private const string CallerKey = "Coverage.Host::Caller()";
+        private const string TargetKey = "Coverage.Host::Target()";
+
+        /// <summary>
+        /// A two-file coverage loss fails both files before the application continuation runs.
+        /// </summary>
+        [Test]
+        public async Task CompleteApplyAfterCoverageAsync_DroppedSourceLiveCaller_FailsEveryFileWithoutContinuation()
+        {
+            HotReloadApplyContext context = CreateContext();
+            TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult = CreateGateResultWithoutExemptions();
+            HotReloadGroupCompileResult compile = CreateCompile(target);
+            int continuationCalls = 0;
+
+            IReadOnlyList<HotReloadFileProcessResult> results =
+                await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                    context,
+                    gateResult,
+                    compile,
+                    () =>
+                    {
+                        continuationCalls++;
+                        return Task.FromResult<IReadOnlyList<HotReloadFileProcessResult>>(
+                            Array.Empty<HotReloadFileProcessResult>());
+                    });
+
+            Assert.That(continuationCalls, Is.EqualTo(0));
+            Assert.That(results, Has.Count.EqualTo(2));
+            string[] expectedPaths = { "Assets/CoverageCaller.cs", "Assets/CoverageTarget.cs" };
+            for (int index = 0; index < results.Count; index++)
+            {
+                HotReloadFileProcessResult result = results[index];
+                Assert.That(result.PatchedCount, Is.EqualTo(0));
+                Assert.That(result.Outcomes, Has.Count.EqualTo(1));
+                Assert.That(result.Outcomes[0].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Failed));
+                Assert.That(result.Outcomes[0].Method, Is.EqualTo("(signature-change-gate)"));
+                Assert.That(result.Outcomes[0].Reason, Does.Contain(TargetKey));
+                Assert.That(result.Outcomes[0].FilePath, Is.EqualTo(expectedPaths[index]));
+            }
+        }
+
+        /// <summary>
+        /// A final source-live caller permits the continuation and preserves its returned results.
+        /// </summary>
+        [Test]
+        public async Task CompleteApplyAfterCoverageAsync_RetainedCaller_InvokesContinuationAndReturnsItsResults()
+        {
+            HotReloadApplyContext context = CreateContext();
+            TransformWorkerEntryDto caller = CreateCallerEntry("Assets/CoverageCaller.cs");
+            TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult = CreateGateResultWithoutExemptions();
+            HotReloadGroupCompileResult compile = CreateCompile(caller, target);
+            int continuationCalls = 0;
+            IReadOnlyList<HotReloadFileProcessResult> expected =
+                new[] { new HotReloadFileProcessResult(new List<HotReloadMethodOutcome>(), new List<string>(), 1) };
+
+            IReadOnlyList<HotReloadFileProcessResult> results =
+                await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                    context,
+                    gateResult,
+                    compile,
+                    () =>
+                    {
+                        continuationCalls++;
+                        return Task.FromResult(expected);
+                    });
+
+            Assert.That(continuationCalls, Is.EqualTo(1));
+            Assert.That(results, Is.SameAs(expected));
+        }
+
+        /// <summary>
+        /// A deletion exemption carried by the gate covers a caller absent from final entries.
+        /// </summary>
+        [Test]
+        public async Task CompleteApplyAfterCoverageAsync_DeletedCallerExemption_InvokesContinuationAndReturnsItsResults()
+        {
+            HotReloadApplyContext context = CreateContext();
+            TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
+            HotReloadGroupCompileResult compile = CreateCompile(target);
+            int continuationCalls = 0;
+            IReadOnlyList<HotReloadFileProcessResult> expected =
+                new[] { new HotReloadFileProcessResult(new List<HotReloadMethodOutcome>(), new List<string>(), 1) };
+
+            IReadOnlyList<HotReloadFileProcessResult> results =
+                await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                    context,
+                    CreateGateResultWithDeletedCallerExemption(),
+                    compile,
+                    () =>
+                    {
+                        continuationCalls++;
+                        return Task.FromResult(expected);
+                    });
+
+            Assert.That(continuationCalls, Is.EqualTo(1));
+            Assert.That(results, Is.SameAs(expected));
+        }
+
+        private static HotReloadSignatureChangeGate.SignatureChangeGateResult CreateGateResultWithoutExemptions()
+        {
+            return HotReloadSignatureChangeGate.SignatureChangeGateResult.WarningsOnly(
+                new List<string>(),
+                new List<HotReloadCallSiteScanner.CallSiteHit>
+                {
+                    new HotReloadCallSiteScanner.CallSiteHit
+                    {
+                        CallerAssemblyName = AssemblyName,
+                        CallerMethodKey = CallerKey,
+                        CallerTypeMetadataName = "Coverage.Host",
+                        CallerMethodName = "Caller",
+                        CallerParameterTypeFullNames = Array.Empty<string>(),
+                        TargetMethodKey = TargetKey
+                    }
+                },
+                new HashSet<HotReloadQualifiedMethodIdentity>());
+        }
+
+        private static HotReloadSignatureChangeGate.SignatureChangeGateResult CreateGateResultWithDeletedCallerExemption()
+        {
+            HashSet<HotReloadQualifiedMethodIdentity> exemptions =
+                new HashSet<HotReloadQualifiedMethodIdentity>
+                {
+                    new HotReloadQualifiedMethodIdentity(AssemblyName, CallerKey)
+                };
+            return HotReloadSignatureChangeGate.SignatureChangeGateResult.WarningsOnly(
+                new List<string>(),
+                new List<HotReloadCallSiteScanner.CallSiteHit>
+                {
+                    new HotReloadCallSiteScanner.CallSiteHit
+                    {
+                        CallerAssemblyName = AssemblyName,
+                        CallerMethodKey = CallerKey,
+                        CallerTypeMetadataName = "Coverage.Host",
+                        CallerMethodName = "Caller",
+                        CallerParameterTypeFullNames = Array.Empty<string>(),
+                        TargetMethodKey = TargetKey
+                    }
+                },
+                exemptions);
+        }
+
+        private static HotReloadGroupCompileResult CreateCompile(params TransformWorkerEntryDto[] entries)
+        {
+            return HotReloadGroupCompileResult.Apply(
+                entries,
+                HotReloadShimCompileResult.SuccessResult(
+                    typeof(HotReloadGroupProcessorTests).Assembly,
+                    new byte[] { 1 },
+                    Array.Empty<byte>()));
+        }
+
+        private static HotReloadApplyContext CreateContext()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            Assembly compilationAssembly = FindCompilationAssembly();
+            HotReloadGroupFile callerFile = CreateFile(
+                "Assets/CoverageCaller.cs", projectRoot, compilationAssembly);
+            HotReloadGroupFile targetFile = CreateFile(
+                "Assets/CoverageTarget.cs", projectRoot, compilationAssembly);
+            TransformWorkerEntryDto caller = CreateCallerEntry(callerFile.ProjectRelativePath);
+            TransformWorkerEntryDto target = CreateTargetEntry(targetFile.ProjectRelativePath);
+            TransformWorkerOutputDto workerOutput = new TransformWorkerOutputDto
+            {
+                entries = new[] { caller, target },
+                skipped = Array.Empty<TransformWorkerSkippedDto>(),
+                unchangedMethods = Array.Empty<TransformWorkerUnchangedMethodDto>(),
+                files = new[] { callerFile.FileOutput, targetFile.FileOutput }
+            };
+            return new HotReloadApplyContext(
+                projectRoot, AssemblyName, "coverage-test", compilationAssembly,
+                callerFile.TargetDllPath, compilationAssembly.defines ?? Array.Empty<string>(),
+                new TransformWorkerInputDto
+                {
+                    sources = new[]
+                    {
+                        new TransformWorkerSourceDto { projectRelativePath = callerFile.ProjectRelativePath },
+                        new TransformWorkerSourceDto { projectRelativePath = targetFile.ProjectRelativePath }
+                    }
+                },
+                workerOutput,
+                new[] { callerFile, targetFile });
+        }
+
+        private static Assembly FindCompilationAssembly()
+        {
+            foreach (Assembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name == AssemblyName)
+                {
+                    return assembly;
+                }
+            }
+
+            Assert.Fail("Compilation assembly was not found.");
+            return null;
+        }
+
+        private static HotReloadGroupFile CreateFile(string path, string projectRoot, Assembly compilationAssembly)
+        {
+            HotReloadGroupFile file = new HotReloadGroupFile(
+                path, path, path, AssemblyName, compilationAssembly,
+                Path.Combine(projectRoot, "Library", "ScriptAssemblies", AssemblyName + ".dll"),
+                projectRoot, new HotReloadFileSinks(new List<string>(), null));
+            file.FileOutput = new TransformWorkerFileOutputDto
+            {
+                projectRelativePath = path,
+                removedMethodSignatures = Array.Empty<TransformWorkerRemovedMethodSignatureDto>()
+            };
+            file.SnapshotLabels = new HashSet<string>();
+            file.SnapshotAddedLabels = new HashSet<string>();
+            return file;
+        }
+
+        private static TransformWorkerEntryDto CreateCallerEntry(string path)
+        {
+            return new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = path,
+                typeMetadataName = "Coverage.Host",
+                methodName = "Caller",
+                parameterTypeFullNames = Array.Empty<string>(),
+                genericArity = 0,
+                replacesCompiledMethod = true
+            };
+        }
+
+        private static TransformWorkerEntryDto CreateTargetEntry(string path)
+        {
+            return new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = path,
+                typeMetadataName = "Coverage.Host",
+                methodName = "Target",
+                parameterTypeFullNames = Array.Empty<string>(),
+                genericArity = 0,
+                replacesCompiledMethod = true
+            };
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c04946f0d3b644518c747bda93d96fa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -4854,6 +4854,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             };
 
             List<string> lost = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                "TestAssembly",
                 new[] { replacement, caller },
                 hits,
                 new[] { "Host::Target(System.Int32)" });
@@ -4875,6 +4876,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             };
 
             List<string> lost = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                "TestAssembly",
                 new[] { replacement },
                 hits,
                 new[] { "Host::Target(System.Int32)" });
@@ -5000,8 +5002,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string names = HotReloadSignatureChangeCoverage.FormatUncoveredCallerShortNames(
                 new[]
                 {
-                    "Ns.Host::AlphaCaller(System.Int32)",
-                    "Ns.Outer/Inner::BetaCaller(System.Int32)"
+                    new HotReloadQualifiedMethodIdentity(
+                        "TestAssembly",
+                        "Ns.Host::AlphaCaller(System.Int32)"),
+                    new HotReloadQualifiedMethodIdentity(
+                        "TestAssembly",
+                        "Ns.Outer/Inner::BetaCaller(System.Int32)")
                 });
 
             Assert.That(names, Is.EqualTo("Host.AlphaCaller, Inner.BetaCaller"));
@@ -5316,7 +5322,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             TransformWorkerEntryDto replacement = CreateReplacementEntry("Host", "Target");
             bool sameFile = HotReloadSignatureChangeCoverage.AreUncoveredCallersInEditedFile(
-                new[] { "Host::OtherFileCaller(System.Int32)" },
+                "TestAssembly",
+                new[]
+                {
+                    new HotReloadQualifiedMethodIdentity(
+                        "TestAssembly",
+                        "Host::OtherFileCaller(System.Int32)")
+                },
                 new[] { replacement },
                 Array.Empty<TransformWorkerUnchangedMethodDto>());
 
@@ -6892,6 +6904,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             return new HotReloadCallSiteScanner.CallSiteHit
             {
+                CallerAssemblyName = "TestAssembly",
                 CallerMethodKey = callerMethodKey,
                 CallerGenericArity = 0,
                 TargetMethodKey = targetMethodKey

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -4857,7 +4857,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "TestAssembly",
                 new[] { replacement, caller },
                 hits,
-                new[] { "Host::Target(System.Int32)" });
+                new HashSet<HotReloadQualifiedMethodIdentity>());
 
             Assert.That(lost, Is.Empty);
         }
@@ -4879,7 +4879,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "TestAssembly",
                 new[] { replacement },
                 hits,
-                new[] { "Host::Target(System.Int32)" });
+                new HashSet<HotReloadQualifiedMethodIdentity>());
 
             Assert.That(lost, Is.EqualTo(new[] { "Host::Target(System.Int32)" }));
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Pure coverage tests for signature-change caller identity and gate classification.
+    /// </summary>
+    public class HotReloadSignatureChangeCoverageTests
+    {
+        private const string EditedAssemblyName = "EditedAssembly";
+        private const string ExternalAssemblyName = "ExternalAssembly";
+        private const string CallerKey = "Example.Caller::Call()";
+        private const string ReplacementKey = "Example.Target::Call()";
+
+        /// <summary>
+        /// What: a caller from another assembly with the same wire key as an edited caller stays uncovered.
+        /// </summary>
+        [Test]
+        public void CollectUncoveredCallersByTarget_ExternalSameKeyCaller_StaysUncovered()
+        {
+            TransformWorkerEntryDto localCaller = CreateOrdinaryEntry();
+            HotReloadCallSiteScanner.CallSiteHit hit = CreateHit(ExternalAssemblyName);
+
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncovered =
+                HotReloadSignatureChangeGate.CollectInitialUncoveredCallers(
+                    EditedAssemblyName,
+                    new[] { localCaller },
+                    Array.Empty<HotReloadCallSiteScanner.CompiledMethodIdentity>(),
+                    new[] { hit });
+
+            Assert.That(uncovered, Does.ContainKey(ReplacementKey));
+            Assert.That(
+                uncovered[ReplacementKey],
+                Does.Contain(new HotReloadQualifiedMethodIdentity(ExternalAssemblyName, CallerKey)));
+        }
+
+        /// <summary>
+        /// What: a caller with the same key in the edited assembly is covered by its worker entry.
+        /// </summary>
+        [Test]
+        public void CollectInitialUncoveredCallers_SameAssemblySameKeyCaller_IsCovered()
+        {
+            TransformWorkerEntryDto localCaller = CreateOrdinaryEntry();
+            HotReloadCallSiteScanner.CallSiteHit hit = CreateHit(EditedAssemblyName);
+
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncovered =
+                HotReloadSignatureChangeGate.CollectInitialUncoveredCallers(
+                    EditedAssemblyName,
+                    new[] { localCaller },
+                    Array.Empty<HotReloadCallSiteScanner.CompiledMethodIdentity>(),
+                    new[] { hit });
+
+            Assert.That(uncovered, Is.Empty);
+        }
+
+        /// <summary>
+        /// What: an external caller sharing an edited-file method key receives the generic gate reason.
+        /// </summary>
+        [Test]
+        public void BuildGatedReplacementSkipOutcomes_ExternalSameKeyCaller_UsesGenericReason()
+        {
+            TransformWorkerEntryDto replacement = CreateReplacementEntry();
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredByTarget =
+                new Dictionary<string, List<HotReloadQualifiedMethodIdentity>>(StringComparer.Ordinal)
+                {
+                    {
+                        ReplacementKey,
+                        new List<HotReloadQualifiedMethodIdentity>
+                        {
+                            new HotReloadQualifiedMethodIdentity(ExternalAssemblyName, CallerKey)
+                        }
+                    }
+                };
+            Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>> editedFileIdentities =
+                new Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>>(StringComparer.Ordinal)
+                {
+                    {
+                        replacement.sourceProjectRelativePath,
+                        new HashSet<HotReloadQualifiedMethodIdentity>
+                        {
+                            new HotReloadQualifiedMethodIdentity(EditedAssemblyName, CallerKey)
+                        }
+                    }
+                };
+            HotReloadGroupFilePaths paths = HotReloadGroupFilePaths.ForSingleFile(
+                replacement.sourceProjectRelativePath,
+                "Assembly.dll");
+
+            List<HotReloadMethodOutcome> outcomes =
+                HotReloadSignatureChangeGate.BuildGatedReplacementSkipOutcomes(
+                    new[] { replacement },
+                    uncoveredByTarget,
+                    editedFileIdentities,
+                    paths);
+
+            string expectedReason = string.Format(
+                HotReloadConstants.SignatureChangedGateSkipReasonFormat,
+                HotReloadSignatureChangeGate.FormatGatedReplacementRegistryKey(replacement));
+            Assert.That(outcomes, Has.Count.EqualTo(1));
+            Assert.That(outcomes[0].Reason, Is.EqualTo(expectedReason));
+        }
+
+        /// <summary>
+        /// What: a same-assembly caller listed by the edited file receives the same-file gate reason.
+        /// </summary>
+        [Test]
+        public void BuildGatedReplacementSkipOutcomes_SameAssemblySameKeyCaller_UsesSameFileReason()
+        {
+            TransformWorkerEntryDto replacement = CreateReplacementEntry();
+            HotReloadQualifiedMethodIdentity localCallerIdentity =
+                new HotReloadQualifiedMethodIdentity(EditedAssemblyName, CallerKey);
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredByTarget =
+                new Dictionary<string, List<HotReloadQualifiedMethodIdentity>>(StringComparer.Ordinal)
+                {
+                    { ReplacementKey, new List<HotReloadQualifiedMethodIdentity> { localCallerIdentity } }
+                };
+            Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>> editedFileIdentities =
+                new Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>>(StringComparer.Ordinal)
+                {
+                    {
+                        replacement.sourceProjectRelativePath,
+                        new HashSet<HotReloadQualifiedMethodIdentity> { localCallerIdentity }
+                    }
+                };
+            HotReloadGroupFilePaths paths = HotReloadGroupFilePaths.ForSingleFile(
+                replacement.sourceProjectRelativePath,
+                "Assembly.dll");
+
+            List<HotReloadMethodOutcome> outcomes =
+                HotReloadSignatureChangeGate.BuildGatedReplacementSkipOutcomes(
+                    new[] { replacement },
+                    uncoveredByTarget,
+                    editedFileIdentities,
+                    paths);
+
+            string expectedReason = string.Format(
+                HotReloadConstants.SignatureChangedGateSkipReasonSameFileCallersFormat,
+                HotReloadSignatureChangeGate.FormatGatedReplacementRegistryKey(replacement),
+                "Caller.Call");
+            Assert.That(outcomes, Has.Count.EqualTo(1));
+            Assert.That(outcomes[0].Reason, Is.EqualTo(expectedReason));
+        }
+
+        /// <summary>
+        /// What: final coverage rejects a replacement when only a same-key caller from another assembly was kept.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_ExternalSameKeyCallerRemains_ReturnsReplacementKey()
+        {
+            TransformWorkerEntryDto replacement = CreateReplacementEntry();
+            TransformWorkerEntryDto localCaller = CreateOrdinaryEntry();
+            HotReloadCallSiteScanner.CallSiteHit hit = CreateHit(ExternalAssemblyName);
+
+            List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                EditedAssemblyName,
+                new[] { replacement, localCaller },
+                new[] { hit },
+                new[] { ReplacementKey });
+
+            Assert.That(losses, Is.EqualTo(new[] { ReplacementKey }));
+        }
+
+        /// <summary>
+        /// What: a foreign same-key caller does not produce an already-patched caller notice.
+        /// </summary>
+        [Test]
+        public void AppendSignatureChangeCallersRepatchedWarnings_ExternalSameKeyCaller_OmitsNotice()
+        {
+            TransformWorkerEntryDto replacement = CreateReplacementEntry();
+            TransformWorkerEntryDto localCaller = CreateOrdinaryEntry();
+            HotReloadCallSiteScanner.CallSiteHit hit = CreateHit(ExternalAssemblyName);
+            List<string> warnings = new List<string>();
+            HashSet<string> snapshotLabels = new HashSet<string>(StringComparer.Ordinal)
+            {
+                HotReloadMethodKeys.FormatMethodLabelParts(
+                    "Example.Caller",
+                    "Call",
+                    Array.Empty<string>(),
+                    0)
+            };
+
+            HotReloadSignatureChangeCoverage.AppendSignatureChangeCallersRepatchedWarnings(
+                warnings,
+                EditedAssemblyName,
+                new[] { replacement, localCaller },
+                new[] { hit },
+                snapshotLabels);
+
+            Assert.That(warnings, Is.Empty);
+        }
+
+        /// <summary>
+        /// What: stale warnings de-duplicate only their displayed caller keys, preserving distinct
+        /// cross-assembly caller identities for coverage decisions.
+        /// </summary>
+        [Test]
+        public void FormatUncoveredCallerMethodKeys_CrossAssemblySameKey_DeduplicatesDisplayOnly()
+        {
+            List<HotReloadQualifiedMethodIdentity> sameKeyCallers =
+                new List<HotReloadQualifiedMethodIdentity>
+                {
+                    new HotReloadQualifiedMethodIdentity(EditedAssemblyName, CallerKey),
+                    new HotReloadQualifiedMethodIdentity(ExternalAssemblyName, CallerKey)
+                };
+            List<HotReloadQualifiedMethodIdentity> differentKeyCallers =
+                new List<HotReloadQualifiedMethodIdentity>
+                {
+                    new HotReloadQualifiedMethodIdentity(EditedAssemblyName, CallerKey),
+                    new HotReloadQualifiedMethodIdentity(
+                        ExternalAssemblyName,
+                        "Example.OtherCaller::Call()")
+                };
+
+            Assert.That(sameKeyCallers, Has.Count.EqualTo(2));
+            Assert.That(
+                CountOccurrences(CollectStaleWarning(sameKeyCallers), CallerKey),
+                Is.EqualTo(1));
+            Assert.That(
+                CollectStaleWarning(differentKeyCallers),
+                Does.Contain("Example.Caller::Call(), Example.OtherCaller::Call()"));
+        }
+
+        private static TransformWorkerEntryDto CreateReplacementEntry()
+        {
+            return new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = "Assets/Fixture.cs",
+                typeMetadataName = "Example.Target",
+                methodName = "Call",
+                parameterTypeFullNames = Array.Empty<string>(),
+                genericArity = 0,
+                replacesCompiledMethod = true
+            };
+        }
+
+        private static string CollectStaleWarning(
+            List<HotReloadQualifiedMethodIdentity> callers)
+        {
+            TransformWorkerRemovedMethodSignatureDto removedSignature =
+                new TransformWorkerRemovedMethodSignatureDto
+                {
+                    typeMetadataName = "Example.Target",
+                    methodName = "Call",
+                    parameterTypeFullNames = Array.Empty<string>(),
+                    genericArity = 0
+                };
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> callersByTarget =
+                new Dictionary<string, List<HotReloadQualifiedMethodIdentity>>(StringComparer.Ordinal)
+                {
+                    { ReplacementKey, callers }
+                };
+
+            List<string> warnings = HotReloadSignatureChangeCoverage.CollectStaleSignatureWarnings(
+                new[] { removedSignature },
+                callersByTarget);
+
+            return warnings[0];
+        }
+
+        private static int CountOccurrences(string text, string value)
+        {
+            int count = 0;
+            int startIndex = 0;
+            while (true)
+            {
+                int occurrenceIndex = text.IndexOf(value, startIndex, StringComparison.Ordinal);
+                if (occurrenceIndex < 0)
+                {
+                    return count;
+                }
+
+                count++;
+                startIndex = occurrenceIndex + value.Length;
+            }
+        }
+
+        private static TransformWorkerEntryDto CreateOrdinaryEntry()
+        {
+            return new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = "Assets/Fixture.cs",
+                typeMetadataName = "Example.Caller",
+                methodName = "Call",
+                parameterTypeFullNames = Array.Empty<string>(),
+                genericArity = 0
+            };
+        }
+
+        private static HotReloadCallSiteScanner.CallSiteHit CreateHit(string callerAssemblyName)
+        {
+            return new HotReloadCallSiteScanner.CallSiteHit
+            {
+                CallerAssemblyName = callerAssemblyName,
+                CallerTypeMetadataName = "Example.Caller",
+                CallerMethodName = "Call",
+                CallerParameterTypeFullNames = Array.Empty<string>(),
+                CallerMethodKey = CallerKey,
+                CallerGenericArity = 0,
+                TargetMethodKey = ReplacementKey
+            };
+        }
+
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
@@ -30,8 +30,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HotReloadSignatureChangeGate.CollectInitialUncoveredCallers(
                     EditedAssemblyName,
                     new[] { localCaller },
-                    Array.Empty<HotReloadCallSiteScanner.CompiledMethodIdentity>(),
-                    new[] { hit });
+                    new[] { hit },
+                    new HashSet<HotReloadQualifiedMethodIdentity>());
 
             Assert.That(uncovered, Does.ContainKey(ReplacementKey));
             Assert.That(
@@ -52,8 +52,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HotReloadSignatureChangeGate.CollectInitialUncoveredCallers(
                     EditedAssemblyName,
                     new[] { localCaller },
-                    Array.Empty<HotReloadCallSiteScanner.CompiledMethodIdentity>(),
-                    new[] { hit });
+                    new[] { hit },
+                    new HashSet<HotReloadQualifiedMethodIdentity>());
 
             Assert.That(uncovered, Is.Empty);
         }
@@ -160,8 +160,176 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 EditedAssemblyName,
                 new[] { replacement, localCaller },
                 new[] { hit },
-                new[] { ReplacementKey });
+                new HashSet<HotReloadQualifiedMethodIdentity>());
 
+            Assert.That(losses, Is.EqualTo(new[] { ReplacementKey }));
+        }
+
+        /// <summary>
+        /// A caller replacement that disappears after the gate retry is not treated as a deletion.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_DroppedSourceLiveCaller_GatesRemainingReplacement()
+        {
+            TransformWorkerEntryDto callerReplacement = CreateOrdinaryEntry();
+            callerReplacement.replacesCompiledMethod = true;
+            TransformWorkerEntryDto targetReplacement = CreateReplacementEntry();
+            HashSet<HotReloadQualifiedMethodIdentity> exemptions = HotReloadDeletedCallerExemptions.Collect(
+                EditedAssemblyName,
+                new[] { callerReplacement, targetReplacement },
+                Array.Empty<TransformWorkerUnchangedMethodDto>(),
+                Array.Empty<TransformWorkerSkippedDto>(),
+                new[] { CreateCallerRemovedSignature() });
+
+            List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                new[] { CreateHit(EditedAssemblyName) },
+                exemptions);
+
+            Assert.That(losses, Is.EqualTo(new[] { ReplacementKey }));
+        }
+
+        /// <summary>
+        /// A caller replacement that remains in the final apply set covers its target.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_RetainedSourceLiveCaller_AllowsRemainingReplacement()
+        {
+            TransformWorkerEntryDto callerReplacement = CreateOrdinaryEntry();
+            callerReplacement.replacesCompiledMethod = true;
+            TransformWorkerEntryDto targetReplacement = CreateReplacementEntry();
+            HashSet<HotReloadQualifiedMethodIdentity> exemptions = HotReloadDeletedCallerExemptions.Collect(
+                EditedAssemblyName,
+                new[] { callerReplacement, targetReplacement },
+                Array.Empty<TransformWorkerUnchangedMethodDto>(),
+                Array.Empty<TransformWorkerSkippedDto>(),
+                new[] { CreateCallerRemovedSignature() });
+
+            List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                EditedAssemblyName,
+                new[] { callerReplacement, targetReplacement },
+                new[] { CreateHit(EditedAssemblyName) },
+                exemptions);
+
+            Assert.That(losses, Is.Empty);
+        }
+
+        /// <summary>
+        /// An unchanged initial caller is source-live and cannot become a deletion exemption.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_UnchangedSourceLiveCaller_GatesRemainingReplacement()
+        {
+            TransformWorkerEntryDto targetReplacement = CreateReplacementEntry();
+            HashSet<HotReloadQualifiedMethodIdentity> exemptions = HotReloadDeletedCallerExemptions.Collect(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                new[] { CreateCallerUnchangedMethod() },
+                Array.Empty<TransformWorkerSkippedDto>(),
+                new[] { CreateCallerRemovedSignature() });
+
+            List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                new[] { CreateHit(EditedAssemblyName) },
+                exemptions);
+
+            Assert.That(exemptions, Is.Empty);
+            Assert.That(losses, Is.EqualTo(new[] { ReplacementKey }));
+        }
+
+        /// <summary>
+        /// A caller absent from the initial source-live rows remains a deletion exemption.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_DeletedCaller_AllowsRemainingReplacement()
+        {
+            TransformWorkerEntryDto targetReplacement = CreateReplacementEntry();
+            HashSet<HotReloadQualifiedMethodIdentity> exemptions = HotReloadDeletedCallerExemptions.Collect(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                Array.Empty<TransformWorkerUnchangedMethodDto>(),
+                Array.Empty<TransformWorkerSkippedDto>(),
+                new[] { CreateCallerRemovedSignature() });
+
+            List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                new[] { CreateHit(EditedAssemblyName) },
+                exemptions);
+
+            Assert.That(losses, Is.Empty);
+        }
+
+        /// <summary>
+        /// A deleted local caller does not exempt a same-key caller from another assembly.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_ExternalSameKeyCaller_IsNotDeletionExempt()
+        {
+            TransformWorkerEntryDto targetReplacement = CreateReplacementEntry();
+            HashSet<HotReloadQualifiedMethodIdentity> exemptions = HotReloadDeletedCallerExemptions.Collect(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                Array.Empty<TransformWorkerUnchangedMethodDto>(),
+                Array.Empty<TransformWorkerSkippedDto>(),
+                new[] { CreateCallerRemovedSignature() });
+
+            List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                new[] { CreateHit(ExternalAssemblyName) },
+                exemptions);
+
+            Assert.That(losses, Is.EqualTo(new[] { ReplacementKey }));
+        }
+
+        /// <summary>
+        /// An unidentified initial skipped row removes every deletion exemption.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_UnknownSkippedMethodKey_GatesRemainingReplacement()
+        {
+            TransformWorkerEntryDto targetReplacement = CreateReplacementEntry();
+            HashSet<HotReloadQualifiedMethodIdentity> exemptions = HotReloadDeletedCallerExemptions.Collect(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                Array.Empty<TransformWorkerUnchangedMethodDto>(),
+                new[] { new TransformWorkerSkippedDto() },
+                new[] { CreateCallerRemovedSignature() });
+
+            List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                new[] { CreateHit(EditedAssemblyName) },
+                exemptions);
+
+            Assert.That(exemptions, Is.Empty);
+            Assert.That(losses, Is.EqualTo(new[] { ReplacementKey }));
+        }
+
+        /// <summary>
+        /// A keyed skipped caller remains source-live and is not a deletion exemption.
+        /// </summary>
+        [Test]
+        public void FindSignatureChangeCoverageLosses_KeyedSkippedCaller_GatesRemainingReplacement()
+        {
+            TransformWorkerEntryDto targetReplacement = CreateReplacementEntry();
+            HashSet<HotReloadQualifiedMethodIdentity> exemptions = HotReloadDeletedCallerExemptions.Collect(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                Array.Empty<TransformWorkerUnchangedMethodDto>(),
+                new[] { new TransformWorkerSkippedDto { methodKey = CallerKey } },
+                new[] { CreateCallerRemovedSignature() });
+
+            List<string> losses = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                EditedAssemblyName,
+                new[] { targetReplacement },
+                new[] { CreateHit(EditedAssemblyName) },
+                exemptions);
+
+            Assert.That(exemptions, Is.Empty);
             Assert.That(losses, Is.EqualTo(new[] { ReplacementKey }));
         }
 
@@ -235,6 +403,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 parameterTypeFullNames = Array.Empty<string>(),
                 genericArity = 0,
                 replacesCompiledMethod = true
+            };
+        }
+
+        private static TransformWorkerRemovedMethodSignatureDto CreateCallerRemovedSignature()
+        {
+            return new TransformWorkerRemovedMethodSignatureDto
+            {
+                typeMetadataName = "Example.Caller",
+                methodName = "Call",
+                parameterTypeFullNames = Array.Empty<string>(),
+                genericArity = 0
+            };
+        }
+
+        private static TransformWorkerUnchangedMethodDto CreateCallerUnchangedMethod()
+        {
+            return new TransformWorkerUnchangedMethodDto
+            {
+                sourceProjectRelativePath = "Assets/Fixture.cs",
+                typeMetadataName = "Example.Caller",
+                methodName = "Call",
+                parameterTypeFullNames = Array.Empty<string>(),
+                genericArity = 0
             };
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e6e965b93aad45d2ba83df0510b5f49
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -1560,6 +1560,51 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// A return-type replacement skipped by the added-call guard keeps its removed signature
+        /// and reports the replacement wire key.
+        /// </summary>
+        [Test]
+        public async Task Classify_ReturnTypeChangeSkippedByAddedCallGuard_ReportsRemovedSignatureAndMethodKey()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(
+                onDisk,
+                "public virtual int AddedVirtual(int value)\n        {\n            return value;\n        }");
+            edited = edited.Replace(
+                "        public int ExistingValue()\n        {\n            return 1;\n        }",
+                "        public long ExistingValue()\n        {\n            return AddedVirtual(1);\n        }",
+                StringComparison.Ordinal);
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited("ReturnTypeGuardSkip.cs", edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingValue)), Is.Null);
+            Assert.That(
+                HasRemovedSignature(
+                    result.Output.files[0],
+                    typeof(HotReloadAddedMemberHost).FullName,
+                    nameof(HotReloadAddedMemberHost.ExistingValue)),
+                Is.True);
+
+            TransformWorkerSkippedDto skippedReplacement = null;
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                if (skipped.method != null
+                    && skipped.method.Contains(nameof(HotReloadAddedMemberHost.ExistingValue)))
+                {
+                    skippedReplacement = skipped;
+                    break;
+                }
+            }
+
+            Assert.That(skippedReplacement, Is.Not.Null);
+            Assert.That(
+                skippedReplacement.methodKey,
+                Is.EqualTo(BuildHostMethodKey(nameof(HotReloadAddedMemberHost.ExistingValue))));
+        }
+
+        /// <summary>
         /// What: a return-type change that is also virtual is skipped with the existing
         /// added-method vtable reason.
         /// </summary>

--- a/Assets/Tests/Editor/HotReloadCallSiteCrossAssembly/HotReloadCallSiteCrossAssemblyCaller.cs
+++ b/Assets/Tests/Editor/HotReloadCallSiteCrossAssembly/HotReloadCallSiteCrossAssemblyCaller.cs
@@ -27,4 +27,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return 8;
         }
     }
+
+    /// <summary>
+    /// Supplies the foreign-assembly side of the same-metadata-name internal caller pair.
+    /// </summary>
+    internal static class HotReloadQualifiedCallerIdentityCaller
+    {
+        internal static int Call()
+        {
+            return HotReloadQualifiedCallerIdentityTarget.Called();
+        }
+    }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDeletedCallerExemptions.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDeletedCallerExemptions.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Identifies removed callers that cannot remain compiled after the initial worker output.
+    /// </summary>
+    internal static class HotReloadDeletedCallerExemptions
+    {
+        internal static HashSet<HotReloadQualifiedMethodIdentity> Collect(
+            string assemblyName,
+            TransformWorkerEntryDto[] entries,
+            TransformWorkerUnchangedMethodDto[] unchangedMethods,
+            TransformWorkerSkippedDto[] skipped,
+            TransformWorkerRemovedMethodSignatureDto[] removedSignatures)
+        {
+            if (ContainsUnknownSkippedMethodKey(skipped))
+            {
+                // A skipped row without an identity might be a live compiled caller. Do not
+                // exempt any deletion when that fact cannot be established from worker output.
+                return new HashSet<HotReloadQualifiedMethodIdentity>();
+            }
+
+            HashSet<HotReloadQualifiedMethodIdentity> sourceLiveIdentities =
+                CollectSourceLiveIdentities(assemblyName, entries, unchangedMethods, skipped);
+            HashSet<HotReloadQualifiedMethodIdentity> deletedCallerExemptions =
+                new HashSet<HotReloadQualifiedMethodIdentity>();
+            foreach (TransformWorkerRemovedMethodSignatureDto removedSignature in removedSignatures)
+            {
+                HotReloadQualifiedMethodIdentity identity = new HotReloadQualifiedMethodIdentity(
+                    assemblyName,
+                    HotReloadMethodKeys.BuildMethodKeyParts(
+                        removedSignature.typeMetadataName,
+                        removedSignature.methodName,
+                        removedSignature.parameterTypeFullNames,
+                        removedSignature.genericArity));
+                if (!sourceLiveIdentities.Contains(identity))
+                {
+                    deletedCallerExemptions.Add(identity);
+                }
+            }
+
+            return deletedCallerExemptions;
+        }
+
+        private static bool ContainsUnknownSkippedMethodKey(TransformWorkerSkippedDto[] skipped)
+        {
+            foreach (TransformWorkerSkippedDto skippedMethod in skipped)
+            {
+                if (string.IsNullOrEmpty(skippedMethod.methodKey))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static HashSet<HotReloadQualifiedMethodIdentity> CollectSourceLiveIdentities(
+            string assemblyName,
+            TransformWorkerEntryDto[] entries,
+            TransformWorkerUnchangedMethodDto[] unchangedMethods,
+            TransformWorkerSkippedDto[] skipped)
+        {
+            HashSet<HotReloadQualifiedMethodIdentity> identities =
+                new HashSet<HotReloadQualifiedMethodIdentity>();
+            foreach (TransformWorkerEntryDto entry in entries)
+            {
+                identities.Add(new HotReloadQualifiedMethodIdentity(
+                    assemblyName,
+                    HotReloadMethodKeys.BuildMethodKey(entry)));
+            }
+
+            foreach (TransformWorkerUnchangedMethodDto unchangedMethod in unchangedMethods)
+            {
+                identities.Add(new HotReloadQualifiedMethodIdentity(
+                    assemblyName,
+                    HotReloadMethodKeys.BuildMethodKeyParts(
+                        unchangedMethod.typeMetadataName,
+                        unchangedMethod.methodName,
+                        unchangedMethod.parameterTypeFullNames,
+                        unchangedMethod.genericArity)));
+            }
+
+            foreach (TransformWorkerSkippedDto skippedMethod in skipped)
+            {
+                identities.Add(new HotReloadQualifiedMethodIdentity(assemblyName, skippedMethod.methodKey));
+            }
+
+            return identities;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDeletedCallerExemptions.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDeletedCallerExemptions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c53f0e3b5feb4e3bbc36d3b8393f6f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -155,6 +155,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // retry can drop a covering caller without dropping the replacement. A third
             // worker run is not allowed (max two); fail the group instead of applying.
             List<string> lostReplacementKeys = HotReloadSignatureChangeCoverage.FindSignatureChangeCoverageLosses(
+                context.AssemblyName,
                 compile.EntriesToPatch,
                 gateResult.Hits,
                 gateResult.ScanTargetKeys);
@@ -176,6 +177,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // the warning belongs to.
                 HotReloadSignatureChangeCoverage.AppendSignatureChangeCallersRepatchedWarnings(
                     file.Sinks.Warnings,
+                    context.AssemblyName,
                     compile.EntriesToPatch,
                     gateResult.Hits,
                     file.SnapshotLabels);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -127,22 +127,36 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return BuildUnappliedResults(files);
             }
 
+            return await CompleteApplyAfterCoverageAsync(
+                context,
+                gateResult,
+                compile,
+                async () =>
+                {
+                    await MainThreadSwitcher.SwitchToMainThread(ct);
+                    IReadOnlyList<HotReloadFileProcessResult> results = HotReloadEntryApplier.ApplyGroupAndBuildResults(
+                        context,
+                        compile.CompileResult,
+                        compile.EntriesToPatch);
+                    RecordSupersededSignaturesAfterApply(context, gateResult.GatedReplacementMethodKeys);
+                    return results;
+                }).ConfigureAwait(false);
+        }
+
+        // Why inject only the post-coverage continuation: coverage failure must use the real
+        // group failure routing, while tests must not invoke Harmony or main-thread work.
+        internal static async Task<IReadOnlyList<HotReloadFileProcessResult>> CompleteApplyAfterCoverageAsync(
+            HotReloadApplyContext context,
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult,
+            HotReloadGroupCompileResult compile,
+            Func<Task<IReadOnlyList<HotReloadFileProcessResult>>> continueAfterCoverage)
+        {
             if (gateResult.DidScan && !AppendSignatureChangeCoverageNotices(context, gateResult, compile))
             {
-                return BuildUnappliedResults(files);
+                return BuildUnappliedResults(context.Files);
             }
 
-            // Harmony Patch/Unpatch and method resolution against loaded modules require main thread.
-            await MainThreadSwitcher.SwitchToMainThread(ct);
-            IReadOnlyList<HotReloadFileProcessResult> results = HotReloadEntryApplier.ApplyGroupAndBuildResults(
-                context,
-                compile.CompileResult,
-                compile.EntriesToPatch);
-            // Why after apply: earlier returns (gate fail, shim compile, coverage loss)
-            // never applied the replacement, so leftover Active rows must not claim they
-            // were superseded.
-            RecordSupersededSignaturesAfterApply(context, gateResult.GatedReplacementMethodKeys);
-            return results;
+            return await continueAfterCoverage().ConfigureAwait(false);
         }
 
         // Returns false when a replacement lost its covering caller and the group must fail.
@@ -158,7 +172,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 context.AssemblyName,
                 compile.EntriesToPatch,
                 gateResult.Hits,
-                gateResult.ScanTargetKeys);
+                gateResult.DeletedCallerExemptions);
             if (lostReplacementKeys.Count > 0)
             {
                 HotReloadGroupOutcomeRouter.AppendGroupFailure(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadQualifiedMethodIdentity.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadQualifiedMethodIdentity.cs
@@ -1,0 +1,46 @@
+using System;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Identifies a compiled method without conflating identical wire keys from different assemblies.
+    /// </summary>
+    internal readonly struct HotReloadQualifiedMethodIdentity : IEquatable<HotReloadQualifiedMethodIdentity>
+    {
+        internal string AssemblyName { get; }
+        internal string MethodKey { get; }
+
+        internal HotReloadQualifiedMethodIdentity(string assemblyName, string methodKey)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
+            Debug.Assert(!string.IsNullOrEmpty(methodKey), "methodKey must not be null or empty.");
+            AssemblyName = assemblyName;
+            MethodKey = methodKey;
+        }
+
+        bool IEquatable<HotReloadQualifiedMethodIdentity>.Equals(HotReloadQualifiedMethodIdentity other)
+        {
+            return HasSameValue(other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is HotReloadQualifiedMethodIdentity other && HasSameValue(other);
+        }
+
+        public override int GetHashCode()
+        {
+            int assemblyHashCode = StringComparer.Ordinal.GetHashCode(AssemblyName);
+            int methodKeyHashCode = StringComparer.Ordinal.GetHashCode(MethodKey);
+            return (assemblyHashCode * 397) ^ methodKeyHashCode;
+        }
+
+        private bool HasSameValue(HotReloadQualifiedMethodIdentity other)
+        {
+            return string.Equals(AssemblyName, other.AssemblyName, StringComparison.Ordinal)
+                && string.Equals(MethodKey, other.MethodKey, StringComparison.Ordinal);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadQualifiedMethodIdentity.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadQualifiedMethodIdentity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c84a11be8bc2470499827821e11b509
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeCoverage.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeCoverage.cs
@@ -11,14 +11,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class HotReloadSignatureChangeCoverage
     {
-        internal static HashSet<string> CollectCoveredMethodKeys(
+        internal static HashSet<HotReloadQualifiedMethodIdentity> CollectCoveredMethodIdentities(
+            string assemblyName,
             TransformWorkerEntryDto[] entries,
             HotReloadCallSiteScanner.CompiledMethodIdentity[] targets)
         {
-            HashSet<string> coveredKeys = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<HotReloadQualifiedMethodIdentity> coveredIdentities =
+                new HashSet<HotReloadQualifiedMethodIdentity>();
             foreach (TransformWorkerEntryDto entry in entries)
             {
-                coveredKeys.Add(HotReloadMethodKeys.BuildMethodKey(entry));
+                coveredIdentities.Add(CreateEntryIdentity(assemblyName, entry));
             }
 
             foreach (HotReloadCallSiteScanner.CompiledMethodIdentity target in targets)
@@ -28,39 +30,37 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // corpse as uncovered would gate a same-file helper-delete + return-type
                 // change, which is still a consistent old world. Fail-closed only for live
                 // compiled callers that will keep invoking the old method.
-                coveredKeys.Add(
-                    HotReloadMethodKeys.BuildMethodKeyParts(
-                        target.TypeMetadataName,
-                        target.MethodName,
-                        target.ParameterTypeFullNames,
-                        target.GenericArity));
+                coveredIdentities.Add(CreateTargetIdentity(target));
             }
 
-            return coveredKeys;
+            return coveredIdentities;
         }
 
-        internal static Dictionary<string, List<string>> CollectUncoveredCallersByTarget(
+        internal static Dictionary<string, List<HotReloadQualifiedMethodIdentity>> CollectUncoveredCallersByTarget(
             IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits,
-            HashSet<string> coveredKeys)
+            HashSet<HotReloadQualifiedMethodIdentity> coveredIdentities)
         {
-            Dictionary<string, List<string>> uncoveredCallersByTarget =
-                new Dictionary<string, List<string>>(StringComparer.Ordinal);
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget =
+                new Dictionary<string, List<HotReloadQualifiedMethodIdentity>>(StringComparer.Ordinal);
             foreach (HotReloadCallSiteScanner.CallSiteHit hit in hits)
             {
-                if (coveredKeys.Contains(hit.CallerMethodKey))
+                HotReloadQualifiedMethodIdentity callerIdentity = CreateCallerIdentity(hit);
+                if (coveredIdentities.Contains(callerIdentity))
                 {
                     continue;
                 }
 
-                if (!uncoveredCallersByTarget.TryGetValue(hit.TargetMethodKey, out List<string> callers))
+                if (!uncoveredCallersByTarget.TryGetValue(
+                        hit.TargetMethodKey,
+                        out List<HotReloadQualifiedMethodIdentity> callers))
                 {
-                    callers = new List<string>();
+                    callers = new List<HotReloadQualifiedMethodIdentity>();
                     uncoveredCallersByTarget.Add(hit.TargetMethodKey, callers);
                 }
 
-                if (!callers.Contains(hit.CallerMethodKey))
+                if (!callers.Contains(callerIdentity))
                 {
-                    callers.Add(hit.CallerMethodKey);
+                    callers.Add(callerIdentity);
                 }
             }
 
@@ -69,7 +69,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal static List<string> CollectStaleSignatureWarnings(
             TransformWorkerRemovedMethodSignatureDto[] removedSignatures,
-            Dictionary<string, List<string>> uncoveredCallersByTarget)
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget)
         {
             List<string> warnings = new List<string>();
             foreach (TransformWorkerRemovedMethodSignatureDto signature in removedSignatures)
@@ -79,7 +79,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     signature.methodName,
                     signature.parameterTypeFullNames,
                     signature.genericArity);
-                if (!uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> callers)
+                if (!uncoveredCallersByTarget.TryGetValue(
+                        methodKey,
+                        out List<HotReloadQualifiedMethodIdentity> callers)
                     || callers.Count == 0)
                 {
                     continue;
@@ -89,7 +91,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     string.Format(
                         HotReloadConstants.StaleSignatureCallersWarningFormat,
                         methodKey,
-                        string.Join(", ", callers)));
+                        FormatUncoveredCallerMethodKeys(callers)));
             }
 
             return warnings;
@@ -106,6 +108,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // from the wire key (same constraint as IsActiveMember).
         internal static void AppendSignatureChangeCallersRepatchedWarnings(
             List<string> warnings,
+            string assemblyName,
             TransformWorkerEntryDto[] entriesToPatch,
             IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits,
             HashSet<string> snapshotLabels)
@@ -115,12 +118,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(hits != null, "hits must not be null.");
             Debug.Assert(snapshotLabels != null, "snapshotLabels must not be null.");
 
-            HashSet<string> entryKeys = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<HotReloadQualifiedMethodIdentity> entryIdentities =
+                new HashSet<HotReloadQualifiedMethodIdentity>();
             HashSet<string> appliedReplacementKeys = new HashSet<string>(StringComparer.Ordinal);
             foreach (TransformWorkerEntryDto entry in entriesToPatch)
             {
                 string methodKey = HotReloadMethodKeys.BuildMethodKey(entry);
-                entryKeys.Add(methodKey);
+                entryIdentities.Add(new HotReloadQualifiedMethodIdentity(assemblyName, methodKey));
                 if (entry.replacesCompiledMethod)
                 {
                     appliedReplacementKeys.Add(methodKey);
@@ -133,7 +137,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 if (hit == null
                     || !appliedReplacementKeys.Contains(hit.TargetMethodKey)
-                    || !entryKeys.Contains(hit.CallerMethodKey))
+                    || !entryIdentities.Contains(CreateCallerIdentity(hit)))
                 {
                     continue;
                 }
@@ -204,17 +208,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// ctor, or another assembly) must return false so the compile-only wording is used.
         /// </summary>
         internal static bool AreUncoveredCallersInEditedFile(
-            IReadOnlyList<string> uncoveredCallerKeys,
+            string assemblyName,
+            IReadOnlyList<HotReloadQualifiedMethodIdentity> uncoveredCallerIdentities,
             TransformWorkerEntryDto[] entries,
             TransformWorkerUnchangedMethodDto[] unchangedMethods)
         {
-            Debug.Assert(uncoveredCallerKeys != null, "uncoveredCallerKeys must not be null.");
+            Debug.Assert(uncoveredCallerIdentities != null, "uncoveredCallerIdentities must not be null.");
             Debug.Assert(entries != null, "entries must not be null.");
             Debug.Assert(unchangedMethods != null, "unchangedMethods must not be null.");
 
             return AreAllUncoveredCallersInEditedFile(
-                uncoveredCallerKeys,
-                CollectEditedFileMethodKeys(entries, unchangedMethods));
+                uncoveredCallerIdentities,
+                CollectEditedFileMethodIdentities(assemblyName, entries, unchangedMethods));
         }
 
         /// <summary>
@@ -222,6 +227,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// still have uncovered compiled callers after isolation or a gate retry shrank entries.
         /// </summary>
         internal static List<string> FindSignatureChangeCoverageLosses(
+            string assemblyName,
             TransformWorkerEntryDto[] entriesToPatch,
             IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits,
             IReadOnlyList<string> scanTargetKeys)
@@ -230,19 +236,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(hits != null, "hits must not be null.");
             Debug.Assert(scanTargetKeys != null, "scanTargetKeys must not be null.");
 
-            HashSet<string> coveredKeys = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<HotReloadQualifiedMethodIdentity> coveredIdentities =
+                new HashSet<HotReloadQualifiedMethodIdentity>();
             foreach (TransformWorkerEntryDto entry in entriesToPatch)
             {
-                coveredKeys.Add(HotReloadMethodKeys.BuildMethodKey(entry));
+                coveredIdentities.Add(CreateEntryIdentity(assemblyName, entry));
             }
 
             foreach (string targetKey in scanTargetKeys)
             {
-                coveredKeys.Add(targetKey);
+                coveredIdentities.Add(new HotReloadQualifiedMethodIdentity(assemblyName, targetKey));
             }
 
-            Dictionary<string, List<string>> uncoveredCallersByTarget =
-                CollectUncoveredCallersByTarget(hits, coveredKeys);
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget =
+                CollectUncoveredCallersByTarget(hits, coveredIdentities);
             List<string> lostReplacementKeys = new List<string>();
             foreach (TransformWorkerEntryDto entry in entriesToPatch)
             {
@@ -252,7 +259,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 string methodKey = HotReloadMethodKeys.BuildMethodKey(entry);
-                if (uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> callers)
+                if (uncoveredCallersByTarget.TryGetValue(
+                        methodKey,
+                        out List<HotReloadQualifiedMethodIdentity> callers)
                     && callers.Count > 0)
                 {
                     lostReplacementKeys.Add(methodKey);
@@ -279,27 +288,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return keys;
         }
 
-        internal static HashSet<string> CollectEditedFileMethodKeys(
+        internal static HashSet<HotReloadQualifiedMethodIdentity> CollectEditedFileMethodIdentities(
+            string assemblyName,
             TransformWorkerEntryDto[] entries,
             TransformWorkerUnchangedMethodDto[] unchangedMethods)
         {
-            HashSet<string> methodKeys = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<HotReloadQualifiedMethodIdentity> methodIdentities =
+                new HashSet<HotReloadQualifiedMethodIdentity>();
             foreach (TransformWorkerEntryDto entry in entries)
             {
-                methodKeys.Add(HotReloadMethodKeys.BuildMethodKey(entry));
+                methodIdentities.Add(CreateEntryIdentity(assemblyName, entry));
             }
 
             foreach (TransformWorkerUnchangedMethodDto unchanged in unchangedMethods)
             {
-                methodKeys.Add(
-                    HotReloadMethodKeys.BuildMethodKeyParts(
-                        unchanged.typeMetadataName,
-                        unchanged.methodName,
-                        unchanged.parameterTypeFullNames,
-                        unchanged.genericArity));
+                methodIdentities.Add(CreateUnchangedMethodIdentity(assemblyName, unchanged));
             }
 
-            return methodKeys;
+            return methodIdentities;
         }
 
         /// <summary>
@@ -311,62 +317,61 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// file. A group run transforms several files at once, so a set built from all of them
         /// would call a caller in a sibling file a same-file caller.
         /// </remarks>
-        internal static Dictionary<string, HashSet<string>> CollectEditedFileMethodKeysByFile(
+        internal static Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>> CollectEditedFileMethodIdentitiesByFile(
+            string assemblyName,
             TransformWorkerEntryDto[] entries,
             TransformWorkerUnchangedMethodDto[] unchangedMethods)
         {
             Debug.Assert(entries != null, "entries must not be null.");
             Debug.Assert(unchangedMethods != null, "unchangedMethods must not be null.");
 
-            Dictionary<string, HashSet<string>> methodKeysByFile =
-                new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+            Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>> methodIdentitiesByFile =
+                new Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>>(StringComparer.Ordinal);
             foreach (TransformWorkerEntryDto entry in entries)
             {
-                AddMethodKeyOfFile(
-                    methodKeysByFile,
+                AddMethodIdentityOfFile(
+                    methodIdentitiesByFile,
                     entry.sourceProjectRelativePath,
-                    HotReloadMethodKeys.BuildMethodKey(entry));
+                    CreateEntryIdentity(assemblyName, entry));
             }
 
             foreach (TransformWorkerUnchangedMethodDto unchanged in unchangedMethods)
             {
-                AddMethodKeyOfFile(
-                    methodKeysByFile,
+                AddMethodIdentityOfFile(
+                    methodIdentitiesByFile,
                     unchanged.sourceProjectRelativePath,
-                    HotReloadMethodKeys.BuildMethodKeyParts(
-                        unchanged.typeMetadataName,
-                        unchanged.methodName,
-                        unchanged.parameterTypeFullNames,
-                        unchanged.genericArity));
+                    CreateUnchangedMethodIdentity(assemblyName, unchanged));
             }
 
-            return methodKeysByFile;
+            return methodIdentitiesByFile;
         }
 
-        private static void AddMethodKeyOfFile(
-            Dictionary<string, HashSet<string>> methodKeysByFile,
+        private static void AddMethodIdentityOfFile(
+            Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>> methodIdentitiesByFile,
             string projectRelativePath,
-            string methodKey)
+            HotReloadQualifiedMethodIdentity methodIdentity)
         {
             Debug.Assert(
                 !string.IsNullOrEmpty(projectRelativePath),
                 "A worker row must name the source file it came from.");
-            if (!methodKeysByFile.TryGetValue(projectRelativePath, out HashSet<string> methodKeys))
+            if (!methodIdentitiesByFile.TryGetValue(
+                    projectRelativePath,
+                    out HashSet<HotReloadQualifiedMethodIdentity> methodIdentities))
             {
-                methodKeys = new HashSet<string>(StringComparer.Ordinal);
-                methodKeysByFile[projectRelativePath] = methodKeys;
+                methodIdentities = new HashSet<HotReloadQualifiedMethodIdentity>();
+                methodIdentitiesByFile[projectRelativePath] = methodIdentities;
             }
 
-            methodKeys.Add(methodKey);
+            methodIdentities.Add(methodIdentity);
         }
 
         internal static bool AreAllUncoveredCallersInEditedFile(
-            IReadOnlyList<string> uncoveredCallerKeys,
-            HashSet<string> editedFileMethodKeys)
+            IReadOnlyList<HotReloadQualifiedMethodIdentity> uncoveredCallerIdentities,
+            HashSet<HotReloadQualifiedMethodIdentity> editedFileMethodIdentities)
         {
-            foreach (string callerKey in uncoveredCallerKeys)
+            foreach (HotReloadQualifiedMethodIdentity callerIdentity in uncoveredCallerIdentities)
             {
-                if (!editedFileMethodKeys.Contains(callerKey))
+                if (!editedFileMethodIdentities.Contains(callerIdentity))
                 {
                     return false;
                 }
@@ -380,7 +385,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// order, de-duplicated. Nested type '/' is normalized to '.' and only the last type
         /// segment is kept.
         /// </summary>
-        internal static string FormatUncoveredCallerShortNames(IReadOnlyList<string> uncoveredCallers)
+        internal static string FormatUncoveredCallerShortNames(
+            IReadOnlyList<HotReloadQualifiedMethodIdentity> uncoveredCallers)
         {
             if (uncoveredCallers == null || uncoveredCallers.Count == 0)
             {
@@ -389,9 +395,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             List<string> names = new List<string>();
             HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
-            foreach (string wireKey in uncoveredCallers)
+            foreach (HotReloadQualifiedMethodIdentity caller in uncoveredCallers)
             {
-                string shortName = FormatCallerShortName(wireKey);
+                string shortName = FormatCallerShortName(caller.MethodKey);
                 if (string.IsNullOrEmpty(shortName) || !seen.Add(shortName))
                 {
                     continue;
@@ -401,6 +407,63 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return string.Join(", ", names);
+        }
+
+        private static string FormatUncoveredCallerMethodKeys(
+            IReadOnlyList<HotReloadQualifiedMethodIdentity> callers)
+        {
+            List<string> methodKeys = new List<string>(callers.Count);
+            HashSet<string> seenMethodKeys = new HashSet<string>(StringComparer.Ordinal);
+            foreach (HotReloadQualifiedMethodIdentity caller in callers)
+            {
+                if (!seenMethodKeys.Add(caller.MethodKey))
+                {
+                    continue;
+                }
+
+                methodKeys.Add(caller.MethodKey);
+            }
+
+            return string.Join(", ", methodKeys);
+        }
+
+        private static HotReloadQualifiedMethodIdentity CreateEntryIdentity(
+            string assemblyName,
+            TransformWorkerEntryDto entry)
+        {
+            return new HotReloadQualifiedMethodIdentity(
+                assemblyName,
+                HotReloadMethodKeys.BuildMethodKey(entry));
+        }
+
+        private static HotReloadQualifiedMethodIdentity CreateUnchangedMethodIdentity(
+            string assemblyName,
+            TransformWorkerUnchangedMethodDto unchanged)
+        {
+            string methodKey = HotReloadMethodKeys.BuildMethodKeyParts(
+                unchanged.typeMetadataName,
+                unchanged.methodName,
+                unchanged.parameterTypeFullNames,
+                unchanged.genericArity);
+            return new HotReloadQualifiedMethodIdentity(assemblyName, methodKey);
+        }
+
+        private static HotReloadQualifiedMethodIdentity CreateTargetIdentity(
+            HotReloadCallSiteScanner.CompiledMethodIdentity target)
+        {
+            string methodKey = HotReloadMethodKeys.BuildMethodKeyParts(
+                target.TypeMetadataName,
+                target.MethodName,
+                target.ParameterTypeFullNames,
+                target.GenericArity);
+            return new HotReloadQualifiedMethodIdentity(target.AssemblyName, methodKey);
+        }
+
+        private static HotReloadQualifiedMethodIdentity CreateCallerIdentity(
+            HotReloadCallSiteScanner.CallSiteHit hit)
+        {
+            Debug.Assert(hit != null, "hit must not be null.");
+            return new HotReloadQualifiedMethodIdentity(hit.CallerAssemblyName, hit.CallerMethodKey);
         }
 
         internal static string FormatCallerShortName(string wireKey)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeCoverage.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeCoverage.cs
@@ -13,24 +13,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         internal static HashSet<HotReloadQualifiedMethodIdentity> CollectCoveredMethodIdentities(
             string assemblyName,
-            TransformWorkerEntryDto[] entries,
-            HotReloadCallSiteScanner.CompiledMethodIdentity[] targets)
+            TransformWorkerEntryDto[] entries)
         {
             HashSet<HotReloadQualifiedMethodIdentity> coveredIdentities =
                 new HashSet<HotReloadQualifiedMethodIdentity>();
             foreach (TransformWorkerEntryDto entry in entries)
             {
                 coveredIdentities.Add(CreateEntryIdentity(assemblyName, entry));
-            }
-
-            foreach (HotReloadCallSiteScanner.CompiledMethodIdentity target in targets)
-            {
-                // Why include removed-signature targets: a deleted helper that called the
-                // replaced method is already stale (removed-members warning). Treating that
-                // corpse as uncovered would gate a same-file helper-delete + return-type
-                // change, which is still a consistent old world. Fail-closed only for live
-                // compiled callers that will keep invoking the old method.
-                coveredIdentities.Add(CreateTargetIdentity(target));
             }
 
             return coveredIdentities;
@@ -230,11 +219,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string assemblyName,
             TransformWorkerEntryDto[] entriesToPatch,
             IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits,
-            IReadOnlyList<string> scanTargetKeys)
+            IReadOnlyCollection<HotReloadQualifiedMethodIdentity> deletedCallerExemptions)
         {
             Debug.Assert(entriesToPatch != null, "entriesToPatch must not be null.");
             Debug.Assert(hits != null, "hits must not be null.");
-            Debug.Assert(scanTargetKeys != null, "scanTargetKeys must not be null.");
+            Debug.Assert(deletedCallerExemptions != null, "deletedCallerExemptions must not be null.");
 
             HashSet<HotReloadQualifiedMethodIdentity> coveredIdentities =
                 new HashSet<HotReloadQualifiedMethodIdentity>();
@@ -243,9 +232,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 coveredIdentities.Add(CreateEntryIdentity(assemblyName, entry));
             }
 
-            foreach (string targetKey in scanTargetKeys)
+            foreach (HotReloadQualifiedMethodIdentity deletedCallerExemption in deletedCallerExemptions)
             {
-                coveredIdentities.Add(new HotReloadQualifiedMethodIdentity(assemblyName, targetKey));
+                coveredIdentities.Add(deletedCallerExemption);
             }
 
             Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget =
@@ -269,23 +258,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return lostReplacementKeys;
-        }
-
-        internal static List<string> CollectScanTargetKeys(
-            HotReloadCallSiteScanner.CompiledMethodIdentity[] targets)
-        {
-            List<string> keys = new List<string>(targets.Length);
-            foreach (HotReloadCallSiteScanner.CompiledMethodIdentity target in targets)
-            {
-                keys.Add(
-                    HotReloadMethodKeys.BuildMethodKeyParts(
-                        target.TypeMetadataName,
-                        target.MethodName,
-                        target.ParameterTypeFullNames,
-                        target.GenericArity));
-            }
-
-            return keys;
         }
 
         internal static HashSet<HotReloadQualifiedMethodIdentity> CollectEditedFileMethodIdentities(
@@ -446,17 +418,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 unchanged.parameterTypeFullNames,
                 unchanged.genericArity);
             return new HotReloadQualifiedMethodIdentity(assemblyName, methodKey);
-        }
-
-        private static HotReloadQualifiedMethodIdentity CreateTargetIdentity(
-            HotReloadCallSiteScanner.CompiledMethodIdentity target)
-        {
-            string methodKey = HotReloadMethodKeys.BuildMethodKeyParts(
-                target.TypeMetadataName,
-                target.MethodName,
-                target.ParameterTypeFullNames,
-                target.GenericArity);
-            return new HotReloadQualifiedMethodIdentity(target.AssemblyName, methodKey);
         }
 
         private static HotReloadQualifiedMethodIdentity CreateCallerIdentity(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
@@ -35,9 +35,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 removedSignatures);
             List<HotReloadCallSiteScanner.CallSiteHit> hits =
                 HotReloadCallSiteScanner.FindCallSites(context.ProjectRoot, targets).Hits;
-            HashSet<string> coveredKeys = HotReloadSignatureChangeCoverage.CollectCoveredMethodKeys(entries, targets);
-            Dictionary<string, List<string>> uncoveredCallersByTarget =
-                HotReloadSignatureChangeCoverage.CollectUncoveredCallersByTarget(hits, coveredKeys);
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget =
+                CollectInitialUncoveredCallers(context.AssemblyName, entries, targets, hits);
 
             List<string> staleWarnings = HotReloadSignatureChangeCoverage.CollectStaleSignatureWarnings(
                 removedSignatures,
@@ -54,14 +53,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             HotReloadShimIsolation.IsolationExclusions exclusions = HotReloadShimIsolation.BuildIsolationExclusions(gatedReplacements, entries);
-            Dictionary<string, HashSet<string>> editedFileMethodKeysByFile =
-                HotReloadSignatureChangeCoverage.CollectEditedFileMethodKeysByFile(
+            Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>> editedFileMethodIdentitiesByFile =
+                HotReloadSignatureChangeCoverage.CollectEditedFileMethodIdentitiesByFile(
+                    context.AssemblyName,
                     entries,
                     context.WorkerOutput.unchangedMethods ?? Array.Empty<TransformWorkerUnchangedMethodDto>());
             List<HotReloadMethodOutcome> skippedOutcomes = BuildGatedReplacementSkipOutcomes(
                 gatedReplacements,
                 uncoveredCallersByTarget,
-                editedFileMethodKeysByFile,
+                editedFileMethodIdentitiesByFile,
                 context.GroupFilePaths);
             skippedOutcomes.AddRange(
                 HotReloadShimIsolation.BuildSkippedCallerOutcomes(
@@ -116,6 +116,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return replacements;
+        }
+
+        /// <summary>
+        /// Classifies scanned callers against the first worker output using the edited assembly.
+        /// </summary>
+        internal static Dictionary<string, List<HotReloadQualifiedMethodIdentity>> CollectInitialUncoveredCallers(
+            string assemblyName,
+            TransformWorkerEntryDto[] entries,
+            HotReloadCallSiteScanner.CompiledMethodIdentity[] targets,
+            IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits)
+        {
+            HashSet<HotReloadQualifiedMethodIdentity> coveredIdentities =
+                HotReloadSignatureChangeCoverage.CollectCoveredMethodIdentities(
+                    assemblyName,
+                    entries,
+                    targets);
+            return HotReloadSignatureChangeCoverage.CollectUncoveredCallersByTarget(
+                hits,
+                coveredIdentities);
         }
 
         private static HotReloadCallSiteScanner.CompiledMethodIdentity[] CollectScanTargets(
@@ -183,13 +202,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static List<TransformWorkerEntryDto> CollectGatedReplacementEntries(
             IReadOnlyList<TransformWorkerEntryDto> replacementEntries,
-            Dictionary<string, List<string>> uncoveredCallersByTarget)
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget)
         {
             List<TransformWorkerEntryDto> gated = new List<TransformWorkerEntryDto>();
             foreach (TransformWorkerEntryDto entry in replacementEntries)
             {
                 string methodKey = HotReloadMethodKeys.BuildMethodKey(entry);
-                if (uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> callers)
+                if (uncoveredCallersByTarget.TryGetValue(
+                        methodKey,
+                        out List<HotReloadQualifiedMethodIdentity> callers)
                     && callers.Count > 0)
                 {
                     gated.Add(entry);
@@ -231,10 +252,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 entry.genericArity);
         }
 
-        private static List<HotReloadMethodOutcome> BuildGatedReplacementSkipOutcomes(
+        internal static List<HotReloadMethodOutcome> BuildGatedReplacementSkipOutcomes(
             IReadOnlyList<TransformWorkerEntryDto> gatedReplacements,
-            Dictionary<string, List<string>> uncoveredCallersByTarget,
-            Dictionary<string, HashSet<string>> editedFileMethodKeysByFile,
+            Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget,
+            Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>> editedFileMethodIdentitiesByFile,
             HotReloadGroupFilePaths groupFilePaths)
         {
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
@@ -256,11 +277,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Why this entry's own file: a caller edited in a sibling file of the group is
                 // not a same-file caller, and telling the user otherwise points them at the
                 // wrong file.
-                else if (uncoveredCallersByTarget.TryGetValue(methodKey, out List<string> uncoveredCallers)
-                    && editedFileMethodKeysByFile.TryGetValue(
+                else if (uncoveredCallersByTarget.TryGetValue(
+                             methodKey,
+                             out List<HotReloadQualifiedMethodIdentity> uncoveredCallers)
+                    && editedFileMethodIdentitiesByFile.TryGetValue(
                         entry.sourceProjectRelativePath,
-                        out HashSet<string> editedFileMethodKeys)
-                    && HotReloadSignatureChangeCoverage.AreAllUncoveredCallersInEditedFile(uncoveredCallers, editedFileMethodKeys))
+                        out HashSet<HotReloadQualifiedMethodIdentity> editedFileMethodIdentities)
+                    && HotReloadSignatureChangeCoverage.AreAllUncoveredCallersInEditedFile(
+                        uncoveredCallers,
+                        editedFileMethodIdentities))
                 {
                     reason = string.Format(
                         HotReloadConstants.SignatureChangedGateSkipReasonSameFileCallersFormat,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
@@ -33,10 +33,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 context.AssemblyName,
                 replacementEntries,
                 removedSignatures);
+            HashSet<HotReloadQualifiedMethodIdentity> deletedCallerExemptions =
+                HotReloadDeletedCallerExemptions.Collect(
+                    context.AssemblyName,
+                    entries,
+                    context.WorkerOutput.unchangedMethods ?? Array.Empty<TransformWorkerUnchangedMethodDto>(),
+                    context.WorkerOutput.skipped ?? Array.Empty<TransformWorkerSkippedDto>(),
+                    removedSignatures);
             List<HotReloadCallSiteScanner.CallSiteHit> hits =
                 HotReloadCallSiteScanner.FindCallSites(context.ProjectRoot, targets).Hits;
             Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget =
-                CollectInitialUncoveredCallers(context.AssemblyName, entries, targets, hits);
+                CollectInitialUncoveredCallers(context.AssemblyName, entries, hits, deletedCallerExemptions);
 
             List<string> staleWarnings = HotReloadSignatureChangeCoverage.CollectStaleSignatureWarnings(
                 removedSignatures,
@@ -49,7 +56,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return SignatureChangeGateResult.WarningsOnly(
                     staleWarnings,
                     hits,
-                    HotReloadSignatureChangeCoverage.CollectScanTargetKeys(targets));
+                    deletedCallerExemptions);
             }
 
             HotReloadShimIsolation.IsolationExclusions exclusions = HotReloadShimIsolation.BuildIsolationExclusions(gatedReplacements, entries);
@@ -99,7 +106,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 skippedOutcomes,
                 staleWarnings,
                 hits,
-                HotReloadSignatureChangeCoverage.CollectScanTargetKeys(targets),
+                deletedCallerExemptions,
                 gatedReplacementMethodKeys);
         }
 
@@ -124,14 +131,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal static Dictionary<string, List<HotReloadQualifiedMethodIdentity>> CollectInitialUncoveredCallers(
             string assemblyName,
             TransformWorkerEntryDto[] entries,
-            HotReloadCallSiteScanner.CompiledMethodIdentity[] targets,
-            IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits)
+            IReadOnlyList<HotReloadCallSiteScanner.CallSiteHit> hits,
+            IReadOnlyCollection<HotReloadQualifiedMethodIdentity> deletedCallerExemptions)
         {
             HashSet<HotReloadQualifiedMethodIdentity> coveredIdentities =
                 HotReloadSignatureChangeCoverage.CollectCoveredMethodIdentities(
                     assemblyName,
-                    entries,
-                    targets);
+                    entries);
+            coveredIdentities.UnionWith(deletedCallerExemptions);
             return HotReloadSignatureChangeCoverage.CollectUncoveredCallersByTarget(
                 hits,
                 coveredIdentities);
@@ -319,7 +326,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public List<HotReloadMethodOutcome> SkippedOutcomes { get; }
             public List<string> Warnings { get; }
             public List<HotReloadCallSiteScanner.CallSiteHit> Hits { get; }
-            public List<string> ScanTargetKeys { get; }
+            public HashSet<HotReloadQualifiedMethodIdentity> DeletedCallerExemptions { get; }
             public List<string> GatedReplacementMethodKeys { get; }
 
             private SignatureChangeGateResult(
@@ -331,7 +338,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 List<HotReloadMethodOutcome> skippedOutcomes,
                 List<string> warnings,
                 List<HotReloadCallSiteScanner.CallSiteHit> hits,
-                List<string> scanTargetKeys,
+                HashSet<HotReloadQualifiedMethodIdentity> deletedCallerExemptions,
                 List<string> gatedReplacementMethodKeys)
             {
                 FileFailed = fileFailed;
@@ -342,7 +349,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 SkippedOutcomes = skippedOutcomes ?? new List<HotReloadMethodOutcome>();
                 Warnings = warnings ?? new List<string>();
                 Hits = hits ?? new List<HotReloadCallSiteScanner.CallSiteHit>();
-                ScanTargetKeys = scanTargetKeys ?? new List<string>();
+                DeletedCallerExemptions = deletedCallerExemptions
+                    ?? new HashSet<HotReloadQualifiedMethodIdentity>();
                 GatedReplacementMethodKeys = gatedReplacementMethodKeys ?? new List<string>();
             }
 
@@ -355,10 +363,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public static SignatureChangeGateResult WarningsOnly(
                 List<string> warnings,
                 List<HotReloadCallSiteScanner.CallSiteHit> hits,
-                List<string> scanTargetKeys)
+                HashSet<HotReloadQualifiedMethodIdentity> deletedCallerExemptions)
             {
                 return new SignatureChangeGateResult(
-                    false, null, false, true, null, null, warnings, hits, scanTargetKeys, null);
+                    false, null, false, true, null, null, warnings, hits, deletedCallerExemptions, null);
             }
 
             public static SignatureChangeGateResult Failed(
@@ -383,7 +391,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 List<HotReloadMethodOutcome> skippedOutcomes,
                 List<string> warnings,
                 List<HotReloadCallSiteScanner.CallSiteHit> hits,
-                List<string> scanTargetKeys,
+                HashSet<HotReloadQualifiedMethodIdentity> deletedCallerExemptions,
                 List<string> gatedReplacementMethodKeys)
             {
                 return new SignatureChangeGateResult(
@@ -395,7 +403,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     skippedOutcomes,
                     warnings,
                     hits,
-                    scanTargetKeys,
+                    deletedCallerExemptions,
                     gatedReplacementMethodKeys);
             }
         }


### PR DESCRIPTION
## Summary

- Prevent unsafe Hot Reload signature changes when compiled callers remain outside the final applied changes.
- Preserve valid deleted-caller exceptions without confusing same-named callers in different assemblies.

## User Impact

Hot Reload now rejects a signature replacement when a live caller would still use the old signature, including when isolation removes that caller from the final changes. Caller notices retain distinct assembly identities while avoiding duplicate display labels.

## Changes

- Integrate the reviewed fixes from #2622 and #2623.
- Qualify caller identities by assembly throughout initial gating, final coverage, classification, and notices.
- Derive deleted-caller exceptions from the initial worker output; unidentified skipped callers conservatively disable these exceptions.
- Cover failure routing and application suppression across two edited files.

## Verification

- Reported local results: coverage tests 14/14, group processor tests 3/3, call-site scanner tests 14/14, and the new worker-output fixture 1/1 with an exact method filter.
- Coverage and group processor tests were repeated successfully on the integration branch.
- Individual PR checks passed: Complexity, Dead Code, File Length, CodeRabbit, and cubic.
- Build and Test did not run against the integration branch because of its base filter; this main-targeted PR must pass that workflow before merging.
- An earlier whole worker-test class run and a local dead-code scan did not yield completion results. They are not counted as passed. The new worker fixture subsequently completed successfully in isolation, and the CI Dead Code Gate passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

