### PR TITLE
fix: execute-dynamic-code no longer leaves an open Undo recording that dirties UI scenes

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerCancellationTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerCancellationTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -274,6 +276,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         private static string _returnValue = "";
         private static bool _shouldComplete;
         private static bool _shouldThrow;
+        private static bool _shouldRecordUndo;
+        private static ScriptableObject _recordedObject;
         private static bool _runCancelledRequestThenNextRequestSequence;
         private static int _sequenceInvocationCount;
         private static string _partialResultName = string.Empty;
@@ -295,6 +299,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
 
         public static Task StartedTask => _startedCompletionSource.Task;
 
+        /// <summary>
+        /// The object the undo-recording command registered, so a fixture can clear and destroy it.
+        /// </summary>
+        public static ScriptableObject RecordedObject => _recordedObject;
+
         public static Task CancelledRequestStartedTask => _cancelledRequestStartedCompletionSource.Task;
 
         public static Task NextRequestStartedTask => _nextRequestStartedCompletionSource.Task;
@@ -305,6 +314,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             _shouldComplete = false;
             _shouldThrow = false;
+            _shouldRecordUndo = false;
             _runCancelledRequestThenNextRequestSequence = false;
             _returnValue = "";
             _partialResultName = "phase";
@@ -319,6 +329,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             _shouldComplete = true;
             _shouldThrow = false;
+            _shouldRecordUndo = false;
             _runCancelledRequestThenNextRequestSequence = false;
             _returnValue = returnValue;
             _partialResultName = string.Empty;
@@ -334,6 +345,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             _shouldComplete = true;
             _shouldThrow = false;
+            _shouldRecordUndo = false;
             _runCancelledRequestThenNextRequestSequence = false;
             _returnValue = returnValue;
             _partialResultName = partialResultName;
@@ -346,6 +358,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             _shouldComplete = false;
             _shouldThrow = true;
+            _shouldRecordUndo = false;
             _runCancelledRequestThenNextRequestSequence = false;
             _returnValue = string.Empty;
             _partialResultName = partialResultName;
@@ -354,10 +367,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
                 TaskCreationOptions.RunContinuationsAsynchronously);
         }
 
+        public static void PrepareUndoRecordingCommand()
+        {
+            _shouldComplete = false;
+            _shouldThrow = false;
+            _shouldRecordUndo = true;
+            _runCancelledRequestThenNextRequestSequence = false;
+            _returnValue = string.Empty;
+            _partialResultName = string.Empty;
+            _partialResultValue = null;
+            _startedCompletionSource = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public static void ClearRecordedObject()
+        {
+            _recordedObject = null;
+        }
+
         public static void PrepareCancelledRequestThenNextRequestSequence()
         {
             _shouldComplete = false;
             _shouldThrow = false;
+            _shouldRecordUndo = false;
             _runCancelledRequestThenNextRequestSequence = true;
             _sequenceInvocationCount = 0;
             _returnValue = string.Empty;
@@ -409,12 +441,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
                 throw new InvalidOperationException("planned failure");
             }
 
+            if (_shouldRecordUndo)
+            {
+                return Task.FromResult<object>(RecordThroughUndoApi());
+            }
+
             if (_shouldComplete)
             {
                 return Task.FromResult<object>(_returnValue);
             }
 
             return _blockingCompletionSource.Task;
+        }
+
+        /// <summary>
+        /// Registers a real Undo recording so a fixture can observe the recording state the runner leaves.
+        /// Why a ScriptableObject: recording a scene object would dirty the open scene and mask the check.
+        /// </summary>
+        private static string RecordThroughUndoApi()
+        {
+            _recordedObject = ScriptableObject.CreateInstance<ScriptableObject>();
+            Undo.RecordObject(_recordedObject, "Probe");
+            _recordedObject.name = "recorded probe";
+            return "recorded";
         }
 
         private static async Task<object> ExecuteCancelledRequestThenNextRequestSequenceAsync()

--- a/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerUndoGroupTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerUndoGroupTests.cs
@@ -23,6 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         public void TearDown()
         {
             UloopDynamicCodePartialResults.Clear();
+            DestroyRecordedObject();
         }
 
         /// <summary>
@@ -65,9 +66,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         [Test]
         public async Task ExecuteAsync_WhenCommandRecordsNothing_LeavesNoPendingUndoRecording()
         {
-            MethodInfo hasUndoRecordObjects = typeof(DrivenRectTransformTracker)
-                .GetMethod("HasUndoRecordObjects", BindingFlags.NonPublic | BindingFlags.Static);
-            Assert.That(hasUndoRecordObjects, Is.Not.Null, "DrivenRectTransformTracker.HasUndoRecordObjects must exist");
+            MethodInfo hasUndoRecordObjects = GetHasUndoRecordObjectsMethod();
 
             // Why increment first: earlier tests or editor interaction may have left a group open,
             // and this test can only prove anything when it starts from a closed group.
@@ -81,6 +80,51 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
 
             Assert.That(result.Success, Is.True);
             Assert.That((bool)hasUndoRecordObjects.Invoke(null, null), Is.False);
+        }
+
+        /// <summary>
+        /// What: a command that does record through the Undo API still leaves no pending recording behind.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenCommandRecordsUndo_LeavesNoPendingUndoRecording()
+        {
+            MethodInfo hasUndoRecordObjects = GetHasUndoRecordObjectsMethod();
+
+            // Why increment first: earlier tests or editor interaction may have left a group open,
+            // and this test can only prove anything when it starts from a closed group.
+            Undo.IncrementCurrentGroup();
+            Assume.That((bool)hasUndoRecordObjects.Invoke(null, null), Is.False, "precondition");
+
+            WrappedDynamicCommandState.PrepareUndoRecordingCommand();
+            CommandRunner runner = new();
+
+            ExecutionResult result = await runner.ExecuteAsync(CreateContext());
+
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.Result, Is.EqualTo("recorded"));
+            Assert.That(WrappedDynamicCommandState.RecordedObject, Is.Not.Null, "the command must have recorded");
+            Assert.That((bool)hasUndoRecordObjects.Invoke(null, null), Is.False);
+        }
+
+        private static void DestroyRecordedObject()
+        {
+            ScriptableObject recorded = WrappedDynamicCommandState.RecordedObject;
+            WrappedDynamicCommandState.ClearRecordedObject();
+            if (recorded == null)
+            {
+                return;
+            }
+
+            Undo.ClearUndo(recorded);
+            UnityEngine.Object.DestroyImmediate(recorded);
+        }
+
+        private static MethodInfo GetHasUndoRecordObjectsMethod()
+        {
+            MethodInfo hasUndoRecordObjects = typeof(DrivenRectTransformTracker)
+                .GetMethod("HasUndoRecordObjects", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(hasUndoRecordObjects, Is.Not.Null, "DrivenRectTransformTracker.HasUndoRecordObjects must exist");
+            return hasUndoRecordObjects;
         }
 
         private static CommandRunnerUndoHooks CreateRecordingHooks(List<string> calls)

--- a/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerUndoGroupTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerUndoGroupTests.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using DynamicExecutionContext = io.github.hatayama.UnityCliLoop.FirstPartyTools.ExecutionContext;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
+{
+    /// <summary>
+    /// Test fixture that verifies CommandRunner closes its Undo group instead of leaving an open recording.
+    /// </summary>
+    [TestFixture]
+    public class CommandRunnerUndoGroupTests
+    {
+        private const int StubUndoGroup = 42;
+
+        [TearDown]
+        public void TearDown()
+        {
+            UloopDynamicCodePartialResults.Clear();
+        }
+
+        /// <summary>
+        /// What: a completed command collapses the group captured at begin and then increments it, without naming it.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenCommandCompletes_CollapsesThenIncrementsUndoGroupWithoutNamingIt()
+        {
+            List<string> calls = new();
+            CommandRunnerUndoHooks hooks = CreateRecordingHooks(calls);
+            WrappedDynamicCommandState.PrepareReturningCommand("ready");
+            CommandRunner runner = new(DynamicCodeServices.CommandEntryPointResolver, hooks);
+
+            ExecutionResult result = await runner.ExecuteAsync(CreateContext());
+
+            Assert.That(result.Success, Is.True);
+            Assert.That(calls, Is.EqualTo(new[] { "GetCurrentGroup", "Collapse:" + StubUndoGroup, "Increment" }));
+        }
+
+        /// <summary>
+        /// What: a throwing command still collapses and then increments the Undo group.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenCommandThrows_StillCollapsesThenIncrementsUndoGroup()
+        {
+            List<string> calls = new();
+            CommandRunnerUndoHooks hooks = CreateRecordingHooks(calls);
+            WrappedDynamicCommandState.PrepareThrowingCommand("beforeThrow", "saved");
+            CommandRunner runner = new(DynamicCodeServices.CommandEntryPointResolver, hooks);
+
+            ExecutionResult result = await runner.ExecuteAsync(CreateContext());
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(calls, Is.EqualTo(new[] { "GetCurrentGroup", "Collapse:" + StubUndoGroup, "Increment" }));
+        }
+
+        /// <summary>
+        /// What: a command that records nothing leaves no pending Undo recording behind (issue #2626).
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_WhenCommandRecordsNothing_LeavesNoPendingUndoRecording()
+        {
+            MethodInfo hasUndoRecordObjects = typeof(DrivenRectTransformTracker)
+                .GetMethod("HasUndoRecordObjects", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(hasUndoRecordObjects, Is.Not.Null, "DrivenRectTransformTracker.HasUndoRecordObjects must exist");
+
+            // Why increment first: earlier tests or editor interaction may have left a group open,
+            // and this test can only prove anything when it starts from a closed group.
+            Undo.IncrementCurrentGroup();
+            Assume.That((bool)hasUndoRecordObjects.Invoke(null, null), Is.False, "precondition");
+
+            WrappedDynamicCommandState.PrepareReturningCommand("ready");
+            CommandRunner runner = new();
+
+            ExecutionResult result = await runner.ExecuteAsync(CreateContext());
+
+            Assert.That(result.Success, Is.True);
+            Assert.That((bool)hasUndoRecordObjects.Invoke(null, null), Is.False);
+        }
+
+        private static CommandRunnerUndoHooks CreateRecordingHooks(List<string> calls)
+        {
+            return new CommandRunnerUndoHooks
+            {
+                GetCurrentGroup = () =>
+                {
+                    calls.Add("GetCurrentGroup");
+                    return StubUndoGroup;
+                },
+                CollapseUndoOperations = group => calls.Add("Collapse:" + group),
+                IncrementCurrentGroup = () => calls.Add("Increment")
+            };
+        }
+
+        private static DynamicExecutionContext CreateContext()
+        {
+            return new DynamicExecutionContext
+            {
+                CompiledAssembly = typeof(global::UnityCliLoop.Dynamic.DynamicCommand).Assembly,
+                CancellationToken = CancellationToken.None
+            };
+        }
+    }
+}

--- a/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerUndoGroupTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerUndoGroupTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b29a45fb8dd842b2809a4e912c30f8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
@@ -150,9 +150,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             Undo.CollapseUndoOperations(undoGroup);
-            // Why increment: collapsing leaves the PropertyUndoManager in a "has recordings" state;
+            // Why increment: recordings made during the command leave the PropertyUndoManager in a
+            // "has recordings" state that CollapseUndoOperations does not clear;
             // DrivenRectTransformTracker then records RectTransforms during later layout rebuilds and
-            // dirties scenes the command never touched (issue #2626). Incrementing closes that state.
+            // dirties scenes the command never touched (issue #2626). IncrementCurrentGroup closes
+            // the group and clears that state.
             Undo.IncrementCurrentGroup();
         }
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
@@ -118,7 +118,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private void EndExecution(int undoGroup)
         {
-            _executionSlot.End(undoGroup, CollapseUndoGroup);
+            _executionSlot.End(undoGroup, FinishUndoGroup);
         }
 
         private int BeginUndoGroup()
@@ -126,31 +126,34 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (_undoHooks != null)
             {
                 System.Diagnostics.Debug.Assert(_undoHooks.GetCurrentGroup != null, "GetCurrentGroup must be set");
-                System.Diagnostics.Debug.Assert(
-                    _undoHooks.SetCurrentGroupName != null,
-                    "SetCurrentGroupName must be set");
-                int hookedGroup = _undoHooks.GetCurrentGroup();
-                _undoHooks.SetCurrentGroupName("ExecuteDynamicCode");
-                return hookedGroup;
+                return _undoHooks.GetCurrentGroup();
             }
 
-            int undoGroup = Undo.GetCurrentGroup();
-            Undo.SetCurrentGroupName("ExecuteDynamicCode");
-            return undoGroup;
+            // Why no SetCurrentGroupName: naming the group appends an empty history entry for every
+            // read-only command and opens a PropertyUndoManager recording that outlives the command.
+            return Undo.GetCurrentGroup();
         }
 
-        private void CollapseUndoGroup(int undoGroup)
+        private void FinishUndoGroup(int undoGroup)
         {
             if (_undoHooks != null)
             {
                 System.Diagnostics.Debug.Assert(
                     _undoHooks.CollapseUndoOperations != null,
                     "CollapseUndoOperations must be set");
+                System.Diagnostics.Debug.Assert(
+                    _undoHooks.IncrementCurrentGroup != null,
+                    "IncrementCurrentGroup must be set");
                 _undoHooks.CollapseUndoOperations(undoGroup);
+                _undoHooks.IncrementCurrentGroup();
                 return;
             }
 
             Undo.CollapseUndoOperations(undoGroup);
+            // Why increment: collapsing leaves the PropertyUndoManager in a "has recordings" state;
+            // DrivenRectTransformTracker then records RectTransforms during later layout rebuilds and
+            // dirties scenes the command never touched (issue #2626). Incrementing closes that state.
+            Undo.IncrementCurrentGroup();
         }
 
         private static ExecutionResult CreateErrorResult(string errorMessage, List<string> logs = null)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunnerExecutionSlot.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunnerExecutionSlot.cs
@@ -40,16 +40,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
-        /// Ends the execution slot even when undo collapse throws.
-        /// Why nested finally: collapse can throw on a torn-down editor; the running flag must clear.
+        /// Ends the execution slot even when the undo finish (collapse + increment) throws.
+        /// Why nested finally: the undo finish can throw on a torn-down editor; the running flag must clear.
         /// </summary>
-        public void End(int undoGroup, Action<int> collapseUndoGroup)
+        public void End(int undoGroup, Action<int> finishUndoGroup)
         {
-            System.Diagnostics.Debug.Assert(collapseUndoGroup != null, "collapseUndoGroup must not be null");
+            System.Diagnostics.Debug.Assert(finishUndoGroup != null, "finishUndoGroup must not be null");
 
             try
             {
-                collapseUndoGroup(undoGroup);
+                finishUndoGroup(undoGroup);
             }
             finally
             {

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunnerUndoHooks.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunnerUndoHooks.cs
@@ -9,8 +9,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public Func<int> GetCurrentGroup { get; set; }
 
-        public Action<string> SetCurrentGroupName { get; set; }
-
         public Action<int> CollapseUndoOperations { get; set; }
+
+        public Action IncrementCurrentGroup { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- Running a read-only `execute-dynamic-code` command no longer marks open scenes as unsaved.
- Such a command no longer pushes an empty entry onto the Undo history.

Closes #2626

## User Impact

Before: after any `execute-dynamic-code` run — even something as harmless as `return 1;` — the next UI layout rebuild or script reload marked the open scene dirty, so scenes had to be saved or discarded even though nothing had changed. Every run also left one empty "ExecuteDynamicCode" entry in the Undo history.

After: a command that records nothing leaves the Undo state exactly as it found it, and no scene is dirtied. A command that does record through the Undo API still collapses into a single entry that one undo reverts, as before.

## Changes

- The runner no longer names its Undo group. Naming it appended an empty history entry and put the property undo manager into a "has recordings" state that collapsing does not clear; `DrivenRectTransformTracker` reads that state and started recording `RectTransform`s during later layout rebuilds.
- After collapsing, the runner now increments the current Undo group. Incrementing clears that recording state and adds no history entry when the group is empty.
- Renamed the internal collapse step to reflect that it now collapses and closes the group, and swapped the corresponding test hook.

## Verification

- `uloop compile` — 0 errors.
- New fixture `CommandRunnerUndoGroupTests` (3 tests): observed all 3 failing before the fix, all 3 passing after.
  - Two hook-injected tests pin the exact Undo call order (`GetCurrentGroup` → `Collapse` → `Increment`, with no group naming), on both the success and the throwing path.
  - One test drives the real Unity Undo API and asserts no pending recording remains.
- Existing fixtures re-run individually, all green: `CommandRunnerTests` (2), `CommandRunnerCancellationTests` (7), `DynamicCodeExecutorTests` (4).
- Manual probe in a live editor: closed the current Undo group, ran `execute-dynamic-code --code 'return 1;'`, then re-read the tracker state 8 seconds later. Result: `Initial=False`, `AfterCommand=False` (before the fix, `AfterCommand` was `True`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

