### PR TITLE
fix: Hot reload no longer re-scans an unchanged assembly for callers on every run

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadCompiledCallSiteCacheTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCompiledCallSiteCacheTests.cs
@@ -178,7 +178,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             {
                 HotReloadCompiledCallSiteCache.Entry entry = cache.GetOrLoad(dllPath);
 
-                Guid onDisk = ModuleDefinition.ReadModule(dllPath, new ReaderParameters { ReadingMode = ReadingMode.Deferred }).Mvid;
+                Guid onDisk;
+                // Why dispose: an undisposed module keeps the dll open, and the TearDown that
+                // deletes the temp directory then fails on Windows.
+                using (ModuleDefinition module = ModuleDefinition.ReadModule(dllPath, new ReaderParameters { ReadingMode = ReadingMode.Deferred }))
+                {
+                    onDisk = module.Mvid;
+                }
                 Assert.That(entry.Fingerprint.ModuleVersionId, Is.EqualTo(entry.Module.Mvid));
                 Assert.That(entry.Module.Mvid, Is.EqualTo(onDisk));
                 Assert.That(cache.LoadCount, Is.EqualTo(2), "The inconsistent first read must be discarded and retried.");

--- a/Assets/Tests/Editor/HotReload/HotReloadCompiledCallSiteCacheTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCompiledCallSiteCacheTests.cs
@@ -1,5 +1,8 @@
 using System;
 using System.IO;
+using System.Linq;
+
+using Mono.Cecil;
 
 using NUnit.Framework;
 
@@ -145,6 +148,118 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: when the dll is replaced between the fingerprint and the Cecil read, the entry
+        /// published describes the file actually read (fingerprint MVID equals the module MVID),
+        /// never the pre-replacement fingerprint paired with the post-replacement view.
+        /// </summary>
+        [Test]
+        public void GetOrLoad_FileReplacedBetweenFingerprintAndRead_PublishesConsistentEntry()
+        {
+            string dllPath = CopyTestAssembly("a.dll");
+            DateTime originalWriteTime = File.GetLastWriteTimeUtc(dllPath);
+            byte[] otherModule = ReadOtherAssemblyPaddedTo(new FileInfo(dllPath).Length);
+            int readCount = 0;
+            HotReloadCompiledCallSiteCache.LoadProbes probes = new HotReloadCompiledCallSiteCache.LoadProbes
+            {
+                BeforeAssemblyRead = _ =>
+                {
+                    readCount++;
+                    if (readCount != 1)
+                    {
+                        return;
+                    }
+
+                    File.WriteAllBytes(dllPath, otherModule);
+                    File.SetLastWriteTimeUtc(dllPath, originalWriteTime);
+                }
+            };
+            HotReloadCompiledCallSiteCache cache = new HotReloadCompiledCallSiteCache(2, probes);
+            try
+            {
+                HotReloadCompiledCallSiteCache.Entry entry = cache.GetOrLoad(dllPath);
+
+                Guid onDisk = ModuleDefinition.ReadModule(dllPath, new ReaderParameters { ReadingMode = ReadingMode.Deferred }).Mvid;
+                Assert.That(entry.Fingerprint.ModuleVersionId, Is.EqualTo(entry.Module.Mvid));
+                Assert.That(entry.Module.Mvid, Is.EqualTo(onDisk));
+                Assert.That(cache.LoadCount, Is.EqualTo(2), "The inconsistent first read must be discarded and retried.");
+                Assert.That(cache.Count, Is.EqualTo(1));
+            }
+            finally
+            {
+                cache.Clear();
+            }
+        }
+
+        /// <summary>
+        /// What: a dll that changes before every read is reported as an I/O failure instead of a
+        /// stale entry, and nothing is published.
+        /// </summary>
+        [Test]
+        public void GetOrLoad_FileChangesBeforeEveryRead_ThrowsWithoutPublishing()
+        {
+            string dllPath = CopyTestAssembly("a.dll");
+            byte[] original = File.ReadAllBytes(dllPath);
+            byte[] otherModule = ReadOtherAssemblyPaddedTo(original.Length);
+            bool useOther = true;
+            HotReloadCompiledCallSiteCache.LoadProbes probes = new HotReloadCompiledCallSiteCache.LoadProbes
+            {
+                BeforeAssemblyRead = _ =>
+                {
+                    File.WriteAllBytes(dllPath, useOther ? otherModule : original);
+                    useOther = !useOther;
+                }
+            };
+            HotReloadCompiledCallSiteCache cache = new HotReloadCompiledCallSiteCache(2, probes);
+            try
+            {
+                Assert.Throws<IOException>(() => cache.GetOrLoad(dllPath));
+                Assert.That(cache.Count, Is.EqualTo(0));
+            }
+            finally
+            {
+                cache.Clear();
+            }
+        }
+
+        /// <summary>
+        /// What: a failure while the index is being built releases the Cecil assembly and lets the
+        /// original exception through unchanged; the cache stays empty.
+        /// </summary>
+        [Test]
+        public void GetOrLoad_IndexBuildFails_DisposesAssemblyAndRethrows()
+        {
+            string dllPath = CopyTestAssembly("a.dll");
+            InvalidOperationException injected = new InvalidOperationException("index failure for test");
+            AssemblyDefinition captured = null;
+            HotReloadCompiledCallSiteCache.LoadProbes probes = new HotReloadCompiledCallSiteCache.LoadProbes
+            {
+                AfterAssemblyRead = assembly =>
+                {
+                    captured = assembly;
+                    throw injected;
+                }
+            };
+            HotReloadCompiledCallSiteCache cache = new HotReloadCompiledCallSiteCache(2, probes);
+            try
+            {
+                InvalidOperationException thrown = Assert.Throws<InvalidOperationException>(() => cache.GetOrLoad(dllPath));
+
+                Assert.That(thrown, Is.SameAs(injected));
+                Assert.That(captured, Is.Not.Null);
+                // Why this observation: metadata tables are already in memory, but a method body
+                // is read lazily from the image stream, which a disposed module has closed. That
+                // read is the only externally visible trace of AssemblyDefinition.Dispose().
+                Assert.Throws<ObjectDisposedException>(() => ReadFirstMethodBody(captured));
+                Assert.That(cache.Count, Is.EqualTo(0));
+                Assert.That(cache.LoadCount, Is.EqualTo(0));
+            }
+            finally
+            {
+                cache.Clear();
+            }
+        }
+
+        /// <summary>
         /// What: the same bytes under a different path are a separate entry and trigger a load.
         /// </summary>
         [Test]
@@ -194,6 +309,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void Constructor_NonPositiveCapacity_Throws()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => new HotReloadCompiledCallSiteCache(0));
+        }
+
+        private static void ReadFirstMethodBody(AssemblyDefinition assembly)
+        {
+            MethodDefinition firstWithBody = assembly.MainModule.GetTypes()
+                .SelectMany(type => type.Methods)
+                .First(method => method.HasBody);
+            _ = firstWithBody.Body.Instructions.Count;
         }
 
         private static byte[] ReadOtherAssemblyPaddedTo(long length)

--- a/Assets/Tests/Editor/HotReload/HotReloadCompiledCallSiteCacheTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCompiledCallSiteCacheTests.cs
@@ -1,0 +1,231 @@
+using System;
+using System.IO;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Invalidation and capacity contract of the compiled call-site cache. Each test works on
+    /// copies of this test assembly's dll in a private temp directory so that mutating the file
+    /// never touches ScriptAssemblies.
+    /// </summary>
+    public class HotReloadCompiledCallSiteCacheTests
+    {
+        private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+        // Why this assembly: it is always compiled alongside the test assembly and is smaller, so
+        // it can be zero-padded to the test assembly's length for the module identity test.
+        private const string OtherAssemblyName = "UnityCLILoop.Tests.Editor.HotReload.CallSiteCrossAssembly";
+
+        private string _tempDirectory;
+        private HotReloadCompiledCallSiteCache _cache;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempDirectory = Path.Combine(
+                Path.GetTempPath(),
+                "uloop-call-site-cache-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDirectory);
+            _cache = new HotReloadCompiledCallSiteCache(2);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _cache.Clear();
+            if (Directory.Exists(_tempDirectory))
+            {
+                Directory.Delete(_tempDirectory, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// What: an unchanged dll is read once; the second lookup returns the same entry without a reload.
+        /// </summary>
+        [Test]
+        public void GetOrLoad_IdenticalFile_ReusesEntry()
+        {
+            string dllPath = CopyTestAssembly("a.dll");
+
+            HotReloadCompiledCallSiteCache.Entry first = _cache.GetOrLoad(dllPath);
+            HotReloadCompiledCallSiteCache.Entry second = _cache.GetOrLoad(dllPath);
+
+            Assert.That(second, Is.SameAs(first));
+            Assert.That(_cache.LoadCount, Is.EqualTo(1));
+            Assert.That(first.CallSites.Count, Is.GreaterThan(0), "A test assembly must contain call sites.");
+        }
+
+        /// <summary>
+        /// What: a newer write time on a byte-identical file invalidates the entry.
+        /// </summary>
+        [Test]
+        public void GetOrLoad_WriteTimeChanged_Reloads()
+        {
+            string dllPath = CopyTestAssembly("a.dll");
+            HotReloadCompiledCallSiteCache.Entry first = _cache.GetOrLoad(dllPath);
+
+            File.SetLastWriteTimeUtc(dllPath, File.GetLastWriteTimeUtc(dllPath).AddSeconds(5));
+            HotReloadCompiledCallSiteCache.Entry second = _cache.GetOrLoad(dllPath);
+
+            Assert.That(second, Is.Not.SameAs(first));
+            Assert.That(_cache.LoadCount, Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// What: a size change invalidates the entry even when the write time is restored.
+        /// </summary>
+        [Test]
+        public void GetOrLoad_SizeChanged_Reloads()
+        {
+            string dllPath = CopyTestAssembly("a.dll");
+            DateTime originalWriteTime = File.GetLastWriteTimeUtc(dllPath);
+            HotReloadCompiledCallSiteCache.Entry first = _cache.GetOrLoad(dllPath);
+
+            // Why append: trailing bytes after the PE image keep the dll readable for Cecil while
+            // changing the length, so the test isolates the size check.
+            using (FileStream stream = new FileStream(dllPath, FileMode.Append))
+            {
+                stream.WriteByte(0);
+            }
+
+            File.SetLastWriteTimeUtc(dllPath, originalWriteTime);
+            HotReloadCompiledCallSiteCache.Entry second = _cache.GetOrLoad(dllPath);
+
+            Assert.That(second, Is.Not.SameAs(first));
+            Assert.That(_cache.LoadCount, Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// What: a same-size rewrite with a restored write time still invalidates the entry when
+        /// the module version id differs. Length and mtime alone would miss this case.
+        /// </summary>
+        [Test]
+        public void GetOrLoad_SameSizeSameWriteTimeDifferentModule_Reloads()
+        {
+            string dllPath = CopyTestAssembly("a.dll");
+            DateTime originalWriteTime = File.GetLastWriteTimeUtc(dllPath);
+            HotReloadCompiledCallSiteCache.Entry first = _cache.GetOrLoad(dllPath);
+
+            // Why pad: trailing bytes after the PE image keep a dll loadable, so padding the other
+            // assembly to the same length isolates the module identity check from the size check.
+            byte[] otherModule = ReadOtherAssemblyPaddedTo(new FileInfo(dllPath).Length);
+            File.WriteAllBytes(dllPath, otherModule);
+            File.SetLastWriteTimeUtc(dllPath, originalWriteTime);
+
+            HotReloadCompiledCallSiteCache.Entry second = _cache.GetOrLoad(dllPath);
+
+            Assert.That(second, Is.Not.SameAs(first));
+            Assert.That(second.Module.Mvid, Is.Not.EqualTo(first.Module.Mvid));
+            Assert.That(_cache.LoadCount, Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// What: a byte-identical copy written again with the original write time is reused, so a
+        /// rewrite that changes nothing observable does not cost a Cecil read.
+        /// </summary>
+        [Test]
+        public void GetOrLoad_RewrittenIdenticalBytesSameWriteTime_ReusesEntry()
+        {
+            string dllPath = CopyTestAssembly("a.dll");
+            DateTime originalWriteTime = File.GetLastWriteTimeUtc(dllPath);
+            HotReloadCompiledCallSiteCache.Entry first = _cache.GetOrLoad(dllPath);
+
+            File.WriteAllBytes(dllPath, File.ReadAllBytes(dllPath));
+            File.SetLastWriteTimeUtc(dllPath, originalWriteTime);
+
+            HotReloadCompiledCallSiteCache.Entry second = _cache.GetOrLoad(dllPath);
+
+            Assert.That(second, Is.SameAs(first));
+            Assert.That(_cache.LoadCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// What: the same bytes under a different path are a separate entry and trigger a load.
+        /// </summary>
+        [Test]
+        public void GetOrLoad_DifferentPath_LoadsSeparately()
+        {
+            string firstPath = CopyTestAssembly("a.dll");
+            string secondPath = CopyTestAssembly("b.dll");
+
+            HotReloadCompiledCallSiteCache.Entry first = _cache.GetOrLoad(firstPath);
+            HotReloadCompiledCallSiteCache.Entry second = _cache.GetOrLoad(secondPath);
+
+            Assert.That(second, Is.Not.SameAs(first));
+            Assert.That(_cache.LoadCount, Is.EqualTo(2));
+            Assert.That(_cache.Count, Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// What: loading beyond the capacity evicts the least recently used entry, so the count
+        /// never exceeds the cap and the evicted dll is read again on its next lookup.
+        /// </summary>
+        [Test]
+        public void GetOrLoad_OverCapacity_EvictsLeastRecentlyUsed()
+        {
+            string pathA = CopyTestAssembly("a.dll");
+            string pathB = CopyTestAssembly("b.dll");
+            string pathC = CopyTestAssembly("c.dll");
+
+            _cache.GetOrLoad(pathA);
+            _cache.GetOrLoad(pathB);
+            _cache.GetOrLoad(pathA);
+            _cache.GetOrLoad(pathC);
+            Assert.That(_cache.Count, Is.EqualTo(2));
+            Assert.That(_cache.LoadCount, Is.EqualTo(3));
+
+            _cache.GetOrLoad(pathA);
+            Assert.That(_cache.LoadCount, Is.EqualTo(3), "A stayed cached because it was used more recently than B.");
+
+            _cache.GetOrLoad(pathB);
+            Assert.That(_cache.LoadCount, Is.EqualTo(4), "B was the least recently used entry and had to be reloaded.");
+            Assert.That(_cache.Count, Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// What: a non-positive capacity is rejected, because the cache could never hold an entry.
+        /// </summary>
+        [Test]
+        public void Constructor_NonPositiveCapacity_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new HotReloadCompiledCallSiteCache(0));
+        }
+
+        private static byte[] ReadOtherAssemblyPaddedTo(long length)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string otherDllPath = Path.Combine(
+                projectRoot,
+                "Library",
+                "ScriptAssemblies",
+                OtherAssemblyName + ".dll");
+            Assert.That(File.Exists(otherDllPath), Is.True, "Other assembly dll missing: " + otherDllPath);
+            byte[] bytes = File.ReadAllBytes(otherDllPath);
+            Assert.That(bytes.Length, Is.LessThanOrEqualTo(length), "The other assembly must not be larger than the padded target.");
+
+            byte[] padded = new byte[length];
+            Buffer.BlockCopy(bytes, 0, padded, 0, bytes.Length);
+            return padded;
+        }
+
+        private string CopyTestAssembly(string fileName)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string sourceDllPath = Path.Combine(
+                projectRoot,
+                "Library",
+                "ScriptAssemblies",
+                TestAssemblyName + ".dll");
+            Assert.That(File.Exists(sourceDllPath), Is.True, "Test assembly dll missing: " + sourceDllPath);
+
+            string destinationPath = Path.Combine(_tempDirectory, fileName);
+            File.Copy(sourceDllPath, destinationPath);
+            return destinationPath;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadCompiledCallSiteCacheTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadCompiledCallSiteCacheTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa1625ba5db014617b95d38bc04821b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs
@@ -172,7 +172,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 graph[assembly.name] = CollectReferenceFileNames(assembly.allReferences);
             }
 
-            _referencedDllFileNamesByAssembly = graph;
+            // Why not memoize an empty graph: GetAssemblies() returns nothing while a compile is in
+            // flight, and caching that would shrink the scan set for the rest of the domain's life.
+            if (graph.Count > 0)
+            {
+                _referencedDllFileNamesByAssembly = graph;
+            }
+
             return graph;
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 
 using Mono.Cecil;
-using Mono.Cecil.Cil;
 
 using UnityEditor.Compilation;
 using UnityEngine;
@@ -136,35 +135,68 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 scanNames.Add(targetAssemblyName);
             }
-            foreach (UnityCompilationAssembly assembly in CompilationPipeline.GetAssemblies())
+            foreach (KeyValuePair<string, string[]> assembly in GetReferencedDllFileNamesByAssembly())
             {
-                if (targetAssemblyNames.Contains(assembly.name)
-                    || ReferencesAnyTargetDll(assembly, targetDllFileNames))
+                if (targetAssemblyNames.Contains(assembly.Key)
+                    || ReferencesAnyTargetDll(assembly.Value, targetDllFileNames))
                 {
-                    scanNames.Add(assembly.name);
+                    scanNames.Add(assembly.Key);
                 }
             }
 
             return scanNames;
         }
 
-        private static bool ReferencesAnyTargetDll(
-            UnityCompilationAssembly assembly,
-            HashSet<string> targetDllFileNames)
+        // Why cache per domain: CompilationPipeline.GetAssemblies() costs ~40 ms on a project with
+        // ~100 assemblies, and the reference graph can only change through an asmdef or package
+        // change, which recompiles and reloads the domain (resetting this field).
+        private static Dictionary<string, string[]> _referencedDllFileNamesByAssembly;
+
+        private static Dictionary<string, string[]> GetReferencedDllFileNamesByAssembly()
         {
-            if (assembly.allReferences == null)
+            if (_referencedDllFileNamesByAssembly != null)
             {
-                return false;
+                return _referencedDllFileNamesByAssembly;
             }
 
-            foreach (string reference in assembly.allReferences)
+            Dictionary<string, string[]> graph = new Dictionary<string, string[]>(StringComparer.Ordinal);
+            foreach (UnityCompilationAssembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                graph[assembly.name] = CollectReferenceFileNames(assembly.allReferences);
+            }
+
+            _referencedDllFileNamesByAssembly = graph;
+            return graph;
+        }
+
+        private static string[] CollectReferenceFileNames(string[] allReferences)
+        {
+            if (allReferences == null)
+            {
+                return Array.Empty<string>();
+            }
+
+            List<string> fileNames = new List<string>(allReferences.Length);
+            foreach (string reference in allReferences)
             {
                 if (string.IsNullOrEmpty(reference))
                 {
                     continue;
                 }
 
-                if (targetDllFileNames.Contains(Path.GetFileName(reference)))
+                fileNames.Add(Path.GetFileName(reference));
+            }
+
+            return fileNames.ToArray();
+        }
+
+        private static bool ReferencesAnyTargetDll(
+            string[] referencedDllFileNames,
+            HashSet<string> targetDllFileNames)
+        {
+            foreach (string fileName in referencedDllFileNames)
+            {
+                if (targetDllFileNames.Contains(fileName))
                 {
                     return true;
                 }
@@ -179,134 +211,48 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             CompiledMethodIdentity[] targets,
             List<CallSiteHit> hits)
         {
-            // InMemory + no resolver: operand FullName comparison does not require type resolution.
-            ReaderParameters readerParameters = new ReaderParameters { InMemory = true };
-            using AssemblyDefinition assemblyDefinition = AssemblyDefinition.ReadAssembly(dllPath, readerParameters);
-            ModuleDefinition module = assemblyDefinition.MainModule;
-            Dictionary<string, MethodDefinition> logicalOwners = BuildLogicalOwnerIndex(module);
-
-            foreach (TypeDefinition type in module.GetTypes())
+            // Why cache: the dll only changes on a compile, which also reloads the domain, so
+            // across the runs in between the Cecil read and the instruction walk are pure repeat work.
+            HotReloadCompiledCallSiteCache.Entry compiled = HotReloadCompiledCallSiteCache.Shared.GetOrLoad(dllPath);
+            foreach (HotReloadCompiledCallSiteCache.CompiledCallSite callSite in compiled.CallSites)
             {
-                foreach (MethodDefinition method in type.Methods)
-                {
-                    CollectHitsFromMethod(assemblyName, module, method, targets, logicalOwners, hits);
-                }
+                CollectHitFromCallSite(assemblyName, compiled, callSite, targets, hits);
             }
         }
 
-        private static Dictionary<string, MethodDefinition> BuildLogicalOwnerIndex(ModuleDefinition module)
-        {
-            Dictionary<string, MethodDefinition> index = new Dictionary<string, MethodDefinition>();
-            foreach (TypeDefinition type in module.GetTypes())
-            {
-                foreach (MethodDefinition method in type.Methods)
-                {
-                    TryIndexStateMachineOwner(method, index);
-                }
-            }
-
-            return index;
-        }
-
-        private static void TryIndexStateMachineOwner(
-            MethodDefinition method,
-            Dictionary<string, MethodDefinition> index)
-        {
-            if (!method.HasCustomAttributes)
-            {
-                return;
-            }
-
-            foreach (CustomAttribute attribute in method.CustomAttributes)
-            {
-                string attributeName = attribute.AttributeType.Name;
-                if (attributeName != HotReloadConstants.AsyncStateMachineAttributeTypeName
-                    && attributeName != HotReloadConstants.IteratorStateMachineAttributeTypeName)
-                {
-                    continue;
-                }
-
-                if (!attribute.HasConstructorArguments || attribute.ConstructorArguments.Count == 0)
-                {
-                    continue;
-                }
-
-                TypeReference stateMachineType = attribute.ConstructorArguments[0].Value as TypeReference;
-                if (stateMachineType == null)
-                {
-                    continue;
-                }
-
-                index[stateMachineType.FullName] = method;
-            }
-        }
-
-        private static void CollectHitsFromMethod(
+        private static void CollectHitFromCallSite(
             string assemblyName,
-            ModuleDefinition module,
-            MethodDefinition method,
+            HotReloadCompiledCallSiteCache.Entry compiled,
+            HotReloadCompiledCallSiteCache.CompiledCallSite callSite,
             CompiledMethodIdentity[] targets,
-            Dictionary<string, MethodDefinition> logicalOwners,
             List<CallSiteHit> hits)
         {
-            if (!method.HasBody)
+            (bool matched, CompiledMethodIdentity target) = FindMatchingTarget(
+                callSite.Operand,
+                assemblyName,
+                compiled.Module,
+                targets);
+            if (!matched)
             {
                 return;
             }
 
-            foreach (Instruction instruction in method.Body.Instructions)
+            MethodDefinition reportedCaller = ResolveReportedCaller(callSite.Caller, compiled.LogicalOwners);
+
+            // Why resolve first: async/iterator self-recursion lives in MoveNext. Matching
+            // the physical caller would miss it, then reporting the logical owner would look
+            // like an external caller of the old method.
+            if (IsSelfCall(assemblyName, compiled.Module, reportedCaller, target))
             {
-                if (!IsCallSiteOpcode(instruction.OpCode))
-                {
-                    continue;
-                }
-
-                MethodReference operand = instruction.Operand as MethodReference;
-                if (operand == null)
-                {
-                    continue;
-                }
-
-                (bool matched, CompiledMethodIdentity target) = FindMatchingTarget(
-                    operand,
-                    assemblyName,
-                    module,
-                    targets);
-                if (!matched)
-                {
-                    continue;
-                }
-
-                MethodDefinition reportedCaller = ResolveReportedCaller(method, logicalOwners);
-
-                // Why resolve first: async/iterator self-recursion lives in MoveNext. Matching
-                // the physical caller would miss it, then reporting the logical owner would look
-                // like an external caller of the old method.
-                if (IsSelfCall(assemblyName, module, reportedCaller, target))
-                {
-                    continue;
-                }
-
-                hits.Add(
-                    CreateHit(
-                        assemblyName,
-                        reportedCaller,
-                        target,
-                        IsFunctionPointerLoadOpcode(instruction.OpCode)));
+                return;
             }
-        }
 
-        private static bool IsCallSiteOpcode(OpCode opCode)
-        {
-            return opCode == OpCodes.Call
-                || opCode == OpCodes.Callvirt
-                || opCode == OpCodes.Ldftn
-                || opCode == OpCodes.Ldvirtftn;
-        }
-
-        private static bool IsFunctionPointerLoadOpcode(OpCode opCode)
-        {
-            return opCode == OpCodes.Ldftn || opCode == OpCodes.Ldvirtftn;
+            hits.Add(
+                CreateHit(
+                    assemblyName,
+                    reportedCaller,
+                    target,
+                    callSite.IsFunctionPointerLoad));
         }
 
         private static (bool matched, CompiledMethodIdentity target) FindMatchingTarget(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs
@@ -152,6 +152,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // change, which recompiles and reloads the domain (resetting this field).
         private static Dictionary<string, string[]> _referencedDllFileNamesByAssembly;
 
+        static HotReloadCallSiteScanner()
+        {
+            // Why: a compile that fails keeps the domain alive, so without this an asmdef change
+            // made during a broken compile would survive in the memo until the next reload.
+            CompilationPipeline.compilationStarted += _ => _referencedDllFileNamesByAssembly = null;
+        }
+
         private static Dictionary<string, string[]> GetReferencedDllFileNamesByAssembly()
         {
             if (_referencedDllFileNamesByAssembly != null)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCompiledCallSiteCache.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCompiledCallSiteCache.cs
@@ -41,6 +41,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         /// <summary>
         /// The reusable Cecil view of one dll file, valid while <see cref="Fingerprint"/> matches the file.
+        /// An entry is returned outside the cache lock and may be disposed by a later lookup that
+        /// replaces or evicts it, so its lifetime relies on hot reload runs being single-flight:
+        /// a caller must finish with an entry before the next run starts.
         /// </summary>
         internal sealed class Entry : IDisposable
         {
@@ -113,16 +116,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
+        /// <summary>
+        /// Test-only hooks into the load path, used to force a file change between the fingerprint
+        /// and the Cecil read, or a failure while the index is being built.
+        /// </summary>
+        internal sealed class LoadProbes
+        {
+            public Action<string> BeforeAssemblyRead;
+            public Action<AssemblyDefinition> AfterAssemblyRead;
+        }
+
+        // Why two attempts: the fingerprint and the full Cecil read are separate opens, so the
+        // file can be replaced in between. One retry absorbs a single replacement; a second
+        // mismatch means the file is being rewritten continuously and the caller must fail.
+        private const int MaxConsistentLoadAttempts = 2;
+
         public static HotReloadCompiledCallSiteCache Shared { get; } =
             new HotReloadCompiledCallSiteCache(DefaultCapacity);
 
         private readonly object _gate = new object();
         private readonly int _capacity;
+        private readonly LoadProbes _probes;
         private readonly Dictionary<string, Entry> _entries = new Dictionary<string, Entry>(StringComparer.Ordinal);
         private long _accessSequence;
         private int _loadCount;
 
-        public HotReloadCompiledCallSiteCache(int capacity)
+        public HotReloadCompiledCallSiteCache(int capacity, LoadProbes probes = null)
         {
             if (capacity <= 0)
             {
@@ -130,6 +149,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             _capacity = capacity;
+            _probes = probes;
         }
 
         /// <summary>
@@ -161,19 +181,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
-        /// Returns the cached view of <paramref name="dllPath"/> when the file is byte-identical to
-        /// the cached one, otherwise reads it and replaces the stale entry. The file must exist.
+        /// Returns the cached view of <paramref name="dllPath"/> while the file's length, last
+        /// write time, and module version id (MVID) all match the cached entry; otherwise reads the
+        /// file and replaces the stale entry. This is a heuristic identity, not a content hash: it
+        /// assumes a recompile assigns a new MVID, which the compiler does for every build output.
+        /// A rewrite that keeps all three (a metadata-preserving edit with the timestamp restored)
+        /// is served stale. The file must exist.
         /// </summary>
+        /// <exception cref="IOException">The file kept changing while it was being read.</exception>
         public Entry GetOrLoad(string dllPath)
         {
             Debug.Assert(!string.IsNullOrEmpty(dllPath), "dllPath must not be null or empty.");
 
             string fullPath = Path.GetFullPath(dllPath);
-            FileInfo fileInfo = new FileInfo(fullPath);
-            DllFingerprint fingerprint = new DllFingerprint(
-                fileInfo.Length,
-                fileInfo.LastWriteTimeUtc.Ticks,
-                ReadModuleVersionId(fullPath));
+            DllFingerprint fingerprint = ReadFingerprint(fullPath);
 
             lock (_gate)
             {
@@ -190,9 +211,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     existing.Dispose();
                 }
 
-                Entry loaded = Load(fullPath, fingerprint);
+                Entry loaded = LoadConsistent(fullPath, fingerprint);
                 loaded.LastAccess = _accessSequence;
-                _loadCount++;
                 EvictLeastRecentlyUsedWhileOverCapacity();
                 _entries[fullPath] = loaded;
                 return loaded;
@@ -237,6 +257,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
+        private static DllFingerprint ReadFingerprint(string fullPath)
+        {
+            FileInfo fileInfo = new FileInfo(fullPath);
+            return new DllFingerprint(
+                fileInfo.Length,
+                fileInfo.LastWriteTimeUtc.Ticks,
+                ReadModuleVersionId(fullPath));
+        }
+
         private static Guid ReadModuleVersionId(string fullPath)
         {
             // Deferred reading touches only the metadata header, which is what makes this check
@@ -246,25 +275,72 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return module.Mvid;
         }
 
-        private static Entry Load(string fullPath, DllFingerprint fingerprint)
+        // Publishes an entry only when the file read by Cecil is the file the fingerprint
+        // describes: the module's own MVID must equal the fingerprinted one, and the length and
+        // write time must still match after the read.
+        private Entry LoadConsistent(string fullPath, DllFingerprint fingerprint)
         {
+            DllFingerprint expected = fingerprint;
+            for (int attempt = 1; attempt <= MaxConsistentLoadAttempts; attempt++)
+            {
+                Entry loaded = Load(fullPath, expected);
+                _loadCount++;
+                FileInfo afterRead = new FileInfo(fullPath);
+                DllFingerprint observed = new DllFingerprint(
+                    afterRead.Length,
+                    afterRead.LastWriteTimeUtc.Ticks,
+                    loaded.Module.Mvid);
+                if (observed.Equals(expected))
+                {
+                    return loaded;
+                }
+
+                loaded.Dispose();
+                expected = ReadFingerprint(fullPath);
+            }
+
+            throw new IOException(
+                "Compiled assembly changed while it was being read " + MaxConsistentLoadAttempts
+                + " times in a row: " + fullPath);
+        }
+
+        private Entry Load(string fullPath, DllFingerprint fingerprint)
+        {
+            _probes?.BeforeAssemblyRead?.Invoke(fullPath);
+
             // InMemory + no resolver: operand FullName comparison in the scanner does not require
             // type resolution, and the file handle is released as soon as the read completes.
             ReaderParameters readerParameters = new ReaderParameters { InMemory = true };
             AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(fullPath, readerParameters);
-            ModuleDefinition module = assembly.MainModule;
-            Dictionary<string, MethodDefinition> logicalOwners = new Dictionary<string, MethodDefinition>();
-            List<CompiledCallSite> callSites = new List<CompiledCallSite>();
-            foreach (TypeDefinition type in module.GetTypes())
+            // Why an ownership flag: the entry takes over disposal once constructed; until then a
+            // failure while indexing must release the assembly here.
+            bool ownershipTransferred = false;
+            try
             {
-                foreach (MethodDefinition method in type.Methods)
+                _probes?.AfterAssemblyRead?.Invoke(assembly);
+                ModuleDefinition module = assembly.MainModule;
+                Dictionary<string, MethodDefinition> logicalOwners = new Dictionary<string, MethodDefinition>();
+                List<CompiledCallSite> callSites = new List<CompiledCallSite>();
+                foreach (TypeDefinition type in module.GetTypes())
                 {
-                    TryIndexStateMachineOwner(method, logicalOwners);
-                    CollectCallSites(method, callSites);
+                    foreach (MethodDefinition method in type.Methods)
+                    {
+                        TryIndexStateMachineOwner(method, logicalOwners);
+                        CollectCallSites(method, callSites);
+                    }
+                }
+
+                Entry entry = new Entry(fullPath, fingerprint, assembly, logicalOwners, callSites);
+                ownershipTransferred = true;
+                return entry;
+            }
+            finally
+            {
+                if (!ownershipTransferred)
+                {
+                    assembly.Dispose();
                 }
             }
-
-            return new Entry(fullPath, fingerprint, assembly, logicalOwners, callSites);
         }
 
         private static void CollectCallSites(MethodDefinition method, List<CompiledCallSite> callSites)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCompiledCallSiteCache.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCompiledCallSiteCache.cs
@@ -1,0 +1,340 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Keeps the Cecil view of a compiled assembly (module, state-machine owner index, and the
+    /// call / ldftn instructions) alive across hot reload runs while the dll on disk is unchanged.
+    /// Why: every hot reload run re-read and re-walked the whole ScriptAssemblies dll to find
+    /// callers (~0.24 s on a large test assembly), although the dll only changes on a compile,
+    /// which also reloads the domain and therefore empties this cache.
+    /// </summary>
+    internal sealed class HotReloadCompiledCallSiteCache
+    {
+        // Why a small cap: each entry holds a full Cecil module in memory. A hot reload run
+        // scans the target assembly plus the assemblies that reference it, which is a handful.
+        internal const int DefaultCapacity = 8;
+
+        /// <summary>
+        /// One compiled instruction that may reference a target method.
+        /// </summary>
+        internal readonly struct CompiledCallSite
+        {
+            public readonly MethodDefinition Caller;
+            public readonly MethodReference Operand;
+            public readonly bool IsFunctionPointerLoad;
+
+            public CompiledCallSite(MethodDefinition caller, MethodReference operand, bool isFunctionPointerLoad)
+            {
+                Caller = caller;
+                Operand = operand;
+                IsFunctionPointerLoad = isFunctionPointerLoad;
+            }
+        }
+
+        /// <summary>
+        /// The reusable Cecil view of one dll file, valid while <see cref="Fingerprint"/> matches the file.
+        /// </summary>
+        internal sealed class Entry : IDisposable
+        {
+            public readonly string DllPath;
+            public readonly DllFingerprint Fingerprint;
+            public readonly ModuleDefinition Module;
+            public readonly Dictionary<string, MethodDefinition> LogicalOwners;
+            public readonly List<CompiledCallSite> CallSites;
+            public long LastAccess;
+
+            private readonly AssemblyDefinition _assembly;
+
+            public Entry(
+                string dllPath,
+                DllFingerprint fingerprint,
+                AssemblyDefinition assembly,
+                Dictionary<string, MethodDefinition> logicalOwners,
+                List<CompiledCallSite> callSites)
+            {
+                DllPath = dllPath;
+                Fingerprint = fingerprint;
+                _assembly = assembly;
+                Module = assembly.MainModule;
+                LogicalOwners = logicalOwners;
+                CallSites = callSites;
+            }
+
+            public void Dispose()
+            {
+                _assembly.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Identity of the dll an entry was built from. Length and write time are the cheap
+        /// first check; the module version id (MVID) catches a same-size rewrite within the same
+        /// timestamp granularity. Why MVID and not a content hash: hashing a megabyte-sized dll
+        /// costs about as much as the Cecil read this cache avoids, while the MVID is read from
+        /// the metadata header in under a millisecond and the compiler assigns a new one to
+        /// every distinct build output.
+        /// </summary>
+        internal readonly struct DllFingerprint : IEquatable<DllFingerprint>
+        {
+            public readonly long Length;
+            public readonly long LastWriteTimeUtcTicks;
+            public readonly Guid ModuleVersionId;
+
+            public DllFingerprint(long length, long lastWriteTimeUtcTicks, Guid moduleVersionId)
+            {
+                Length = length;
+                LastWriteTimeUtcTicks = lastWriteTimeUtcTicks;
+                ModuleVersionId = moduleVersionId;
+            }
+
+            public bool Equals(DllFingerprint other)
+            {
+                return Length == other.Length
+                    && LastWriteTimeUtcTicks == other.LastWriteTimeUtcTicks
+                    && ModuleVersionId == other.ModuleVersionId;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is DllFingerprint other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                return ModuleVersionId.GetHashCode();
+            }
+        }
+
+        public static HotReloadCompiledCallSiteCache Shared { get; } =
+            new HotReloadCompiledCallSiteCache(DefaultCapacity);
+
+        private readonly object _gate = new object();
+        private readonly int _capacity;
+        private readonly Dictionary<string, Entry> _entries = new Dictionary<string, Entry>(StringComparer.Ordinal);
+        private long _accessSequence;
+        private int _loadCount;
+
+        public HotReloadCompiledCallSiteCache(int capacity)
+        {
+            if (capacity <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity), "capacity must be positive.");
+            }
+
+            _capacity = capacity;
+        }
+
+        /// <summary>
+        /// Number of entries currently held.
+        /// </summary>
+        public int Count
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _entries.Count;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Number of times a dll was read and walked with Cecil, i.e. cache misses.
+        /// </summary>
+        public int LoadCount
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _loadCount;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns the cached view of <paramref name="dllPath"/> when the file is byte-identical to
+        /// the cached one, otherwise reads it and replaces the stale entry. The file must exist.
+        /// </summary>
+        public Entry GetOrLoad(string dllPath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(dllPath), "dllPath must not be null or empty.");
+
+            string fullPath = Path.GetFullPath(dllPath);
+            FileInfo fileInfo = new FileInfo(fullPath);
+            DllFingerprint fingerprint = new DllFingerprint(
+                fileInfo.Length,
+                fileInfo.LastWriteTimeUtc.Ticks,
+                ReadModuleVersionId(fullPath));
+
+            lock (_gate)
+            {
+                _accessSequence++;
+                if (_entries.TryGetValue(fullPath, out Entry existing))
+                {
+                    if (existing.Fingerprint.Equals(fingerprint))
+                    {
+                        existing.LastAccess = _accessSequence;
+                        return existing;
+                    }
+
+                    _entries.Remove(fullPath);
+                    existing.Dispose();
+                }
+
+                Entry loaded = Load(fullPath, fingerprint);
+                loaded.LastAccess = _accessSequence;
+                _loadCount++;
+                EvictLeastRecentlyUsedWhileOverCapacity();
+                _entries[fullPath] = loaded;
+                return loaded;
+            }
+        }
+
+        /// <summary>
+        /// Drops every entry. Intended for tests and for callers that know the dlls changed.
+        /// </summary>
+        public void Clear()
+        {
+            lock (_gate)
+            {
+                foreach (Entry entry in _entries.Values)
+                {
+                    entry.Dispose();
+                }
+
+                _entries.Clear();
+            }
+        }
+
+        private void EvictLeastRecentlyUsedWhileOverCapacity()
+        {
+            // The new entry is added after this call, so make room for it.
+            while (_entries.Count >= _capacity)
+            {
+                string leastRecentPath = null;
+                long leastRecentAccess = long.MaxValue;
+                foreach (KeyValuePair<string, Entry> pair in _entries)
+                {
+                    if (pair.Value.LastAccess < leastRecentAccess)
+                    {
+                        leastRecentAccess = pair.Value.LastAccess;
+                        leastRecentPath = pair.Key;
+                    }
+                }
+
+                Entry evicted = _entries[leastRecentPath];
+                _entries.Remove(leastRecentPath);
+                evicted.Dispose();
+            }
+        }
+
+        private static Guid ReadModuleVersionId(string fullPath)
+        {
+            // Deferred reading touches only the metadata header, which is what makes this check
+            // cheap enough to run on every lookup.
+            ReaderParameters headerOnly = new ReaderParameters { ReadingMode = ReadingMode.Deferred };
+            using ModuleDefinition module = ModuleDefinition.ReadModule(fullPath, headerOnly);
+            return module.Mvid;
+        }
+
+        private static Entry Load(string fullPath, DllFingerprint fingerprint)
+        {
+            // InMemory + no resolver: operand FullName comparison in the scanner does not require
+            // type resolution, and the file handle is released as soon as the read completes.
+            ReaderParameters readerParameters = new ReaderParameters { InMemory = true };
+            AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(fullPath, readerParameters);
+            ModuleDefinition module = assembly.MainModule;
+            Dictionary<string, MethodDefinition> logicalOwners = new Dictionary<string, MethodDefinition>();
+            List<CompiledCallSite> callSites = new List<CompiledCallSite>();
+            foreach (TypeDefinition type in module.GetTypes())
+            {
+                foreach (MethodDefinition method in type.Methods)
+                {
+                    TryIndexStateMachineOwner(method, logicalOwners);
+                    CollectCallSites(method, callSites);
+                }
+            }
+
+            return new Entry(fullPath, fingerprint, assembly, logicalOwners, callSites);
+        }
+
+        private static void CollectCallSites(MethodDefinition method, List<CompiledCallSite> callSites)
+        {
+            if (!method.HasBody)
+            {
+                return;
+            }
+
+            foreach (Instruction instruction in method.Body.Instructions)
+            {
+                if (!IsCallSiteOpcode(instruction.OpCode))
+                {
+                    continue;
+                }
+
+                MethodReference operand = instruction.Operand as MethodReference;
+                if (operand == null)
+                {
+                    continue;
+                }
+
+                callSites.Add(new CompiledCallSite(method, operand, IsFunctionPointerLoadOpcode(instruction.OpCode)));
+            }
+        }
+
+        private static void TryIndexStateMachineOwner(
+            MethodDefinition method,
+            Dictionary<string, MethodDefinition> index)
+        {
+            if (!method.HasCustomAttributes)
+            {
+                return;
+            }
+
+            foreach (CustomAttribute attribute in method.CustomAttributes)
+            {
+                string attributeName = attribute.AttributeType.Name;
+                if (attributeName != HotReloadConstants.AsyncStateMachineAttributeTypeName
+                    && attributeName != HotReloadConstants.IteratorStateMachineAttributeTypeName)
+                {
+                    continue;
+                }
+
+                if (!attribute.HasConstructorArguments || attribute.ConstructorArguments.Count == 0)
+                {
+                    continue;
+                }
+
+                TypeReference stateMachineType = attribute.ConstructorArguments[0].Value as TypeReference;
+                if (stateMachineType == null)
+                {
+                    continue;
+                }
+
+                index[stateMachineType.FullName] = method;
+            }
+        }
+
+        private static bool IsCallSiteOpcode(OpCode opCode)
+        {
+            return opCode == OpCodes.Call
+                || opCode == OpCodes.Callvirt
+                || opCode == OpCodes.Ldftn
+                || opCode == OpCodes.Ldvirtftn;
+        }
+
+        private static bool IsFunctionPointerLoadOpcode(OpCode opCode)
+        {
+            return opCode == OpCodes.Ldftn || opCode == OpCodes.Ldvirtftn;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCompiledCallSiteCache.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCompiledCallSiteCache.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e08aad51eb4b24fd2988d065b7f1225f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Each hot reload run no longer re-reads and re-walks the compiled assembly to find callers of the patched methods; the Cecil view is kept while the dll on disk is unchanged, and the assembly reference graph is reused for the lifetime of the domain.
- Per run this removes ~110 ms of fixed work on a project of this size, and the HotReload EditMode fixtures that drive the orchestrator get ~22% faster.

## User Impact
- Before: every `uloop hot-reload` run read the target `ScriptAssemblies` dll with Cecil, walked every instruction of every method, and asked `CompilationPipeline` for the whole assembly graph (~117 ms measured on the HotReload test assembly, ~40 ms of it in `GetAssemblies()`), even though neither can change between two runs without a compile, which reloads the domain anyway.
- After: the same lookup takes ~5 ms once warm. A cached view is reused only while the dll's length, last write time, and module version id (MVID) all match; any of the three changing triggers a fresh read. This relies on the compiler assigning a new MVID to every build output, which it does.

## Changes
- New `HotReloadCompiledCallSiteCache` (`Packages/src/Editor/FirstPartyTools/HotReload/`): per dll path it keeps the `AssemblyDefinition`, the async/iterator state-machine owner index, and the list of call / ldftn instructions.
  - Fingerprint = length + `LastWriteTimeUtc` ticks + MVID. The MVID is read with a deferred Cecil read of the metadata header (<1 ms). A content hash was tried first and rejected: SHA-256 over the 1.3 MB test assembly cost 40 ms, as much as the read it was meant to avoid.
  - The fingerprint and the full Cecil read are separate opens, so after the read the cache re-checks the module's own MVID and the file's length and write time before publishing the entry. A mismatch is retried once; a file that changes again is reported as an `IOException` rather than cached.
  - A failure while the index is being built releases the `AssemblyDefinition` (try/finally with ownership transfer to the entry) and rethrows the original exception.
  - Capacity 8 with least-recently-used eviction; evicted and replaced entries dispose their `AssemblyDefinition`. Access is serialized with a lock. Entries are returned outside the lock, so their lifetime relies on hot reload runs being single-flight (they are, via the tool execution session).
- `HotReloadCallSiteScanner` matches targets against the cached call sites instead of re-walking the module, and memoizes the `CompilationPipeline.GetAssemblies()` reference graph per domain. The memo is cleared on `CompilationPipeline.compilationStarted` so an asmdef change made during a failed compile cannot survive in it. Matching logic (`MatchesIdentity`, scope checks, logical-owner resolution, self-call exclusion) is unchanged.
- Tests (`HotReloadCompiledCallSiteCacheTests`, 11 cases): identical file reused; write-time change, size change, same-size-same-mtime different module, and different path each reload; byte-identical rewrite with restored mtime is reused; over-capacity evicts the least recently used entry; non-positive capacity is rejected; a dll replaced between fingerprint and read publishes an entry whose fingerprint matches the module actually read; a dll changing before every read throws without publishing; an index-build failure disposes the assembly and rethrows the original exception. All work on copies of the test assembly dll in a private temp directory.

## Known limitations
- The fingerprint is a heuristic identity, not a content hash: a metadata-preserving rewrite that keeps the length and restores the write time would be served stale. Unity's compiler output never does this.
- The reference-graph memo has no invalidation other than domain reload and `compilationStarted`; an asmdef edit that does not trigger a compile is not observed until the next one.
- With more than 8 dlls in one run's working set, LRU eviction thrashes and the hit rate drops to zero; correctness is unaffected and performance returns to the pre-PR level for that run.

## Verification
- `dist/darwin-arm64/uloop compile` — 0 errors; file-length gate: no files exceeded.
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value 'HotReloadCompiledCallSiteCacheTests|HotReloadCallSiteScannerTests|HotReloadOneShotCallerNoteBuilderTests'` — 57/57 passed.
- `dist/darwin-arm64/uloop run-tests --filter-type class --filter-value HotReloadOrchestratorTests` — 153/153 passed.

| Measurement (same machine, same command) | `main` (with #2640) | this branch |
|---|---|---|
| `FindCallSites` on the HotReload test assembly, 6 consecutive calls | 127 / 117 / 155 / 117 / 113 / 161 ms | 268 (first, cold) / 102 / 97 / 93 / 94 / 93 ms with the SHA-256 fingerprint; **5 / 5 / 4 / 5 / 4 / 4 ms** with the MVID fingerprint |
| `HotReloadOrchestratorTests` wall clock (153 tests, `--skip-compile`) | 156 s | 122 s |

Cache hits were confirmed by reading `HotReloadCompiledCallSiteCache.Shared.LoadCount` after the orchestrator fixture: 2 loads (two distinct dlls) for 153 tests.

Part of #2634.
