### PR TITLE
chore: HotReload EditMode tests no longer idle on the Editor's 100 ms update cadence

### DIFF
--- a/Assets/Tests/Editor/HotReload/EditorTickPump.cs
+++ b/Assets/Tests/Editor/HotReload/EditorTickPump.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Threading;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Invokes a tick signal from a timer thread at a fixed interval until disposed.
+    /// Why a background thread: an unfocused Editor runs EditorApplication.update only every
+    /// ~100 ms, and EditorApplication.SignalTick() re-arms a tick only when called from a thread
+    /// other than the main thread (a call from inside an update handler is a no-op). Every
+    /// awaited continuation in an async EditMode test resumes on the next update, so the
+    /// suite otherwise idles 0.2-0.4 s per test.
+    /// </summary>
+    internal sealed class EditorTickPump : IDisposable
+    {
+        // Why bounded: Dispose must not hang the Editor if the timer thread is wedged, but a
+        // normal callback finishes in microseconds, so this only guards the pathological case.
+        private const int DisposeWaitMilliseconds = 1000;
+
+        private readonly Timer _timer;
+        private readonly Action _signalTick;
+        private int _disposed;
+
+        public EditorTickPump(Action signalTick, int intervalMilliseconds)
+        {
+            if (signalTick == null)
+            {
+                throw new ArgumentNullException(nameof(signalTick));
+            }
+
+            if (intervalMilliseconds <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(intervalMilliseconds),
+                    "The pump interval must be positive.");
+            }
+
+            _signalTick = signalTick;
+            _timer = new Timer(OnTimer, null, 0, intervalMilliseconds);
+        }
+
+        private void OnTimer(object state)
+        {
+            // Why re-check: Timer can deliver a callback that was already queued when Dispose
+            // began; the disposed flag keeps that late callback from signaling a torn-down Editor.
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                return;
+            }
+
+            _signalTick();
+        }
+
+        /// <summary>
+        /// Stops the pump. Blocks until any in-flight callback has finished, so no signal runs
+        /// after this returns. Safe to call more than once.
+        /// </summary>
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            using ManualResetEvent callbacksDrained = new ManualResetEvent(false);
+            if (_timer.Dispose(callbacksDrained))
+            {
+                callbacksDrained.WaitOne(DisposeWaitMilliseconds);
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/EditorTickPump.cs.meta
+++ b/Assets/Tests/Editor/HotReload/EditorTickPump.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 71320b3d92a864e38a64fa1492e996d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/EditorTickPumpTests.cs
+++ b/Assets/Tests/Editor/HotReload/EditorTickPumpTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    public class EditorTickPumpTests
+    {
+        /// <summary>
+        /// What: a started pump invokes the signal callback repeatedly at roughly the requested interval.
+        /// </summary>
+        [Test]
+        public async Task Start_InvokesSignalRepeatedly()
+        {
+            int count = 0;
+            using (EditorTickPump pump = new EditorTickPump(() => Interlocked.Increment(ref count), 5))
+            {
+                await Task.Delay(200);
+                Assert.That(Volatile.Read(ref count), Is.GreaterThanOrEqualTo(5));
+            }
+        }
+
+        /// <summary>
+        /// What: after Dispose returns, no further signal callback runs, so a torn-down fixture
+        /// cannot signal the Editor from a background thread.
+        /// </summary>
+        [Test]
+        public async Task Dispose_StopsSignalsBeforeReturning()
+        {
+            int count = 0;
+            EditorTickPump pump = new EditorTickPump(() => Interlocked.Increment(ref count), 5);
+            await Task.Delay(100);
+            pump.Dispose();
+            int countAtDispose = Volatile.Read(ref count);
+            await Task.Delay(100);
+            Assert.That(Volatile.Read(ref count), Is.EqualTo(countAtDispose));
+        }
+
+        /// <summary>
+        /// What: Dispose is idempotent so OneTimeTearDown and a reload hook can both call it.
+        /// </summary>
+        [Test]
+        public void Dispose_Twice_DoesNotThrow()
+        {
+            EditorTickPump pump = new EditorTickPump(() => { }, 5);
+            pump.Dispose();
+            Assert.DoesNotThrow(() => pump.Dispose());
+        }
+
+        /// <summary>
+        /// What: the constructor rejects a null signal callback.
+        /// </summary>
+        [Test]
+        public void Constructor_NullSignal_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new EditorTickPump(null, 5));
+        }
+
+        /// <summary>
+        /// What: the constructor rejects a non-positive interval, which would spin a thread.
+        /// </summary>
+        [Test]
+        public void Constructor_NonPositiveInterval_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new EditorTickPump(() => { }, 0));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/EditorTickPumpTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/EditorTickPumpTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86d06a79afa8d46c5a134586951502c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadEditorTickPumpTestSafety.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadEditorTickPumpTestSafety.cs
@@ -1,0 +1,50 @@
+using NUnit.Framework;
+
+using UnityEditor;
+
+using io.github.hatayama.UnityCliLoop.InternalAPIBridge;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Keeps the Editor loop ticking while the HotReload EditMode fixtures run.
+    /// Why: the fixtures are async and each awaited continuation resumes on the next
+    /// EditorApplication.update, which fires only every ~100 ms in an unfocused Editor; the
+    /// pump drives it at <see cref="PumpIntervalMilliseconds"/> for the duration of the run only,
+    /// so normal Editor behavior outside the test run is unchanged.
+    /// </summary>
+    [SetUpFixture]
+    public sealed class HotReloadEditorTickPumpTestSafety
+    {
+        private const int PumpIntervalMilliseconds = 8;
+
+        private static EditorTickPump _pump;
+
+        [OneTimeSetUp]
+        public void StartPump()
+        {
+            StopPump();
+            // EditorApplication.SignalTick is [ThreadSafe] in the Editor bindings, which is what
+            // allows the timer thread to call it.
+            _pump = new EditorTickPump(EditorApplicationTickBridge.SignalTick, PumpIntervalMilliseconds);
+            // Why: a compile or a test-triggered reload tears the domain down while the run is
+            // still open; the timer must stop before that so it cannot signal across the reload.
+            AssemblyReloadEvents.beforeAssemblyReload -= StopPump;
+            AssemblyReloadEvents.beforeAssemblyReload += StopPump;
+        }
+
+        [OneTimeTearDown]
+        public void StopPumpAfterRun()
+        {
+            AssemblyReloadEvents.beforeAssemblyReload -= StopPump;
+            StopPump();
+        }
+
+        private static void StopPump()
+        {
+            EditorTickPump pump = _pump;
+            _pump = null;
+            pump?.Dispose();
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadEditorTickPumpTestSafety.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadEditorTickPumpTestSafety.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5df4a23415dc6418ba776e33b2c02faa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/UnityCLILoop.Tests.Editor.HotReload.asmdef
+++ b/Assets/Tests/Editor/HotReload/UnityCLILoop.Tests.Editor.HotReload.asmdef
@@ -9,7 +9,8 @@
         "GUID:fc3fd32eddbee40e39c2d76dc184957b",
         "GUID:94d8abc693f543a691a4645a5ff42e5c",
         "GUID:527f26a36b5043c2bd4d4036d04cd76d",
-        "GUID:18e6dd30a99d14f32a045f79a2956f46"
+        "GUID:18e6dd30a99d14f32a045f79a2956f46",
+        "GUID:5079a8d3a72924a81aa1cbc25f65ed1b"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
## Summary
- The HotReload EditMode test assembly no longer idles on the Editor's 100 ms update cadence while it runs, cutting roughly 40 s off the local suite time without changing any test.

## User Impact
- Before: with the Editor unfocused (the normal state during a `uloop run-tests` run), `EditorApplication.update` fires only every ~100 ms. Every `await` continuation in the async HotReload fixtures resumes on the next update, so each of the ~400 hot-reload tests paid 0.2–0.4 s of pure idle. This is one of the three dominant factors identified in #2634.
- After: a tick pump keeps the Editor loop running at 8 ms for the duration of the HotReload assembly's test run only. Normal Editor behavior outside the run is unchanged.

## Changes
- `Assets/Tests/Editor/HotReload/EditorTickPump.cs`: a `System.Threading.Timer` that calls the tick signal from a timer thread. `EditorApplication.SignalTick()` is `[ThreadSafe]` in the Editor bindings, and it re-arms a tick only when called from a thread other than the main thread (a call from inside an update handler is a no-op, which is why the existing main-thread pump does not help here). `Dispose` is idempotent and blocks (bounded to 1 s) until any in-flight callback has drained, so no signal runs after it returns.
- `Assets/Tests/Editor/HotReload/HotReloadEditorTickPumpTestSafety.cs`: a `[SetUpFixture]` for the HotReload test namespace. `OneTimeSetUp` starts the pump and subscribes `AssemblyReloadEvents.beforeAssemblyReload`; `OneTimeTearDown` unsubscribes and disposes. The timer therefore cannot survive a domain reload triggered mid-run.
- `Assets/Tests/Editor/HotReload/EditorTickPumpTests.cs`: 5 unit tests (signals repeatedly, no signal after Dispose returns, Dispose twice is safe, null callback rejected, non-positive interval rejected).
- The HotReload test asmdef now references the InternalAPIBridge assembly for `EditorApplicationTickBridge.SignalTick`.

Reviewed against `docs/unity-editmode-test-guardrails.md`: the pump is test-run scoped, torn down in `OneTimeTearDown` and before assembly reload, and never blocks the main thread on a background operation.

## Verification
- `dist/darwin-arm64/uloop compile` — 0 errors.
- `dist/darwin-arm64/uloop run-tests --filter-type class --filter-value EditorTickPumpTests` — 5/5 passed.
- `dist/darwin-arm64/uloop run-tests --filter-type assembly --filter-value UnityCLILoop.Tests.Editor.HotReload --timeout-seconds 1500` — 806/806 passed.

| Measurement | Before | After |
|---|---|---|
| HotReload test assembly duration | 463.8 s (assembly `test-suite` duration inside the full local run on `main`) | 423 s (wall clock of the assembly-filtered run above) |

Measurement bases differ slightly (full-run assembly duration vs. filtered-run wall clock), so treat the delta as approximate. The per-test effect measured in #2634 was −33% on worker-only fixtures and −5% on orchestrator fixtures, consistent with this total.

Part of #2634.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

