### PR TITLE
feat: emit bodied added property accessors

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberHost.cs
@@ -6,6 +6,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     /// Compiled host type for cross-file worker tests. Tests copy this source, add members to the
     /// copy, and expect a body edited in the sibling caller file to bind against them.
     /// </summary>
+    // Why public: accessor-delegate plans compile in a separate shim assembly.
     public sealed class HotReloadCrossFileAddedMemberHost
     {
         private int _stored;

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileAddedMemberHost.cs
@@ -6,8 +6,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     /// Compiled host type for cross-file worker tests. Tests copy this source, add members to the
     /// copy, and expect a body edited in the sibling caller file to bind against them.
     /// </summary>
-    internal sealed class HotReloadCrossFileAddedMemberHost
+    public sealed class HotReloadCrossFileAddedMemberHost
     {
+        private int _stored;
+
         public int Value()
         {
             return 1;

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
@@ -158,6 +158,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// A bodied property added in the host file is callable from the patched sibling and
+        /// reaches the host's compiled private state through accessor delegates.
+        /// </summary>
+        [Test]
+        public async Task Run_CallerFileUsesBodiedPropertyAddedInOtherFile_AppliesAndRoundTripsValue()
+        {
+            HotReloadOrchestratorResult result = await RunPairAsync(
+                "CrossFileAddedBodiedProperty",
+                InsertHostMember(
+                    "        public int Stored\n        {\n            get => _stored;\n"
+                    + "            set => _stored = value;\n        }\n\n"),
+                ReplaceCallerBody(
+                    CallerCallBodyAnchor,
+                    "host.Stored = 3;\n            return host.Stored + 1;"));
+
+            AssertNoFailure(result);
+            AssertKind(result, HotReloadMethodOutcomeKind.Patched, "Call");
+            AssertKind(result, HotReloadMethodOutcomeKind.Added, "get_Stored");
+            AssertKind(result, HotReloadMethodOutcomeKind.Added, "set_Stored");
+            Assert.That(
+                new HotReloadCrossFileAddedMemberCaller().Call(new HotReloadCrossFileAddedMemberHost()),
+                Is.EqualTo(4));
+        }
+
+        /// <summary>
         /// What: a compile error in one file of the group takes down only that file — its other
         /// edited method reports the file-atomic skip and it starts no generation — while the
         /// healthy sibling file is applied and its runtime is updated.

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -74,17 +74,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: an expression-bodied property present only in the edited source is skipped with
-        /// the added-property reason and does not become a getter entry.
+        /// An expression-bodied property present only in the edited source is emitted as
+        /// an added getter entry instead of a skipped property.
         /// </summary>
         [Test]
-        public async Task Classify_AddedExpressionBodiedProperty_SkipsGetterWithAddedPropertyReason()
+        public async Task Emit_AddedExpressionBodiedProperty_RegistersAddedGetter()
         {
-            const string expectedReason =
-                "Added properties are out of scope for hot reload; the compiled assembly has no such member. "
-                + "For a computed value, add a same-file method instead (e.g. 'private T GetX()'), which applies "
-                + "through hot reload; for a constant, use a 'const' or a plain added field; otherwise run "
-                + "'uloop compile'.";
             string onDisk = File.ReadAllText(ResolveHostPath());
             string edited = WithHostMembers(
                 onDisk,
@@ -97,11 +92,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
 
-            Assert.That(
-                FindEntry(result, "get_AddedAmplitude"),
-                Is.Null,
-                "Added property getter must not be an entry.");
-            Assert.That(FindSkipReason(result, "get_AddedAmplitude"), Is.EqualTo(expectedReason));
+            TransformWorkerEntryDto getter = FindEntry(result, "get_AddedAmplitude");
+            Assert.That(getter, Is.Not.Null, "Added property getter must be an entry.");
+            Assert.That(getter.patchKind, Is.EqualTo(HotReloadConstants.PatchKindAddedMethod));
+            Assert.That(FindSkipReason(result, "get_AddedAmplitude"), Is.Null);
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -1703,6 +1703,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// An added bodied property on a partial host is skipped before accessor shims are emitted.
+        /// </summary>
+        [Test]
+        public async Task Skip_AddedBodiedPropertyOnPartialHost_SkipsAccessors()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int PartialKept()\n        {\n            return 1;\n        }",
+                "        public int AddedPartial { get => 1; set { } }\n\n"
+                + "        public int PartialKept()\n        {\n            return 1;\n        }",
+                StringComparison.Ordinal);
+            string sourcePath = WriteEdited("AddedPartialProperty.cs", edited);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                sourcePath,
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, "get_AddedPartial"), Is.Null);
+            Assert.That(FindEntry(result, "set_AddedPartial"), Is.Null);
+            Assert.That(FindSkipReason(result, "get_AddedPartial"), Does.Contain("Partial types are skipped"));
+            Assert.That(FindSkipReason(result, "set_AddedPartial"), Does.Contain("Partial types are skipped"));
+        }
+
+        /// <summary>
         /// What: an existing method whose return type is unchanged stays a normal edit
         /// (not an addedMethod replacement).
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedPropertyTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedPropertyTests.cs
@@ -1,0 +1,586 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Worker coverage for added properties that are emitted through added-method shims.
+    /// </summary>
+    public class TransformWorkerAddedPropertyTests
+    {
+        private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+        private const string HostProjectRelativePath =
+            "Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs";
+
+        private const string HostCloseMarker =
+            "        public int ReadPrivateSeed()\n        {\n            return _privateSeed;\n        }\n    }";
+
+        private const string ExistingCallerOriginal =
+            "        public int ExistingCaller(int value)\n        {\n            return value;\n        }";
+
+        private const string VirtualOrAbstractReason =
+            "Added virtual, override, abstract, or interface properties are skipped; the compiled type has no vtable slot. "
+            + "Run 'uloop compile' to add them.";
+
+        private const string InitAccessorReason =
+            "Added properties with init accessors are skipped; the shim cannot preserve initialization-only assignment. "
+            + "Run 'uloop compile' to add them.";
+
+        private const string CompoundAssignmentReason =
+            "Compound assignment, increment, and decrement of an added property are skipped; the accessor shim cannot preserve the operation. "
+            + "Run 'uloop compile' to add it.";
+
+        private const string ConsumedWriteReason =
+            "The value of an assignment to an added property is consumed; the setter shim returns void. "
+            + "Run 'uloop compile' to add it.";
+
+        private const string NameofReferenceReason =
+            "References to added properties inside nameof are skipped; the member does not exist in the compiled assembly. "
+            + "Run 'uloop compile' to add it.";
+
+        private const string ObjectInitializerReason =
+            "Object initializers that assign added properties are skipped; the setter shim cannot rewrite the initializer. "
+            + "Run 'uloop compile' to add it.";
+
+        private const string RefOutInReason =
+            "Added properties cannot be passed by ref, out, or in. Run 'uloop compile' to add them.";
+
+        /// <summary>
+        /// An expression-bodied property added to a compiled host emits an added getter
+        /// and rewrites an edited caller to that getter shim.
+        /// </summary>
+        [Test]
+        public async Task Emit_AddedExpressionBodiedGetter_RegistersAddedMethodEntry()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedExpressionBodiedGetter.cs",
+                "public int Doubled => PublicSeed * 2;",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return Doubled + value;\n        }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            TransformWorkerEntryDto getter = FindEntry(result, "get_Doubled");
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(getter, Is.Not.Null, FormatSkipped(result.Output.skipped));
+            Assert.That(getter.patchKind, Is.EqualTo(HotReloadConstants.PatchKindAddedMethod));
+            Assert.That(FindSkipReason(result, "get_Doubled"), Is.Null);
+            Assert.That(result.Output.shimSource, Does.Contain(getter.shimMethodName));
+            Assert.That(caller, Is.Not.Null, FormatSkipped(result.Output.skipped));
+            Assert.That(
+                SliceShimMethod(result.Output.shimSource, caller.shimMethodName),
+                Does.Contain(getter.shimMethodName));
+            Assert.That(caller.calledAddedMethodKeys, Does.Contain(BuildHostMethodKey("get_Doubled")));
+        }
+
+        /// <summary>
+        /// A property with bodied accessors emits both added accessor entries and rewrites
+        /// simple assignment to the setter shim.
+        /// </summary>
+        [Test]
+        public async Task Emit_AddedBodiedSetter_RegistersSetterEntryAndRewritesAssignment()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedBodiedSetter.cs",
+                "public int Stored\n        {\n            get { return _privateSeed; }\n"
+                + "            set { _privateSeed = value; }\n        }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            Stored = value;\n            return Stored;\n        }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            TransformWorkerEntryDto getter = FindEntry(result, "get_Stored");
+            TransformWorkerEntryDto setter = FindEntry(result, "set_Stored");
+            TransformWorkerEntryDto caller = FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller));
+            Assert.That(getter, Is.Not.Null, FormatSkipped(result.Output.skipped));
+            Assert.That(setter, Is.Not.Null, FormatSkipped(result.Output.skipped));
+            Assert.That(caller, Is.Not.Null, FormatSkipped(result.Output.skipped));
+            string callerShim = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
+            Assert.That(callerShim, Does.Contain(getter.shimMethodName));
+            Assert.That(callerShim, Does.Contain(setter.shimMethodName));
+        }
+
+        /// <summary>
+        /// A static bodied property emits a getter shim without an instance parameter.
+        /// </summary>
+        [Test]
+        public async Task Emit_AddedStaticBodiedGetter_UsesNoInstanceParameter()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedStaticBodiedGetter.cs",
+                "public static int StaticDoubled => 4;",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return StaticDoubled + value;\n        }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            TransformWorkerEntryDto getter = FindEntry(result, "get_StaticDoubled");
+            Assert.That(getter, Is.Not.Null, FormatSkipped(result.Output.skipped));
+            Assert.That(
+                result.Output.shimSource,
+                Does.Contain("public static int " + getter.shimMethodName + "()"));
+        }
+
+        /// <summary>
+        /// A virtual added property is rejected with the property-specific vtable reason.
+        /// </summary>
+        [Test]
+        public async Task Skip_AddedVirtualProperty_SkipsWithVirtualReason()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedVirtualProperty.cs",
+                "public virtual int AddedVirtual => 1;");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, "get_AddedVirtual"), Is.Null);
+            Assert.That(FindSkipReason(result, "get_AddedVirtual"), Is.EqualTo(VirtualOrAbstractReason));
+        }
+
+        /// <summary>
+        /// An added init accessor is rejected with the property-specific initialization reason.
+        /// </summary>
+        [Test]
+        public async Task Skip_AddedInitAccessor_SkipsWithInitReason()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedInitAccessor.cs",
+                "public int AddedInit { get => 1; init { } }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, "get_AddedInit"), Is.Null);
+            Assert.That(FindSkipReason(result, "get_AddedInit"), Is.EqualTo(InitAccessorReason));
+        }
+
+        /// <summary>
+        /// Compound assignment to an added property skips the edited caller before shim compilation.
+        /// </summary>
+        [Test]
+        public async Task Skip_AddedPropertyCompoundAssignment_SkipsBodyWithPreciseReason()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedPropertyCompoundAssignment.cs",
+                "public int Stored { get { return _privateSeed; } set { _privateSeed = value; } }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            Stored += value;\n            return value;\n        }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                FindSkipReason(result, nameof(HotReloadAddedMemberHost.ExistingCaller)),
+                Is.EqualTo(CompoundAssignmentReason));
+            Assert.That(FindEntry(result, "get_Stored"), Is.Not.Null);
+        }
+
+        /// <summary>
+        /// A consumed simple assignment to an added property skips the caller because a setter returns void.
+        /// </summary>
+        [Test]
+        public async Task Skip_AddedPropertyConsumedWrite_SkipsBody()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedPropertyConsumedWrite.cs",
+                "public int Stored { get { return _privateSeed; } set { _privateSeed = value; } }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            int stored = (Stored = value);\n            return stored;\n        }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                FindSkipReason(result, nameof(HotReloadAddedMemberHost.ExistingCaller)),
+                Is.EqualTo(ConsumedWriteReason));
+            Assert.That(FindEntry(result, "get_Stored"), Is.Not.Null);
+        }
+
+        /// <summary>
+        /// Incrementing an added property skips the caller before shim compilation.
+        /// </summary>
+        [Test]
+        public async Task Skip_AddedPropertyIncrement_SkipsBody()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedPropertyIncrement.cs",
+                "public int Stored { get { return _privateSeed; } set { _privateSeed = value; } }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            Stored++;\n            return value;\n        }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(
+                FindSkipReason(result, nameof(HotReloadAddedMemberHost.ExistingCaller)),
+                Is.EqualTo(CompoundAssignmentReason));
+            Assert.That(FindEntry(result, "get_Stored"), Is.Not.Null);
+        }
+
+        /// <summary>
+        /// Nameof of an added property skips the caller instead of leaving an unresolvable member reference.
+        /// </summary>
+        [Test]
+        public async Task Skip_AddedPropertyNameof_SkipsBody()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedPropertyNameof.cs",
+                "public int Stored { get { return _privateSeed; } set { _privateSeed = value; } }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return nameof(Stored).Length + value;\n        }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindSkipReason(result, nameof(HotReloadAddedMemberHost.ExistingCaller)), Is.EqualTo(NameofReferenceReason));
+        }
+
+        /// <summary>
+        /// An object initializer assigning an added property skips the caller before shim compilation.
+        /// </summary>
+        [Test]
+        public async Task Skip_AddedPropertyObjectInitializer_SkipsBody()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedPropertyObjectInitializer.cs",
+                "public int Stored { get { return _privateSeed; } set { _privateSeed = value; } }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return new HotReloadAddedMemberHost { Stored = value }.ReadPrivateSeed();\n        }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindSkipReason(result, nameof(HotReloadAddedMemberHost.ExistingCaller)), Is.EqualTo(ObjectInitializerReason));
+        }
+
+        /// <summary>
+        /// Passing an added property through an in argument skips the caller.
+        /// </summary>
+        [Test]
+        public async Task Skip_AddedPropertyInArgument_SkipsBody()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedPropertyInArgument.cs",
+                "public int Stored { get { return _privateSeed; } set { _privateSeed = value; } }\n\n"
+                + "        private static int Consume(in int input) { return input; }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return Consume(in Stored) + value;\n        }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindSkipReason(result, nameof(HotReloadAddedMemberHost.ExistingCaller)), Is.EqualTo(RefOutInReason));
+        }
+
+        /// <summary>
+        /// An expression-bodied added setter preserves its original source line in the emitted shim.
+        /// </summary>
+        [Test]
+        public async Task Emit_AddedExpressionBodiedSetter_CarriesLineDirective()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedExpressionBodiedSetterLine.cs",
+                "public int Stored { get => _privateSeed; set => _privateSeed = value; }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            TransformWorkerEntryDto setter = FindEntry(result, "set_Stored");
+            Assert.That(setter, Is.Not.Null, FormatSkipped(result.Output.skipped));
+            Assert.That(
+                SliceShimMethodDeclaration(result.Output.shimSource, setter.shimMethodName),
+                Does.Contain("#line "));
+        }
+
+        /// <summary>
+        /// Excluding an added accessor removes its shim and skips callers that depend on it.
+        /// </summary>
+        [Test]
+        public async Task Isolation_ExcludedAddedAccessorKey_DropsAccessorShimAndSkipsCaller()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "ExcludedAddedPropertyAccessor.cs",
+                "public int Doubled => PublicSeed * 2;",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return Doubled + value;\n        }",
+                new[] { BuildHostMethodKey("get_Doubled") });
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, "get_Doubled"), Is.Null);
+            Assert.That(
+                FindSkipReason(result, nameof(HotReloadAddedMemberHost.ExistingCaller)),
+                Does.Contain("Uses an added property that hot reload cannot emit."));
+        }
+
+        /// <summary>
+        /// An unavailable accessor body removes the complete property and skips dependent callers.
+        /// </summary>
+        [Test]
+        public async Task Isolation_UnavailableAddedPropertyAccessor_DropsBothAccessors()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "UnavailableAddedPropertyAccessor.cs",
+                "public int Blocked\n        {\n            get { return nameof(Stored).Length; }\n"
+                + "            set { _privateSeed = value; }\n        }\n\n"
+                + "        public int Stored { get { return _privateSeed; } set { _privateSeed = value; } }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return Blocked + value;\n        }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, "get_Blocked"), Is.Null);
+            Assert.That(FindEntry(result, "set_Blocked"), Is.Null);
+            Assert.That(FindSkipReason(result, "get_Blocked"), Is.EqualTo(NameofReferenceReason));
+            Assert.That(FindSkipReason(result, "set_Blocked"), Is.EqualTo(NameofReferenceReason));
+            Assert.That(
+                FindSkipReason(result, nameof(HotReloadAddedMemberHost.ExistingCaller)),
+                Does.Contain("Uses an added property that hot reload cannot emit."));
+        }
+
+        /// <summary>
+        /// An added bodied property with a baseline remains excluded from outside-body drift.
+        /// </summary>
+        [Test]
+        public async Task Drift_AddedBodiedProperty_ProducesNoOutsideBodyWarning()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedBodiedPropertyDrift.cs",
+                "public int DriftSafe => PublicSeed * 2;");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            string[] warnings = result.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>();
+            Assert.That(warnings, Has.None.Contain("Edits outside method bodies"));
+        }
+
+        private static async Task<TransformWorkerClientResult> RunEditedHostAsync(
+            string fileName,
+            string extraMembers,
+            string callerReplacement = null,
+            string[] excludedAddedMethodKeys = null)
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, extraMembers);
+            if (callerReplacement != null)
+            {
+                edited = edited.Replace(ExistingCallerOriginal, callerReplacement, StringComparison.Ordinal);
+                Assert.That(edited, Is.Not.EqualTo(onDisk));
+            }
+
+            return await RunWorkerOnSourceAsync(
+                HotReloadTestSourceWriter.WriteEditedSource(fileName, edited),
+                HostProjectRelativePath,
+                onDisk,
+                excludedAddedMethodKeys);
+        }
+
+        private static TransformWorkerEntryDto FindEntry(TransformWorkerClientResult result, string methodName)
+        {
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                if (entry.methodName == methodName)
+                {
+                    return entry;
+                }
+            }
+
+            return null;
+        }
+
+        private static string FindSkipReason(TransformWorkerClientResult result, string methodNameFragment)
+        {
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                if (skipped.method != null
+                    && skipped.method.IndexOf(methodNameFragment, StringComparison.Ordinal) >= 0)
+                {
+                    return skipped.reason;
+                }
+            }
+
+            return null;
+        }
+
+        private static string FormatSkipped(TransformWorkerSkippedDto[] skipped)
+        {
+            if (skipped == null || skipped.Length == 0)
+            {
+                return "(none)";
+            }
+
+            List<string> rows = new List<string>();
+            foreach (TransformWorkerSkippedDto entry in skipped)
+            {
+                rows.Add(entry.method + " :: " + entry.reason);
+            }
+
+            return string.Join("\n", rows);
+        }
+
+        private static string SliceShimMethod(string shimSource, string shimMethodName)
+        {
+            int nameIndex = shimSource.IndexOf(shimMethodName, StringComparison.Ordinal);
+            Assert.That(nameIndex, Is.GreaterThanOrEqualTo(0), "Shim method missing: " + shimMethodName);
+            int declarationStart = shimSource.LastIndexOf("public static", nameIndex, StringComparison.Ordinal);
+            int openBrace = shimSource.IndexOf('{', nameIndex);
+            Assert.That(openBrace, Is.GreaterThan(0));
+            int depth = 0;
+            for (int index = openBrace; index < shimSource.Length; index++)
+            {
+                if (shimSource[index] == '{')
+                {
+                    depth++;
+                }
+                else if (shimSource[index] == '}')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        return shimSource.Substring(declarationStart, index - declarationStart + 1);
+                    }
+                }
+            }
+
+            Assert.Fail("Unbalanced shim method: " + shimMethodName);
+            return string.Empty;
+        }
+
+        private static string SliceShimMethodDeclaration(string shimSource, string shimMethodName)
+        {
+            int nameIndex = shimSource.IndexOf(shimMethodName, StringComparison.Ordinal);
+            Assert.That(nameIndex, Is.GreaterThanOrEqualTo(0), "Shim method missing: " + shimMethodName);
+            int declarationStart = shimSource.LastIndexOf("#line", nameIndex, StringComparison.Ordinal);
+            int declarationEnd = shimSource.IndexOf(';', nameIndex);
+            Assert.That(declarationEnd, Is.GreaterThan(nameIndex));
+            return declarationStart >= 0
+                ? shimSource.Substring(declarationStart, declarationEnd - declarationStart + 1)
+                : shimSource.Substring(nameIndex, declarationEnd - nameIndex + 1);
+        }
+
+        private static string WithHostMembers(string onDisk, string extraMembers)
+        {
+            Assert.That(onDisk, Does.Contain(HostCloseMarker));
+            return onDisk.Replace(
+                HostCloseMarker,
+                "        public int ReadPrivateSeed()\n        {\n            return _privateSeed;\n        }\n\n        "
+                + extraMembers
+                + "\n    }",
+                StringComparison.Ordinal);
+        }
+
+        private static string ResolveHostPath()
+        {
+            string path = Path.Combine(
+                Application.dataPath,
+                "Tests",
+                "Editor",
+                "HotReload",
+                "HotReloadAddedMemberHost.cs");
+            Assert.That(File.Exists(path), Is.True, "Added-member host source missing: " + path);
+            return Path.GetFullPath(path);
+        }
+
+        private static string BuildHostMethodKey(string methodName)
+        {
+            return typeof(HotReloadAddedMemberHost).FullName + "::" + methodName + "()";
+        }
+
+        private static async Task<TransformWorkerClientResult> RunWorkerOnSourceAsync(
+            string sourcePath,
+            string projectRelativePath,
+            string snapshotSource,
+            string[] excludedAddedMethodKeys)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string targetDllPath = Path.Combine(
+                projectRoot,
+                "Library",
+                "ScriptAssemblies",
+                TestAssemblyName + ".dll");
+            Assert.That(File.Exists(targetDllPath), Is.True, "Test assembly dll missing: " + targetDllPath);
+
+            UnityEditor.Compilation.Assembly compilationAssembly = FindCompilationAssembly();
+            Assert.That(compilationAssembly, Is.Not.Null, "CompilationPipeline assembly not found.");
+
+            TransformWorkerInputDto input = new TransformWorkerInputDto
+            {
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = sourcePath,
+                        projectRelativePath = projectRelativePath,
+                        snapshotSource = snapshotSource
+                    }
+                },
+                defines = compilationAssembly.defines ?? Array.Empty<string>(),
+                referencePaths = BuildAbsoluteReferencePaths(compilationAssembly.allReferences, targetDllPath),
+                targetTypesAssemblyPath = targetDllPath,
+                assemblySourcePaths = BuildAbsoluteAssemblySourcePaths(compilationAssembly.sourceFiles),
+                excludedMethodKeys = Array.Empty<string>(),
+                excludedAddedMethodKeys = excludedAddedMethodKeys ?? Array.Empty<string>()
+            };
+
+            return await TransformWorkerClient.RunAsync(input, CancellationToken.None);
+        }
+
+        private static UnityEditor.Compilation.Assembly FindCompilationAssembly()
+        {
+            foreach (UnityEditor.Compilation.Assembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name == TestAssemblyName)
+                {
+                    return assembly;
+                }
+            }
+
+            return null;
+        }
+
+        private static string[] BuildAbsoluteReferencePaths(string[] allReferences, string targetDllPath)
+        {
+            List<string> paths = new List<string>();
+            if (allReferences != null)
+            {
+                foreach (string reference in allReferences)
+                {
+                    if (!string.IsNullOrEmpty(reference) && File.Exists(reference))
+                    {
+                        paths.Add(Path.GetFullPath(reference));
+                    }
+                }
+            }
+
+            string fullTargetPath = Path.GetFullPath(targetDllPath);
+            if (!ContainsOrdinalIgnoreCase(paths, fullTargetPath))
+            {
+                paths.Add(fullTargetPath);
+            }
+
+            return paths.ToArray();
+        }
+
+        private static bool ContainsOrdinalIgnoreCase(List<string> paths, string candidate)
+        {
+            foreach (string path in paths)
+            {
+                if (string.Equals(path, candidate, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string[] BuildAbsoluteAssemblySourcePaths(string[] sourceFiles)
+        {
+            if (sourceFiles == null || sourceFiles.Length == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string[] paths = new string[sourceFiles.Length];
+            for (int index = 0; index < sourceFiles.Length; index++)
+            {
+                string normalizedRelativePath = sourceFiles[index].Replace('\\', '/');
+                string absolutePath = Path.Combine(
+                    projectRoot,
+                    normalizedRelativePath.Replace('/', Path.DirectorySeparatorChar));
+                paths[index] = Path.GetFullPath(absolutePath);
+            }
+
+            return paths;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedPropertyTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedPropertyTests.cs
@@ -337,7 +337,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             TransformWorkerEntryDto setter = FindEntry(result, "set_Stored");
             Assert.That(setter, Is.Not.Null, FormatSkipped(result.Output.skipped));
-            AssertLineDirectiveFollowsMethodName(result.Output.shimSource, setter.shimMethodName);
+            string setterShim = SliceSetterShimBeforeTrailingLineDefault(
+                result.Output.shimSource,
+                setter.shimMethodName);
+            Assert.That(setterShim, Does.Match("#line [0-9]+ \""));
         }
 
         /// <summary>
@@ -515,12 +518,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return -1;
         }
 
-        private static void AssertLineDirectiveFollowsMethodName(string shimSource, string shimMethodName)
+        private static string SliceSetterShimBeforeTrailingLineDefault(string shimSource, string shimMethodName)
         {
-            int methodNameIndex = shimSource.IndexOf(shimMethodName, StringComparison.Ordinal);
-            Assert.That(methodNameIndex, Is.GreaterThanOrEqualTo(0), "Shim method missing: " + shimMethodName);
-            int directiveIndex = shimSource.IndexOf("#line ", methodNameIndex, StringComparison.Ordinal);
-            Assert.That(directiveIndex, Is.GreaterThan(methodNameIndex));
+            string declaration = "public static void " + shimMethodName + "(";
+            int declarationStart = shimSource.IndexOf(declaration, StringComparison.Ordinal);
+            Assert.That(declarationStart, Is.GreaterThanOrEqualTo(0), "Setter shim missing: " + shimMethodName);
+            int defaultDirective = shimSource.IndexOf("#line default", declarationStart, StringComparison.Ordinal);
+            Assert.That(defaultDirective, Is.GreaterThan(declarationStart));
+            return shimSource.Substring(declarationStart, defaultDirective - declarationStart);
         }
 
         private static string WithHostMembers(string onDisk, string extraMembers)

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedPropertyTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedPropertyTests.cs
@@ -56,6 +56,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string RefOutInReason =
             "Added properties cannot be passed by ref, out, or in. Run 'uloop compile' to add them.";
 
+        private const string SetOnlyReason =
+            "Added properties with only a setter are skipped; the shim requires a getter identity. "
+            + "Run 'uloop compile' to add them.";
+
         /// <summary>
         /// An expression-bodied property added to a compiled host emits an added getter
         /// and rewrites an edited caller to that getter shim.
@@ -107,6 +111,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string callerShim = SliceShimMethod(result.Output.shimSource, caller.shimMethodName);
             Assert.That(callerShim, Does.Contain(getter.shimMethodName));
             Assert.That(callerShim, Does.Contain(setter.shimMethodName));
+            Assert.That(
+                SliceShimMethod(result.Output.shimSource, getter.shimMethodName),
+                Does.Not.Contain("__uloopInstance._privateSeed"));
+            Assert.That(
+                SliceShimMethod(result.Output.shimSource, setter.shimMethodName),
+                Does.Not.Contain("__uloopInstance._privateSeed"));
         }
 
         /// <summary>
@@ -266,6 +276,55 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// A set-only property is skipped without attempting to construct a missing getter binding.
+        /// </summary>
+        [Test]
+        public async Task Skip_AddedSetOnlyProperty_SkipsWithSetOnlyReason()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedSetOnlyProperty.cs",
+                "public int Sink { set => _privateSeed = value; }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, "set_Sink"), Is.Null);
+            Assert.That(FindSkipReason(result, "set_Sink"), Is.EqualTo(SetOnlyReason));
+        }
+
+        /// <summary>
+        /// A same-named local remains a local and does not trigger added-property shape guards.
+        /// </summary>
+        [Test]
+        public async Task Keep_SameNamedLocal_EmitsCaller()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "SameNamedLocal.cs",
+                "public int Stored { get { return _privateSeed; } set { _privateSeed = value; } }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            int Stored = value;\n            Stored++;\n            return Stored;\n        }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller)), Is.Not.Null);
+            Assert.That(FindSkipReason(result, nameof(HotReloadAddedMemberHost.ExistingCaller)), Is.Null);
+        }
+
+        /// <summary>
+        /// A base receiver in an added accessor is skipped before a static shim is emitted.
+        /// </summary>
+        [Test]
+        public async Task Skip_AddedPropertyBaseReceiver_SkipsAccessor()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedPropertyBaseReceiver.cs",
+                "public int BaseValue => base.GetHashCode();");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, "get_BaseValue"), Is.Null);
+            Assert.That(
+                FindSkipReason(result, "get_BaseValue"),
+                Does.Contain("base. members are skipped"));
+        }
+
+        /// <summary>
         /// An expression-bodied added setter preserves its original source line in the emitted shim.
         /// </summary>
         [Test]
@@ -278,9 +337,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             TransformWorkerEntryDto setter = FindEntry(result, "set_Stored");
             Assert.That(setter, Is.Not.Null, FormatSkipped(result.Output.skipped));
-            Assert.That(
-                SliceShimMethodDeclaration(result.Output.shimSource, setter.shimMethodName),
-                Does.Contain("#line "));
+            AssertLineDirectiveFollowsMethodName(result.Output.shimSource, setter.shimMethodName);
         }
 
         /// <summary>
@@ -298,6 +355,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(FindEntry(result, "get_Doubled"), Is.Null);
+            Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller)), Is.Null);
             Assert.That(
                 FindSkipReason(result, nameof(HotReloadAddedMemberHost.ExistingCaller)),
                 Does.Contain("Uses an added property that hot reload cannot emit."));
@@ -408,10 +466,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private static string SliceShimMethod(string shimSource, string shimMethodName)
         {
-            int nameIndex = shimSource.IndexOf(shimMethodName, StringComparison.Ordinal);
-            Assert.That(nameIndex, Is.GreaterThanOrEqualTo(0), "Shim method missing: " + shimMethodName);
-            int declarationStart = shimSource.LastIndexOf("public static", nameIndex, StringComparison.Ordinal);
-            int openBrace = shimSource.IndexOf('{', nameIndex);
+            int declarationStart = FindShimMethodDeclarationStart(shimSource, shimMethodName);
+            int openBrace = shimSource.IndexOf('{', declarationStart);
             Assert.That(openBrace, Is.GreaterThan(0));
             int depth = 0;
             for (int index = openBrace; index < shimSource.Length; index++)
@@ -434,16 +490,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return string.Empty;
         }
 
-        private static string SliceShimMethodDeclaration(string shimSource, string shimMethodName)
+        private static int FindShimMethodDeclarationStart(string shimSource, string shimMethodName)
         {
-            int nameIndex = shimSource.IndexOf(shimMethodName, StringComparison.Ordinal);
-            Assert.That(nameIndex, Is.GreaterThanOrEqualTo(0), "Shim method missing: " + shimMethodName);
-            int declarationStart = shimSource.LastIndexOf("#line", nameIndex, StringComparison.Ordinal);
-            int declarationEnd = shimSource.IndexOf(';', nameIndex);
-            Assert.That(declarationEnd, Is.GreaterThan(nameIndex));
-            return declarationStart >= 0
-                ? shimSource.Substring(declarationStart, declarationEnd - declarationStart + 1)
-                : shimSource.Substring(nameIndex, declarationEnd - nameIndex + 1);
+            int searchStart = 0;
+            while (searchStart < shimSource.Length)
+            {
+                int declarationStart = shimSource.IndexOf("public static", searchStart, StringComparison.Ordinal);
+                if (declarationStart < 0)
+                {
+                    break;
+                }
+
+                int openBrace = shimSource.IndexOf('{', declarationStart);
+                int nameIndex = shimSource.IndexOf(shimMethodName, declarationStart, StringComparison.Ordinal);
+                if (nameIndex >= declarationStart && nameIndex < openBrace)
+                {
+                    return declarationStart;
+                }
+
+                searchStart = declarationStart + 1;
+            }
+
+            Assert.Fail("Shim method missing: " + shimMethodName);
+            return -1;
+        }
+
+        private static void AssertLineDirectiveFollowsMethodName(string shimSource, string shimMethodName)
+        {
+            int methodNameIndex = shimSource.IndexOf(shimMethodName, StringComparison.Ordinal);
+            Assert.That(methodNameIndex, Is.GreaterThanOrEqualTo(0), "Shim method missing: " + shimMethodName);
+            int directiveIndex = shimSource.IndexOf("#line ", methodNameIndex, StringComparison.Ordinal);
+            Assert.That(directiveIndex, Is.GreaterThan(methodNameIndex));
         }
 
         private static string WithHostMembers(string onDisk, string extraMembers)

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedPropertyTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedPropertyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 089992048343a47bfb2350fe61ba6039
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedCallSiteGuard.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedCallSiteGuard.cs
@@ -21,12 +21,23 @@ internal static class AddedCallSiteGuard
         List<TypeEmitState> typeEmitStates,
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog,
+        AddedPropertyCatalog addedPropertyCatalog,
         List<WorkerSkipped> skipped)
     {
         bool progressed;
         do
         {
             progressed = false;
+            if (AddedPropertyAccessorGuard.SkipUnavailableAccessors(
+                typeEmitStates,
+                addedPropertyCatalog,
+                addedMethodCatalog,
+                addedFieldCatalog,
+                skipped))
+            {
+                progressed = true;
+            }
+
             foreach (TypeEmitState typeState in typeEmitStates)
             {
                 // Why per state (not one model for the run): the states of a group run come from
@@ -43,7 +54,9 @@ internal static class AddedCallSiteGuard
                         bodyNode,
                         semanticModel,
                         addedMethodCatalog,
-                        addedFieldCatalog);
+                        addedFieldCatalog,
+                        addedPropertyCatalog,
+                        typeState.TypeSymbol);
                     if (skipReason != null)
                     {
                         skipped.Add(new WorkerSkipped
@@ -77,7 +90,9 @@ internal static class AddedCallSiteGuard
         SyntaxNode bodyNode,
         SemanticModel semanticModel,
         AddedMethodCatalog addedMethodCatalog,
-        AddedFieldCatalog addedFieldCatalog)
+        AddedFieldCatalog addedFieldCatalog,
+        AddedPropertyCatalog addedPropertyCatalog = null,
+        INamedTypeSymbol enclosingType = null)
     {
         if (bodyNode == null)
         {
@@ -117,6 +132,16 @@ internal static class AddedCallSiteGuard
         if (BodyReferencesAddedMethodGroup(bodyNode, semanticModel, addedMethodCatalog))
         {
             return (AddedMethodSkipReasons.MethodGroupReference, null);
+        }
+
+        string propertyReason = AddedPropertyBodyScan.EvaluateAddedPropertySkipReason(
+            bodyNode,
+            semanticModel,
+            addedPropertyCatalog,
+            enclosingType);
+        if (propertyReason != null)
+        {
+            return (propertyReason, null);
         }
 
         return (AddedFieldClassifier.EvaluateAddedFieldSkipReason(bodyNode, semanticModel, addedFieldCatalog), null);
@@ -257,6 +282,7 @@ internal static class AddedCallSiteGuard
         SyntaxNode bodyNode,
         SemanticModel semanticModel,
         AddedMethodCatalog addedMethodCatalog,
+        AddedPropertyCatalog addedPropertyCatalog,
         string selfMethodKey)
     {
         if (bodyNode == null)
@@ -286,6 +312,13 @@ internal static class AddedCallSiteGuard
             keys.Add(binding.MethodKey);
         }
 
+        CollectReferencedAddedPropertyAccessorKeys(
+            bodyNode,
+            semanticModel,
+            addedPropertyCatalog,
+            selfMethodKey,
+            keys);
+
         if (keys.Count == 0)
         {
             return Array.Empty<string>();
@@ -294,5 +327,42 @@ internal static class AddedCallSiteGuard
         string[] result = new string[keys.Count];
         keys.CopyTo(result);
         return result;
+    }
+
+    private static void CollectReferencedAddedPropertyAccessorKeys(
+        SyntaxNode bodyNode,
+        SemanticModel semanticModel,
+        AddedPropertyCatalog addedPropertyCatalog,
+        string selfMethodKey,
+        HashSet<string> keys)
+    {
+        if (addedPropertyCatalog == null)
+        {
+            return;
+        }
+
+        foreach (ExpressionSyntax expression in bodyNode.DescendantNodesAndSelf().OfType<ExpressionSyntax>())
+        {
+            IPropertySymbol propertySymbol = semanticModel.GetSymbolInfo(expression).Symbol as IPropertySymbol;
+            AddedPropertyBinding binding = addedPropertyCatalog.FindBySymbolOrNull(propertySymbol);
+            if (binding == null || binding.UnavailableReason != null)
+            {
+                continue;
+            }
+
+            AddedMethodBinding accessor = IsPropertyWrite(expression)
+                ? binding.Setter
+                : binding.Getter;
+            if (accessor != null && accessor.MethodKey != selfMethodKey)
+            {
+                keys.Add(accessor.MethodKey);
+            }
+        }
+    }
+
+    private static bool IsPropertyWrite(ExpressionSyntax expression)
+    {
+        return expression.Parent is AssignmentExpressionSyntax assignment
+            && assignment.Left == expression;
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyAccessorGuard.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyAccessorGuard.cs
@@ -43,7 +43,7 @@ internal static class AddedPropertyAccessorGuard
 
             string reason = FindAccessorSkipReason(
                 binding,
-                typeState.SourceUnit.SemanticModel,
+                typeState,
                 addedMethodCatalog,
                 addedFieldCatalog,
                 addedPropertyCatalog);
@@ -69,7 +69,8 @@ internal static class AddedPropertyAccessorGuard
     {
         foreach (TypeEmitState typeState in typeEmitStates)
         {
-            if (typeState.SourceUnit.SyntaxTree == binding.Declaration.SyntaxTree)
+            if (typeState.SourceUnit.SyntaxTree == binding.Declaration.SyntaxTree
+                && SymbolEqualityComparer.Default.Equals(typeState.TypeSymbol, binding.HostType))
             {
                 return typeState;
             }
@@ -80,40 +81,109 @@ internal static class AddedPropertyAccessorGuard
 
     private static string FindAccessorSkipReason(
         AddedPropertyBinding binding,
-        SemanticModel semanticModel,
+        TypeEmitState typeState,
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog,
         AddedPropertyCatalog addedPropertyCatalog)
     {
+        SemanticModel semanticModel = typeState.SourceUnit.SemanticModel;
+        if (binding.Declaration.ExpressionBody != null)
+        {
+            return EvaluateAccessor(
+                binding,
+                binding.Getter,
+                binding.Symbol.GetMethod,
+                binding.Declaration.ExpressionBody,
+                typeState,
+                addedMethodCatalog,
+                addedFieldCatalog,
+                addedPropertyCatalog);
+        }
+
         foreach (AccessorDeclarationSyntax accessor in GetAccessors(binding.Declaration))
         {
             SyntaxNode bodyNode = (SyntaxNode)accessor.Body ?? accessor.ExpressionBody;
-            (string reason, _) = AddedCallSiteGuard.EvaluateAddedCallSiteSkipReason(
+            bool isGetter = accessor.IsKind(SyntaxKind.GetAccessorDeclaration);
+            string reason = EvaluateAccessor(
+                binding,
+                isGetter ? binding.Getter : binding.Setter,
+                isGetter ? binding.Symbol.GetMethod : binding.Symbol.SetMethod,
                 bodyNode,
-                semanticModel,
+                typeState,
                 addedMethodCatalog,
                 addedFieldCatalog,
-                addedPropertyCatalog,
-                binding.HostType);
+                addedPropertyCatalog);
             if (reason != null)
             {
                 return reason;
             }
         }
 
-        if (binding.Declaration.ExpressionBody == null)
+        return null;
+    }
+
+    private static string EvaluateAccessor(
+        AddedPropertyBinding binding,
+        AddedMethodBinding accessorBinding,
+        IMethodSymbol accessorSymbol,
+        SyntaxNode bodyNode,
+        TypeEmitState typeState,
+        AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog,
+        AddedPropertyCatalog addedPropertyCatalog)
+    {
+        if (accessorBinding == null || accessorSymbol == null || bodyNode == null)
         {
             return null;
         }
 
-        (string expressionReason, _) = AddedCallSiteGuard.EvaluateAddedCallSiteSkipReason(
-            binding.Declaration.ExpressionBody,
-            semanticModel,
+        MethodTransformDecision decision = MethodTransformDecider.DecideMethodTransform(
+            typeState.TypeDeclaration,
+            typeState.TypeSymbol,
+            methodDeclaration: null,
+            accessorSymbol,
+            bodyNode,
+            typeState.SourceUnit.SemanticModel,
+            typeState.CompiledType);
+        if (decision.SkipReason != null)
+        {
+            return decision.SkipReason;
+        }
+
+        decision = MethodTransformDecider.DecideAddedMethodAccessors(
+            accessorSymbol,
+            typeState.TypeSymbol,
+            bodyNode,
+            typeState.SourceUnit.SemanticModel,
+            decision);
+        if (decision.SkipReason != null)
+        {
+            return decision.SkipReason;
+        }
+
+        SetAccessorDecision(binding, accessorBinding, decision);
+        (string callSiteReason, _) = AddedCallSiteGuard.EvaluateAddedCallSiteSkipReason(
+            bodyNode,
+            typeState.SourceUnit.SemanticModel,
             addedMethodCatalog,
             addedFieldCatalog,
             addedPropertyCatalog,
             binding.HostType);
-        return expressionReason;
+        return callSiteReason;
+    }
+
+    private static void SetAccessorDecision(
+        AddedPropertyBinding binding,
+        AddedMethodBinding accessorBinding,
+        MethodTransformDecision decision)
+    {
+        if (accessorBinding == binding.Getter)
+        {
+            binding.GetterDecision = decision;
+            return;
+        }
+
+        binding.SetterDecision = decision;
     }
 
     private static IEnumerable<AccessorDeclarationSyntax> GetAccessors(PropertyDeclarationSyntax declaration)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyAccessorGuard.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyAccessorGuard.cs
@@ -86,7 +86,6 @@ internal static class AddedPropertyAccessorGuard
         AddedFieldCatalog addedFieldCatalog,
         AddedPropertyCatalog addedPropertyCatalog)
     {
-        SemanticModel semanticModel = typeState.SourceUnit.SemanticModel;
         if (binding.Declaration.ExpressionBody != null)
         {
             return EvaluateAccessor(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyAccessorGuard.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyAccessorGuard.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+/// <summary>
+/// Removes an added property's accessor pair when either accessor body cannot be emitted safely.
+/// </summary>
+internal static class AddedPropertyAccessorGuard
+{
+    internal static bool SkipUnavailableAccessors(
+        List<TypeEmitState> typeEmitStates,
+        AddedPropertyCatalog addedPropertyCatalog,
+        AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog,
+        List<WorkerSkipped> skipped)
+    {
+        bool skippedAny = false;
+        foreach (AddedPropertyBinding binding in addedPropertyCatalog.Bindings)
+        {
+            if (binding.UnavailableReason != null || binding.IsAuto)
+            {
+                continue;
+            }
+
+            TypeEmitState typeState = FindTypeState(typeEmitStates, binding);
+            if (typeState == null)
+            {
+                continue;
+            }
+
+            string reason = FindAccessorSkipReason(
+                binding,
+                typeState.SourceUnit.SemanticModel,
+                addedMethodCatalog,
+                addedFieldCatalog,
+                addedPropertyCatalog);
+            if (reason == null)
+            {
+                continue;
+            }
+
+            addedPropertyCatalog.MarkUnavailable(binding.PropertyKey, reason);
+            UnregisterAccessor(addedMethodCatalog, binding.Getter);
+            UnregisterAccessor(addedMethodCatalog, binding.Setter);
+            AppendSkippedAccessor(binding, binding.Symbol.GetMethod, skipped);
+            AppendSkippedAccessor(binding, binding.Symbol.SetMethod, skipped);
+            skippedAny = true;
+        }
+
+        return skippedAny;
+    }
+
+    private static TypeEmitState FindTypeState(
+        List<TypeEmitState> typeEmitStates,
+        AddedPropertyBinding binding)
+    {
+        foreach (TypeEmitState typeState in typeEmitStates)
+        {
+            if (typeState.SourceUnit.SyntaxTree == binding.Declaration.SyntaxTree)
+            {
+                return typeState;
+            }
+        }
+
+        return null;
+    }
+
+    private static string FindAccessorSkipReason(
+        AddedPropertyBinding binding,
+        SemanticModel semanticModel,
+        AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog,
+        AddedPropertyCatalog addedPropertyCatalog)
+    {
+        foreach (AccessorDeclarationSyntax accessor in GetAccessors(binding.Declaration))
+        {
+            SyntaxNode bodyNode = (SyntaxNode)accessor.Body ?? accessor.ExpressionBody;
+            (string reason, _) = AddedCallSiteGuard.EvaluateAddedCallSiteSkipReason(
+                bodyNode,
+                semanticModel,
+                addedMethodCatalog,
+                addedFieldCatalog,
+                addedPropertyCatalog,
+                binding.HostType);
+            if (reason != null)
+            {
+                return reason;
+            }
+        }
+
+        if (binding.Declaration.ExpressionBody == null)
+        {
+            return null;
+        }
+
+        (string expressionReason, _) = AddedCallSiteGuard.EvaluateAddedCallSiteSkipReason(
+            binding.Declaration.ExpressionBody,
+            semanticModel,
+            addedMethodCatalog,
+            addedFieldCatalog,
+            addedPropertyCatalog,
+            binding.HostType);
+        return expressionReason;
+    }
+
+    private static IEnumerable<AccessorDeclarationSyntax> GetAccessors(PropertyDeclarationSyntax declaration)
+    {
+        return declaration.AccessorList == null
+            ? Array.Empty<AccessorDeclarationSyntax>()
+            : declaration.AccessorList.Accessors;
+    }
+
+    private static void UnregisterAccessor(AddedMethodCatalog addedMethodCatalog, AddedMethodBinding accessor)
+    {
+        if (accessor != null)
+        {
+            addedMethodCatalog.Unregister(accessor.MethodKey);
+        }
+    }
+
+    private static void AppendSkippedAccessor(
+        AddedPropertyBinding binding,
+        IMethodSymbol accessorSymbol,
+        List<WorkerSkipped> skipped)
+    {
+        if (accessorSymbol == null)
+        {
+            return;
+        }
+
+        skipped.Add(new WorkerSkipped
+        {
+            SourceProjectRelativePath = binding.SourceProjectRelativePath,
+            Method = WorkerMethodKeys.FormatMethodLabel(accessorSymbol),
+            Reason = binding.UnavailableReason
+        });
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyBinding.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyBinding.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+/// <summary>
+/// One added property's accessor bindings and declaration state for shim emission.
+/// </summary>
+internal sealed class AddedPropertyBinding
+{
+    public string SourceProjectRelativePath { get; set; }
+
+    public string PropertyKey { get; set; }
+
+    public string SyntaxKey { get; set; }
+
+    public string Name { get; set; }
+
+    public INamedTypeSymbol HostType { get; set; }
+
+    public ITypeSymbol ValueType { get; set; }
+
+    public bool IsStatic { get; set; }
+
+    public bool IsAuto { get; set; }
+
+    public AddedMethodBinding Getter { get; set; }
+
+    public AddedMethodBinding Setter { get; set; }
+
+    public string StoreFieldKey { get; set; }
+
+    public ExpressionSyntax Initializer { get; set; }
+
+    public string UnavailableReason { get; set; }
+
+    public PropertyDeclarationSyntax Declaration { get; set; }
+
+    public IPropertySymbol Symbol { get; set; }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyBinding.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyBinding.cs
@@ -40,6 +40,10 @@ internal sealed class AddedPropertyBinding
 
     public AddedMethodBinding Setter { get; set; }
 
+    public MethodTransformDecision GetterDecision { get; set; }
+
+    public MethodTransformDecision SetterDecision { get; set; }
+
     public string StoreFieldKey { get; set; }
 
     public ExpressionSyntax Initializer { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyBodyScan.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyBodyScan.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+/// <summary>
+/// Detects added-property uses whose source shape cannot be rewritten without changing meaning.
+/// </summary>
+internal static class AddedPropertyBodyScan
+{
+    internal static string EvaluateAddedPropertySkipReason(
+        SyntaxNode bodyNode,
+        SemanticModel semanticModel,
+        AddedPropertyCatalog addedPropertyCatalog,
+        INamedTypeSymbol enclosingType)
+    {
+        if (bodyNode == null || addedPropertyCatalog == null)
+        {
+            return null;
+        }
+
+        string refArgumentReason = EvaluateRefArgumentSkipReason(
+            bodyNode,
+            semanticModel,
+            addedPropertyCatalog,
+            enclosingType);
+        if (refArgumentReason != null)
+        {
+            return refArgumentReason;
+        }
+
+        foreach (ExpressionSyntax expression in bodyNode.DescendantNodesAndSelf().OfType<ExpressionSyntax>())
+        {
+            string expressionReason = EvaluateExpressionSkipReason(
+                expression,
+                semanticModel,
+                addedPropertyCatalog,
+                enclosingType);
+            if (expressionReason != null)
+            {
+                return expressionReason;
+            }
+        }
+
+        return null;
+    }
+
+    private static string EvaluateRefArgumentSkipReason(
+        SyntaxNode bodyNode,
+        SemanticModel semanticModel,
+        AddedPropertyCatalog addedPropertyCatalog,
+        INamedTypeSymbol enclosingType)
+    {
+        foreach (ArgumentSyntax argument in bodyNode.DescendantNodesAndSelf().OfType<ArgumentSyntax>())
+        {
+            if (!HasRefKind(argument))
+            {
+                continue;
+            }
+
+            AddedPropertyBinding binding = FindBinding(
+                argument.Expression,
+                semanticModel,
+                addedPropertyCatalog,
+                enclosingType);
+            if (binding != null && !binding.IsAuto)
+            {
+                return AddedPropertySkipReasons.RefOutIn;
+            }
+        }
+
+        return null;
+    }
+
+    private static string EvaluateExpressionSkipReason(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        AddedPropertyCatalog addedPropertyCatalog,
+        INamedTypeSymbol enclosingType)
+    {
+        AddedPropertyBinding binding = FindBinding(
+            expression,
+            semanticModel,
+            addedPropertyCatalog,
+            enclosingType);
+        if (binding == null || binding.IsAuto)
+        {
+            return null;
+        }
+
+        if (binding.UnavailableReason != null)
+        {
+            return AddedPropertySkipReasons.UnavailableAddedProperty;
+        }
+
+        if (NameofRules.IsInsideNameofArgument(expression))
+        {
+            return AddedPropertySkipReasons.NameofReference;
+        }
+
+        if (expression is MemberBindingExpressionSyntax || IsConditionalAccess(expression))
+        {
+            return AddedPropertySkipReasons.ConditionalAccess;
+        }
+
+        return EvaluateWriteSkipReason(expression);
+    }
+
+    private static string EvaluateWriteSkipReason(ExpressionSyntax expression)
+    {
+        if (expression.Parent is AssignmentExpressionSyntax assignment && assignment.Left == expression)
+        {
+            if (assignment.Parent is InitializerExpressionSyntax)
+            {
+                return AddedPropertySkipReasons.ObjectInitializer;
+            }
+
+            if (!assignment.IsKind(SyntaxKind.SimpleAssignmentExpression))
+            {
+                return AddedPropertySkipReasons.CompoundAssignment;
+            }
+
+            if (assignment.Parent is not ExpressionStatementSyntax)
+            {
+                return AddedPropertySkipReasons.ConsumedWrite;
+            }
+        }
+
+        if (expression.Parent is PrefixUnaryExpressionSyntax prefix
+            && IsIncrementOrDecrement(prefix.Kind()))
+        {
+            return AddedPropertySkipReasons.CompoundAssignment;
+        }
+
+        if (expression.Parent is PostfixUnaryExpressionSyntax postfix
+            && IsIncrementOrDecrement(postfix.Kind()))
+        {
+            return AddedPropertySkipReasons.CompoundAssignment;
+        }
+
+        return null;
+    }
+
+    private static bool IsIncrementOrDecrement(SyntaxKind kind)
+    {
+        return kind == SyntaxKind.PreIncrementExpression
+            || kind == SyntaxKind.PreDecrementExpression
+            || kind == SyntaxKind.PostIncrementExpression
+            || kind == SyntaxKind.PostDecrementExpression;
+    }
+
+    private static bool HasRefKind(ArgumentSyntax argument)
+    {
+        SyntaxKind kind = argument.RefKindKeyword.Kind();
+        return kind == SyntaxKind.RefKeyword
+            || kind == SyntaxKind.OutKeyword
+            || kind == SyntaxKind.InKeyword
+            || argument.ToString().StartsWith("in ", StringComparison.Ordinal);
+    }
+
+    private static AddedPropertyBinding FindBinding(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        AddedPropertyCatalog addedPropertyCatalog,
+        INamedTypeSymbol enclosingType)
+    {
+        ISymbol symbol = semanticModel.GetSymbolInfo(expression).Symbol;
+        IPropertySymbol propertySymbol = symbol as IPropertySymbol;
+        if (propertySymbol == null && symbol is IMethodSymbol accessorSymbol)
+        {
+            propertySymbol = accessorSymbol.AssociatedSymbol as IPropertySymbol;
+        }
+
+        AddedPropertyBinding binding = addedPropertyCatalog.FindBySymbolOrNull(propertySymbol);
+        if (binding != null || propertySymbol != null || enclosingType == null)
+        {
+            return binding;
+        }
+
+        if (expression is not IdentifierNameSyntax identifier)
+        {
+            return null;
+        }
+
+        return addedPropertyCatalog.FindOrNull(AddedPropertyCatalog.FormatPropertyKey(
+            CecilTypeNames.ToMetadataName(enclosingType),
+            identifier.Identifier.ValueText));
+    }
+
+    private static bool IsConditionalAccess(ExpressionSyntax expression)
+    {
+        SyntaxNode current = expression;
+        while (current != null)
+        {
+            if (current is ConditionalAccessExpressionSyntax)
+            {
+                return true;
+            }
+
+            if (current.Parent is not ExpressionSyntax parent)
+            {
+                return false;
+            }
+
+            current = parent;
+        }
+
+        return false;
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyBodyScan.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyBodyScan.cs
@@ -166,8 +166,7 @@ internal static class AddedPropertyBodyScan
         SyntaxKind kind = argument.RefKindKeyword.Kind();
         return kind == SyntaxKind.RefKeyword
             || kind == SyntaxKind.OutKeyword
-            || kind == SyntaxKind.InKeyword
-            || argument.ToString().StartsWith("in ", StringComparison.Ordinal);
+            || kind == SyntaxKind.InKeyword;
     }
 
     private static AddedPropertyBinding FindBinding(
@@ -184,7 +183,7 @@ internal static class AddedPropertyBodyScan
         }
 
         AddedPropertyBinding binding = addedPropertyCatalog.FindBySymbolOrNull(propertySymbol);
-        if (binding != null || propertySymbol != null || enclosingType == null)
+        if (binding != null || symbol != null || enclosingType == null)
         {
             return binding;
         }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyCatalog.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyCatalog.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+/// <summary>
+/// Added-property bindings indexed by property and accessor identity for classification and rewrite.
+/// </summary>
+internal sealed class AddedPropertyCatalog
+{
+    private readonly Dictionary<string, AddedPropertyBinding> _byPropertyKey =
+        new Dictionary<string, AddedPropertyBinding>(StringComparer.Ordinal);
+    private readonly Dictionary<string, AddedPropertyBinding> _byAccessorKey =
+        new Dictionary<string, AddedPropertyBinding>(StringComparer.Ordinal);
+    private readonly HashSet<string> _classifiedAddedKeys = new HashSet<string>(StringComparer.Ordinal);
+
+    public IEnumerable<AddedPropertyBinding> Bindings => _byPropertyKey.Values;
+
+    public void MarkClassifiedAdded(string propertyKey)
+    {
+        if (propertyKey != null)
+        {
+            _classifiedAddedKeys.Add(propertyKey);
+        }
+    }
+
+    public bool IsClassifiedAdded(string propertyKey)
+    {
+        return propertyKey != null && _classifiedAddedKeys.Contains(propertyKey);
+    }
+
+    public void Register(AddedPropertyBinding binding)
+    {
+        Debug.Assert(binding != null, "binding must not be null.");
+        Debug.Assert(!string.IsNullOrEmpty(binding.PropertyKey), "binding.PropertyKey must not be null or empty.");
+        _byPropertyKey[binding.PropertyKey] = binding;
+        MarkClassifiedAdded(binding.PropertyKey);
+        RegisterAccessor(binding.Getter, binding);
+        RegisterAccessor(binding.Setter, binding);
+    }
+
+    public AddedPropertyBinding FindOrNull(string propertyKey)
+    {
+        if (propertyKey == null)
+        {
+            return null;
+        }
+
+        return _byPropertyKey.TryGetValue(propertyKey, out AddedPropertyBinding binding) ? binding : null;
+    }
+
+    public AddedPropertyBinding FindByAccessorKeyOrNull(string accessorKey)
+    {
+        if (accessorKey == null)
+        {
+            return null;
+        }
+
+        return _byAccessorKey.TryGetValue(accessorKey, out AddedPropertyBinding binding) ? binding : null;
+    }
+
+    public AddedPropertyBinding FindBySymbolOrNull(IPropertySymbol propertySymbol)
+    {
+        if (propertySymbol == null || propertySymbol.ContainingType == null)
+        {
+            return null;
+        }
+
+        return FindOrNull(FormatPropertyKey(
+            CecilTypeNames.ToMetadataName(propertySymbol.ContainingType),
+            propertySymbol.Name));
+    }
+
+    public void MarkUnavailable(string propertyKey, string reason)
+    {
+        AddedPropertyBinding binding = FindOrNull(propertyKey);
+        if (binding != null)
+        {
+            binding.UnavailableReason = reason;
+        }
+    }
+
+    public static string FormatPropertyKey(string typeMetadataName, string propertyName)
+    {
+        return typeMetadataName + TransformWorkerProgramMarker.AddedFieldKeySeparator + propertyName;
+    }
+
+    private void RegisterAccessor(AddedMethodBinding accessor, AddedPropertyBinding binding)
+    {
+        if (accessor != null && accessor.MethodKey != null)
+        {
+            _byAccessorKey[accessor.MethodKey] = binding;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
@@ -167,7 +167,9 @@ internal static class AddedPropertyClassifier
         bool isAuto = IsAutoProperty(declaration);
         string getterKey = BuildGetterKey(typeState.TypeSymbol, symbol);
         string setterKey = BuildSetterKey(typeState.TypeSymbol, symbol);
-        string reason = EvaluateDeclarationSkipReason(symbol, declaration, typeState.TypeSymbol);
+        string reason = symbol.GetMethod == null
+            ? AddedPropertySkipReasons.SetOnly
+            : EvaluateDeclarationSkipReason(symbol, declaration, typeState.TypeSymbol);
         if (isAuto && reason == null)
         {
             reason = AddedMethodSkipReasons.AddedProperty;
@@ -256,7 +258,11 @@ internal static class AddedPropertyClassifier
         AddedPropertyCandidate candidate,
         AddedMethodCatalog addedMethodCatalog)
     {
-        addedMethodCatalog.MarkClassifiedAdded(candidate.GetterKey);
+        if (candidate.GetterKey != null)
+        {
+            addedMethodCatalog.MarkClassifiedAdded(candidate.GetterKey);
+        }
+
         if (candidate.SetterKey != null)
         {
             addedMethodCatalog.MarkClassifiedAdded(candidate.SetterKey);
@@ -265,6 +271,11 @@ internal static class AddedPropertyClassifier
 
     private static string BuildGetterKey(INamedTypeSymbol hostType, IPropertySymbol symbol)
     {
+        if (symbol.GetMethod == null)
+        {
+            return null;
+        }
+
         return WorkerMethodKeys.BuildMethodKey(
             CecilTypeNames.ToMetadataName(hostType),
             symbol.GetMethod.Name,
@@ -364,21 +375,29 @@ internal static class AddedPropertyClassifier
 
     private static void AppendSkippedAccessors(AddedPropertyBinding binding, List<WorkerSkipped> skipped)
     {
+        AppendSkippedAccessor(binding, binding.Symbol.GetMethod, skipped);
+        if (binding.Symbol.SetMethod != null)
+        {
+            AppendSkippedAccessor(binding, binding.Symbol.SetMethod, skipped);
+        }
+    }
+
+    private static void AppendSkippedAccessor(
+        AddedPropertyBinding binding,
+        IMethodSymbol accessorSymbol,
+        List<WorkerSkipped> skipped)
+    {
+        if (accessorSymbol == null)
+        {
+            return;
+        }
+
         skipped.Add(new WorkerSkipped
         {
             SourceProjectRelativePath = binding.SourceProjectRelativePath,
-            Method = WorkerMethodKeys.FormatMethodLabel(binding.Symbol.GetMethod),
+            Method = WorkerMethodKeys.FormatMethodLabel(accessorSymbol),
             Reason = binding.UnavailableReason
         });
-        if (binding.Symbol.SetMethod != null)
-        {
-            skipped.Add(new WorkerSkipped
-            {
-                SourceProjectRelativePath = binding.SourceProjectRelativePath,
-                Method = WorkerMethodKeys.FormatMethodLabel(binding.Symbol.SetMethod),
-                Reason = binding.UnavailableReason
-            });
-        }
     }
 
     private sealed class AddedPropertyCandidate

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
@@ -1,0 +1,394 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+/// <summary>
+/// Classifies properties missing from a compiled type before accessor skips and body emission.
+/// </summary>
+internal static class AddedPropertyClassifier
+{
+    internal static (int ShimTypeCounter, int GlobalShimMethodCounter) ClassifyAddedProperties(
+        TypeEmitState typeState,
+        SemanticModel semanticModel,
+        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerInput input,
+        BaselineSnapshotState baseline,
+        CompilationUnitSyntax root,
+        List<UsingDirectiveSyntax> assemblyGlobalUsings,
+        List<ShimTypeBuilder> shimTypes,
+        AddedPropertyCatalog addedPropertyCatalog,
+        AddedMethodCatalog addedMethodCatalog,
+        List<WorkerSkipped> skipped,
+        int shimTypeCounter,
+        int globalShimMethodCounter)
+    {
+        INamedTypeSymbol compiledType = CompiledMemberMatcher.FindCompiledType(
+            typeState.TypeSymbol,
+            targetTypesAssemblySymbol);
+        if (compiledType == null)
+        {
+            return (shimTypeCounter, globalShimMethodCounter);
+        }
+
+        typeState.CompiledType = compiledType;
+        foreach (PropertyDeclarationSyntax declaration in typeState.TypeDeclaration.Members
+            .OfType<PropertyDeclarationSyntax>())
+        {
+            (shimTypeCounter, globalShimMethodCounter) = ClassifyProperty(
+                declaration,
+                typeState,
+                compiledType,
+                semanticModel,
+                input,
+                baseline,
+                root,
+                assemblyGlobalUsings,
+                shimTypes,
+                addedPropertyCatalog,
+                addedMethodCatalog,
+                skipped,
+                shimTypeCounter,
+                globalShimMethodCounter);
+        }
+
+        return (shimTypeCounter, globalShimMethodCounter);
+    }
+
+    private static (int ShimTypeCounter, int GlobalShimMethodCounter) ClassifyProperty(
+        PropertyDeclarationSyntax declaration,
+        TypeEmitState typeState,
+        INamedTypeSymbol compiledType,
+        SemanticModel semanticModel,
+        WorkerInput input,
+        BaselineSnapshotState baseline,
+        CompilationUnitSyntax root,
+        List<UsingDirectiveSyntax> assemblyGlobalUsings,
+        List<ShimTypeBuilder> shimTypes,
+        AddedPropertyCatalog addedPropertyCatalog,
+        AddedMethodCatalog addedMethodCatalog,
+        List<WorkerSkipped> skipped,
+        int shimTypeCounter,
+        int globalShimMethodCounter)
+    {
+        AddedPropertyCandidate candidate = CreateCandidateOrNull(
+            declaration,
+            typeState,
+            compiledType,
+            semanticModel,
+            baseline,
+            addedMethodCatalog);
+        if (candidate == null)
+        {
+            return (shimTypeCounter, globalShimMethodCounter);
+        }
+
+        MarkClassifiedAccessors(candidate, addedMethodCatalog);
+        if (candidate.Reason != null || IsExcluded(input, candidate.GetterKey, candidate.SetterKey))
+        {
+            candidate.Binding.UnavailableReason = candidate.Reason
+                ?? AddedPropertySkipReasons.UnavailableAddedProperty;
+            addedPropertyCatalog.Register(candidate.Binding);
+            AppendSkippedAccessors(candidate.Binding, skipped);
+            return (shimTypeCounter, globalShimMethodCounter);
+        }
+
+        (ShimTypeBuilder shimType, int nextShimTypeCounter) = OrdinaryMethodQueue.EnsureShimType(
+            typeState,
+            root,
+            assemblyGlobalUsings,
+            shimTypes,
+            shimTypeCounter);
+        candidate.Binding.Getter = CreateBinding(
+            candidate.GetterKey,
+            candidate.Binding.Symbol.GetMethod,
+            shimType,
+            globalShimMethodCounter);
+        globalShimMethodCounter++;
+        if (candidate.Binding.Symbol.SetMethod != null)
+        {
+            candidate.Binding.Setter = CreateBinding(
+                candidate.SetterKey,
+                candidate.Binding.Symbol.SetMethod,
+                shimType,
+                globalShimMethodCounter);
+            globalShimMethodCounter++;
+        }
+
+        addedMethodCatalog.Register(candidate.Binding.Getter);
+        if (candidate.Binding.Setter != null)
+        {
+            addedMethodCatalog.Register(candidate.Binding.Setter);
+        }
+
+        addedPropertyCatalog.Register(candidate.Binding);
+        return (nextShimTypeCounter, globalShimMethodCounter);
+    }
+
+    private static AddedPropertyCandidate CreateCandidateOrNull(
+        PropertyDeclarationSyntax declaration,
+        TypeEmitState typeState,
+        INamedTypeSymbol compiledType,
+        SemanticModel semanticModel,
+        BaselineSnapshotState baseline,
+        AddedMethodCatalog addedMethodCatalog)
+    {
+        IPropertySymbol symbol = semanticModel.GetDeclaredSymbol(declaration);
+        if (symbol == null || HasCompiledProperty(compiledType, symbol.Name))
+        {
+            return null;
+        }
+
+        string syntaxKey = WorkerSyntaxIndex.BuildSyntaxPropertyKey(
+            typeState.TypeMetadataNameFromSyntax,
+            declaration);
+        if (IsUnchangedBaselineProperty(baseline, syntaxKey))
+        {
+            return null;
+        }
+
+        if (baseline.HasBaseline)
+        {
+            addedMethodCatalog.AddAddedPropertySyntaxKey(syntaxKey);
+        }
+
+        bool isAuto = IsAutoProperty(declaration);
+        string getterKey = BuildGetterKey(typeState.TypeSymbol, symbol);
+        string setterKey = BuildSetterKey(typeState.TypeSymbol, symbol);
+        string reason = EvaluateDeclarationSkipReason(symbol, declaration, typeState.TypeSymbol);
+        if (isAuto && reason == null)
+        {
+            reason = AddedMethodSkipReasons.AddedProperty;
+        }
+
+        AddedPropertyBinding binding = new AddedPropertyBinding
+        {
+            SourceProjectRelativePath = typeState.SourceUnit.Input.ProjectRelativePath,
+            PropertyKey = AddedPropertyCatalog.FormatPropertyKey(
+                CecilTypeNames.ToMetadataName(typeState.TypeSymbol),
+                symbol.Name),
+            SyntaxKey = syntaxKey,
+            Name = symbol.Name,
+            HostType = typeState.TypeSymbol,
+            ValueType = symbol.Type,
+            IsStatic = symbol.IsStatic,
+            IsAuto = isAuto,
+            Declaration = declaration,
+            Symbol = symbol
+        };
+        return new AddedPropertyCandidate
+        {
+            Binding = binding,
+            GetterKey = getterKey,
+            SetterKey = setterKey,
+            Reason = reason
+        };
+    }
+
+    private static bool HasCompiledProperty(INamedTypeSymbol compiledType, string propertyName)
+    {
+        foreach (ISymbol member in compiledType.GetMembers(propertyName))
+        {
+            if (member is IPropertySymbol)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsUnchangedBaselineProperty(BaselineSnapshotState baseline, string syntaxKey)
+    {
+        if (!baseline.HasBaseline
+            || baseline.SnapshotPropertyMap == null
+            || baseline.PlainCurrentPropertyMap == null)
+        {
+            return false;
+        }
+
+        if (!baseline.SnapshotPropertyMap.TryGetValue(syntaxKey, out PropertyDeclarationSyntax snapshot)
+            || !baseline.PlainCurrentPropertyMap.TryGetValue(syntaxKey, out PropertyDeclarationSyntax current))
+        {
+            return false;
+        }
+
+        return SyntaxFactory.AreEquivalent(snapshot, current, topLevel: false);
+    }
+
+    private static bool IsAutoProperty(PropertyDeclarationSyntax declaration)
+    {
+        if (declaration.ExpressionBody != null || declaration.AccessorList == null)
+        {
+            return false;
+        }
+
+        foreach (AccessorDeclarationSyntax accessor in declaration.AccessorList.Accessors)
+        {
+            if (accessor.Body != null || accessor.ExpressionBody != null)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsExcluded(WorkerInput input, string getterKey, string setterKey)
+    {
+        return input.ExcludedAddedMethodKeys.Contains(getterKey)
+            || (setterKey != null && input.ExcludedAddedMethodKeys.Contains(setterKey));
+    }
+
+    private static void MarkClassifiedAccessors(
+        AddedPropertyCandidate candidate,
+        AddedMethodCatalog addedMethodCatalog)
+    {
+        addedMethodCatalog.MarkClassifiedAdded(candidate.GetterKey);
+        if (candidate.SetterKey != null)
+        {
+            addedMethodCatalog.MarkClassifiedAdded(candidate.SetterKey);
+        }
+    }
+
+    private static string BuildGetterKey(INamedTypeSymbol hostType, IPropertySymbol symbol)
+    {
+        return WorkerMethodKeys.BuildMethodKey(
+            CecilTypeNames.ToMetadataName(hostType),
+            symbol.GetMethod.Name,
+            Array.Empty<string>(),
+            symbol.GetMethod.Arity);
+    }
+
+    private static string BuildSetterKey(INamedTypeSymbol hostType, IPropertySymbol symbol)
+    {
+        if (symbol.SetMethod == null)
+        {
+            return null;
+        }
+
+        return WorkerMethodKeys.BuildMethodKey(
+            CecilTypeNames.ToMetadataName(hostType),
+            symbol.SetMethod.Name,
+            new[] { CecilTypeNames.ToCecilFullName(symbol.Type) },
+            symbol.SetMethod.Arity);
+    }
+
+    private static AddedMethodBinding CreateBinding(
+        string methodKey,
+        IMethodSymbol accessorSymbol,
+        ShimTypeBuilder shimType,
+        int shimMethodCounter)
+    {
+        return new AddedMethodBinding
+        {
+            MethodKey = methodKey,
+            ShimTypeName = shimType.ShimTypeName,
+            ShimMethodName = accessorSymbol.Name + "__shim" + shimMethodCounter,
+            NamespaceName = shimType.NamespaceName,
+            IsStatic = accessorSymbol.IsStatic,
+            ParameterCount = accessorSymbol.Parameters.Length
+        };
+    }
+
+    private static string EvaluateDeclarationSkipReason(
+        IPropertySymbol symbol,
+        PropertyDeclarationSyntax declaration,
+        INamedTypeSymbol hostType)
+    {
+        if (hostType.TypeKind == TypeKind.Struct)
+        {
+            return AddedPropertySkipReasons.StructHost;
+        }
+
+        if (hostType.TypeKind == TypeKind.Interface
+            || symbol.IsVirtual
+            || symbol.IsOverride
+            || symbol.IsAbstract)
+        {
+            return AddedPropertySkipReasons.VirtualOrAbstract;
+        }
+
+        if (declaration.ExplicitInterfaceSpecifier != null)
+        {
+            return AddedPropertySkipReasons.ExplicitInterface;
+        }
+
+        if (HasInitAccessor(declaration))
+        {
+            return AddedPropertySkipReasons.InitAccessor;
+        }
+
+        if (symbol.ReturnsByRef || symbol.ReturnsByRefReadonly)
+        {
+            return AddedPropertySkipReasons.RefOutIn;
+        }
+
+        if (!AccessibilityRules.IsExternallyVisibleType(symbol.Type))
+        {
+            return AddedPropertySkipReasons.ValueTypeNotExternallyVisible;
+        }
+
+        return null;
+    }
+
+    private static bool HasInitAccessor(PropertyDeclarationSyntax declaration)
+    {
+        if (declaration.AccessorList == null)
+        {
+            return false;
+        }
+
+        foreach (AccessorDeclarationSyntax accessor in declaration.AccessorList.Accessors)
+        {
+            if (accessor.IsKind(SyntaxKind.InitAccessorDeclaration))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void AppendSkippedAccessors(AddedPropertyBinding binding, List<WorkerSkipped> skipped)
+    {
+        skipped.Add(new WorkerSkipped
+        {
+            SourceProjectRelativePath = binding.SourceProjectRelativePath,
+            Method = WorkerMethodKeys.FormatMethodLabel(binding.Symbol.GetMethod),
+            Reason = binding.UnavailableReason
+        });
+        if (binding.Symbol.SetMethod != null)
+        {
+            skipped.Add(new WorkerSkipped
+            {
+                SourceProjectRelativePath = binding.SourceProjectRelativePath,
+                Method = WorkerMethodKeys.FormatMethodLabel(binding.Symbol.SetMethod),
+                Reason = binding.UnavailableReason
+            });
+        }
+    }
+
+    private sealed class AddedPropertyCandidate
+    {
+        public AddedPropertyBinding Binding { get; set; }
+
+        public string GetterKey { get; set; }
+
+        public string SetterKey { get; set; }
+
+        public string Reason { get; set; }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyEmitter.cs
@@ -30,6 +30,7 @@ internal static class AddedPropertyEmitter
         foreach (AddedPropertyBinding binding in addedPropertyCatalog.Bindings)
         {
             if (!SymbolEqualityComparer.Default.Equals(binding.HostType, typeState.TypeSymbol)
+                || binding.Declaration.SyntaxTree != typeState.SourceUnit.SyntaxTree
                 || binding.UnavailableReason != null
                 || binding.IsAuto)
             {
@@ -53,16 +54,23 @@ internal static class AddedPropertyEmitter
         AddedFieldCatalog addedFieldCatalog,
         List<WorkerEntry> entries)
     {
-        SyntaxNode body = GetAccessorBody(binding.Declaration, accessor.MethodKey == binding.Getter.MethodKey);
+        bool isGetter = accessor.MethodKey == binding.Getter.MethodKey;
+        SyntaxNode body = GetAccessorBody(binding.Declaration, isGetter);
         if (body == null)
         {
             return;
         }
 
+        MethodTransformDecision decision = isGetter
+            ? binding.GetterDecision
+            : binding.SetterDecision;
+        Debug.Assert(decision != null, "Each emitted added accessor must keep its transform decision.");
+
         MethodDeclarationSyntax shimMethod = BuildAccessorShim(
             binding,
             accessor,
             body,
+            decision,
             typeState,
             addedPropertyCatalog,
             addedMethodCatalog,
@@ -100,15 +108,21 @@ internal static class AddedPropertyEmitter
         AddedPropertyBinding binding,
         AddedMethodBinding accessor,
         SyntaxNode body,
+        MethodTransformDecision decision,
         TypeEmitState typeState,
         AddedPropertyCatalog addedPropertyCatalog,
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog)
     {
+        // The guard decides this before caller rewrites; emission must retain the same plan so
+        // private compiled members are not emitted as illegal direct shim access.
+        AccessorPlan accessorPlan = decision.UsesDelegation
+            ? typeState.CurrentShimType.AccessorPlan
+            : null;
         ShimBodyRewriter rewriter = new ShimBodyRewriter(
             typeState.SourceUnit.SemanticModel,
             typeState.TypeSymbol,
-            null,
+            accessorPlan,
             addedMethodCatalog,
             addedFieldCatalog,
             addedPropertyCatalog);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyEmitter.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+/// <summary>
+/// Emits bodied added-property accessors as added-method shims after ordinary methods are queued.
+/// </summary>
+internal static class AddedPropertyEmitter
+{
+    internal static void EmitAddedPropertyAccessors(
+        TypeEmitState typeState,
+        AddedPropertyCatalog addedPropertyCatalog,
+        AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog,
+        List<WorkerEntry> entries)
+    {
+        foreach (AddedPropertyBinding binding in addedPropertyCatalog.Bindings)
+        {
+            if (!SymbolEqualityComparer.Default.Equals(binding.HostType, typeState.TypeSymbol)
+                || binding.UnavailableReason != null
+                || binding.IsAuto)
+            {
+                continue;
+            }
+
+            EmitAccessor(typeState, binding, binding.Getter, addedPropertyCatalog, addedMethodCatalog, addedFieldCatalog, entries);
+            if (binding.Setter != null)
+            {
+                EmitAccessor(typeState, binding, binding.Setter, addedPropertyCatalog, addedMethodCatalog, addedFieldCatalog, entries);
+            }
+        }
+    }
+
+    private static void EmitAccessor(
+        TypeEmitState typeState,
+        AddedPropertyBinding binding,
+        AddedMethodBinding accessor,
+        AddedPropertyCatalog addedPropertyCatalog,
+        AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog,
+        List<WorkerEntry> entries)
+    {
+        SyntaxNode body = GetAccessorBody(binding.Declaration, accessor.MethodKey == binding.Getter.MethodKey);
+        if (body == null)
+        {
+            return;
+        }
+
+        MethodDeclarationSyntax shimMethod = BuildAccessorShim(
+            binding,
+            accessor,
+            body,
+            typeState,
+            addedPropertyCatalog,
+            addedMethodCatalog,
+            addedFieldCatalog);
+        typeState.CurrentShimType.AddMethod(shimMethod, accessor.ShimMethodName);
+
+        FileLinePositionSpan span = binding.Declaration.GetLocation().GetLineSpan();
+        entries.Add(new WorkerEntry
+        {
+            SourceProjectRelativePath = binding.SourceProjectRelativePath,
+            TypeMetadataName = CecilTypeNames.ToMetadataName(typeState.TypeSymbol),
+            MethodName = accessor.MethodKey == binding.Getter.MethodKey
+                ? binding.Symbol.GetMethod.Name
+                : binding.Symbol.SetMethod.Name,
+            ParameterTypeFullNames = accessor.MethodKey == binding.Getter.MethodKey
+                ? Array.Empty<string>()
+                : new[] { CecilTypeNames.ToCecilFullName(binding.ValueType) },
+            GenericArity = 0,
+            ShimTypeName = accessor.ShimTypeName,
+            ShimMethodName = accessor.ShimMethodName,
+            PatchKind = PatchKinds.AddedMethod,
+            CalledAddedMethodKeys = AddedCallSiteGuard.CollectCalledAddedMethodKeys(
+                body,
+                typeState.SourceUnit.SemanticModel,
+                addedMethodCatalog,
+                addedPropertyCatalog,
+                accessor.MethodKey),
+            SourceStartLine = span.StartLinePosition.Line + 1,
+            SourceEndLine = span.EndLinePosition.Line + 1,
+            LifecycleNote = null
+        });
+    }
+
+    private static MethodDeclarationSyntax BuildAccessorShim(
+        AddedPropertyBinding binding,
+        AddedMethodBinding accessor,
+        SyntaxNode body,
+        TypeEmitState typeState,
+        AddedPropertyCatalog addedPropertyCatalog,
+        AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        ShimBodyRewriter rewriter = new ShimBodyRewriter(
+            typeState.SourceUnit.SemanticModel,
+            typeState.TypeSymbol,
+            null,
+            addedMethodCatalog,
+            addedFieldCatalog,
+            addedPropertyCatalog);
+        SyntaxNode rewrittenBody = PropertyGetterEmitter.TransferUloopLineAnnotations(
+            body,
+            rewriter.Visit(body));
+        bool isGetter = accessor.MethodKey == binding.Getter.MethodKey;
+        MethodDeclarationSyntax method = SyntaxFactory.MethodDeclaration(
+                isGetter
+                    ? binding.Declaration.Type.WithoutTrivia()
+                    : SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)),
+                accessor.ShimMethodName)
+            .WithParameterList(isGetter ? SyntaxFactory.ParameterList() : CreateSetterParameterList(binding));
+        method = ApplyBody(method, rewrittenBody);
+        return ShimMethodFactory.ToShimMethod(method, isGetter ? binding.Symbol.GetMethod : binding.Symbol.SetMethod);
+    }
+
+    private static ParameterListSyntax CreateSetterParameterList(AddedPropertyBinding binding)
+    {
+        ParameterSyntax parameter = SyntaxFactory.Parameter(SyntaxFactory.Identifier("value"))
+            .WithType(binding.Declaration.Type.WithoutTrivia());
+        return SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList(parameter));
+    }
+
+    private static MethodDeclarationSyntax ApplyBody(MethodDeclarationSyntax method, SyntaxNode body)
+    {
+        if (body is BlockSyntax block)
+        {
+            return method.WithBody(block);
+        }
+
+        ArrowExpressionClauseSyntax arrow = body as ArrowExpressionClauseSyntax;
+        if (arrow == null)
+        {
+            arrow = SyntaxFactory.ArrowExpressionClause((ExpressionSyntax)body);
+        }
+
+        return method
+            .WithExpressionBody(arrow)
+            .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+    }
+
+    private static SyntaxNode GetAccessorBody(PropertyDeclarationSyntax declaration, bool getter)
+    {
+        if (getter && declaration.ExpressionBody != null)
+        {
+            return declaration.ExpressionBody;
+        }
+
+        if (declaration.AccessorList == null)
+        {
+            return null;
+        }
+
+        SyntaxKind expectedKind = getter ? SyntaxKind.GetAccessorDeclaration : SyntaxKind.SetAccessorDeclaration;
+        foreach (AccessorDeclarationSyntax accessor in declaration.AccessorList.Accessors)
+        {
+            if (accessor.IsKind(expectedKind))
+            {
+                return (SyntaxNode)accessor.Body ?? accessor.ExpressionBody;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyShimRewrite.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyShimRewrite.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+/// <summary>
+/// Rewrites reads and simple writes of added properties into accessor shim invocations.
+/// </summary>
+internal sealed class AddedPropertyShimRewrite
+{
+    private readonly ShimBodyRewriter _rewriter;
+
+    internal AddedPropertyShimRewrite(ShimBodyRewriter rewriter)
+    {
+        _rewriter = rewriter;
+    }
+
+    internal SyntaxNode TryRewriteRead(
+        ISymbol symbol,
+        ExpressionSyntax receiverSyntax,
+        string memberName,
+        SyntaxNode triviaSource)
+    {
+        AddedPropertyBinding binding = ResolveBinding(symbol, receiverSyntax, memberName);
+        if (binding == null || binding.UnavailableReason != null)
+        {
+            return null;
+        }
+
+        return CreateAccessorInvocation(binding, binding.Getter, receiverSyntax).WithTriviaFrom(triviaSource);
+    }
+
+    internal SyntaxNode TryRewriteBareRead(SimpleNameSyntax node, ISymbol symbol)
+    {
+        AddedPropertyBinding binding = ResolveBinding(symbol, null, null);
+        if (binding == null || binding.UnavailableReason != null)
+        {
+            return null;
+        }
+
+        return CreateAccessorInvocation(
+            binding,
+            binding.Getter,
+            SyntaxFactory.IdentifierName(TransformWorkerProgramMarker.InstanceParameterName)).WithTriviaFrom(node);
+    }
+
+    internal SyntaxNode TryRewriteSimpleAssignment(AssignmentExpressionSyntax node)
+    {
+        if (!node.IsKind(SyntaxKind.SimpleAssignmentExpression))
+        {
+            return null;
+        }
+
+        ISymbol symbol = _rewriter._semanticModel.GetSymbolInfo(node.Left).Symbol;
+        ExpressionSyntax receiverSyntax = node.Left is MemberAccessExpressionSyntax memberAccess
+            ? memberAccess.Expression
+            : null;
+        string memberName = node.Left is MemberAccessExpressionSyntax namedAccess
+            ? namedAccess.Name.Identifier.ValueText
+            : null;
+        AddedPropertyBinding binding = ResolveBinding(symbol, receiverSyntax, memberName);
+        if (binding == null || binding.Setter == null || binding.UnavailableReason != null)
+        {
+            return null;
+        }
+
+        List<ArgumentSyntax> arguments = CreateReceiverArguments(binding, receiverSyntax);
+        arguments.Add(SyntaxFactory.Argument((ExpressionSyntax)_rewriter.Visit(node.Right)));
+        return CreateAccessorInvocation(binding.Setter, arguments).WithTriviaFrom(node);
+    }
+
+    private AddedPropertyBinding ResolveBinding(
+        ISymbol symbol,
+        ExpressionSyntax receiverSyntax,
+        string memberName)
+    {
+        if (symbol is IPropertySymbol propertySymbol)
+        {
+            return _rewriter._addedPropertyCatalog.FindBySymbolOrNull(propertySymbol);
+        }
+
+        if (receiverSyntax == null || memberName == null)
+        {
+            return null;
+        }
+
+        ITypeSymbol receiverType = _rewriter._semanticModel.GetTypeInfo(receiverSyntax).Type;
+        if (receiverType is not INamedTypeSymbol namedType || namedType.TypeKind == TypeKind.Error)
+        {
+            return null;
+        }
+
+        return _rewriter._addedPropertyCatalog.FindOrNull(AddedPropertyCatalog.FormatPropertyKey(
+            CecilTypeNames.ToMetadataName(namedType),
+            memberName));
+    }
+
+    private InvocationExpressionSyntax CreateAccessorInvocation(
+        AddedPropertyBinding binding,
+        AddedMethodBinding accessor,
+        ExpressionSyntax receiverSyntax)
+    {
+        List<ArgumentSyntax> arguments = CreateReceiverArguments(binding, receiverSyntax);
+        return CreateAccessorInvocation(accessor, arguments);
+    }
+
+    private List<ArgumentSyntax> CreateReceiverArguments(
+        AddedPropertyBinding binding,
+        ExpressionSyntax receiverSyntax)
+    {
+        List<ArgumentSyntax> arguments = new List<ArgumentSyntax>();
+        if (!binding.IsStatic)
+        {
+            ExpressionSyntax receiver = receiverSyntax
+                ?? SyntaxFactory.IdentifierName(TransformWorkerProgramMarker.InstanceParameterName);
+            arguments.Add(SyntaxFactory.Argument(_rewriter.VisitReceiver(receiver)));
+        }
+
+        return arguments;
+    }
+
+    private static InvocationExpressionSyntax CreateAccessorInvocation(
+        AddedMethodBinding accessor,
+        List<ArgumentSyntax> arguments)
+    {
+        string qualifiedShimType = "global::"
+            + ShimNamespaceNames.ResolveShimNamespaceName(accessor.NamespaceName)
+            + "."
+            + accessor.ShimTypeName;
+        ExpressionSyntax member = SyntaxFactory.MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            SyntaxFactory.ParseTypeName(qualifiedShimType),
+            SyntaxFactory.IdentifierName(accessor.ShimMethodName));
+        return SyntaxFactory.InvocationExpression(
+            member,
+            SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments)));
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertySkipReasons.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertySkipReasons.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+/// <summary>
+/// Skip strings for added-property classification and call-site rewriting.
+/// </summary>
+internal static class AddedPropertySkipReasons
+{
+    public const string VirtualOrAbstract =
+        "Added virtual, override, abstract, or interface properties are skipped; the compiled type has no vtable slot. "
+        + "Run 'uloop compile' to add them.";
+
+    public const string ExplicitInterface =
+        "Added explicit interface properties are skipped; the compiled type has no interface member slot. "
+        + "Run 'uloop compile' to add them.";
+
+    public const string InitAccessor =
+        "Added properties with init accessors are skipped; the shim cannot preserve initialization-only assignment. "
+        + "Run 'uloop compile' to add them.";
+
+    public const string Indexer =
+        "Added indexers are skipped; the shim does not support indexer access. Run 'uloop compile' to add them.";
+
+    public const string StructHost =
+        "Added properties on struct types are skipped; the shim requires a reference-type instance. "
+        + "Run 'uloop compile' to add them.";
+
+    public const string ValueTypeNotExternallyVisible =
+        "Added property type is not visible to the shim assembly. Run 'uloop compile' to add it.";
+
+    public const string CompoundAssignment =
+        "Compound assignment, increment, and decrement of an added property are skipped; the accessor shim cannot preserve the operation. "
+        + "Run 'uloop compile' to add it.";
+
+    public const string ConsumedWrite =
+        "The value of an assignment to an added property is consumed; the setter shim returns void. "
+        + "Run 'uloop compile' to add it.";
+
+    public const string NameofReference =
+        "References to added properties inside nameof are skipped; the member does not exist in the compiled assembly. "
+        + "Run 'uloop compile' to add it.";
+
+    public const string ObjectInitializer =
+        "Object initializers that assign added properties are skipped; the setter shim cannot rewrite the initializer. "
+        + "Run 'uloop compile' to add it.";
+
+    public const string ConditionalAccess =
+        "Conditional access to added properties is skipped; there is no rewrite shape. Run 'uloop compile' to add it.";
+
+    public const string RefOutIn =
+        "Added properties cannot be passed by ref, out, or in. Run 'uloop compile' to add them.";
+
+    public const string UnavailableAddedProperty =
+        "Uses an added property that hot reload cannot emit. Run 'uloop compile'.";
+
+    public const string InitializerNotEmittable =
+        "Added property initializer cannot run in the shim lambda. Run 'uloop compile' to add it.";
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertySkipReasons.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertySkipReasons.cs
@@ -20,6 +20,10 @@ using Microsoft.CodeAnalysis.Text;
 /// </summary>
 internal static class AddedPropertySkipReasons
 {
+    public const string SetOnly =
+        "Added properties with only a setter are skipped; the shim requires a getter identity. "
+        + "Run 'uloop compile' to add them.";
+
     public const string VirtualOrAbstract =
         "Added virtual, override, abstract, or interface properties are skipped; the compiled type has no vtable slot. "
         + "Run 'uloop compile' to add them.";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterClassifier.cs
@@ -55,40 +55,6 @@ internal static class PropertyGetterClassifier
         return false;
     }
 
-    internal static bool TrySkipAddedProperty(
-        string sourceProjectRelativePath,
-        bool hasBaseline,
-        Dictionary<string, PropertyDeclarationSyntax> snapshotPropertyMap,
-        Dictionary<string, PropertyDeclarationSyntax> plainCurrentPropertyMap,
-        string typeMetadataNameFromSyntax,
-        PropertyDeclarationSyntax propertyDeclaration,
-        IMethodSymbol getterSymbol,
-        List<WorkerSkipped> skipped,
-        AddedMethodCatalog addedMethodCatalog)
-    {
-        if (!hasBaseline
-            || snapshotPropertyMap == null
-            || plainCurrentPropertyMap == null)
-        {
-            return false;
-        }
-
-        string addedPropertyKey = WorkerSyntaxIndex.BuildSyntaxPropertyKey(typeMetadataNameFromSyntax, propertyDeclaration);
-        if (snapshotPropertyMap.ContainsKey(addedPropertyKey))
-        {
-            return false;
-        }
-
-        skipped.Add(new WorkerSkipped
-        {
-            SourceProjectRelativePath = sourceProjectRelativePath,
-            Method = WorkerMethodKeys.FormatMethodLabel(getterSymbol),
-            Reason = AddedMethodSkipReasons.AddedProperty
-        });
-        addedMethodCatalog.AddAddedPropertySyntaxKey(addedPropertyKey);
-        return true;
-    }
-
     internal static (bool SkipGetter, MethodTransformDecision Decision) TrySkipPropertyGetterByDecision(
         string sourceProjectRelativePath,
         TypeDeclarationSyntax typeDeclaration,
@@ -99,6 +65,7 @@ internal static class PropertyGetterClassifier
         INamedTypeSymbol compiledType,
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog,
+        AddedPropertyCatalog addedPropertyCatalog,
         List<WorkerSkipped> skipped)
     {
         MethodTransformDecision decision = MethodTransformDecider.DecideMethodTransform(
@@ -124,7 +91,9 @@ internal static class PropertyGetterClassifier
             getterBodyNode,
             semanticModel,
             addedMethodCatalog,
-            addedFieldCatalog);
+            addedFieldCatalog,
+            addedPropertyCatalog,
+            typeSymbol);
         if (addedCallSiteSkip == null)
         {
             return (false, decision);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
@@ -21,6 +21,7 @@ internal static class PropertyGetterEmitter
         TypeEmitState typeState,
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog,
+        AddedPropertyCatalog addedPropertyCatalog,
         WorkerInput input,
         List<WorkerEntry> entries,
         List<WorkerSkipped> skipped,
@@ -36,6 +37,12 @@ internal static class PropertyGetterEmitter
         foreach (PropertyDeclarationSyntax propertyDeclaration in typeState.TypeDeclaration.Members
             .OfType<PropertyDeclarationSyntax>())
         {
+            IPropertySymbol propertySymbol = semanticModel.GetDeclaredSymbol(propertyDeclaration);
+            if (addedPropertyCatalog.FindBySymbolOrNull(propertySymbol) != null)
+            {
+                continue;
+            }
+
             if (typeState.TypeIsAbsentFromCompiledAssembly)
             {
                 PropertyGetterClassifier.SkipPropertyGetterOnUncompiledType(
@@ -69,7 +76,8 @@ internal static class PropertyGetterEmitter
                     typeState.CurrentShimType,
                     assemblyGlobalUsings,
                     addedMethodCatalog,
-                    addedFieldCatalog);
+                    addedFieldCatalog,
+                    addedPropertyCatalog);
             typeState.CurrentShimType = nextShimType;
             shimTypeCounter = nextShimTypeCounter;
             globalShimMethodCounter = nextGlobalShimMethodCounter;
@@ -102,10 +110,19 @@ internal static class PropertyGetterEmitter
             ShimTypeBuilder currentShimType,
             List<UsingDirectiveSyntax> assemblyGlobalUsings,
             AddedMethodCatalog addedMethodCatalog,
-            AddedFieldCatalog addedFieldCatalog)
+            AddedFieldCatalog addedFieldCatalog,
+            AddedPropertyCatalog addedPropertyCatalog)
     {
         IPropertySymbol propertySymbol = semanticModel.GetDeclaredSymbol(propertyDeclaration);
         if (propertySymbol == null || propertySymbol.GetMethod == null)
+        {
+            return (currentShimType, shimTypeCounter, globalShimMethodCounter);
+        }
+
+        string propertyKey = AddedPropertyCatalog.FormatPropertyKey(
+            CecilTypeNames.ToMetadataName(typeSymbol),
+            propertySymbol.Name);
+        if (addedPropertyCatalog.IsClassifiedAdded(propertyKey))
         {
             return (currentShimType, shimTypeCounter, globalShimMethodCounter);
         }
@@ -114,18 +131,6 @@ internal static class PropertyGetterEmitter
             PropertyGetterClassifier.TryGetPropertyGetterBody(propertyDeclaration);
         if (!hasGetterBody)
         {
-            // Why skip added auto-properties: Harmony looks up get_<Name> on the compiled type
-            // and fails when the member does not exist. An existing auto-property stays silent.
-            PropertyGetterClassifier.TrySkipAddedProperty(
-                sourceProjectRelativePath,
-                hasBaseline,
-                snapshotPropertyMap,
-                plainCurrentPropertyMap,
-                typeMetadataNameFromSyntax,
-                propertyDeclaration,
-                propertySymbol.GetMethod,
-                skipped,
-                addedMethodCatalog);
             return (currentShimType, shimTypeCounter, globalShimMethodCounter);
         }
 
@@ -156,22 +161,6 @@ internal static class PropertyGetterEmitter
             return (currentShimType, shimTypeCounter, globalShimMethodCounter);
         }
 
-        // Why skip newly added properties: Harmony looks up get_<Name> on the compiled type
-        // and fails with "No method 'get_X' ... was found" when the member does not exist.
-        if (PropertyGetterClassifier.TrySkipAddedProperty(
-            sourceProjectRelativePath,
-            hasBaseline,
-            snapshotPropertyMap,
-            plainCurrentPropertyMap,
-            typeMetadataNameFromSyntax,
-            propertyDeclaration,
-            getterSymbol,
-            skipped,
-            addedMethodCatalog))
-        {
-            return (currentShimType, shimTypeCounter, globalShimMethodCounter);
-        }
-
         if (propertyDeclaration.ExplicitInterfaceSpecifier != null)
         {
             skipped.Add(new WorkerSkipped
@@ -198,6 +187,7 @@ internal static class PropertyGetterEmitter
             compiledType,
             addedMethodCatalog,
             addedFieldCatalog,
+            addedPropertyCatalog,
             skipped);
         if (skipGetter)
         {
@@ -223,7 +213,8 @@ internal static class PropertyGetterEmitter
             currentShimType,
             assemblyGlobalUsings,
             addedMethodCatalog,
-            addedFieldCatalog);
+            addedFieldCatalog,
+            addedPropertyCatalog);
     }
 
     internal static (ShimTypeBuilder CurrentShimType, int ShimTypeCounter, int GlobalShimMethodCounter)
@@ -246,7 +237,8 @@ internal static class PropertyGetterEmitter
             ShimTypeBuilder currentShimType,
             List<UsingDirectiveSyntax> assemblyGlobalUsings,
             AddedMethodCatalog addedMethodCatalog,
-            AddedFieldCatalog addedFieldCatalog)
+            AddedFieldCatalog addedFieldCatalog,
+            AddedPropertyCatalog addedPropertyCatalog)
     {
         if (currentShimType == null)
         {
@@ -282,7 +274,8 @@ internal static class PropertyGetterEmitter
             semanticModel,
             rewritePlan,
             addedMethodCatalog,
-            addedFieldCatalog);
+            addedFieldCatalog,
+            addedPropertyCatalog);
         currentShimType.AddMethod(rewrittenMethod, shimMethodName);
 
         entries.Add(new WorkerEntry
@@ -299,6 +292,7 @@ internal static class PropertyGetterEmitter
                 getterBodyNode,
                 semanticModel,
                 addedMethodCatalog,
+                addedPropertyCatalog,
                 methodKey),
             SourceStartLine = sourceStartLine,
             SourceEndLine = sourceEndLine,
@@ -317,14 +311,16 @@ internal static class PropertyGetterEmitter
         SemanticModel semanticModel,
         AccessorPlan accessorPlan,
         AddedMethodCatalog addedMethodCatalog,
-        AddedFieldCatalog addedFieldCatalog)
+        AddedFieldCatalog addedFieldCatalog,
+        AddedPropertyCatalog addedPropertyCatalog)
     {
         ShimBodyRewriter rewriter = new ShimBodyRewriter(
             semanticModel,
             targetType,
             accessorPlan,
             addedMethodCatalog,
-            addedFieldCatalog);
+            addedFieldCatalog,
+            addedPropertyCatalog);
         SyntaxNode rewrittenBody = rewriter.Visit(getterBodyNode);
         // Why transfer: Visit may rebuild ArrowExpressionClause nodes and drop #line annotations.
         rewrittenBody = TransferUloopLineAnnotations(getterBodyNode, rewrittenBody);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimBodyRewriter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimBodyRewriter.cs
@@ -26,7 +26,9 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
     internal readonly AccessorPlan _accessorPlan;
     internal readonly AddedMethodCatalog _addedMethodCatalog;
     internal readonly AddedFieldCatalog _addedFieldCatalog;
+    internal readonly AddedPropertyCatalog _addedPropertyCatalog;
     internal readonly AddedFieldShimRewrite AddedFields;
+    internal readonly AddedPropertyShimRewrite AddedProperties;
     internal readonly HarmonyAccessorShimRewrite HarmonyAccessors;
 
     public ShimBodyRewriter(
@@ -34,14 +36,17 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
         INamedTypeSymbol targetType,
         AccessorPlan accessorPlan,
         AddedMethodCatalog addedMethodCatalog,
-        AddedFieldCatalog addedFieldCatalog)
+        AddedFieldCatalog addedFieldCatalog,
+        AddedPropertyCatalog addedPropertyCatalog = null)
     {
         _semanticModel = semanticModel;
         _targetType = targetType;
         _accessorPlan = accessorPlan;
         _addedMethodCatalog = addedMethodCatalog ?? new AddedMethodCatalog();
         _addedFieldCatalog = addedFieldCatalog ?? new AddedFieldCatalog();
+        _addedPropertyCatalog = addedPropertyCatalog ?? new AddedPropertyCatalog();
         AddedFields = new AddedFieldShimRewrite(this);
+        AddedProperties = new AddedPropertyShimRewrite(this);
         HarmonyAccessors = new HarmonyAccessorShimRewrite(this);
     }
 
@@ -298,6 +303,12 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
             return AddedFields.RewriteAddedFieldAssignment(node, assignedField);
         }
 
+        SyntaxNode addedPropertyWrite = AddedProperties.TryRewriteSimpleAssignment(node);
+        if (addedPropertyWrite != null)
+        {
+            return addedPropertyWrite;
+        }
+
         if (_accessorPlan == null)
         {
             return base.VisitAssignmentExpression(node);
@@ -386,6 +397,16 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
             {
                 return addedFieldRead;
             }
+
+            SyntaxNode addedPropertyRead = AddedProperties.TryRewriteRead(
+                symbol,
+                node.Expression,
+                node.Name.Identifier.ValueText,
+                node);
+            if (addedPropertyRead != null)
+            {
+                return addedPropertyRead;
+            }
         }
 
         if (_accessorPlan == null)
@@ -434,6 +455,12 @@ internal sealed class ShimBodyRewriter : CSharpSyntaxRewriter
         if (addedFieldRead != null)
         {
             return addedFieldRead;
+        }
+
+        SyntaxNode addedPropertyRead = AddedProperties.TryRewriteBareRead(node, symbol);
+        if (addedPropertyRead != null)
+        {
+            return addedPropertyRead;
         }
 
         // Local/anonymous functions are emitted into the shim assembly — keep bare calls.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimMethodEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimMethodEmitter.cs
@@ -21,6 +21,7 @@ internal static class ShimMethodEmitter
         List<TypeEmitState> typeEmitStates,
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog,
+        AddedPropertyCatalog addedPropertyCatalog,
         WorkerInput input,
         List<WorkerEntry> entries,
         List<WorkerSkipped> skipped,
@@ -36,11 +37,19 @@ internal static class ShimMethodEmitter
                 typeState,
                 addedMethodCatalog,
                 addedFieldCatalog,
+                addedPropertyCatalog,
+                entries);
+            AddedPropertyEmitter.EmitAddedPropertyAccessors(
+                typeState,
+                addedPropertyCatalog,
+                addedMethodCatalog,
+                addedFieldCatalog,
                 entries);
             (shimTypeCounter, globalShimMethodCounter) = PropertyGetterEmitter.EmitPropertyGettersForType(
                 typeState,
                 addedMethodCatalog,
                 addedFieldCatalog,
+                addedPropertyCatalog,
                 input,
                 entries,
                 skipped,
@@ -58,6 +67,7 @@ internal static class ShimMethodEmitter
         TypeEmitState typeState,
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog,
+        AddedPropertyCatalog addedPropertyCatalog,
         List<WorkerEntry> entries)
     {
         SemanticModel semanticModel = typeState.SourceUnit.SemanticModel;
@@ -73,7 +83,8 @@ internal static class ShimMethodEmitter
                 semanticModel,
                 rewritePlan,
                 addedMethodCatalog,
-                addedFieldCatalog);
+                addedFieldCatalog,
+                addedPropertyCatalog);
             queued.ShimType.AddMethod(rewrittenMethod, queued.ShimMethodName);
 
             SyntaxNode bodyNode =
@@ -82,6 +93,7 @@ internal static class ShimMethodEmitter
                 bodyNode,
                 semanticModel,
                 addedMethodCatalog,
+                addedPropertyCatalog,
                 queued.MethodKey);
 
             entries.Add(new WorkerEntry
@@ -113,7 +125,8 @@ internal static class ShimMethodEmitter
         SemanticModel semanticModel,
         AccessorPlan accessorPlan,
         AddedMethodCatalog addedMethodCatalog,
-        AddedFieldCatalog addedFieldCatalog)
+        AddedFieldCatalog addedFieldCatalog,
+        AddedPropertyCatalog addedPropertyCatalog)
     {
         // Why a single rewriter: rewriting the tree invalidates SemanticModel for new nodes.
         // Qualify + accessor rewrite both classify symbols on the original tree in one Visit pass.
@@ -122,7 +135,8 @@ internal static class ShimMethodEmitter
             targetType,
             accessorPlan,
             addedMethodCatalog,
-            addedFieldCatalog);
+            addedFieldCatalog,
+            addedPropertyCatalog);
         MethodDeclarationSyntax rewritten = (MethodDeclarationSyntax)rewriter.Visit(methodDeclaration);
         return ShimMethodFactory.ToShimMethod(rewritten, methodSymbol);
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitPlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitPlanner.cs
@@ -26,6 +26,7 @@ internal static class TypeEmitPlanner
             List<ShimTypeBuilder> shimTypes,
             AddedMethodCatalog addedMethodCatalog,
             AddedFieldCatalog addedFieldCatalog,
+            AddedPropertyCatalog addedPropertyCatalog,
             List<WorkerSkipped> skipped,
             List<WorkerUnchangedMethod> unchangedMethods,
             List<string> declarationDriftWarnings,
@@ -48,8 +49,30 @@ internal static class TypeEmitPlanner
 
             string typeMetadataNameFromSyntax = WorkerSyntaxIndex.BuildTypeMetadataNameFromSyntax(typeDeclaration);
 
-            // Property setters/init and all indexer accessors with bodies stay Skipped.
-            // Property getters are patched below (not reported here).
+            TypeEmitState typeState = new TypeEmitState
+            {
+                SourceUnit = sourceUnit,
+                TypeDeclaration = typeDeclaration,
+                TypeSymbol = typeSymbol,
+                TypeMetadataNameFromSyntax = typeMetadataNameFromSyntax
+            };
+            (shimTypeCounter, globalShimMethodCounter) = AddedPropertyClassifier.ClassifyAddedProperties(
+                typeState,
+                semanticModel,
+                targetTypesAssemblySymbol,
+                input,
+                baseline,
+                root,
+                assemblyGlobalUsings,
+                shimTypes,
+                addedPropertyCatalog,
+                addedMethodCatalog,
+                skipped,
+                shimTypeCounter,
+                globalShimMethodCounter);
+
+            // Existing property setters/init and all indexer accessors with bodies stay Skipped.
+            // Added properties were classified above and must not receive duplicate skip rows.
             (Dictionary<string, PropertyDeclarationSyntax> snapshotPropertyMap,
                 Dictionary<string, IndexerDeclarationSyntax> snapshotIndexerMap,
                 Dictionary<string, PropertyDeclarationSyntax> plainCurrentPropertyMap,
@@ -65,7 +88,8 @@ internal static class TypeEmitPlanner
                 snapshotIndexerMap,
                 plainCurrentPropertyMap,
                 plainCurrentIndexerMap,
-                addedMethodCatalog);
+                addedMethodCatalog,
+                addedPropertyCatalog);
             (Dictionary<string, ConstructorDeclarationSyntax> snapshotConstructorMap,
                 Dictionary<string, MemberDeclarationSyntax> snapshotOperatorMap,
                 Dictionary<string, EventDeclarationSyntax> snapshotEventMap,
@@ -86,13 +110,6 @@ internal static class TypeEmitPlanner
                 plainCurrentOperatorMap,
                 plainCurrentEventMap);
 
-            TypeEmitState typeState = new TypeEmitState
-            {
-                SourceUnit = sourceUnit,
-                TypeDeclaration = typeDeclaration,
-                TypeSymbol = typeSymbol,
-                TypeMetadataNameFromSyntax = typeMetadataNameFromSyntax
-            };
             (int nextShimTypeCounter, int nextGlobalShimMethodCounter) = QueueTypeMethods(
                 typeState,
                 semanticModel,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/UnsupportedMemberSkipCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/UnsupportedMemberSkipCollector.cs
@@ -39,13 +39,20 @@ internal static class UnsupportedMemberSkipCollector
         Dictionary<string, IndexerDeclarationSyntax> snapshotIndexerMap,
         Dictionary<string, PropertyDeclarationSyntax> plainCurrentPropertyMap,
         Dictionary<string, IndexerDeclarationSyntax> plainCurrentIndexerMap,
-        AddedMethodCatalog addedMethodCatalog)
+        AddedMethodCatalog addedMethodCatalog,
+        AddedPropertyCatalog addedPropertyCatalog)
     {
         int firstAppendedIndex = skipped.Count;
         foreach (MemberDeclarationSyntax member in typeDeclaration.Members)
         {
             if (member is PropertyDeclarationSyntax propertyDeclaration)
             {
+                IPropertySymbol propertySymbol = semanticModel.GetDeclaredSymbol(propertyDeclaration);
+                if (addedPropertyCatalog.FindBySymbolOrNull(propertySymbol) != null)
+                {
+                    continue;
+                }
+
                 string propertyKey = WorkerSyntaxIndex.BuildSyntaxPropertyKey(typeMetadataNameFromSyntax, propertyDeclaration);
                 // Why plainCurrentPropertyMap: annotated property nodes break AreEquivalent the
                 // same way annotated method bodies do; compare unannotated peers only.
@@ -64,7 +71,7 @@ internal static class UnsupportedMemberSkipCollector
 
                 AppendExplicitAccessorSkipsForProperty(
                     propertyDeclaration,
-                    semanticModel.GetDeclaredSymbol(propertyDeclaration),
+                    propertySymbol,
                     skipped,
                     typeMetadataNameFromSyntax,
                     snapshotPropertyMap,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
@@ -90,6 +90,7 @@ internal static class WorkerGroupPipeline
         List<ShimTypeBuilder> shimTypes = new List<ShimTypeBuilder>();
         AddedMethodCatalog addedMethodCatalog = new AddedMethodCatalog();
         AddedFieldCatalog addedFieldCatalog = new AddedFieldCatalog();
+        AddedPropertyCatalog addedPropertyCatalog = new AddedPropertyCatalog();
         // Why counters run across units: shim type and method names must stay unique when two
         // files of the group declare types of the same name.
         int shimTypeCounter = 0;
@@ -105,6 +106,7 @@ internal static class WorkerGroupPipeline
                 shimTypes,
                 addedMethodCatalog,
                 addedFieldCatalog,
+                addedPropertyCatalog,
                 skipped,
                 unchangedMethods,
                 shimTypeCounter,
@@ -137,12 +139,14 @@ internal static class WorkerGroupPipeline
             allTypeEmitStates,
             addedMethodCatalog,
             addedFieldCatalog,
+            addedPropertyCatalog,
             skipped);
 
         ShimMethodEmitter.EmitQueuedMethodsAndPropertyGetters(
             allTypeEmitStates,
             addedMethodCatalog,
             addedFieldCatalog,
+            addedPropertyCatalog,
             input,
             entries,
             skipped,
@@ -178,6 +182,7 @@ internal static class WorkerGroupPipeline
         List<ShimTypeBuilder> shimTypes,
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog,
+        AddedPropertyCatalog addedPropertyCatalog,
         List<WorkerSkipped> skipped,
         List<WorkerUnchangedMethod> unchangedMethods,
         int shimTypeCounter,
@@ -210,6 +215,7 @@ internal static class WorkerGroupPipeline
                 shimTypes,
                 addedMethodCatalog,
                 addedFieldCatalog,
+                addedPropertyCatalog,
                 skipped,
                 unchangedMethods,
                 unit.DeclarationDriftWarnings,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceAnnotator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceAnnotator.cs
@@ -56,7 +56,7 @@ internal static class WorkerSourceAnnotator
         List<SyntaxNode> nodesToAnnotate = new List<SyntaxNode>();
         nodesToAnnotate.AddRange(root.DescendantNodes().OfType<MethodDeclarationSyntax>());
         nodesToAnnotate.AddRange(root.DescendantNodes().OfType<StatementSyntax>());
-        // Why property/accessor arrows: expression-bodied getters are rewritten into synthetic
+        // Why property/accessor arrows: expression-bodied accessors are rewritten into synthetic
         // MethodDeclarations that would otherwise carry no #line annotations into the shim.
         foreach (PropertyDeclarationSyntax propertyDeclaration in root.DescendantNodes()
             .OfType<PropertyDeclarationSyntax>())
@@ -70,7 +70,9 @@ internal static class WorkerSourceAnnotator
         foreach (AccessorDeclarationSyntax accessor in root.DescendantNodes()
             .OfType<AccessorDeclarationSyntax>())
         {
-            if (accessor.IsKind(SyntaxKind.GetAccessorDeclaration) && accessor.ExpressionBody != null)
+            if ((accessor.IsKind(SyntaxKind.GetAccessorDeclaration)
+                || accessor.IsKind(SyntaxKind.SetAccessorDeclaration))
+                && accessor.ExpressionBody != null)
             {
                 nodesToAnnotate.Add(accessor.ExpressionBody);
             }


### PR DESCRIPTION
## Summary
- classify bodied properties absent from the compiled type as added accessor shims
- rewrite supported reads and simple writes through getter and setter shims
- preserve all-or-nothing isolation and reject unsupported call-site shapes

This PR deliberately leaves auto-property storage and the public hot-reload wiring to the following PRs.

## Validation
- `uloop compile`: 0 errors (8 existing fixture warnings)
- `TransformWorkerAddedPropertyTests`: 15 passed
- `TransformWorkerAddedMemberTests`: 56 passed
- `TransformWorkerAddedFieldTests`: 62 passed
- `HotReloadCrossFileE2ETests`: 17 passed
- file-length and complexity checks: passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

