### PR TITLE
feat: Hot reload now applies added auto-properties instead of asking for a GetX() workaround

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
@@ -136,25 +136,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: referencing an auto-property added in another file of the same reload fails
-        /// the caller with the skipped-member compile note that names the property.
+        /// What: an auto-property added in the host file is readable and writable from the caller
+        /// file's edited body within one reload, its backing value lives in the added-field store,
+        /// and the run reports that one added field once.
         /// </summary>
         [Test]
-        public async Task Run_CallerFileUsesAutoPropertyAddedInOtherFile_FailsWithSkippedPropertyNote()
+        public async Task Run_CallerFileUsesAutoPropertyAddedInOtherFile_AppliesAndRoundTripsValue()
         {
             HotReloadOrchestratorResult result = await RunPairAsync(
                 "CrossFileAddedAutoProperty",
-                InsertHostMember("        public bool HasTarget { get; private set; }\n\n"),
-                ReplaceCallerBody(CallerCallBodyAnchor, "return host.HasTarget ? 1 : 0;"));
+                InsertHostMember("        public int Count { get; set; }\n\n"),
+                ReplaceCallerBody(
+                    CallerCallBodyAnchor,
+                    "host.Count = 3;\n            return host.Count + 1;"));
 
-            HotReloadMethodOutcome failure = FindOutcome(result, HotReloadMethodOutcomeKind.Failed, "Call");
+            AssertNoFailure(result);
+            AssertKind(result, HotReloadMethodOutcomeKind.Patched, "Call");
+            AssertKind(result, HotReloadMethodOutcomeKind.Added, "get_Count");
+            AssertKind(result, HotReloadMethodOutcomeKind.Added, "set_Count");
             Assert.That(
-                failure.Reason,
-                Does.Contain(string.Format(
-                    HotReloadConstants.SkippedMemberCompileFailureNoteFormat,
-                    "HasTarget",
-                    "Added properties are out of scope")));
-            Assert.That(failure.Reason, Does.Contain("Added properties are out of scope"));
+                new HotReloadCrossFileAddedMemberCaller().Call(new HotReloadCrossFileAddedMemberHost()),
+                Is.EqualTo(4));
+            Assert.That(
+                HotReloadAddedFieldRegistry.GetFieldsForType(
+                    typeof(HotReloadCrossFileAddedMemberHost).FullName),
+                Is.EqualTo(new[] { "Count" }));
+            Assert.That(result.AddedFields, Has.Length.EqualTo(1));
+            Assert.That(result.AddedFields[0], Does.Contain("Count"));
+            Assert.That(CountAddedFieldsLifetimeWarnings(result), Is.EqualTo(1));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
@@ -137,8 +137,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: an auto-property added in the host file is readable and writable from the caller
-        /// file's edited body within one reload, its backing value lives in the added-field store,
-        /// and the run reports that one added field once.
+        /// file's edited body within one reload, its backing value survives across calls because
+        /// it lives in the added-field store, and the run reports that one added field once.
         /// </summary>
         [Test]
         public async Task Run_CallerFileUsesAutoPropertyAddedInOtherFile_AppliesAndRoundTripsValue()
@@ -148,15 +148,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 InsertHostMember("        public int Count { get; set; }\n\n"),
                 ReplaceCallerBody(
                     CallerCallBodyAnchor,
-                    "host.Count = 3;\n            return host.Count + 1;"));
+                    "host.Count = host.Count + 1;\n            return host.Count + 40;"));
 
             AssertNoFailure(result);
             AssertKind(result, HotReloadMethodOutcomeKind.Patched, "Call");
             AssertKind(result, HotReloadMethodOutcomeKind.Added, "get_Count");
             AssertKind(result, HotReloadMethodOutcomeKind.Added, "set_Count");
-            Assert.That(
-                new HotReloadCrossFileAddedMemberCaller().Call(new HotReloadCrossFileAddedMemberHost()),
-                Is.EqualTo(4));
+            HotReloadCrossFileAddedMemberCaller caller = new HotReloadCrossFileAddedMemberCaller();
+            HotReloadCrossFileAddedMemberHost host = new HotReloadCrossFileAddedMemberHost();
+
+            // Why two calls on the same host: only a value that outlives the call proves the
+            // accessors read and write the store rather than transient state.
+            Assert.That(caller.Call(host), Is.EqualTo(41));
+            Assert.That(caller.Call(host), Is.EqualTo(42));
             Assert.That(
                 HotReloadAddedFieldRegistry.GetFieldsForType(
                     typeof(HotReloadCrossFileAddedMemberHost).FullName),

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -1613,10 +1613,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: adding an auto-property does not emit the compiled property warning and
-        /// skips the getter with the added-property reason.
+        /// emits its getter as an added entry.
         /// </summary>
         [Test]
-        public async Task Classify_AddedProperty_SkipsGetterWithAddedPropertyReason()
+        public async Task Classify_AddedProperty_EmitsGetterWithoutCompiledKindWarning()
         {
             string onDisk = File.ReadAllText(ResolveHostPath());
             string edited = onDisk.Replace(
@@ -1629,7 +1629,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             AssertHasNoCompiledKindChangeWarningForMember(result, "ExtraHp");
-            AssertHasSkip(result, "get_ExtraHp", "Added properties are out of scope");
+            Assert.That(FindEntry(result, "get_ExtraHp"), Is.Not.Null);
+            AssertHasNoSkipContaining(result, "get_ExtraHp");
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -99,17 +99,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: an auto-property present only in the edited source is skipped with the
-        /// added-property reason and does not fire the outside-body drift warning.
+        /// What: an auto-property present only in the edited source emits its accessors as
+        /// added members and does not fire the outside-body drift warning.
         /// </summary>
         [Test]
-        public async Task Classify_AddedAutoProperty_SkipsGetterWithAddedPropertyReason()
+        public async Task Classify_AddedAutoProperty_EmitsAccessorsWithoutDrift()
         {
-            const string expectedReason =
-                "Added properties are out of scope for hot reload; the compiled assembly has no such member. "
-                + "For a computed value, add a same-file method instead (e.g. 'private T GetX()'), which applies "
-                + "through hot reload; for a constant, use a 'const' or a plain added field; otherwise run "
-                + "'uloop compile'.";
             string onDisk = File.ReadAllText(ResolveHostPath());
             string edited = WithHostMembers(
                 onDisk,
@@ -124,9 +119,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(
                 FindEntry(result, "get_AddedAuto"),
-                Is.Null,
-                "Added auto-property getter must not be an entry.");
-            Assert.That(FindSkipReason(result, "get_AddedAuto"), Is.EqualTo(expectedReason));
+                Is.Not.Null,
+                "Added auto-property getter must be an added entry.");
+            Assert.That(FindSkipReason(result, "get_AddedAuto"), Is.Null);
             Assert.That(
                 result.Output.files[0].declarationDriftWarnings,
                 Has.None.Contain("Edits outside method bodies"),

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedPropertyTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedPropertyTests.cs
@@ -592,7 +592,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(FindEntry(result, "get_PublicSeed"), Is.Null);
+            Assert.That(FindEntry(result, "set_PublicSeed"), Is.Null);
             Assert.That(FindSkipReason(result, "get_PublicSeed"), Is.EqualTo(CompiledMemberKindChangedReason));
+            Assert.That(FindSkipReason(result, "set_PublicSeed"), Is.EqualTo(CompiledMemberKindChangedReason));
         }
 
         private static async Task<TransformWorkerClientResult> RunEditedHostAsync(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedPropertyTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedPropertyTests.cs
@@ -60,6 +60,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             "Added properties with only a setter are skipped; the shim requires a getter identity. "
             + "Run 'uloop compile' to add them.";
 
+        private const string StructHostReason =
+            "Added properties on struct types are skipped; the shim requires a reference-type instance. "
+            + "Run 'uloop compile' to add them.";
+
+        private const string InitializerNotEmittableReason =
+            "Added property initializer cannot run in the shim lambda. Run 'uloop compile' to add it.";
+
+        private const string HostStoreKeyPrefix =
+            "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadAddedMemberHost::";
+
         /// <summary>
         /// An expression-bodied property added to a compiled host emits an added getter
         /// and rewrites an edited caller to that getter shim.
@@ -397,6 +407,159 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             TransformWorkerClientResult result = await RunEditedHostAsync(
                 "AddedBodiedPropertyDrift.cs",
                 "public int DriftSafe => PublicSeed * 2;");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            string[] warnings = result.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>();
+            Assert.That(warnings, Has.None.Contain("Edits outside method bodies"));
+        }
+
+        /// <summary>
+        /// An added auto-property emits store-backed accessor shims and reports its backing
+        /// value through the added-field rows so the Editor keeps the added-field lifetime.
+        /// </summary>
+        [Test]
+        public async Task Emit_AddedAutoProperty_EmitsStoreBackedAccessors()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedAutoProperty.cs",
+                "public int Count { get; set; }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            Count = value;\n            return Count;\n        }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            TransformWorkerEntryDto getter = FindEntry(result, "get_Count");
+            TransformWorkerEntryDto setter = FindEntry(result, "set_Count");
+            Assert.That(getter, Is.Not.Null, FormatSkipped(result.Output.skipped));
+            Assert.That(setter, Is.Not.Null, FormatSkipped(result.Output.skipped));
+            Assert.That(getter.patchKind, Is.EqualTo(HotReloadConstants.PatchKindAddedMethod));
+            string getterShim = SliceShimMethod(result.Output.shimSource, getter.shimMethodName);
+            Assert.That(getterShim, Does.Contain("GetOrInit<"));
+            Assert.That(getterShim, Does.Contain(HostStoreKeyPrefix + "Count"));
+            string setterShim = SliceShimMethod(result.Output.shimSource, setter.shimMethodName);
+            Assert.That(setterShim, Does.Contain("Set<"));
+            Assert.That(setterShim, Does.Contain(HostStoreKeyPrefix + "Count"));
+            Assert.That(
+                result.Output.files[0].addedFieldNames,
+                Has.Some.Contains("HotReloadAddedMemberHost.Count"));
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
+        }
+
+        /// <summary>
+        /// A literal initializer on an added auto-property becomes the store's static lambda so
+        /// the first read produces the declared value.
+        /// </summary>
+        [Test]
+        public async Task Emit_AddedAutoPropertyWithInitializer_UsesStaticLambda()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedAutoPropertyInitializer.cs",
+                "public int Base { get; } = 41;",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            return Base + value;\n        }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            TransformWorkerEntryDto getter = FindEntry(result, "get_Base");
+            Assert.That(getter, Is.Not.Null, FormatSkipped(result.Output.skipped));
+            Assert.That(
+                SliceShimMethod(result.Output.shimSource, getter.shimMethodName),
+                Does.Contain("static () => 41"));
+        }
+
+        /// <summary>
+        /// An object-creation initializer on an added auto-property is skipped for the same
+        /// reason as an added field, because the shim lambda cannot run the constructor.
+        /// </summary>
+        [Test]
+        public async Task Skip_AddedAutoPropertyObjectCreationInitializer_SkipsWithInitializerReason()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedAutoPropertyObjectCreationInitializer.cs",
+                "public System.Collections.Generic.List<int> Items { get; }"
+                + " = new System.Collections.Generic.List<int>();");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, "get_Items"), Is.Null);
+            Assert.That(FindSkipReason(result, "get_Items"), Is.EqualTo(InitializerNotEmittableReason));
+        }
+
+        /// <summary>
+        /// A static added auto-property uses the static store entry points so no instance
+        /// receiver is required.
+        /// </summary>
+        [Test]
+        public async Task Emit_AddedStaticAutoProperty_UsesStaticStore()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedStaticAutoProperty.cs",
+                "public static int Total { get; set; }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            Total = value;\n            return Total;\n        }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            TransformWorkerEntryDto getter = FindEntry(result, "get_Total");
+            TransformWorkerEntryDto setter = FindEntry(result, "set_Total");
+            Assert.That(getter, Is.Not.Null, FormatSkipped(result.Output.skipped));
+            Assert.That(setter, Is.Not.Null, FormatSkipped(result.Output.skipped));
+            string getterShim = SliceShimMethod(result.Output.shimSource, getter.shimMethodName);
+            Assert.That(getterShim, Does.Contain("GetOrInitStatic<"));
+            Assert.That(getterShim, Does.Not.Contain("GetOrInit<"));
+            Assert.That(
+                SliceShimMethod(result.Output.shimSource, setter.shimMethodName),
+                Does.Contain("SetStatic<"));
+        }
+
+        /// <summary>
+        /// An added auto-property on a struct host is skipped, because the store cannot keep
+        /// identity for a boxed value-type receiver.
+        /// </summary>
+        [Test]
+        public async Task Skip_AddedAutoPropertyOnStruct_SkipsWithStructHostReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int Existing;\n",
+                "        public int Existing;\n\n        public int Added { get; set; }\n",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                HotReloadTestSourceWriter.WriteEditedSource("AddedAutoPropertyStructHost.cs", edited),
+                HostProjectRelativePath,
+                onDisk,
+                null);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, "get_Added"), Is.Null);
+            Assert.That(FindSkipReason(result, "get_Added"), Is.EqualTo(StructHostReason));
+        }
+
+        /// <summary>
+        /// An added auto-property initializer that calls a member of its own host is skipped,
+        /// because the store's static lambda cannot reach the compiled host's members.
+        /// Why not an instance member: a property initializer that reads instance state does not
+        /// compile, so the host's own static method is the reachable shape of the same rule.
+        /// </summary>
+        [Test]
+        public async Task Skip_AddedAutoPropertyInitializerReferencingHostMember_SkipsWithInitializerReason()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedAutoPropertyHostMemberInitializer.cs",
+                "public int Twice { get; } = PrivateStaticSeven();");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, "get_Twice"), Is.Null);
+            Assert.That(FindSkipReason(result, "get_Twice"), Is.EqualTo(InitializerNotEmittableReason));
+        }
+
+        /// <summary>
+        /// An added auto-property with a baseline stays out of the outside-body drift warnings.
+        /// </summary>
+        [Test]
+        public async Task Drift_AddedAutoProperty_ProducesNoOutsideBodyWarning()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedAutoPropertyDrift.cs",
+                "public int DriftSafeAuto { get; set; }");
 
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             string[] warnings = result.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>();

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedPropertyTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedPropertyTests.cs
@@ -597,6 +597,50 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(FindSkipReason(result, "set_PublicSeed"), Is.EqualTo(CompiledMemberKindChangedReason));
         }
 
+        /// <summary>
+        /// Compound assignment to an added auto-property skips the caller, because the accessor
+        /// shims cannot carry an operation that reads and writes in one expression.
+        /// </summary>
+        [Test]
+        public async Task Skip_CallerCompoundAssignsAddedAutoProperty_SkipsCallerWithCompoundReason()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedAutoPropertyCompoundAssignment.cs",
+                "public int Count { get; set; }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            Count += 1;\n            return value;\n        }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller)), Is.Null);
+            Assert.That(
+                FindSkipReason(result, nameof(HotReloadAddedMemberHost.ExistingCaller)),
+                Is.EqualTo(CompoundAssignmentReason));
+            Assert.That(FindEntry(result, "get_Count"), Is.Not.Null);
+            Assert.That(FindEntry(result, "set_Count"), Is.Not.Null);
+        }
+
+        /// <summary>
+        /// Incrementing an added auto-property skips the caller for the same reason as a
+        /// compound assignment; only plain reads and simple assignment have a rewrite shape.
+        /// </summary>
+        [Test]
+        public async Task Skip_CallerIncrementsAddedAutoProperty_SkipsCallerWithCompoundReason()
+        {
+            TransformWorkerClientResult result = await RunEditedHostAsync(
+                "AddedAutoPropertyIncrement.cs",
+                "public int Count { get; set; }",
+                "        public int ExistingCaller(int value)\n        {\n"
+                + "            Count++;\n            return value;\n        }");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, nameof(HotReloadAddedMemberHost.ExistingCaller)), Is.Null);
+            Assert.That(
+                FindSkipReason(result, nameof(HotReloadAddedMemberHost.ExistingCaller)),
+                Is.EqualTo(CompoundAssignmentReason));
+            Assert.That(FindEntry(result, "get_Count"), Is.Not.Null);
+            Assert.That(FindEntry(result, "set_Count"), Is.Not.Null);
+        }
+
         private static async Task<TransformWorkerClientResult> RunEditedHostAsync(
             string fileName,
             string extraMembers,

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedPropertyTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedPropertyTests.cs
@@ -64,6 +64,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             "Added properties on struct types are skipped; the shim requires a reference-type instance. "
             + "Run 'uloop compile' to add them.";
 
+        private const string CompiledMemberKindChangedReason =
+            "Property 'PublicSeed' is declared as a field or an event in the compiled assembly. "
+            + "Run 'uloop compile'.";
+
         private const string InitializerNotEmittableReason =
             "Added property initializer cannot run in the shim lambda. Run 'uloop compile' to add it.";
 
@@ -564,6 +568,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             string[] warnings = result.Output.files[0].declarationDriftWarnings ?? Array.Empty<string>();
             Assert.That(warnings, Has.None.Contain("Edits outside method bodies"));
+        }
+
+        /// <summary>
+        /// Turning a compiled field into a property is skipped rather than emitted, because the
+        /// compiled field keeps owning the value that unedited code reads and writes.
+        /// </summary>
+        [Test]
+        public async Task Skip_CompiledFieldReplacedByProperty_SkipsWithMemberKindReason()
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = onDisk.Replace(
+                "        public int PublicSeed = 3;",
+                "        public int PublicSeed { get; set; }",
+                StringComparison.Ordinal);
+            Assert.That(edited, Is.Not.EqualTo(onDisk));
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                HotReloadTestSourceWriter.WriteEditedSource("CompiledFieldToProperty.cs", edited),
+                HostProjectRelativePath,
+                onDisk,
+                null);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindEntry(result, "get_PublicSeed"), Is.Null);
+            Assert.That(FindSkipReason(result, "get_PublicSeed"), Is.EqualTo(CompiledMemberKindChangedReason));
         }
 
         private static async Task<TransformWorkerClientResult> RunEditedHostAsync(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -1013,22 +1013,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(foundCompute, Is.True, "Body edit must still emit a Patched ComputeWithPrivate entry.");
         }
 
-        private const string ExpectedAddedPropertySkipReason =
-            "Added properties are out of scope for hot reload; the compiled assembly has no such member. "
-            + "For a computed value, add a same-file method instead (e.g. 'private T GetX()'), which applies "
-            + "through hot reload; for a constant, use a 'const' or a plain added field; otherwise run "
-            + "'uloop compile'.";
-
         private const string ExpectedExplicitAccessorSkipReason =
             "Property setter, init, or indexer accessors are out of scope for v1; "
             + "run 'uloop compile' to apply accessor edits.";
 
+        private const string ExpectedSetOnlyPropertySkipReason =
+            "Added properties with only a setter are skipped; the shim requires a getter identity. "
+            + "Run 'uloop compile' to add them.";
+
         /// <summary>
-        /// What: adding a get-accessor property plus a method-body edit skips the getter with
-        /// the added-property reason and does not emit the outside-body drift warning.
+        /// What: adding an expression-bodied property plus a method-body edit emits the getter
+        /// as an added member and does not emit the outside-body drift warning.
         /// </summary>
         [Test]
-        public async Task Run_AddedExpressionBodiedPropertyPlusBodyEdit_SkipsGetterWithoutOutsideBodyWarning()
+        public async Task Run_AddedExpressionBodiedPropertyPlusBodyEdit_EmitsGetterWithoutOutsideBodyWarning()
         {
             const string fileName = "AddedExpressionBodiedPropertyDrift.cs";
             TransformWorkerClientResult result = await RunWorkerOnEditedE2ECopyAsync(
@@ -1045,14 +1043,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         StringComparison.Ordinal);
                 });
 
-            AssertSkippedContains(result, "get_AddedProbe", ExpectedAddedPropertySkipReason);
+            AssertEmittedWithoutSkip(result, "get_AddedProbe");
             AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
             AssertPatchedComputeWithPrivate(result);
         }
 
         /// <summary>
-        /// What: adding a setter-only property plus a method-body edit skips the setter with
-        /// the explicit-accessor reason and does not emit the outside-body drift warning.
+        /// What: adding a setter-only property plus a method-body edit skips the setter, because
+        /// an added property needs a getter identity, and does not emit the outside-body warning.
         /// </summary>
         [Test]
         public async Task Run_AddedSetterOnlyPropertyPlusBodyEdit_SkipsSetterWithoutOutsideBodyWarning()
@@ -1072,17 +1070,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         StringComparison.Ordinal);
                 });
 
-            AssertSkippedContains(result, "set_AddedSetterOnly", ExpectedExplicitAccessorSkipReason);
+            AssertSkippedContains(result, "set_AddedSetterOnly", ExpectedSetOnlyPropertySkipReason);
             AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
             AssertPatchedComputeWithPrivate(result);
         }
 
         /// <summary>
-        /// What: adding an auto-property plus a method-body edit skips the getter with the
-        /// added-property reason and does not emit the outside-body drift warning.
+        /// What: adding an auto-property plus a method-body edit emits both accessors as added
+        /// members and does not emit the outside-body drift warning.
         /// </summary>
         [Test]
-        public async Task Run_AddedAutoPropertyPlusBodyEdit_SkipsGetterWithoutOutsideBodyWarning()
+        public async Task Run_AddedAutoPropertyPlusBodyEdit_EmitsAccessorsWithoutOutsideBodyWarning()
         {
             const string fileName = "AddedAutoPropertyDrift.cs";
             TransformWorkerClientResult result = await RunWorkerOnEditedE2ECopyAsync(
@@ -1099,7 +1097,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         StringComparison.Ordinal);
                 });
 
-            AssertSkippedContains(result, "get_AddedAuto", ExpectedAddedPropertySkipReason);
+            AssertEmittedWithoutSkip(result, "get_AddedAuto");
+            AssertEmittedWithoutSkip(result, "set_AddedAuto");
             AssertDoesNotContainOutsideMethodBodyDriftWarning(result, fileName);
             AssertPatchedComputeWithPrivate(result);
         }
@@ -2189,6 +2188,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Does.Contain(expectedWarning),
                 "Declaration-only unsupported-kind edits must emit the outside-body warning.\n"
                 + string.Join("\n", warnings));
+        }
+
+        private static void AssertEmittedWithoutSkip(
+            TransformWorkerClientResult result,
+            string methodName)
+        {
+            bool found = false;
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                if (entry.methodName == methodName)
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            Assert.That(found, Is.True, "Expected an entry for '" + methodName + "'.");
+            AssertSkippedDoesNotContain(result, methodName);
         }
 
         private static void AssertSkippedContains(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
@@ -154,6 +154,25 @@ internal static class AddedFieldClassifier
 
         // Why after const: added consts on struct hosts still fold to literals; the store
         // identity problem only applies to instance/static storage.
+        return EvaluateStoreAvailability(
+            hostType,
+            semanticModel,
+            targetTypesAssemblySymbol,
+            fieldSymbol.Type,
+            binding.Initializer);
+    }
+
+    /// <summary>
+    /// Reports why a value cannot live in the added-field store, for any member backed by it.
+    /// Added auto-properties reuse this so their backing store follows the same rules as fields.
+    /// </summary>
+    internal static string EvaluateStoreAvailability(
+        INamedTypeSymbol hostType,
+        SemanticModel semanticModel,
+        IAssemblySymbol targetTypesAssemblySymbol,
+        ITypeSymbol valueType,
+        ExpressionSyntax initializer)
+    {
         if (hostType.TypeKind == TypeKind.Struct)
         {
             return AddedFieldSkipReasons.StructHost;
@@ -161,7 +180,7 @@ internal static class AddedFieldClassifier
 
         // Why unresolved types before visibility: TypeKind.Error is not externally
         // visible, so the shim-visibility reason would hide a missing using or typo.
-        if (TryFindUnresolvedType(fieldSymbol.Type, out ITypeSymbol unresolvedType))
+        if (TryFindUnresolvedType(valueType, out ITypeSymbol unresolvedType))
         {
             return string.Format(
                 CultureInfo.InvariantCulture,
@@ -169,14 +188,14 @@ internal static class AddedFieldClassifier
                 unresolvedType.ToDisplayString());
         }
 
-        if (!AccessibilityRules.IsExternallyVisibleType(fieldSymbol.Type))
+        if (!AccessibilityRules.IsExternallyVisibleType(valueType))
         {
             return AddedFieldSkipReasons.FieldTypeNotExternallyVisible;
         }
 
-        if (binding.Initializer != null
+        if (initializer != null
             && InitializerCannotEmitInShimLambda(
-                binding.Initializer,
+                initializer,
                 semanticModel,
                 hostType,
                 targetTypesAssemblySymbol))

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyBodyScan.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyBodyScan.cs
@@ -75,7 +75,7 @@ internal static class AddedPropertyBodyScan
                 semanticModel,
                 addedPropertyCatalog,
                 enclosingType);
-            if (binding != null && !binding.IsAuto)
+            if (binding != null)
             {
                 return AddedPropertySkipReasons.RefOutIn;
             }
@@ -95,7 +95,7 @@ internal static class AddedPropertyBodyScan
             semanticModel,
             addedPropertyCatalog,
             enclosingType);
-        if (binding == null || binding.IsAuto)
+        if (binding == null)
         {
             return null;
         }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
@@ -31,6 +31,7 @@ internal static class AddedPropertyClassifier
         List<ShimTypeBuilder> shimTypes,
         AddedPropertyCatalog addedPropertyCatalog,
         AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog,
         List<WorkerSkipped> skipped,
         int shimTypeCounter,
         int globalShimMethodCounter)
@@ -52,6 +53,7 @@ internal static class AddedPropertyClassifier
                 typeState,
                 compiledType,
                 semanticModel,
+                targetTypesAssemblySymbol,
                 input,
                 baseline,
                 root,
@@ -59,6 +61,7 @@ internal static class AddedPropertyClassifier
                 shimTypes,
                 addedPropertyCatalog,
                 addedMethodCatalog,
+                addedFieldCatalog,
                 skipped,
                 shimTypeCounter,
                 globalShimMethodCounter);
@@ -72,6 +75,7 @@ internal static class AddedPropertyClassifier
         TypeEmitState typeState,
         INamedTypeSymbol compiledType,
         SemanticModel semanticModel,
+        IAssemblySymbol targetTypesAssemblySymbol,
         WorkerInput input,
         BaselineSnapshotState baseline,
         CompilationUnitSyntax root,
@@ -79,6 +83,7 @@ internal static class AddedPropertyClassifier
         List<ShimTypeBuilder> shimTypes,
         AddedPropertyCatalog addedPropertyCatalog,
         AddedMethodCatalog addedMethodCatalog,
+        AddedFieldCatalog addedFieldCatalog,
         List<WorkerSkipped> skipped,
         int shimTypeCounter,
         int globalShimMethodCounter)
@@ -88,6 +93,7 @@ internal static class AddedPropertyClassifier
             typeState,
             compiledType,
             semanticModel,
+            targetTypesAssemblySymbol,
             baseline,
             addedMethodCatalog);
         if (candidate == null)
@@ -103,6 +109,11 @@ internal static class AddedPropertyClassifier
             addedPropertyCatalog.Register(candidate.Binding);
             AppendSkippedAccessors(candidate.Binding, skipped);
             return (shimTypeCounter, globalShimMethodCounter);
+        }
+
+        if (candidate.Binding.IsAuto)
+        {
+            RegisterAutoPropertyStore(candidate.Binding, addedFieldCatalog);
         }
 
         (ShimTypeBuilder shimType, int nextShimTypeCounter) = OrdinaryMethodQueue.EnsureShimType(
@@ -142,6 +153,7 @@ internal static class AddedPropertyClassifier
         TypeEmitState typeState,
         INamedTypeSymbol compiledType,
         SemanticModel semanticModel,
+        IAssemblySymbol targetTypesAssemblySymbol,
         BaselineSnapshotState baseline,
         AddedMethodCatalog addedMethodCatalog)
     {
@@ -172,7 +184,12 @@ internal static class AddedPropertyClassifier
             : EvaluateDeclarationSkipReason(symbol, declaration, typeState.TypeSymbol);
         if (isAuto && reason == null)
         {
-            reason = AddedMethodSkipReasons.AddedProperty;
+            reason = EvaluateAutoPropertyStoreSkipReason(
+                declaration,
+                symbol,
+                typeState.TypeSymbol,
+                semanticModel,
+                targetTypesAssemblySymbol);
         }
 
         AddedPropertyBinding binding = new AddedPropertyBinding
@@ -312,6 +329,70 @@ internal static class AddedPropertyClassifier
             IsStatic = accessorSymbol.IsStatic,
             ParameterCount = accessorSymbol.Parameters.Length
         };
+    }
+
+    // Why the shared store rules: an auto-property's backing value lives in the same
+    // side table as an added field, so it must be rejected on exactly the same grounds.
+    private static string EvaluateAutoPropertyStoreSkipReason(
+        PropertyDeclarationSyntax declaration,
+        IPropertySymbol symbol,
+        INamedTypeSymbol hostType,
+        SemanticModel semanticModel,
+        IAssemblySymbol targetTypesAssemblySymbol)
+    {
+        string storeReason = AddedFieldClassifier.EvaluateStoreAvailability(
+            hostType,
+            semanticModel,
+            targetTypesAssemblySymbol,
+            symbol.Type,
+            declaration.Initializer?.Value);
+        if (storeReason == null)
+        {
+            return null;
+        }
+
+        if (string.Equals(storeReason, AddedFieldSkipReasons.StructHost, StringComparison.Ordinal))
+        {
+            return AddedPropertySkipReasons.StructHost;
+        }
+
+        if (string.Equals(
+                storeReason,
+                AddedFieldSkipReasons.InitializerNotLiteralOrExternalStatic,
+                StringComparison.Ordinal))
+        {
+            return AddedPropertySkipReasons.InitializerNotEmittable;
+        }
+
+        // The declaration check already rejects unresolved and non-visible value types, so
+        // anything left names a type the shim assembly cannot see.
+        return AddedPropertySkipReasons.ValueTypeNotExternallyVisible;
+    }
+
+    // Why register here and not at rewrite time: the accessor shims themselves read and write
+    // the store, so an emitted auto-property always rewrites, unlike an added field that a body
+    // may never touch.
+    private static void RegisterAutoPropertyStore(
+        AddedPropertyBinding binding,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        binding.StoreFieldKey = binding.PropertyKey;
+        binding.Initializer = binding.Declaration.Initializer?.Value;
+
+        // Why not AddAddedSyntaxKey: the field syntax-key set drives field drift stripping,
+        // while the property declaration is already registered as an added property key.
+        addedFieldCatalog.RegisterStore(new AddedFieldBinding
+        {
+            SourceProjectRelativePath = binding.SourceProjectRelativePath,
+            FieldKey = binding.PropertyKey,
+            SyntaxKey = binding.SyntaxKey,
+            FieldName = binding.Name,
+            FieldType = binding.ValueType,
+            IsStatic = binding.IsStatic,
+            IsConst = false,
+            Initializer = binding.Initializer
+        });
+        addedFieldCatalog.MarkStoreRewrite(binding.PropertyKey);
     }
 
     private static string EvaluateDeclarationSkipReason(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
@@ -179,9 +179,14 @@ internal static class AddedPropertyClassifier
         bool isAuto = IsAutoProperty(declaration);
         string getterKey = BuildGetterKey(typeState.TypeSymbol, symbol);
         string setterKey = BuildSetterKey(typeState.TypeSymbol, symbol);
-        string reason = symbol.GetMethod == null
-            ? AddedPropertySkipReasons.SetOnly
-            : EvaluateDeclarationSkipReason(symbol, declaration, typeState.TypeSymbol);
+        string reason = EvaluateCompiledMemberKindChangeReason(compiledType, symbol.Name);
+        if (reason == null)
+        {
+            reason = symbol.GetMethod == null
+                ? AddedPropertySkipReasons.SetOnly
+                : EvaluateDeclarationSkipReason(symbol, declaration, typeState.TypeSymbol);
+        }
+
         if (isAuto && reason == null)
         {
             reason = EvaluateAutoPropertyStoreSkipReason(
@@ -214,6 +219,27 @@ internal static class AddedPropertyClassifier
             SetterKey = setterKey,
             Reason = reason
         };
+    }
+
+    // Why before every other rule: a compiled field or event of the same name still owns the
+    // member, so emitting accessors would leave compiled code on the old storage while edited
+    // code reads a side table that never sees the compiled value.
+    private static string EvaluateCompiledMemberKindChangeReason(
+        INamedTypeSymbol compiledType,
+        string propertyName)
+    {
+        foreach (ISymbol member in compiledType.GetMembers(propertyName))
+        {
+            if (member is IFieldSymbol || member is IEventSymbol)
+            {
+                return string.Format(
+                    CultureInfo.InvariantCulture,
+                    AddedPropertySkipReasons.CompiledMemberKindChanged,
+                    propertyName);
+            }
+        }
+
+        return null;
     }
 
     private static bool HasCompiledProperty(INamedTypeSymbol compiledType, string propertyName)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyEmitter.cs
@@ -31,9 +31,19 @@ internal static class AddedPropertyEmitter
         {
             if (!SymbolEqualityComparer.Default.Equals(binding.HostType, typeState.TypeSymbol)
                 || binding.Declaration.SyntaxTree != typeState.SourceUnit.SyntaxTree
-                || binding.UnavailableReason != null
-                || binding.IsAuto)
+                || binding.UnavailableReason != null)
             {
+                continue;
+            }
+
+            if (binding.IsAuto)
+            {
+                EmitStoreBackedAccessor(typeState, binding, binding.Getter, entries);
+                if (binding.Setter != null)
+                {
+                    EmitStoreBackedAccessor(typeState, binding, binding.Setter, entries);
+                }
+
                 continue;
             }
 
@@ -43,6 +53,87 @@ internal static class AddedPropertyEmitter
                 EmitAccessor(typeState, binding, binding.Setter, addedPropertyCatalog, addedMethodCatalog, addedFieldCatalog, entries);
             }
         }
+    }
+
+    // Why synthesized instead of rewritten: an auto-property has no user body, so the accessor
+    // is built directly against the added-field store rather than visited by the body rewriter.
+    private static void EmitStoreBackedAccessor(
+        TypeEmitState typeState,
+        AddedPropertyBinding binding,
+        AddedMethodBinding accessor,
+        List<WorkerEntry> entries)
+    {
+        bool isGetter = accessor.MethodKey == binding.Getter.MethodKey;
+        MethodDeclarationSyntax method = isGetter
+            ? BuildStoreGetter(binding, accessor)
+            : BuildStoreSetter(binding, accessor);
+        method = ShimMethodFactory.ToShimMethod(
+            method,
+            isGetter ? binding.Symbol.GetMethod : binding.Symbol.SetMethod);
+        typeState.CurrentShimType.AddMethod(method, accessor.ShimMethodName);
+        entries.Add(CreateAccessorEntry(typeState, binding, accessor, Array.Empty<string>()));
+    }
+
+    private static MethodDeclarationSyntax BuildStoreGetter(
+        AddedPropertyBinding binding,
+        AddedMethodBinding accessor)
+    {
+        List<ArgumentSyntax> arguments = CreateStoreArguments(binding);
+        arguments.Add(SyntaxFactory.Argument(CreateStoreInitializer(binding)));
+        InvocationExpressionSyntax invocation = AddedFieldShimRewrite.CreateAddedFieldStoreInvocation(
+            binding.IsStatic
+                ? TransformWorkerProgramMarker.AddedFieldGetOrInitStaticMethodName
+                : TransformWorkerProgramMarker.AddedFieldGetOrInitMethodName,
+            binding.ValueType,
+            arguments);
+        // Why a block and not an arrow: a synthesized accessor carries no source line, so a
+        // braced body keeps every emitted store accessor delimited in the shim source.
+        return SyntaxFactory.MethodDeclaration(binding.Declaration.Type.WithoutTrivia(), accessor.ShimMethodName)
+            .WithParameterList(SyntaxFactory.ParameterList())
+            .WithBody(SyntaxFactory.Block(SyntaxFactory.ReturnStatement(invocation)));
+    }
+
+    private static MethodDeclarationSyntax BuildStoreSetter(
+        AddedPropertyBinding binding,
+        AddedMethodBinding accessor)
+    {
+        List<ArgumentSyntax> arguments = CreateStoreArguments(binding);
+        arguments.Add(SyntaxFactory.Argument(SyntaxFactory.IdentifierName("value")));
+        InvocationExpressionSyntax invocation = AddedFieldShimRewrite.CreateAddedFieldStoreInvocation(
+            binding.IsStatic
+                ? TransformWorkerProgramMarker.AddedFieldSetStaticMethodName
+                : TransformWorkerProgramMarker.AddedFieldSetMethodName,
+            binding.ValueType,
+            arguments);
+        return SyntaxFactory.MethodDeclaration(
+                SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)),
+                accessor.ShimMethodName)
+            .WithParameterList(CreateSetterParameterList(binding))
+            .WithBody(SyntaxFactory.Block(SyntaxFactory.ExpressionStatement(invocation)));
+    }
+
+    private static List<ArgumentSyntax> CreateStoreArguments(AddedPropertyBinding binding)
+    {
+        List<ArgumentSyntax> arguments = new List<ArgumentSyntax>();
+        if (!binding.IsStatic)
+        {
+            arguments.Add(SyntaxFactory.Argument(
+                SyntaxFactory.IdentifierName(TransformWorkerProgramMarker.InstanceParameterName)));
+        }
+
+        arguments.Add(SyntaxFactory.Argument(
+            SyntaxFactory.LiteralExpression(
+                SyntaxKind.StringLiteralExpression,
+                SyntaxFactory.Literal(binding.StoreFieldKey))));
+        return arguments;
+    }
+
+    private static ExpressionSyntax CreateStoreInitializer(AddedPropertyBinding binding)
+    {
+        return AddedFieldShimRewrite.CreateAddedFieldInitializer(new AddedFieldBinding
+        {
+            Initializer = binding.Initializer
+        });
     }
 
     private static void EmitAccessor(
@@ -76,32 +167,43 @@ internal static class AddedPropertyEmitter
             addedMethodCatalog,
             addedFieldCatalog);
         typeState.CurrentShimType.AddMethod(shimMethod, accessor.ShimMethodName);
+        entries.Add(CreateAccessorEntry(
+            typeState,
+            binding,
+            accessor,
+            AddedCallSiteGuard.CollectCalledAddedMethodKeys(
+                body,
+                typeState.SourceUnit.SemanticModel,
+                addedMethodCatalog,
+                addedPropertyCatalog,
+                accessor.MethodKey)));
+    }
 
+    private static WorkerEntry CreateAccessorEntry(
+        TypeEmitState typeState,
+        AddedPropertyBinding binding,
+        AddedMethodBinding accessor,
+        string[] calledAddedMethodKeys)
+    {
+        bool isGetter = accessor.MethodKey == binding.Getter.MethodKey;
         FileLinePositionSpan span = binding.Declaration.GetLocation().GetLineSpan();
-        entries.Add(new WorkerEntry
+        return new WorkerEntry
         {
             SourceProjectRelativePath = binding.SourceProjectRelativePath,
             TypeMetadataName = CecilTypeNames.ToMetadataName(typeState.TypeSymbol),
-            MethodName = accessor.MethodKey == binding.Getter.MethodKey
-                ? binding.Symbol.GetMethod.Name
-                : binding.Symbol.SetMethod.Name,
-            ParameterTypeFullNames = accessor.MethodKey == binding.Getter.MethodKey
+            MethodName = isGetter ? binding.Symbol.GetMethod.Name : binding.Symbol.SetMethod.Name,
+            ParameterTypeFullNames = isGetter
                 ? Array.Empty<string>()
                 : new[] { CecilTypeNames.ToCecilFullName(binding.ValueType) },
             GenericArity = 0,
             ShimTypeName = accessor.ShimTypeName,
             ShimMethodName = accessor.ShimMethodName,
             PatchKind = PatchKinds.AddedMethod,
-            CalledAddedMethodKeys = AddedCallSiteGuard.CollectCalledAddedMethodKeys(
-                body,
-                typeState.SourceUnit.SemanticModel,
-                addedMethodCatalog,
-                addedPropertyCatalog,
-                accessor.MethodKey),
+            CalledAddedMethodKeys = calledAddedMethodKeys,
             SourceStartLine = span.StartLinePosition.Line + 1,
             SourceEndLine = span.EndLinePosition.Line + 1,
             LifecycleNote = null
-        });
+        };
     }
 
     private static MethodDeclarationSyntax BuildAccessorShim(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertySkipReasons.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertySkipReasons.cs
@@ -71,6 +71,9 @@ internal static class AddedPropertySkipReasons
     public const string UnavailableAddedProperty =
         "Uses an added property that hot reload cannot emit. Run 'uloop compile'.";
 
+    public const string CompiledMemberKindChanged =
+        "Property '{0}' is declared as a field or an event in the compiled assembly. Run 'uloop compile'.";
+
     public const string InitializerNotEmittable =
         "Added property initializer cannot run in the shim lambda. Run 'uloop compile' to add it.";
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitPlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitPlanner.cs
@@ -67,6 +67,7 @@ internal static class TypeEmitPlanner
                 shimTypes,
                 addedPropertyCatalog,
                 addedMethodCatalog,
+                addedFieldCatalog,
                 skipped,
                 shimTypeCounter,
                 globalShimMethodCounter);


### PR DESCRIPTION
## Summary
- An auto-property added to an existing type now applies through hot reload instead of being reported as out of scope.
- Its value lives in the added-field store, so it behaves exactly like an added field and is reported the same way.

## User Impact

Before, adding `public int Count { get; set; }` to a type and hot reloading printed:

```
Skipped Host.get_Count: Added properties are out of scope for hot reload...
For a computed value, add a same-file method instead (e.g. 'private T GetX()')
```

Following that advice left a `GetX()` workaround in the product code, and the property still had to be written by hand after the next compile.

Now the accessors apply. Edited code in the same reload can read and write the property, `--status` lists the accessors as added members and the backing value as an added field, and the existing added-field lifetime warning covers it, so the value is known to reset on Domain Reload, `uloop compile`, or revert.

Shapes that still cannot apply keep a precise skip reason rather than the generic out-of-scope text: struct hosts, initializers the shim cannot evaluate (object creation, or a call into the host's own members), and callers that use the property in a shape the accessors cannot express (compound assignment, increment, a consumed write, `nameof`, an object initializer, conditional access, or a `ref`/`out`/`in` argument).

## Changes
- Classification puts the auto-property's backing value in the added-field store under the property key, so it reuses the store's lifetime, its reported names, and the shim-compile reference it already requires.
- The rules that decide whether a value can live in the store were extracted from the field-specific availability check, so fields and auto-properties are rejected on the same grounds and cannot drift apart. Their reasons are translated into the property-specific wording.
- Emission synthesizes the accessor pair directly against the store instead of routing it through the body rewriter, because an auto-property has no user body to rewrite. Static properties use the static store entry points.
- Callers go through the same usage-shape guards as bodied accessors, so a shape the rewriter cannot express is reported as a skip instead of reaching shim compilation as invalid code.
- Replacing a compiled field or event with a property of the same name is refused, because the compiled member keeps owning the value that unedited code reads.
- The tests that pinned the old skip now assert the accessors are emitted. The outside-body drift assertions stay: an added property must still be excluded from declaration-drift warnings.

## Verification
- `uloop compile`: ErrorCount 0
- Single-flight test runs (one class at a time):
  - `TransformWorkerAddedPropertyTests` 28/28
  - `TransformWorkerAddedMemberTests` 57/57
  - `TransformWorkerAddedFieldTests` 62/62
  - `TransformWorkerClientTests` 55/55
  - `HotReloadCrossFileE2ETests` 18/18
  - `HotReloadSkippedMemberCompileNoteTests` 12/12
- `scripts/check-file-length.sh`: no findings
- `scripts/check-code-complexity.sh`: 0 issues (Go cyclop and C# CA1502)
