### PR TITLE
fix: The dynamic compilation error now names the compiler files it could not find

### DIFF
--- a/.github/workflows/unity-editmode-tests.yml
+++ b/.github/workflows/unity-editmode-tests.yml
@@ -2,6 +2,13 @@ name: Unity EditMode Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      inspect-layout-only:
+        description: >-
+          Print the 6000.7 editor's compiler layout and skip the test run.
+          Temporary; removed once the resolver probes that layout.
+        type: boolean
+        default: false
   schedule:
     - cron: '0 18 * * *'
 
@@ -13,6 +20,7 @@ jobs:
   concurrency-unit-tests:
     name: Concurrency Unit Tests
     runs-on: ubuntu-latest
+    if: ${{ !inputs.inspect-layout-only }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -31,6 +39,7 @@ jobs:
   editmode-tests:
     name: EditMode Tests (${{ matrix.unity-version }})
     runs-on: ubuntu-latest
+    if: ${{ !inputs.inspect-layout-only }}
     strategy:
       fail-fast: false
       matrix:
@@ -260,6 +269,30 @@ jobs:
           echo "Installed Unity $UNITY_VERSION at $UNITY_EDITOR"
           df -h
 
+      # Temporary: prints where this editor keeps the external compiler so the
+      # resolver's probe list can be extended. Removed once the probe lands.
+      - name: Inspect editor compiler layout
+        if: env.HAS_UNITY_LICENSE == 'true' && inputs.inspect-layout-only
+        run: |
+          set -eu
+          EDITOR_DATA=$(dirname "$UNITY_EDITOR")/Data
+          echo "::group::Editor/Data"
+          ls -1 "$EDITOR_DATA"
+          echo "::endgroup::"
+          echo "::group::Editor/Data/Resources/Scripting"
+          ls -1 "$EDITOR_DATA/Resources/Scripting" || echo "(absent)"
+          echo "::endgroup::"
+          echo "::group::compiler components"
+          find "$EDITOR_DATA" \
+            \( -name csc.dll \
+            -o -name csc.runtimeconfig.json \
+            -o -name csc.deps.json \
+            -o -name 'Microsoft.CodeAnalysis*.dll' \
+            -o -name dotnet -type f \
+            -o -name Microsoft.NETCore.App \) \
+            -printf '%P\n' | sort
+          echo "::endgroup::"
+
       - name: Cache Library folder
         if: env.HAS_UNITY_LICENSE == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
@@ -270,7 +303,7 @@ jobs:
             Library-${{ env.UNITY_VERSION }}-debug-
 
       - name: Activate Unity license and run EditMode tests
-        if: env.HAS_UNITY_LICENSE == 'true'
+        if: env.HAS_UNITY_LICENSE == 'true' && !inputs.inspect-layout-only
         timeout-minutes: 60
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -342,7 +375,7 @@ jobs:
 
       - name: Upload latest 6000.7 test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        if: always() && env.HAS_UNITY_LICENSE == 'true'
+        if: always() && env.HAS_UNITY_LICENSE == 'true' && !inputs.inspect-layout-only
         with:
           name: Unity test results (latest 6000.7)
           path: artifacts

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCompilationHealthMonitorTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCompilationHealthMonitorTests.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
+{
+    /// <summary>
+    /// Test fixture that verifies how Dynamic Compilation Health reports name the paths it could not find.
+    /// </summary>
+    [TestFixture]
+    public class DynamicCompilationHealthMonitorTests
+    {
+        /// <summary>
+        /// Every missing path reaches the report text, so a layout change can be diagnosed from the log alone.
+        /// </summary>
+        [Test]
+        public void FormatMissingComponents_WithSeveralPaths_ListsEveryPath()
+        {
+            string formatted = DynamicCompilationHealthMonitor.FormatMissingComponents(new[]
+            {
+                "/editor/Data/DotNetSdkRoslyn/csc.dll",
+                "/editor/Data/DotNetSdk/dotnet",
+                "/editor/Data/NetCoreRuntime/shared/Microsoft.NETCore.App"
+            });
+
+            Assert.That(formatted, Does.Contain("/editor/Data/DotNetSdkRoslyn/csc.dll"));
+            Assert.That(formatted, Does.Contain("/editor/Data/DotNetSdk/dotnet"));
+            Assert.That(formatted, Does.Contain("/editor/Data/NetCoreRuntime/shared/Microsoft.NETCore.App"));
+        }
+
+        /// <summary>
+        /// The report must never fall back to the collection's type name, which is what hid the paths before.
+        /// </summary>
+        [Test]
+        public void FormatMissingComponents_WithSeveralPaths_DoesNotPrintTheCollectionTypeName()
+        {
+            List<string> missingComponents = new()
+            {
+                "/editor/Data/DotNetSdkRoslyn/csc.dll"
+            };
+
+            string formatted = DynamicCompilationHealthMonitor.FormatMissingComponents(missingComponents);
+
+            Assert.That(formatted, Does.Not.Contain("System.Collections.Generic"));
+            Assert.That(formatted, Does.Not.Contain(missingComponents.GetType().ToString()));
+        }
+
+        /// <summary>
+        /// An empty list still has to read as "nothing was reported" rather than as an empty log line.
+        /// </summary>
+        [Test]
+        public void FormatMissingComponents_WithNoPaths_ReportsThatNoneWereCollected()
+        {
+            string formatted = DynamicCompilationHealthMonitor.FormatMissingComponents(new string[0]);
+
+            Assert.That(formatted, Is.Not.Empty);
+        }
+
+        /// <summary>
+        /// A null collection must not throw while a report is being written about a failure.
+        /// </summary>
+        [Test]
+        public void FormatMissingComponents_WithNullCollection_ReportsThatNoneWereCollected()
+        {
+            string formatted = DynamicCompilationHealthMonitor.FormatMissingComponents(null);
+
+            Assert.That(formatted, Is.Not.Empty);
+        }
+
+        /// <summary>
+        /// The context the report carries names each missing path, so the console line is self-contained.
+        /// </summary>
+        [Test]
+        public void BuildFastPathUnavailableContext_WithMissingPaths_NamesEachPathInItsText()
+        {
+            object context = DynamicCompilationHealthMonitor.BuildFastPathUnavailableContext(
+                "/editor/Unity",
+                "/editor/Data",
+                new[]
+                {
+                    "/editor/Data/DotNetSdkRoslyn/csc.dll",
+                    "/editor/Data/DotNetSdk/dotnet"
+                });
+
+            string contextText = context.ToString();
+
+            Assert.That(contextText, Does.Contain("/editor/Unity"));
+            Assert.That(contextText, Does.Contain("/editor/Data"));
+            Assert.That(contextText, Does.Contain("/editor/Data/DotNetSdkRoslyn/csc.dll"));
+            Assert.That(contextText, Does.Contain("/editor/Data/DotNetSdk/dotnet"));
+            Assert.That(contextText, Does.Not.Contain("System.Collections.Generic"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCompilationHealthMonitorTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCompilationHealthMonitorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f282fed8f83d5405ea6b52c05ae0619f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/DynamicCompilationHealthMonitor.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/DynamicCompilationHealthMonitor.cs
@@ -10,6 +10,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public static class DynamicCompilationHealthMonitor
     {
+        private const string MissingComponentSeparator = " | ";
+        private const string NoMissingComponentsText = "(none collected)";
+
         private static readonly object ReportedIssueLock = new();
         private static readonly HashSet<string> ReportedIssues = new(System.StringComparer.Ordinal);
 
@@ -23,12 +26,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 issueKey,
                 "dynamic_code_fast_path_unavailable",
                 "execute-dynamic-code fast Roslyn path is unavailable; AssemblyBuilder fallback will be used",
-                new
-                {
-                    editor_path = editorPath,
-                    editor_contents_path = contentsPath,
-                    missing_components = missingComponents
-                },
+                BuildFastPathUnavailableContext(editorPath, contentsPath, missingComponents),
                 "Fast dynamic compilation path is unavailable in this Unity installation.",
                 "Check Unity version layout changes and external compiler path resolution assumptions.");
         }
@@ -79,6 +77,34 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 context,
                 "One-shot Roslyn compiler could not be started.",
                 "Investigate Unity-bundled dotnet/csc availability and process launch assumptions.");
+        }
+
+        // Why the paths are joined here: the console report renders the context with ToString, and a
+        // collection answers that with its type name, which hid every path this report exists to name.
+        internal static object BuildFastPathUnavailableContext(
+            string editorPath,
+            string contentsPath,
+            IReadOnlyCollection<string> missingComponents)
+        {
+            return new
+            {
+                editor_path = editorPath,
+                editor_contents_path = contentsPath,
+                missing_components = FormatMissingComponents(missingComponents)
+            };
+        }
+
+        /// <summary>
+        /// Renders the paths a resolver could not find as one line a reader can act on.
+        /// </summary>
+        internal static string FormatMissingComponents(IReadOnlyCollection<string> missingComponents)
+        {
+            if (missingComponents == null || missingComponents.Count == 0)
+            {
+                return NoMissingComponentsText;
+            }
+
+            return string.Join(MissingComponentSeparator, missingComponents);
         }
 
         private static void LogErrorOnce(


### PR DESCRIPTION
## Summary

- When the fast Roslyn compilation path is unavailable, the error now names the paths that were missing instead of printing a collection type name.

## User Impact

Hot reload and `execute-dynamic-code` fall back to a slower path when the Editor's bundled compiler
cannot be located, and the report that explains why is the only place the absent paths are named. That
report printed them as `System.Collections.Generic.List\`1[System.String]`, so it told a reader that
something was missing without saying what. Every Editor layout change therefore had to be diagnosed by
guesswork.

The report now lists each path, so the cause is visible in the log line itself.

Before:

```
context: { editor_path = .../Editor/Unity, editor_contents_path = .../Editor/Data, missing_components = System.Collections.Generic.List`1[System.String] }
```

After:

```
context: { editor_path = .../Editor/Unity, editor_contents_path = .../Editor/Data, missing_components = .../DotNetSdkRoslyn/csc.dll | .../DotNetSdk/dotnet | .../NetCoreRuntime/shared/Microsoft.NETCore.App }
```

## Changes

- Build the report's context through a dedicated helper that joins the missing paths, and cover the
  formatting with tests including the empty and null cases.
- Add a temporary, opt-in workflow step that prints where the newest 6000.7 alpha keeps its compiler
  components, so the resolver's probe list can be extended from an observed layout rather than a guess.
  The step only runs on a manual dispatch with `inspect-layout-only`, skips the license activation and
  the test run, and is removed by the change that adds the probe.

## Verification

- `run-tests --filter-type class --filter-value DynamicCompilationHealthMonitorTests`: 5 passed, 0 failed.
- Non-vacuity: restoring the old formatting turns 3 of the 5 into failures.
- Workflow parses as YAML and the dispatch input is present.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

