### PR TITLE
chore: Stop the Editor from leaving an uncommitted physics settings change on every launch

### DIFF
--- a/ProjectSettings/DynamicsManager.asset
+++ b/ProjectSettings/DynamicsManager.asset
@@ -3,10 +3,11 @@
 --- !u!55 &1
 PhysicsManager:
   m_ObjectHideFlags: 0
-  serializedVersion: 13
+  serializedVersion: 14
   m_Gravity: {x: 0, y: -9.81, z: 0}
   m_DefaultMaterial: {fileID: 0}
   m_BounceThreshold: 2
+  m_DefaultMaxDepenetrationVelocity: 10
   m_SleepThreshold: 0.005
   m_DefaultContactOffset: 0.01
   m_DefaultSolverIterations: 6
@@ -18,9 +19,10 @@ PhysicsManager:
   m_ClothInterCollisionStiffness: 0.2
   m_ContactsGeneration: 1
   m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-  m_AutoSimulation: 1
+  m_SimulationMode: 0
   m_AutoSyncTransforms: 0
   m_ReuseCollisionCallbacks: 1
+  m_InvokeCollisionCallbacks: 1
   m_ClothInterCollisionSettingsToggle: 0
   m_ClothGravity: {x: 0, y: -9.81, z: 0}
   m_ContactPairsMode: 0
@@ -32,5 +34,7 @@ PhysicsManager:
   m_FrictionType: 0
   m_EnableEnhancedDeterminism: 0
   m_EnableUnifiedHeightmaps: 1
+  m_ImprovedPatchFriction: 0
   m_SolverType: 0
   m_DefaultMaxAngularSpeed: 50
+  m_FastMotionThreshold: 3.4028235e+38


### PR DESCRIPTION
## Summary

- A fresh clone of this project no longer shows a modified physics settings file as soon as the Editor opens it.

## User Impact

Opening the project in the Editor upgraded the physics settings asset to the serialization version the
current Editor writes, and rewrote the file with the fields that version adds. The upgraded file was never
committed, so every session left the same unstaged change in the working tree — noise in `git status` that
had to be re-checked and set aside before every commit, and a diff that reappeared as soon as it was
reverted.

The upgraded file is now the committed one, so the Editor finds nothing to rewrite and the working tree
stays clean.

## Changes

- Commit `ProjectSettings/DynamicsManager.asset` as the Editor writes it: `serializedVersion` 13 to 14,
  plus the fields that version introduces, each holding the Editor's own default.
- No settings change is carried by the upgrade. `m_AutoSimulation: 1` is renamed to `m_SimulationMode: 0`,
  which is the same FixedUpdate simulation, and every added field keeps its default value.

## Verification

- `git diff` on the branch touches this one file only, and every line is either the version bump, a renamed
  key with an equivalent value, or an added key at its default.
- The full EditMode suite passed on the merge commit this branch is cut from (4065 passed, 0 failed,
  8 skipped).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

