### PR TITLE
fix: release PR checks skip instead of fail when release-please moves the PR head mid-run

### DIFF
--- a/cli/release-automation/internal/automation/release_pr_checks.go
+++ b/cli/release-automation/internal/automation/release_pr_checks.go
@@ -99,9 +99,14 @@ func runReleasePleasePRChecksWithDeps(ctx context.Context, stdout io.Writer, std
 	if code := prepareReleasePRForChecks(ctx, stdout, stderr, config, releasePR, deps); code != 0 {
 		return code
 	}
-	checkedHeadSHA, code := dispatchAndWatchReleasePRCheckWorkflows(ctx, stdout, stderr, config, releasePR, deps)
+	checkedHeadSHA, skipped, code := dispatchAndWatchReleasePRCheckWorkflows(ctx, stdout, stderr, config, releasePR, deps)
 	if code != 0 {
 		return code
+	}
+	// Skip and failure are separate results because exit 0 covers both "marked ready"
+	// and "left in draft", and only the latter must bypass finalize.
+	if skipped {
+		return 0
 	}
 	return finalizeReleasePRChecks(ctx, stdout, stderr, config, releasePR, checkedHeadSHA, deps)
 }
@@ -136,9 +141,11 @@ func prepareReleasePRForChecks(
 }
 
 // dispatchAndWatchReleasePRCheckWorkflows dispatches each required workflow
-// and waits for the same head SHA. Why reject mixed heads: a release-please
-// force-push between dispatches would otherwise let a mixed set of green runs
-// mark the PR ready.
+// and waits for the same head SHA. Why never mark ready on mixed heads: a
+// release-please force-push between dispatches would otherwise let a mixed set
+// of green runs mark the PR ready. Why skip instead of failing: that update
+// means a newer release-please run already owns the checks for the new head, so
+// failing here only files a release-failure issue nobody acts on.
 func dispatchAndWatchReleasePRCheckWorkflows(
 	ctx context.Context,
 	stdout io.Writer,
@@ -146,29 +153,28 @@ func dispatchAndWatchReleasePRCheckWorkflows(
 	config releasePRCheckConfig,
 	releasePR releasePullRequest,
 	deps releasePRCheckDeps,
-) (string, int) {
+) (checkedHeadSHA string, skipped bool, exitCode int) {
 	description := fmt.Sprintf("release PR #%d: %s", releasePR.Number, releasePR.URL)
 	dispatchedAt, err := dispatchPullRequestCheckWorkflows(
 		ctx, stdout, config.repository, releasePR.HeadRefName, description, config.workflows, deps)
 	if err != nil {
 		writeReleasePRCheckLine(stderr, err)
-		return "", 1
+		return "", false, 1
 	}
 
-	checkedHeadSHA := ""
 	checkedHeadWorkflow := ""
 	for _, workflow := range config.workflows {
 		run, err := findDispatchedReleasePRCheckRun(ctx, config, workflow, releasePR, dispatchedAt, deps)
 		if err != nil {
 			writeReleasePRCheckLine(stderr, err)
-			return "", 1
+			return "", false, 1
 		}
 
 		writeReleasePRCheckLine(stdout, fmt.Sprintf("Watching %s run %d for release PR #%d.", workflow, run.DatabaseID, releasePR.Number))
 		err = watchReleasePRCheckRun(ctx, config, run.DatabaseID, deps)
 		if err != nil {
 			writeReleasePRCheckLine(stderr, err)
-			return "", 1
+			return "", false, 1
 		}
 
 		if checkedHeadSHA == "" {
@@ -177,13 +183,13 @@ func dispatchAndWatchReleasePRCheckWorkflows(
 			continue
 		}
 		if run.HeadSHA != checkedHeadSHA {
-			writeReleasePRCheckLine(stderr, fmt.Errorf(
-				"release PR #%d checks ran on different heads: %s checked %s but %s checked %s",
+			writeReleasePRCheckLine(stdout, fmt.Sprintf(
+				"Skipping release PR #%d: checks ran on different heads (%s checked %s, %s checked %s); the release-please run for the new head will re-dispatch the checks.",
 				releasePR.Number, checkedHeadWorkflow, checkedHeadSHA, workflow, run.HeadSHA))
-			return "", 1
+			return "", true, 0
 		}
 	}
-	return checkedHeadSHA, 0
+	return checkedHeadSHA, false, 0
 }
 
 func finalizeReleasePRChecks(
@@ -195,10 +201,14 @@ func finalizeReleasePRChecks(
 	checkedHeadSHA string,
 	deps releasePRCheckDeps,
 ) int {
-	err := verifyReleasePRCheckHeadMatchesRun(ctx, config, releasePR, checkedHeadSHA, deps)
+	skipMessage, err := verifyReleasePRCheckHeadMatchesRun(ctx, config, releasePR, checkedHeadSHA, deps)
 	if err != nil {
 		writeReleasePRCheckLine(stderr, err)
 		return 1
+	}
+	if skipMessage != "" {
+		writeReleasePRCheckLine(stdout, skipMessage)
+		return 0
 	}
 
 	err = markReleasePRCheckReady(ctx, config, releasePR, deps)
@@ -405,27 +415,34 @@ func clarifyReleasePRCheckBody(ctx context.Context, config releasePRCheckConfig,
 	return true, nil
 }
 
+// verifyReleasePRCheckHeadMatchesRun re-reads the pending release PR before
+// marking it ready. A moved head is returned as a skip message rather than an
+// error, because the release-please run for the new head re-dispatches the
+// checks; a missing or renumbered PR stays an error because it is not a race
+// the next run resolves.
 func verifyReleasePRCheckHeadMatchesRun(
 	ctx context.Context,
 	config releasePRCheckConfig,
 	releasePR releasePullRequest,
 	checkedHeadSHA string,
 	deps releasePRCheckDeps,
-) error {
+) (string, error) {
 	currentReleasePR, found, err := findReleasePRCheckPullRequest(ctx, config, deps)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if !found {
-		return fmt.Errorf("release PR #%d is no longer pending before marking ready", releasePR.Number)
+		return "", fmt.Errorf("release PR #%d is no longer pending before marking ready", releasePR.Number)
 	}
 	if currentReleasePR.Number != releasePR.Number {
-		return fmt.Errorf("pending release PR changed from #%d to #%d before marking ready", releasePR.Number, currentReleasePR.Number)
+		return "", fmt.Errorf("pending release PR changed from #%d to #%d before marking ready", releasePR.Number, currentReleasePR.Number)
 	}
 	if currentReleasePR.HeadRefOID != checkedHeadSHA {
-		return fmt.Errorf("release PR #%d head changed from %s to %s before marking ready", releasePR.Number, checkedHeadSHA, currentReleasePR.HeadRefOID)
+		return fmt.Sprintf(
+			"Skipping release PR #%d: head changed from %s to %s after the checks ran; the release-please run for the new head will re-dispatch the checks.",
+			releasePR.Number, checkedHeadSHA, currentReleasePR.HeadRefOID), nil
 	}
-	return nil
+	return "", nil
 }
 
 func runReleasePRCheckCommandOutput(ctx context.Context, name string, args ...string) (string, error) {

--- a/cli/release-automation/internal/automation/release_pr_checks_test.go
+++ b/cli/release-automation/internal/automation/release_pr_checks_test.go
@@ -228,8 +228,8 @@ func TestReleasePRChecksFailWhenWorkflowListIsBlank(t *testing.T) {
 	assertReleasePRCheckLogContains(t, result.stderr, "RELEASE_PR_CHECK_WORKFLOWS must list at least one workflow")
 }
 
-// Verifies that check runs watching different branch heads fail while leaving the PR drafted.
-func TestReleasePRChecksFailWhenRunsCheckDifferentHeads(t *testing.T) {
+// Verifies that a release PR whose dispatched checks ran on different heads is left in draft and the run exits 0, because the newer release-please run owns the re-check.
+func TestReleasePRChecksSkipWhenRunsCheckDifferentHeads(t *testing.T) {
 	result := runReleasePRCheckCase(t, releasePRCheckCase{
 		prListJSON:              `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"abc123","title":"chore: release v3-beta","url":"https://example.test/pr/1043"}]`,
 		runListJSON:             `[{"databaseId":4242,"headSha":"abc123","createdAt":"2026-05-30T01:00:01Z","status":"queued","conclusion":"","url":"https://example.test/run/4242"}]`,
@@ -237,10 +237,13 @@ func TestReleasePRChecksFailWhenRunsCheckDifferentHeads(t *testing.T) {
 		runWatchStatus:          "0",
 	})
 
-	if result.exitCode != 1 {
-		t.Fatalf("expected exit code 1, got %d", result.exitCode)
+	if result.exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", result.exitCode, result.stderr)
 	}
-	assertReleasePRCheckLogContains(t, result.stderr, "release PR #1043 checks ran on different heads: build-and-test.yml checked abc123 but unity-compile-check-and-test-runner.yml checked def456")
+	assertReleasePRCheckLogContains(t, result.stdout, "Skipping release PR #1043: checks ran on different heads (build-and-test.yml checked abc123, unity-compile-check-and-test-runner.yml checked def456); the release-please run for the new head will re-dispatch the checks.")
+	if result.stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", result.stderr)
+	}
 	assertReleasePRCheckLogContains(t, result.ghLog, "pr ready 1043 --repo owner/repository --undo")
 	assertReleasePRCheckLogDoesNotContainLine(t, result.ghLog, "pr ready 1043 --repo owner/repository")
 }
@@ -385,8 +388,8 @@ func TestReleasePRChecksFailWhenWatchedRunFails(t *testing.T) {
 	assertReleasePRCheckLogDoesNotContainLine(t, result.ghLog, "pr ready 1043 --repo owner/repository")
 }
 
-// Verifies that a changed release PR head is not marked ready after stale checks pass.
-func TestReleasePRChecksFailWhenHeadChangesBeforeReady(t *testing.T) {
+// Verifies that a release PR whose head moved after the checks passed is left in draft and the run exits 0 instead of failing.
+func TestReleasePRChecksSkipWhenHeadChangesBeforeReady(t *testing.T) {
 	result := runReleasePRCheckCase(t, releasePRCheckCase{
 		prListJSON:           `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"abc123","title":"chore: release v3-beta","url":"https://example.test/pr/1043"}]`,
 		prListJSONAfterWatch: `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"def456","title":"chore: release v3-beta","url":"https://example.test/pr/1043"}]`,
@@ -394,10 +397,13 @@ func TestReleasePRChecksFailWhenHeadChangesBeforeReady(t *testing.T) {
 		runWatchStatus:       "0",
 	})
 
-	if result.exitCode != 1 {
-		t.Fatalf("expected exit code 1, got %d", result.exitCode)
+	if result.exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", result.exitCode, result.stderr)
 	}
-	assertReleasePRCheckLogContains(t, result.stderr, "release PR #1043 head changed from abc123 to def456 before marking ready")
+	assertReleasePRCheckLogContains(t, result.stdout, "Skipping release PR #1043: head changed from abc123 to def456 after the checks ran; the release-please run for the new head will re-dispatch the checks.")
+	if result.stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", result.stderr)
+	}
 	assertReleasePRCheckLogContains(t, result.ghLog, "pr ready 1043 --repo owner/repository --undo")
 	assertReleasePRCheckLogDoesNotContainLine(t, result.ghLog, "pr ready 1043 --repo owner/repository")
 }


### PR DESCRIPTION
## Summary

`Dispatch release PR checks` dispatches `build-and-test.yml` and `unity-compile-check-and-test-runner.yml` against the release PR head and waits for both before marking the PR ready. When another pull request lands on the target branch during that wait, release-please rewrites the release PR and its head SHA moves. Two things could then happen, and both exited 1:

- the two dispatched workflows checked different heads
- the head no longer matched the checked SHA at the final re-verification

A failure there files a `release-failure` issue, but nobody has to act on it: the release-please run triggered by the new main commit re-drafts the PR, re-dispatches the checks against the new head, and marks it ready. Issues #2617, #2542 and #2505 are all this pattern and all recovered on the next run.

Observed failure line from #2617:

```
release PR #2610 checks ran on different heads: build-and-test.yml checked <sha-a> but unity-compile-check-and-test-runner.yml checked <sha-b>
```

## Change

Both head-moved cases now write a one-line explanation to stdout and exit 0, leaving the release PR in draft so the next release-please run picks it up. With the same input as above the command now exits 0 and prints:

```
Skipping release PR #2610: checks ran on different heads (build-and-test.yml checked <sha-a>, unity-compile-check-and-test-runner.yml checked <sha-b>); the release-please run for the new head will re-dispatch the checks.
```

Nothing else is relaxed. `gh pr ready` is still never called on a head the checks did not cover, and a missing pending PR, a renumbered PR, a dispatch error, and a failing watched run all remain exit 1.

## Verification

- `cd cli/release-automation && go test ./...` — pass
- `scripts/check-go-cli.sh` — exit 0 (format / vet / lint incl. cyclop / tests / dist rebuild)

The two tests covering these cases were rewritten from failure expectations to skip expectations (`TestReleasePRChecksSkipWhenRunsCheckDifferentHeads`, `TestReleasePRChecksSkipWhenHeadChangesBeforeReady`); both also assert that stderr stays empty so a skip cannot be misread as a failure.

Refs #2617


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

