### PR TITLE
feat: Hot reload newly added scripts safely

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadAssemblyResolutionDiagnosticsTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAssemblyResolutionDiagnosticsTests.cs
@@ -61,11 +61,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a path that Unity resolves to a compiled assembly but that is not in that
-        /// assembly's last compiled source list gets the newly-added-script reason.
+        /// A path that Unity resolves to a compiled assembly is deferred to new-source
+        /// membership validation instead of being rejected only because its source list is stale.
         /// </summary>
         [Test]
-        public void TryGetAssemblyResolutionFailureReason_WhenSourceFilesDoNotContainPath_ReturnsNewScriptReason()
+        public void TryGetAssemblyResolutionFailureReason_WhenSourceFilesDoNotContainPath_ReturnsNull()
         {
             UnityCompilationAssembly compilationAssembly = FindCompilationAssembly(HotReloadTestAssemblyName);
             Assert.That(compilationAssembly, Is.Not.Null);
@@ -76,10 +76,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 MissingHotReloadScriptPath,
                 false);
 
-            Assert.That(
-                reason,
-                Is.EqualTo(
-                    "'Assets/Tests/Editor/HotReload/UncompiledNewScript.cs' is not part of the last compiled assembly 'UnityCLILoop.Tests.Editor.HotReload' (a newly added script). New files require a real compile; run 'uloop compile' first."));
+            Assert.That(reason, Is.Null);
         }
 
         /// <summary>
@@ -153,12 +150,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: ResolvePatchTarget fails with the newly-added-script reason when
-        /// CompilationPipeline maps a missing path onto an existing asmdef whose compiled
-        /// source list does not contain that path.
+        /// ResolvePatchTarget admits a new source when the imported assembly definition
+        /// still matches its disk boundary and compiled assembly.
         /// </summary>
         [Test]
-        public void ResolvePatchTarget_WhenScriptIsNotInCompiledAssemblySourceFiles_ReturnsFailedReason()
+        public void ResolvePatchTarget_WhenScriptIsNotInCompiledAssemblySourceFiles_ReturnsMembershipEvidence()
         {
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
             List<string> warnings = new List<string>();
@@ -169,7 +165,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 UnityCompilationAssembly compilationAssembly,
                 string targetDllPath,
                 string projectRoot,
-                HotReloadUnchangedSourceDecision unchangedDecision) = HotReloadPatchTargetSupport.ResolvePatchTarget(
+                HotReloadUnchangedSourceDecision unchangedDecision,
+                HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence) = HotReloadPatchTargetSupport.ResolvePatchTarget(
                 MissingHotReloadScriptPath,
                 MissingHotReloadScriptPath,
                 outcomes,
@@ -177,19 +174,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "assembly-resolution-wiring",
                 new List<HotReloadMethodOutcome>());
 
-            Assert.That(earlyResult, Is.Not.Null);
-            Assert.That(earlyResult.Outcomes.Count, Is.EqualTo(1));
-            Assert.That(earlyResult.Outcomes[0].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Failed));
-            Assert.That(
-                earlyResult.Outcomes[0].Reason,
-                Is.EqualTo(
-                    "'Assets/Tests/Editor/HotReload/UncompiledNewScript.cs' is not part of the last compiled assembly 'UnityCLILoop.Tests.Editor.HotReload' (a newly added script). New files require a real compile; run 'uloop compile' first."));
-            Assert.That(projectRelativePath, Is.Null);
-            Assert.That(assemblyName, Is.Null);
-            Assert.That(compilationAssembly, Is.Null);
-            Assert.That(targetDllPath, Is.Null);
-            Assert.That(projectRoot, Is.Null);
+            Assert.That(earlyResult, Is.Null);
+            Assert.That(projectRelativePath, Is.EqualTo(MissingHotReloadScriptPath));
+            Assert.That(assemblyName, Is.EqualTo(HotReloadTestAssemblyName));
+            Assert.That(compilationAssembly, Is.Not.Null);
+            Assert.That(targetDllPath, Is.Not.Null.And.Not.Empty);
+            Assert.That(projectRoot, Is.Not.Null.And.Not.Empty);
             Assert.That(unchangedDecision, Is.EqualTo(HotReloadUnchangedSourceDecision.NotUnchanged));
+            Assert.That(newSourceMembershipEvidence, Is.Not.Null);
         }
 
         private static UnityCompilationAssembly FindCompilationAssembly(string assemblyName)

--- a/Assets/Tests/Editor/HotReload/HotReloadAssemblyResolutionDiagnosticsTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAssemblyResolutionDiagnosticsTests.cs
@@ -22,6 +22,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             "Assets/Tests/Editor/HotReload/HotReloadToolTests.cs";
         private const string HotReloadTestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
 
+        private Func<HotReloadEditorStateSnapshot> _previousSnapshotProvider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _previousSnapshotProvider = HotReloadEditorStateSnapshotProvider.CaptureForTesting;
+            HotReloadEditorStateSnapshotProvider.CaptureForTesting = () =>
+                new HotReloadEditorStateSnapshot(false, false, false);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadEditorStateSnapshotProvider.CaptureForTesting = _previousSnapshotProvider;
+        }
+
         /// <summary>
         /// What: a resolved assembly that is absent from CompilationPipeline gets the
         /// compile-first reason that names the fallback predefined-assembly behavior.

--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 using NUnit.Framework;
@@ -38,6 +39,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     context,
                     gateResult,
                     compile,
+                    CancellationToken.None,
                     () =>
                     {
                         continuationCalls++;
@@ -80,6 +82,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     context,
                     gateResult,
                     compile,
+                    CancellationToken.None,
                     () =>
                     {
                         continuationCalls++;
@@ -108,6 +111,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     context,
                     CreateGateResultWithDeletedCallerExemption(),
                     compile,
+                    CancellationToken.None,
                     () =>
                     {
                         continuationCalls++;
@@ -116,6 +120,41 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(continuationCalls, Is.EqualTo(1));
             Assert.That(results, Is.SameAs(expected));
+        }
+
+        /// <summary>
+        /// Membership evidence that changes after the worker prevents the production apply continuation from running.
+        /// </summary>
+        [Test]
+        public async Task CompleteApplyAfterCoverageAsync_WhenNewSourceMembershipChanges_DoesNotInvokeContinuation()
+        {
+            HotReloadApplyContext context = CreateContext(CreateChangedMembershipEvidence());
+            TransformWorkerEntryDto caller = CreateCallerEntry("Assets/CoverageCaller.cs");
+            TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
+            HotReloadGroupCompileResult compile = CreateCompile(caller, target);
+            int continuationCalls = 0;
+
+            IReadOnlyList<HotReloadFileProcessResult> results =
+                await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                    context,
+                    CreateGateResultWithoutExemptions(),
+                    compile,
+                    CancellationToken.None,
+                    () =>
+                    {
+                        continuationCalls++;
+                        return Task.FromResult<IReadOnlyList<HotReloadFileProcessResult>>(
+                            Array.Empty<HotReloadFileProcessResult>());
+                    });
+
+            Assert.That(continuationCalls, Is.EqualTo(0));
+            Assert.That(results, Has.Count.EqualTo(2));
+            for (int index = 0; index < results.Count; index++)
+            {
+                Assert.That(results[index].Outcomes, Has.Count.EqualTo(1));
+                Assert.That(results[index].Outcomes[0].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Failed));
+                Assert.That(results[index].Outcomes[0].Reason, Does.Contain("compiled assembly changed"));
+            }
         }
 
         private static HotReloadSignatureChangeGate.SignatureChangeGateResult CreateGateResultWithoutExemptions()
@@ -171,12 +210,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     Array.Empty<byte>()));
         }
 
-        private static HotReloadApplyContext CreateContext()
+        private static HotReloadApplyContext CreateContext(
+            HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence = null)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             Assembly compilationAssembly = FindCompilationAssembly();
             HotReloadGroupFile callerFile = CreateFile(
-                "Assets/CoverageCaller.cs", projectRoot, compilationAssembly);
+                "Assets/CoverageCaller.cs", projectRoot, compilationAssembly, newSourceMembershipEvidence);
             HotReloadGroupFile targetFile = CreateFile(
                 "Assets/CoverageTarget.cs", projectRoot, compilationAssembly);
             TransformWorkerEntryDto caller = CreateCallerEntry(callerFile.ProjectRelativePath);
@@ -217,12 +257,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return null;
         }
 
-        private static HotReloadGroupFile CreateFile(string path, string projectRoot, Assembly compilationAssembly)
+        private static HotReloadGroupFile CreateFile(
+            string path,
+            string projectRoot,
+            Assembly compilationAssembly,
+            HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence = null)
         {
             HotReloadGroupFile file = new HotReloadGroupFile(
                 path, path, path, AssemblyName, compilationAssembly,
                 Path.Combine(projectRoot, "Library", "ScriptAssemblies", AssemblyName + ".dll"),
-                projectRoot, new HotReloadFileSinks(new List<string>(), null));
+                projectRoot, new HotReloadFileSinks(new List<string>(), null), newSourceMembershipEvidence);
             file.FileOutput = new TransformWorkerFileOutputDto
             {
                 projectRelativePath = path,
@@ -231,6 +275,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             file.SnapshotLabels = new HashSet<string>();
             file.SnapshotAddedLabels = new HashSet<string>();
             return file;
+        }
+
+        private static HotReloadNewSourceMembershipEvidence CreateChangedMembershipEvidence()
+        {
+            return new HotReloadNewSourceMembershipEvidence(
+                "Assets/CoverageCaller.cs",
+                AssemblyName,
+                Path.Combine("Library", "ScriptAssemblies", AssemblyName + ".dll"),
+                "different-mvid",
+                null,
+                Array.Empty<HotReloadNewSourceMembershipBoundary>());
         }
 
         private static TransformWorkerEntryDto CreateCallerEntry(string path)

--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -21,6 +21,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string AssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
         private const string CallerKey = "Coverage.Host::Caller()";
         private const string TargetKey = "Coverage.Host::Target()";
+        private const string MissingNewSourcePath = "Assets/Tests/Editor/HotReload/UncompiledNewScript.cs";
+        private const string PersistedAddedMemberKey = "Coverage.Host::Persisted()";
+
+        private Func<HotReloadEditorStateSnapshot> _previousSnapshotProvider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _previousSnapshotProvider = HotReloadEditorStateSnapshotProvider.CaptureForTesting;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadEditorStateSnapshotProvider.CaptureForTesting = _previousSnapshotProvider;
+            HotReloadAddedMemberRegistry.Clear();
+        }
 
         /// <summary>
         /// A two-file coverage loss fails both files before the application continuation runs.
@@ -157,6 +174,206 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
         }
 
+        /// <summary>
+        /// A ready Editor state permits the final production continuation after revalidating actual membership evidence.
+        /// </summary>
+        [Test]
+        public async Task CompleteApplyAfterCoverageAsync_WhenMembershipEvidenceStaysReady_InvokesContinuation()
+        {
+            HotReloadNewSourceMembershipEvidence evidence = CaptureCurrentMembershipEvidence();
+            HotReloadApplyContext context = CreateContext(evidence);
+            TransformWorkerEntryDto caller = CreateCallerEntry("Assets/CoverageCaller.cs");
+            TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
+            int continuationCalls = 0;
+
+            await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                context,
+                CreateGateResultWithoutExemptions(),
+                CreateCompile(caller, target),
+                CancellationToken.None,
+                () =>
+                {
+                    continuationCalls++;
+                    return Task.FromResult<IReadOnlyList<HotReloadFileProcessResult>>(
+                        Array.Empty<HotReloadFileProcessResult>());
+                });
+
+            Assert.That(continuationCalls, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// An Editor state that becomes unsafe after evidence capture blocks the final production continuation.
+        /// </summary>
+        [Test]
+        public async Task CompleteApplyAfterCoverageAsync_WhenEditorBecomesUnsafe_DoesNotInvokeContinuation()
+        {
+            HotReloadNewSourceMembershipEvidence evidence = CaptureCurrentMembershipEvidence();
+            HotReloadEditorStateSnapshotProvider.CaptureForTesting = () =>
+                new HotReloadEditorStateSnapshot(true, false, false);
+            HotReloadApplyContext context = CreateContext(evidence);
+            TransformWorkerEntryDto caller = CreateCallerEntry("Assets/CoverageCaller.cs");
+            TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
+            int continuationCalls = 0;
+
+            IReadOnlyList<HotReloadFileProcessResult> results =
+                await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                    context,
+                    CreateGateResultWithoutExemptions(),
+                    CreateCompile(caller, target),
+                    CancellationToken.None,
+                    () =>
+                    {
+                        continuationCalls++;
+                        return Task.FromResult<IReadOnlyList<HotReloadFileProcessResult>>(
+                            Array.Empty<HotReloadFileProcessResult>());
+                    });
+
+            Assert.That(continuationCalls, Is.EqualTo(0));
+            Assert.That(results, Has.Count.EqualTo(2));
+            Assert.That(results[0].Outcomes[0].Reason, Does.Contain("compiling"));
+        }
+
+        /// <summary>
+        /// Cancellation before the final main-thread revalidation prevents the production continuation.
+        /// </summary>
+        [Test]
+        public void CompleteApplyAfterCoverageAsync_WhenCancelled_DoesNotInvokeContinuation()
+        {
+            HotReloadApplyContext context = CreateContext();
+            TransformWorkerEntryDto caller = CreateCallerEntry("Assets/CoverageCaller.cs");
+            TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
+            int continuationCalls = 0;
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+
+            Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                    context,
+                    CreateGateResultWithoutExemptions(),
+                    CreateCompile(caller, target),
+                    cancellation.Token,
+                    () =>
+                    {
+                        continuationCalls++;
+                        return Task.FromResult<IReadOnlyList<HotReloadFileProcessResult>>(
+                            Array.Empty<HotReloadFileProcessResult>());
+                    }));
+
+            Assert.That(continuationCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Unsafe membership evidence after a worker result prevents the production revert continuation.
+        /// </summary>
+        [Test]
+        public async Task RevalidateBeforeRevertAsync_WhenEditorBecomesUnsafe_DoesNotInvokeRevert()
+        {
+            HotReloadNewSourceMembershipEvidence evidence = CaptureCurrentMembershipEvidence();
+            HotReloadEditorStateSnapshotProvider.CaptureForTesting = () =>
+                new HotReloadEditorStateSnapshot(false, true, false);
+            HotReloadApplyContext context = CreateContext(evidence);
+            int revertCalls = 0;
+
+            bool didRevert = await HotReloadGroupProcessor.RevalidateBeforeRevertAsync(
+                context.Files,
+                CancellationToken.None,
+                () => revertCalls++);
+
+            Assert.That(didRevert, Is.False);
+            Assert.That(revertCalls, Is.EqualTo(0));
+            Assert.That(context.Files[0].Sinks.Outcomes[0].Reason, Does.Contain("importing assets"));
+        }
+
+        /// <summary>
+        /// Planning a new source through the orchestrator retains evidence for the later pre-revert rejection.
+        /// </summary>
+        [Test]
+        public async Task ResolveInputFile_WhenNewSourceIsPlanned_PreservesEvidenceForPreRevertRevalidation()
+        {
+            HotReloadRunAccumulator run = new HotReloadRunAccumulator();
+            HotReloadFileProcessResult[] resultSlots = new HotReloadFileProcessResult[1];
+            string[] resultPaths = new string[1];
+            HotReloadGroupFile[] groupFiles = new HotReloadGroupFile[1];
+            List<(int InputIndex, string AssemblyName, string ProjectRelativePath)> plannerInput =
+                new List<(int InputIndex, string AssemblyName, string ProjectRelativePath)>();
+            List<HotReloadMethodOutcome>[] deferredAlreadyActive = new List<HotReloadMethodOutcome>[1];
+
+            HotReloadOrchestrator.ResolveInputFile(
+                MissingNewSourcePath,
+                0,
+                null,
+                null,
+                "new-source-planning",
+                run,
+                resultSlots,
+                resultPaths,
+                groupFiles,
+                plannerInput,
+                deferredAlreadyActive);
+
+            Assert.That(resultSlots[0], Is.Null);
+            Assert.That(groupFiles[0], Is.Not.Null);
+            Assert.That(groupFiles[0].NewSourceMembershipEvidence, Is.Not.Null);
+            Assert.That(plannerInput, Has.Count.EqualTo(1));
+
+            HotReloadEditorStateSnapshotProvider.CaptureForTesting = () =>
+                new HotReloadEditorStateSnapshot(false, true, false);
+            int revertCalls = 0;
+            bool didRevert = await HotReloadGroupProcessor.RevalidateBeforeRevertAsync(
+                new[] { groupFiles[0] },
+                CancellationToken.None,
+                () => revertCalls++);
+
+            Assert.That(didRevert, Is.False);
+            Assert.That(revertCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Empty entries preserve an active added-member generation when membership becomes unsafe.
+        /// </summary>
+        [Test]
+        public async Task ResolveEntriesToPatchAsync_WhenEditorBecomesUnsafe_KeepsAddedMemberGeneration()
+        {
+            HotReloadNewSourceMembershipEvidence evidence = CaptureCurrentMembershipEvidence();
+            HotReloadApplyContext context = CreateEmptyEntriesContext(evidence);
+            HotReloadGroupFile file = context.Files[0];
+            SeedActiveAddedMember(file.ProjectRelativePath);
+            HotReloadEditorStateSnapshotProvider.CaptureForTesting = () =>
+                new HotReloadEditorStateSnapshot(false, false, true);
+
+            HotReloadGroupCompileResult result = await HotReloadShimFirstCompile.ResolveEntriesToPatchAsync(
+                context,
+                CreateEmptyGateResult(),
+                CancellationToken.None);
+
+            Assert.That(result.HasEntriesToApply, Is.False);
+            Assert.That(HotReloadAddedMemberRegistry.HasGeneration(file.ProjectRelativePath), Is.True);
+            Assert.That(HotReloadAddedMemberRegistry.IsActiveMember(file.ProjectRelativePath, PersistedAddedMemberKey), Is.True);
+            Assert.That(file.ClearedAddedFieldNames, Is.Null);
+        }
+
+        /// <summary>
+        /// Empty entries clear an active added-member generation when membership remains ready.
+        /// </summary>
+        [Test]
+        public async Task ResolveEntriesToPatchAsync_WhenMembershipStaysReady_ClearsAddedMemberGeneration()
+        {
+            HotReloadNewSourceMembershipEvidence evidence = CaptureCurrentMembershipEvidence();
+            HotReloadApplyContext context = CreateEmptyEntriesContext(evidence);
+            HotReloadGroupFile file = context.Files[0];
+            SeedActiveAddedMember(file.ProjectRelativePath);
+
+            HotReloadGroupCompileResult result = await HotReloadShimFirstCompile.ResolveEntriesToPatchAsync(
+                context,
+                CreateEmptyGateResult(),
+                CancellationToken.None);
+
+            Assert.That(result.HasEntriesToApply, Is.False);
+            Assert.That(HotReloadAddedMemberRegistry.HasGeneration(file.ProjectRelativePath), Is.True);
+            Assert.That(HotReloadAddedMemberRegistry.IsActiveMember(file.ProjectRelativePath, PersistedAddedMemberKey), Is.False);
+            Assert.That(file.ClearedAddedFieldNames, Is.Not.Null);
+        }
+
         private static HotReloadSignatureChangeGate.SignatureChangeGateResult CreateGateResultWithoutExemptions()
         {
             return HotReloadSignatureChangeGate.SignatureChangeGateResult.WarningsOnly(
@@ -173,6 +390,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         TargetMethodKey = TargetKey
                     }
                 },
+                new HashSet<HotReloadQualifiedMethodIdentity>());
+        }
+
+        private static HotReloadSignatureChangeGate.SignatureChangeGateResult CreateEmptyGateResult()
+        {
+            return HotReloadSignatureChangeGate.SignatureChangeGateResult.WarningsOnly(
+                new List<string>(),
+                new List<HotReloadCallSiteScanner.CallSiteHit>(),
                 new HashSet<HotReloadQualifiedMethodIdentity>());
         }
 
@@ -243,6 +468,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 new[] { callerFile, targetFile });
         }
 
+        private static HotReloadApplyContext CreateEmptyEntriesContext(
+            HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence)
+        {
+            HotReloadApplyContext context = CreateContext(newSourceMembershipEvidence);
+            context.Files[0].FileOutput.addedFieldNames = Array.Empty<string>();
+            TransformWorkerOutputDto emptyWorkerOutput = new TransformWorkerOutputDto
+            {
+                shimSource = string.Empty,
+                entries = Array.Empty<TransformWorkerEntryDto>(),
+                skipped = Array.Empty<TransformWorkerSkippedDto>(),
+                unchangedMethods = Array.Empty<TransformWorkerUnchangedMethodDto>(),
+                files = context.WorkerOutput.files
+            };
+            return new HotReloadApplyContext(
+                context.ProjectRoot,
+                context.AssemblyName,
+                context.CorrelationId,
+                context.CompilationAssembly,
+                context.TargetDllPath,
+                context.Defines,
+                context.WorkerInput,
+                emptyWorkerOutput,
+                context.Files);
+        }
+
         private static Assembly FindCompilationAssembly()
         {
             foreach (Assembly assembly in CompilationPipeline.GetAssemblies())
@@ -286,6 +536,48 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "different-mvid",
                 null,
                 Array.Empty<HotReloadNewSourceMembershipBoundary>());
+        }
+
+        private static HotReloadNewSourceMembershipEvidence CaptureCurrentMembershipEvidence()
+        {
+            HotReloadEditorStateSnapshotProvider.CaptureForTesting = () =>
+                new HotReloadEditorStateSnapshot(false, false, false);
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            Assembly compilationAssembly = FindCompilationAssembly();
+            string targetDllPath = Path.Combine(
+                projectRoot,
+                "Library",
+                "ScriptAssemblies",
+                AssemblyName + ".dll");
+            string failure = HotReloadNewSourceMembershipValidator.TryCapture(
+                projectRoot,
+                MissingNewSourcePath,
+                AssemblyName,
+                compilationAssembly,
+                targetDllPath,
+                out HotReloadNewSourceMembershipEvidence evidence);
+
+            Assert.That(failure, Is.Null);
+            Assert.That(evidence, Is.Not.Null);
+            return evidence;
+        }
+
+        private static void SeedActiveAddedMember(string projectRelativePath)
+        {
+            System.Reflection.MethodInfo shimMethod = typeof(HotReloadGroupProcessorTests).GetMethod(
+                nameof(AddedMemberShim),
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            Assert.That(shimMethod, Is.Not.Null);
+            HotReloadAddedMemberRegistry.BeginFileGeneration(projectRelativePath);
+            HotReloadAddedMemberRegistry.Register(
+                projectRelativePath,
+                PersistedAddedMemberKey,
+                shimMethod,
+                projectRelativePath);
+        }
+
+        private static void AddedMemberShim()
+        {
         }
 
         private static TransformWorkerEntryDto CreateCallerEntry(string path)

--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -319,6 +319,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Cancellation during pre-revert membership revalidation prevents the revert continuation.
+        /// </summary>
+        [Test]
+        public void RevalidateBeforeRevertAsync_WhenCancelledDuringRevalidation_DoesNotInvokeRevert()
+        {
+            HotReloadNewSourceMembershipEvidence evidence = CaptureCurrentMembershipEvidence();
+            HotReloadApplyContext context = CreateContext(evidence);
+            int revertCalls = 0;
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            HotReloadEditorStateSnapshotProvider.CaptureForTesting = () =>
+            {
+                cancellation.Cancel();
+                return new HotReloadEditorStateSnapshot(false, false, false);
+            };
+
+            Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                await HotReloadGroupProcessor.RevalidateBeforeRevertAsync(
+                    context.Files,
+                    cancellation.Token,
+                    () => revertCalls++));
+
+            Assert.That(revertCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
         /// Planning a new source through the orchestrator retains evidence for the later pre-revert rejection.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -263,6 +263,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Cancellation that arrives during synchronous membership revalidation prevents the final continuation.
+        /// </summary>
+        [Test]
+        public void CompleteApplyAfterCoverageAsync_WhenCancelledDuringRevalidation_DoesNotInvokeContinuation()
+        {
+            HotReloadNewSourceMembershipEvidence evidence = CaptureCurrentMembershipEvidence();
+            HotReloadApplyContext context = CreateContext(evidence);
+            TransformWorkerEntryDto caller = CreateCallerEntry("Assets/CoverageCaller.cs");
+            TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
+            int continuationCalls = 0;
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            HotReloadEditorStateSnapshotProvider.CaptureForTesting = () =>
+            {
+                cancellation.Cancel();
+                return new HotReloadEditorStateSnapshot(false, false, false);
+            };
+
+            Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                    context,
+                    CreateGateResultWithoutExemptions(),
+                    CreateCompile(caller, target),
+                    cancellation.Token,
+                    () =>
+                    {
+                        continuationCalls++;
+                        return Task.FromResult<IReadOnlyList<HotReloadFileProcessResult>>(
+                            Array.Empty<HotReloadFileProcessResult>());
+                    }));
+
+            Assert.That(continuationCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
         /// Unsafe membership evidence after a worker result prevents the production revert continuation.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/HotReloadNewSourceMembershipTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadNewSourceMembershipTests.cs
@@ -1,0 +1,420 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Verifies that new-source membership admission stops before group processing while Editor state is unsafe.
+    /// </summary>
+    public sealed class HotReloadNewSourceMembershipTests
+    {
+        private const string MissingHotReloadScriptPath =
+            "Assets/Tests/Editor/HotReload/UncompiledNewScript.cs";
+        private const string MissingPredefinedScriptPath =
+            "Assets/Util/UncompiledNewPredefinedScript.cs";
+
+        private Func<HotReloadEditorStateSnapshot> _previousSnapshotProvider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _previousSnapshotProvider = HotReloadEditorStateSnapshotProvider.CaptureForTesting;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadEditorStateSnapshotProvider.CaptureForTesting = _previousSnapshotProvider;
+        }
+
+        /// <summary>
+        /// Compiling, importing, and compilation-failed Editor states each stop the production target resolver before a group can be planned.
+        /// </summary>
+        [TestCase(true, false, false)]
+        [TestCase(false, true, false)]
+        [TestCase(false, false, true)]
+        public void ResolvePatchTarget_WhenEditorStateIsUnsafe_ReturnsEarlyResult(
+            bool isCompiling,
+            bool isUpdating,
+            bool scriptCompilationFailed)
+        {
+            HotReloadEditorStateSnapshotProvider.CaptureForTesting = () =>
+                new HotReloadEditorStateSnapshot(isCompiling, isUpdating, scriptCompilationFailed);
+            List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
+            List<string> warnings = new List<string>();
+
+            (HotReloadFileProcessResult earlyResult,
+                string projectRelativePath,
+                string assemblyName,
+                UnityEditor.Compilation.Assembly compilationAssembly,
+                string targetDllPath,
+                string projectRoot,
+                HotReloadUnchangedSourceDecision unchangedDecision,
+                HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence) = HotReloadPatchTargetSupport.ResolvePatchTarget(
+                MissingHotReloadScriptPath,
+                MissingHotReloadScriptPath,
+                outcomes,
+                warnings,
+                "new-source-editor-state",
+                new List<HotReloadMethodOutcome>());
+
+            Assert.That(earlyResult, Is.Not.Null);
+            Assert.That(earlyResult.Outcomes, Has.Count.EqualTo(1));
+            Assert.That(earlyResult.Outcomes[0].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Failed));
+            Assert.That(earlyResult.Outcomes[0].Reason, Does.Contain("retry hot reload"));
+            Assert.That(projectRelativePath, Is.Null);
+            Assert.That(assemblyName, Is.Null);
+            Assert.That(compilationAssembly, Is.Null);
+            Assert.That(targetDllPath, Is.Null);
+            Assert.That(projectRoot, Is.Null);
+            Assert.That(unchangedDecision, Is.EqualTo(HotReloadUnchangedSourceDecision.NotUnchanged));
+            Assert.That(newSourceMembershipEvidence, Is.Null);
+        }
+
+        /// <summary>
+        /// A ready Editor state admits the new source through the production resolver with membership evidence.
+        /// </summary>
+        [Test]
+        public void ResolvePatchTarget_WhenEditorStateIsReady_ReturnsMembershipEvidence()
+        {
+            HotReloadEditorStateSnapshotProvider.CaptureForTesting = () =>
+                new HotReloadEditorStateSnapshot(false, false, false);
+            List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
+            List<string> warnings = new List<string>();
+
+            (HotReloadFileProcessResult earlyResult,
+                string projectRelativePath,
+                string assemblyName,
+                UnityEditor.Compilation.Assembly compilationAssembly,
+                string targetDllPath,
+                string projectRoot,
+                HotReloadUnchangedSourceDecision unchangedDecision,
+                HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence) = HotReloadPatchTargetSupport.ResolvePatchTarget(
+                MissingHotReloadScriptPath,
+                MissingHotReloadScriptPath,
+                outcomes,
+                warnings,
+                "new-source-editor-ready",
+                new List<HotReloadMethodOutcome>());
+
+            Assert.That(earlyResult, Is.Null);
+            Assert.That(projectRelativePath, Is.EqualTo(MissingHotReloadScriptPath));
+            Assert.That(assemblyName, Is.Not.Null.And.Not.Empty);
+            Assert.That(compilationAssembly, Is.Not.Null);
+            Assert.That(targetDllPath, Is.Not.Null.And.Not.Empty);
+            Assert.That(projectRoot, Is.Not.Null.And.Not.Empty);
+            Assert.That(unchangedDecision, Is.EqualTo(HotReloadUnchangedSourceDecision.NotUnchanged));
+            Assert.That(newSourceMembershipEvidence, Is.Not.Null);
+        }
+
+        /// <summary>
+        /// Disk bytes, imported bytes, and GUIDs are each part of the immutable membership evidence.
+        /// </summary>
+        [Test]
+        public void EvidenceMatches_WhenBoundaryContentOrGuidChanges_ReturnsFalse()
+        {
+            HotReloadNewSourceMembershipEvidence baseline = CreateEvidence("disk", "import", "guid");
+            HotReloadNewSourceMembershipEvidence diskChanged = CreateEvidence("next-disk", "import", "guid");
+            HotReloadNewSourceMembershipEvidence importChanged = CreateEvidence("disk", "next-import", "guid");
+            HotReloadNewSourceMembershipEvidence guidChanged = CreateEvidence("disk", "import", "next-guid");
+            HotReloadNewSourceMembershipEvidence referencedTargetGuidChanged = CreateEvidence(
+                "disk",
+                "import",
+                "guid",
+                "next-target-guid");
+
+            Assert.That(HotReloadNewSourceMembershipValidator.EvidenceMatches(baseline, diskChanged), Is.False);
+            Assert.That(HotReloadNewSourceMembershipValidator.EvidenceMatches(baseline, importChanged), Is.False);
+            Assert.That(HotReloadNewSourceMembershipValidator.EvidenceMatches(baseline, guidChanged), Is.False);
+            Assert.That(HotReloadNewSourceMembershipValidator.EvidenceMatches(baseline, referencedTargetGuidChanged), Is.False);
+        }
+
+        /// <summary>
+        /// A missing script outside every asmdef is admitted through the production predefined-assembly route with empty boundaries.
+        /// </summary>
+        [Test]
+        public void ResolvePatchTarget_WhenNewPredefinedSourceIsReady_ReturnsMembershipEvidence()
+        {
+            HotReloadEditorStateSnapshotProvider.CaptureForTesting = () =>
+                new HotReloadEditorStateSnapshot(false, false, false);
+            List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
+            List<string> warnings = new List<string>();
+
+            (HotReloadFileProcessResult earlyResult,
+                string projectRelativePath,
+                string assemblyName,
+                UnityEditor.Compilation.Assembly compilationAssembly,
+                string targetDllPath,
+                string projectRoot,
+                HotReloadUnchangedSourceDecision unchangedDecision,
+                HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence) = HotReloadPatchTargetSupport.ResolvePatchTarget(
+                MissingPredefinedScriptPath,
+                MissingPredefinedScriptPath,
+                outcomes,
+                warnings,
+                "new-predefined-source",
+                new List<HotReloadMethodOutcome>());
+
+            Assert.That(earlyResult, Is.Null);
+            Assert.That(projectRelativePath, Is.EqualTo(MissingPredefinedScriptPath));
+            Assert.That(assemblyName, Is.EqualTo("Assembly-CSharp"));
+            Assert.That(compilationAssembly, Is.Not.Null);
+            Assert.That(targetDllPath, Is.Not.Null.And.Not.Empty);
+            Assert.That(projectRoot, Is.Not.Null.And.Not.Empty);
+            Assert.That(unchangedDecision, Is.EqualTo(HotReloadUnchangedSourceDecision.NotUnchanged));
+            Assert.That(newSourceMembershipEvidence, Is.Not.Null);
+            Assert.That(newSourceMembershipEvidence.Boundaries, Is.Empty);
+            Assert.That(newSourceMembershipEvidence.ResolvedAssemblyDefinitionPath, Is.Null);
+        }
+
+        /// <summary>
+        /// Windows separator normalization keeps otherwise identical new-source evidence equal.
+        /// </summary>
+        [Test]
+        public void EvidenceMatches_WhenSourcePathUsesWindowsSeparators_ReturnsTrue()
+        {
+            HotReloadNewSourceMembershipEvidence forwardSlash = CreateEvidence("disk", "import", "guid");
+            HotReloadNewSourceMembershipEvidence backslash = new HotReloadNewSourceMembershipEvidence(
+                "Assets\\Tests\\Editor\\HotReload\\UncompiledNewScript.cs",
+                "TestAssembly",
+                "Library/ScriptAssemblies/TestAssembly.dll",
+                "mvid",
+                "Assets\\Tests\\Editor\\HotReload\\Test.asmdef",
+                new[]
+                {
+                    new HotReloadNewSourceMembershipBoundary(
+                        "Assets\\Tests\\Editor\\HotReload\\Test.asmref",
+                        "disk",
+                        "import",
+                        "guid",
+                        "guid"),
+                    new HotReloadNewSourceMembershipBoundary(
+                        "Assets\\Definitions\\ReferencedTarget.asmdef",
+                        "target-disk",
+                        "target-import",
+                        "target-guid",
+                        "target-guid")
+                });
+
+            Assert.That(HotReloadNewSourceMembershipValidator.EvidenceMatches(forwardSlash, backslash), Is.True);
+        }
+
+        /// <summary>
+        /// An asmref resolves a differently named asmdef file through the JSON assembly name despite JSON whitespace.
+        /// </summary>
+        [Test]
+        public void ResolveNearestBoundaryTarget_WhenAsmrefUsesAssemblyName_ReturnsDifferentlyNamedAsmdefPath()
+        {
+            string asmdefContents = "{\n  \"name\" : \"Declared Assembly\"\n}";
+            HotReloadNewSourceMembershipBoundary asmref = new HotReloadNewSourceMembershipBoundary(
+                "Assets/Feature/Nearest.asmref",
+                Convert.ToBase64String(Encoding.UTF8.GetBytes("{ \"reference\" : \"Declared Assembly\" }")),
+                "import",
+                "guid",
+                "guid");
+
+            string resolvedPath = HotReloadNewSourceMembershipValidator.ResolveNearestBoundaryTarget(
+                new[] { asmref },
+                reference => null,
+                reference => string.Equals(reference, HotReloadNewSourceMembershipValidator.ReadAssemblyDefinitionName(asmdefContents), StringComparison.Ordinal)
+                    ? "Assets/Definitions/FileNameDoesNotMatch.asmdef"
+                    : null);
+
+            Assert.That(HotReloadNewSourceMembershipValidator.ReadAssemblyDefinitionName(asmdefContents), Is.EqualTo("Declared Assembly"));
+            Assert.That(resolvedPath, Is.EqualTo("Assets/Definitions/FileNameDoesNotMatch.asmdef"));
+        }
+
+        /// <summary>
+        /// The nearest asmdef wins before an outer asmref can resolve a different target.
+        /// </summary>
+        [Test]
+        public void ResolveNearestBoundaryTarget_WhenNearestBoundaryIsAsmdef_IgnoresOuterAsmref()
+        {
+            HotReloadNewSourceMembershipBoundary nearestAsmdef = new HotReloadNewSourceMembershipBoundary(
+                "Assets/Feature/Child/Nearest.asmdef",
+                "disk",
+                "import",
+                "guid",
+                "guid");
+            HotReloadNewSourceMembershipBoundary outerAsmref = new HotReloadNewSourceMembershipBoundary(
+                "Assets/Feature/Outer.asmref",
+                Convert.ToBase64String(Encoding.UTF8.GetBytes("{\"reference\":\"OuterAssembly\"}")),
+                "import",
+                "guid",
+                "guid");
+
+            string resolvedPath = HotReloadNewSourceMembershipValidator.ResolveNearestBoundaryTarget(
+                new[] { nearestAsmdef, outerAsmref },
+                reference => "Assets/Definitions/Unexpected.asmdef",
+                reference => "Assets/Definitions/Unexpected.asmdef");
+
+            Assert.That(resolvedPath, Is.EqualTo("Assets/Feature/Child/Nearest.asmdef"));
+        }
+
+        /// <summary>
+        /// The collector does not resolve an outer asmref target when an inner asmdef is nearest.
+        /// </summary>
+        [Test]
+        public void ResolveNearestAsmrefTargetPath_WhenNearestBoundaryIsAsmdef_DoesNotResolveOuterAsmref()
+        {
+            List<string> boundaryPaths = new List<string>
+            {
+                "Assets/Feature/Child/Nearest.asmdef",
+                "Assets/Feature/Outer.asmref"
+            };
+            int resolutionCalls = 0;
+
+            string resolvedPath = HotReloadNewSourceMembershipBoundaryCollector.ResolveNearestAsmrefTargetPath(
+                boundaryPaths,
+                path =>
+                {
+                    resolutionCalls++;
+                    return "Assets/Definitions/Unexpected.asmdef";
+                });
+
+            Assert.That(resolvedPath, Is.Null);
+            Assert.That(resolutionCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// The collector resolves the target only when the nearest boundary is an asmref.
+        /// </summary>
+        [Test]
+        public void ResolveNearestAsmrefTargetPath_WhenNearestBoundaryIsAsmref_ResolvesItsTarget()
+        {
+            List<string> boundaryPaths = new List<string>
+            {
+                "Assets/Feature/Child/Nearest.asmref",
+                "Assets/Feature/Outer.asmdef"
+            };
+            string resolvedFromPath = null;
+
+            string resolvedPath = HotReloadNewSourceMembershipBoundaryCollector.ResolveNearestAsmrefTargetPath(
+                boundaryPaths,
+                path =>
+                {
+                    resolvedFromPath = path;
+                    return "Assets/Definitions/NearestTarget.asmdef";
+                });
+
+            Assert.That(resolvedFromPath, Is.EqualTo("Assets/Feature/Child/Nearest.asmref"));
+            Assert.That(resolvedPath, Is.EqualTo("Assets/Definitions/NearestTarget.asmdef"));
+        }
+
+        /// <summary>
+        /// A disk-only boundary rejects a new assembly definition that Unity has not imported.
+        /// </summary>
+        [Test]
+        public void TryCreateBoundary_WhenBoundaryIsNotImported_ReturnsFailure()
+        {
+            string failure = HotReloadNewSourceMembershipBoundaryCollector.TryCreateBoundary(
+                "Assets/Feature/New.asmdef",
+                Encoding.UTF8.GetBytes("disk"),
+                null,
+                "guid",
+                "guid",
+                out HotReloadNewSourceMembershipBoundary boundary);
+
+            Assert.That(failure, Does.Contain("not imported"));
+            Assert.That(boundary, Is.Null);
+        }
+
+        /// <summary>
+        /// An imported boundary rejects deletion of its disk file.
+        /// </summary>
+        [Test]
+        public void TryCreateBoundary_WhenDiskFileWasDeleted_ReturnsFailure()
+        {
+            string failure = HotReloadNewSourceMembershipBoundaryCollector.TryCreateBoundary(
+                "Assets/Feature/Deleted.asmdef",
+                null,
+                Encoding.UTF8.GetBytes("import"),
+                "guid",
+                "guid",
+                out HotReloadNewSourceMembershipBoundary boundary);
+
+            Assert.That(failure, Does.Contain("deleted"));
+            Assert.That(boundary, Is.Null);
+        }
+
+        /// <summary>
+        /// Changed disk bytes and a changed imported GUID each invalidate a captured boundary.
+        /// </summary>
+        [Test]
+        public void TryCreateBoundary_WhenContentsOrGuidChanges_ReturnsFailure()
+        {
+            string contentFailure = HotReloadNewSourceMembershipBoundaryCollector.TryCreateBoundary(
+                "Assets/Feature/Changed.asmdef",
+                Encoding.UTF8.GetBytes("disk"),
+                Encoding.UTF8.GetBytes("import"),
+                "guid",
+                "guid",
+                out HotReloadNewSourceMembershipBoundary contentBoundary);
+            string guidFailure = HotReloadNewSourceMembershipBoundaryCollector.TryCreateBoundary(
+                "Assets/Feature/Changed.asmdef",
+                Encoding.UTF8.GetBytes("content"),
+                Encoding.UTF8.GetBytes("content"),
+                "disk-guid",
+                "import-guid",
+                out HotReloadNewSourceMembershipBoundary guidBoundary);
+
+            Assert.That(contentFailure, Does.Contain("changed on disk"));
+            Assert.That(guidFailure, Does.Contain("GUID differs"));
+            Assert.That(contentBoundary, Is.Null);
+            Assert.That(guidBoundary, Is.Null);
+        }
+
+        /// <summary>
+        /// Matching disk and imported boundary data creates evidence for the production capture path.
+        /// </summary>
+        [Test]
+        public void TryCreateBoundary_WhenDiskImportAndGuidMatch_ReturnsBoundary()
+        {
+            string failure = HotReloadNewSourceMembershipBoundaryCollector.TryCreateBoundary(
+                "Assets/Feature/Ready.asmdef",
+                Encoding.UTF8.GetBytes("content"),
+                Encoding.UTF8.GetBytes("content"),
+                "guid",
+                "guid",
+                out HotReloadNewSourceMembershipBoundary boundary);
+
+            Assert.That(failure, Is.Null);
+            Assert.That(boundary, Is.Not.Null);
+            Assert.That(boundary.ProjectRelativePath, Is.EqualTo("Assets/Feature/Ready.asmdef"));
+        }
+
+        private static HotReloadNewSourceMembershipEvidence CreateEvidence(
+            string diskContents,
+            string importedContents,
+            string guid,
+            string referencedTargetGuid = "target-guid")
+        {
+            return new HotReloadNewSourceMembershipEvidence(
+                "Assets/Tests/Editor/HotReload/UncompiledNewScript.cs",
+                "TestAssembly",
+                "Library/ScriptAssemblies/TestAssembly.dll",
+                "mvid",
+                "Assets/Tests/Editor/HotReload/Test.asmdef",
+                new[]
+                {
+                    new HotReloadNewSourceMembershipBoundary(
+                        "Assets/Tests/Editor/HotReload/Test.asmref",
+                        diskContents,
+                        importedContents,
+                        guid,
+                        guid),
+                    new HotReloadNewSourceMembershipBoundary(
+                        "Assets/Definitions/ReferencedTarget.asmdef",
+                        "target-disk",
+                        "target-import",
+                        referencedTargetGuid,
+                        referencedTargetGuid)
+                });
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadNewSourceMembershipTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadNewSourceMembershipTests.cs
@@ -257,6 +257,67 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// An unresolved nearest asmref target is rejected instead of being mistaken for a predefined assembly.
+        /// </summary>
+        [Test]
+        public void TryResolveNearestBoundaryTarget_WhenAsmrefTargetIsMissing_ReturnsFailure()
+        {
+            HotReloadNewSourceMembershipBoundary asmref = new HotReloadNewSourceMembershipBoundary(
+                "Assets/Feature/Nearest.asmref",
+                Convert.ToBase64String(Encoding.UTF8.GetBytes("{\"reference\":\"MissingAssembly\"}")),
+                "import",
+                "guid",
+                "guid");
+
+            string failure = HotReloadNewSourceMembershipValidator.TryResolveNearestBoundaryTarget(
+                new[] { asmref },
+                reference => null,
+                reference => null,
+                out string targetPath);
+
+            Assert.That(failure, Does.Contain("could not be resolved"));
+            Assert.That(targetPath, Is.Null);
+        }
+
+        /// <summary>
+        /// Malformed assembly boundary JSON is treated as unresolved by Unity's structured parser.
+        /// </summary>
+        [Test]
+        public void ReadAssemblyBoundaryJson_WhenMalformed_ReturnsNull()
+        {
+            Assert.That(HotReloadNewSourceMembershipValidator.ReadAssemblyDefinitionName("{ invalid"), Is.Null);
+            Assert.That(HotReloadNewSourceMembershipValidator.ReadAsmrefReference("{ invalid"), Is.Null);
+        }
+
+        /// <summary>
+        /// Malformed asmdef and asmref boundary contents fail membership validation with retry guidance.
+        /// </summary>
+        [Test]
+        public void TryValidateBoundaryJson_WhenAsmdefOrAsmrefIsMalformed_ReturnsFailure()
+        {
+            HotReloadNewSourceMembershipBoundary malformedAsmdef = new HotReloadNewSourceMembershipBoundary(
+                "Assets/Feature/Invalid.asmdef",
+                Convert.ToBase64String(Encoding.UTF8.GetBytes("{ invalid")),
+                "import",
+                "guid",
+                "guid");
+            HotReloadNewSourceMembershipBoundary malformedAsmref = new HotReloadNewSourceMembershipBoundary(
+                "Assets/Feature/Invalid.asmref",
+                Convert.ToBase64String(Encoding.UTF8.GetBytes("{ invalid")),
+                "import",
+                "guid",
+                "guid");
+
+            string asmdefFailure = HotReloadNewSourceMembershipValidator.TryValidateBoundaryJson(
+                new[] { malformedAsmdef });
+            string asmrefFailure = HotReloadNewSourceMembershipValidator.TryValidateBoundaryJson(
+                new[] { malformedAsmref });
+
+            Assert.That(asmdefFailure, Does.Contain("invalid JSON"));
+            Assert.That(asmrefFailure, Does.Contain("invalid JSON"));
+        }
+
+        /// <summary>
         /// The collector does not resolve an outer asmref target when an inner asmdef is nearest.
         /// </summary>
         [Test]
@@ -386,6 +447,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(failure, Is.Null);
             Assert.That(boundary, Is.Not.Null);
             Assert.That(boundary.ProjectRelativePath, Is.EqualTo("Assets/Feature/Ready.asmdef"));
+        }
+
+        /// <summary>
+        /// A package path without a readable physical directory fails membership capture before directory enumeration.
+        /// </summary>
+        [Test]
+        public void TryCapture_WhenPackageBoundaryDirectoryIsUnavailable_ReturnsFailure()
+        {
+            string projectRoot = System.IO.Path.GetFullPath(
+                System.IO.Path.Combine(UnityEngine.Application.dataPath, ".."));
+
+            string failure = HotReloadNewSourceMembershipBoundaryCollector.TryCapture(
+                projectRoot,
+                "Packages/unavailable-package/NewSource.cs",
+                out HotReloadNewSourceMembershipBoundary[] boundaries);
+
+            Assert.That(failure, Does.Contain("not available on disk"));
+            Assert.That(boundaries, Is.Null);
         }
 
         private static HotReloadNewSourceMembershipEvidence CreateEvidence(

--- a/Assets/Tests/Editor/HotReload/HotReloadNewSourceMembershipTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadNewSourceMembershipTests.cs
@@ -318,6 +318,58 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// The production resolved-assembly boundary rejects malformed boundary JSON before admitting a new source.
+        /// </summary>
+        [Test]
+        public void ValidateResolvedAssemblyDefinition_WhenBoundaryJsonIsMalformed_ReturnsFailure()
+        {
+            UnityEditor.Compilation.Assembly compilationAssembly = FindHotReloadCompilationAssembly();
+            string resolvedAssemblyDefinitionPath = UnityEditor.Compilation.CompilationPipeline
+                .GetAssemblyDefinitionFilePathFromScriptPath(MissingHotReloadScriptPath);
+            HotReloadNewSourceMembershipBoundary malformedBoundary = new HotReloadNewSourceMembershipBoundary(
+                resolvedAssemblyDefinitionPath,
+                Convert.ToBase64String(Encoding.UTF8.GetBytes("{ invalid")),
+                "import",
+                "guid",
+                "guid");
+
+            string failure = HotReloadNewSourceMembershipValidator.ValidateResolvedAssemblyDefinition(
+                MissingHotReloadScriptPath,
+                compilationAssembly.name,
+                compilationAssembly,
+                new[] { malformedBoundary },
+                resolvedAssemblyDefinitionPath);
+
+            Assert.That(failure, Does.Contain("invalid JSON"));
+        }
+
+        /// <summary>
+        /// The production resolved-assembly boundary rejects an unresolved nearest asmref before admitting a new source.
+        /// </summary>
+        [Test]
+        public void ValidateResolvedAssemblyDefinition_WhenNearestAsmrefIsUnresolved_ReturnsFailure()
+        {
+            UnityEditor.Compilation.Assembly compilationAssembly = FindHotReloadCompilationAssembly();
+            string resolvedAssemblyDefinitionPath = UnityEditor.Compilation.CompilationPipeline
+                .GetAssemblyDefinitionFilePathFromScriptPath(MissingHotReloadScriptPath);
+            HotReloadNewSourceMembershipBoundary unresolvedAsmref = new HotReloadNewSourceMembershipBoundary(
+                "Assets/Tests/Editor/HotReload/Unresolved.asmref",
+                Convert.ToBase64String(Encoding.UTF8.GetBytes("{ \"reference\" : \"Missing Assembly\" }")),
+                "import",
+                "guid",
+                "guid");
+
+            string failure = HotReloadNewSourceMembershipValidator.ValidateResolvedAssemblyDefinition(
+                MissingHotReloadScriptPath,
+                compilationAssembly.name,
+                compilationAssembly,
+                new[] { unresolvedAsmref },
+                resolvedAssemblyDefinitionPath);
+
+            Assert.That(failure, Does.Contain("could not be resolved"));
+        }
+
+        /// <summary>
         /// The collector does not resolve an outer asmref target when an inner asmdef is nearest.
         /// </summary>
         [Test]
@@ -494,6 +546,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         referencedTargetGuid,
                         referencedTargetGuid)
                 });
+        }
+
+        private static UnityEditor.Compilation.Assembly FindHotReloadCompilationAssembly()
+        {
+            UnityEditor.Compilation.Assembly[] assemblies = UnityEditor.Compilation.CompilationPipeline.GetAssemblies();
+            for (int index = 0; index < assemblies.Length; index++)
+            {
+                if (string.Equals(assemblies[index].name, "UnityCLILoop.Tests.Editor.HotReload", StringComparison.Ordinal))
+                {
+                    return assemblies[index];
+                }
+            }
+
+            Assert.Fail("The hot reload test assembly was not found.");
+            return null;
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadNewSourceMembershipTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadNewSourceMembershipTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 098c5493166b84bb6a20cad7b9b036ac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAssemblyResolutionDiagnostics.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAssemblyResolutionDiagnostics.cs
@@ -36,14 +36,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     assemblyName);
             }
 
-            if (!ContainsProjectRelativeSourceFile(compilationAssembly.sourceFiles, projectRelativePath))
-            {
-                return string.Format(
-                    HotReloadConstants.SourceFileNotInCompiledAssemblyReasonFormat,
-                    projectRelativePath,
-                    compilationAssembly.name);
-            }
-
             return null;
         }
 
@@ -79,7 +71,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return false;
         }
 
-        private static bool ContainsProjectRelativeSourceFile(string[] sourceFiles, string projectRelativePath)
+        internal static bool ContainsProjectRelativeSourceFile(string[] sourceFiles, string projectRelativePath)
         {
             if (sourceFiles == null || sourceFiles.Length == 0)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEditorStateSnapshotProvider.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEditorStateSnapshotProvider.cs
@@ -1,0 +1,68 @@
+using System;
+
+using UnityEditor;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Captures the Editor state that makes a new-source assembly membership unsafe to trust.
+    /// </summary>
+    internal sealed class HotReloadEditorStateSnapshot
+    {
+        internal HotReloadEditorStateSnapshot(bool isCompiling, bool isUpdating, bool scriptCompilationFailed)
+        {
+            IsCompiling = isCompiling;
+            IsUpdating = isUpdating;
+            ScriptCompilationFailed = scriptCompilationFailed;
+        }
+
+        internal bool IsCompiling { get; }
+
+        internal bool IsUpdating { get; }
+
+        internal bool ScriptCompilationFailed { get; }
+    }
+
+    /// <summary>
+    /// Separates Editor-state collection from the pure readiness decision used by new-source admission.
+    /// </summary>
+    internal static class HotReloadEditorStateSnapshotProvider
+    {
+        // Why a replaceable seam: the real Editor flags are process state, while tests must prove
+        // that each unsafe state reaches the production resolver without starting a group.
+        internal static Func<HotReloadEditorStateSnapshot> CaptureForTesting = Capture;
+
+        internal static HotReloadEditorStateSnapshot CaptureCurrent()
+        {
+            return CaptureForTesting();
+        }
+
+        internal static string GetNotReadyReason(HotReloadEditorStateSnapshot snapshot)
+        {
+            if (snapshot.IsCompiling)
+            {
+                return "The Editor is compiling, so new source membership is not ready. Compile the project first and retry hot reload.";
+            }
+
+            if (snapshot.IsUpdating)
+            {
+                return "The Editor is importing assets, so new source membership is not ready. Wait for import to finish, then retry hot reload.";
+            }
+
+            if (snapshot.ScriptCompilationFailed)
+            {
+                return "The last script compilation failed, so new source membership cannot be verified. Fix the compile errors, compile the project, and retry hot reload.";
+            }
+
+            return null;
+        }
+
+        private static HotReloadEditorStateSnapshot Capture()
+        {
+            return new HotReloadEditorStateSnapshot(
+                EditorApplication.isCompiling,
+                EditorApplication.isUpdating,
+                EditorUtility.scriptCompilationFailed);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEditorStateSnapshotProvider.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEditorStateSnapshotProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5430bac728f64f16bf7a7d0b75b1304
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupFile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupFile.cs
@@ -26,7 +26,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             UnityCompilationAssembly compilationAssembly,
             string targetDllPath,
             string projectRoot,
-            HotReloadFileSinks sinks)
+            HotReloadFileSinks sinks,
+            HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence = null)
         {
             Debug.Assert(!string.IsNullOrEmpty(assemblyResolvePath), "assemblyResolvePath must not be empty.");
             Debug.Assert(!string.IsNullOrEmpty(workerSourcePath), "workerSourcePath must not be empty.");
@@ -45,6 +46,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             TargetDllPath = targetDllPath;
             ProjectRoot = projectRoot;
             Sinks = sinks;
+            NewSourceMembershipEvidence = newSourceMembershipEvidence;
         }
 
         internal static HotReloadGroupFile ForActiveSibling(
@@ -62,7 +64,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 template.CompilationAssembly,
                 template.TargetDllPath,
                 template.ProjectRoot,
-                sinks);
+                sinks,
+                null);
         }
 
         // The path the caller asked to reload, used as the outcome file path.
@@ -82,6 +85,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal string ProjectRoot { get; }
 
         internal HotReloadFileSinks Sinks { get; }
+
+        // Null for a source already present in CompilationPipeline.sourceFiles.
+        internal HotReloadNewSourceMembershipEvidence NewSourceMembershipEvidence { get; }
 
         // Verified snapshot text of this file, or null when it has no baseline.
         internal string SnapshotSource { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -102,6 +102,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadGroupFile gateWarningSink,
             CancellationToken ct)
         {
+            // The worker-bound continuation after the pre-revert check is not guaranteed to
+            // resume on Unity's context, while the signature gate reads compilation state.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+            ct.ThrowIfCancellationRequested();
             IReadOnlyList<HotReloadGroupFile> files = context.Files;
             HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult = await HotReloadSignatureChangeGate.TryApplySignatureChangeGateAsync(
                 context,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -76,13 +76,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // Why before the empty-entries return: all-unchanged runs exit there, and those are
             // exactly the runs that must peel leftover patches so behavior converges to compiled IL.
-            await MainThreadSwitcher.SwitchToMainThread(ct);
-            if (!TryAppendNewSourceMembershipFailure(files))
+            if (!await RevalidateBeforeRevertAsync(
+                    files,
+                    ct,
+                    () => RevertUnchangedPatchesPerFile(files, rows)).ConfigureAwait(false))
             {
                 return BuildUnappliedResults(files);
             }
-
-            RevertUnchangedPatchesPerFile(files, rows);
 
             HotReloadApplyContext context = new HotReloadApplyContext(
                 firstFile.ProjectRoot,
@@ -187,6 +187,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             HotReloadGroupOutcomeRouter.AppendGroupFailure(files, "(file)", failure);
             return false;
+        }
+
+        internal static async Task<bool> RevalidateBeforeRevertAsync(
+            IReadOnlyList<HotReloadGroupFile> files,
+            CancellationToken ct,
+            Action revertUnchangedPatches)
+        {
+            Debug.Assert(revertUnchangedPatches != null, "revertUnchangedPatches must not be null.");
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+            ct.ThrowIfCancellationRequested();
+            if (!TryAppendNewSourceMembershipFailure(files))
+            {
+                return false;
+            }
+
+            revertUnchangedPatches();
+            return true;
         }
 
         // Returns false when a replacement lost its covering caller and the group must fail.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -31,6 +31,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadGroupFile firstFile = files[0];
             // Application.dataPath and the ledgers require the Unity main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
+            if (!TryAppendNewSourceMembershipFailure(files))
+            {
+                return BuildUnappliedResults(files);
+            }
+
             SnapshotGroupState(files);
 
             HotReloadChangedSiblingScanResult siblingScan = HotReloadChangedSiblingSourceDetector.Detect(
@@ -72,6 +77,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why before the empty-entries return: all-unchanged runs exit there, and those are
             // exactly the runs that must peel leftover patches so behavior converges to compiled IL.
             await MainThreadSwitcher.SwitchToMainThread(ct);
+            if (!TryAppendNewSourceMembershipFailure(files))
+            {
+                return BuildUnappliedResults(files);
+            }
+
             RevertUnchangedPatchesPerFile(files, rows);
 
             HotReloadApplyContext context = new HotReloadApplyContext(
@@ -131,15 +141,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 context,
                 gateResult,
                 compile,
-                async () =>
+                ct,
+                () =>
                 {
-                    await MainThreadSwitcher.SwitchToMainThread(ct);
                     IReadOnlyList<HotReloadFileProcessResult> results = HotReloadEntryApplier.ApplyGroupAndBuildResults(
                         context,
                         compile.CompileResult,
                         compile.EntriesToPatch);
                     RecordSupersededSignaturesAfterApply(context, gateResult.GatedReplacementMethodKeys);
-                    return results;
+                    return Task.FromResult(results);
                 }).ConfigureAwait(false);
         }
 
@@ -149,6 +159,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadApplyContext context,
             HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult,
             HotReloadGroupCompileResult compile,
+            CancellationToken ct,
             Func<Task<IReadOnlyList<HotReloadFileProcessResult>>> continueAfterCoverage)
         {
             if (gateResult.DidScan && !AppendSignatureChangeCoverageNotices(context, gateResult, compile))
@@ -156,7 +167,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return BuildUnappliedResults(context.Files);
             }
 
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+            ct.ThrowIfCancellationRequested();
+            if (!TryAppendNewSourceMembershipFailure(context.Files))
+            {
+                return BuildUnappliedResults(context.Files);
+            }
+
             return await continueAfterCoverage().ConfigureAwait(false);
+        }
+
+        internal static bool TryAppendNewSourceMembershipFailure(IReadOnlyList<HotReloadGroupFile> files)
+        {
+            string failure = HotReloadNewSourceMembershipValidator.TryRevalidateFiles(files);
+            if (failure == null)
+            {
+                return true;
+            }
+
+            HotReloadGroupOutcomeRouter.AppendGroupFailure(files, "(file)", failure);
+            return false;
         }
 
         // Returns false when a replacement lost its covering caller and the group must fail.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -174,6 +174,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return BuildUnappliedResults(context.Files);
             }
 
+            ct.ThrowIfCancellationRequested();
             return await continueAfterCoverage().ConfigureAwait(false);
         }
 
@@ -202,6 +203,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return false;
             }
 
+            ct.ThrowIfCancellationRequested();
             revertUnchangedPatches();
             return true;
         }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipBoundaryCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipBoundaryCollector.cs
@@ -39,13 +39,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 string boundaryPath = paths[index];
                 string absolutePath = Path.Combine(projectRoot, boundaryPath);
-                string boundaryDirectory = Path.GetDirectoryName(absolutePath);
-                if (string.IsNullOrEmpty(boundaryDirectory) || !Directory.Exists(boundaryDirectory))
-                {
-                    boundaries = null;
-                    return "The assembly definition membership boundary is not available on disk. Compile the project and retry hot reload.";
-                }
-
                 TextAsset imported = AssetDatabase.LoadAssetAtPath<TextAsset>(boundaryPath);
                 byte[] diskBytes = File.Exists(absolutePath) ? File.ReadAllBytes(absolutePath) : null;
                 byte[] importedBytes = imported?.bytes;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipBoundaryCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipBoundaryCollector.cs
@@ -22,6 +22,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string projectRelativePath,
             out HotReloadNewSourceMembershipBoundary[] boundaries)
         {
+            string sourceAbsolutePath = Path.Combine(projectRoot, projectRelativePath);
+            string sourceDirectory = Path.GetDirectoryName(sourceAbsolutePath);
+            if (string.IsNullOrEmpty(sourceDirectory) || !Directory.Exists(sourceDirectory))
+            {
+                boundaries = null;
+                return "The new source membership boundary is not available on disk. Compile the project and retry hot reload.";
+            }
+
             List<string> paths = CollectAncestorBoundaryPaths(projectRoot, projectRelativePath);
             AppendImportedAncestorBoundaryPaths(projectRoot, projectRelativePath, paths);
             AppendNearestAsmrefTargetPath(paths);
@@ -31,6 +39,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 string boundaryPath = paths[index];
                 string absolutePath = Path.Combine(projectRoot, boundaryPath);
+                string boundaryDirectory = Path.GetDirectoryName(absolutePath);
+                if (string.IsNullOrEmpty(boundaryDirectory) || !Directory.Exists(boundaryDirectory))
+                {
+                    boundaries = null;
+                    return "The assembly definition membership boundary is not available on disk. Compile the project and retry hot reload.";
+                }
+
                 TextAsset imported = AssetDatabase.LoadAssetAtPath<TextAsset>(boundaryPath);
                 byte[] diskBytes = File.Exists(absolutePath) ? File.ReadAllBytes(absolutePath) : null;
                 byte[] importedBytes = imported?.bytes;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipBoundaryCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipBoundaryCollector.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+using UnityEditor;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Captures matching disk and imported assembly-definition boundaries for one new source path.
+    /// </summary>
+    internal static class HotReloadNewSourceMembershipBoundaryCollector
+    {
+        private static readonly Regex MetaGuidRegex = new(
+            "^guid:\\s*(?<guid>[0-9a-fA-F]+)\\s*$",
+            RegexOptions.Compiled | RegexOptions.Multiline);
+        internal static string TryCapture(
+            string projectRoot,
+            string projectRelativePath,
+            out HotReloadNewSourceMembershipBoundary[] boundaries)
+        {
+            List<string> paths = CollectAncestorBoundaryPaths(projectRoot, projectRelativePath);
+            AppendImportedAncestorBoundaryPaths(projectRoot, projectRelativePath, paths);
+            AppendNearestAsmrefTargetPath(paths);
+            List<HotReloadNewSourceMembershipBoundary> captured =
+                new List<HotReloadNewSourceMembershipBoundary>(paths.Count);
+            for (int index = 0; index < paths.Count; index++)
+            {
+                string boundaryPath = paths[index];
+                string absolutePath = Path.Combine(projectRoot, boundaryPath);
+                TextAsset imported = AssetDatabase.LoadAssetAtPath<TextAsset>(boundaryPath);
+                byte[] diskBytes = File.Exists(absolutePath) ? File.ReadAllBytes(absolutePath) : null;
+                byte[] importedBytes = imported?.bytes;
+                string diskGuid = ReadMetaGuid(absolutePath + ".meta");
+                string importedGuid = AssetDatabase.AssetPathToGUID(boundaryPath);
+                string captureFailure = TryCreateBoundary(
+                    boundaryPath,
+                    diskBytes,
+                    importedBytes,
+                    diskGuid,
+                    importedGuid,
+                    out HotReloadNewSourceMembershipBoundary boundary);
+                if (captureFailure != null)
+                {
+                    boundaries = null;
+                    return captureFailure;
+                }
+
+                captured.Add(boundary);
+            }
+
+            boundaries = captured.ToArray();
+            return null;
+        }
+
+        private static List<string> CollectAncestorBoundaryPaths(string projectRoot, string projectRelativePath)
+        {
+            List<string> paths = new List<string>();
+            string directory = Path.GetDirectoryName(Path.Combine(projectRoot, projectRelativePath));
+            string normalizedRoot = Path.GetFullPath(projectRoot);
+            while (!string.IsNullOrEmpty(directory))
+            {
+                AppendBoundaryPaths(projectRoot, paths, Directory.GetFiles(directory, "*.asmref", SearchOption.TopDirectoryOnly));
+                AppendBoundaryPaths(projectRoot, paths, Directory.GetFiles(directory, "*.asmdef", SearchOption.TopDirectoryOnly));
+                if (string.Equals(Path.GetFullPath(directory), normalizedRoot, PathComparison))
+                {
+                    break;
+                }
+
+                directory = Path.GetDirectoryName(directory);
+            }
+
+            return paths;
+        }
+
+        private static void AppendImportedAncestorBoundaryPaths(
+            string projectRoot,
+            string projectRelativePath,
+            List<string> paths)
+        {
+            AppendImportedBoundaryPaths(
+                projectRoot,
+                projectRelativePath,
+                paths,
+                AssetDatabase.FindAssets("t:AssemblyDefinitionAsset"));
+            AppendImportedBoundaryPaths(
+                projectRoot,
+                projectRelativePath,
+                paths,
+                AssetDatabase.FindAssets("t:AssemblyDefinitionReferenceAsset"));
+            paths.Sort(CompareBoundaryPaths);
+        }
+
+        private static void AppendNearestAsmrefTargetPath(List<string> paths)
+        {
+            string targetPath = ResolveNearestAsmrefTargetPath(paths, ResolveAsmrefTargetPath);
+            if (!string.IsNullOrEmpty(targetPath) && !ContainsPath(paths, targetPath))
+            {
+                paths.Add(NormalizeProjectRelativePath(targetPath));
+            }
+        }
+
+        internal static string ResolveNearestAsmrefTargetPath(
+            IReadOnlyList<string> paths,
+            Func<string, string> resolveAsmrefTargetPath)
+        {
+            Debug.Assert(paths != null, "paths must not be null.");
+            Debug.Assert(resolveAsmrefTargetPath != null, "resolveAsmrefTargetPath must not be null.");
+            if (paths.Count == 0 || !paths[0].EndsWith(".asmref", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            return resolveAsmrefTargetPath(paths[0]);
+        }
+
+        private static string ResolveAsmrefTargetPath(string asmrefPath)
+        {
+            TextAsset asmref = AssetDatabase.LoadAssetAtPath<TextAsset>(asmrefPath);
+            if (asmref == null)
+            {
+                return null;
+            }
+
+            string reference = HotReloadNewSourceMembershipValidator.ReadAsmrefReference(asmref.text);
+            if (string.IsNullOrEmpty(reference))
+            {
+                return null;
+            }
+
+            if (reference.StartsWith("GUID:", StringComparison.OrdinalIgnoreCase))
+            {
+                return AssetDatabase.GUIDToAssetPath(reference.Substring("GUID:".Length));
+            }
+
+            return HotReloadNewSourceMembershipValidator.FindAsmdefPathByName(reference);
+        }
+
+        internal static string TryCreateBoundary(
+            string projectRelativePath,
+            byte[] diskBytes,
+            byte[] importedBytes,
+            string diskGuid,
+            string importedGuid,
+            out HotReloadNewSourceMembershipBoundary boundary)
+        {
+            boundary = null;
+            if (diskBytes == null)
+            {
+                return "An imported assembly definition was deleted on disk. Compile the project and retry hot reload.";
+            }
+
+            if (importedBytes == null)
+            {
+                return "An assembly definition changed on disk but is not imported. Compile the project and retry hot reload.";
+            }
+
+            string diskContents = Convert.ToBase64String(diskBytes);
+            string importedContents = Convert.ToBase64String(importedBytes);
+            if (diskContents != importedContents
+                || string.IsNullOrEmpty(diskGuid)
+                || !string.Equals(diskGuid, importedGuid, StringComparison.OrdinalIgnoreCase))
+            {
+                return "An assembly definition changed on disk or its GUID differs from the imported asset. Compile the project and retry hot reload.";
+            }
+
+            boundary = new HotReloadNewSourceMembershipBoundary(
+                projectRelativePath,
+                diskContents,
+                importedContents,
+                diskGuid,
+                importedGuid);
+            return null;
+        }
+
+        private static void AppendImportedBoundaryPaths(
+            string projectRoot,
+            string projectRelativePath,
+            List<string> paths,
+            string[] guids)
+        {
+            for (int index = 0; index < guids.Length; index++)
+            {
+                string assetPath = AssetDatabase.GUIDToAssetPath(guids[index]);
+                if (!IsAncestorBoundaryPath(projectRelativePath, assetPath) || ContainsPath(paths, assetPath))
+                {
+                    continue;
+                }
+
+                paths.Add(NormalizeProjectRelativePath(assetPath));
+            }
+        }
+
+        private static bool IsAncestorBoundaryPath(string projectRelativePath, string boundaryPath)
+        {
+            string sourceDirectory = Path.GetDirectoryName(NormalizeProjectRelativePath(projectRelativePath));
+            string boundaryDirectory = Path.GetDirectoryName(NormalizeProjectRelativePath(boundaryPath));
+            while (!string.IsNullOrEmpty(sourceDirectory))
+            {
+                if (string.Equals(sourceDirectory, boundaryDirectory, PathComparison))
+                {
+                    return true;
+                }
+
+                sourceDirectory = Path.GetDirectoryName(sourceDirectory);
+            }
+
+            return false;
+        }
+
+        private static bool ContainsPath(List<string> paths, string path)
+        {
+            for (int index = 0; index < paths.Count; index++)
+            {
+                if (string.Equals(paths[index], path, PathComparison))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static int CompareBoundaryPaths(string left, string right)
+        {
+            int leftDepth = Path.GetDirectoryName(left)?.Split('/').Length ?? 0;
+            int rightDepth = Path.GetDirectoryName(right)?.Split('/').Length ?? 0;
+            int depthComparison = rightDepth.CompareTo(leftDepth);
+            if (depthComparison != 0)
+            {
+                return depthComparison;
+            }
+
+            bool leftIsAsmref = left.EndsWith(".asmref", StringComparison.OrdinalIgnoreCase);
+            bool rightIsAsmref = right.EndsWith(".asmref", StringComparison.OrdinalIgnoreCase);
+            if (leftIsAsmref != rightIsAsmref)
+            {
+                return leftIsAsmref ? -1 : 1;
+            }
+
+            return string.Compare(left, right, PathComparison);
+        }
+
+        private static void AppendBoundaryPaths(string projectRoot, List<string> paths, string[] absolutePaths)
+        {
+            for (int index = 0; index < absolutePaths.Length; index++)
+            {
+                string relativePath = absolutePaths[index].Substring(projectRoot.Length).TrimStart(Path.DirectorySeparatorChar);
+                paths.Add(NormalizeProjectRelativePath(relativePath));
+            }
+        }
+
+        private static string ReadMetaGuid(string metaPath)
+        {
+            if (!File.Exists(metaPath))
+            {
+                return null;
+            }
+
+            Match match = MetaGuidRegex.Match(File.ReadAllText(metaPath));
+            return match.Success ? match.Groups["guid"].Value : null;
+        }
+
+        private static string NormalizeProjectRelativePath(string path)
+        {
+            return string.IsNullOrEmpty(path) ? null : path.Replace('\\', '/');
+        }
+
+        private static StringComparison PathComparison => Application.platform == RuntimePlatform.WindowsEditor
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipBoundaryCollector.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipBoundaryCollector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79cb37f5b35c44142bbc00ed7387e673
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipValidator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipValidator.cs
@@ -1,0 +1,393 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using Mono.Cecil;
+
+using UnityEditor;
+using UnityEditor.Compilation;
+using UnityEngine;
+
+using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Immutable evidence that a source absent from the last compiled source list belongs to an unchanged assembly.
+    /// </summary>
+    internal sealed class HotReloadNewSourceMembershipEvidence
+    {
+        internal HotReloadNewSourceMembershipEvidence(
+            string projectRelativePath,
+            string assemblyName,
+            string targetDllPath,
+            string targetDllMvid,
+            string resolvedAssemblyDefinitionPath,
+            HotReloadNewSourceMembershipBoundary[] boundaries)
+        {
+            ProjectRelativePath = projectRelativePath;
+            AssemblyName = assemblyName;
+            TargetDllPath = targetDllPath;
+            TargetDllMvid = targetDllMvid;
+            ResolvedAssemblyDefinitionPath = resolvedAssemblyDefinitionPath;
+            Boundaries = boundaries;
+        }
+
+        internal string ProjectRelativePath { get; }
+
+        internal string AssemblyName { get; }
+
+        internal string TargetDllPath { get; }
+
+        internal string TargetDllMvid { get; }
+
+        internal string ResolvedAssemblyDefinitionPath { get; }
+
+        internal HotReloadNewSourceMembershipBoundary[] Boundaries { get; }
+    }
+
+    /// <summary>
+    /// One disk/import assembly boundary captured for a new source membership decision.
+    /// </summary>
+    internal sealed class HotReloadNewSourceMembershipBoundary
+    {
+        internal HotReloadNewSourceMembershipBoundary(
+            string projectRelativePath,
+            string diskContents,
+            string importedContents,
+            string diskGuid,
+            string importedGuid)
+        {
+            ProjectRelativePath = projectRelativePath;
+            DiskContents = diskContents;
+            ImportedContents = importedContents;
+            DiskGuid = diskGuid;
+            ImportedGuid = importedGuid;
+        }
+
+        internal string ProjectRelativePath { get; }
+
+        internal string DiskContents { get; }
+
+        internal string ImportedContents { get; }
+
+        internal string DiskGuid { get; }
+
+        internal string ImportedGuid { get; }
+    }
+
+    /// <summary>
+    /// Captures and rechecks the assembly membership evidence required before a new source can enter hot reload.
+    /// </summary>
+    internal static class HotReloadNewSourceMembershipValidator
+    {
+        [Serializable]
+        private sealed class AssemblyDefinitionJson
+        {
+            public string name;
+        }
+
+        [Serializable]
+        private sealed class AssemblyReferenceJson
+        {
+            public string reference;
+        }
+
+        internal static string TryCapture(
+            string projectRoot,
+            string projectRelativePath,
+            string assemblyName,
+            UnityCompilationAssembly compilationAssembly,
+            string targetDllPath,
+            out HotReloadNewSourceMembershipEvidence evidence)
+        {
+            evidence = null;
+            string notReadyReason = HotReloadEditorStateSnapshotProvider.GetNotReadyReason(
+                HotReloadEditorStateSnapshotProvider.CaptureCurrent());
+            if (notReadyReason != null)
+            {
+                return notReadyReason;
+            }
+
+            string captureFailure = HotReloadNewSourceMembershipBoundaryCollector.TryCapture(
+                projectRoot,
+                projectRelativePath,
+                out HotReloadNewSourceMembershipBoundary[] boundaries);
+            if (captureFailure != null)
+            {
+                return captureFailure;
+            }
+
+            string resolvedAssemblyDefinitionPath =
+                CompilationPipeline.GetAssemblyDefinitionFilePathFromScriptPath(projectRelativePath);
+            string resolutionFailure = ValidateResolvedAssemblyDefinition(
+                projectRelativePath,
+                assemblyName,
+                compilationAssembly,
+                boundaries,
+                resolvedAssemblyDefinitionPath);
+            if (resolutionFailure != null)
+            {
+                return resolutionFailure;
+            }
+
+            evidence = new HotReloadNewSourceMembershipEvidence(
+                NormalizeProjectRelativePath(projectRelativePath),
+                assemblyName,
+                Path.GetFullPath(targetDllPath),
+                ReadMvid(targetDllPath),
+                NormalizeProjectRelativePath(resolvedAssemblyDefinitionPath),
+                boundaries);
+            return null;
+        }
+
+        internal static string TryRevalidate(HotReloadNewSourceMembershipEvidence evidence)
+        {
+            Debug.Assert(evidence != null, "evidence must not be null.");
+            string notReadyReason = HotReloadEditorStateSnapshotProvider.GetNotReadyReason(
+                HotReloadEditorStateSnapshotProvider.CaptureCurrent());
+            if (notReadyReason != null)
+            {
+                return notReadyReason;
+            }
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            UnityCompilationAssembly compilationAssembly = FindCompilationAssembly(evidence.AssemblyName);
+            if (compilationAssembly == null)
+            {
+                return "The resolved assembly is no longer present in the compilation pipeline. Compile the project and retry hot reload.";
+            }
+
+            string targetDllPath = Path.Combine(
+                projectRoot,
+                HotReloadConstants.ScriptAssembliesRelativeDirectory,
+                evidence.AssemblyName + HotReloadConstants.CompiledAssemblyExtension);
+            if (!string.Equals(Path.GetFullPath(targetDllPath), evidence.TargetDllPath, StringComparison.Ordinal)
+                || !File.Exists(targetDllPath)
+                || !string.Equals(ReadMvid(targetDllPath), evidence.TargetDllMvid, StringComparison.Ordinal)
+                || HotReloadPatchTargetSupport.CheckMvidGuard(evidence.AssemblyName, targetDllPath) != null)
+            {
+                return "The compiled assembly changed while hot reload was preparing. Compile the project and retry hot reload.";
+            }
+
+            string captureFailure = HotReloadNewSourceMembershipBoundaryCollector.TryCapture(
+                projectRoot,
+                evidence.ProjectRelativePath,
+                out HotReloadNewSourceMembershipBoundary[] currentBoundaries);
+            if (captureFailure != null)
+            {
+                return captureFailure;
+            }
+
+            string resolvedAssemblyDefinitionPath =
+                CompilationPipeline.GetAssemblyDefinitionFilePathFromScriptPath(evidence.ProjectRelativePath);
+            string resolutionFailure = ValidateResolvedAssemblyDefinition(
+                evidence.ProjectRelativePath,
+                evidence.AssemblyName,
+                compilationAssembly,
+                currentBoundaries,
+                resolvedAssemblyDefinitionPath);
+            if (resolutionFailure != null)
+            {
+                return resolutionFailure;
+            }
+
+            HotReloadNewSourceMembershipEvidence currentEvidence = new HotReloadNewSourceMembershipEvidence(
+                NormalizeProjectRelativePath(evidence.ProjectRelativePath),
+                evidence.AssemblyName,
+                Path.GetFullPath(targetDllPath),
+                ReadMvid(targetDllPath),
+                NormalizeProjectRelativePath(resolvedAssemblyDefinitionPath),
+                currentBoundaries);
+            if (!EvidenceMatches(evidence, currentEvidence))
+            {
+                return "Assembly definition membership changed while hot reload was preparing. Compile the project and retry hot reload.";
+            }
+
+            return null;
+        }
+
+        internal static string TryRevalidateFiles(IReadOnlyList<HotReloadGroupFile> files)
+        {
+            Debug.Assert(files != null && files.Count > 0, "files must not be empty.");
+            for (int index = 0; index < files.Count; index++)
+            {
+                HotReloadNewSourceMembershipEvidence evidence = files[index].NewSourceMembershipEvidence;
+                if (evidence == null)
+                {
+                    continue;
+                }
+
+                string failure = TryRevalidate(evidence);
+                if (failure != null)
+                {
+                    return failure;
+                }
+            }
+
+            return null;
+        }
+
+        private static string ValidateResolvedAssemblyDefinition(
+            string projectRelativePath,
+            string assemblyName,
+            UnityCompilationAssembly compilationAssembly,
+            HotReloadNewSourceMembershipBoundary[] boundaries,
+            string resolvedAssemblyDefinitionPath)
+        {
+            string rawAssemblyName = CompilationPipeline.GetAssemblyNameFromScriptPath(projectRelativePath);
+            if (string.IsNullOrEmpty(rawAssemblyName)
+                || !string.Equals(Path.GetFileNameWithoutExtension(rawAssemblyName), assemblyName, StringComparison.Ordinal)
+                || !string.Equals(compilationAssembly.name, assemblyName, StringComparison.Ordinal))
+            {
+                return "Unity resolved the new source to a different assembly. Compile the project and retry hot reload.";
+            }
+
+            string expectedAssemblyDefinitionPath = ResolveNearestBoundaryTarget(
+                boundaries,
+                AssetDatabase.GUIDToAssetPath,
+                FindAsmdefPathByName);
+            if (!string.Equals(
+                    NormalizeProjectRelativePath(expectedAssemblyDefinitionPath),
+                    NormalizeProjectRelativePath(resolvedAssemblyDefinitionPath),
+                    StringComparison.Ordinal))
+            {
+                return "The imported assembly definition does not match the new source boundary. Compile the project and retry hot reload.";
+            }
+
+            return null;
+        }
+
+        internal static string ResolveNearestBoundaryTarget(
+            HotReloadNewSourceMembershipBoundary[] boundaries,
+            Func<string, string> resolveGuidToAssetPath,
+            Func<string, string> findAsmdefPathByName)
+        {
+            Debug.Assert(resolveGuidToAssetPath != null, "resolveGuidToAssetPath must not be null.");
+            Debug.Assert(findAsmdefPathByName != null, "findAsmdefPathByName must not be null.");
+            if (boundaries.Length == 0)
+            {
+                return null;
+            }
+
+            HotReloadNewSourceMembershipBoundary nearest = boundaries[0];
+            if (nearest.ProjectRelativePath.EndsWith(".asmdef", StringComparison.OrdinalIgnoreCase))
+            {
+                return nearest.ProjectRelativePath;
+            }
+
+            string reference = ReadAsmrefReference(
+                System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(nearest.DiskContents)));
+            if (string.IsNullOrEmpty(reference))
+            {
+                return null;
+            }
+
+            if (reference.StartsWith("GUID:", StringComparison.OrdinalIgnoreCase))
+            {
+                return resolveGuidToAssetPath(reference.Substring("GUID:".Length));
+            }
+
+            return findAsmdefPathByName(reference);
+        }
+
+        internal static string ReadAssemblyDefinitionName(string contents)
+        {
+            AssemblyDefinitionJson asmdef = JsonUtility.FromJson<AssemblyDefinitionJson>(contents);
+            return asmdef?.name;
+        }
+
+        internal static string ReadAsmrefReference(string contents)
+        {
+            AssemblyReferenceJson asmref = JsonUtility.FromJson<AssemblyReferenceJson>(contents);
+            return asmref?.reference;
+        }
+
+        internal static string FindAsmdefPathByName(string assemblyName)
+        {
+            string[] asmdefGuids = AssetDatabase.FindAssets("t:AssemblyDefinitionAsset");
+            for (int index = 0; index < asmdefGuids.Length; index++)
+            {
+                string assetPath = AssetDatabase.GUIDToAssetPath(asmdefGuids[index]);
+                TextAsset asmdef = AssetDatabase.LoadAssetAtPath<TextAsset>(assetPath);
+                if (asmdef != null
+                    && string.Equals(ReadAssemblyDefinitionName(asmdef.text), assemblyName, StringComparison.Ordinal))
+                {
+                    return assetPath;
+                }
+            }
+
+            return null;
+        }
+
+        internal static bool EvidenceMatches(
+            HotReloadNewSourceMembershipEvidence expected,
+            HotReloadNewSourceMembershipEvidence current)
+        {
+            if (!string.Equals(
+                    NormalizeProjectRelativePath(expected.ProjectRelativePath),
+                    NormalizeProjectRelativePath(current.ProjectRelativePath),
+                    PathComparison)
+                || !string.Equals(expected.AssemblyName, current.AssemblyName, StringComparison.Ordinal)
+                || !string.Equals(expected.TargetDllMvid, current.TargetDllMvid, StringComparison.Ordinal)
+                || !string.Equals(
+                    NormalizeProjectRelativePath(expected.ResolvedAssemblyDefinitionPath),
+                    NormalizeProjectRelativePath(current.ResolvedAssemblyDefinitionPath),
+                    PathComparison)
+                || expected.Boundaries.Length != current.Boundaries.Length)
+            {
+                return false;
+            }
+
+            for (int index = 0; index < expected.Boundaries.Length; index++)
+            {
+                HotReloadNewSourceMembershipBoundary expectedBoundary = expected.Boundaries[index];
+                HotReloadNewSourceMembershipBoundary currentBoundary = current.Boundaries[index];
+                if (!string.Equals(
+                        NormalizeProjectRelativePath(expectedBoundary.ProjectRelativePath),
+                        NormalizeProjectRelativePath(currentBoundary.ProjectRelativePath),
+                        PathComparison)
+                    || !string.Equals(expectedBoundary.DiskContents, currentBoundary.DiskContents, StringComparison.Ordinal)
+                    || !string.Equals(expectedBoundary.ImportedContents, currentBoundary.ImportedContents, StringComparison.Ordinal)
+                    || !string.Equals(expectedBoundary.DiskGuid, currentBoundary.DiskGuid, StringComparison.OrdinalIgnoreCase)
+                    || !string.Equals(expectedBoundary.ImportedGuid, currentBoundary.ImportedGuid, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static UnityCompilationAssembly FindCompilationAssembly(string assemblyName)
+        {
+            UnityCompilationAssembly[] assemblies = CompilationPipeline.GetAssemblies();
+            for (int index = 0; index < assemblies.Length; index++)
+            {
+                if (assemblies[index].name == assemblyName)
+                {
+                    return assemblies[index];
+                }
+            }
+
+            return null;
+        }
+
+        private static string ReadMvid(string assemblyPath)
+        {
+            ReaderParameters readerParameters = new ReaderParameters { InMemory = true };
+            using AssemblyDefinition assemblyDefinition =
+                AssemblyDefinition.ReadAssembly(assemblyPath, readerParameters);
+            return assemblyDefinition.MainModule.Mvid.ToString();
+        }
+
+        private static string NormalizeProjectRelativePath(string path)
+        {
+            return string.IsNullOrEmpty(path) ? null : path.Replace('\\', '/');
+        }
+
+        private static StringComparison PathComparison => Application.platform == RuntimePlatform.WindowsEditor
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipValidator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipValidator.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
-using Mono.Cecil;
-
 using UnityEditor;
 using UnityEditor.Compilation;
 using UnityEngine;
@@ -135,7 +133,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 NormalizeProjectRelativePath(projectRelativePath),
                 assemblyName,
                 Path.GetFullPath(targetDllPath),
-                ReadMvid(targetDllPath),
+                HotReloadSourceSnapshotter.ReadAssemblyMvid(targetDllPath),
                 NormalizeProjectRelativePath(resolvedAssemblyDefinitionPath),
                 boundaries);
             return null;
@@ -164,7 +162,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 evidence.AssemblyName + HotReloadConstants.CompiledAssemblyExtension);
             if (!string.Equals(Path.GetFullPath(targetDllPath), evidence.TargetDllPath, StringComparison.Ordinal)
                 || !File.Exists(targetDllPath)
-                || !string.Equals(ReadMvid(targetDllPath), evidence.TargetDllMvid, StringComparison.Ordinal)
+                || !string.Equals(
+                    HotReloadSourceSnapshotter.ReadAssemblyMvid(targetDllPath),
+                    evidence.TargetDllMvid,
+                    StringComparison.Ordinal)
                 || HotReloadPatchTargetSupport.CheckMvidGuard(evidence.AssemblyName, targetDllPath) != null)
             {
                 return "The compiled assembly changed while hot reload was preparing. Compile the project and retry hot reload.";
@@ -196,7 +197,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 NormalizeProjectRelativePath(evidence.ProjectRelativePath),
                 evidence.AssemblyName,
                 Path.GetFullPath(targetDllPath),
-                ReadMvid(targetDllPath),
+                HotReloadSourceSnapshotter.ReadAssemblyMvid(targetDllPath),
                 NormalizeProjectRelativePath(resolvedAssemblyDefinitionPath),
                 currentBoundaries);
             if (!EvidenceMatches(evidence, currentEvidence))
@@ -243,10 +244,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return "Unity resolved the new source to a different assembly. Compile the project and retry hot reload.";
             }
 
-            string expectedAssemblyDefinitionPath = ResolveNearestBoundaryTarget(
+            string boundaryJsonFailure = TryValidateBoundaryJson(boundaries);
+            if (boundaryJsonFailure != null)
+            {
+                return boundaryJsonFailure;
+            }
+
+            string boundaryResolutionFailure = TryResolveNearestBoundaryTarget(
                 boundaries,
                 AssetDatabase.GUIDToAssetPath,
-                FindAsmdefPathByName);
+                FindAsmdefPathByName,
+                out string expectedAssemblyDefinitionPath);
+            if (boundaryResolutionFailure != null)
+            {
+                return boundaryResolutionFailure;
+            }
+
             if (!string.Equals(
                     NormalizeProjectRelativePath(expectedAssemblyDefinitionPath),
                     NormalizeProjectRelativePath(resolvedAssemblyDefinitionPath),
@@ -291,16 +304,75 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return findAsmdefPathByName(reference);
         }
 
+        internal static string TryResolveNearestBoundaryTarget(
+            HotReloadNewSourceMembershipBoundary[] boundaries,
+            Func<string, string> resolveGuidToAssetPath,
+            Func<string, string> findAsmdefPathByName,
+            out string targetPath)
+        {
+            targetPath = ResolveNearestBoundaryTarget(
+                boundaries,
+                resolveGuidToAssetPath,
+                findAsmdefPathByName);
+            if (boundaries.Length == 0
+                || !boundaries[0].ProjectRelativePath.EndsWith(".asmref", StringComparison.OrdinalIgnoreCase)
+                || !string.IsNullOrEmpty(targetPath))
+            {
+                return null;
+            }
+
+            return "The nearest assembly reference could not be resolved. Compile the project and retry hot reload.";
+        }
+
+        internal static string TryValidateBoundaryJson(HotReloadNewSourceMembershipBoundary[] boundaries)
+        {
+            for (int index = 0; index < boundaries.Length; index++)
+            {
+                HotReloadNewSourceMembershipBoundary boundary = boundaries[index];
+                string contents = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(boundary.DiskContents));
+                bool isAsmdef = boundary.ProjectRelativePath.EndsWith(".asmdef", StringComparison.OrdinalIgnoreCase);
+                string value = isAsmdef
+                    ? ReadAssemblyDefinitionName(contents)
+                    : ReadAsmrefReference(contents);
+                if (string.IsNullOrEmpty(value))
+                {
+                    return "An assembly definition membership boundary has invalid JSON. Compile the project and retry hot reload.";
+                }
+            }
+
+            return null;
+        }
+
         internal static string ReadAssemblyDefinitionName(string contents)
         {
-            AssemblyDefinitionJson asmdef = JsonUtility.FromJson<AssemblyDefinitionJson>(contents);
-            return asmdef?.name;
+            try
+            {
+                AssemblyDefinitionJson asmdef = JsonUtility.FromJson<AssemblyDefinitionJson>(contents);
+                return asmdef?.name;
+            }
+            catch (ArgumentException exception)
+            {
+                Debug.LogWarning(
+                    "Assembly definition membership JSON could not be parsed. Compile the project and retry hot reload. "
+                    + exception.Message);
+                return null;
+            }
         }
 
         internal static string ReadAsmrefReference(string contents)
         {
-            AssemblyReferenceJson asmref = JsonUtility.FromJson<AssemblyReferenceJson>(contents);
-            return asmref?.reference;
+            try
+            {
+                AssemblyReferenceJson asmref = JsonUtility.FromJson<AssemblyReferenceJson>(contents);
+                return asmref?.reference;
+            }
+            catch (ArgumentException exception)
+            {
+                Debug.LogWarning(
+                    "Assembly reference membership JSON could not be parsed. Compile the project and retry hot reload. "
+                    + exception.Message);
+                return null;
+            }
         }
 
         internal static string FindAsmdefPathByName(string assemblyName)
@@ -371,14 +443,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return null;
-        }
-
-        private static string ReadMvid(string assemblyPath)
-        {
-            ReaderParameters readerParameters = new ReaderParameters { InMemory = true };
-            using AssemblyDefinition assemblyDefinition =
-                AssemblyDefinition.ReadAssembly(assemblyPath, readerParameters);
-            return assemblyDefinition.MainModule.Mvid.ToString();
         }
 
         private static string NormalizeProjectRelativePath(string path)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipValidator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipValidator.cs
@@ -229,7 +229,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return null;
         }
 
-        private static string ValidateResolvedAssemblyDefinition(
+        internal static string ValidateResolvedAssemblyDefinition(
             string projectRelativePath,
             string assemblyName,
             UnityCompilationAssembly compilationAssembly,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipValidator.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2cc71e31d7c747319a15f14d662d8c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -150,7 +150,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         // Resolves one input path's patch target and either records its early result or enrolls
         // it in the group plan.
-        private static void ResolveInputFile(
+        internal static void ResolveInputFile(
             string filePath,
             int index,
             string contentPathOverride,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -178,7 +178,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 UnityCompilationAssembly compilationAssembly,
                 string targetDllPath,
                 string projectRoot,
-                HotReloadUnchangedSourceDecision unchangedDecision) = HotReloadPatchTargetSupport.ResolvePatchTarget(
+                HotReloadUnchangedSourceDecision unchangedDecision,
+                HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence) = HotReloadPatchTargetSupport.ResolvePatchTarget(
                 filePath,
                 workerSourcePath,
                 sinks.Outcomes,
@@ -205,7 +206,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 compilationAssembly,
                 targetDllPath,
                 projectRoot,
-                sinks);
+                sinks,
+                newSourceMembershipEvidence);
             resultPaths[index] = projectRelativePath;
             plannerInput.Add((index, assemblyName, projectRelativePath));
         }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
@@ -30,7 +30,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             UnityCompilationAssembly CompilationAssembly,
             string TargetDllPath,
             string ProjectRoot,
-            HotReloadUnchangedSourceDecision UnchangedDecision) ResolvePatchTarget(
+            HotReloadUnchangedSourceDecision UnchangedDecision,
+            HotReloadNewSourceMembershipEvidence NewSourceMembershipEvidence) ResolvePatchTarget(
             string assemblyResolvePath,
             string workerSourcePath,
             List<HotReloadMethodOutcome> outcomes,
@@ -59,7 +60,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     null,
                     null,
                     null,
-                    HotReloadUnchangedSourceDecision.NotUnchanged);
+                    HotReloadUnchangedSourceDecision.NotUnchanged,
+                    null);
             }
 
             string assemblyName = Path.GetFileNameWithoutExtension(rawAssemblyName);
@@ -90,7 +92,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     null,
                     null,
                     null,
-                    HotReloadUnchangedSourceDecision.NotUnchanged);
+                    HotReloadUnchangedSourceDecision.NotUnchanged,
+                    null);
+            }
+
+            bool isNewSource = !HotReloadAssemblyResolutionDiagnostics.ContainsProjectRelativeSourceFile(
+                compilationAssembly.sourceFiles,
+                projectRelativePath);
+            if (isNewSource)
+            {
+                string notReadyReason = HotReloadEditorStateSnapshotProvider.GetNotReadyReason(
+                    HotReloadEditorStateSnapshotProvider.CaptureCurrent());
+                if (notReadyReason != null)
+                {
+                    outcomes.Add(HotReloadMethodOutcome.Failed("(file)", notReadyReason, assemblyResolvePath));
+                    return (
+                        new HotReloadFileProcessResult(outcomes, warnings, 0),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        HotReloadUnchangedSourceDecision.NotUnchanged,
+                        null);
+                }
             }
 
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
@@ -113,7 +138,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     null,
                     null,
                     null,
-                    HotReloadUnchangedSourceDecision.NotUnchanged);
+                    HotReloadUnchangedSourceDecision.NotUnchanged,
+                    null);
             }
 
             string mvidGuardError = CheckMvidGuard(assemblyName, targetDllPath);
@@ -127,7 +153,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     null,
                     null,
                     null,
-                    HotReloadUnchangedSourceDecision.NotUnchanged);
+                    HotReloadUnchangedSourceDecision.NotUnchanged,
+                    null);
+            }
+
+            HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence = null;
+            if (isNewSource)
+            {
+                string membershipFailure = HotReloadNewSourceMembershipValidator.TryCapture(
+                    projectRoot,
+                    projectRelativePath,
+                    assemblyName,
+                    compilationAssembly,
+                    targetDllPath,
+                    out newSourceMembershipEvidence);
+                if (membershipFailure != null)
+                {
+                    outcomes.Add(HotReloadMethodOutcome.Failed("(file)", membershipFailure, assemblyResolvePath));
+                    return (
+                        new HotReloadFileProcessResult(outcomes, warnings, 0),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        HotReloadUnchangedSourceDecision.NotUnchanged,
+                        null);
+                }
             }
 
             HotReloadUnchangedSourceDecision unchangedDecision = HotReloadAppliedSourceLifecycle.TryShortCircuitUnchangedAppliedSource(
@@ -151,7 +203,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 compilationAssembly,
                 targetDllPath,
                 projectRoot,
-                unchangedDecision);
+                unchangedDecision,
+                newSourceMembershipEvidence);
         }
 
         private static UnityCompilationAssembly FindCompilationAssembly(string assemblyName)
@@ -190,7 +243,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return paths;
         }
 
-        private static string CheckMvidGuard(string assemblyName, string targetDllPath)
+        internal static string CheckMvidGuard(string assemblyName, string targetDllPath)
         {
             ReaderParameters readerParameters = new ReaderParameters { InMemory = true };
             using AssemblyDefinition assemblyDefinition =

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
@@ -25,6 +25,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(context != null, "context must not be null.");
             Debug.Assert(gateResult != null, "gateResult must not be null.");
 
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+            if (!HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(context.Files))
+            {
+                return HotReloadGroupCompileResult.NothingToApply();
+            }
+
             if (gateResult.UsedWorkerRetry)
             {
                 AdoptRetryAddedMemberNames(context.Files, gateResult.Isolation.RetryFiles);


### PR DESCRIPTION
## Summary

- Hot reload can now admit newly added scripts when their assembly membership is unchanged.
- Unsafe Editor states or changed assembly boundaries stop the operation with compile-and-retry guidance.

## User Impact

Previously, a new script was rejected solely because it was absent from the last compiled source list. It can now proceed when the compiled assembly and imported boundaries still agree, while a stale or changing target remains safely blocked before patching.

## Changes

- Capture Editor state, compiled assembly identity, and relevant assembly-definition boundaries for new sources.
- Revalidate that evidence before worker-dependent and apply-time mutations.
- Cover predefined assemblies, asmref name resolution, boundary changes, and stale apply continuations.

## Verification

- `uloop compile`
- Targeted EditMode tests: 15 new-source membership, 8 assembly diagnostics, and 4 group processor cases
- File-length, code-complexity, and asmdef reference-policy checks


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

