### PR TITLE
feat: Keep hot-reload introduced types loaded for the whole Editor session

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeArtifactPathFactoryTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeArtifactPathFactoryTests.cs
@@ -1,0 +1,33 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Covers artifact output isolation without creating files during planning.
+    /// </summary>
+    public class HotReloadIntroducedTypeArtifactPathFactoryTests
+    {
+        /// <summary>
+        /// Verifies that separate preparation attempts receive different assembly names and retain
+        /// the DLL/PDB pair beneath the introduced-types lifetime directory.
+        /// </summary>
+        [Test]
+        public void Create_SeparateBatches_UsesUniqueAssemblyAndPairedPaths()
+        {
+            HotReloadIntroducedTypeArtifactPathFactory factory =
+                new HotReloadIntroducedTypeArtifactPathFactory("project", "session");
+
+            HotReloadIntroducedTypeArtifactPaths first = factory.Create();
+            HotReloadIntroducedTypeArtifactPaths second = factory.Create();
+
+            Assert.That(first.AssemblyName, Is.Not.EqualTo(second.AssemblyName));
+            Assert.That(first.DllPath, Does.Contain("IntroducedTypes"));
+            Assert.That(first.DllPath, Does.EndWith(first.AssemblyName + ".dll"));
+            Assert.That(first.PdbPath, Does.EndWith(first.AssemblyName + ".pdb"));
+            Assert.That(first.SourcePath, Does.EndWith(first.AssemblyName + ".cs"));
+            Assert.That(first.AssemblyFullName, Does.StartWith(first.AssemblyName + ", Version=0.0.0.0"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeArtifactPathFactoryTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeArtifactPathFactoryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 838020e66f1ee473d9cbc9f84768afaa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompilerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompilerTests.cs
@@ -297,11 +297,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// Verifies that source-path uniqueness follows the platform's file-system case rules, so
-        /// two spellings Windows resolves to one file are rejected before either source is written.
+        /// Verifies that two source paths differing only in case are rejected before either is
+        /// written, because a case-insensitive volume resolves both spellings to one file.
         /// </summary>
         [Test]
-        public void CompilationRequest_CaseOnlyDuplicateSources_FollowsPlatformPathRules()
+        public void CompilationRequest_CaseOnlyDuplicateSources_RejectsBeforeWrites()
         {
             HotReloadIntroducedTypeDescriptor descriptor = CreateDescriptor("Example.Introduced", "Assets/Example.cs");
             FakeEnvironment environment = new FakeEnvironment();
@@ -311,16 +311,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 new HotReloadIntroducedTypeSource("duplicate.cs", descriptor)
             };
 
-            if (Path.DirectorySeparatorChar == '\\')
-            {
-                ArgumentException exception = Assert.Throws<ArgumentException>(() => CreateRequestFrom(sources));
-                Assert.That(exception.ParamName, Is.EqualTo("sources"));
-            }
-            else
-            {
-                Assert.DoesNotThrow(() => CreateRequestFrom(sources));
-            }
+            ArgumentException exception = Assert.Throws<ArgumentException>(() => CreateRequestFrom(sources));
 
+            Assert.That(exception.ParamName, Is.EqualTo("sources"));
             Assert.That(environment.WriteSourceCalls, Is.EqualTo(0));
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompilerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompilerTests.cs
@@ -318,6 +318,130 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that a batch carrying two descriptors with one identity is rejected before any
+        /// source is written or any assembly is loaded.
+        /// </summary>
+        [Test]
+        public void CompilationRequest_DuplicateDescriptorIdentity_RejectsBeforeWrites()
+        {
+            HotReloadIntroducedTypeDescriptor first = CreateDescriptor("Example.Introduced", "Assets/Example.cs");
+            HotReloadIntroducedTypeDescriptor second = CreateDescriptor("Example.Introduced", "Assets/Other.cs");
+            FakeEnvironment environment = new FakeEnvironment();
+            HotReloadIntroducedTypeSource[] sources =
+            {
+                new HotReloadIntroducedTypeSource("first.cs", first),
+                new HotReloadIntroducedTypeSource("second.cs", second)
+            };
+
+            ArgumentException exception = Assert.Throws<ArgumentException>(() => CreateRequestFrom(sources));
+
+            Assert.That(exception.ParamName, Is.EqualTo("descriptors"));
+            Assert.That(environment.WriteSourceCalls, Is.EqualTo(0));
+            Assert.That(environment.LoadCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies that a descriptor list whose count differs from the source list is rejected,
+        /// so a source can never be compiled without the descriptor it belongs to.
+        /// </summary>
+        [Test]
+        public void CompilationRequest_DescriptorCountMismatch_RejectsBeforeWrites()
+        {
+            HotReloadIntroducedTypeDescriptor first = CreateDescriptor("Example.First", "Assets/First.cs");
+            HotReloadIntroducedTypeDescriptor second = CreateDescriptor("Example.Second", "Assets/Second.cs");
+            FakeEnvironment environment = new FakeEnvironment();
+
+            ArgumentException exception = Assert.Throws<ArgumentException>(
+                () => new HotReloadIntroducedTypeCompilationRequest(
+                    new[] { new HotReloadIntroducedTypeSource("first.cs", first) },
+                    "artifact.dll",
+                    "artifact.pdb",
+                    typeof(HotReloadIntroducedTypeCompilerTests).Assembly.FullName,
+                    new[] { first, second },
+                    Array.Empty<string>(),
+                    Array.Empty<string>()));
+
+            Assert.That(exception.ParamName, Is.EqualTo("sources"));
+            Assert.That(environment.WriteSourceCalls, Is.EqualTo(0));
+            Assert.That(environment.LoadCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies that a source paired with a descriptor at another position is rejected, so the
+        /// diagnostics that map a source path back to its owner cannot name the wrong file.
+        /// </summary>
+        [Test]
+        public void CompilationRequest_MisorderedDescriptors_RejectsBeforeWrites()
+        {
+            HotReloadIntroducedTypeDescriptor first = CreateDescriptor("Example.First", "Assets/First.cs");
+            HotReloadIntroducedTypeDescriptor second = CreateDescriptor("Example.Second", "Assets/Second.cs");
+            FakeEnvironment environment = new FakeEnvironment();
+
+            ArgumentException exception = Assert.Throws<ArgumentException>(
+                () => new HotReloadIntroducedTypeCompilationRequest(
+                    new[]
+                    {
+                        new HotReloadIntroducedTypeSource("first.cs", first),
+                        new HotReloadIntroducedTypeSource("second.cs", second)
+                    },
+                    "artifact.dll",
+                    "artifact.pdb",
+                    typeof(HotReloadIntroducedTypeCompilerTests).Assembly.FullName,
+                    new[] { second, first },
+                    Array.Empty<string>(),
+                    Array.Empty<string>()));
+
+            Assert.That(exception.ParamName, Is.EqualTo("sources"));
+            Assert.That(environment.WriteSourceCalls, Is.EqualTo(0));
+            Assert.That(environment.LoadCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies that a descriptor with an empty identity part is rejected at construction,
+        /// because BuildIdentity would otherwise collapse distinct declarations onto one key.
+        /// </summary>
+        [Test]
+        public void Descriptor_EmptyIdentityPart_IsRejected()
+        {
+            Assert.That(
+                Assert.Throws<ArgumentException>(() => new HotReloadIntroducedTypeDescriptor(
+                    string.Empty,
+                    "original-mvid",
+                    "Example.Introduced",
+                    "Assets/Example.cs",
+                    "fingerprint",
+                    "public class Introduced { }")).ParamName,
+                Is.EqualTo("originalAssemblyName"));
+            Assert.That(
+                Assert.Throws<ArgumentException>(() => new HotReloadIntroducedTypeDescriptor(
+                    "OriginalAssembly",
+                    null,
+                    "Example.Introduced",
+                    "Assets/Example.cs",
+                    "fingerprint",
+                    "public class Introduced { }")).ParamName,
+                Is.EqualTo("originalAssemblyMvid"));
+            Assert.That(
+                Assert.Throws<ArgumentException>(() => new HotReloadIntroducedTypeDescriptor(
+                    "OriginalAssembly",
+                    "original-mvid",
+                    "   ",
+                    "Assets/Example.cs",
+                    "fingerprint",
+                    "public class Introduced { }")).ParamName,
+                Is.EqualTo("metadataName"));
+            Assert.That(
+                Assert.Throws<ArgumentException>(() => new HotReloadIntroducedTypeDescriptor(
+                    "OriginalAssembly",
+                    "original-mvid",
+                    "Example.Introduced",
+                    "Assets/Example.cs",
+                    string.Empty,
+                    "public class Introduced { }")).ParamName,
+                Is.EqualTo("declarationFingerprint"));
+        }
+
+        /// <summary>
         /// Verifies that a request copies its source records so later caller mutations cannot
         /// change the batch that awaits compilation.
         /// </summary>
@@ -462,13 +586,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 request,
                 CancellationToken.None);
 
-            Assert.That(result.Success, Is.True, result.ErrorMessage);
-            Assert.That(result.Artifact, Is.Not.Null);
-            Assert.That(File.Exists(paths.DllPath), Is.True);
-            Assert.That(File.Exists(paths.PdbPath), Is.True);
-            Assert.That(result.Artifact.Assembly.GetType("CompilerFixture.One.First"), Is.Not.Null);
-            Assert.That(result.Artifact.Assembly.GetType("CompilerFixture.Two.ISecond"), Is.Not.Null);
-            Assert.That(result.Artifact.Assembly.GetType("CompilerFixture.Initializer"), Is.Not.Null);
+            try
+            {
+                Assert.That(result.Success, Is.True, result.ErrorMessage);
+                Assert.That(result.Artifact, Is.Not.Null);
+                Assert.That(File.Exists(paths.DllPath), Is.True);
+                Assert.That(File.Exists(paths.PdbPath), Is.True);
+                Assert.That(result.Artifact.Assembly.GetType("CompilerFixture.One.First"), Is.Not.Null);
+                Assert.That(result.Artifact.Assembly.GetType("CompilerFixture.Two.ISecond"), Is.Not.Null);
+                Assert.That(result.Artifact.Assembly.GetType("CompilerFixture.Initializer"), Is.Not.Null);
+            }
+            finally
+            {
+                DeleteArtifactDirectory(paths.DllPath);
+            }
         }
 
         /// <summary>
@@ -504,9 +635,41 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 request,
                 CancellationToken.None);
 
-            Assert.That(result.Success, Is.True, result.ErrorMessage);
-            Assert.That(result.Artifact, Is.Not.Null);
-            Assert.That(result.Artifact.Assembly.GetType("NestedFixture.Outer+Inner"), Is.Not.Null);
+            try
+            {
+                Assert.That(result.Success, Is.True, result.ErrorMessage);
+                Assert.That(result.Artifact, Is.Not.Null);
+                Assert.That(result.Artifact.Assembly.GetType("NestedFixture.Outer+Inner"), Is.Not.Null);
+            }
+            finally
+            {
+                DeleteArtifactDirectory(paths.DllPath);
+            }
+        }
+
+        // The artifact assembly is loaded from bytes rather than mapped from the file, so its
+        // directory can be removed as soon as the assertions have read the emitted DLL and PDB.
+        private static void DeleteArtifactDirectory(string dllPath)
+        {
+            string directory = Path.GetDirectoryName(dllPath);
+            if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+            {
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException exception)
+            {
+                // A leftover artifact directory must not turn into a test failure of its own.
+                UnityEngine.Debug.Log("Artifact directory could not be removed: " + exception.Message);
+            }
+            catch (UnauthorizedAccessException exception)
+            {
+                UnityEngine.Debug.Log("Artifact directory could not be removed: " + exception.Message);
+            }
         }
 
         private static string[] CreateReferencePaths()

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompilerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompilerTests.cs
@@ -1,0 +1,610 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Covers compiler rejection before an artifact can be loaded or registered.
+    /// </summary>
+    public class HotReloadIntroducedTypeCompilerTests
+    {
+        /// <summary>
+        /// Verifies that compiler path resolution happens before compilation and loading.
+        /// </summary>
+        [Test]
+        public async Task CompileAsync_PathsUnavailable_DoesNotCompileOrLoad()
+        {
+            FakeEnvironment environment = new FakeEnvironment { PathsAvailable = false };
+            HotReloadIntroducedTypeCompiler compiler = new HotReloadIntroducedTypeCompiler(environment);
+
+            HotReloadIntroducedTypeCompilerResult result = await compiler.CompileAsync(
+                CreateRequest(),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(environment.CompileCalls, Is.EqualTo(0));
+            Assert.That(environment.LoadCalls, Is.EqualTo(0));
+            Assert.That(environment.WriteSourceCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies that fallback output is rejected before loading an irreversible assembly.
+        /// </summary>
+        [Test]
+        public async Task CompileAsync_FallbackBackend_DoesNotLoad()
+        {
+            FakeEnvironment environment = new FakeEnvironment
+            {
+                BackendKind = DynamicCompilationBackendKind.AssemblyBuilderFallback
+            };
+            HotReloadIntroducedTypeCompiler compiler = new HotReloadIntroducedTypeCompiler(environment);
+
+            HotReloadIntroducedTypeCompilerResult result = await compiler.CompileAsync(
+                CreateRequest(),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(environment.LoadCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies that an error diagnostic rejects a residual DLL before the loader is called.
+        /// </summary>
+        [Test]
+        public async Task CompileAsync_ErrorDiagnosticWithDll_DoesNotLoad()
+        {
+            FakeEnvironment environment = new FakeEnvironment
+            {
+                CompilerMessages = new[]
+                {
+                    new CompilerMessage
+                    {
+                        type = CompilerMessageType.Error,
+                        message = "compiler error"
+                    }
+                }
+            };
+            HotReloadIntroducedTypeCompiler compiler = new HotReloadIntroducedTypeCompiler(environment);
+
+            HotReloadIntroducedTypeCompilerResult result = await compiler.CompileAsync(
+                CreateRequest(),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(environment.LoadCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies that a missing portable PDB prevents loading the generated DLL.
+        /// </summary>
+        [Test]
+        public async Task CompileAsync_MissingPdb_DoesNotLoad()
+        {
+            FakeEnvironment environment = new FakeEnvironment { PdbExists = false };
+            HotReloadIntroducedTypeCompiler compiler = new HotReloadIntroducedTypeCompiler(environment);
+
+            HotReloadIntroducedTypeCompilerResult result = await compiler.CompileAsync(
+                CreateRequest(),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(environment.LoadCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies that a DLL identity mismatch is rejected before its bytes are loaded.
+        /// </summary>
+        [Test]
+        public async Task CompileAsync_AssemblyIdentityMismatch_DoesNotLoad()
+        {
+            FakeEnvironment environment = new FakeEnvironment { IdentityMatches = false };
+            HotReloadIntroducedTypeCompiler compiler = new HotReloadIntroducedTypeCompiler(environment);
+
+            HotReloadIntroducedTypeCompilerResult result = await compiler.CompileAsync(
+                CreateRequest(),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(environment.LoadCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies that a missing requested type definition is rejected before loading.
+        /// </summary>
+        [Test]
+        public async Task CompileAsync_MissingRequestedTypeDefinition_DoesNotLoad()
+        {
+            FakeEnvironment environment = new FakeEnvironment { ContainsRequestedType = false };
+            HotReloadIntroducedTypeCompiler compiler = new HotReloadIntroducedTypeCompiler(environment);
+
+            HotReloadIntroducedTypeCompilerResult result = await compiler.CompileAsync(
+                CreateRequest(),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(environment.LoadCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies that a fully validated output produces a prepared artifact without activation.
+        /// </summary>
+        [Test]
+        public async Task CompileAsync_ValidatedOutput_ReturnsPreparedArtifact()
+        {
+            FakeEnvironment environment = new FakeEnvironment();
+            HotReloadIntroducedTypeCompiler compiler = new HotReloadIntroducedTypeCompiler(environment);
+
+            HotReloadIntroducedTypeCompilerResult result = await compiler.CompileAsync(
+                CreateRequest(),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Artifact, Is.Not.Null);
+            Assert.That(environment.LoadCalls, Is.EqualTo(1));
+            Assert.That(environment.WriteSourceCalls, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// Verifies that an error emitted for a later source retains that descriptor's owner.
+        /// </summary>
+        [Test]
+        public async Task CompileAsync_LaterSourceError_RetainsOwnerDiagnostic()
+        {
+            HotReloadIntroducedTypeDescriptor first = CreateDescriptor("Example.First", "Assets/First.cs");
+            HotReloadIntroducedTypeDescriptor second = CreateDescriptor("Example.Second", "Assets/Second.cs");
+            HotReloadIntroducedTypeCompilationRequest request =
+                new HotReloadIntroducedTypeCompilationRequest(
+                    new[]
+                    {
+                        new HotReloadIntroducedTypeSource("first.cs", first),
+                        new HotReloadIntroducedTypeSource("second.cs", second)
+                    },
+                    "artifact.dll",
+                    "artifact.pdb",
+                    typeof(HotReloadIntroducedTypeCompilerTests).Assembly.FullName,
+                    new[] { first, second },
+                    Array.Empty<string>(),
+                    Array.Empty<string>());
+            FakeEnvironment environment = new FakeEnvironment
+            {
+                CompilerMessages = new[]
+                {
+                    new CompilerMessage
+                    {
+                        type = CompilerMessageType.Error,
+                        file = "second.cs",
+                        message = "second source error"
+                    }
+                }
+            };
+            HotReloadIntroducedTypeCompiler compiler = new HotReloadIntroducedTypeCompiler(environment);
+
+            HotReloadIntroducedTypeCompilerResult result = await compiler.CompileAsync(
+                request,
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.Diagnostics, Has.Count.EqualTo(1));
+            Assert.That(result.Diagnostics[0].OwnerProjectRelativePath, Is.EqualTo("Assets/Second.cs"));
+            Assert.That(result.Diagnostics[0].Message, Is.EqualTo("second source error"));
+            Assert.That(environment.LoadCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies that a real Roslyn error in the second emitted source retains its descriptor
+        /// owner instead of being reported only as a batch-level failure.
+        /// </summary>
+        [Test]
+        public async Task CompileAsync_ProductionLaterSourceError_RetainsOwnerDiagnostic()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            HotReloadIntroducedTypeArtifactPaths paths =
+                new HotReloadIntroducedTypeArtifactPathFactory(projectRoot, "compiler-diagnostic-tests").Create();
+            HotReloadIntroducedTypeDescriptor first = new HotReloadIntroducedTypeDescriptor(
+                "OriginalAssembly",
+                "original-mvid",
+                "CompilerDiagnostic.First",
+                "Assets/First.cs",
+                "first",
+                "namespace CompilerDiagnostic { public class First { } }");
+            HotReloadIntroducedTypeDescriptor second = new HotReloadIntroducedTypeDescriptor(
+                "OriginalAssembly",
+                "original-mvid",
+                "CompilerDiagnostic.Second",
+                "Assets/Second.cs",
+                "second",
+                "namespace CompilerDiagnostic { public class Second { public MissingType Value; } }");
+            HotReloadIntroducedTypeCompilationRequest request =
+                new HotReloadIntroducedTypeCompilationRequest(
+                    new[]
+                    {
+                        new HotReloadIntroducedTypeSource(paths.CreateSourcePath(0), first),
+                        new HotReloadIntroducedTypeSource(paths.CreateSourcePath(1), second)
+                    },
+                    paths.DllPath,
+                    paths.PdbPath,
+                    paths.AssemblyFullName,
+                    new[] { first, second },
+                    CreateReferencePaths(),
+                    Array.Empty<string>());
+            HotReloadIntroducedTypeCompiler compiler = new HotReloadIntroducedTypeCompiler(
+                new HotReloadIntroducedTypeCompilerEnvironment());
+
+            HotReloadIntroducedTypeCompilerResult result = await compiler.CompileAsync(
+                request,
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.Diagnostics, Has.Count.EqualTo(1));
+            Assert.That(result.Diagnostics[0].OwnerProjectRelativePath, Is.EqualTo("Assets/Second.cs"));
+            Assert.That(result.Diagnostics[0].Message, Does.Contain("MissingType"));
+        }
+
+        /// <summary>
+        /// Verifies that invalid later source records are rejected before any source can be written.
+        /// </summary>
+        [Test]
+        public void CompilationRequest_DuplicateOrNullSources_RejectsBeforeWrites()
+        {
+            HotReloadIntroducedTypeDescriptor descriptor = CreateDescriptor("Example.Introduced", "Assets/Example.cs");
+            FakeEnvironment environment = new FakeEnvironment();
+
+            Assert.Throws<ArgumentException>(() => new HotReloadIntroducedTypeCompilationRequest(
+                new[]
+                {
+                    new HotReloadIntroducedTypeSource("duplicate.cs", descriptor),
+                    new HotReloadIntroducedTypeSource("duplicate.cs", descriptor)
+                },
+                "artifact.dll",
+                "artifact.pdb",
+                typeof(HotReloadIntroducedTypeCompilerTests).Assembly.FullName,
+                new[] { descriptor },
+                Array.Empty<string>(),
+                Array.Empty<string>()));
+            Assert.Throws<ArgumentException>(() => new HotReloadIntroducedTypeCompilationRequest(
+                new HotReloadIntroducedTypeSource[]
+                {
+                    new HotReloadIntroducedTypeSource("first.cs", descriptor),
+                    null
+                },
+                "artifact.dll",
+                "artifact.pdb",
+                typeof(HotReloadIntroducedTypeCompilerTests).Assembly.FullName,
+                new[] { descriptor },
+                Array.Empty<string>(),
+                Array.Empty<string>()));
+
+            Assert.That(environment.WriteSourceCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies that a request copies its source records so later caller mutations cannot
+        /// change the batch that awaits compilation.
+        /// </summary>
+        [Test]
+        public void CompilationRequest_SourceCollectionMutation_DoesNotChangeRequest()
+        {
+            HotReloadIntroducedTypeDescriptor first = CreateDescriptor("Example.First", "Assets/First.cs");
+            HotReloadIntroducedTypeDescriptor second = CreateDescriptor("Example.Second", "Assets/Second.cs");
+            List<HotReloadIntroducedTypeSource> sources = new List<HotReloadIntroducedTypeSource>
+            {
+                new HotReloadIntroducedTypeSource("first.cs", first),
+                new HotReloadIntroducedTypeSource("second.cs", second)
+            };
+            HotReloadIntroducedTypeCompilationRequest request = new HotReloadIntroducedTypeCompilationRequest(
+                sources,
+                "artifact.dll",
+                "artifact.pdb",
+                typeof(HotReloadIntroducedTypeCompilerTests).Assembly.FullName,
+                new[] { first, second },
+                Array.Empty<string>(),
+                Array.Empty<string>());
+            sources[1] = new HotReloadIntroducedTypeSource("changed.cs", second);
+
+            Assert.That(request.Sources[1].Path, Does.EndWith("second.cs"));
+            Assert.That(request.Sources[1].Text, Is.EqualTo(second.Source));
+        }
+
+        /// <summary>
+        /// Verifies that result factories reject contradictory internal success and failure
+        /// states instead of constructing a result every caller must defensively reinterpret.
+        /// </summary>
+        [Test]
+        public void CompilerResult_InvalidFactoryArguments_Throw()
+        {
+            Assert.Throws<ArgumentNullException>(() => HotReloadIntroducedTypeCompilerResult.Prepared(null));
+            Assert.Throws<ArgumentException>(() => HotReloadIntroducedTypeCompilerResult.Failure(string.Empty));
+            Assert.Throws<ArgumentException>(() => HotReloadIntroducedTypeCompilerResult.Failure("  "));
+        }
+
+        /// <summary>
+        /// Verifies that cancellation after backend completion prevents the irreversible loader
+        /// call even when every emitted output validation would otherwise succeed.
+        /// </summary>
+        [Test]
+        public void CompileAsync_CancelledAfterBackend_DoesNotLoad()
+        {
+            CancellationTokenSource cancellation = new CancellationTokenSource();
+            FakeEnvironment environment = new FakeEnvironment
+            {
+                AfterCompile = cancellation.Cancel
+            };
+            HotReloadIntroducedTypeCompiler compiler = new HotReloadIntroducedTypeCompiler(environment);
+
+            Assert.CatchAsync<OperationCanceledException>(async () => await compiler.CompileAsync(
+                CreateRequest(),
+                cancellation.Token));
+
+            Assert.That(environment.LoadCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies that cancellation occurring while artifact bytes are read is rechecked
+        /// immediately before loading and cannot begin the irreversible loader operation.
+        /// </summary>
+        [Test]
+        public void CompileAsync_CancelledDuringByteReads_DoesNotLoad()
+        {
+            CancellationTokenSource cancellation = new CancellationTokenSource();
+            FakeEnvironment environment = new FakeEnvironment
+            {
+                AfterFirstReadAllBytes = cancellation.Cancel
+            };
+            HotReloadIntroducedTypeCompiler compiler = new HotReloadIntroducedTypeCompiler(environment);
+
+            Assert.CatchAsync<OperationCanceledException>(async () => await compiler.CompileAsync(
+                CreateRequest(),
+                cancellation.Token));
+
+            Assert.That(environment.LoadCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies that the production Roslyn environment writes a uniquely named DLL/PDB pair,
+        /// honors defines, and returns a loaded artifact containing every requested type.
+        /// </summary>
+        [Test]
+        public async Task CompileAsync_ProductionEnvironment_ProducesDefinedArtifact()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            HotReloadIntroducedTypeArtifactPathFactory factory =
+                new HotReloadIntroducedTypeArtifactPathFactory(projectRoot, "compiler-tests");
+            HotReloadIntroducedTypeArtifactPaths paths = factory.Create();
+            List<HotReloadIntroducedTypeDescriptor> descriptors =
+                new List<HotReloadIntroducedTypeDescriptor>
+                {
+                    new HotReloadIntroducedTypeDescriptor(
+                        "OriginalAssembly",
+                        "original-mvid",
+                        "CompilerFixture.One.First",
+                        "Assets/First.cs",
+                        "first",
+                        "namespace CompilerFixture.One {\nusing Alias = System.IDisposable;\n#if INTRODUCED_DEFINE\npublic class First { public Alias Create() { return null; } }\n#endif\n}"),
+                    new HotReloadIntroducedTypeDescriptor(
+                        "OriginalAssembly",
+                        "original-mvid",
+                        "CompilerFixture.Two.ISecond",
+                        "Assets/Second.cs",
+                        "second",
+                        "namespace CompilerFixture.Two { using Alias = System.ICloneable; public interface ISecond { Alias Create(); } }"),
+                    new HotReloadIntroducedTypeDescriptor(
+                        "OriginalAssembly",
+                        "original-mvid",
+                        "CompilerFixture.Initializer",
+                        "Assets/Initializer.cs",
+                        "initializer",
+                        "namespace CompilerFixture { public class Initializer { static Initializer() { throw new System.InvalidOperationException(); } } }")
+                };
+            HotReloadIntroducedTypeCompilationRequest request =
+                HotReloadIntroducedTypeCompilationRequest.CreateBatch(
+                    paths,
+                    descriptors,
+                    CreateReferencePaths(),
+                    new[] { "INTRODUCED_DEFINE" });
+            HotReloadIntroducedTypeCompiler compiler = new HotReloadIntroducedTypeCompiler(
+                new HotReloadIntroducedTypeCompilerEnvironment());
+
+            HotReloadIntroducedTypeCompilerResult result = await compiler.CompileAsync(
+                request,
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Artifact, Is.Not.Null);
+            Assert.That(File.Exists(paths.DllPath), Is.True);
+            Assert.That(File.Exists(paths.PdbPath), Is.True);
+            Assert.That(result.Artifact.Assembly.GetType("CompilerFixture.One.First"), Is.Not.Null);
+            Assert.That(result.Artifact.Assembly.GetType("CompilerFixture.Two.ISecond"), Is.Not.Null);
+            Assert.That(result.Artifact.Assembly.GetType("CompilerFixture.Initializer"), Is.Not.Null);
+        }
+
+        private static string[] CreateReferencePaths()
+        {
+            UnityEditor.Compilation.Assembly targetAssembly = null;
+            string testAssemblyName = typeof(HotReloadIntroducedTypeCompilerTests).Assembly.GetName().Name;
+            foreach (UnityEditor.Compilation.Assembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name == testAssemblyName)
+                {
+                    targetAssembly = assembly;
+                    break;
+                }
+            }
+
+            Assert.That(targetAssembly, Is.Not.Null, "Test compilation assembly must exist.");
+            List<string> references = new List<string>();
+            foreach (string referencePath in targetAssembly.allReferences)
+            {
+                if (!string.IsNullOrEmpty(referencePath) && File.Exists(referencePath))
+                {
+                    references.Add(Path.GetFullPath(referencePath));
+                }
+            }
+
+            string assemblyPath = Path.Combine(
+                Path.GetFullPath(Path.Combine(Application.dataPath, "..")),
+                "Library",
+                "ScriptAssemblies",
+                testAssemblyName + ".dll");
+            if (!references.Contains(assemblyPath))
+            {
+                references.Add(assemblyPath);
+            }
+
+            return references.ToArray();
+        }
+
+        private static HotReloadIntroducedTypeCompilationRequest CreateRequest()
+        {
+            AssemblyName assemblyName = typeof(HotReloadIntroducedTypeCompilerTests).Assembly.GetName();
+            List<HotReloadIntroducedTypeDescriptor> descriptors =
+                new List<HotReloadIntroducedTypeDescriptor>
+                {
+                    new HotReloadIntroducedTypeDescriptor(
+                        "OriginalAssembly",
+                        "original-mvid",
+                        "Example.Introduced",
+                        "Assets/Example.cs",
+                        "fingerprint",
+                        "public class Introduced { }")
+                };
+            HotReloadIntroducedTypeDescriptor descriptor = descriptors[0];
+            return new HotReloadIntroducedTypeCompilationRequest(
+                new[] { new HotReloadIntroducedTypeSource("source.cs", descriptor) },
+                "artifact.dll",
+                "artifact.pdb",
+                assemblyName.FullName,
+                descriptors,
+                Array.Empty<string>(),
+                Array.Empty<string>());
+        }
+
+        private static HotReloadIntroducedTypeDescriptor CreateDescriptor(
+            string metadataName,
+            string ownerProjectRelativePath)
+        {
+            return new HotReloadIntroducedTypeDescriptor(
+                "OriginalAssembly",
+                "original-mvid",
+                metadataName,
+                ownerProjectRelativePath,
+                "fingerprint",
+                "public class Introduced { }");
+        }
+
+        private sealed class FakeEnvironment : IHotReloadIntroducedTypeCompilerEnvironment
+        {
+            public bool PathsAvailable { get; set; } = true;
+
+            public DynamicCompilationBackendKind BackendKind { get; set; } =
+                DynamicCompilationBackendKind.SharedRoslynWorker;
+
+            public bool DllExists { get; set; } = true;
+
+            public bool PdbExists { get; set; } = true;
+
+            public bool IdentityMatches { get; set; } = true;
+
+            public bool ContainsRequestedType { get; set; } = true;
+
+            public CompilerMessage[] CompilerMessages { get; set; } = Array.Empty<CompilerMessage>();
+
+            public int CompileCalls { get; private set; }
+
+            public int LoadCalls { get; private set; }
+
+            public int WriteSourceCalls { get; private set; }
+
+            public Action AfterCompile { get; set; }
+
+            public Action AfterFirstReadAllBytes { get; set; }
+
+            public int ReadAllBytesCalls { get; private set; }
+
+            public Task<ExternalCompilerPaths> ResolveCompilerPathsOnMainThreadAsync(CancellationToken ct)
+            {
+                ExternalCompilerPaths paths = PathsAvailable
+                    ? new ExternalCompilerPaths(
+                        "contents",
+                        "scripting",
+                        "dotnet",
+                        "compiler",
+                        "runtimeconfig",
+                        "deps",
+                        "codeanalysis",
+                        "codeanalysiscsharp",
+                        "shared",
+                        ExternalCompilerLayoutKind.Unknown)
+                    : null;
+                return Task.FromResult(paths);
+            }
+
+            public Task<DynamicCompilationBackendResult> CompileAsync(
+                HotReloadIntroducedTypeCompilationRequest request,
+                ExternalCompilerPaths paths,
+                CancellationToken ct)
+            {
+                CompileCalls++;
+                AfterCompile?.Invoke();
+                DynamicCompilationBackendResult result = new DynamicCompilationBackendResult(
+                    CompilerMessages,
+                    BackendKind);
+                return Task.FromResult(result);
+            }
+
+            public bool FileExists(string path)
+            {
+                return path.EndsWith(".pdb", StringComparison.Ordinal) ? PdbExists : DllExists;
+            }
+
+            public AssemblyName ReadAssemblyName(string path)
+            {
+                return IdentityMatches
+                    ? typeof(HotReloadIntroducedTypeCompilerTests).Assembly.GetName()
+                    : new AssemblyName("UnexpectedArtifact");
+            }
+
+            public byte[] ReadAllBytes(string path)
+            {
+                ReadAllBytesCalls++;
+                if (ReadAllBytesCalls == 1)
+                {
+                    AfterFirstReadAllBytes?.Invoke();
+                }
+
+                return new byte[] { 1 };
+            }
+
+            public CompiledAssemblyLoadResult Load(byte[] assemblyBytes, byte[] pdbBytes)
+            {
+                LoadCalls++;
+                return new CompiledAssemblyLoadResult(
+                    true,
+                    typeof(HotReloadIntroducedTypeCompilerTests).Assembly,
+                    0.0d);
+            }
+
+            public IReadOnlyCollection<string> ReadDefinedTypeNames(string path)
+            {
+                return ContainsRequestedType
+                    ? new[] { "Example.Introduced" }
+                    : Array.Empty<string>();
+            }
+
+            public void WriteSource(string path, string source)
+            {
+                WriteSourceCalls++;
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompilerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompilerTests.cs
@@ -33,6 +33,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CancellationToken.None);
 
             Assert.That(result.Success, Is.False);
+            Assert.That(result.Artifact, Is.Null);
             Assert.That(environment.CompileCalls, Is.EqualTo(0));
             Assert.That(environment.LoadCalls, Is.EqualTo(0));
             Assert.That(environment.WriteSourceCalls, Is.EqualTo(0));
@@ -55,6 +56,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CancellationToken.None);
 
             Assert.That(result.Success, Is.False);
+            Assert.That(result.Artifact, Is.Null);
             Assert.That(environment.LoadCalls, Is.EqualTo(0));
         }
 
@@ -82,6 +84,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CancellationToken.None);
 
             Assert.That(result.Success, Is.False);
+            Assert.That(result.Artifact, Is.Null);
             Assert.That(environment.LoadCalls, Is.EqualTo(0));
         }
 
@@ -99,6 +102,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CancellationToken.None);
 
             Assert.That(result.Success, Is.False);
+            Assert.That(result.Artifact, Is.Null);
             Assert.That(environment.LoadCalls, Is.EqualTo(0));
         }
 
@@ -116,6 +120,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CancellationToken.None);
 
             Assert.That(result.Success, Is.False);
+            Assert.That(result.Artifact, Is.Null);
             Assert.That(environment.LoadCalls, Is.EqualTo(0));
         }
 
@@ -133,6 +138,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CancellationToken.None);
 
             Assert.That(result.Success, Is.False);
+            Assert.That(result.Artifact, Is.Null);
             Assert.That(environment.LoadCalls, Is.EqualTo(0));
         }
 
@@ -195,6 +201,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CancellationToken.None);
 
             Assert.That(result.Success, Is.False);
+            Assert.That(result.Artifact, Is.Null);
             Assert.That(result.Diagnostics, Has.Count.EqualTo(1));
             Assert.That(result.Diagnostics[0].OwnerProjectRelativePath, Is.EqualTo("Assets/Second.cs"));
             Assert.That(result.Diagnostics[0].Message, Is.EqualTo("second source error"));
@@ -246,6 +253,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CancellationToken.None);
 
             Assert.That(result.Success, Is.False);
+            Assert.That(result.Artifact, Is.Null);
             Assert.That(result.Diagnostics, Has.Count.EqualTo(1));
             Assert.That(result.Diagnostics[0].OwnerProjectRelativePath, Is.EqualTo("Assets/Second.cs"));
             Assert.That(result.Diagnostics[0].Message, Does.Contain("MissingType"));
@@ -333,7 +341,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// call even when every emitted output validation would otherwise succeed.
         /// </summary>
         [Test]
-        public void CompileAsync_CancelledAfterBackend_DoesNotLoad()
+        public async Task CompileAsync_CancelledAfterBackend_DoesNotLoad()
         {
             CancellationTokenSource cancellation = new CancellationTokenSource();
             FakeEnvironment environment = new FakeEnvironment
@@ -342,10 +350,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             };
             HotReloadIntroducedTypeCompiler compiler = new HotReloadIntroducedTypeCompiler(environment);
 
-            Assert.CatchAsync<OperationCanceledException>(async () => await compiler.CompileAsync(
-                CreateRequest(),
-                cancellation.Token));
+            bool cancelled = false;
+            try
+            {
+                await compiler.CompileAsync(CreateRequest(), cancellation.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                cancelled = true;
+            }
 
+            Assert.That(cancelled, Is.True);
             Assert.That(environment.LoadCalls, Is.EqualTo(0));
         }
 
@@ -354,7 +369,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// immediately before loading and cannot begin the irreversible loader operation.
         /// </summary>
         [Test]
-        public void CompileAsync_CancelledDuringByteReads_DoesNotLoad()
+        public async Task CompileAsync_CancelledDuringByteReads_DoesNotLoad()
         {
             CancellationTokenSource cancellation = new CancellationTokenSource();
             FakeEnvironment environment = new FakeEnvironment
@@ -363,10 +378,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             };
             HotReloadIntroducedTypeCompiler compiler = new HotReloadIntroducedTypeCompiler(environment);
 
-            Assert.CatchAsync<OperationCanceledException>(async () => await compiler.CompileAsync(
-                CreateRequest(),
-                cancellation.Token));
+            bool cancelled = false;
+            try
+            {
+                await compiler.CompileAsync(CreateRequest(), cancellation.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                cancelled = true;
+            }
 
+            Assert.That(cancelled, Is.True);
             Assert.That(environment.LoadCalls, Is.EqualTo(0));
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompilerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompilerTests.cs
@@ -297,6 +297,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that source-path uniqueness follows the platform's file-system case rules, so
+        /// two spellings Windows resolves to one file are rejected before either source is written.
+        /// </summary>
+        [Test]
+        public void CompilationRequest_CaseOnlyDuplicateSources_FollowsPlatformPathRules()
+        {
+            HotReloadIntroducedTypeDescriptor descriptor = CreateDescriptor("Example.Introduced", "Assets/Example.cs");
+            FakeEnvironment environment = new FakeEnvironment();
+            HotReloadIntroducedTypeSource[] sources =
+            {
+                new HotReloadIntroducedTypeSource("Duplicate.cs", descriptor),
+                new HotReloadIntroducedTypeSource("duplicate.cs", descriptor)
+            };
+
+            if (Path.DirectorySeparatorChar == '\\')
+            {
+                ArgumentException exception = Assert.Throws<ArgumentException>(() => CreateRequestFrom(sources));
+                Assert.That(exception.ParamName, Is.EqualTo("sources"));
+            }
+            else
+            {
+                Assert.DoesNotThrow(() => CreateRequestFrom(sources));
+            }
+
+            Assert.That(environment.WriteSourceCalls, Is.EqualTo(0));
+        }
+
+        /// <summary>
         /// Verifies that a request copies its source records so later caller mutations cannot
         /// change the batch that awaits compilation.
         /// </summary>
@@ -450,6 +478,44 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Artifact.Assembly.GetType("CompilerFixture.Initializer"), Is.Not.Null);
         }
 
+        /// <summary>
+        /// Verifies that emitted-type validation reads nested definitions in their Cecil metadata
+        /// form, so a descriptor is matched by the name the artifact actually defines.
+        /// </summary>
+        [Test]
+        public async Task CompileAsync_NestedDefinition_MatchesCecilMetadataName()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            HotReloadIntroducedTypeArtifactPaths paths =
+                new HotReloadIntroducedTypeArtifactPathFactory(projectRoot, "compiler-nested-tests").Create();
+            HotReloadIntroducedTypeDescriptor nested = new HotReloadIntroducedTypeDescriptor(
+                "OriginalAssembly",
+                "original-mvid",
+                "NestedFixture.Outer/Inner",
+                "Assets/Nested.cs",
+                "nested",
+                "namespace NestedFixture { public class Outer { public class Inner { } } }");
+            HotReloadIntroducedTypeCompilationRequest request =
+                new HotReloadIntroducedTypeCompilationRequest(
+                    new[] { new HotReloadIntroducedTypeSource(paths.CreateSourcePath(0), nested) },
+                    paths.DllPath,
+                    paths.PdbPath,
+                    paths.AssemblyFullName,
+                    new[] { nested },
+                    CreateReferencePaths(),
+                    Array.Empty<string>());
+            HotReloadIntroducedTypeCompiler compiler = new HotReloadIntroducedTypeCompiler(
+                new HotReloadIntroducedTypeCompilerEnvironment());
+
+            HotReloadIntroducedTypeCompilerResult result = await compiler.CompileAsync(
+                request,
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Artifact, Is.Not.Null);
+            Assert.That(result.Artifact.Assembly.GetType("NestedFixture.Outer+Inner"), Is.Not.Null);
+        }
+
         private static string[] CreateReferencePaths()
         {
             UnityEditor.Compilation.Assembly targetAssembly = null;
@@ -484,6 +550,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             return references.ToArray();
+        }
+
+        private static HotReloadIntroducedTypeCompilationRequest CreateRequestFrom(
+            IReadOnlyList<HotReloadIntroducedTypeSource> sources)
+        {
+            List<HotReloadIntroducedTypeDescriptor> descriptors =
+                new List<HotReloadIntroducedTypeDescriptor>();
+            foreach (HotReloadIntroducedTypeSource source in sources)
+            {
+                descriptors.Add(source.Descriptor);
+            }
+
+            return new HotReloadIntroducedTypeCompilationRequest(
+                sources,
+                "artifact.dll",
+                "artifact.pdb",
+                typeof(HotReloadIntroducedTypeCompilerTests).Assembly.FullName,
+                descriptors,
+                Array.Empty<string>(),
+                Array.Empty<string>());
         }
 
         private static HotReloadIntroducedTypeCompilationRequest CreateRequest()

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompilerTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompilerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d2dcfff229a764791875083033f672e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs
@@ -422,6 +422,60 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(resolved, Is.SameAs(artifact));
         }
 
+        /// <summary>
+        /// Verifies that activating an artifact that was never prepared is rejected before any
+        /// mutation and leaves both lifecycle counts and the existing active mapping unchanged.
+        /// </summary>
+        [Test]
+        public void Activate_NeverPreparedArtifact_RejectsWithoutStateChange()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeArtifact active = CreateArtifact("active");
+            registry.RegisterPrepared(active);
+            registry.Activate(active);
+            HotReloadIntroducedTypeArtifact neverPrepared = CreateArtifactWithAssembly(
+                CreateDynamicAssembly("NeverPrepared"),
+                CreateOtherDescriptor("never-prepared"));
+
+            Assert.Throws<InvalidOperationException>(() => registry.Activate(neverPrepared));
+
+            Assert.That(registry.PreparedCount, Is.EqualTo(0));
+            Assert.That(registry.ActiveCount, Is.EqualTo(1));
+            Assert.That(
+                registry.TryResolveActiveAssembly(neverPrepared.AssemblyFullName, out HotReloadIntroducedTypeArtifact rejected),
+                Is.False);
+            Assert.That(rejected, Is.Null);
+            Assert.That(
+                registry.TryResolveActiveAssembly(active.AssemblyFullName, out HotReloadIntroducedTypeArtifact resolved),
+                Is.True);
+            Assert.That(resolved, Is.SameAs(active));
+        }
+
+        /// <summary>
+        /// Verifies that a discarded candidate loses its prepared membership, so a later
+        /// activation of the same artifact is rejected without publishing its type identity.
+        /// </summary>
+        [Test]
+        public void Activate_DiscardedPreparedArtifact_RejectsWithoutStateChange()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeDescriptor descriptor = CreateOtherDescriptor("discarded");
+            HotReloadIntroducedTypeArtifact candidate = CreateArtifactWithAssembly(
+                CreateDynamicAssembly("Discarded"),
+                descriptor);
+            registry.RegisterPrepared(candidate);
+            registry.DiscardPrepared(candidate);
+
+            Assert.Throws<InvalidOperationException>(() => registry.Activate(candidate));
+
+            Assert.That(registry.PreparedCount, Is.EqualTo(0));
+            Assert.That(registry.ActiveCount, Is.EqualTo(0));
+            Assert.That(
+                registry.TryFindActiveDescriptor(descriptor, out HotReloadIntroducedTypeArtifact found),
+                Is.False);
+            Assert.That(found, Is.Null);
+        }
+
         private static Assembly CreateDynamicAssembly(string prefix)
         {
             AssemblyName assemblyName = new AssemblyName(prefix + Guid.NewGuid().ToString("N"));

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs
@@ -179,6 +179,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "ResolverFixtures",
                 Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(directory);
+            try
+            {
+                RunResolvedTypeShapeAssertions(directory);
+            }
+            finally
+            {
+                DeleteFixtureDirectory(directory);
+            }
+        }
+
+        // The fixture DLLs are loaded from bytes rather than from disk, so the directory can be
+        // removed even though the assemblies stay loaded for the rest of the session.
+        private static void DeleteFixtureDirectory(string directory)
+        {
+            if (!Directory.Exists(directory))
+            {
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException exception)
+            {
+                // A leftover fixture directory must not turn into a test failure of its own.
+                UnityEngine.Debug.Log("Resolver fixture directory could not be removed: " + exception.Message);
+            }
+            catch (UnauthorizedAccessException exception)
+            {
+                UnityEngine.Debug.Log("Resolver fixture directory could not be removed: " + exception.Message);
+            }
+        }
+
+        private static void RunResolvedTypeShapeAssertions(string directory)
+        {
             string dependencyName = "ResolverDependency" + Guid.NewGuid().ToString("N");
             string consumerName = "ResolverConsumer" + Guid.NewGuid().ToString("N");
             string dependencyPath = Path.Combine(directory, dependencyName + ".dll");

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Threading;
+using System.Threading.Tasks;
 
 using NUnit.Framework;
 
@@ -510,6 +512,103 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 registry.TryFindActiveDescriptor(descriptor, out HotReloadIntroducedTypeArtifact found),
                 Is.False);
             Assert.That(found, Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies that resolving from another thread while prepared registrations and their
+        /// scopes change on this thread neither throws nor returns an unregistered assembly.
+        /// </summary>
+        [Test]
+        public async Task ResolveExact_ConcurrentWithPreparedRegistration_StaysConsistent()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeArtifact active = CreateArtifact("active");
+            registry.RegisterPrepared(active);
+            registry.Activate(active);
+            HotReloadIntroducedTypeArtifact prepared = CreateArtifactWithAssembly(
+                CreateDynamicAssembly("ConcurrentPrepared"),
+                CreateOtherDescriptor("prepared"));
+            using HotReloadIntroducedTypeAssemblyResolver resolver =
+                new HotReloadIntroducedTypeAssemblyResolver(registry);
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            ResolutionTally tally = new ResolutionTally(prepared.Assembly, active.Assembly);
+
+            // A background reader is the only way to exercise the AssemblyResolve thread this
+            // resolver actually runs on; it touches no Unity API and ends before the test returns.
+            Task reader = Task.Run(() =>
+            {
+                while (!cancellation.IsCancellationRequested)
+                {
+                    tally.Record(resolver.ResolveExact(prepared.AssemblyFullName));
+                    tally.Record(resolver.ResolveExact(active.AssemblyFullName));
+                }
+            });
+
+            // Churn the prepared scope until the reader has observed the artifact both registered
+            // and absent, so the assertions below describe an interleaving that really happened.
+            // The iteration bound keeps the test finite if the reader never gets scheduled.
+            for (int iteration = 0; iteration < 200000 && !tally.SawBothPreparedStates; iteration++)
+            {
+                using (resolver.RegisterPrepared(prepared))
+                {
+                }
+            }
+
+            cancellation.Cancel();
+            Task completed = await Task.WhenAny(reader, Task.Delay(TimeSpan.FromSeconds(10)))
+                .ConfigureAwait(false);
+            Assert.That(completed, Is.SameAs(reader), "The background reader did not finish in time.");
+            await reader.ConfigureAwait(false);
+
+            Assert.That(tally.ResolveCount, Is.GreaterThan(0));
+            Assert.That(tally.UnexpectedCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Counts background resolutions without keeping one entry per call in memory.
+        /// </summary>
+        private sealed class ResolutionTally
+        {
+            private readonly Assembly preparedAssembly;
+            private readonly Assembly activeAssembly;
+            private int resolveCount;
+            private int unexpectedCount;
+            private int preparedHitCount;
+            private int preparedMissCount;
+
+            public int ResolveCount => Volatile.Read(ref resolveCount);
+
+            public int UnexpectedCount => Volatile.Read(ref unexpectedCount);
+
+            public bool SawBothPreparedStates =>
+                Volatile.Read(ref preparedHitCount) > 0 && Volatile.Read(ref preparedMissCount) > 0;
+
+            public ResolutionTally(Assembly preparedAssembly, Assembly activeAssembly)
+            {
+                this.preparedAssembly = preparedAssembly;
+                this.activeAssembly = activeAssembly;
+            }
+
+            public void Record(Assembly resolved)
+            {
+                Interlocked.Increment(ref resolveCount);
+                if (resolved == null)
+                {
+                    Interlocked.Increment(ref preparedMissCount);
+                    return;
+                }
+
+                if (ReferenceEquals(resolved, preparedAssembly))
+                {
+                    Interlocked.Increment(ref preparedHitCount);
+                    return;
+                }
+
+                if (!ReferenceEquals(resolved, activeAssembly))
+                {
+                    Interlocked.Increment(ref unexpectedCount);
+                }
+            }
         }
 
         private static Assembly CreateDynamicAssembly(string prefix)

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs
@@ -1,0 +1,548 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+
+using NUnit.Framework;
+
+using Mono.Cecil;
+
+using CecilFieldAttributes = Mono.Cecil.FieldAttributes;
+using CecilMethodAttributes = Mono.Cecil.MethodAttributes;
+using CecilTypeAttributes = Mono.Cecil.TypeAttributes;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Covers prepared and active lifecycle isolation for introduced type artifacts.
+    /// </summary>
+    public class HotReloadIntroducedTypeRegistryTests
+    {
+        /// <summary>
+        /// Verifies that a prepared artifact stays invisible until activation and remains visible
+        /// after its temporary resolver scope closes.
+        /// </summary>
+        [Test]
+        public void PreparedArtifact_ActivatesOnlyAtExplicitCommit()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeArtifact artifact = CreateArtifact("one");
+            HotReloadIntroducedTypeAssemblyResolver resolver =
+                new HotReloadIntroducedTypeAssemblyResolver(registry);
+
+            registry.RegisterPrepared(artifact);
+            using (resolver.RegisterPrepared(artifact))
+            {
+                Assert.That(registry.PreparedCount, Is.EqualTo(1));
+                Assert.That(registry.ActiveCount, Is.EqualTo(0));
+                Assert.That(resolver.ResolveExact(artifact.AssemblyFullName), Is.EqualTo(artifact.Assembly));
+                registry.Activate(artifact);
+            }
+
+            Assert.That(registry.PreparedCount, Is.EqualTo(0));
+            Assert.That(registry.ActiveCount, Is.EqualTo(1));
+            Assert.That(resolver.ResolveExact(artifact.AssemblyFullName), Is.EqualTo(artifact.Assembly));
+            resolver.Dispose();
+        }
+
+        /// <summary>
+        /// Verifies that same-name assembly requests do not resolve unless their full identity is exact.
+        /// </summary>
+        [Test]
+        public void ResolveExact_DifferentAssemblyIdentity_ReturnsNull()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeArtifact artifact = CreateArtifact("one");
+            HotReloadIntroducedTypeAssemblyResolver resolver =
+                new HotReloadIntroducedTypeAssemblyResolver(registry);
+            registry.RegisterPrepared(artifact);
+            registry.Activate(artifact);
+
+            Assert.That(resolver.ResolveExact(artifact.AssemblyFullName + ".different"), Is.Null);
+            resolver.Dispose();
+        }
+
+        /// <summary>
+        /// Verifies that an unchanged active definition is reused instead of becoming a new artifact.
+        /// </summary>
+        [Test]
+        public void TryFindActive_SameDefinition_ReturnsExistingArtifact()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeArtifact artifact = CreateArtifact("same");
+            registry.RegisterPrepared(artifact);
+            registry.Activate(artifact);
+            List<HotReloadIntroducedTypeDescriptor> descriptors =
+                new List<HotReloadIntroducedTypeDescriptor> { CreateDescriptor("same") };
+
+            bool found = registry.TryFindActive(descriptors, out HotReloadIntroducedTypeArtifact foundArtifact);
+
+            Assert.That(found, Is.True);
+            Assert.That(foundArtifact, Is.SameAs(artifact));
+        }
+
+        /// <summary>
+        /// Verifies that moving an otherwise identical declaration to another source owner does
+        /// not reuse the artifact that belongs to the original owner.
+        /// </summary>
+        [Test]
+        public void TryFindActive_OwnerChanged_DoesNotReuseArtifact()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeArtifact artifact = CreateArtifact("same");
+            registry.RegisterPrepared(artifact);
+            registry.Activate(artifact);
+            List<HotReloadIntroducedTypeDescriptor> descriptors =
+                new List<HotReloadIntroducedTypeDescriptor>
+                {
+                    new HotReloadIntroducedTypeDescriptor(
+                        "OriginalAssembly",
+                        "original-mvid",
+                        "Example.Introduced",
+                        "Assets/Moved.cs",
+                        "same",
+                        "public class Introduced { }")
+                };
+
+            bool found = registry.TryFindActive(descriptors, out HotReloadIntroducedTypeArtifact foundArtifact);
+
+            Assert.That(found, Is.False);
+            Assert.That(foundArtifact, Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies that an activation conflict preserves the prepared candidate and existing
+        /// active identity without publishing a partial artifact.
+        /// </summary>
+        [Test]
+        public void Activate_ConflictingAssemblyIdentity_PreservesPreparedAndActiveState()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeArtifact active = CreateArtifact("active");
+            HotReloadIntroducedTypeArtifact candidate = new HotReloadIntroducedTypeArtifact(
+                active.Assembly,
+                "candidate.dll",
+                "candidate.pdb",
+                new List<HotReloadIntroducedTypeDescriptor> { CreateOtherDescriptor("candidate") });
+            registry.RegisterPrepared(active);
+            registry.Activate(active);
+            registry.RegisterPrepared(candidate);
+
+            Assert.Throws<InvalidOperationException>(() => registry.Activate(candidate));
+
+            Assert.That(registry.ActiveCount, Is.EqualTo(1));
+            Assert.That(registry.PreparedCount, Is.EqualTo(1));
+            Assert.That(registry.TryResolveActiveAssembly(active.AssemblyFullName, out HotReloadIntroducedTypeArtifact resolved), Is.True);
+            Assert.That(resolved, Is.SameAs(active));
+        }
+
+        /// <summary>
+        /// Verifies that an active type can be reused from a request that also contains a new
+        /// type, independently of the request ordering.
+        /// </summary>
+        [Test]
+        public void TryFindActive_MixedRequest_ReturnsExistingTypeArtifact()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeArtifact artifact = CreateArtifact("same");
+            registry.RegisterPrepared(artifact);
+            registry.Activate(artifact);
+            List<HotReloadIntroducedTypeDescriptor> descriptors =
+                new List<HotReloadIntroducedTypeDescriptor>
+                {
+                    CreateOtherDescriptor("new"),
+                    CreateDescriptor("same")
+                };
+
+            bool found = registry.TryFindActiveDescriptor(descriptors[1], out HotReloadIntroducedTypeArtifact foundArtifact);
+
+            Assert.That(found, Is.True);
+            Assert.That(foundArtifact, Is.SameAs(artifact));
+            Assert.That(registry.TryFindActive(descriptors, out HotReloadIntroducedTypeArtifact wholeArtifact), Is.False);
+            Assert.That(wholeArtifact, Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies that the AppDomain resolver returns one active artifact assembly for field,
+        /// base, interface, and method-signature references in a separately loaded real DLL.
+        /// </summary>
+        [Test]
+        public void AssemblyResolve_ActiveArtifact_ResolvesAllReferencedTypeShapes()
+        {
+            string directory = Path.Combine(
+                Path.GetFullPath(Path.Combine(UnityEngine.Application.dataPath, "..")),
+                "Library",
+                "UloopHotReload",
+                "ResolverFixtures",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+            string dependencyName = "ResolverDependency" + Guid.NewGuid().ToString("N");
+            string consumerName = "ResolverConsumer" + Guid.NewGuid().ToString("N");
+            string dependencyPath = Path.Combine(directory, dependencyName + ".dll");
+            string consumerPath = Path.Combine(directory, consumerName + ".dll");
+            WriteDependencyAssembly(dependencyPath, dependencyName);
+            WriteConsumerAssembly(consumerPath, consumerName, dependencyName);
+            Assembly dependencyAssembly = Assembly.Load(File.ReadAllBytes(dependencyPath));
+            HotReloadIntroducedTypeArtifact artifact = new HotReloadIntroducedTypeArtifact(
+                dependencyAssembly,
+                dependencyPath,
+                Path.ChangeExtension(dependencyPath, ".pdb"),
+                new List<HotReloadIntroducedTypeDescriptor> { CreateDescriptor("dependency") });
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            registry.RegisterPrepared(artifact);
+            registry.Activate(artifact);
+
+            HotReloadIntroducedTypeAssemblyResolver resolver =
+                new HotReloadIntroducedTypeAssemblyResolver(registry);
+            using (resolver)
+            {
+                Assembly consumerAssembly = Assembly.Load(File.ReadAllBytes(consumerPath));
+                Type sharedType = dependencyAssembly.GetType("ResolverFixture.Shared");
+                Type baseType = dependencyAssembly.GetType("ResolverFixture.Base");
+                Type interfaceType = dependencyAssembly.GetType("ResolverFixture.Contract");
+                Type fieldType = consumerAssembly.GetType("ResolverFixture.FieldHolder").GetField("Value").FieldType;
+                Type derivedBaseType = consumerAssembly.GetType("ResolverFixture.Derived").BaseType;
+                Type implementedInterface = consumerAssembly.GetType("ResolverFixture.Implementation").GetInterfaces()[0];
+                Type returnType = consumerAssembly.GetType("ResolverFixture.MethodHolder").GetMethod("Create").ReturnType;
+
+                Assert.That(fieldType, Is.SameAs(sharedType));
+                Assert.That(derivedBaseType, Is.SameAs(baseType));
+                Assert.That(implementedInterface, Is.SameAs(interfaceType));
+                Assert.That(returnType, Is.SameAs(sharedType));
+                int beforeUnknownRequest = resolver.ResolutionCount;
+                Assert.Throws<FileNotFoundException>(() => Assembly.Load(
+                    new AssemblyName("MissingResolverDependency" + Guid.NewGuid().ToString("N")
+                        + ", Version=1.0.0.0, Culture=neutral, PublicKeyToken=null")));
+                Assert.That(resolver.ResolutionCount, Is.GreaterThan(beforeUnknownRequest));
+            }
+
+            int countAfterDispose = resolver.ResolutionCount;
+            Assert.Throws<FileNotFoundException>(() => Assembly.Load(
+                new AssemblyName("MissingResolverDependency" + Guid.NewGuid().ToString("N")
+                    + ", Version=1.0.0.0, Culture=neutral, PublicKeyToken=null")));
+            Assert.That(resolver.ResolutionCount, Is.EqualTo(countAfterDispose));
+        }
+
+        /// <summary>
+        /// Verifies that an artifact retains an immutable descriptor snapshot when the caller
+        /// changes the list used to prepare it.
+        /// </summary>
+        [Test]
+        public void Artifact_DescriptorInputChanges_RetainsImmutableSnapshot()
+        {
+            List<HotReloadIntroducedTypeDescriptor> descriptors =
+                new List<HotReloadIntroducedTypeDescriptor> { CreateDescriptor("original") };
+            HotReloadIntroducedTypeArtifact artifact = new HotReloadIntroducedTypeArtifact(
+                typeof(HotReloadIntroducedTypeRegistryTests).Assembly,
+                "artifact.dll",
+                "artifact.pdb",
+                descriptors);
+
+            descriptors.Clear();
+
+            Assert.That(artifact.Descriptors, Has.Count.EqualTo(1));
+            Assert.That(artifact.Descriptors[0].DeclarationFingerprint, Is.EqualTo("original"));
+        }
+
+        /// <summary>
+        /// Verifies that discarding a failed prepared candidate does not remove an independently
+        /// active artifact from the resolver or registry.
+        /// </summary>
+        [Test]
+        public void DiscardPrepared_FailedCandidate_PreservesActiveArtifact()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeArtifact active = CreateArtifact("active");
+            HotReloadIntroducedTypeArtifact candidate = CreateArtifactWithAssembly(
+                CreateDynamicAssembly("DiscardCandidate"),
+                CreateOtherDescriptor("candidate"));
+            registry.RegisterPrepared(active);
+            registry.Activate(active);
+            registry.RegisterPrepared(candidate);
+
+            using (HotReloadIntroducedTypeAssemblyResolver resolver =
+                new HotReloadIntroducedTypeAssemblyResolver(registry))
+            {
+                using (resolver.RegisterPrepared(candidate))
+                {
+                    registry.DiscardPrepared(candidate);
+                }
+
+                Assert.That(registry.ActiveCount, Is.EqualTo(1));
+                Assert.That(registry.PreparedCount, Is.EqualTo(0));
+                Assert.That(resolver.ResolveExact(active.AssemblyFullName), Is.SameAs(active.Assembly));
+            }
+        }
+
+        /// <summary>
+        /// Verifies that an artifact rejects missing assembly and descriptor inputs before it can
+        /// enter either the prepared or active registry state.
+        /// </summary>
+        [Test]
+        public void Artifact_RequiredInputsMissing_ThrowsBeforeConstruction()
+        {
+            List<HotReloadIntroducedTypeDescriptor> validDescriptors =
+                new List<HotReloadIntroducedTypeDescriptor> { CreateDescriptor("valid") };
+
+            Assert.Throws<ArgumentNullException>(() => new HotReloadIntroducedTypeArtifact(
+                null,
+                "artifact.dll",
+                "artifact.pdb",
+                validDescriptors));
+            Assert.Throws<ArgumentNullException>(() => new HotReloadIntroducedTypeArtifact(
+                typeof(HotReloadIntroducedTypeRegistryTests).Assembly,
+                "artifact.dll",
+                "artifact.pdb",
+                null));
+            Assert.Throws<ArgumentException>(() => new HotReloadIntroducedTypeArtifact(
+                typeof(HotReloadIntroducedTypeRegistryTests).Assembly,
+                "artifact.dll",
+                "artifact.pdb",
+                new List<HotReloadIntroducedTypeDescriptor>()));
+            Assert.Throws<ArgumentException>(() => new HotReloadIntroducedTypeArtifact(
+                typeof(HotReloadIntroducedTypeRegistryTests).Assembly,
+                "artifact.dll",
+                "artifact.pdb",
+                new List<HotReloadIntroducedTypeDescriptor> { null }));
+        }
+
+        /// <summary>
+        /// Verifies that a type identity conflict in a different artifact assembly leaves the
+        /// candidate prepared and every existing active mapping unchanged.
+        /// </summary>
+        [Test]
+        public void Activate_TypeIdentityConflictAcrossAssemblies_PreservesState()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeArtifact active = CreateArtifactWithAssembly(
+                CreateDynamicAssembly("ActiveArtifact"),
+                CreateDescriptor("active"));
+            HotReloadIntroducedTypeArtifact candidate = CreateArtifactWithAssembly(
+                CreateDynamicAssembly("CandidateArtifact"),
+                CreateDescriptor("candidate"));
+            registry.RegisterPrepared(active);
+            registry.Activate(active);
+            registry.RegisterPrepared(candidate);
+
+            Assert.Throws<InvalidOperationException>(() => registry.Activate(candidate));
+
+            Assert.That(registry.ActiveCount, Is.EqualTo(1));
+            Assert.That(registry.PreparedCount, Is.EqualTo(1));
+            Assert.That(registry.TryResolveActiveAssembly(active.AssemblyFullName, out HotReloadIntroducedTypeArtifact resolved), Is.True);
+            Assert.That(resolved, Is.SameAs(active));
+            Assert.That(registry.TryResolveActiveAssembly(candidate.AssemblyFullName, out HotReloadIntroducedTypeArtifact unexpected), Is.False);
+            Assert.That(unexpected, Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies that activation publishes every descriptor mapping and removes the prepared
+        /// membership only after the complete artifact becomes active.
+        /// </summary>
+        [Test]
+        public void Activate_MultipleDescriptors_PublishesEveryTypeAndRemovesPrepared()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            List<HotReloadIntroducedTypeDescriptor> descriptors =
+                new List<HotReloadIntroducedTypeDescriptor>
+                {
+                    CreateDescriptor("first"),
+                    CreateOtherDescriptor("second")
+                };
+            HotReloadIntroducedTypeArtifact artifact = new HotReloadIntroducedTypeArtifact(
+                typeof(HotReloadIntroducedTypeRegistryTests).Assembly,
+                "artifact.dll",
+                "artifact.pdb",
+                descriptors);
+            registry.RegisterPrepared(artifact);
+
+            registry.Activate(artifact);
+
+            Assert.That(registry.PreparedCount, Is.EqualTo(0));
+            Assert.That(registry.ActiveCount, Is.EqualTo(1));
+            Assert.That(registry.TryFindActiveDescriptor(descriptors[0], out HotReloadIntroducedTypeArtifact first), Is.True);
+            Assert.That(registry.TryFindActiveDescriptor(descriptors[1], out HotReloadIntroducedTypeArtifact second), Is.True);
+            Assert.That(first, Is.SameAs(artifact));
+            Assert.That(second, Is.SameAs(artifact));
+        }
+
+        /// <summary>
+        /// Verifies that a duplicate descriptor request cannot match an active artifact whose
+        /// same-sized definition set contains a distinct second type.
+        /// </summary>
+        [Test]
+        public void TryFindActive_DuplicateRequest_DoesNotMatchDistinctDefinitionSet()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            List<HotReloadIntroducedTypeDescriptor> activeDescriptors =
+                new List<HotReloadIntroducedTypeDescriptor>
+                {
+                    CreateDescriptor("first"),
+                    CreateOtherDescriptor("second")
+                };
+            HotReloadIntroducedTypeArtifact artifact = new HotReloadIntroducedTypeArtifact(
+                typeof(HotReloadIntroducedTypeRegistryTests).Assembly,
+                "artifact.dll",
+                "artifact.pdb",
+                activeDescriptors);
+            registry.RegisterPrepared(artifact);
+            registry.Activate(artifact);
+            List<HotReloadIntroducedTypeDescriptor> duplicateRequest =
+                new List<HotReloadIntroducedTypeDescriptor>
+                {
+                    CreateDescriptor("first"),
+                    CreateDescriptor("first")
+                };
+
+            bool found = registry.TryFindActive(duplicateRequest, out HotReloadIntroducedTypeArtifact foundArtifact);
+
+            Assert.That(found, Is.False);
+            Assert.That(foundArtifact, Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies that an already active artifact cannot return to Prepared and leaves both
+        /// lifecycle counts and its existing active mapping unchanged.
+        /// </summary>
+        [Test]
+        public void RegisterPrepared_AlreadyActiveArtifact_RejectsWithoutStateChange()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeArtifact artifact = CreateArtifact("active");
+            registry.RegisterPrepared(artifact);
+            registry.Activate(artifact);
+
+            Assert.Throws<InvalidOperationException>(() => registry.RegisterPrepared(artifact));
+
+            Assert.That(registry.PreparedCount, Is.EqualTo(0));
+            Assert.That(registry.ActiveCount, Is.EqualTo(1));
+            Assert.That(registry.TryResolveActiveAssembly(artifact.AssemblyFullName, out HotReloadIntroducedTypeArtifact resolved), Is.True);
+            Assert.That(resolved, Is.SameAs(artifact));
+        }
+
+        private static Assembly CreateDynamicAssembly(string prefix)
+        {
+            AssemblyName assemblyName = new AssemblyName(prefix + Guid.NewGuid().ToString("N"));
+            return AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+        }
+
+        private static HotReloadIntroducedTypeArtifact CreateArtifactWithAssembly(
+            Assembly assembly,
+            HotReloadIntroducedTypeDescriptor descriptor)
+        {
+            return new HotReloadIntroducedTypeArtifact(
+                assembly,
+                "artifact.dll",
+                "artifact.pdb",
+                new List<HotReloadIntroducedTypeDescriptor> { descriptor });
+        }
+
+        private static void WriteDependencyAssembly(string path, string assemblyName)
+        {
+            AssemblyDefinition assembly = AssemblyDefinition.CreateAssembly(
+                new AssemblyNameDefinition(assemblyName, new Version(1, 0, 0, 0)),
+                assemblyName,
+                ModuleKind.Dll);
+            ModuleDefinition module = assembly.MainModule;
+            module.Types.Add(new TypeDefinition(
+                "ResolverFixture",
+                "Base",
+                CecilTypeAttributes.Public | CecilTypeAttributes.Class,
+                module.TypeSystem.Object));
+            module.Types.Add(new TypeDefinition(
+                "ResolverFixture",
+                "Shared",
+                CecilTypeAttributes.Public | CecilTypeAttributes.Class,
+                module.TypeSystem.Object));
+            module.Types.Add(new TypeDefinition(
+                "ResolverFixture",
+                "Contract",
+                CecilTypeAttributes.Public | CecilTypeAttributes.Interface | CecilTypeAttributes.Abstract,
+                module.TypeSystem.Object));
+            assembly.Write(path);
+            assembly.Dispose();
+        }
+
+        private static void WriteConsumerAssembly(string path, string assemblyName, string dependencyName)
+        {
+            AssemblyDefinition assembly = AssemblyDefinition.CreateAssembly(
+                new AssemblyNameDefinition(assemblyName, new Version(1, 0, 0, 0)),
+                assemblyName,
+                ModuleKind.Dll);
+            ModuleDefinition module = assembly.MainModule;
+            AssemblyNameReference dependencyReference = new AssemblyNameReference(
+                dependencyName,
+                new Version(1, 0, 0, 0));
+            module.AssemblyReferences.Add(dependencyReference);
+            TypeReference baseReference = new TypeReference("ResolverFixture", "Base", module, dependencyReference);
+            TypeReference sharedReference = new TypeReference("ResolverFixture", "Shared", module, dependencyReference);
+            TypeReference contractReference = new TypeReference("ResolverFixture", "Contract", module, dependencyReference);
+            TypeDefinition fieldHolder = new TypeDefinition(
+                "ResolverFixture",
+                "FieldHolder",
+                CecilTypeAttributes.Public | CecilTypeAttributes.Class,
+                module.TypeSystem.Object);
+            fieldHolder.Fields.Add(new FieldDefinition("Value", CecilFieldAttributes.Public, sharedReference));
+            module.Types.Add(fieldHolder);
+            module.Types.Add(new TypeDefinition(
+                "ResolverFixture",
+                "Derived",
+                CecilTypeAttributes.Public | CecilTypeAttributes.Class,
+                baseReference));
+            TypeDefinition implementation = new TypeDefinition(
+                "ResolverFixture",
+                "Implementation",
+                CecilTypeAttributes.Public | CecilTypeAttributes.Class,
+                module.TypeSystem.Object);
+            implementation.Interfaces.Add(new InterfaceImplementation(contractReference));
+            module.Types.Add(implementation);
+            TypeDefinition methodHolder = new TypeDefinition(
+                "ResolverFixture",
+                "MethodHolder",
+                CecilTypeAttributes.Public | CecilTypeAttributes.Class,
+                module.TypeSystem.Object);
+            MethodDefinition method = new MethodDefinition(
+                "Create",
+                CecilMethodAttributes.Public | CecilMethodAttributes.Static,
+                sharedReference);
+            method.Body.GetILProcessor().Append(method.Body.GetILProcessor().Create(Mono.Cecil.Cil.OpCodes.Ldnull));
+            method.Body.GetILProcessor().Append(method.Body.GetILProcessor().Create(Mono.Cecil.Cil.OpCodes.Ret));
+            methodHolder.Methods.Add(method);
+            module.Types.Add(methodHolder);
+            assembly.Write(path);
+            assembly.Dispose();
+        }
+
+        private static HotReloadIntroducedTypeArtifact CreateArtifact(string fingerprint)
+        {
+            Assembly assembly = typeof(HotReloadIntroducedTypeRegistryTests).Assembly;
+            List<HotReloadIntroducedTypeDescriptor> descriptors =
+                new List<HotReloadIntroducedTypeDescriptor> { CreateDescriptor(fingerprint) };
+            return new HotReloadIntroducedTypeArtifact(assembly, "artifact.dll", "artifact.pdb", descriptors);
+        }
+
+        private static HotReloadIntroducedTypeDescriptor CreateDescriptor(string fingerprint)
+        {
+            return new HotReloadIntroducedTypeDescriptor(
+                "OriginalAssembly",
+                "original-mvid",
+                "Example.Introduced",
+                "Assets/Example.cs",
+                fingerprint,
+                "public class Introduced { }");
+        }
+
+        private static HotReloadIntroducedTypeDescriptor CreateOtherDescriptor(string fingerprint)
+        {
+            return new HotReloadIntroducedTypeDescriptor(
+                "OriginalAssembly",
+                "original-mvid",
+                "Example.OtherIntroduced",
+                "Assets/Other.cs",
+                fingerprint,
+                "public class OtherIntroduced { }");
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs
@@ -515,6 +515,45 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that preparing the same artifact twice is rejected without changing state, so
+        /// one discard cannot revoke a membership another registration still relies on.
+        /// </summary>
+        [Test]
+        public void RegisterPrepared_SameArtifactTwice_RejectsWithoutStateChange()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeArtifact artifact = CreateArtifact("prepared");
+            registry.RegisterPrepared(artifact);
+
+            Assert.Throws<InvalidOperationException>(() => registry.RegisterPrepared(artifact));
+
+            Assert.That(registry.PreparedCount, Is.EqualTo(1));
+            Assert.That(registry.ActiveCount, Is.EqualTo(0));
+            registry.DiscardPrepared(artifact);
+            Assert.That(registry.PreparedCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies that a disposed resolver refuses a prepared registration, because its handler
+        /// is already detached and the assembly would never be resolved.
+        /// </summary>
+        [Test]
+        public void RegisterPrepared_AfterDispose_Throws()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeArtifact artifact = CreateArtifactWithAssembly(
+                CreateDynamicAssembly("DisposedResolver"),
+                CreateOtherDescriptor("prepared"));
+            HotReloadIntroducedTypeAssemblyResolver resolver =
+                new HotReloadIntroducedTypeAssemblyResolver(registry);
+            resolver.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => resolver.RegisterPrepared(artifact));
+
+            Assert.That(resolver.ResolveExact(artifact.AssemblyFullName), Is.Null);
+        }
+
+        /// <summary>
         /// Verifies that resolving from another thread while prepared registrations and their
         /// scopes change on this thread neither throws nor returns an unregistered assembly.
         /// </summary>
@@ -531,7 +570,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             using HotReloadIntroducedTypeAssemblyResolver resolver =
                 new HotReloadIntroducedTypeAssemblyResolver(registry);
             using CancellationTokenSource cancellation = new CancellationTokenSource();
-            ResolutionTally tally = new ResolutionTally(prepared.Assembly, active.Assembly);
+            ResolutionTally tally = new ResolutionTally(prepared, active);
 
             // A background reader is the only way to exercise the AssemblyResolve thread this
             // resolver actually runs on; it touches no Unity API and ends before the test returns.
@@ -539,8 +578,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             {
                 while (!cancellation.IsCancellationRequested)
                 {
-                    tally.Record(resolver.ResolveExact(prepared.AssemblyFullName));
-                    tally.Record(resolver.ResolveExact(active.AssemblyFullName));
+                    tally.Record(
+                        prepared.AssemblyFullName,
+                        resolver.ResolveExact(prepared.AssemblyFullName));
+                    tally.Record(
+                        active.AssemblyFullName,
+                        resolver.ResolveExact(active.AssemblyFullName));
                 }
             });
 
@@ -562,15 +605,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(tally.ResolveCount, Is.GreaterThan(0));
             Assert.That(tally.UnexpectedCount, Is.EqualTo(0));
+            // Without both states the run never interleaved, so a zero unexpected count would
+            // prove nothing about concurrent access.
+            Assert.That(
+                tally.SawBothPreparedStates,
+                Is.True,
+                "The reader never observed the prepared artifact both registered and absent.");
         }
 
         /// <summary>
-        /// Counts background resolutions without keeping one entry per call in memory.
+        /// Judges each background resolution against the identity that was requested, without
+        /// keeping one entry per call in memory.
         /// </summary>
         private sealed class ResolutionTally
         {
-            private readonly Assembly preparedAssembly;
-            private readonly Assembly activeAssembly;
+            private readonly HotReloadIntroducedTypeArtifact prepared;
+            private readonly HotReloadIntroducedTypeArtifact active;
             private int resolveCount;
             private int unexpectedCount;
             private int preparedHitCount;
@@ -583,31 +633,49 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             public bool SawBothPreparedStates =>
                 Volatile.Read(ref preparedHitCount) > 0 && Volatile.Read(ref preparedMissCount) > 0;
 
-            public ResolutionTally(Assembly preparedAssembly, Assembly activeAssembly)
+            public ResolutionTally(
+                HotReloadIntroducedTypeArtifact prepared,
+                HotReloadIntroducedTypeArtifact active)
             {
-                this.preparedAssembly = preparedAssembly;
-                this.activeAssembly = activeAssembly;
+                this.prepared = prepared;
+                this.active = active;
             }
 
-            public void Record(Assembly resolved)
+            public void Record(string requestedAssemblyFullName, Assembly resolved)
             {
                 Interlocked.Increment(ref resolveCount);
+                // The active artifact stays registered for the whole run, so only the prepared
+                // identity may legitimately answer null. Judging the two requests separately is
+                // what makes a resolver that always answers null fail here.
+                if (requestedAssemblyFullName == active.AssemblyFullName)
+                {
+                    if (!ReferenceEquals(resolved, active.Assembly))
+                    {
+                        Interlocked.Increment(ref unexpectedCount);
+                    }
+
+                    return;
+                }
+
+                if (requestedAssemblyFullName != prepared.AssemblyFullName)
+                {
+                    Interlocked.Increment(ref unexpectedCount);
+                    return;
+                }
+
                 if (resolved == null)
                 {
                     Interlocked.Increment(ref preparedMissCount);
                     return;
                 }
 
-                if (ReferenceEquals(resolved, preparedAssembly))
+                if (ReferenceEquals(resolved, prepared.Assembly))
                 {
                     Interlocked.Increment(ref preparedHitCount);
                     return;
                 }
 
-                if (!ReferenceEquals(resolved, activeAssembly))
-                {
-                    Interlocked.Increment(ref unexpectedCount);
-                }
+                Interlocked.Increment(ref unexpectedCount);
             }
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 82a0574ed1caa428bba7552895bae529
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerRequestFileWriter.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerRequestFileWriter.cs
@@ -162,7 +162,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private static StringComparer CreatePathComparer()
+        // Source-path uniqueness must follow the file system, not the string: Windows treats two
+        // spellings that differ only in case as one file, every other platform as two.
+        internal static StringComparer CreatePathComparer()
         {
             return Path.DirectorySeparatorChar == '\\'
                 ? StringComparer.OrdinalIgnoreCase

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerRequestFileWriter.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerRequestFileWriter.cs
@@ -162,9 +162,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        // Source-path uniqueness must follow the file system, not the string: Windows treats two
-        // spellings that differ only in case as one file, every other platform as two.
-        internal static StringComparer CreatePathComparer()
+        private static StringComparer CreatePathComparer()
         {
             return Path.DirectorySeparatorChar == '\\'
                 ? StringComparer.OrdinalIgnoreCase

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeArtifact.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeArtifact.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Retains the loaded assembly and emitted files of one introduced-type preparation batch.
+    /// </summary>
+    internal sealed class HotReloadIntroducedTypeArtifact
+    {
+        public Assembly Assembly { get; }
+
+        public string DllPath { get; }
+
+        public string PdbPath { get; }
+
+        public IReadOnlyList<HotReloadIntroducedTypeDescriptor> Descriptors { get; }
+
+        public string AssemblyFullName => Assembly.FullName;
+
+        public HotReloadIntroducedTypeArtifact(
+            Assembly assembly,
+            string dllPath,
+            string pdbPath,
+            IReadOnlyList<HotReloadIntroducedTypeDescriptor> descriptors)
+        {
+            if (assembly == null)
+            {
+                throw new ArgumentNullException(nameof(assembly));
+            }
+
+            if (descriptors == null)
+            {
+                throw new ArgumentNullException(nameof(descriptors));
+            }
+
+            if (descriptors.Count == 0)
+            {
+                throw new ArgumentException("Introduced-type descriptors must not be empty.", nameof(descriptors));
+            }
+
+            foreach (HotReloadIntroducedTypeDescriptor descriptor in descriptors)
+            {
+                if (descriptor == null)
+                {
+                    throw new ArgumentException("Introduced-type descriptors must not contain null.", nameof(descriptors));
+                }
+            }
+
+            Assembly = assembly;
+            DllPath = dllPath;
+            PdbPath = pdbPath;
+            Descriptors = new List<HotReloadIntroducedTypeDescriptor>(descriptors).AsReadOnly();
+        }
+
+        public bool MatchesDefinitionSet(IReadOnlyList<HotReloadIntroducedTypeDescriptor> descriptors)
+        {
+            if (descriptors == null || descriptors.Count != Descriptors.Count)
+            {
+                return false;
+            }
+
+            bool[] matched = new bool[Descriptors.Count];
+            foreach (HotReloadIntroducedTypeDescriptor descriptor in descriptors)
+            {
+                if (!TryMatchUnmatchedDescriptor(descriptor, matched))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private bool TryMatchUnmatchedDescriptor(
+            HotReloadIntroducedTypeDescriptor descriptor,
+            bool[] matched)
+        {
+            for (int index = 0; index < Descriptors.Count; index++)
+            {
+                if (matched[index] || !Descriptors[index].HasSameDefinition(descriptor))
+                {
+                    continue;
+                }
+
+                matched[index] = true;
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool MatchesDescriptor(HotReloadIntroducedTypeDescriptor descriptor)
+        {
+            foreach (HotReloadIntroducedTypeDescriptor existing in Descriptors)
+            {
+                if (existing.HasSameDefinition(descriptor))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeArtifact.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeArtifact.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec3f824424d054144a371fa19f6f8815
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeArtifactPathFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeArtifactPathFactory.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Allocates a unique, domain-reload-lifetime location for one introduced-type artifact batch.
+    /// </summary>
+    internal sealed class HotReloadIntroducedTypeArtifactPathFactory
+    {
+        private readonly string projectRoot;
+        private readonly string sessionId;
+
+        public HotReloadIntroducedTypeArtifactPathFactory(string projectRoot, string sessionId)
+        {
+            this.projectRoot = projectRoot;
+            this.sessionId = sessionId;
+        }
+
+        public HotReloadIntroducedTypeArtifactPaths Create()
+        {
+            string artifactId = Guid.NewGuid().ToString("N");
+            string directory = Path.Combine(
+                projectRoot,
+                "Library",
+                "UloopHotReload",
+                "IntroducedTypes",
+                sessionId,
+                artifactId);
+            string assemblyName = "UloopIntroducedTypes_" + artifactId;
+            string dllPath = Path.Combine(directory, assemblyName + ".dll");
+            return new HotReloadIntroducedTypeArtifactPaths(
+                Path.Combine(directory, assemblyName + ".cs"),
+                dllPath,
+                Path.Combine(directory, assemblyName + ".pdb"),
+                assemblyName);
+        }
+    }
+
+    /// <summary>
+    /// Carries the file paths and assembly identity allocated to one preparation batch.
+    /// </summary>
+    internal sealed class HotReloadIntroducedTypeArtifactPaths
+    {
+        public string DirectoryPath { get; }
+
+        public string SourcePath { get; }
+
+        public string DllPath { get; }
+
+        public string PdbPath { get; }
+
+        public string AssemblyName { get; }
+
+        public string AssemblyFullName { get; }
+
+        public HotReloadIntroducedTypeArtifactPaths(
+            string sourcePath,
+            string dllPath,
+            string pdbPath,
+            string assemblyName)
+        {
+            DirectoryPath = Path.GetDirectoryName(sourcePath);
+            SourcePath = sourcePath;
+            DllPath = dllPath;
+            PdbPath = pdbPath;
+            AssemblyName = assemblyName;
+            AssemblyName identity = new AssemblyName(assemblyName)
+            {
+                Version = new Version(0, 0, 0, 0),
+                CultureInfo = CultureInfo.InvariantCulture
+            };
+            identity.SetPublicKeyToken(Array.Empty<byte>());
+            AssemblyFullName = identity.FullName;
+        }
+
+        public string CreateSourcePath(int ordinal)
+        {
+            if (ordinal < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
+            }
+
+            return Path.Combine(DirectoryPath, AssemblyName + "_source_" + ordinal + ".cs");
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeArtifactPathFactory.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeArtifactPathFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 24ca62d9540144c46a23227748930757
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeAssemblyResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeAssemblyResolver.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
@@ -10,15 +11,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal sealed class HotReloadIntroducedTypeAssemblyResolver : IDisposable
     {
         private readonly HotReloadIntroducedTypeRegistry registry;
+        private readonly object gate;
         private readonly Dictionary<string, Assembly> preparedAssemblies =
             new Dictionary<string, Assembly>(StringComparer.Ordinal);
+        private int resolutionCount;
         private bool disposed;
 
-        internal int ResolutionCount { get; private set; }
+        internal int ResolutionCount => Volatile.Read(ref resolutionCount);
 
         public HotReloadIntroducedTypeAssemblyResolver(HotReloadIntroducedTypeRegistry registry)
         {
             this.registry = registry ?? throw new ArgumentNullException(nameof(registry));
+            // The prepared map and the registry's mappings are read together inside one resolve, so
+            // they share the registry's gate rather than taking two locks in an unspecified order.
+            gate = registry.Gate;
             AppDomain.CurrentDomain.AssemblyResolve += Resolve;
         }
 
@@ -29,8 +35,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 throw new ArgumentNullException(nameof(artifact));
             }
 
-            preparedAssemblies.Add(artifact.AssemblyFullName, artifact.Assembly);
-            return new PreparedAssemblyScope(preparedAssemblies, artifact.AssemblyFullName);
+            lock (gate)
+            {
+                preparedAssemblies.Add(artifact.AssemblyFullName, artifact.Assembly);
+            }
+
+            return new PreparedAssemblyScope(gate, preparedAssemblies, artifact.AssemblyFullName);
         }
 
         public void Dispose()
@@ -41,7 +51,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             AppDomain.CurrentDomain.AssemblyResolve -= Resolve;
-            preparedAssemblies.Clear();
+            lock (gate)
+            {
+                preparedAssemblies.Clear();
+            }
+
             disposed = true;
         }
 
@@ -52,39 +66,50 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return null;
             }
 
-            if (preparedAssemblies.TryGetValue(requestedAssemblyFullName, out Assembly prepared))
+            // This body must stay a pure lookup. It runs inside AssemblyResolve while the gate is
+            // held, so loading an assembly or calling a Unity API here could re-enter the handler
+            // on the same thread or block the main thread and deadlock the Editor.
+            lock (gate)
             {
-                return prepared;
-            }
+                if (preparedAssemblies.TryGetValue(requestedAssemblyFullName, out Assembly prepared))
+                {
+                    return prepared;
+                }
 
-            if (registry.TryResolveActiveAssembly(requestedAssemblyFullName, out HotReloadIntroducedTypeArtifact active))
-            {
-                return active.Assembly;
+                return registry.TryResolveActiveAssembly(requestedAssemblyFullName, out HotReloadIntroducedTypeArtifact active)
+                    ? active.Assembly
+                    : null;
             }
-
-            return null;
         }
 
         private Assembly Resolve(object sender, ResolveEventArgs arguments)
         {
-            ResolutionCount++;
+            Interlocked.Increment(ref resolutionCount);
             return arguments == null ? null : ResolveExact(arguments.Name);
         }
 
         private sealed class PreparedAssemblyScope : IDisposable
         {
+            private readonly object gate;
             private readonly Dictionary<string, Assembly> assemblies;
             private readonly string assemblyFullName;
 
-            public PreparedAssemblyScope(Dictionary<string, Assembly> assemblies, string assemblyFullName)
+            public PreparedAssemblyScope(
+                object gate,
+                Dictionary<string, Assembly> assemblies,
+                string assemblyFullName)
             {
+                this.gate = gate;
                 this.assemblies = assemblies;
                 this.assemblyFullName = assemblyFullName;
             }
 
             public void Dispose()
             {
-                assemblies.Remove(assemblyFullName);
+                lock (gate)
+                {
+                    assemblies.Remove(assemblyFullName);
+                }
             }
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeAssemblyResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeAssemblyResolver.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Resolves active and scoped prepared artifact assemblies by exact full identity only.
+    /// </summary>
+    internal sealed class HotReloadIntroducedTypeAssemblyResolver : IDisposable
+    {
+        private readonly HotReloadIntroducedTypeRegistry registry;
+        private readonly Dictionary<string, Assembly> preparedAssemblies =
+            new Dictionary<string, Assembly>(StringComparer.Ordinal);
+        private bool disposed;
+
+        internal int ResolutionCount { get; private set; }
+
+        public HotReloadIntroducedTypeAssemblyResolver(HotReloadIntroducedTypeRegistry registry)
+        {
+            this.registry = registry ?? throw new ArgumentNullException(nameof(registry));
+            AppDomain.CurrentDomain.AssemblyResolve += Resolve;
+        }
+
+        public IDisposable RegisterPrepared(HotReloadIntroducedTypeArtifact artifact)
+        {
+            if (artifact == null)
+            {
+                throw new ArgumentNullException(nameof(artifact));
+            }
+
+            preparedAssemblies.Add(artifact.AssemblyFullName, artifact.Assembly);
+            return new PreparedAssemblyScope(preparedAssemblies, artifact.AssemblyFullName);
+        }
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            AppDomain.CurrentDomain.AssemblyResolve -= Resolve;
+            preparedAssemblies.Clear();
+            disposed = true;
+        }
+
+        internal Assembly ResolveExact(string requestedAssemblyFullName)
+        {
+            if (string.IsNullOrEmpty(requestedAssemblyFullName))
+            {
+                return null;
+            }
+
+            if (preparedAssemblies.TryGetValue(requestedAssemblyFullName, out Assembly prepared))
+            {
+                return prepared;
+            }
+
+            if (registry.TryResolveActiveAssembly(requestedAssemblyFullName, out HotReloadIntroducedTypeArtifact active))
+            {
+                return active.Assembly;
+            }
+
+            return null;
+        }
+
+        private Assembly Resolve(object sender, ResolveEventArgs arguments)
+        {
+            ResolutionCount++;
+            return arguments == null ? null : ResolveExact(arguments.Name);
+        }
+
+        private sealed class PreparedAssemblyScope : IDisposable
+        {
+            private readonly Dictionary<string, Assembly> assemblies;
+            private readonly string assemblyFullName;
+
+            public PreparedAssemblyScope(Dictionary<string, Assembly> assemblies, string assemblyFullName)
+            {
+                this.assemblies = assemblies;
+                this.assemblyFullName = assemblyFullName;
+            }
+
+            public void Dispose()
+            {
+                assemblies.Remove(assemblyFullName);
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeAssemblyResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeAssemblyResolver.cs
@@ -37,6 +37,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             lock (gate)
             {
+                // Dispose has already detached the handler, so an assembly registered afterwards
+                // would never be resolved and the caller would silently get an unresolvable type.
+                if (disposed)
+                {
+                    throw new ObjectDisposedException(nameof(HotReloadIntroducedTypeAssemblyResolver));
+                }
+
                 preparedAssemblies.Add(artifact.AssemblyFullName, artifact.Assembly);
             }
 
@@ -45,18 +52,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public void Dispose()
         {
-            if (disposed)
-            {
-                return;
-            }
-
-            AppDomain.CurrentDomain.AssemblyResolve -= Resolve;
             lock (gate)
             {
+                if (disposed)
+                {
+                    return;
+                }
+
+                disposed = true;
                 preparedAssemblies.Clear();
             }
 
-            disposed = true;
+            // Detaching outside the gate keeps the handler subscription change off the lock a
+            // resolve on another thread may already hold.
+            AppDomain.CurrentDomain.AssemblyResolve -= Resolve;
         }
 
         internal Assembly ResolveExact(string requestedAssemblyFullName)
@@ -93,6 +102,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             private readonly object gate;
             private readonly Dictionary<string, Assembly> assemblies;
             private readonly string assemblyFullName;
+            private bool removed;
 
             public PreparedAssemblyScope(
                 object gate,
@@ -108,6 +118,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 lock (gate)
                 {
+                    // A second Dispose must not remove an entry a later RegisterPrepared re-added
+                    // under the same assembly identity.
+                    if (removed)
+                    {
+                        return;
+                    }
+
+                    removed = true;
                     assemblies.Remove(assemblyFullName);
                 }
             }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeAssemblyResolver.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeAssemblyResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1aeaebee25ef0447ba4a95bca99c318f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompiler.cs
@@ -287,7 +287,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 throw new ArgumentException("Introduced-type sources must not be empty.", nameof(sources));
             }
 
-            HashSet<string> paths = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<string> paths = new HashSet<string>(RoslynCompilerRequestFileWriter.CreatePathComparer());
             List<HotReloadIntroducedTypeSource> copiedSources =
                 new List<HotReloadIntroducedTypeSource>(sources.Count);
             foreach (HotReloadIntroducedTypeSource source in sources)
@@ -402,11 +402,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             using AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(path);
             List<string> typeNames = new List<string>();
-            foreach (TypeDefinition type in assembly.MainModule.Types)
+            // GetTypes descends into nested types, and Cecil's FullName keeps the '/' metadata
+            // separator, so a descriptor naming a nested type is matched instead of missed.
+            foreach (TypeDefinition type in assembly.MainModule.GetTypes())
             {
                 if (type.Name != "<Module>")
                 {
-                    typeNames.Add(type.FullName.Replace('/', '.'));
+                    typeNames.Add(type.FullName);
                 }
             }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompiler.cs
@@ -1,0 +1,517 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Mono.Cecil;
+
+using UnityEditor.Compilation;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Compiles immutable type declarations into a retained artifact without publishing it active.
+    /// </summary>
+    internal sealed class HotReloadIntroducedTypeCompiler
+    {
+        private readonly IHotReloadIntroducedTypeCompilerEnvironment environment;
+
+        public HotReloadIntroducedTypeCompiler(IHotReloadIntroducedTypeCompilerEnvironment environment)
+        {
+            this.environment = environment ?? throw new ArgumentNullException(nameof(environment));
+        }
+
+        public async Task<HotReloadIntroducedTypeCompilerResult> CompileAsync(
+            HotReloadIntroducedTypeCompilationRequest request,
+            CancellationToken ct)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            ExternalCompilerPaths paths = await environment.ResolveCompilerPathsOnMainThreadAsync(ct);
+            if (paths == null)
+            {
+                return HotReloadIntroducedTypeCompilerResult.Failure(
+                    "External compiler paths could not be resolved for this Unity installation.");
+            }
+
+            foreach (HotReloadIntroducedTypeSource source in request.Sources)
+            {
+                environment.WriteSource(source.Path, source.Text);
+            }
+
+            DynamicCompilationBackendResult backendResult = await environment.CompileAsync(request, paths, ct)
+                .ConfigureAwait(false);
+            HotReloadIntroducedTypeCompilerResult backendFailure = ValidateBackendResult(request, backendResult);
+            if (backendFailure != null)
+            {
+                return backendFailure;
+            }
+
+            HotReloadIntroducedTypeCompilerResult outputFailure = ValidateOutput(request);
+            if (outputFailure != null)
+            {
+                return outputFailure;
+            }
+
+            ct.ThrowIfCancellationRequested();
+            byte[] assemblyBytes = environment.ReadAllBytes(request.DllPath);
+            byte[] pdbBytes = environment.ReadAllBytes(request.PdbPath);
+            ct.ThrowIfCancellationRequested();
+            CompiledAssemblyLoadResult loadResult = environment.Load(assemblyBytes, pdbBytes);
+            if (!loadResult.Success || loadResult.CompiledAssembly == null)
+            {
+                return HotReloadIntroducedTypeCompilerResult.Failure(
+                    "Introduced-type artifact failed to load.");
+            }
+
+            HotReloadIntroducedTypeArtifact artifact = new HotReloadIntroducedTypeArtifact(
+                loadResult.CompiledAssembly,
+                request.DllPath,
+                request.PdbPath,
+                request.Descriptors);
+            return HotReloadIntroducedTypeCompilerResult.Prepared(artifact);
+        }
+
+        private HotReloadIntroducedTypeCompilerResult ValidateBackendResult(
+            HotReloadIntroducedTypeCompilationRequest request,
+            DynamicCompilationBackendResult backendResult)
+        {
+            if (backendResult == null)
+            {
+                return HotReloadIntroducedTypeCompilerResult.Failure("Introduced-type compilation produced no result.");
+            }
+
+            if (backendResult.BackendKind == DynamicCompilationBackendKind.AssemblyBuilderFallback)
+            {
+                return HotReloadIntroducedTypeCompilerResult.Failure(
+                    "Introduced-type compilation requires the Roslyn compiler backend.");
+            }
+
+            return HasErrors(backendResult.CompilerMessages)
+                ? HotReloadIntroducedTypeCompilerResult.Failure(
+                    "Introduced-type compilation reported errors.",
+                    CreateDiagnostics(request.Sources, backendResult.CompilerMessages))
+                : null;
+        }
+
+        private HotReloadIntroducedTypeCompilerResult ValidateOutput(
+            HotReloadIntroducedTypeCompilationRequest request)
+        {
+            if (!environment.FileExists(request.DllPath) || !environment.FileExists(request.PdbPath))
+            {
+                return HotReloadIntroducedTypeCompilerResult.Failure(
+                    "Introduced-type compilation did not produce both DLL and PDB files.");
+            }
+
+            AssemblyName assemblyName = environment.ReadAssemblyName(request.DllPath);
+            if (assemblyName == null || assemblyName.FullName != request.ExpectedAssemblyFullName)
+            {
+                return HotReloadIntroducedTypeCompilerResult.Failure(
+                    "Introduced-type artifact identity does not match the requested assembly identity. Expected: "
+                    + request.ExpectedAssemblyFullName + "; actual: "
+                    + (assemblyName == null ? "(missing)" : assemblyName.FullName));
+            }
+
+            IReadOnlyCollection<string> emittedTypeNames = environment.ReadDefinedTypeNames(request.DllPath);
+            foreach (HotReloadIntroducedTypeDescriptor descriptor in request.Descriptors)
+            {
+                if (!emittedTypeNames.Contains(descriptor.MetadataName))
+                {
+                    return HotReloadIntroducedTypeCompilerResult.Failure(
+                        "Introduced-type artifact does not define every requested type.");
+                }
+            }
+
+            return null;
+        }
+
+        private static bool HasErrors(CompilerMessage[] messages)
+        {
+            if (messages == null)
+            {
+                return false;
+            }
+
+            foreach (CompilerMessage message in messages)
+            {
+                if (message.type == CompilerMessageType.Error)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static IReadOnlyList<HotReloadIntroducedTypeCompilerDiagnostic> CreateDiagnostics(
+            IReadOnlyList<HotReloadIntroducedTypeSource> sources,
+            CompilerMessage[] messages)
+        {
+            List<HotReloadIntroducedTypeCompilerDiagnostic> diagnostics =
+                new List<HotReloadIntroducedTypeCompilerDiagnostic>();
+            if (messages == null)
+            {
+                return diagnostics;
+            }
+
+            foreach (CompilerMessage message in messages)
+            {
+                if (message.type != CompilerMessageType.Error)
+                {
+                    continue;
+                }
+
+                string ownerProjectRelativePath = string.Empty;
+                string diagnosticPath = string.IsNullOrWhiteSpace(message.file)
+                    ? string.Empty
+                    : Path.GetFullPath(message.file);
+                foreach (HotReloadIntroducedTypeSource source in sources)
+                {
+                    if (string.Equals(source.Path, diagnosticPath, StringComparison.Ordinal))
+                    {
+                        ownerProjectRelativePath = source.Descriptor.OwnerProjectRelativePath;
+                        break;
+                    }
+                }
+
+                diagnostics.Add(new HotReloadIntroducedTypeCompilerDiagnostic(ownerProjectRelativePath, message.message));
+            }
+
+            return diagnostics;
+        }
+    }
+
+    /// <summary>
+    /// Defines the side-effect boundary of introduced-type compilation for deterministic tests.
+    /// </summary>
+    internal interface IHotReloadIntroducedTypeCompilerEnvironment
+    {
+        Task<ExternalCompilerPaths> ResolveCompilerPathsOnMainThreadAsync(CancellationToken ct);
+
+        Task<DynamicCompilationBackendResult> CompileAsync(
+            HotReloadIntroducedTypeCompilationRequest request,
+            ExternalCompilerPaths paths,
+            CancellationToken ct);
+
+        bool FileExists(string path);
+
+        AssemblyName ReadAssemblyName(string path);
+
+        byte[] ReadAllBytes(string path);
+
+        CompiledAssemblyLoadResult Load(byte[] assemblyBytes, byte[] pdbBytes);
+
+        IReadOnlyCollection<string> ReadDefinedTypeNames(string path);
+
+        void WriteSource(string path, string source);
+    }
+
+    /// <summary>
+    /// Supplies all immutable inputs and output paths for one artifact compilation attempt.
+    /// </summary>
+    internal sealed class HotReloadIntroducedTypeCompilationRequest
+    {
+        public IReadOnlyList<HotReloadIntroducedTypeSource> Sources { get; }
+
+        public string DllPath { get; }
+
+        public string PdbPath { get; }
+
+        public string ExpectedAssemblyFullName { get; }
+
+        public IReadOnlyList<HotReloadIntroducedTypeDescriptor> Descriptors { get; }
+
+        public IReadOnlyList<string> ReferencePaths { get; }
+
+        public IReadOnlyList<string> DefineSymbols { get; }
+
+        public HotReloadIntroducedTypeCompilationRequest(
+            IReadOnlyList<HotReloadIntroducedTypeSource> sources,
+            string dllPath,
+            string pdbPath,
+            string expectedAssemblyFullName,
+            IReadOnlyList<HotReloadIntroducedTypeDescriptor> descriptors,
+            IReadOnlyList<string> referencePaths,
+            IReadOnlyList<string> defineSymbols)
+        {
+            Sources = CopySources(sources);
+            DllPath = dllPath;
+            PdbPath = pdbPath;
+            ExpectedAssemblyFullName = expectedAssemblyFullName;
+            Descriptors = CopyDescriptors(descriptors);
+            ReferencePaths = CopyStrings(referencePaths);
+            DefineSymbols = CopyStrings(defineSymbols);
+        }
+
+        public static HotReloadIntroducedTypeCompilationRequest CreateBatch(
+            HotReloadIntroducedTypeArtifactPaths paths,
+            IReadOnlyList<HotReloadIntroducedTypeDescriptor> descriptors,
+            IReadOnlyList<string> referencePaths,
+            IReadOnlyList<string> defineSymbols)
+        {
+            if (paths == null)
+            {
+                throw new ArgumentNullException(nameof(paths));
+            }
+
+            List<HotReloadIntroducedTypeSource> sources = new List<HotReloadIntroducedTypeSource>();
+            for (int index = 0; index < descriptors.Count; index++)
+            {
+                sources.Add(new HotReloadIntroducedTypeSource(paths.CreateSourcePath(index), descriptors[index]));
+            }
+
+            return new HotReloadIntroducedTypeCompilationRequest(
+                sources,
+                paths.DllPath,
+                paths.PdbPath,
+                paths.AssemblyFullName,
+                descriptors,
+                referencePaths,
+                defineSymbols);
+        }
+
+        private static IReadOnlyList<HotReloadIntroducedTypeSource> CopySources(
+            IReadOnlyList<HotReloadIntroducedTypeSource> sources)
+        {
+            if (sources == null || sources.Count == 0)
+            {
+                throw new ArgumentException("Introduced-type sources must not be empty.", nameof(sources));
+            }
+
+            HashSet<string> paths = new HashSet<string>(StringComparer.Ordinal);
+            List<HotReloadIntroducedTypeSource> copiedSources =
+                new List<HotReloadIntroducedTypeSource>(sources.Count);
+            foreach (HotReloadIntroducedTypeSource source in sources)
+            {
+                if (source == null)
+                {
+                    throw new ArgumentException("Introduced-type sources must not contain null.", nameof(sources));
+                }
+
+                string normalizedPath = Path.GetFullPath(source.Path);
+                if (!paths.Add(normalizedPath))
+                {
+                    throw new ArgumentException("Introduced-type source paths must be unique.", nameof(sources));
+                }
+
+                copiedSources.Add(new HotReloadIntroducedTypeSource(normalizedPath, source.Descriptor));
+            }
+
+            return copiedSources.AsReadOnly();
+        }
+
+        private static IReadOnlyList<HotReloadIntroducedTypeDescriptor> CopyDescriptors(
+            IReadOnlyList<HotReloadIntroducedTypeDescriptor> descriptors)
+        {
+            if (descriptors == null || descriptors.Count == 0)
+            {
+                throw new ArgumentException("Introduced-type descriptors must not be empty.", nameof(descriptors));
+            }
+
+            List<HotReloadIntroducedTypeDescriptor> copiedDescriptors =
+                new List<HotReloadIntroducedTypeDescriptor>(descriptors.Count);
+            foreach (HotReloadIntroducedTypeDescriptor descriptor in descriptors)
+            {
+                if (descriptor == null)
+                {
+                    throw new ArgumentException("Introduced-type descriptors must not contain null.", nameof(descriptors));
+                }
+
+                copiedDescriptors.Add(descriptor);
+            }
+
+            return copiedDescriptors.AsReadOnly();
+        }
+
+        private static IReadOnlyList<string> CopyStrings(IReadOnlyList<string> values)
+        {
+            return values == null
+                ? Array.Empty<string>()
+                : new List<string>(values).AsReadOnly();
+        }
+    }
+
+    /// <summary>
+    /// Runs introduced-type compilation through the Unity Roslyn backend without fallback.
+    /// </summary>
+    internal sealed class HotReloadIntroducedTypeCompilerEnvironment : IHotReloadIntroducedTypeCompilerEnvironment
+    {
+        public async Task<ExternalCompilerPaths> ResolveCompilerPathsOnMainThreadAsync(CancellationToken ct)
+        {
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+            return ExternalCompilerPathResolver.Resolve();
+        }
+
+        public Task<DynamicCompilationBackendResult> CompileAsync(
+            HotReloadIntroducedTypeCompilationRequest request,
+            ExternalCompilerPaths paths,
+            CancellationToken ct)
+        {
+            RoslynCompilerOptions options = new RoslynCompilerOptions(
+                request.DefineSymbols,
+                allowUnsafeCode: false,
+                emitDebugCode: true);
+            List<string> sourcePaths = new List<string>();
+            foreach (HotReloadIntroducedTypeSource source in request.Sources)
+            {
+                sourcePaths.Add(source.Path);
+            }
+
+            return RoslynCompilerBackend.CompileMultipleSourcesAsync(
+                sourcePaths,
+                request.DllPath,
+                new List<string>(request.ReferencePaths),
+                paths,
+                options,
+                ct,
+                markBuildStarted: static () => { },
+                markBuildFinished: static () => { },
+                incrementBuildCount: static () => { });
+        }
+
+        public bool FileExists(string path)
+        {
+            return File.Exists(path);
+        }
+
+        public AssemblyName ReadAssemblyName(string path)
+        {
+            return AssemblyName.GetAssemblyName(path);
+        }
+
+        public byte[] ReadAllBytes(string path)
+        {
+            return File.ReadAllBytes(path);
+        }
+
+        public CompiledAssemblyLoadResult Load(byte[] assemblyBytes, byte[] pdbBytes)
+        {
+            return CompiledAssemblyLoader.Load(assemblyBytes, pdbBytes);
+        }
+
+        public IReadOnlyCollection<string> ReadDefinedTypeNames(string path)
+        {
+            using AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(path);
+            List<string> typeNames = new List<string>();
+            foreach (TypeDefinition type in assembly.MainModule.Types)
+            {
+                if (type.Name != "<Module>")
+                {
+                    typeNames.Add(type.FullName.Replace('/', '.'));
+                }
+            }
+
+            return typeNames;
+        }
+
+        public void WriteSource(string path, string source)
+        {
+            string directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(path, source);
+        }
+    }
+
+    /// <summary>
+    /// Reports a prepared artifact or a rejection that left both prepared and active state unchanged.
+    /// </summary>
+    internal sealed class HotReloadIntroducedTypeSource
+    {
+        public string Path { get; }
+
+        public string Text { get; }
+
+        public HotReloadIntroducedTypeDescriptor Descriptor { get; }
+
+        public HotReloadIntroducedTypeSource(string path, HotReloadIntroducedTypeDescriptor descriptor)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException("Source path must not be empty.", nameof(path));
+            }
+
+            Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+            if (string.IsNullOrWhiteSpace(Descriptor.Source))
+            {
+                throw new ArgumentException("Source text must not be empty.", nameof(descriptor));
+            }
+
+            Path = path;
+            Text = Descriptor.Source;
+        }
+    }
+
+    internal sealed class HotReloadIntroducedTypeCompilerDiagnostic
+    {
+        public string OwnerProjectRelativePath { get; }
+
+        public string Message { get; }
+
+        public HotReloadIntroducedTypeCompilerDiagnostic(string ownerProjectRelativePath, string message)
+        {
+            OwnerProjectRelativePath = ownerProjectRelativePath ?? string.Empty;
+            Message = message ?? string.Empty;
+        }
+    }
+
+    internal sealed class HotReloadIntroducedTypeCompilerResult
+    {
+        public bool Success { get; }
+
+        public HotReloadIntroducedTypeArtifact Artifact { get; }
+
+        public string ErrorMessage { get; }
+
+        public IReadOnlyList<HotReloadIntroducedTypeCompilerDiagnostic> Diagnostics { get; }
+
+        private HotReloadIntroducedTypeCompilerResult(
+            bool success,
+            HotReloadIntroducedTypeArtifact artifact,
+            string errorMessage,
+            IReadOnlyList<HotReloadIntroducedTypeCompilerDiagnostic> diagnostics)
+        {
+            Success = success;
+            Artifact = artifact;
+            ErrorMessage = errorMessage;
+            Diagnostics = diagnostics ?? Array.Empty<HotReloadIntroducedTypeCompilerDiagnostic>();
+        }
+
+        public static HotReloadIntroducedTypeCompilerResult Prepared(HotReloadIntroducedTypeArtifact artifact)
+        {
+            if (artifact == null)
+            {
+                throw new ArgumentNullException(nameof(artifact));
+            }
+
+            return new HotReloadIntroducedTypeCompilerResult(
+                true,
+                artifact,
+                string.Empty,
+                Array.Empty<HotReloadIntroducedTypeCompilerDiagnostic>());
+        }
+
+        public static HotReloadIntroducedTypeCompilerResult Failure(
+            string errorMessage,
+            IReadOnlyList<HotReloadIntroducedTypeCompilerDiagnostic> diagnostics = null)
+        {
+            if (string.IsNullOrWhiteSpace(errorMessage))
+            {
+                throw new ArgumentException("Failure message must not be empty.", nameof(errorMessage));
+            }
+
+            return new HotReloadIntroducedTypeCompilerResult(false, null, errorMessage, diagnostics);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompiler.cs
@@ -243,11 +243,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             IReadOnlyList<string> referencePaths,
             IReadOnlyList<string> defineSymbols)
         {
-            Sources = CopySources(sources);
+            IReadOnlyList<HotReloadIntroducedTypeSource> copiedSources = CopySources(sources);
+            IReadOnlyList<HotReloadIntroducedTypeDescriptor> copiedDescriptors = CopyDescriptors(descriptors);
+            ValidateSourceDescriptorPairing(copiedSources, copiedDescriptors);
+            Sources = copiedSources;
             DllPath = dllPath;
             PdbPath = pdbPath;
             ExpectedAssemblyFullName = expectedAssemblyFullName;
-            Descriptors = CopyDescriptors(descriptors);
+            Descriptors = copiedDescriptors;
             ReferencePaths = CopyStrings(referencePaths);
             DefineSymbols = CopyStrings(defineSymbols);
         }
@@ -277,6 +280,40 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 descriptors,
                 referencePaths,
                 defineSymbols);
+        }
+
+        // The compiler writes one source file per entry and then loads the produced assembly, so a
+        // count mismatch, a source paired with a different descriptor, or two descriptors sharing
+        // one identity has to be rejected here. Detecting it after the load would leave an
+        // unloadable assembly behind for an activation that can only be refused.
+        private static void ValidateSourceDescriptorPairing(
+            IReadOnlyList<HotReloadIntroducedTypeSource> sources,
+            IReadOnlyList<HotReloadIntroducedTypeDescriptor> descriptors)
+        {
+            if (sources.Count != descriptors.Count)
+            {
+                throw new ArgumentException(
+                    "Introduced-type sources and descriptors must have the same count.",
+                    nameof(sources));
+            }
+
+            HashSet<string> identities = new HashSet<string>(StringComparer.Ordinal);
+            for (int index = 0; index < sources.Count; index++)
+            {
+                if (!ReferenceEquals(sources[index].Descriptor, descriptors[index]))
+                {
+                    throw new ArgumentException(
+                        "Each introduced-type source must carry the descriptor at the same position.",
+                        nameof(sources));
+                }
+
+                if (!identities.Add(descriptors[index].BuildIdentity()))
+                {
+                    throw new ArgumentException(
+                        "Introduced-type descriptors must have unique identities.",
+                        nameof(descriptors));
+                }
+            }
         }
 
         private static IReadOnlyList<HotReloadIntroducedTypeSource> CopySources(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompiler.cs
@@ -35,7 +35,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 throw new ArgumentNullException(nameof(request));
             }
 
-            ExternalCompilerPaths paths = await environment.ResolveCompilerPathsOnMainThreadAsync(ct);
+            ExternalCompilerPaths paths = await environment.ResolveCompilerPathsOnMainThreadAsync(ct)
+                .ConfigureAwait(false);
             if (paths == null)
             {
                 return HotReloadIntroducedTypeCompilerResult.Failure(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompiler.cs
@@ -287,7 +287,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 throw new ArgumentException("Introduced-type sources must not be empty.", nameof(sources));
             }
 
-            HashSet<string> paths = new HashSet<string>(RoslynCompilerRequestFileWriter.CreatePathComparer());
+            // Every introduced-type source path is generated with a distinct ordinal suffix, so two
+            // paths differing only in case are never legitimate here. Rejecting them regardless of
+            // platform matters because a case-insensitive volume (the macOS default, and Windows)
+            // resolves both spellings to one file, and the second write would silently replace the
+            // first descriptor's source before compilation.
+            HashSet<string> paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             List<HotReloadIntroducedTypeSource> copiedSources =
                 new List<HotReloadIntroducedTypeSource>(sources.Count);
             foreach (HotReloadIntroducedTypeSource source in sources)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompiler.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompiler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 96f88140d15854ab2b24f8816d3fb646
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeDescriptor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeDescriptor.cs
@@ -27,12 +27,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string declarationFingerprint,
             string source)
         {
+            // BuildIdentity concatenates the first three parts and HasSameDefinition compares the
+            // fingerprint, so a missing part would collapse distinct declarations onto one identity
+            // key in the registry's mappings or make a changed definition compare as unchanged.
+            RequireValue(originalAssemblyName, nameof(originalAssemblyName));
+            RequireValue(originalAssemblyMvid, nameof(originalAssemblyMvid));
+            RequireValue(metadataName, nameof(metadataName));
+            RequireValue(declarationFingerprint, nameof(declarationFingerprint));
             OriginalAssemblyName = originalAssemblyName;
             OriginalAssemblyMvid = originalAssemblyMvid;
             MetadataName = metadataName;
             OwnerProjectRelativePath = ownerProjectRelativePath;
             DeclarationFingerprint = declarationFingerprint;
             Source = source;
+        }
+
+        private static void RequireValue(string value, string parameterName)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException("An introduced-type descriptor part must not be empty.", parameterName);
+            }
         }
 
         public string BuildIdentity()

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeDescriptor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeDescriptor.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Identifies one immutable type declaration owned by a compiled source assembly.
+    /// </summary>
+    internal sealed class HotReloadIntroducedTypeDescriptor
+    {
+        public string OriginalAssemblyName { get; }
+
+        public string OriginalAssemblyMvid { get; }
+
+        public string MetadataName { get; }
+
+        public string OwnerProjectRelativePath { get; }
+
+        public string DeclarationFingerprint { get; }
+
+        public string Source { get; }
+
+        public HotReloadIntroducedTypeDescriptor(
+            string originalAssemblyName,
+            string originalAssemblyMvid,
+            string metadataName,
+            string ownerProjectRelativePath,
+            string declarationFingerprint,
+            string source)
+        {
+            OriginalAssemblyName = originalAssemblyName;
+            OriginalAssemblyMvid = originalAssemblyMvid;
+            MetadataName = metadataName;
+            OwnerProjectRelativePath = ownerProjectRelativePath;
+            DeclarationFingerprint = declarationFingerprint;
+            Source = source;
+        }
+
+        public string BuildIdentity()
+        {
+            return OriginalAssemblyName + "|" + OriginalAssemblyMvid + "|" + MetadataName;
+        }
+
+        public bool HasSameDefinition(HotReloadIntroducedTypeDescriptor other)
+        {
+            return other != null
+                && BuildIdentity() == other.BuildIdentity()
+                && OwnerProjectRelativePath == other.OwnerProjectRelativePath
+                && DeclarationFingerprint == other.DeclarationFingerprint;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeDescriptor.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeDescriptor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8521507d8059e481fb1273f56fa36f4d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeRegistry.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeRegistry.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Keeps prepared artifacts isolated until activation publishes them for runtime resolution.
+    /// </summary>
+    internal sealed class HotReloadIntroducedTypeRegistry
+    {
+        private readonly Dictionary<string, HotReloadIntroducedTypeArtifact> activeByTypeIdentity =
+            new Dictionary<string, HotReloadIntroducedTypeArtifact>(StringComparer.Ordinal);
+        private readonly Dictionary<string, HotReloadIntroducedTypeArtifact> activeByAssemblyIdentity =
+            new Dictionary<string, HotReloadIntroducedTypeArtifact>(StringComparer.Ordinal);
+        private readonly HashSet<HotReloadIntroducedTypeArtifact> preparedArtifacts =
+            new HashSet<HotReloadIntroducedTypeArtifact>();
+
+        public int ActiveCount => activeByAssemblyIdentity.Count;
+
+        public int PreparedCount => preparedArtifacts.Count;
+
+        public bool TryFindActive(
+            IReadOnlyList<HotReloadIntroducedTypeDescriptor> descriptors,
+            out HotReloadIntroducedTypeArtifact artifact)
+        {
+            artifact = null;
+            if (descriptors == null || descriptors.Count == 0)
+            {
+                return false;
+            }
+
+            if (descriptors[0] == null
+                || !activeByTypeIdentity.TryGetValue(descriptors[0].BuildIdentity(), out artifact))
+            {
+                artifact = null;
+                return false;
+            }
+
+            if (artifact.MatchesDefinitionSet(descriptors))
+            {
+                return true;
+            }
+
+            artifact = null;
+            return false;
+        }
+
+        public bool TryFindActiveDescriptor(
+            HotReloadIntroducedTypeDescriptor descriptor,
+            out HotReloadIntroducedTypeArtifact artifact)
+        {
+            artifact = null;
+            if (descriptor == null
+                || !activeByTypeIdentity.TryGetValue(descriptor.BuildIdentity(), out artifact))
+            {
+                return false;
+            }
+
+            if (artifact.MatchesDescriptor(descriptor))
+            {
+                return true;
+            }
+
+            artifact = null;
+            return false;
+        }
+
+        public void RegisterPrepared(HotReloadIntroducedTypeArtifact artifact)
+        {
+            if (artifact == null)
+            {
+                throw new ArgumentNullException(nameof(artifact));
+            }
+
+            if (activeByAssemblyIdentity.TryGetValue(
+                artifact.AssemblyFullName,
+                out HotReloadIntroducedTypeArtifact activeArtifact)
+                && ReferenceEquals(activeArtifact, artifact))
+            {
+                throw new InvalidOperationException("An active introduced-type artifact cannot be prepared again.");
+            }
+
+            preparedArtifacts.Add(artifact);
+        }
+
+        public void Activate(HotReloadIntroducedTypeArtifact artifact)
+        {
+            if (artifact == null)
+            {
+                throw new ArgumentNullException(nameof(artifact));
+            }
+
+            if (!preparedArtifacts.Contains(artifact))
+            {
+                throw new InvalidOperationException("Only a prepared introduced-type artifact can be activated.");
+            }
+
+            ValidateActivation(artifact);
+            activeByAssemblyIdentity.Add(artifact.AssemblyFullName, artifact);
+            foreach (HotReloadIntroducedTypeDescriptor descriptor in artifact.Descriptors)
+            {
+                activeByTypeIdentity.Add(descriptor.BuildIdentity(), artifact);
+            }
+
+            preparedArtifacts.Remove(artifact);
+        }
+
+        public void DiscardPrepared(HotReloadIntroducedTypeArtifact artifact)
+        {
+            if (artifact != null)
+            {
+                preparedArtifacts.Remove(artifact);
+            }
+        }
+
+        public bool TryResolveActiveAssembly(string requestedAssemblyFullName, out HotReloadIntroducedTypeArtifact artifact)
+        {
+            return activeByAssemblyIdentity.TryGetValue(requestedAssemblyFullName, out artifact);
+        }
+
+        private void ValidateActivation(HotReloadIntroducedTypeArtifact artifact)
+        {
+            if (activeByAssemblyIdentity.ContainsKey(artifact.AssemblyFullName))
+            {
+                throw new InvalidOperationException("An introduced-type artifact assembly is already active.");
+            }
+
+            HashSet<string> descriptorIdentities = new HashSet<string>(StringComparer.Ordinal);
+            foreach (HotReloadIntroducedTypeDescriptor descriptor in artifact.Descriptors)
+            {
+                if (descriptor == null)
+                {
+                    throw new InvalidOperationException("An introduced-type artifact cannot contain a null descriptor.");
+                }
+
+                string identity = descriptor.BuildIdentity();
+                if (!descriptorIdentities.Add(identity))
+                {
+                    throw new InvalidOperationException("An introduced-type artifact cannot contain duplicate descriptors.");
+                }
+
+                if (activeByTypeIdentity.ContainsKey(identity))
+                {
+                    throw new InvalidOperationException("An introduced-type identity is already active.");
+                }
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeRegistry.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeRegistry.cs
@@ -117,7 +117,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     throw new InvalidOperationException("An active introduced-type artifact cannot be prepared again.");
                 }
 
-                preparedArtifacts.Add(artifact);
+                // A second Prepared registration of the same artifact would make one
+                // DiscardPrepared drop the membership the other registration still relies on, so
+                // the later Activate would be rejected as never prepared.
+                if (!preparedArtifacts.Add(artifact))
+                {
+                    throw new InvalidOperationException("An introduced-type artifact is already prepared.");
+                }
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeRegistry.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeRegistry.cs
@@ -15,25 +15,53 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly HashSet<HotReloadIntroducedTypeArtifact> preparedArtifacts =
             new HashSet<HotReloadIntroducedTypeArtifact>();
 
-        public int ActiveCount => activeByAssemblyIdentity.Count;
+        // AppDomain.AssemblyResolve runs on whichever thread requested the failed bind, so the
+        // resolver reads this state off the main thread while activation mutates it on the main
+        // thread. Every access takes this gate, and the resolver takes the same one, so the two
+        // never see a dictionary mid-write.
+        private readonly object gate = new object();
 
-        public int PreparedCount => preparedArtifacts.Count;
+        internal object Gate => gate;
+
+        public int ActiveCount
+        {
+            get
+            {
+                lock (gate)
+                {
+                    return activeByAssemblyIdentity.Count;
+                }
+            }
+        }
+
+        public int PreparedCount
+        {
+            get
+            {
+                lock (gate)
+                {
+                    return preparedArtifacts.Count;
+                }
+            }
+        }
 
         public bool TryFindActive(
             IReadOnlyList<HotReloadIntroducedTypeDescriptor> descriptors,
             out HotReloadIntroducedTypeArtifact artifact)
         {
             artifact = null;
-            if (descriptors == null || descriptors.Count == 0)
+            if (descriptors == null || descriptors.Count == 0 || descriptors[0] == null)
             {
                 return false;
             }
 
-            if (descriptors[0] == null
-                || !activeByTypeIdentity.TryGetValue(descriptors[0].BuildIdentity(), out artifact))
+            lock (gate)
             {
-                artifact = null;
-                return false;
+                if (!activeByTypeIdentity.TryGetValue(descriptors[0].BuildIdentity(), out artifact))
+                {
+                    artifact = null;
+                    return false;
+                }
             }
 
             if (artifact.MatchesDefinitionSet(descriptors))
@@ -50,10 +78,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             out HotReloadIntroducedTypeArtifact artifact)
         {
             artifact = null;
-            if (descriptor == null
-                || !activeByTypeIdentity.TryGetValue(descriptor.BuildIdentity(), out artifact))
+            if (descriptor == null)
             {
                 return false;
+            }
+
+            lock (gate)
+            {
+                if (!activeByTypeIdentity.TryGetValue(descriptor.BuildIdentity(), out artifact))
+                {
+                    return false;
+                }
             }
 
             if (artifact.MatchesDescriptor(descriptor))
@@ -72,15 +107,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 throw new ArgumentNullException(nameof(artifact));
             }
 
-            if (activeByAssemblyIdentity.TryGetValue(
-                artifact.AssemblyFullName,
-                out HotReloadIntroducedTypeArtifact activeArtifact)
-                && ReferenceEquals(activeArtifact, artifact))
+            lock (gate)
             {
-                throw new InvalidOperationException("An active introduced-type artifact cannot be prepared again.");
-            }
+                if (activeByAssemblyIdentity.TryGetValue(
+                    artifact.AssemblyFullName,
+                    out HotReloadIntroducedTypeArtifact activeArtifact)
+                    && ReferenceEquals(activeArtifact, artifact))
+                {
+                    throw new InvalidOperationException("An active introduced-type artifact cannot be prepared again.");
+                }
 
-            preparedArtifacts.Add(artifact);
+                preparedArtifacts.Add(artifact);
+            }
         }
 
         public void Activate(HotReloadIntroducedTypeArtifact artifact)
@@ -90,24 +128,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 throw new ArgumentNullException(nameof(artifact));
             }
 
-            if (!preparedArtifacts.Contains(artifact))
+            lock (gate)
             {
-                throw new InvalidOperationException("Only a prepared introduced-type artifact can be activated.");
-            }
+                if (!preparedArtifacts.Contains(artifact))
+                {
+                    throw new InvalidOperationException("Only a prepared introduced-type artifact can be activated.");
+                }
 
-            ValidateActivation(artifact);
-            activeByAssemblyIdentity.Add(artifact.AssemblyFullName, artifact);
-            foreach (HotReloadIntroducedTypeDescriptor descriptor in artifact.Descriptors)
-            {
-                activeByTypeIdentity.Add(descriptor.BuildIdentity(), artifact);
-            }
+                ValidateActivation(artifact);
+                activeByAssemblyIdentity.Add(artifact.AssemblyFullName, artifact);
+                foreach (HotReloadIntroducedTypeDescriptor descriptor in artifact.Descriptors)
+                {
+                    activeByTypeIdentity.Add(descriptor.BuildIdentity(), artifact);
+                }
 
-            preparedArtifacts.Remove(artifact);
+                preparedArtifacts.Remove(artifact);
+            }
         }
 
         public void DiscardPrepared(HotReloadIntroducedTypeArtifact artifact)
         {
-            if (artifact != null)
+            if (artifact == null)
+            {
+                return;
+            }
+
+            lock (gate)
             {
                 preparedArtifacts.Remove(artifact);
             }
@@ -115,7 +161,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public bool TryResolveActiveAssembly(string requestedAssemblyFullName, out HotReloadIntroducedTypeArtifact artifact)
         {
-            return activeByAssemblyIdentity.TryGetValue(requestedAssemblyFullName, out artifact);
+            lock (gate)
+            {
+                return activeByAssemblyIdentity.TryGetValue(requestedAssemblyFullName, out artifact);
+            }
         }
 
         private void ValidateActivation(HotReloadIntroducedTypeArtifact artifact)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeRegistry.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b4ba445a6f2d4062bc01a1ca269dea8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- Groundwork so that a type introduced by hot reload can stay alive for the rest of the Editor session instead of disappearing with the shim assembly.
- Nothing is reachable from a tool yet; this change only adds the preparation layer and its tests.

## User Impact

Today a new type declaration is compiled into the throwaway shim assembly, whose DLL is deleted right after the patch is applied. Editing the caller a second time therefore rebinds against a type whose assembly is no longer loaded, and hot reload has to tell the user to compile.

This change adds the piece that makes the introduced type survive: it is compiled into its own uniquely named assembly, kept loaded until the next Domain Reload, and handed back by exact identity whenever the runtime asks for it. On its own it changes no user-visible behavior — the introduced-type path stays explicitly skipped until the production wiring lands in a later change.

## Changes

- A descriptor identifies one immutable declaration by original assembly name, original MVID and metadata name, plus the owner path and declaration fingerprint used to detect a changed definition.
- A path factory allocates a unique assembly name and a paired DLL/PDB location per batch, so retrying a changed definition never reuses the identity of an assembly that is already loaded and cannot be unloaded.
- The compiler drives the Roslyn multi-source backend and rejects fallback output, error diagnostics, missing DLL/PDB, assembly identity mismatch and missing type definitions before the irreversible loader call. Compiler errors are mapped from source path back to the owning file, and cancellation is rechecked immediately before loading.
- The registry keeps prepared artifacts separate from active ones and validates every assembly-identity and type-identity collision before it mutates either mapping, so a rejected activation leaves the previous state untouched.
- The resolver answers `AssemblyResolve` for active and scoped prepared artifacts by exact full identity only, and never searches disk from inside the callback. This is what lets a later batch reference a type introduced by an earlier one: the earlier artifact is already loaded and is returned by identity instead of being compiled again.

## Verification

- `uloop compile`: Success, 0 errors.
- `uloop run-tests` (single-flight, regex filter over the three introduced-type classes): 32 passed, 0 failed, 0 skipped. Includes two tests that exercise the real Roslyn environment end to end (a defined artifact, and a real second-source error mapped to its owner) and one that loads two real DLLs to confirm the resolver returns a single active artifact assembly for field, base, interface and return-type references, that an unknown request still reaches the handler, and that no request reaches it after `Dispose`.
- Guard mutation check: removing the prepared-membership precondition from activation makes exactly the two new activation tests fail (`Expected: <System.InvalidOperationException> But was: null`); the guard was restored and the suite re-run green.
- `scripts/check-file-length.sh`: no findings. `scripts/check-code-complexity.sh`: 0 Go issues, no CA1502 findings. `check-asmdef-policy`: no violations. `scripts/check-dead-code.sh`: no candidates.
- This pull request targets an integration branch, so the repository pull-request workflows do not fire; the checks above were run locally in their place. Full CI runs on the final pull request from the integration branch.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

