### PR TITLE
fix: uloop --help and uloop list now read skill descriptions from packages referenced by a relative file: path

### DIFF
--- a/cli/common/skillscan/packages.go
+++ b/cli/common/skillscan/packages.go
@@ -300,7 +300,10 @@ func resolveLocalDependencyPath(dependencyValue string, projectRoot string) stri
 	if filepath.IsAbs(rawPath) {
 		return rawPath
 	}
-	return filepath.Join(projectRoot, rawPath)
+	// Why the Packages folder and not the project root: Unity resolves a relative file:/path:
+	// dependency against the folder holding manifest.json, so file:../../x names a sibling of
+	// the project. Joining onto the project root looked one level too high and found nothing.
+	return filepath.Join(projectRoot, "Packages", rawPath)
 }
 
 func isTargetPackageCacheDir(dirName string) bool {

--- a/cli/common/skillscan/packages_test.go
+++ b/cli/common/skillscan/packages_test.go
@@ -239,3 +239,73 @@ func writeManifest(t *testing.T, projectRoot string, content string) {
 		t.Fatalf("failed to write manifest: %v", err)
 	}
 }
+
+// Tests that a relative file: dependency resolves against the Packages folder, the way Unity reads it.
+func TestResolveLocalDependencyPathResolvesRelativePathsAgainstPackagesFolder(t *testing.T) {
+	projectRoot := filepath.Join(t.TempDir(), "workspace", "project")
+
+	resolved := resolveLocalDependencyPath("file:../../sibling/Packages/src", projectRoot)
+
+	expected := filepath.Clean(filepath.Join(projectRoot, "Packages", "..", "..", "sibling", "Packages", "src"))
+	if resolved != expected {
+		t.Fatalf("resolved path mismatch:\nactual:   %q\nexpected: %q", resolved, expected)
+	}
+}
+
+// Tests that a relative path: dependency uses the same Packages-relative base as file:.
+func TestResolveLocalDependencyPathResolvesRelativePathPrefixAgainstPackagesFolder(t *testing.T) {
+	projectRoot := filepath.Join(t.TempDir(), "workspace", "project")
+
+	resolved := resolveLocalDependencyPath("path:../sibling-package", projectRoot)
+
+	expected := filepath.Clean(filepath.Join(projectRoot, "Packages", "..", "sibling-package"))
+	if resolved != expected {
+		t.Fatalf("resolved path mismatch:\nactual:   %q\nexpected: %q", resolved, expected)
+	}
+}
+
+// Tests that an absolute dependency path is used as written, with no project directory prepended.
+func TestResolveLocalDependencyPathKeepsAbsolutePaths(t *testing.T) {
+	projectRoot := t.TempDir()
+	absolutePackageRoot := filepath.Join(t.TempDir(), "absolute-package")
+
+	resolved := resolveLocalDependencyPath("file:"+filepath.ToSlash(absolutePackageRoot), projectRoot)
+
+	if resolved != absolutePackageRoot {
+		t.Fatalf("resolved path mismatch:\nactual:   %q\nexpected: %q", resolved, absolutePackageRoot)
+	}
+}
+
+// Tests that the file:// form keeps resolving to the absolute path that follows the slashes.
+func TestResolveLocalDependencyPathKeepsFileSchemeAbsolutePaths(t *testing.T) {
+	projectRoot := t.TempDir()
+	absolutePackageRoot := filepath.Join(t.TempDir(), "scheme-package")
+
+	resolved := resolveLocalDependencyPath("file://"+filepath.ToSlash(absolutePackageRoot), projectRoot)
+
+	if resolved != absolutePackageRoot {
+		t.Fatalf("resolved path mismatch:\nactual:   %q\nexpected: %q", resolved, absolutePackageRoot)
+	}
+}
+
+// Tests that a package reached through a relative manifest entry is enumerated at its real location.
+func TestEnumeratePackageSearchResultsResolvesRelativeManifestDependency(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	projectRoot := filepath.Join(workspaceRoot, "project")
+	siblingPackageRoot := filepath.Join(workspaceRoot, "sibling", "Packages", "src")
+	if err := os.MkdirAll(siblingPackageRoot, 0o755); err != nil {
+		t.Fatalf("failed to create sibling package: %v", err)
+	}
+	writeManifest(
+		t,
+		projectRoot,
+		`{"dependencies":{"com.example.sibling":"file:../../sibling/Packages/src"}}`)
+
+	results := EnumeratePackageSearchResults(projectRoot)
+
+	actual := packageResultSummaries(results)
+	expected := []string{"com.example.sibling|" + filepath.Clean(siblingPackageRoot)}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("package results mismatch:\nactual:   %#v\nexpected: %#v", actual, expected)
+	}
+}

--- a/cli/common/skillscan/packages_test.go
+++ b/cli/common/skillscan/packages_test.go
@@ -267,24 +267,26 @@ func TestResolveLocalDependencyPathResolvesRelativePathPrefixAgainstPackagesFold
 // Tests that an absolute dependency path is used as written, with no project directory prepended.
 func TestResolveLocalDependencyPathKeepsAbsolutePaths(t *testing.T) {
 	projectRoot := t.TempDir()
-	absolutePackageRoot := filepath.Join(t.TempDir(), "absolute-package")
+	// Manifests spell paths with forward slashes on every platform, and an absolute path is
+	// meant to pass through untouched, so the written form is what must come back.
+	dependencyPath := filepath.ToSlash(filepath.Join(t.TempDir(), "absolute-package"))
 
-	resolved := resolveLocalDependencyPath("file:"+filepath.ToSlash(absolutePackageRoot), projectRoot)
+	resolved := resolveLocalDependencyPath("file:"+dependencyPath, projectRoot)
 
-	if resolved != absolutePackageRoot {
-		t.Fatalf("resolved path mismatch:\nactual:   %q\nexpected: %q", resolved, absolutePackageRoot)
+	if resolved != dependencyPath {
+		t.Fatalf("resolved path mismatch:\nactual:   %q\nexpected: %q", resolved, dependencyPath)
 	}
 }
 
 // Tests that the file:// form keeps resolving to the absolute path that follows the slashes.
 func TestResolveLocalDependencyPathKeepsFileSchemeAbsolutePaths(t *testing.T) {
 	projectRoot := t.TempDir()
-	absolutePackageRoot := filepath.Join(t.TempDir(), "scheme-package")
+	dependencyPath := filepath.ToSlash(filepath.Join(t.TempDir(), "scheme-package"))
 
-	resolved := resolveLocalDependencyPath("file://"+filepath.ToSlash(absolutePackageRoot), projectRoot)
+	resolved := resolveLocalDependencyPath("file://"+dependencyPath, projectRoot)
 
-	if resolved != absolutePackageRoot {
-		t.Fatalf("resolved path mismatch:\nactual:   %q\nexpected: %q", resolved, absolutePackageRoot)
+	if resolved != dependencyPath {
+		t.Fatalf("resolved path mismatch:\nactual:   %q\nexpected: %q", resolved, dependencyPath)
 	}
 }
 

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "8af65616624737a1a6fbe5a91487ad5cc460a3fa"
+  "sharedInputsHash": "aca594f435e3812a53acdc5939db4449ec6f3177"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "ecfb879d8115713e787432cf5b0f89aeca137a07"
+  "sharedInputsHash": "7418e4a413a8668338db4d14bad2be24fb34512c"
 }


### PR DESCRIPTION
## Summary

- `uloop --help` and `uloop list` now show each command's real description in projects whose `manifest.json` points at the package with a relative `file:` or `path:` entry.

## User Impact

A Unity project can depend on a local package by relative path — an entry such as
`"io.github.hatayama.uloopmcp": "file:../../<name>/Packages/src"`, which is how a project sitting beside
a package checkout refers to it. In those projects the CLI could not find the package, so it fell back to
the command descriptions compiled into the binary at release time. The help text a reader saw was the one
from whichever release they installed, not the one from the package they are actually running against, and
it silently drifted further apart with every package update.

The cause is how the relative path was read. Unity resolves a relative `file:` or `path:` dependency
against the folder that holds `manifest.json` — the project's `Packages` folder — so `file:../../x` names
a sibling of the project directory. The resolver joined the same text onto the project root instead, which
is one level too high, found nothing there, and gave up.

Projects using an absolute path, a registry version, or a package under `Packages/` were never affected.

## Changes

- Resolve a relative local dependency against the project's `Packages` folder, matching Unity's own rule.
  Absolute paths and the `file://` form are untouched.
- Cover the behaviour with unit tests: relative `file:`, relative `path:`, absolute, `file://`, and an
  end-to-end enumeration through a manifest that uses a relative entry.
- Re-stamp the shared release inputs, since the change is in a module both binaries build from.

## Verification

- Wrote the tests first: the three relative-path tests fail against the old resolver
  (`.../sibling/...` instead of `.../workspace/sibling/...`), the two absolute-path tests pass throughout.
- `go test ./skillscan/` in the shared module: pass.
- `scripts/check-go-cli.sh`: pass (format, vet, lint 0 issues, all module tests, binary rebuild).
- End to end against a scratch project whose manifest uses `file:../../<name>/Packages/src` and whose
  package declares a distinctive description: with the fix the CLI prints that description, and reverting
  the single changed line puts the embedded text back.
- `scripts/stamp-release-inputs.sh` updated both stamps, so the change reaches a release of each binary.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

