### PR TITLE
fix: Dynamic code execution keeps using the fast compiler on the newest editor releases

### DIFF
--- a/.github/workflows/unity-editmode-tests.yml
+++ b/.github/workflows/unity-editmode-tests.yml
@@ -2,13 +2,6 @@ name: Unity EditMode Tests
 
 on:
   workflow_dispatch:
-    inputs:
-      inspect-layout-only:
-        description: >-
-          Print the 6000.7 editor's compiler layout and skip the test run.
-          Temporary; removed once the resolver probes that layout.
-        type: boolean
-        default: false
   schedule:
     - cron: '0 18 * * *'
 
@@ -20,7 +13,6 @@ jobs:
   concurrency-unit-tests:
     name: Concurrency Unit Tests
     runs-on: ubuntu-latest
-    if: ${{ !inputs.inspect-layout-only }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -39,7 +31,6 @@ jobs:
   editmode-tests:
     name: EditMode Tests (${{ matrix.unity-version }})
     runs-on: ubuntu-latest
-    if: ${{ !inputs.inspect-layout-only }}
     strategy:
       fail-fast: false
       matrix:
@@ -269,30 +260,6 @@ jobs:
           echo "Installed Unity $UNITY_VERSION at $UNITY_EDITOR"
           df -h
 
-      # Temporary: prints where this editor keeps the external compiler so the
-      # resolver's probe list can be extended. Removed once the probe lands.
-      - name: Inspect editor compiler layout
-        if: env.HAS_UNITY_LICENSE == 'true' && inputs.inspect-layout-only
-        run: |
-          set -eu
-          EDITOR_DATA=$(dirname "$UNITY_EDITOR")/Data
-          echo "::group::Editor/Data"
-          ls -1 "$EDITOR_DATA"
-          echo "::endgroup::"
-          echo "::group::Editor/Data/Resources/Scripting"
-          ls -1 "$EDITOR_DATA/Resources/Scripting" || echo "(absent)"
-          echo "::endgroup::"
-          echo "::group::compiler components"
-          find "$EDITOR_DATA" \
-            \( -name csc.dll \
-            -o -name csc.runtimeconfig.json \
-            -o -name csc.deps.json \
-            -o -name 'Microsoft.CodeAnalysis*.dll' \
-            -o -name dotnet -type f \
-            -o -name Microsoft.NETCore.App \) \
-            -printf '%P\n' | sort
-          echo "::endgroup::"
-
       - name: Cache Library folder
         if: env.HAS_UNITY_LICENSE == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
@@ -303,7 +270,7 @@ jobs:
             Library-${{ env.UNITY_VERSION }}-debug-
 
       - name: Activate Unity license and run EditMode tests
-        if: env.HAS_UNITY_LICENSE == 'true' && !inputs.inspect-layout-only
+        if: env.HAS_UNITY_LICENSE == 'true'
         timeout-minutes: 60
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -375,7 +342,7 @@ jobs:
 
       - name: Upload latest 6000.7 test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        if: always() && env.HAS_UNITY_LICENSE == 'true' && !inputs.inspect-layout-only
+        if: always() && env.HAS_UNITY_LICENSE == 'true'
         with:
           name: Unity test results (latest 6000.7)
           path: artifacts

--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExternalCompilerPathResolverTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExternalCompilerPathResolverTests.cs
@@ -180,6 +180,60 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.That(resolvedScriptingRootPath, Is.EqualTo(expectedScriptingRootPath));
         }
 
+        /// <summary>
+        /// What: an editor that ships no NetCoreRuntime, but whose DotNetSdk root carries the host
+        /// and the shared framework beside Roslyn, is still recognised as a compiler layout.
+        /// </summary>
+        [Test]
+        public void ResolveScriptingRootPath_WhenDotNetSdkRootCarriesTheRuntime_ShouldReturnContentsPath()
+        {
+            string contentsPath = CreateDirectory("Contents");
+            CreateFile(Path.Combine("Contents", "DotNetSdk", "dotnet"));
+            CreateDirectory(Path.Combine("Contents", "DotNetSdk", "shared", "Microsoft.NETCore.App", "10.0.9"));
+            CreateFile(Path.Combine("Contents", "DotNetSdk", "sdk", "10.0.301", "Roslyn", "bincore", "csc.dll"));
+
+            string resolvedScriptingRootPath = ExternalCompilerPathResolver.ResolveScriptingRootPath(contentsPath);
+
+            Assert.That(resolvedScriptingRootPath, Is.EqualTo(contentsPath));
+        }
+
+        /// <summary>
+        /// What: a Roslyn directory with neither NetCoreRuntime nor a shared framework beside it is
+        /// not a usable layout, so nothing is reported as the scripting root.
+        /// </summary>
+        [Test]
+        public void ResolveScriptingRootPath_WhenNoRuntimeAccompaniesTheCompiler_ShouldReturnNull()
+        {
+            string contentsPath = CreateDirectory("Contents");
+            CreateFile(Path.Combine("Contents", "DotNetSdk", "dotnet"));
+            CreateFile(Path.Combine("Contents", "DotNetSdk", "sdk", "10.0.301", "Roslyn", "bincore", "csc.dll"));
+
+            string resolvedScriptingRootPath = ExternalCompilerPathResolver.ResolveScriptingRootPath(contentsPath);
+
+            Assert.That(resolvedScriptingRootPath, Is.Null);
+        }
+
+        /// <summary>
+        /// What: the runtime-carrying DotNetSdk layout is classified as a contents-root DotNetSdk
+        /// layout rather than as a scanned or legacy one.
+        /// </summary>
+        [Test]
+        public void ResolveCompilerLayoutKind_WhenDotNetSdkRootCarriesTheRuntime_ShouldReturnContentsRootDotNetSdk()
+        {
+            string contentsPath = CreateDirectory("Contents");
+            CreateFile(Path.Combine("Contents", "DotNetSdk", "dotnet"));
+            CreateDirectory(Path.Combine("Contents", "DotNetSdk", "shared", "Microsoft.NETCore.App", "10.0.9"));
+            string compilerDirectoryPath = CreateDirectory(
+                Path.Combine("Contents", "DotNetSdk", "sdk", "10.0.301", "Roslyn", "bincore"));
+
+            ExternalCompilerLayoutKind layoutKind = ExternalCompilerPathResolver.ResolveCompilerLayoutKind(
+                contentsPath,
+                ExternalCompilerPathResolver.ResolveScriptingRootPath(contentsPath),
+                compilerDirectoryPath);
+
+            Assert.That(layoutKind, Is.EqualTo(ExternalCompilerLayoutKind.ContentsRootDotNetSdk));
+        }
+
         [Test]
         public void ResolveCompilerDirectoryPath_WhenLegacyLayoutExists_ShouldReturnDotNetSdkRoslynPath()
         {

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/ExternalCompilerPathResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/ExternalCompilerPathResolver.cs
@@ -243,10 +243,41 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 .First();
         }
 
+        // Why the runtime may sit in either place: the newest editors ship no NetCoreRuntime at all and
+        // keep the host and the shared framework inside the same DotNetSdk root that holds Roslyn, so
+        // demanding NetCoreRuntime made a complete layout look like no layout and disabled the fast path.
         private static bool ContainsExternalCompilerLayout(string rootPath)
         {
-            return Directory.Exists(Path.Combine(rootPath, NetCoreRuntimeDirectoryName))
-                && !string.IsNullOrEmpty(ResolveCompilerDirectoryPath(rootPath));
+            string compilerDirectoryPath = ResolveCompilerDirectoryPath(rootPath);
+            if (string.IsNullOrEmpty(compilerDirectoryPath))
+            {
+                return false;
+            }
+
+            if (Directory.Exists(Path.Combine(rootPath, NetCoreRuntimeDirectoryName)))
+            {
+                return true;
+            }
+
+            return ContainsDotNetSdkSharedRuntime(compilerDirectoryPath);
+        }
+
+        /// <summary>
+        /// Reports whether the DotNetSdk root holding this compiler also holds the shared framework it needs.
+        /// </summary>
+        private static bool ContainsDotNetSdkSharedRuntime(string compilerDirectoryPath)
+        {
+            string dotNetSdkRootPath = FindDirectoryContainingSdk(compilerDirectoryPath);
+            if (string.IsNullOrEmpty(dotNetSdkRootPath))
+            {
+                return false;
+            }
+
+            return Directory.Exists(
+                Path.Combine(
+                    dotNetSdkRootPath,
+                    NetCoreRuntimeSharedDirectoryName,
+                    NetCoreRuntimeSharedFrameworkName));
         }
 
         internal static string ResolveCompilerDirectoryPath(string scriptingRootPath)


### PR DESCRIPTION
## Summary

- Dynamic code execution and hot reload use the fast compiler again on editors that ship no `NetCoreRuntime` directory, instead of silently falling back to the slow path.

## User Impact

On the newest editor releases every `execute-dynamic-code` and hot-reload compilation fell back to the
slower `AssemblyBuilder` path and logged an error saying the fast Roslyn path was unavailable — on an
installation that has every component the fast path needs.

The cause was the layout probe. It required a `NetCoreRuntime` directory next to the compiler, which
these editors no longer ship: the `dotnet` host and the shared framework now live inside the same
`DotNetSdk` root that holds Roslyn. With that directory absent, every probe location failed, no
scripting root was found, and the resolver gave up before it ever looked at the compiler it had.

A root now counts as a compiler layout when a compiler directory resolves **and** a runtime accompanies
it — from `NetCoreRuntime` as before, or from the `DotNetSdk` root itself. Older layouts keep taking the
same path they took before, and a compiler with no runtime beside it is still rejected.

## Changes

- Rewrite the layout predicate to pair "a compiler resolves here" with "a runtime is reachable from it",
  rather than testing for one fixed directory name.
- Cover all three cases with fake directory trees: the runtime-carrying `DotNetSdk` root, the existing
  layouts, and the negative case where neither runtime location exists.
- Remove the temporary workflow step that printed an editor's compiler layout. It was added to observe
  the layout this change now probes, and the workflow is byte-identical to its state before that step.

## Verification

- Observed the layout on the newest alpha before writing the fix: `csc.dll`, `csc.runtimeconfig.json`,
  `csc.deps.json` and both `Microsoft.CodeAnalysis` assemblies under `DotNetSdk/sdk/<version>/Roslyn/bincore`,
  the host at `DotNetSdk/dotnet`, the shared framework at `DotNetSdk/shared/Microsoft.NETCore.App`, and
  neither `NetCoreRuntime` nor `Resources/Scripting` present anywhere.
- `run-tests --filter-type class --filter-value ExternalCompilerPathResolverTests`: 21 passed, 0 failed.
- Non-vacuity: the two new positive tests fail against the old predicate (`Expected: <contents path> But was: null`,
  `Expected: ContentsRootDotNetSdk But was: Unknown`), and the negative test passes both before and after.
- The scheduled EditMode workflow was dispatched once on this branch to confirm the newest editor's job
  is green with the step removed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

