### PR TITLE
fix: preserve source boundaries during dynamic compilation

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/RoslynCompilerBackendTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/RoslynCompilerBackendTests.cs
@@ -200,6 +200,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
+        /// Multi-source source-path validation follows the platform case rules for one parent directory.
+        /// </summary>
+        [Test]
+        public void ValidateSourcePaths_SameDirectoryWithDifferentCase_FollowsPlatformPathRules()
+        {
+            string rootDirectory = Path.Combine(Path.GetTempPath(), "roslyn-case-directory-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(rootDirectory);
+            string parentDirectory = Path.GetDirectoryName(rootDirectory);
+            string alternateDirectory = Path.Combine(parentDirectory, Path.GetFileName(rootDirectory).ToUpperInvariant());
+            string firstSourcePath = Path.Combine(rootDirectory, "first.cs");
+            string secondSourcePath = Path.Combine(alternateDirectory, "second.cs");
+            try
+            {
+                if (Path.DirectorySeparatorChar == '\\')
+                {
+                    Assert.DoesNotThrow(
+                        () => RoslynCompilerRequestFileWriter.ValidateSourcePaths(
+                            new[] { firstSourcePath, secondSourcePath }));
+                    return;
+                }
+
+                ArgumentException exception = Assert.Throws<ArgumentException>(
+                    () => RoslynCompilerRequestFileWriter.ValidateSourcePaths(
+                        new[] { firstSourcePath, secondSourcePath }));
+                Assert.That(exception.ParamName, Is.EqualTo("sourcePaths"));
+            }
+            finally
+            {
+                if (Directory.Exists(rootDirectory))
+                {
+                    Directory.Delete(rootDirectory, recursive: true);
+                }
+            }
+        }
+
+        /// <summary>
         /// WriteWorkerRequestFile encodes emitDebugCode for the shared Roslyn worker.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/DynamicCodeToolTests/RoslynCompilerBackendTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/RoslynCompilerBackendTests.cs
@@ -1,6 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
+using UnityEngine.TestTools;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -22,7 +27,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             string responseFilePath = Path.Combine(Path.GetTempPath(), "uloop-roslyn-rsp-" + Path.GetRandomFileName());
             try
             {
-                RoslynCompilerBackend.WriteCompilerResponseFile(
+                RoslynCompilerRequestFileWriter.WriteCompilerResponseFile(
                     responseFilePath,
                     sourcePath: "snippet.cs",
                     dllPath: "snippet.dll",
@@ -46,7 +51,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
-        /// What: WriteCompilerResponseFile requests English diagnostics and UTF-8 compiler output.
+        /// WriteCompilerResponseFile requests English diagnostics and UTF-8 compiler output.
         /// </summary>
         [Test]
         public void WriteCompilerResponseFile_IncludesEnglishDiagnosticsAndUtf8OutputOptions()
@@ -54,7 +59,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             string responseFilePath = Path.Combine(Path.GetTempPath(), "uloop-roslyn-rsp-" + Path.GetRandomFileName());
             try
             {
-                RoslynCompilerBackend.WriteCompilerResponseFile(
+                RoslynCompilerRequestFileWriter.WriteCompilerResponseFile(
                     responseFilePath,
                     sourcePath: "snippet.cs",
                     dllPath: "snippet.dll",
@@ -77,7 +82,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
-        /// What: emitDebugCode writes -optimize- so hot-reload shim one-shot fallback keeps locals.
+        /// emitDebugCode writes -optimize- so hot-reload shim one-shot fallback keeps locals.
         /// </summary>
         [Test]
         public void WriteCompilerResponseFile_WithEmitDebugCode_DisablesOptimization()
@@ -85,7 +90,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             string responseFilePath = Path.Combine(Path.GetTempPath(), "uloop-roslyn-rsp-" + Path.GetRandomFileName());
             try
             {
-                RoslynCompilerBackend.WriteCompilerResponseFile(
+                RoslynCompilerRequestFileWriter.WriteCompilerResponseFile(
                     responseFilePath,
                     sourcePath: "snippet.cs",
                     dllPath: "snippet.dll",
@@ -108,7 +113,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
-        /// What: WriteCompilerResponseFile maps the source directory onto the project root via -pathmap.
+        /// WriteCompilerResponseFile maps the source directory onto the project root via -pathmap.
         /// </summary>
         [Test]
         public void WriteCompilerResponseFile_MapsSourceDirectoryToProjectRoot()
@@ -120,7 +125,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             string dllPath = Path.Combine(tempDirectory, "snippet.dll");
             try
             {
-                RoslynCompilerBackend.WriteCompilerResponseFile(
+                RoslynCompilerRequestFileWriter.WriteCompilerResponseFile(
                     responseFilePath,
                     sourcePath,
                     dllPath,
@@ -144,7 +149,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
-        /// What: WriteWorkerRequestFile encodes emitDebugCode for the shared Roslyn worker.
+        /// WriteWorkerRequestFile encodes emitDebugCode for the shared Roslyn worker.
         /// </summary>
         [Test]
         public void WriteWorkerRequestFile_IncludesDebugCodeFlag()
@@ -155,7 +160,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             File.WriteAllText(sourcePath, "class C {}");
             try
             {
-                RoslynCompilerBackend.WriteWorkerRequestFile(
+                RoslynCompilerRequestFileWriter.WriteWorkerRequestFile(
                     requestFilePath,
                     sourcePath,
                     dllPath,
@@ -180,6 +185,326 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
                     File.Delete(sourcePath);
                 }
             }
+        }
+
+        /// <summary>
+        /// Verifies that a shared and one-shot infrastructure failure reaches AssemblyBuilder for
+        /// the preserved single-source API but never for the multi-source API.
+        /// </summary>
+        [Test]
+        public async Task CompileMultipleSourcesAsync_InfrastructureFailure_DoesNotInvokeFallback()
+        {
+            ExternalCompilerPaths paths = ExternalCompilerPathResolver.Resolve();
+            Assert.That(paths, Is.Not.Null);
+            string directory = Path.Combine(Path.GetTempPath(), "roslyn-multiple-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(directory);
+            string firstSourcePath = Path.Combine(directory, "first.cs");
+            string secondSourcePath = Path.Combine(directory, "second.cs");
+            string dllPath = Path.Combine(directory, "output.dll");
+            File.WriteAllText(firstSourcePath, "public class First { }");
+            File.WriteAllText(secondSourcePath, "public class Second { }");
+            int fallbackCalls = 0;
+            Func<ExternalCompilerPaths, string, string, string, UnityEditor.Compilation.CompilerMessage[]> previousWorker =
+                SharedRoslynCompilerWorkerHost.SwapWorkerAssemblyCompilerForTests(
+                    (ExternalCompilerPaths _, string __, string ___, string ____) =>
+                        new[]
+                        {
+                            new UnityEditor.Compilation.CompilerMessage
+                            {
+                                type = UnityEditor.Compilation.CompilerMessageType.Error,
+                                message = "worker unavailable"
+                            }
+                        });
+            Func<System.Diagnostics.ProcessStartInfo, System.Diagnostics.Process> previousStarter =
+                RoslynCompilerBackend.SwapOneShotProcessStarterForTests(_ => null);
+            Func<string, string, List<string>, CancellationToken, Action, Action, Action, Task<DynamicCompilationBackendResult>> previousFallback =
+                AssemblyBuilderFallbackCompilerBackend.SwapCompilerForTests(
+                    (string _, string __, List<string> ___, CancellationToken ____, Action _____, Action ______, Action _______) =>
+                    {
+                        fallbackCalls++;
+                        return Task.FromResult(
+                            new DynamicCompilationBackendResult(
+                                System.Array.Empty<UnityEditor.Compilation.CompilerMessage>(),
+                                DynamicCompilationBackendKind.AssemblyBuilderFallback));
+                    });
+
+            SharedRoslynCompilerWorkerHost.ShutdownForTests();
+            DynamicCompilationHealthMonitor.ResetForTests();
+            LogAssert.Expect(
+                UnityEngine.LogType.Error,
+                new System.Text.RegularExpressions.Regex(
+                    "execute-dynamic-code shared Roslyn worker failed to operate correctly; reason=worker_build_failed"));
+            LogAssert.Expect(
+                UnityEngine.LogType.Error,
+                new System.Text.RegularExpressions.Regex(
+                    "execute-dynamic-code shared Roslyn worker is unavailable; falling back to one-shot compiler execution; reason=worker_unavailable"));
+            LogAssert.Expect(
+                UnityEngine.LogType.Error,
+                new System.Text.RegularExpressions.Regex(
+                    "execute-dynamic-code one-shot Roslyn compiler process failed to start"));
+            try
+            {
+                DynamicCompilationBackendResult single = await RoslynCompilerBackend.CompileAsync(
+                    firstSourcePath,
+                    dllPath,
+                    new List<string>(),
+                    paths,
+                    new RoslynCompilerOptions(System.Array.Empty<string>(), false, false),
+                    CancellationToken.None,
+                    () => { },
+                    () => { },
+                    () => { });
+                DynamicCompilationBackendResult multiple = await RoslynCompilerBackend.CompileMultipleSourcesAsync(
+                    new[] { firstSourcePath, secondSourcePath },
+                    dllPath,
+                    new List<string>(),
+                    paths,
+                    new RoslynCompilerOptions(System.Array.Empty<string>(), false, false),
+                    CancellationToken.None,
+                    () => { },
+                    () => { },
+                    () => { });
+
+                Assert.That(single.BackendKind, Is.EqualTo(DynamicCompilationBackendKind.AssemblyBuilderFallback));
+                Assert.That(multiple.BackendKind, Is.EqualTo(DynamicCompilationBackendKind.Unknown));
+                Assert.That(FindError(multiple.CompilerMessages).HasValue, Is.True);
+                Assert.That(fallbackCalls, Is.EqualTo(1));
+            }
+            finally
+            {
+                SharedRoslynCompilerWorkerHost.ShutdownForTests();
+                AssemblyBuilderFallbackCompilerBackend.SwapCompilerForTests(previousFallback);
+                RoslynCompilerBackend.SwapOneShotProcessStarterForTests(previousStarter);
+                SharedRoslynCompilerWorkerHost.SwapWorkerAssemblyCompilerForTests(previousWorker);
+                if (Directory.Exists(directory))
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the real shared Roslyn worker compiles independent UTF-8 CRLF sources
+        /// whose directory and file names contain spaces.
+        /// </summary>
+        [Test]
+        public async Task CompileMultipleSourcesAsync_RealSharedWorker_CompilesUtf8CrLfSpacePaths()
+        {
+            ExternalCompilerPaths paths = ExternalCompilerPathResolver.Resolve();
+            Assert.That(paths, Is.Not.Null);
+            string directory = Path.Combine(Path.GetTempPath(), "roslyn sources 日本語 " + Path.GetRandomFileName());
+            Directory.CreateDirectory(directory);
+            string firstSourcePath = Path.Combine(directory, "First Source.cs");
+            string secondSourcePath = Path.Combine(directory, "Second 日本語.cs");
+            string dllPath = Path.Combine(directory, "output.dll");
+            File.WriteAllText(firstSourcePath, "public class SharedFirst { }\r\n");
+            File.WriteAllText(
+                secondSourcePath,
+                "public class SharedSecond { public string Value() { return \"日本語\"; } }\r\n");
+            List<string> references = new DynamicReferenceSetBuilderService().BuildReferenceSet(
+                new List<string>(),
+                null,
+                paths);
+
+            SharedRoslynCompilerWorkerHost.ShutdownForTests();
+            try
+            {
+                DynamicCompilationBackendResult result = await RoslynCompilerBackend.CompileMultipleSourcesAsync(
+                    new[] { firstSourcePath, secondSourcePath },
+                    dllPath,
+                    references,
+                    paths,
+                    new RoslynCompilerOptions(Array.Empty<string>(), false, emitDebugCode: false),
+                    CancellationToken.None,
+                    () => { },
+                    () => { },
+                    () => { });
+
+                Assert.That(result.BackendKind, Is.EqualTo(DynamicCompilationBackendKind.SharedRoslynWorker));
+                Assert.That(result.CompilerMessages, Is.Empty);
+                Assert.That(File.Exists(dllPath), Is.True);
+                Assert.That(File.Exists(Path.ChangeExtension(dllPath, ".pdb")), Is.True);
+                Assembly assembly = Assembly.Load(File.ReadAllBytes(dllPath));
+                Assert.That(assembly.GetType("SharedFirst"), Is.Not.Null);
+                Assert.That(assembly.GetType("SharedSecond"), Is.Not.Null);
+            }
+            finally
+            {
+                SharedRoslynCompilerWorkerHost.ShutdownForTests();
+                if (Directory.Exists(directory))
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a real one-shot compiler process handles multiple source trees when the
+        /// shared worker build is unavailable.
+        /// </summary>
+        [Test]
+        public async Task CompileMultipleSourcesAsync_WorkerBuildFailure_UsesRealOneShotRoslyn()
+        {
+            ExternalCompilerPaths paths = ExternalCompilerPathResolver.Resolve();
+            Assert.That(paths, Is.Not.Null);
+            string directory = Path.Combine(Path.GetTempPath(), "roslyn multiple one-shot 日本語 " + Path.GetRandomFileName());
+            Directory.CreateDirectory(directory);
+            string firstSourcePath = Path.Combine(directory, "First Source.cs");
+            string secondSourcePath = Path.Combine(directory, "Second 日本語.cs");
+            string dllPath = Path.Combine(directory, "output.dll");
+            File.WriteAllText(firstSourcePath, "public class OneShotFirst { }\r\n");
+            File.WriteAllText(
+                secondSourcePath,
+                "public class OneShotSecond { public string Value() { return \"日本語\"; } }\r\n");
+            List<string> references = new DynamicReferenceSetBuilderService().BuildReferenceSet(
+                new List<string>(),
+                null,
+                paths);
+            Func<ExternalCompilerPaths, string, string, string, UnityEditor.Compilation.CompilerMessage[]> previousWorker =
+                SharedRoslynCompilerWorkerHost.SwapWorkerAssemblyCompilerForTests(
+                    (ExternalCompilerPaths _, string __, string ___, string ____) =>
+                        new[]
+                        {
+                            new UnityEditor.Compilation.CompilerMessage
+                            {
+                                type = UnityEditor.Compilation.CompilerMessageType.Error,
+                                message = "worker unavailable"
+                            }
+                        });
+
+            DynamicCompilationHealthMonitor.ResetForTests();
+            SharedRoslynCompilerWorkerHost.ShutdownForTests();
+            LogAssert.Expect(
+                UnityEngine.LogType.Error,
+                new System.Text.RegularExpressions.Regex(
+                    "execute-dynamic-code shared Roslyn worker failed to operate correctly; reason=worker_build_failed"));
+            LogAssert.Expect(
+                UnityEngine.LogType.Error,
+                new System.Text.RegularExpressions.Regex(
+                    "execute-dynamic-code shared Roslyn worker is unavailable; falling back to one-shot compiler execution; reason=worker_unavailable"));
+            try
+            {
+                DynamicCompilationBackendResult result = await RoslynCompilerBackend.CompileMultipleSourcesAsync(
+                    new[] { firstSourcePath, secondSourcePath },
+                    dllPath,
+                    references,
+                    paths,
+                    new RoslynCompilerOptions(Array.Empty<string>(), false, emitDebugCode: false),
+                    CancellationToken.None,
+                    () => { },
+                    () => { },
+                    () => { });
+
+                Assert.That(result.BackendKind, Is.EqualTo(DynamicCompilationBackendKind.OneShotRoslyn));
+                Assert.That(result.CompilerMessages, Is.Empty);
+                Assert.That(File.Exists(Path.ChangeExtension(dllPath, ".pdb")), Is.True);
+                Assembly assembly = Assembly.Load(File.ReadAllBytes(dllPath));
+                Assert.That(assembly.GetType("OneShotFirst"), Is.Not.Null);
+                Assert.That(assembly.GetType("OneShotSecond"), Is.Not.Null);
+            }
+            finally
+            {
+                SharedRoslynCompilerWorkerHost.SwapWorkerAssemblyCompilerForTests(previousWorker);
+                SharedRoslynCompilerWorkerHost.ShutdownForTests();
+                if (Directory.Exists(directory))
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the shared worker returns an error diagnostic attributed to the second source tree.
+        /// </summary>
+        [Test]
+        public async Task CompileMultipleSourcesAsync_SecondSourceError_ReportsSecondSourceFromSharedWorker()
+        {
+            ExternalCompilerPaths paths = ExternalCompilerPathResolver.Resolve();
+            Assert.That(paths, Is.Not.Null);
+            string directory = Path.Combine(Path.GetTempPath(), "roslyn-multiple-shared-error-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(directory);
+            string firstSourcePath = Path.Combine(directory, "first.cs");
+            string secondSourcePath = Path.Combine(directory, "second.cs");
+            string dllPath = Path.Combine(directory, "output.dll");
+            File.WriteAllText(firstSourcePath, "public class ValidFirst { }");
+            File.WriteAllText(secondSourcePath, "public class BrokenSecond { public MissingType Value; }");
+            List<string> references = new DynamicReferenceSetBuilderService().BuildReferenceSet(new List<string>(), null, paths);
+            SharedRoslynCompilerWorkerHost.ShutdownForTests();
+            try
+            {
+                DynamicCompilationBackendResult result = await RoslynCompilerBackend.CompileMultipleSourcesAsync(
+                    new[] { firstSourcePath, secondSourcePath }, dllPath, references, paths,
+                    new RoslynCompilerOptions(Array.Empty<string>(), false, emitDebugCode: false),
+                    CancellationToken.None, () => { }, () => { }, () => { });
+                UnityEditor.Compilation.CompilerMessage? error = FindError(result.CompilerMessages);
+
+                Assert.That(result.BackendKind, Is.EqualTo(DynamicCompilationBackendKind.SharedRoslynWorker));
+                Assert.That(error.HasValue, Is.True);
+                Assert.That(error.Value.file, Is.EqualTo(secondSourcePath));
+            }
+            finally
+            {
+                SharedRoslynCompilerWorkerHost.ShutdownForTests();
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the one-shot fallback returns an error diagnostic attributed to the second source tree.
+        /// </summary>
+        [Test]
+        public async Task CompileMultipleSourcesAsync_SecondSourceError_ReportsSecondSourceFromOneShotRoslyn()
+        {
+            ExternalCompilerPaths paths = ExternalCompilerPathResolver.Resolve();
+            Assert.That(paths, Is.Not.Null);
+            string directory = Path.Combine(Path.GetTempPath(), "roslyn-multiple-oneshot-error-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(directory);
+            string firstSourcePath = Path.Combine(directory, "first.cs");
+            string secondSourcePath = Path.Combine(directory, "second.cs");
+            string dllPath = Path.Combine(directory, "output.dll");
+            File.WriteAllText(firstSourcePath, "public class ValidFirst { }");
+            File.WriteAllText(secondSourcePath, "public class BrokenSecond { public MissingType Value; }");
+            List<string> references = new DynamicReferenceSetBuilderService().BuildReferenceSet(new List<string>(), null, paths);
+            Func<ExternalCompilerPaths, string, string, string, UnityEditor.Compilation.CompilerMessage[]> previousWorker =
+                SharedRoslynCompilerWorkerHost.SwapWorkerAssemblyCompilerForTests(
+                    (ExternalCompilerPaths _, string __, string ___, string ____) =>
+                        new[] { new UnityEditor.Compilation.CompilerMessage { type = UnityEditor.Compilation.CompilerMessageType.Error, message = "worker unavailable" } });
+            DynamicCompilationHealthMonitor.ResetForTests();
+            SharedRoslynCompilerWorkerHost.ShutdownForTests();
+            LogAssert.Expect(UnityEngine.LogType.Error, new System.Text.RegularExpressions.Regex("reason=worker_build_failed"));
+            LogAssert.Expect(UnityEngine.LogType.Error, new System.Text.RegularExpressions.Regex("falling back to one-shot"));
+            try
+            {
+                DynamicCompilationBackendResult result = await RoslynCompilerBackend.CompileMultipleSourcesAsync(
+                    new[] { firstSourcePath, secondSourcePath }, dllPath, references, paths,
+                    new RoslynCompilerOptions(Array.Empty<string>(), false, emitDebugCode: false),
+                    CancellationToken.None, () => { }, () => { }, () => { });
+                UnityEditor.Compilation.CompilerMessage? error = FindError(result.CompilerMessages);
+
+                Assert.That(result.BackendKind, Is.EqualTo(DynamicCompilationBackendKind.OneShotRoslyn));
+                Assert.That(error.HasValue, Is.True);
+                Assert.That(error.Value.file, Is.EqualTo(secondSourcePath));
+            }
+            finally
+            {
+                SharedRoslynCompilerWorkerHost.SwapWorkerAssemblyCompilerForTests(previousWorker);
+                SharedRoslynCompilerWorkerHost.ShutdownForTests();
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+
+        private static UnityEditor.Compilation.CompilerMessage? FindError(
+            UnityEditor.Compilation.CompilerMessage[] messages)
+        {
+            foreach (UnityEditor.Compilation.CompilerMessage message in messages)
+            {
+                if (message.type == UnityEditor.Compilation.CompilerMessageType.Error)
+                {
+                    return message;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/Assets/Tests/Editor/DynamicCodeToolTests/RoslynCompilerBackendTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/RoslynCompilerBackendTests.cs
@@ -149,6 +149,57 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
+        /// Multi-source request writers reject source paths from different directories without writing either request file.
+        /// </summary>
+        [Test]
+        public void MultiSourceRequestWriters_DifferentSourceDirectories_RejectWithoutWritingFiles()
+        {
+            string rootDirectory = Path.Combine(Path.GetTempPath(), "roslyn-writer-directories-" + Path.GetRandomFileName());
+            string firstDirectory = Path.Combine(rootDirectory, "first");
+            string secondDirectory = Path.Combine(rootDirectory, "second");
+            Directory.CreateDirectory(firstDirectory);
+            Directory.CreateDirectory(secondDirectory);
+            string firstSourcePath = Path.Combine(firstDirectory, "first.cs");
+            string secondSourcePath = Path.Combine(secondDirectory, "second.cs");
+            string dllPath = Path.Combine(firstDirectory, "output.dll");
+            string workerRequestFilePath = Path.Combine(rootDirectory, "request.worker");
+            string responseFilePath = Path.Combine(rootDirectory, "request.rsp");
+            try
+            {
+                ArgumentException workerException = Assert.Throws<ArgumentException>(
+                    () => RoslynCompilerRequestFileWriter.WriteMultipleSourcesWorkerRequestFile(
+                        workerRequestFilePath,
+                        new[] { firstSourcePath, secondSourcePath },
+                        dllPath,
+                        new List<string>(),
+                        new List<string>(),
+                        allowUnsafeCode: false,
+                        emitDebugCode: false));
+                ArgumentException responseException = Assert.Throws<ArgumentException>(
+                    () => RoslynCompilerRequestFileWriter.WriteMultipleSourcesCompilerResponseFile(
+                        responseFilePath,
+                        new[] { firstSourcePath, secondSourcePath },
+                        dllPath,
+                        new List<string>(),
+                        new List<string>(),
+                        allowUnsafeCode: false,
+                        emitDebugCode: false));
+
+                Assert.That(workerException.ParamName, Is.EqualTo("sourcePaths"));
+                Assert.That(responseException.ParamName, Is.EqualTo("sourcePaths"));
+                Assert.That(File.Exists(workerRequestFilePath), Is.False);
+                Assert.That(File.Exists(responseFilePath), Is.False);
+            }
+            finally
+            {
+                if (Directory.Exists(rootDirectory))
+                {
+                    Directory.Delete(rootDirectory, recursive: true);
+                }
+            }
+        }
+
+        /// <summary>
         /// WriteWorkerRequestFile encodes emitDebugCode for the shared Roslyn worker.
         /// </summary>
         [Test]
@@ -284,7 +335,77 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
-        /// Verifies that the real shared Roslyn worker compiles independent UTF-8 CRLF sources
+        /// Verifies that sources from different directories are rejected before a build starts without request-file leftovers.
+        /// </summary>
+        [Test]
+        public async Task CompileMultipleSourcesAsync_DifferentSourceDirectories_RejectsBeforeStartingBuildWithoutRequestFileLeftovers()
+        {
+            ExternalCompilerPaths paths = ExternalCompilerPathResolver.Resolve();
+            Assert.That(paths, Is.Not.Null);
+            string rootDirectory = Path.Combine(Path.GetTempPath(), "roslyn-multiple-directories-" + Path.GetRandomFileName());
+            string firstDirectory = Path.Combine(rootDirectory, "first");
+            string secondDirectory = Path.Combine(rootDirectory, "second");
+            Directory.CreateDirectory(firstDirectory);
+            Directory.CreateDirectory(secondDirectory);
+            string firstSourcePath = Path.Combine(firstDirectory, "first.cs");
+            string secondSourcePath = Path.Combine(secondDirectory, "second.cs");
+            string dllPath = Path.Combine(firstDirectory, "output.dll");
+            File.WriteAllText(firstSourcePath, "public class First { }");
+            File.WriteAllText(secondSourcePath, "public class Second { }");
+            int buildCount = 0;
+            Func<ExternalCompilerPaths, string, string, string, UnityEditor.Compilation.CompilerMessage[]> previousWorker =
+                SharedRoslynCompilerWorkerHost.SwapWorkerAssemblyCompilerForTests(
+                    (ExternalCompilerPaths _, string __, string ___, string ____) =>
+                        throw new AssertionException(
+                            "Worker assembly build must not start for sources in different directories."));
+            Func<System.Diagnostics.ProcessStartInfo, System.Diagnostics.Process> previousStarter =
+                RoslynCompilerBackend.SwapOneShotProcessStarterForTests(
+                    _ => throw new AssertionException(
+                        "One-shot compiler must not start for sources in different directories."));
+
+            SharedRoslynCompilerWorkerHost.ShutdownForTests();
+            DynamicCompilationHealthMonitor.ResetForTests();
+            try
+            {
+                ArgumentException captured = null;
+                try
+                {
+                    await RoslynCompilerBackend.CompileMultipleSourcesAsync(
+                        new[] { firstSourcePath, secondSourcePath },
+                        dllPath,
+                        new List<string>(),
+                        paths,
+                        new RoslynCompilerOptions(Array.Empty<string>(), false, emitDebugCode: false),
+                        CancellationToken.None,
+                        () => { },
+                        () => { },
+                        () => buildCount++);
+                }
+                catch (ArgumentException exception)
+                {
+                    captured = exception;
+                }
+
+                Assert.That(captured, Is.Not.Null);
+                Assert.That(captured.ParamName, Is.EqualTo("sourcePaths"));
+                Assert.That(buildCount, Is.Zero);
+                Assert.That(Directory.GetFiles(firstDirectory, "*.worker"), Is.Empty);
+                Assert.That(Directory.GetFiles(firstDirectory, "*.rsp"), Is.Empty);
+            }
+            finally
+            {
+                SharedRoslynCompilerWorkerHost.ShutdownForTests();
+                RoslynCompilerBackend.SwapOneShotProcessStarterForTests(previousStarter);
+                SharedRoslynCompilerWorkerHost.SwapWorkerAssemblyCompilerForTests(previousWorker);
+                if (Directory.Exists(rootDirectory))
+                {
+                    Directory.Delete(rootDirectory, recursive: true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the real shared Roslyn worker preserves per-source aliases in UTF-8 CRLF sources
         /// whose directory and file names contain spaces.
         /// </summary>
         [Test]
@@ -297,10 +418,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             string firstSourcePath = Path.Combine(directory, "First Source.cs");
             string secondSourcePath = Path.Combine(directory, "Second 日本語.cs");
             string dllPath = Path.Combine(directory, "output.dll");
-            File.WriteAllText(firstSourcePath, "public class SharedFirst { }\r\n");
+            File.WriteAllText(firstSourcePath, "using Alias = System.Int32;\r\npublic class SharedFirst { public Alias Value; }\r\n");
             File.WriteAllText(
                 secondSourcePath,
-                "public class SharedSecond { public string Value() { return \"日本語\"; } }\r\n");
+                "using Alias = System.String;\r\npublic class SharedSecond { public Alias Value; public string Text() { return \"日本語\"; } }\r\n");
             List<string> references = new DynamicReferenceSetBuilderService().BuildReferenceSet(
                 new List<string>(),
                 null,
@@ -325,8 +446,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
                 Assert.That(File.Exists(dllPath), Is.True);
                 Assert.That(File.Exists(Path.ChangeExtension(dllPath, ".pdb")), Is.True);
                 Assembly assembly = Assembly.Load(File.ReadAllBytes(dllPath));
-                Assert.That(assembly.GetType("SharedFirst"), Is.Not.Null);
-                Assert.That(assembly.GetType("SharedSecond"), Is.Not.Null);
+                Type firstType = assembly.GetType("SharedFirst");
+                Type secondType = assembly.GetType("SharedSecond");
+                Assert.That(firstType, Is.Not.Null);
+                Assert.That(secondType, Is.Not.Null);
+                FieldInfo firstField = firstType.GetField("Value");
+                FieldInfo secondField = secondType.GetField("Value");
+                Assert.That(firstField, Is.Not.Null);
+                Assert.That(secondField, Is.Not.Null);
+                Assert.That(firstField.FieldType, Is.EqualTo(typeof(int)));
+                Assert.That(secondField.FieldType, Is.EqualTo(typeof(string)));
             }
             finally
             {
@@ -339,7 +468,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
-        /// Verifies that a real one-shot compiler process handles multiple source trees when the
+        /// Verifies that a real one-shot compiler process preserves per-source aliases when the
         /// shared worker build is unavailable.
         /// </summary>
         [Test]
@@ -352,10 +481,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             string firstSourcePath = Path.Combine(directory, "First Source.cs");
             string secondSourcePath = Path.Combine(directory, "Second 日本語.cs");
             string dllPath = Path.Combine(directory, "output.dll");
-            File.WriteAllText(firstSourcePath, "public class OneShotFirst { }\r\n");
+            File.WriteAllText(firstSourcePath, "using Alias = System.Int32;\r\npublic class OneShotFirst { public Alias Value; }\r\n");
             File.WriteAllText(
                 secondSourcePath,
-                "public class OneShotSecond { public string Value() { return \"日本語\"; } }\r\n");
+                "using Alias = System.String;\r\npublic class OneShotSecond { public Alias Value; public string Text() { return \"日本語\"; } }\r\n");
             List<string> references = new DynamicReferenceSetBuilderService().BuildReferenceSet(
                 new List<string>(),
                 null,
@@ -399,8 +528,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
                 Assert.That(result.CompilerMessages, Is.Empty);
                 Assert.That(File.Exists(Path.ChangeExtension(dllPath, ".pdb")), Is.True);
                 Assembly assembly = Assembly.Load(File.ReadAllBytes(dllPath));
-                Assert.That(assembly.GetType("OneShotFirst"), Is.Not.Null);
-                Assert.That(assembly.GetType("OneShotSecond"), Is.Not.Null);
+                Type firstType = assembly.GetType("OneShotFirst");
+                Type secondType = assembly.GetType("OneShotSecond");
+                Assert.That(firstType, Is.Not.Null);
+                Assert.That(secondType, Is.Not.Null);
+                FieldInfo firstField = firstType.GetField("Value");
+                FieldInfo secondField = secondType.GetField("Value");
+                Assert.That(firstField, Is.Not.Null);
+                Assert.That(secondField, Is.Not.Null);
+                Assert.That(firstField.FieldType, Is.EqualTo(typeof(int)));
+                Assert.That(secondField.FieldType, Is.EqualTo(typeof(string)));
             }
             finally
             {

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/AssemblyBuilderFallbackCompilerBackend.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/AssemblyBuilderFallbackCompilerBackend.cs
@@ -11,6 +11,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class AssemblyBuilderFallbackCompilerBackend
     {
+        private static Func<
+            string,
+            string,
+            List<string>,
+            CancellationToken,
+            Action,
+            Action,
+            Action,
+            Task<DynamicCompilationBackendResult>> compilerOverride;
+
         public static async Task<DynamicCompilationBackendResult> CompileAsync(
             string sourcePath,
             string dllPath,
@@ -20,6 +30,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Action markBuildFinished,
             Action incrementBuildCount)
         {
+            if (compilerOverride != null)
+            {
+                return await compilerOverride(
+                    sourcePath,
+                    dllPath,
+                    references,
+                    ct,
+                    markBuildStarted,
+                    markBuildFinished,
+                    incrementBuildCount).ConfigureAwait(false);
+            }
+
             TaskCompletionSource<CompilerMessage[]> taskCompletionSource = new();
             ct.ThrowIfCancellationRequested();
             incrementBuildCount();
@@ -63,6 +85,38 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return new DynamicCompilationBackendResult(
                 messages,
                 DynamicCompilationBackendKind.AssemblyBuilderFallback);
+        }
+
+        internal static Func<
+            string,
+            string,
+            List<string>,
+            CancellationToken,
+            Action,
+            Action,
+            Action,
+            Task<DynamicCompilationBackendResult>> SwapCompilerForTests(
+            Func<
+                string,
+                string,
+                List<string>,
+                CancellationToken,
+                Action,
+                Action,
+                Action,
+                Task<DynamicCompilationBackendResult>> replacement)
+        {
+            Func<
+                string,
+                string,
+                List<string>,
+                CancellationToken,
+                Action,
+                Action,
+                Action,
+                Task<DynamicCompilationBackendResult>> previous = compilerOverride;
+            compilerOverride = replacement;
+            return previous;
         }
 
         internal static async Task<CompilerMessage[]> AwaitBuildCompletionAsync(

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerBackend.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerBackend.cs
@@ -72,6 +72,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 allowAssemblyBuilderFallback: true).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Compiles source files that share one normalized parent directory.
+        /// </summary>
         public static async Task<DynamicCompilationBackendResult> CompileMultipleSourcesAsync(
             IReadOnlyList<string> sourcePaths,
             string dllPath,

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerBackend.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerBackend.cs
@@ -17,6 +17,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class RoslynCompilerBackend
     {
+        private static Func<ProcessStartInfo, Process> oneShotProcessStarter = ProcessStartHelper.TryStart;
         /// <summary>
         /// Carries the result data produced by One Shot Compile behavior.
         /// </summary>
@@ -58,16 +59,67 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Action markBuildFinished,
             Action incrementBuildCount)
         {
-            string workerRequestFilePath = Path.ChangeExtension(sourcePath, ".worker");
+            return await CompileSourcesAsync(
+                new[] { sourcePath },
+                dllPath,
+                references,
+                externalCompilerPaths,
+                compilerOptions,
+                ct,
+                markBuildStarted,
+                markBuildFinished,
+                incrementBuildCount,
+                allowAssemblyBuilderFallback: true).ConfigureAwait(false);
+        }
+
+        public static async Task<DynamicCompilationBackendResult> CompileMultipleSourcesAsync(
+            IReadOnlyList<string> sourcePaths,
+            string dllPath,
+            List<string> references,
+            ExternalCompilerPaths externalCompilerPaths,
+            RoslynCompilerOptions compilerOptions,
+            CancellationToken ct,
+            Action markBuildStarted,
+            Action markBuildFinished,
+            Action incrementBuildCount)
+        {
+            return await CompileSourcesAsync(
+                sourcePaths,
+                dllPath,
+                references,
+                externalCompilerPaths,
+                compilerOptions,
+                ct,
+                markBuildStarted,
+                markBuildFinished,
+                incrementBuildCount,
+                allowAssemblyBuilderFallback: false).ConfigureAwait(false);
+        }
+
+        private static async Task<DynamicCompilationBackendResult> CompileSourcesAsync(
+            IReadOnlyList<string> sourcePaths,
+            string dllPath,
+            List<string> references,
+            ExternalCompilerPaths externalCompilerPaths,
+            RoslynCompilerOptions compilerOptions,
+            CancellationToken ct,
+            Action markBuildStarted,
+            Action markBuildFinished,
+            Action incrementBuildCount,
+            bool allowAssemblyBuilderFallback)
+        {
+            RoslynCompilerRequestFileWriter.ValidateSourcePaths(sourcePaths);
+            string sourcePath = sourcePaths[0];
+            string workerRequestFilePath = RoslynCompilerRequestFileWriter.CreateRequestFilePath(sourcePath, ".worker", sourcePaths.Count > 1);
             IReadOnlyCollection<string> defineSymbols = compilerOptions.DefineSymbols;
             bool allowUnsafeCode = compilerOptions.AllowUnsafeCode;
             bool emitDebugCode = compilerOptions.EmitDebugCode;
 
             try
             {
-                WriteWorkerRequestFile(
+                RoslynCompilerRequestFileWriter.WriteMultipleSourcesWorkerRequestFile(
                     workerRequestFilePath,
-                    sourcePath,
+                    sourcePaths,
                     dllPath,
                     references,
                     defineSymbols,
@@ -104,7 +156,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 ct.ThrowIfCancellationRequested();
                 OneShotCompileResult oneShotResult = await CompileWithOneShotAsync(
-                    sourcePath,
+                    sourcePaths,
                     dllPath,
                     references,
                     defineSymbols,
@@ -115,7 +167,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     markBuildStarted,
                     markBuildFinished,
                     incrementBuildCount).ConfigureAwait(false);
-                if (oneShotResult.ShouldFallback)
+                if (oneShotResult.ShouldFallback && allowAssemblyBuilderFallback)
                 {
                     return await AssemblyBuilderFallbackCompilerBackend.CompileAsync(
                         sourcePath,
@@ -125,6 +177,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         markBuildStarted,
                         markBuildFinished,
                         incrementBuildCount).ConfigureAwait(false);
+                }
+
+                if (oneShotResult.ShouldFallback)
+                {
+                    return new DynamicCompilationBackendResult(
+                        new[]
+                        {
+                            new CompilerMessage
+                            {
+                                type = CompilerMessageType.Error,
+                                message = "No supported Roslyn compiler backend is available for multiple sources."
+                            }
+                        },
+                        DynamicCompilationBackendKind.Unknown);
                 }
 
                 return oneShotResult.BackendResult;
@@ -139,7 +205,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         private static async Task<OneShotCompileResult> CompileWithOneShotAsync(
-            string sourcePath,
+            IReadOnlyList<string> sourcePaths,
             string dllPath,
             List<string> references,
             IReadOnlyCollection<string> defineSymbols,
@@ -151,10 +217,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Action markBuildFinished,
             Action incrementBuildCount)
         {
-            string responseFilePath = Path.ChangeExtension(sourcePath, ".rsp");
-            WriteCompilerResponseFile(
+            string sourcePath = sourcePaths[0];
+            string responseFilePath = RoslynCompilerRequestFileWriter.CreateRequestFilePath(sourcePath, ".rsp", sourcePaths.Count > 1);
+            RoslynCompilerRequestFileWriter.WriteMultipleSourcesCompilerResponseFile(
                 responseFilePath,
-                sourcePath,
+                sourcePaths,
                 dllPath,
                 references,
                 defineSymbols,
@@ -182,7 +249,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 try
                 {
-                    using Process process = ProcessStartHelper.TryStart(startInfo);
+                    using Process process = oneShotProcessStarter(startInfo);
                     if (process == null)
                     {
                         DynamicCompilationHealthMonitor.ReportOneShotCompilerStartFailure(new
@@ -224,124 +291,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        internal static void WriteCompilerResponseFile(
-            string responseFilePath,
-            string sourcePath,
-            string dllPath,
-            IReadOnlyCollection<string> references,
-            IReadOnlyCollection<string> defineSymbols,
-            bool allowUnsafeCode,
-            bool emitDebugCode)
-        {
-            List<string> lines = new()
-            {
-                "-nologo",
-                // Diagnostics must be machine-readable by AI agents: English text, UTF-8 bytes.
-                "-preferreduilang:en-US",
-                "-utf8output",
-                "-nostdlib+",
-                "-target:library",
-                // Why -optimize- for emitDebugCode: hot-reload shims need locals in the PDB for
-                // pause-point capture; execute-dynamic-code keeps -optimize+.
-                emitDebugCode ? "-optimize-" : "-optimize+",
-                // Why portable: one-shot csc fallback must emit a PDB so Assembly.Load can map
-                // runtime exceptions back to user-snippet.cs lines (same as the shared worker).
-                "-debug:portable",
-                allowUnsafeCode ? "-unsafe+" : "-unsafe-",
-                QuoteResponseFileArgument("-out:", dllPath)
-            };
-
-            // Why pathmap: csc resolves relative #line document paths against the source file's
-            // directory and writes work-directory absolute URLs into the PDB; map the compile
-            // directory back to the project root so PDB documents point at the real project files
-            // (the shared worker's ParseText path leaves the literal as-is and needs no mapping).
-            // Why GetProjectRoot: it is the single source of truth; process CWD can be moved by
-            // external assets via Directory.SetCurrentDirectory.
-            string sourceDirectory = Path.GetDirectoryName(Path.GetFullPath(sourcePath));
-            lines.Add(QuoteResponseFileArgument("-pathmap:", sourceDirectory + "=" + UnityCliLoopPathResolver.GetProjectRoot()));
-
-            string defineOption = BuildDefineOption(defineSymbols);
-            if (!string.IsNullOrEmpty(defineOption))
-            {
-                lines.Add(defineOption);
-            }
-
-            foreach (string reference in references)
-            {
-                lines.Add(QuoteResponseFileArgument("-r:", reference));
-            }
-
-            lines.Add(QuoteResponseFilePath(sourcePath));
-            File.WriteAllLines(responseFilePath, lines);
-        }
-
-        internal static void WriteWorkerRequestFile(
-            string requestFilePath,
-            string sourcePath,
-            string dllPath,
-            IReadOnlyCollection<string> references,
-            IReadOnlyCollection<string> defineSymbols,
-            bool allowUnsafeCode,
-            bool emitDebugCode)
-        {
-            List<string> lines = new() { Path.GetFullPath(sourcePath), Path.GetFullPath(dllPath) };
-            lines.Add(allowUnsafeCode ? "unsafe:1" : "unsafe:0");
-            lines.Add(emitDebugCode ? "debugCode:1" : "debugCode:0");
-
-            string serializedDefines = SerializeDefineSymbols(defineSymbols);
-            if (!string.IsNullOrEmpty(serializedDefines))
-            {
-                lines.Add($"define:{serializedDefines}");
-            }
-
-            foreach (string reference in references)
-            {
-                lines.Add($"ref:{Path.GetFullPath(reference)}");
-            }
-
-            File.WriteAllLines(Path.GetFullPath(requestFilePath), lines);
-        }
-
-        private static string BuildDefineOption(IReadOnlyCollection<string> defineSymbols)
-        {
-            string serializedDefines = SerializeDefineSymbols(defineSymbols);
-            if (string.IsNullOrEmpty(serializedDefines))
-            {
-                return null;
-            }
-
-            return $"-define:{serializedDefines}";
-        }
-
-        private static string SerializeDefineSymbols(IReadOnlyCollection<string> defineSymbols)
-        {
-            if (defineSymbols == null || defineSymbols.Count == 0)
-            {
-                return string.Empty;
-            }
-
-            List<string> filteredDefines = new(defineSymbols.Count);
-            foreach (string defineSymbol in defineSymbols)
-            {
-                if (!string.IsNullOrWhiteSpace(defineSymbol))
-                {
-                    filteredDefines.Add(defineSymbol);
-                }
-            }
-
-            return filteredDefines.Count == 0 ? string.Empty : string.Join(";", filteredDefines);
-        }
-
-        private static string QuoteResponseFileArgument(string prefix, string value)
-        {
-            return $"{prefix}{QuoteResponseFilePath(value)}";
-        }
-
-        private static string QuoteResponseFilePath(string path)
-        {
-            return $"\"{path}\"";
-        }
-
         // Infrastructure-level failures (non-zero exit without file-specific diagnostics)
         // indicate the compiler itself broke, not the user's code.
         private static bool ShouldRetryWithAssemblyBuilder(
@@ -368,6 +317,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static string QuoteCommandLineArgument(string value)
         {
             return $"\"{value}\"";
+        }
+
+        internal static Func<ProcessStartInfo, Process> SwapOneShotProcessStarterForTests(
+            Func<ProcessStartInfo, Process> replacement)
+        {
+            Func<ProcessStartInfo, Process> previous = oneShotProcessStarter;
+            oneShotProcessStarter = replacement ?? throw new ArgumentNullException(nameof(replacement));
+            return previous;
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerRequestFileWriter.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerRequestFileWriter.cs
@@ -100,11 +100,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             HashSet<string> paths = new HashSet<string>(StringComparer.Ordinal);
+            string sourceDirectory = null;
             foreach (string sourcePath in sourcePaths)
             {
-                if (string.IsNullOrWhiteSpace(sourcePath) || !paths.Add(Path.GetFullPath(sourcePath)))
+                if (string.IsNullOrWhiteSpace(sourcePath))
                 {
                     throw new ArgumentException("Source paths must be non-empty and unique.", nameof(sourcePaths));
+                }
+
+                string fullPath = Path.GetFullPath(sourcePath);
+                if (!paths.Add(fullPath))
+                {
+                    throw new ArgumentException("Source paths must be non-empty and unique.", nameof(sourcePaths));
+                }
+
+                string currentDirectory = Path.GetDirectoryName(fullPath);
+                if (sourceDirectory == null)
+                {
+                    sourceDirectory = currentDirectory;
+                    continue;
+                }
+
+                // This request format emits a single source-directory mapping.
+                if (!string.Equals(sourceDirectory, currentDirectory, StringComparison.Ordinal))
+                {
+                    throw new ArgumentException(
+                        "Source paths must share one normalized parent directory.",
+                        nameof(sourcePaths));
                 }
             }
         }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerRequestFileWriter.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerRequestFileWriter.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Serializes source batches for the shared worker and one-shot Roslyn processes.
+    /// </summary>
+    internal static class RoslynCompilerRequestFileWriter
+    {
+        internal static void WriteCompilerResponseFile(
+            string responseFilePath,
+            string sourcePath,
+            string dllPath,
+            IReadOnlyCollection<string> references,
+            IReadOnlyCollection<string> defineSymbols,
+            bool allowUnsafeCode,
+            bool emitDebugCode)
+        {
+            List<string> lines = CreateCompilerOptions(dllPath, allowUnsafeCode, emitDebugCode);
+            string sourceDirectory = Path.GetDirectoryName(Path.GetFullPath(sourcePath));
+            lines.Add(QuoteArgument("-pathmap:", sourceDirectory + "=" + UnityCliLoopPathResolver.GetProjectRoot()));
+            AddDefines(lines, defineSymbols);
+            AddReferences(lines, references);
+            lines.Add(QuotePath(sourcePath));
+            File.WriteAllLines(responseFilePath, lines);
+        }
+
+        internal static void WriteMultipleSourcesCompilerResponseFile(
+            string responseFilePath,
+            IReadOnlyList<string> sourcePaths,
+            string dllPath,
+            IReadOnlyCollection<string> references,
+            IReadOnlyCollection<string> defineSymbols,
+            bool allowUnsafeCode,
+            bool emitDebugCode)
+        {
+            ValidateSourcePaths(sourcePaths);
+            WriteCompilerResponseFile(responseFilePath, sourcePaths[0], dllPath, references, defineSymbols, allowUnsafeCode, emitDebugCode);
+            List<string> lines = new List<string>(File.ReadAllLines(responseFilePath));
+            for (int index = 1; index < sourcePaths.Count; index++)
+            {
+                lines.Add(QuotePath(sourcePaths[index]));
+            }
+
+            File.WriteAllLines(responseFilePath, lines);
+        }
+
+        internal static void WriteWorkerRequestFile(
+            string requestFilePath,
+            string sourcePath,
+            string dllPath,
+            IReadOnlyCollection<string> references,
+            IReadOnlyCollection<string> defineSymbols,
+            bool allowUnsafeCode,
+            bool emitDebugCode)
+        {
+            List<string> lines = new List<string>
+            {
+                Path.GetFullPath(sourcePath),
+                Path.GetFullPath(dllPath),
+                allowUnsafeCode ? "unsafe:1" : "unsafe:0",
+                emitDebugCode ? "debugCode:1" : "debugCode:0"
+            };
+            AddWorkerDefines(lines, defineSymbols);
+            AddWorkerReferences(lines, references);
+            File.WriteAllLines(Path.GetFullPath(requestFilePath), lines);
+        }
+
+        internal static void WriteMultipleSourcesWorkerRequestFile(
+            string requestFilePath,
+            IReadOnlyList<string> sourcePaths,
+            string dllPath,
+            IReadOnlyCollection<string> references,
+            IReadOnlyCollection<string> defineSymbols,
+            bool allowUnsafeCode,
+            bool emitDebugCode)
+        {
+            ValidateSourcePaths(sourcePaths);
+            WriteWorkerRequestFile(requestFilePath, sourcePaths[0], dllPath, references, defineSymbols, allowUnsafeCode, emitDebugCode);
+            List<string> lines = new List<string>(File.ReadAllLines(requestFilePath));
+            for (int index = 1; index < sourcePaths.Count; index++)
+            {
+                string fullPath = Path.GetFullPath(sourcePaths[index]);
+                lines.Add("source-base64:" + Convert.ToBase64String(Encoding.UTF8.GetBytes(fullPath)));
+            }
+
+            File.WriteAllLines(requestFilePath, lines);
+        }
+
+        internal static void ValidateSourcePaths(IReadOnlyList<string> sourcePaths)
+        {
+            if (sourcePaths == null || sourcePaths.Count == 0)
+            {
+                throw new ArgumentException("Source paths must not be empty.", nameof(sourcePaths));
+            }
+
+            HashSet<string> paths = new HashSet<string>(StringComparer.Ordinal);
+            foreach (string sourcePath in sourcePaths)
+            {
+                if (string.IsNullOrWhiteSpace(sourcePath) || !paths.Add(Path.GetFullPath(sourcePath)))
+                {
+                    throw new ArgumentException("Source paths must be non-empty and unique.", nameof(sourcePaths));
+                }
+            }
+        }
+
+        internal static string CreateRequestFilePath(string sourcePath, string extension, bool isMultipleSources)
+        {
+            return isMultipleSources
+                ? Path.ChangeExtension(sourcePath, Guid.NewGuid().ToString("N") + extension)
+                : Path.ChangeExtension(sourcePath, extension);
+        }
+
+        private static List<string> CreateCompilerOptions(string dllPath, bool allowUnsafeCode, bool emitDebugCode)
+        {
+            return new List<string>
+            {
+                "-nologo",
+                "-preferreduilang:en-US",
+                "-utf8output",
+                "-nostdlib+",
+                "-target:library",
+                emitDebugCode ? "-optimize-" : "-optimize+",
+                "-debug:portable",
+                allowUnsafeCode ? "-unsafe+" : "-unsafe-",
+                QuoteArgument("-out:", dllPath)
+            };
+        }
+
+        private static void AddDefines(List<string> lines, IReadOnlyCollection<string> defineSymbols)
+        {
+            string serializedDefines = SerializeDefineSymbols(defineSymbols);
+            if (!string.IsNullOrEmpty(serializedDefines))
+            {
+                lines.Add("-define:" + serializedDefines);
+            }
+        }
+
+        private static void AddReferences(List<string> lines, IReadOnlyCollection<string> references)
+        {
+            foreach (string reference in references)
+            {
+                lines.Add(QuoteArgument("-r:", reference));
+            }
+        }
+
+        private static void AddWorkerDefines(List<string> lines, IReadOnlyCollection<string> defineSymbols)
+        {
+            string serializedDefines = SerializeDefineSymbols(defineSymbols);
+            if (!string.IsNullOrEmpty(serializedDefines))
+            {
+                lines.Add("define:" + serializedDefines);
+            }
+        }
+
+        private static void AddWorkerReferences(List<string> lines, IReadOnlyCollection<string> references)
+        {
+            foreach (string reference in references)
+            {
+                lines.Add("ref:" + Path.GetFullPath(reference));
+            }
+        }
+
+        private static string SerializeDefineSymbols(IReadOnlyCollection<string> defineSymbols)
+        {
+            if (defineSymbols == null || defineSymbols.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            List<string> filteredDefines = new List<string>(defineSymbols.Count);
+            foreach (string defineSymbol in defineSymbols)
+            {
+                if (!string.IsNullOrWhiteSpace(defineSymbol))
+                {
+                    filteredDefines.Add(defineSymbol);
+                }
+            }
+
+            return filteredDefines.Count == 0 ? string.Empty : string.Join(";", filteredDefines);
+        }
+
+        private static string QuoteArgument(string prefix, string value)
+        {
+            return prefix + QuotePath(value);
+        }
+
+        private static string QuotePath(string path)
+        {
+            return "\"" + path + "\"";
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerRequestFileWriter.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerRequestFileWriter.cs
@@ -22,6 +22,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool emitDebugCode)
         {
             List<string> lines = CreateCompilerOptions(dllPath, allowUnsafeCode, emitDebugCode);
+            // csc resolves relative #line document paths from the source directory and otherwise
+            // writes work-directory absolute URLs into PDB files. Map that directory to the project
+            // root so PDB documents identify project files even if external code changes the CWD.
+            // UnityCliLoopPathResolver owns the project-root value as the single source of truth.
             string sourceDirectory = Path.GetDirectoryName(Path.GetFullPath(sourcePath));
             lines.Add(QuoteArgument("-pathmap:", sourceDirectory + "=" + UnityCliLoopPathResolver.GetProjectRoot()));
             AddDefines(lines, defineSymbols);
@@ -99,7 +103,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 throw new ArgumentException("Source paths must not be empty.", nameof(sourcePaths));
             }
 
-            HashSet<string> paths = new HashSet<string>(StringComparer.Ordinal);
+            StringComparer pathComparer = CreatePathComparer();
+            HashSet<string> paths = new HashSet<string>(pathComparer);
             string sourceDirectory = null;
             foreach (string sourcePath in sourcePaths)
             {
@@ -122,7 +127,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 // This request format emits a single source-directory mapping.
-                if (!string.Equals(sourceDirectory, currentDirectory, StringComparison.Ordinal))
+                if (!pathComparer.Equals(sourceDirectory, currentDirectory))
                 {
                     throw new ArgumentException(
                         "Source paths must share one normalized parent directory.",
@@ -143,15 +148,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return new List<string>
             {
                 "-nologo",
+                // AI consumers need machine-readable English diagnostics encoded as UTF-8.
                 "-preferreduilang:en-US",
                 "-utf8output",
                 "-nostdlib+",
                 "-target:library",
+                // Hot-reload shims need PDB locals for pause-point capture; dynamic code keeps optimization enabled.
                 emitDebugCode ? "-optimize-" : "-optimize+",
+                // One-shot compilation needs a portable PDB to map Assembly.Load exceptions to user-snippet.cs lines.
                 "-debug:portable",
                 allowUnsafeCode ? "-unsafe+" : "-unsafe-",
                 QuoteArgument("-out:", dllPath)
             };
+        }
+
+        private static StringComparer CreatePathComparer()
+        {
+            return Path.DirectorySeparatorChar == '\\'
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal;
         }
 
         private static void AddDefines(List<string> lines, IReadOnlyCollection<string> defineSymbols)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerRequestFileWriter.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerRequestFileWriter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e0c90053734d421da648fb08da30caf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/Templates/SharedRoslynCompilerWorkerProgram.cs.template
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/Templates/SharedRoslynCompilerWorkerProgram.cs.template
@@ -17,6 +17,7 @@ public static class Program
     private const string DebugCodePrefix = "debugCode:";
     private const string DefinePrefix = "define:";
     private const string ReferencePrefix = "ref:";
+    private const string AdditionalSourcePrefix = "source-base64:";
     private static readonly object SyncRoot = new object();
     private static readonly Dictionary<string, CachedReference> Cache = new Dictionary<string, CachedReference>(StringComparer.OrdinalIgnoreCase);
 
@@ -169,11 +170,9 @@ public static class Program
         bool allowUnsafe = ParseAllowUnsafe(requestLines);
         bool emitDebugCode = ParseEmitDebugCode(requestLines);
         string[] defineSymbols = ParseDefineSymbols(requestLines);
-        string source = File.ReadAllText(sourcePath, Encoding.UTF8);
-        SourceText sourceText = SourceText.From(source, Encoding.UTF8);
-        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(sourceText, CreateParseOptions(defineSymbols), sourcePath);
+        List<SyntaxTree> syntaxTrees = BuildSyntaxTrees(requestLines, defineSymbols);
         List<MetadataReference> references = BuildReferences(requestLines);
-        CSharpCompilation compilation = CSharpCompilation.Create(Path.GetFileNameWithoutExtension(dllPath), new[] { syntaxTree }, references, CreateCompilationOptions(allowUnsafe, emitDebugCode));
+        CSharpCompilation compilation = CSharpCompilation.Create(Path.GetFileNameWithoutExtension(dllPath), syntaxTrees, references, CreateCompilationOptions(allowUnsafe, emitDebugCode));
         // Why portable PDB: execute-dynamic-code loads these bytes so runtime exceptions can
         // surface user-snippet.cs line numbers from #line directives in the wrapper.
         string pdbPath = Path.ChangeExtension(dllPath, ".pdb");
@@ -208,6 +207,32 @@ public static class Program
 
             return new CompileResponse(exitCode, diagnosticLines);
         }
+    }
+
+    private static List<SyntaxTree> BuildSyntaxTrees(string[] requestLines, string[] defineSymbols)
+    {
+        List<string> sourcePaths = new List<string> { requestLines[0] };
+        for (int i = 2; i < requestLines.Length; i++)
+        {
+            string line = requestLines[i];
+            if (!line.StartsWith(AdditionalSourcePrefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            string encodedPath = line.Substring(AdditionalSourcePrefix.Length);
+            sourcePaths.Add(Encoding.UTF8.GetString(Convert.FromBase64String(encodedPath)));
+        }
+
+        List<SyntaxTree> syntaxTrees = new List<SyntaxTree>(sourcePaths.Count);
+        foreach (string sourcePath in sourcePaths)
+        {
+            string source = File.ReadAllText(sourcePath, Encoding.UTF8);
+            SourceText sourceText = SourceText.From(source, Encoding.UTF8);
+            syntaxTrees.Add(CSharpSyntaxTree.ParseText(sourceText, CreateParseOptions(defineSymbols), sourcePath));
+        }
+
+        return syntaxTrees;
     }
 
     private static CSharpParseOptions CreateParseOptions(string[] defineSymbols)
@@ -290,7 +315,8 @@ public static class Program
                 string referencePath = requestLines[i];
                 if (referencePath.StartsWith(UnsafePrefix, StringComparison.Ordinal)
                     || referencePath.StartsWith(DebugCodePrefix, StringComparison.Ordinal)
-                    || referencePath.StartsWith(DefinePrefix, StringComparison.Ordinal))
+                    || referencePath.StartsWith(DefinePrefix, StringComparison.Ordinal)
+                    || referencePath.StartsWith(AdditionalSourcePrefix, StringComparison.Ordinal))
                 {
                     continue;
                 }


### PR DESCRIPTION
## Summary

- Adds a compiler foundation that keeps each source file in a multi-source request independent.
- Rejects unsupported source batches before compilation begins, while retaining existing single-source behavior.

## User Impact

Future multi-source compilation requests will preserve file-scoped imports and aliases instead of combining source text into an invalid or altered compilation unit. This PR provides only the shared compiler foundation; it does not expose or wire the multi-source path into HotReload, which remains in later PRs.

## Changes

- Added a multi-source compiler entry point while retaining existing single-source fallback behavior.
- Added shared-worker and one-shot request support for independent source paths and source-owned diagnostics.
- Required all sources in a request to share the request format's single directory mapping before any build starts.
- Preserved explicit multi-source infrastructure failures instead of falling back to an incomplete AssemblyBuilder compile.

## Verification

- Unity compile: Success, 0 errors, 0 warnings.
- `RoslynCompilerBackendTests`: 12 passed, 0 failed, 0 skipped.
- `SharedRoslynCompilerWorkerHostTests`: 33 passed, 0 failed, 1 environment-dependent skip.
- `ExternalCompilerPathResolverTests`: 18 passed, 0 failed, 0 skipped.
- File-length, complexity, and asmdef-policy gates passed.
