### PR TITLE
chore: Add a resident transform worker host for hot reload (not yet wired)

### DIFF
--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -2369,6 +2369,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string secondSourcePath = null,
             string secondProjectRelativePath = null)
         {
+            TransformWorkerInputDto input = BuildInputForSource(
+                sourcePath,
+                projectRelativePath,
+                snapshotSource,
+                additionalAssemblySourcePaths,
+                changedSiblingSourcePaths,
+                secondSourcePath,
+                secondProjectRelativePath);
+            return await TransformWorkerClient.RunAsync(input, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Builds a worker input for the e2e fixture source with this test assembly as the target.
+        /// Shared with the resident-worker host tests so they exercise the real worker on the same input.
+        /// </summary>
+        internal static TransformWorkerInputDto BuildE2EFixtureInput()
+        {
+            return BuildInputForSource(ResolveE2EFixturePath(), ResolveE2EFixtureProjectRelativePath());
+        }
+
+        private static TransformWorkerInputDto BuildInputForSource(
+            string sourcePath,
+            string projectRelativePath,
+            string snapshotSource = null,
+            string[] additionalAssemblySourcePaths = null,
+            string[] changedSiblingSourcePaths = null,
+            string secondSourcePath = null,
+            string secondProjectRelativePath = null)
+        {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string targetDllPath = Path.Combine(
                 projectRoot,
@@ -2437,7 +2466,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 changedSiblingSourcePaths = changedSiblingSourcePaths
             };
 
-            return await TransformWorkerClient.RunAsync(input, CancellationToken.None);
+            return input;
         }
 
         private static string[] BuildAbsoluteReferencePaths(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerHostProcessTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerHostProcessTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// The host against the real compiled worker in `--serve` mode: one dotnet process answers
+    /// consecutive requests, an externally killed worker is replaced, Shutdown stops the process,
+    /// and a request the worker rejects leaves the process alive.
+    /// </summary>
+    public class TransformWorkerHostProcessTests
+    {
+        private const int ExitWaitMilliseconds = 10_000;
+
+        private TransformWorkerHost _host;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _host = new TransformWorkerHost(
+                TransformWorkerLaunchTargetResolution.ResolveAsync,
+                TransformWorkerProcessChannel.Start,
+                HotReloadConstants.WorkerProcessTimeoutMilliseconds);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _host.Shutdown("test teardown");
+        }
+
+        /// <summary>
+        /// What: two transforms of the e2e fixture complete through the same worker process, with the
+        /// same shim entries the one-shot path produces, and only one process is launched.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_TwiceOnE2EFixture_ReusesOneProcessAndCompletes()
+        {
+            TransformWorkerInputDto input = TransformWorkerClientTests.BuildE2EFixtureInput();
+
+            TransformWorkerHostResult first = await _host.RunAsync(input, CancellationToken.None);
+            int? firstPid = _host.CurrentProcessId;
+            TransformWorkerHostResult second = await _host.RunAsync(input, CancellationToken.None);
+
+            Assert.That(first.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), first.ErrorMessage);
+            Assert.That(first.Output.entries.Length, Is.GreaterThan(0));
+            Assert.That(first.Output.files.Length, Is.EqualTo(input.sources.Length));
+            Assert.That(second.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), second.ErrorMessage);
+            Assert.That(second.Output.entries.Length, Is.EqualTo(first.Output.entries.Length));
+            Assert.That(_host.LaunchCount, Is.EqualTo(1));
+            Assert.That(firstPid, Is.Not.Null);
+            Assert.That(_host.CurrentProcessId, Is.EqualTo(firstPid));
+        }
+
+        /// <summary>
+        /// What: when the worker process is killed from outside between requests, the next request
+        /// starts a new process (new pid) and completes.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_AfterExternalKill_RelaunchesWithNewProcess()
+        {
+            TransformWorkerInputDto input = TransformWorkerClientTests.BuildE2EFixtureInput();
+            TransformWorkerHostResult first = await _host.RunAsync(input, CancellationToken.None);
+            Assert.That(first.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), first.ErrorMessage);
+            int firstPid = _host.CurrentProcessId.Value;
+
+            using (Process worker = Process.GetProcessById(firstPid))
+            {
+                worker.Kill();
+                Assert.That(worker.WaitForExit(ExitWaitMilliseconds), Is.True, "The killed worker must exit.");
+            }
+
+            TransformWorkerHostResult second = await _host.RunAsync(input, CancellationToken.None);
+
+            Assert.That(second.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), second.ErrorMessage);
+            Assert.That(_host.LaunchCount, Is.EqualTo(2));
+            Assert.That(_host.CurrentProcessId, Is.Not.Null.And.Not.EqualTo(firstPid));
+        }
+
+        /// <summary>
+        /// What: Shutdown stops the resident process; it exits and the host reports no current process.
+        /// </summary>
+        [Test]
+        public async Task Shutdown_StopsResidentProcess()
+        {
+            TransformWorkerInputDto input = TransformWorkerClientTests.BuildE2EFixtureInput();
+            TransformWorkerHostResult first = await _host.RunAsync(input, CancellationToken.None);
+            Assert.That(first.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), first.ErrorMessage);
+            int pid = _host.CurrentProcessId.Value;
+
+            using (Process worker = Process.GetProcessById(pid))
+            {
+                _host.Shutdown("test");
+
+                Assert.That(worker.WaitForExit(ExitWaitMilliseconds), Is.True, "The worker must exit after Shutdown.");
+            }
+
+            Assert.That(_host.CurrentProcessId, Is.Null);
+        }
+
+        /// <summary>
+        /// What: a request the worker rejects at run level (two sources sharing a projectRelativePath)
+        /// is reported as WorkerFailed with the worker's message, and the same process still serves
+        /// the next request.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_RunLevelRejection_ReportsWorkerFailedAndKeepsProcess()
+        {
+            TransformWorkerInputDto good = TransformWorkerClientTests.BuildE2EFixtureInput();
+            TransformWorkerInputDto rejected = TransformWorkerClientTests.BuildE2EFixtureInput();
+            TransformWorkerSourceDto duplicate = new TransformWorkerSourceDto
+            {
+                sourcePath = rejected.sources[0].sourcePath,
+                projectRelativePath = rejected.sources[0].projectRelativePath
+            };
+            rejected.sources = new[] { rejected.sources[0], duplicate };
+
+            TransformWorkerHostResult failed = await _host.RunAsync(rejected, CancellationToken.None);
+            TransformWorkerHostResult next = await _host.RunAsync(good, CancellationToken.None);
+
+            Assert.That(failed.Kind, Is.EqualTo(TransformWorkerHostResultKind.WorkerFailed), failed.ErrorMessage);
+            Assert.That(failed.ErrorMessage, Does.Contain("projectRelativePath"));
+            Assert.That(next.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), next.ErrorMessage);
+            Assert.That(_host.LaunchCount, Is.EqualTo(1));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerHostProcessTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerHostProcessTests.cs
@@ -17,6 +17,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     public class TransformWorkerHostProcessTests
     {
         private const int ExitWaitMilliseconds = 10_000;
+        private const int ExitPollIntervalMilliseconds = 50;
 
         private TransformWorkerHost _host;
 
@@ -73,7 +74,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             using (Process worker = Process.GetProcessById(firstPid))
             {
                 worker.Kill();
-                Assert.That(worker.WaitForExit(ExitWaitMilliseconds), Is.True, "The killed worker must exit.");
+                Assert.That(await WaitForExitAsync(worker, ExitWaitMilliseconds), Is.True, "The killed worker must exit.");
             }
 
             TransformWorkerHostResult second = await _host.RunAsync(input, CancellationToken.None);
@@ -98,7 +99,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             {
                 _host.Shutdown("test");
 
-                Assert.That(worker.WaitForExit(ExitWaitMilliseconds), Is.True, "The worker must exit after Shutdown.");
+                Assert.That(await WaitForExitAsync(worker, ExitWaitMilliseconds), Is.True, "The worker must exit after Shutdown.");
             }
 
             Assert.That(_host.CurrentProcessId, Is.Null);
@@ -128,6 +129,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(failed.ErrorMessage, Does.Contain("projectRelativePath"));
             Assert.That(next.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), next.ErrorMessage);
             Assert.That(_host.LaunchCount, Is.EqualTo(1));
+        }
+
+        // Why poll instead of Process.WaitForExit: an EditMode test that blocks the Editor's main
+        // thread on a child process stalls the whole run.
+        private static async Task<bool> WaitForExitAsync(Process process, int timeoutMilliseconds)
+        {
+            Stopwatch waited = Stopwatch.StartNew();
+            while (waited.ElapsedMilliseconds < timeoutMilliseconds)
+            {
+                if (process.HasExited)
+                {
+                    return true;
+                }
+
+                await Task.Delay(ExitPollIntervalMilliseconds);
+            }
+
+            return process.HasExited;
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/TransformWorkerHostProcessTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerHostProcessTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 369c91581cc35458991be4aae0aa2014
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerHostTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerHostTests.cs
@@ -1,0 +1,643 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Host state machine over a scripted in-process channel: process reuse, broken-conversation
+    /// retry and its bound, final worker failures, timeout, cancellation while queued and while in
+    /// flight, shutdown during a request, worker-directory change, and bootstrap failure.
+    /// </summary>
+    public class TransformWorkerHostTests
+    {
+        private const int DefaultTimeoutMilliseconds = 30_000;
+        private const int ShortTimeoutMilliseconds = 300;
+        private const int WaitMilliseconds = 15_000;
+
+        private ScriptedChannelFactory _factory;
+        private string _workerDirectory;
+        private TransformWorkerHost _host;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _factory = new ScriptedChannelFactory();
+            _workerDirectory = "/worker/a";
+            _host = CreateHost(DefaultTimeoutMilliseconds);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _host.Shutdown("test teardown");
+            _factory.DisposeAll();
+        }
+
+        /// <summary>
+        /// What: two consecutive requests are answered by the same process; only one launch happens.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_TwoRequests_ReuseOneProcess()
+        {
+            _factory.Enqueue(ScriptStep.Succeed, ScriptStep.Succeed);
+
+            TransformWorkerHostResult first = await _host.RunAsync(CreateInput(2), CancellationToken.None);
+            TransformWorkerHostResult second = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+
+            Assert.That(first.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), first.ErrorMessage);
+            Assert.That(first.Output.files.Length, Is.EqualTo(2));
+            Assert.That(second.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), second.ErrorMessage);
+            Assert.That(second.Output.files.Length, Is.EqualTo(1));
+            Assert.That(_host.LaunchCount, Is.EqualTo(1));
+            Assert.That(_factory.Channels[0].RequestCount, Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// What: a process that dies without answering is discarded and the request is retried once on
+        /// a fresh process, which succeeds.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_FirstProcessCrashes_RetriesOnceOnFreshProcess()
+        {
+            _factory.Enqueue(ScriptStep.Crash);
+            _factory.Enqueue(ScriptStep.Succeed);
+
+            TransformWorkerHostResult result = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+
+            Assert.That(result.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), result.ErrorMessage);
+            Assert.That(_host.LaunchCount, Is.EqualTo(2));
+            Assert.That(_factory.Channels[0].HasExited, Is.True);
+        }
+
+        /// <summary>
+        /// What: two consecutive broken conversations end the request as RetryExhausted; no third
+        /// process is started and the failure names the last reason.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_TwoBrokenConversations_ReportsRetryExhaustedWithoutThirdLaunch()
+        {
+            _factory.Enqueue(ScriptStep.Garbage);
+            _factory.Enqueue(ScriptStep.Crash);
+
+            TransformWorkerHostResult result = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+
+            Assert.That(result.Kind, Is.EqualTo(TransformWorkerHostResultKind.RetryExhausted));
+            Assert.That(result.ErrorMessage, Does.Contain("closed its output"));
+            Assert.That(_host.LaunchCount, Is.EqualTo(2));
+            Assert.That(_host.CurrentProcessId, Is.Null);
+        }
+
+        /// <summary>
+        /// What: a non-zero exit code is a final WorkerFailed result carrying the worker's diagnostics
+        /// and stderr tail; the process is kept and answers the next request.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_WorkerReportsFailure_IsFinalAndKeepsProcess()
+        {
+            _factory.Enqueue(ScriptStep.Fail, ScriptStep.Succeed);
+
+            TransformWorkerHostResult failed = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+            TransformWorkerHostResult next = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+
+            Assert.That(failed.Kind, Is.EqualTo(TransformWorkerHostResultKind.WorkerFailed));
+            Assert.That(failed.ErrorMessage, Does.Contain("exited with code 1"));
+            Assert.That(failed.ErrorMessage, Does.Contain("scripted failure"));
+            Assert.That(failed.ErrorMessage, Does.Contain("stderr tail for test"));
+            Assert.That(next.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), next.ErrorMessage);
+            Assert.That(_host.LaunchCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// What: run-level parse errors in a valid output file are a final WorkerFailed result, not a
+        /// broken conversation, and the process is kept.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_OutputCarriesRunLevelParseErrors_IsWorkerFailed()
+        {
+            _factory.Enqueue(ScriptStep.SucceedWithParseErrors);
+
+            TransformWorkerHostResult result = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+
+            Assert.That(result.Kind, Is.EqualTo(TransformWorkerHostResultKind.WorkerFailed));
+            Assert.That(result.ErrorMessage, Does.Contain("run-level problem"));
+            Assert.That(_host.LaunchCount, Is.EqualTo(1));
+            Assert.That(_host.CurrentProcessId, Is.Not.Null);
+        }
+
+        /// <summary>
+        /// What: exit code 0 without an output file, or with the wrong number of file rows, is a broken
+        /// conversation: the process is replaced and the retry on a fresh process succeeds.
+        /// </summary>
+        [TestCase(ScriptStep.SucceedWithoutOutput)]
+        [TestCase(ScriptStep.SucceedWrongFileCount)]
+        public async Task RunAsync_ExitZeroWithUnusableOutput_TreatedAsBrokenConversation(ScriptStep firstStep)
+        {
+            _factory.Enqueue(firstStep);
+            _factory.Enqueue(ScriptStep.Succeed);
+
+            TransformWorkerHostResult result = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+
+            Assert.That(result.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), result.ErrorMessage);
+            Assert.That(_host.LaunchCount, Is.EqualTo(2));
+            Assert.That(_factory.Channels[0].HasExited, Is.True);
+        }
+
+        /// <summary>
+        /// What: a worker that never answers is killed at the response timeout, the request ends as
+        /// TimedOut without a retry, and the next request starts a fresh process.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_WorkerHangs_TimesOutKillsAndRelaunchesNextTime()
+        {
+            _host.Shutdown("swap host");
+            _host = CreateHost(ShortTimeoutMilliseconds);
+            _factory.Enqueue(ScriptStep.Hang);
+            _factory.Enqueue(ScriptStep.Succeed);
+
+            TransformWorkerHostResult timedOut = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+            TransformWorkerHostResult next = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+
+            Assert.That(timedOut.Kind, Is.EqualTo(TransformWorkerHostResultKind.TimedOut));
+            Assert.That(timedOut.ErrorMessage, Does.Contain("was killed"));
+            Assert.That(_factory.Channels[0].HasExited, Is.True);
+            Assert.That(_factory.Channels[0].KillCount, Is.EqualTo(1));
+            Assert.That(next.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), next.ErrorMessage);
+            Assert.That(_host.LaunchCount, Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// What: a request canceled while waiting for the conversation gate throws
+        /// OperationCanceledException, starts no process, and leaves the in-flight request untouched.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_CanceledWhileQueued_ThrowsWithoutLaunching()
+        {
+            _factory.Enqueue(ScriptStep.Hang, ScriptStep.Succeed);
+            using CancellationTokenSource firstCancellation = new CancellationTokenSource();
+            using CancellationTokenSource queuedCancellation = new CancellationTokenSource();
+
+            Task<TransformWorkerHostResult> first = _host.RunAsync(CreateInput(1), firstCancellation.Token);
+            await _factory.Channels[0].WaitForRequestAsync(WaitMilliseconds);
+            Task<TransformWorkerHostResult> queued = _host.RunAsync(CreateInput(1), queuedCancellation.Token);
+            queuedCancellation.Cancel();
+
+            // Why not Assert.ThrowsAsync: it blocks the Unity main thread while the awaited task
+            // needs that thread for its continuation, which deadlocks the Editor.
+            Assert.That(await CompletesWithCancellationAsync(queued), Is.True, "The queued request must be canceled.");
+            Assert.That(_host.LaunchCount, Is.EqualTo(1));
+            Assert.That(first.IsCompleted, Is.False, "Canceling a queued request must not disturb the in-flight one.");
+
+            _factory.Channels[0].ReleaseHang(ScriptStep.Succeed);
+            TransformWorkerHostResult firstResult = await first;
+            Assert.That(firstResult.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), firstResult.ErrorMessage);
+        }
+
+        /// <summary>
+        /// What: canceling a request mid-conversation throws OperationCanceledException and discards
+        /// the process; the next request starts a fresh one and completes.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_CanceledMidConversation_DiscardsProcessAndRecovers()
+        {
+            _factory.Enqueue(ScriptStep.Hang);
+            _factory.Enqueue(ScriptStep.Succeed);
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+
+            Task<TransformWorkerHostResult> inFlight = _host.RunAsync(CreateInput(1), cancellation.Token);
+            await _factory.Channels[0].WaitForRequestAsync(WaitMilliseconds);
+            cancellation.Cancel();
+
+            Assert.That(await CompletesWithCancellationAsync(inFlight), Is.True, "The in-flight request must be canceled.");
+            Assert.That(_factory.Channels[0].HasExited, Is.True);
+            Assert.That(_host.CurrentProcessId, Is.Null);
+
+            TransformWorkerHostResult next = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+            Assert.That(next.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), next.ErrorMessage);
+            Assert.That(_host.LaunchCount, Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// What: Shutdown during a request terminates the process without waiting for the gate; the
+        /// request ends as LifecycleClosed and does not start a replacement. A later request launches anew.
+        /// </summary>
+        [Test]
+        public async Task Shutdown_DuringRequest_ClosesRequestWithoutRelaunch()
+        {
+            _factory.Enqueue(ScriptStep.Hang);
+            _factory.Enqueue(ScriptStep.Succeed);
+
+            Task<TransformWorkerHostResult> inFlight = _host.RunAsync(CreateInput(1), CancellationToken.None);
+            await _factory.Channels[0].WaitForRequestAsync(WaitMilliseconds);
+            _host.Shutdown("assembly reload for test");
+
+            TransformWorkerHostResult closed = await inFlight;
+            Assert.That(closed.Kind, Is.EqualTo(TransformWorkerHostResultKind.LifecycleClosed));
+            Assert.That(_host.LaunchCount, Is.EqualTo(1));
+            Assert.That(_factory.Channels[0].HasExited, Is.True);
+
+            TransformWorkerHostResult next = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+            Assert.That(next.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), next.ErrorMessage);
+            Assert.That(_host.LaunchCount, Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// What: Shutdown with no process running is a no-op that still invalidates nothing observable;
+        /// the next request launches normally.
+        /// </summary>
+        [Test]
+        public async Task Shutdown_WithoutProcess_IsHarmless()
+        {
+            _factory.Enqueue(ScriptStep.Succeed);
+
+            _host.Shutdown("idle shutdown");
+            TransformWorkerHostResult result = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+
+            Assert.That(result.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), result.ErrorMessage);
+            Assert.That(_host.LaunchCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// What: when the compiled worker moves to a new directory (worker source changed), the old
+        /// process is stopped and a new one is started from the new directory.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_WorkerDirectoryChanges_RestartsProcess()
+        {
+            _factory.Enqueue(ScriptStep.Succeed);
+            _factory.Enqueue(ScriptStep.Succeed);
+
+            TransformWorkerHostResult first = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+            _workerDirectory = "/worker/b";
+            TransformWorkerHostResult second = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+
+            Assert.That(first.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), first.ErrorMessage);
+            Assert.That(second.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), second.ErrorMessage);
+            Assert.That(_host.LaunchCount, Is.EqualTo(2));
+            Assert.That(_factory.Channels[0].HasExited, Is.True);
+            Assert.That(_factory.Channels[0].QuitRequested, Is.True, "The old process must be asked to quit gracefully first.");
+            Assert.That(_factory.Channels[1].WorkerDirectory, Is.EqualTo("/worker/b"));
+        }
+
+        /// <summary>
+        /// What: a process that exited on its own between requests (idle exit) is replaced silently.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_ProcessExitedBetweenRequests_Relaunches()
+        {
+            _factory.Enqueue(ScriptStep.Succeed);
+            _factory.Enqueue(ScriptStep.Succeed);
+
+            TransformWorkerHostResult first = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+            _factory.Channels[0].SimulateIdleExit();
+            TransformWorkerHostResult second = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+
+            Assert.That(first.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), first.ErrorMessage);
+            Assert.That(second.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), second.ErrorMessage);
+            Assert.That(_host.LaunchCount, Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// What: a launch-target failure (worker could not be compiled) is BootstrapFailed and starts nothing.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_BootstrapFails_ReturnsBootstrapFailedWithoutLaunch()
+        {
+            _workerDirectory = null;
+
+            TransformWorkerHostResult result = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+
+            Assert.That(result.Kind, Is.EqualTo(TransformWorkerHostResultKind.BootstrapFailed));
+            Assert.That(result.ErrorMessage, Does.Contain("bootstrap failed for test"));
+            Assert.That(_host.LaunchCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: a process that cannot be started counts as a broken conversation; two failures in a row
+        /// end as RetryExhausted with no launch recorded.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_ProcessStartFailsTwice_ReportsRetryExhausted()
+        {
+            _factory.StartFailuresRemaining = 2;
+
+            TransformWorkerHostResult result = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+
+            Assert.That(result.Kind, Is.EqualTo(TransformWorkerHostResultKind.RetryExhausted));
+            Assert.That(result.ErrorMessage, Does.Contain("could not be started"));
+            Assert.That(_host.LaunchCount, Is.EqualTo(0));
+        }
+
+        private static async Task<bool> CompletesWithCancellationAsync(Task<TransformWorkerHostResult> request)
+        {
+            try
+            {
+                await request;
+                return false;
+            }
+            catch (OperationCanceledException)
+            {
+                return true;
+            }
+        }
+
+        private TransformWorkerHost CreateHost(int responseTimeoutMilliseconds)
+        {
+            return new TransformWorkerHost(ResolveTargetAsync, _factory.Start, responseTimeoutMilliseconds);
+        }
+
+        private Task<TransformWorkerLaunchTarget> ResolveTargetAsync(CancellationToken ct)
+        {
+            if (_workerDirectory == null)
+            {
+                return Task.FromResult(TransformWorkerLaunchTarget.Failure("bootstrap failed for test"));
+            }
+
+            return Task.FromResult(TransformWorkerLaunchTarget.Resolved(_workerDirectory, "dotnet"));
+        }
+
+        private static TransformWorkerInputDto CreateInput(int sourceCount)
+        {
+            TransformWorkerSourceDto[] sources = new TransformWorkerSourceDto[sourceCount];
+            for (int index = 0; index < sourceCount; index++)
+            {
+                sources[index] = new TransformWorkerSourceDto
+                {
+                    sourcePath = "/project/Source" + index + ".cs",
+                    projectRelativePath = "Assets/Source" + index + ".cs"
+                };
+            }
+
+            return new TransformWorkerInputDto { sources = sources };
+        }
+    }
+
+    /// <summary>
+    /// What the scripted worker does with the next request it receives.
+    /// </summary>
+    public enum ScriptStep
+    {
+        Succeed,
+        SucceedWithParseErrors,
+        SucceedWithoutOutput,
+        SucceedWrongFileCount,
+        Fail,
+        Garbage,
+        Crash,
+        Hang
+    }
+
+    /// <summary>
+    /// Creates <see cref="ScriptedWorkerChannel"/> instances in launch order, each with its own
+    /// request script, and can be told to fail the next launches.
+    /// </summary>
+    internal sealed class ScriptedChannelFactory
+    {
+        private readonly Queue<Queue<ScriptStep>> _scriptsPerLaunch = new Queue<Queue<ScriptStep>>();
+
+        public List<ScriptedWorkerChannel> Channels { get; } = new List<ScriptedWorkerChannel>();
+        public int StartFailuresRemaining { get; set; }
+
+        /// <summary>Queues the script for the next launched process.</summary>
+        public void Enqueue(params ScriptStep[] steps)
+        {
+            _scriptsPerLaunch.Enqueue(new Queue<ScriptStep>(steps));
+        }
+
+        public ITransformWorkerChannel Start(string workerDirectory, string dotnetHostPath)
+        {
+            if (StartFailuresRemaining > 0)
+            {
+                StartFailuresRemaining--;
+                return null;
+            }
+
+            Queue<ScriptStep> script = _scriptsPerLaunch.Count > 0 ? _scriptsPerLaunch.Dequeue() : new Queue<ScriptStep>();
+            ScriptedWorkerChannel channel = new ScriptedWorkerChannel(Channels.Count + 1, workerDirectory, script);
+            Channels.Add(channel);
+            return channel;
+        }
+
+        public void DisposeAll()
+        {
+            foreach (ScriptedWorkerChannel channel in Channels)
+            {
+                channel.Kill(0);
+                channel.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// In-process worker that speaks the serve protocol over blocking line pipes and follows a script
+    /// per request, so host tests can provoke every conversation outcome deterministically.
+    /// </summary>
+    internal sealed class ScriptedWorkerChannel : ITransformWorkerChannel
+    {
+        private readonly BlockingLinePipe _requests = new BlockingLinePipe();
+        private readonly BlockingLinePipe _responses = new BlockingLinePipe();
+        private readonly BlockingLineWriter _protocolOutput;
+        private readonly Queue<ScriptStep> _script;
+        private readonly Thread _thread;
+        private readonly ManualResetEventSlim _hangRelease = new ManualResetEventSlim(false);
+        private readonly TaskCompletionSource<bool> _firstRequestReceived = new TaskCompletionSource<bool>();
+        private volatile bool _exited;
+        private ScriptStep _stepAfterHang = ScriptStep.Crash;
+
+        public ScriptedWorkerChannel(int id, string workerDirectory, Queue<ScriptStep> script)
+        {
+            Id = id;
+            WorkerDirectory = workerDirectory;
+            _script = script;
+            _protocolOutput = new BlockingLineWriter(_responses);
+            RequestWriter = new BlockingLineWriter(_requests);
+            ResponseReader = _responses;
+            _thread = new Thread(Serve) { IsBackground = true, Name = "scripted-worker-" + id };
+            _thread.Start();
+        }
+
+        public int Id { get; }
+        public string WorkerDirectory { get; }
+        public TextWriter RequestWriter { get; }
+        public TextReader ResponseReader { get; }
+        public int RequestCount { get; private set; }
+        public int KillCount { get; private set; }
+        public bool QuitRequested { get; private set; }
+
+        public bool HasExited
+        {
+            get { return _exited; }
+        }
+
+        public Task WaitForRequestAsync(int timeoutMilliseconds)
+        {
+            return Task.WhenAny(_firstRequestReceived.Task, Task.Delay(timeoutMilliseconds));
+        }
+
+        /// <summary>Lets a hanging request continue with <paramref name="step"/>.</summary>
+        public void ReleaseHang(ScriptStep step)
+        {
+            _stepAfterHang = step;
+            _hangRelease.Set();
+        }
+
+        /// <summary>Simulates the worker's own idle exit between requests.</summary>
+        public void SimulateIdleExit()
+        {
+            Exit();
+        }
+
+        public bool TryQuitGracefully(int waitMilliseconds)
+        {
+            if (_exited)
+            {
+                return true;
+            }
+
+            QuitRequested = true;
+            RequestWriter.WriteLine(TransformWorkerServeProtocol.QuitCommand);
+            return _thread.Join(waitMilliseconds);
+        }
+
+        public void Kill(int waitMilliseconds)
+        {
+            if (_exited)
+            {
+                return;
+            }
+
+            KillCount++;
+            Exit();
+            _hangRelease.Set();
+            _thread.Join(waitMilliseconds);
+        }
+
+        public string ReadStandardErrorTail()
+        {
+            return "stderr tail for test";
+        }
+
+        public void Dispose()
+        {
+            _hangRelease.Dispose();
+        }
+
+        private void Serve()
+        {
+            while (!_exited)
+            {
+                string line = _requests.ReadLine();
+                if (line == null || line == TransformWorkerServeProtocol.QuitCommand)
+                {
+                    Exit();
+                    return;
+                }
+
+                RequestCount++;
+                _firstRequestReceived.TrySetResult(true);
+                if (!TransformWorkerServeProtocol.TryDecodeRequestLine(line, out string inputPath, out string outputPath))
+                {
+                    WriteFrame(TransformWorkerServeProtocol.MalformedRequestExitCode, "malformed");
+                    continue;
+                }
+
+                ScriptStep step = _script.Count > 0 ? _script.Dequeue() : ScriptStep.Succeed;
+                if (step == ScriptStep.Hang)
+                {
+                    _hangRelease.Wait();
+                    if (_exited)
+                    {
+                        return;
+                    }
+
+                    step = _stepAfterHang;
+                }
+
+                if (!Perform(step, inputPath, outputPath))
+                {
+                    return;
+                }
+            }
+        }
+
+        // Returns false when the scripted worker "died".
+        private bool Perform(ScriptStep step, string inputPath, string outputPath)
+        {
+            int sourceCount = CountSources(inputPath);
+            switch (step)
+            {
+                case ScriptStep.Succeed:
+                    WriteOutput(outputPath, sourceCount, Array.Empty<string>());
+                    WriteFrame(0, "ok");
+                    return true;
+                case ScriptStep.SucceedWithParseErrors:
+                    WriteOutput(outputPath, 0, new[] { "run-level problem" });
+                    WriteFrame(0, "ok");
+                    return true;
+                case ScriptStep.SucceedWithoutOutput:
+                    WriteFrame(0, "forgot the file");
+                    return true;
+                case ScriptStep.SucceedWrongFileCount:
+                    WriteOutput(outputPath, sourceCount + 1, Array.Empty<string>());
+                    WriteFrame(0, "ok");
+                    return true;
+                case ScriptStep.Fail:
+                    WriteFrame(1, "scripted failure");
+                    return true;
+                case ScriptStep.Garbage:
+                    _protocolOutput.WriteLine("this is not a frame");
+                    return true;
+                case ScriptStep.Crash:
+                    Exit();
+                    return false;
+                default:
+                    throw new InvalidOperationException("Unhandled step " + step);
+            }
+        }
+
+        private static int CountSources(string inputPath)
+        {
+            if (!File.Exists(inputPath))
+            {
+                return 0;
+            }
+
+            TransformWorkerInputDto input = JsonConvert.DeserializeObject<TransformWorkerInputDto>(File.ReadAllText(inputPath));
+            return input?.sources?.Length ?? 0;
+        }
+
+        private static void WriteOutput(string outputPath, int fileCount, string[] parseErrors)
+        {
+            TransformWorkerFileOutputDto[] files = new TransformWorkerFileOutputDto[fileCount];
+            for (int index = 0; index < fileCount; index++)
+            {
+                files[index] = new TransformWorkerFileOutputDto();
+            }
+
+            TransformWorkerOutputDto output = new TransformWorkerOutputDto { files = files, parseErrors = parseErrors };
+            File.WriteAllText(outputPath, JsonConvert.SerializeObject(output));
+        }
+
+        private void WriteFrame(int exitCode, string diagnostics)
+        {
+            string payload = TransformWorkerServeProtocol.EncodeDiagnostics(diagnostics, out int byteCount);
+            _protocolOutput.WriteLine(TransformWorkerServeProtocol.EncodeResponseHeader(exitCode, byteCount));
+            _protocolOutput.WriteLine(payload);
+        }
+
+        private void Exit()
+        {
+            _exited = true;
+            _responses.Complete();
+            _requests.Complete();
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerHostTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerHostTests.cs
@@ -194,7 +194,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             using CancellationTokenSource queuedCancellation = new CancellationTokenSource();
 
             Task<TransformWorkerHostResult> first = _host.RunAsync(CreateInput(1), firstCancellation.Token);
-            await _factory.Channels[0].WaitForRequestAsync(WaitMilliseconds);
+            Assert.That(
+                await _factory.Channels[0].WaitForRequestAsync(WaitMilliseconds),
+                Is.True,
+                "The scripted worker never received the request.");
             Task<TransformWorkerHostResult> queued = _host.RunAsync(CreateInput(1), queuedCancellation.Token);
             queuedCancellation.Cancel();
 
@@ -221,7 +224,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             using CancellationTokenSource cancellation = new CancellationTokenSource();
 
             Task<TransformWorkerHostResult> inFlight = _host.RunAsync(CreateInput(1), cancellation.Token);
-            await _factory.Channels[0].WaitForRequestAsync(WaitMilliseconds);
+            Assert.That(
+                await _factory.Channels[0].WaitForRequestAsync(WaitMilliseconds),
+                Is.True,
+                "The scripted worker never received the request.");
             cancellation.Cancel();
 
             Assert.That(await CompletesWithCancellationAsync(inFlight), Is.True, "The in-flight request must be canceled.");
@@ -244,7 +250,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             _factory.Enqueue(ScriptStep.Succeed);
 
             Task<TransformWorkerHostResult> inFlight = _host.RunAsync(CreateInput(1), CancellationToken.None);
-            await _factory.Channels[0].WaitForRequestAsync(WaitMilliseconds);
+            Assert.That(
+                await _factory.Channels[0].WaitForRequestAsync(WaitMilliseconds),
+                Is.True,
+                "The scripted worker never received the request.");
             _host.Shutdown("assembly reload for test");
 
             TransformWorkerHostResult closed = await inFlight;
@@ -391,7 +400,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             _factory.Enqueue(ScriptStep.Hang);
 
             Task<TransformWorkerHostResult> first = _host.RunAsync(CreateInput(1), CancellationToken.None);
-            await _factory.Channels[0].WaitForRequestAsync(WaitMilliseconds);
+            Assert.That(
+                await _factory.Channels[0].WaitForRequestAsync(WaitMilliseconds),
+                Is.True,
+                "The scripted worker never received the request.");
             Task<TransformWorkerHostResult> queued = _host.RunAsync(CreateInput(1), CancellationToken.None);
 
             TransformWorkerHostResult firstResult = await first;
@@ -417,7 +429,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Stopwatch elapsed = Stopwatch.StartNew();
             Task<TransformWorkerHostResult> request = _host.RunAsync(CreateInput(1), CancellationToken.None);
-            await _factory.Channels[0].WaitForRequestAsync(WaitMilliseconds);
+            Assert.That(
+                await _factory.Channels[0].WaitForRequestAsync(WaitMilliseconds),
+                Is.True,
+                "The scripted worker never received the request.");
             await Task.Delay(BreakConversationDelayMilliseconds);
             _factory.Channels[0].ReleaseHang(ScriptStep.Garbage);
 
@@ -575,9 +590,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             get { return _exited; }
         }
 
-        public Task WaitForRequestAsync(int timeoutMilliseconds)
+        /// <summary>True when the first request arrived, false when the wait timed out.</summary>
+        public async Task<bool> WaitForRequestAsync(int timeoutMilliseconds)
         {
-            return Task.WhenAny(_firstRequestReceived.Task, Task.Delay(timeoutMilliseconds));
+            Task completed = await Task.WhenAny(_firstRequestReceived.Task, Task.Delay(timeoutMilliseconds));
+            return ReferenceEquals(completed, _firstRequestReceived.Task);
         }
 
         /// <summary>Lets a hanging request continue with <paramref name="step"/>.</summary>

--- a/Assets/Tests/Editor/HotReload/TransformWorkerHostTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerHostTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,6 +23,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const int DefaultTimeoutMilliseconds = 30_000;
         private const int ShortTimeoutMilliseconds = 300;
         private const int WaitMilliseconds = 15_000;
+        private const int GateDeadlineTimeoutMilliseconds = 1_000;
+        private const int RemainderDeadlineTimeoutMilliseconds = 1_000;
+        private const int BreakConversationDelayMilliseconds = 800;
+        // The response budget (1000) plus the graceful-quit wait the timeout path spends killing the
+        // hung worker (500), plus slack. An implementation that restarts the budget per attempt spends
+        // 800 + 1000 + 500 instead and lands well above this bound.
+        private const int RemainderDeadlineBudgetMilliseconds = 1_900;
 
         private ScriptedChannelFactory _factory;
         private string _workerDirectory;
@@ -306,6 +314,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a response frame whose diagnostics payload is shorter than its declared length is a
+        /// broken conversation, so the process is discarded and a fresh one answers the retry.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_DiagnosticsLengthMismatch_TreatedAsBrokenConversation()
+        {
+            _factory.Enqueue(ScriptStep.LengthMismatchDiagnostics);
+            _factory.Enqueue(ScriptStep.Succeed);
+
+            TransformWorkerHostResult result = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+
+            Assert.That(result.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), result.ErrorMessage);
+            Assert.That(_host.LaunchCount, Is.EqualTo(2));
+            Assert.That(_factory.Channels[0].HasExited, Is.True);
+        }
+
+        /// <summary>
         /// What: a launch-target failure (worker could not be compiled) is BootstrapFailed and starts nothing.
         /// </summary>
         [Test]
@@ -334,6 +359,74 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Kind, Is.EqualTo(TransformWorkerHostResultKind.RetryExhausted));
             Assert.That(result.ErrorMessage, Does.Contain("could not be started"));
             Assert.That(_host.LaunchCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: a shutdown that lands while a process is starting discards that process instead of
+        /// registering it, and ends the request without retrying on yet another process.
+        /// </summary>
+        [Test]
+        public async Task Shutdown_DuringProcessStart_DiscardsNewProcessAndClosesRequest()
+        {
+            _factory.Enqueue(ScriptStep.Succeed);
+            _factory.OnStarted = channel => _host.Shutdown("reload during start");
+
+            TransformWorkerHostResult result = await _host.RunAsync(CreateInput(1), CancellationToken.None);
+
+            Assert.That(result.Kind, Is.EqualTo(TransformWorkerHostResultKind.LifecycleClosed), result.ErrorMessage);
+            Assert.That(_host.LaunchCount, Is.EqualTo(0));
+            Assert.That(_host.CurrentProcessId, Is.Null);
+            Assert.That(_factory.Channels.Count, Is.EqualTo(1));
+            Assert.That(_factory.Channels[0].HasExited, Is.True);
+        }
+
+        /// <summary>
+        /// What: the response budget starts before the gate wait, so a request that spends it all
+        /// queued behind another times out without starting or touching a worker.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_GateWaitConsumesDeadline_TimesOutWithoutLaunch()
+        {
+            _host = CreateHost(GateDeadlineTimeoutMilliseconds);
+            _factory.Enqueue(ScriptStep.Hang);
+
+            Task<TransformWorkerHostResult> first = _host.RunAsync(CreateInput(1), CancellationToken.None);
+            await _factory.Channels[0].WaitForRequestAsync(WaitMilliseconds);
+            Task<TransformWorkerHostResult> queued = _host.RunAsync(CreateInput(1), CancellationToken.None);
+
+            TransformWorkerHostResult firstResult = await first;
+            TransformWorkerHostResult queuedResult = await queued;
+
+            Assert.That(firstResult.Kind, Is.EqualTo(TransformWorkerHostResultKind.TimedOut), firstResult.ErrorMessage);
+            Assert.That(queuedResult.Kind, Is.EqualTo(TransformWorkerHostResultKind.TimedOut), queuedResult.ErrorMessage);
+            Assert.That(queuedResult.ErrorMessage, Does.Contain("before attempt 1"));
+            Assert.That(_host.LaunchCount, Is.EqualTo(1));
+            Assert.That(_factory.Channels.Count, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// What: a conversation that breaks late leaves the retry only the unspent remainder of the
+        /// budget, instead of restarting the full response timeout per attempt.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_BrokenNearDeadline_SecondAttemptGetsOnlyRemainder()
+        {
+            _host = CreateHost(RemainderDeadlineTimeoutMilliseconds);
+            _factory.Enqueue(ScriptStep.Hang);
+            _factory.Enqueue(ScriptStep.Hang);
+
+            Stopwatch elapsed = Stopwatch.StartNew();
+            Task<TransformWorkerHostResult> request = _host.RunAsync(CreateInput(1), CancellationToken.None);
+            await _factory.Channels[0].WaitForRequestAsync(WaitMilliseconds);
+            await Task.Delay(BreakConversationDelayMilliseconds);
+            _factory.Channels[0].ReleaseHang(ScriptStep.Garbage);
+
+            TransformWorkerHostResult result = await request;
+            elapsed.Stop();
+
+            Assert.That(result.Kind, Is.EqualTo(TransformWorkerHostResultKind.TimedOut), result.ErrorMessage);
+            Assert.That(_host.LaunchCount, Is.EqualTo(2));
+            Assert.That(elapsed.ElapsedMilliseconds, Is.LessThan(RemainderDeadlineBudgetMilliseconds));
         }
 
         private static async Task<bool> CompletesWithCancellationAsync(Task<TransformWorkerHostResult> request)
@@ -391,6 +484,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         SucceedWrongFileCount,
         Fail,
         Garbage,
+        LengthMismatchDiagnostics,
         Crash,
         Hang
     }
@@ -405,6 +499,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         public List<ScriptedWorkerChannel> Channels { get; } = new List<ScriptedWorkerChannel>();
         public int StartFailuresRemaining { get; set; }
+
+        /// <summary>Runs while the host is still starting the process, before it registers it.</summary>
+        public Action<ScriptedWorkerChannel> OnStarted { get; set; }
 
         /// <summary>Queues the script for the next launched process.</summary>
         public void Enqueue(params ScriptStep[] steps)
@@ -423,6 +520,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Queue<ScriptStep> script = _scriptsPerLaunch.Count > 0 ? _scriptsPerLaunch.Dequeue() : new Queue<ScriptStep>();
             ScriptedWorkerChannel channel = new ScriptedWorkerChannel(Channels.Count + 1, workerDirectory, script);
             Channels.Add(channel);
+            OnStarted?.Invoke(channel);
             return channel;
         }
 
@@ -595,6 +693,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 case ScriptStep.Garbage:
                     _protocolOutput.WriteLine("this is not a frame");
                     return true;
+                case ScriptStep.LengthMismatchDiagnostics:
+                    WriteLengthMismatchFrame();
+                    return true;
                 case ScriptStep.Crash:
                     Exit();
                     return false;
@@ -624,6 +725,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             TransformWorkerOutputDto output = new TransformWorkerOutputDto { files = files, parseErrors = parseErrors };
             File.WriteAllText(outputPath, JsonConvert.SerializeObject(output));
+        }
+
+        // Announces one byte more than the payload carries, which the host must reject.
+        private void WriteLengthMismatchFrame()
+        {
+            string payload = TransformWorkerServeProtocol.EncodeDiagnostics("ok", out int byteCount);
+            _protocolOutput.WriteLine(TransformWorkerServeProtocol.EncodeResponseHeader(0, byteCount + 1));
+            _protocolOutput.WriteLine(payload);
         }
 
         private void WriteFrame(int exitCode, string diagnostics)

--- a/Assets/Tests/Editor/HotReload/TransformWorkerHostTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerHostTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36a0b13d978324115b1a916e15281b63
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerOutputReaderTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerOutputReaderTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Worker output files that exist but cannot be read.
+    /// </summary>
+    public class TransformWorkerOutputReaderTests
+    {
+        private string _tempDirectory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempDirectory = Path.Combine(Path.GetTempPath(), "uloop-output-reader-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDirectory);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(_tempDirectory))
+            {
+                Directory.Delete(_tempDirectory, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// What: an output path that is a directory rather than a file is reported as a read failure
+        /// instead of throwing, whichever exception type the platform raises for it.
+        /// </summary>
+        [Test]
+        public void TryRead_PathIsDirectory_ReturnsNullWithReadFailureReason()
+        {
+            string directoryAsOutputPath = Path.Combine(_tempDirectory, "output.json");
+            Directory.CreateDirectory(directoryAsOutputPath);
+
+            TransformWorkerOutputDto output = TransformWorkerOutputReader.TryRead(directoryAsOutputPath, 1, out string error);
+
+            Assert.That(output, Is.Null);
+            Assert.That(error, Does.Contain("could not be read"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerOutputReaderTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerOutputReaderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa3ec8d56ee044c7eab2216d12523ef6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerServeLoopTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerServeLoopTests.cs
@@ -1,0 +1,199 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Worker-side request loop driven over in-process pipes: frame shape, stdout capture, failure
+    /// isolation, malformed input, quit, end of input, and the idle exit firing only between requests.
+    /// </summary>
+    public class TransformWorkerServeLoopTests
+    {
+        private const int LongIdleTimeoutMilliseconds = 30_000;
+        private const int FrameWaitMilliseconds = 10_000;
+
+        private BlockingLinePipe _requests;
+        private BlockingLinePipe _responses;
+        private BlockingLineWriter _protocolOutput;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _requests = new BlockingLinePipe();
+            _responses = new BlockingLinePipe();
+            _protocolOutput = new BlockingLineWriter(_responses);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _requests.Complete();
+        }
+
+        /// <summary>
+        /// What: a request produces exactly one two-line frame on the protocol writer, and everything
+        /// the transform wrote to Console.Out, including a line equal to the result marker, arrives
+        /// inside the diagnostics payload instead of on the protocol stream.
+        /// </summary>
+        [Test]
+        public void Run_TransformWritesMarkerLikeNoise_NoiseStaysInsideFrame()
+        {
+            Task<int> loop = StartLoop((inputPath, outputPath) =>
+            {
+                Console.WriteLine("noise before");
+                Console.WriteLine(TransformWorkerServeProtocol.ResultPrefix + " 0 0");
+                Console.WriteLine("noise after");
+                return 0;
+            }, LongIdleTimeoutMilliseconds);
+
+            _requests.Push(TransformWorkerServeProtocol.EncodeRequestLine("/in.json", "/out.json"));
+            (int exitCode, string diagnostics) = ReadFrame();
+
+            Assert.That(exitCode, Is.EqualTo(0));
+            Assert.That(diagnostics, Does.Contain("noise before"));
+            Assert.That(diagnostics, Does.Contain(TransformWorkerServeProtocol.ResultPrefix + " 0 0"));
+            Assert.That(diagnostics, Does.Contain("noise after"));
+            Assert.That(_responses.PendingLineCount, Is.EqualTo(0), "Only the two frame lines may reach the protocol stream.");
+
+            _requests.Push(TransformWorkerServeProtocol.QuitCommand);
+            Assert.That(loop.Wait(FrameWaitMilliseconds), Is.True);
+            Assert.That(loop.Result, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: an exception inside the transform becomes a frame with exit code 1 carrying the
+        /// exception text, the loop keeps serving, and Console.Out is restored afterwards.
+        /// </summary>
+        [Test]
+        public void Run_TransformThrows_ReportsExitOneAndKeepsServing()
+        {
+            TextWriter originalOut = Console.Out;
+            int calls = 0;
+            Task<int> loop = StartLoop((inputPath, outputPath) =>
+            {
+                calls++;
+                if (calls == 1)
+                {
+                    throw new InvalidOperationException("transform exploded\n" + TransformWorkerServeProtocol.ResultPrefix + " 9 9");
+                }
+
+                return 0;
+            }, LongIdleTimeoutMilliseconds);
+
+            _requests.Push(TransformWorkerServeProtocol.EncodeRequestLine("/in.json", "/out.json"));
+            (int firstExit, string firstDiagnostics) = ReadFrame();
+            _requests.Push(TransformWorkerServeProtocol.EncodeRequestLine("/in.json", "/out.json"));
+            (int secondExit, string _) = ReadFrame();
+
+            Assert.That(firstExit, Is.EqualTo(1));
+            Assert.That(firstDiagnostics, Does.Contain("transform exploded"));
+            Assert.That(firstDiagnostics, Does.Contain("InvalidOperationException"));
+            Assert.That(secondExit, Is.EqualTo(0));
+            Assert.That(Console.Out, Is.SameAs(originalOut), "Console.Out must be restored between requests.");
+
+            _requests.Complete();
+            Assert.That(loop.Wait(FrameWaitMilliseconds), Is.True);
+        }
+
+        /// <summary>
+        /// What: a line that is not a run request is answered with the malformed-request exit code and
+        /// does not invoke the transform or end the loop.
+        /// </summary>
+        [Test]
+        public void Run_MalformedRequest_AnswersExitTwoWithoutInvokingTransform()
+        {
+            int calls = 0;
+            Task<int> loop = StartLoop((inputPath, outputPath) =>
+            {
+                calls++;
+                return 0;
+            }, LongIdleTimeoutMilliseconds);
+
+            _requests.Push("run garbage");
+            (int exitCode, string diagnostics) = ReadFrame();
+
+            Assert.That(exitCode, Is.EqualTo(TransformWorkerServeProtocol.MalformedRequestExitCode));
+            Assert.That(diagnostics, Does.Contain("malformed request line"));
+            Assert.That(calls, Is.EqualTo(0));
+
+            _requests.Push(TransformWorkerServeProtocol.QuitCommand);
+            Assert.That(loop.Wait(FrameWaitMilliseconds), Is.True);
+            Assert.That(loop.Result, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: end of input (the host closed stdin) ends the loop with exit code 0 and no frame.
+        /// </summary>
+        [Test]
+        public void Run_EndOfInput_ReturnsZeroWithoutFrame()
+        {
+            Task<int> loop = StartLoop((inputPath, outputPath) => 0, LongIdleTimeoutMilliseconds);
+
+            _requests.Complete();
+
+            Assert.That(loop.Wait(FrameWaitMilliseconds), Is.True);
+            Assert.That(loop.Result, Is.EqualTo(0));
+            Assert.That(_responses.PendingLineCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: the idle timeout fires only while waiting for a request. A transform that runs longer
+        /// than the idle timeout still completes and answers; the loop then exits once no further
+        /// request arrives within the idle window.
+        /// </summary>
+        [Test]
+        public void Run_IdleTimeout_FiresOnlyBetweenRequests()
+        {
+            const int idleTimeoutMilliseconds = 300;
+            Task<int> loop = StartLoop((inputPath, outputPath) =>
+            {
+                Thread.Sleep(idleTimeoutMilliseconds * 3);
+                return 0;
+            }, idleTimeoutMilliseconds);
+
+            _requests.Push(TransformWorkerServeProtocol.EncodeRequestLine("/in.json", "/out.json"));
+            (int exitCode, string _) = ReadFrame();
+
+            Assert.That(exitCode, Is.EqualTo(0), "The slow transform must be answered, not cut off by the idle timer.");
+            Assert.That(loop.Wait(FrameWaitMilliseconds), Is.True, "The loop must exit on its own once idle.");
+            Assert.That(loop.Result, Is.EqualTo(0));
+            Assert.That(_requests.IsCompleted, Is.False, "The exit must come from the idle timer, not from end of input.");
+        }
+
+        /// <summary>
+        /// What: null arguments and a non-positive idle timeout are rejected before the loop starts.
+        /// </summary>
+        [Test]
+        public void Run_InvalidArguments_Throw()
+        {
+            TransformWorkerServeLoop.TransformHandler handler = (inputPath, outputPath) => 0;
+
+            Assert.Throws<ArgumentNullException>(() => TransformWorkerServeLoop.Run(null, _protocolOutput, handler, 1000));
+            Assert.Throws<ArgumentNullException>(() => TransformWorkerServeLoop.Run(_requests, null, handler, 1000));
+            Assert.Throws<ArgumentNullException>(() => TransformWorkerServeLoop.Run(_requests, _protocolOutput, null, 1000));
+            Assert.Throws<ArgumentOutOfRangeException>(() => TransformWorkerServeLoop.Run(_requests, _protocolOutput, handler, 0));
+        }
+
+        private Task<int> StartLoop(TransformWorkerServeLoop.TransformHandler handler, int idleTimeoutMilliseconds)
+        {
+            return Task.Run(() => TransformWorkerServeLoop.Run(_requests, _protocolOutput, handler, idleTimeoutMilliseconds));
+        }
+
+        private (int exitCode, string diagnostics) ReadFrame()
+        {
+            string header = _responses.ReadLineWithin(FrameWaitMilliseconds);
+            Assert.That(header, Is.Not.Null, "No response header arrived.");
+            Assert.That(TransformWorkerServeProtocol.TryParseResponseHeader(header, out int exitCode, out int byteCount), Is.True, "Bad header: " + header);
+            string payload = _responses.ReadLineWithin(FrameWaitMilliseconds);
+            Assert.That(payload, Is.Not.Null, "No diagnostics line arrived.");
+            Assert.That(TransformWorkerServeProtocol.TryDecodeDiagnostics(payload, byteCount, out string diagnostics), Is.True);
+            return (exitCode, diagnostics);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerServeLoopTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerServeLoopTests.cs
@@ -42,7 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// inside the diagnostics payload instead of on the protocol stream.
         /// </summary>
         [Test]
-        public void Run_TransformWritesMarkerLikeNoise_NoiseStaysInsideFrame()
+        public async Task Run_TransformWritesMarkerLikeNoise_NoiseStaysInsideFrame()
         {
             Task<int> loop = StartLoop((inputPath, outputPath) =>
             {
@@ -53,7 +53,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }, LongIdleTimeoutMilliseconds);
 
             _requests.Push(TransformWorkerServeProtocol.EncodeRequestLine("/in.json", "/out.json"));
-            (int exitCode, string diagnostics) = ReadFrame();
+            (int exitCode, string diagnostics) = await ReadFrameAsync();
 
             Assert.That(exitCode, Is.EqualTo(0));
             Assert.That(diagnostics, Does.Contain("noise before"));
@@ -62,8 +62,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(_responses.PendingLineCount, Is.EqualTo(0), "Only the two frame lines may reach the protocol stream.");
 
             _requests.Push(TransformWorkerServeProtocol.QuitCommand);
-            Assert.That(loop.Wait(FrameWaitMilliseconds), Is.True);
-            Assert.That(loop.Result, Is.EqualTo(0));
+            Assert.That(await AwaitLoopExitAsync(loop), Is.EqualTo(0));
         }
 
         /// <summary>
@@ -71,7 +70,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// exception text, the loop keeps serving, and Console.Out is restored afterwards.
         /// </summary>
         [Test]
-        public void Run_TransformThrows_ReportsExitOneAndKeepsServing()
+        public async Task Run_TransformThrows_ReportsExitOneAndKeepsServing()
         {
             TextWriter originalOut = Console.Out;
             int calls = 0;
@@ -87,9 +86,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }, LongIdleTimeoutMilliseconds);
 
             _requests.Push(TransformWorkerServeProtocol.EncodeRequestLine("/in.json", "/out.json"));
-            (int firstExit, string firstDiagnostics) = ReadFrame();
+            (int firstExit, string firstDiagnostics) = await ReadFrameAsync();
             _requests.Push(TransformWorkerServeProtocol.EncodeRequestLine("/in.json", "/out.json"));
-            (int secondExit, string _) = ReadFrame();
+            (int secondExit, string _) = await ReadFrameAsync();
 
             Assert.That(firstExit, Is.EqualTo(1));
             Assert.That(firstDiagnostics, Does.Contain("transform exploded"));
@@ -98,7 +97,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(Console.Out, Is.SameAs(originalOut), "Console.Out must be restored between requests.");
 
             _requests.Complete();
-            Assert.That(loop.Wait(FrameWaitMilliseconds), Is.True);
+            await AwaitLoopExitAsync(loop);
         }
 
         /// <summary>
@@ -106,7 +105,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// does not invoke the transform or end the loop.
         /// </summary>
         [Test]
-        public void Run_MalformedRequest_AnswersExitTwoWithoutInvokingTransform()
+        public async Task Run_MalformedRequest_AnswersExitTwoWithoutInvokingTransform()
         {
             int calls = 0;
             Task<int> loop = StartLoop((inputPath, outputPath) =>
@@ -116,29 +115,27 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }, LongIdleTimeoutMilliseconds);
 
             _requests.Push("run garbage");
-            (int exitCode, string diagnostics) = ReadFrame();
+            (int exitCode, string diagnostics) = await ReadFrameAsync();
 
             Assert.That(exitCode, Is.EqualTo(TransformWorkerServeProtocol.MalformedRequestExitCode));
             Assert.That(diagnostics, Does.Contain("malformed request line"));
             Assert.That(calls, Is.EqualTo(0));
 
             _requests.Push(TransformWorkerServeProtocol.QuitCommand);
-            Assert.That(loop.Wait(FrameWaitMilliseconds), Is.True);
-            Assert.That(loop.Result, Is.EqualTo(0));
+            Assert.That(await AwaitLoopExitAsync(loop), Is.EqualTo(0));
         }
 
         /// <summary>
         /// What: end of input (the host closed stdin) ends the loop with exit code 0 and no frame.
         /// </summary>
         [Test]
-        public void Run_EndOfInput_ReturnsZeroWithoutFrame()
+        public async Task Run_EndOfInput_ReturnsZeroWithoutFrame()
         {
             Task<int> loop = StartLoop((inputPath, outputPath) => 0, LongIdleTimeoutMilliseconds);
 
             _requests.Complete();
 
-            Assert.That(loop.Wait(FrameWaitMilliseconds), Is.True);
-            Assert.That(loop.Result, Is.EqualTo(0));
+            Assert.That(await AwaitLoopExitAsync(loop), Is.EqualTo(0));
             Assert.That(_responses.PendingLineCount, Is.EqualTo(0));
         }
 
@@ -148,7 +145,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// request arrives within the idle window.
         /// </summary>
         [Test]
-        public void Run_IdleTimeout_FiresOnlyBetweenRequests()
+        public async Task Run_IdleTimeout_FiresOnlyBetweenRequests()
         {
             const int idleTimeoutMilliseconds = 300;
             Task<int> loop = StartLoop((inputPath, outputPath) =>
@@ -158,11 +155,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }, idleTimeoutMilliseconds);
 
             _requests.Push(TransformWorkerServeProtocol.EncodeRequestLine("/in.json", "/out.json"));
-            (int exitCode, string _) = ReadFrame();
+            (int exitCode, string _) = await ReadFrameAsync();
 
             Assert.That(exitCode, Is.EqualTo(0), "The slow transform must be answered, not cut off by the idle timer.");
-            Assert.That(loop.Wait(FrameWaitMilliseconds), Is.True, "The loop must exit on its own once idle.");
-            Assert.That(loop.Result, Is.EqualTo(0));
+            Assert.That(await AwaitLoopExitAsync(loop), Is.EqualTo(0), "The loop must exit on its own once idle.");
             Assert.That(_requests.IsCompleted, Is.False, "The exit must come from the idle timer, not from end of input.");
         }
 
@@ -185,12 +181,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return Task.Run(() => TransformWorkerServeLoop.Run(_requests, _protocolOutput, handler, idleTimeoutMilliseconds));
         }
 
-        private (int exitCode, string diagnostics) ReadFrame()
+        // Why await instead of Task.Wait: blocking the Editor's main thread on the loop task
+        // deadlocks EditMode runs. Reading Result after the task completed does not block.
+        private static async Task<int> AwaitLoopExitAsync(Task<int> loop)
         {
-            string header = _responses.ReadLineWithin(FrameWaitMilliseconds);
+            Task completed = await Task.WhenAny(loop, Task.Delay(FrameWaitMilliseconds));
+            Assert.That(completed, Is.SameAs(loop), "The serve loop did not exit in time.");
+            return loop.Result;
+        }
+
+        private async Task<(int exitCode, string diagnostics)> ReadFrameAsync()
+        {
+            string header = await _responses.ReadLineWithinAsync(FrameWaitMilliseconds);
             Assert.That(header, Is.Not.Null, "No response header arrived.");
             Assert.That(TransformWorkerServeProtocol.TryParseResponseHeader(header, out int exitCode, out int byteCount), Is.True, "Bad header: " + header);
-            string payload = _responses.ReadLineWithin(FrameWaitMilliseconds);
+            string payload = await _responses.ReadLineWithinAsync(FrameWaitMilliseconds);
             Assert.That(payload, Is.Not.Null, "No diagnostics line arrived.");
             Assert.That(TransformWorkerServeProtocol.TryDecodeDiagnostics(payload, byteCount, out string diagnostics), Is.True);
             return (exitCode, diagnostics);

--- a/Assets/Tests/Editor/HotReload/TransformWorkerServeLoopTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerServeLoopTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b31829e3710842179d17e1f2b520712
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerServeProtocolTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerServeProtocolTests.cs
@@ -1,0 +1,162 @@
+using System.Text;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Encoding contract of the resident-worker line protocol: request lines, response headers,
+    /// and the length-prefixed diagnostics payload.
+    /// </summary>
+    public class TransformWorkerServeProtocolTests
+    {
+        /// <summary>
+        /// What: a request line round-trips paths containing spaces, quotes, and non-ASCII characters
+        /// because both paths travel base64-encoded.
+        /// </summary>
+        [Test]
+        public void RequestLine_RoundTripsPathsWithSpacesAndUnicode()
+        {
+            string inputPath = "/tmp/uloop hot reload/入力 \"quoted\".json";
+            string outputPath = "C:\\Temp\\uloop\\出力.json";
+
+            string line = TransformWorkerServeProtocol.EncodeRequestLine(inputPath, outputPath);
+            bool decoded = TransformWorkerServeProtocol.TryDecodeRequestLine(line, out string decodedInput, out string decodedOutput);
+
+            Assert.That(line.Split(' ').Length, Is.EqualTo(3), "The request must stay a single three-token line.");
+            Assert.That(decoded, Is.True);
+            Assert.That(decodedInput, Is.EqualTo(inputPath));
+            Assert.That(decodedOutput, Is.EqualTo(outputPath));
+        }
+
+        /// <summary>
+        /// What: lines that are not a well-formed run request are rejected instead of being guessed at.
+        /// </summary>
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("run")]
+        [TestCase("run onlyone")]
+        [TestCase("run a b c")]
+        [TestCase("walk YQ== Yg==")]
+        [TestCase("run !!! Yg==")]
+        [TestCase("run  Yg==")]
+        public void TryDecodeRequestLine_MalformedLine_ReturnsFalse(string line)
+        {
+            bool decoded = TransformWorkerServeProtocol.TryDecodeRequestLine(line, out string inputPath, out string outputPath);
+
+            Assert.That(decoded, Is.False);
+            Assert.That(inputPath, Is.Null);
+            Assert.That(outputPath, Is.Null);
+        }
+
+        /// <summary>
+        /// What: an empty path is rejected by the encoder rather than producing a request the worker
+        /// would decode as an empty file name.
+        /// </summary>
+        [Test]
+        public void EncodeRequestLine_EmptyPath_Throws()
+        {
+            Assert.Throws<System.ArgumentException>(() => TransformWorkerServeProtocol.EncodeRequestLine(string.Empty, "/out"));
+            Assert.Throws<System.ArgumentException>(() => TransformWorkerServeProtocol.EncodeRequestLine("/in", string.Empty));
+        }
+
+        /// <summary>
+        /// What: a response header round-trips the exit code and the diagnostics byte count.
+        /// </summary>
+        [Test]
+        public void ResponseHeader_RoundTripsExitCodeAndByteCount()
+        {
+            string header = TransformWorkerServeProtocol.EncodeResponseHeader(-7, 1234);
+            bool parsed = TransformWorkerServeProtocol.TryParseResponseHeader(header, out int exitCode, out int byteCount);
+
+            Assert.That(parsed, Is.True);
+            Assert.That(exitCode, Is.EqualTo(-7));
+            Assert.That(byteCount, Is.EqualTo(1234));
+        }
+
+        /// <summary>
+        /// What: a header with the wrong prefix, wrong arity, non-numeric fields, or a negative byte
+        /// count is rejected so the host treats the conversation as broken.
+        /// </summary>
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("noise")]
+        [TestCase("__ULOOP_TRANSFORM_RESULT__ 0")]
+        [TestCase("__ULOOP_TRANSFORM_RESULT__ zero 0")]
+        [TestCase("__ULOOP_TRANSFORM_RESULT__ 0 -1")]
+        [TestCase("__ULOOP_TRANSFORM_RESULT__ 0 0 extra")]
+        public void TryParseResponseHeader_MalformedHeader_ReturnsFalse(string header)
+        {
+            bool parsed = TransformWorkerServeProtocol.TryParseResponseHeader(header, out int _, out int _);
+
+            Assert.That(parsed, Is.False);
+        }
+
+        /// <summary>
+        /// What: diagnostics round-trip through one base64 line, including embedded newlines and a line
+        /// that equals the response marker, which is exactly what an end-marker protocol could not carry.
+        /// </summary>
+        [Test]
+        public void Diagnostics_RoundTripMarkerLikeMultilineText()
+        {
+            string diagnostics = "line one\n" + TransformWorkerServeProtocol.ResultPrefix + " 0 0\n診断 line three";
+
+            string payload = TransformWorkerServeProtocol.EncodeDiagnostics(diagnostics, out int byteCount);
+            bool decoded = TransformWorkerServeProtocol.TryDecodeDiagnostics(payload, byteCount, out string roundTripped);
+
+            Assert.That(payload.Contains("\n"), Is.False, "The payload must stay on one line.");
+            Assert.That(byteCount, Is.EqualTo(Encoding.UTF8.GetByteCount(diagnostics)));
+            Assert.That(decoded, Is.True);
+            Assert.That(roundTripped, Is.EqualTo(diagnostics));
+        }
+
+        /// <summary>
+        /// What: diagnostics beyond the cap are truncated to the cap with a visible suffix, so an
+        /// unbounded exception dump cannot stall the response frame.
+        /// </summary>
+        [Test]
+        public void EncodeDiagnostics_OverCap_TruncatesWithSuffix()
+        {
+            string oversized = new string('x', TransformWorkerServeProtocol.MaxDiagnosticBytes * 2);
+
+            string payload = TransformWorkerServeProtocol.EncodeDiagnostics(oversized, out int byteCount);
+            bool decoded = TransformWorkerServeProtocol.TryDecodeDiagnostics(payload, byteCount, out string truncated);
+
+            Assert.That(byteCount, Is.EqualTo(TransformWorkerServeProtocol.MaxDiagnosticBytes));
+            Assert.That(decoded, Is.True);
+            Assert.That(truncated.EndsWith(TransformWorkerServeProtocol.DiagnosticsTruncatedSuffix), Is.True);
+            Assert.That(truncated.StartsWith("xxxx"), Is.True);
+        }
+
+        /// <summary>
+        /// What: a payload whose decoded length does not match the header's byte count, or that is not
+        /// base64 at all, is rejected instead of being accepted as partial diagnostics.
+        /// </summary>
+        [Test]
+        public void TryDecodeDiagnostics_LengthMismatchOrInvalidBase64_ReturnsFalse()
+        {
+            string payload = TransformWorkerServeProtocol.EncodeDiagnostics("hello", out int byteCount);
+
+            Assert.That(TransformWorkerServeProtocol.TryDecodeDiagnostics(payload, byteCount + 1, out string _), Is.False);
+            Assert.That(TransformWorkerServeProtocol.TryDecodeDiagnostics("%%%not base64%%%", byteCount, out string _), Is.False);
+            Assert.That(TransformWorkerServeProtocol.TryDecodeDiagnostics(null, byteCount, out string _), Is.False);
+        }
+
+        /// <summary>
+        /// What: empty diagnostics encode as an empty payload with byte count zero and decode back to empty.
+        /// </summary>
+        [Test]
+        public void Diagnostics_Empty_RoundTripsAsZeroBytes()
+        {
+            string payload = TransformWorkerServeProtocol.EncodeDiagnostics(null, out int byteCount);
+            bool decoded = TransformWorkerServeProtocol.TryDecodeDiagnostics(payload, byteCount, out string roundTripped);
+
+            Assert.That(byteCount, Is.EqualTo(0));
+            Assert.That(payload, Is.EqualTo(string.Empty));
+            Assert.That(decoded, Is.True);
+            Assert.That(roundTripped, Is.EqualTo(string.Empty));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerServeProtocolTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerServeProtocolTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f52bb81c4c11408f873266f8816ff57
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerTestPipes.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerTestPipes.cs
@@ -1,0 +1,121 @@
+using System.Collections.Concurrent;
+using System.IO;
+using System.Text;
+using System.Threading;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// In-process stand-in for one direction of a process pipe: a reader that blocks on
+    /// <see cref="ReadLine"/> until a line is pushed or the pipe is completed (then returns null),
+    /// so serve-loop and host tests can drive the protocol without a child process.
+    /// </summary>
+    internal sealed class BlockingLinePipe : TextReader
+    {
+        private readonly BlockingCollection<string> _lines = new BlockingCollection<string>();
+
+        public int PendingLineCount
+        {
+            get { return _lines.Count; }
+        }
+
+        public bool IsCompleted
+        {
+            get { return _lines.IsAddingCompleted; }
+        }
+
+        public void Push(string line)
+        {
+            if (_lines.IsAddingCompleted)
+            {
+                throw new IOException("pipe closed");
+            }
+
+            _lines.Add(line);
+        }
+
+        /// <summary>Signals end of stream: pending lines are still delivered, then ReadLine returns null.</summary>
+        public void Complete()
+        {
+            if (!_lines.IsAddingCompleted)
+            {
+                _lines.CompleteAdding();
+            }
+        }
+
+        public override string ReadLine()
+        {
+            if (_lines.TryTake(out string line, Timeout.Infinite))
+            {
+                return line;
+            }
+
+            return null;
+        }
+
+        /// <summary>Waits up to <paramref name="timeoutMilliseconds"/> for the next line; null on timeout or end.</summary>
+        public string ReadLineWithin(int timeoutMilliseconds)
+        {
+            if (_lines.TryTake(out string line, timeoutMilliseconds))
+            {
+                return line;
+            }
+
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// TextWriter that turns each completed line into a push on a <see cref="BlockingLinePipe"/>.
+    /// </summary>
+    internal sealed class BlockingLineWriter : TextWriter
+    {
+        private readonly BlockingLinePipe _target;
+        private readonly StringBuilder _pending = new StringBuilder();
+        private readonly object _lock = new object();
+
+        public BlockingLineWriter(BlockingLinePipe target)
+        {
+            _target = target;
+        }
+
+        public override Encoding Encoding
+        {
+            get { return Encoding.UTF8; }
+        }
+
+        public override void Write(char value)
+        {
+            lock (_lock)
+            {
+                if (value == '\r')
+                {
+                    return;
+                }
+
+                if (value != '\n')
+                {
+                    _pending.Append(value);
+                    return;
+                }
+
+                string line = _pending.ToString();
+                _pending.Clear();
+                _target.Push(line);
+            }
+        }
+
+        public override void Write(string value)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            foreach (char character in value)
+            {
+                Write(character);
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerTestPipes.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerTestPipes.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
@@ -62,6 +63,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Same wait off the calling thread, so an EditMode test can await a line instead of blocking
+        /// the Editor's main thread on it.
+        /// </summary>
+        public Task<string> ReadLineWithinAsync(int timeoutMilliseconds)
+        {
+            return Task.Run(() => ReadLineWithin(timeoutMilliseconds));
         }
     }
 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerTestPipes.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerTestPipes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4a8e2455a08654d9697b238fcb55628f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -35,6 +35,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string WorkerSourcePackageRelativePath =
             "Editor/FirstPartyTools/HotReload/TransformWorker~";
 
+        // Package-relative sources compiled into the worker in addition to the tilde directory.
+        // Why: the resident-mode line protocol is shared verbatim between the Editor host and the
+        // worker so the two ends cannot drift apart.
+        public static readonly string[] WorkerSharedSourcePackageRelativePaths =
+        {
+            "Editor/FirstPartyTools/HotReload/TransformWorkerServeProtocol.cs"
+        };
+
         public const string WorkerDllFileName = "worker.dll";
         public const string WorkerRuntimeConfigFileName = "worker.runtimeconfig.json";
         public const string WorkerRoslynDirectorySidecarFileName = "roslyn-directory.txt";
@@ -290,6 +298,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Format: skipped method identity, then the reason it could not be patched.
         public const string SkippedMethodWarningFormat = "Skipped {0}: {1}";
 
+        public const string VibeLogWorkerHostStarted = "hot_reload_worker_started";
+        public const string VibeLogWorkerHostRestarted = "hot_reload_worker_restarted";
+        public const string VibeLogWorkerHostShutdown = "hot_reload_worker_shutdown";
+        public const string VibeLogWorkerHostLifecycleClosed = "hot_reload_worker_lifecycle_closed";
+        public const string VibeLogWorkerHostBrokenConversation = "hot_reload_worker_broken_conversation";
         public const string VibeLogFileStart = "hot_reload_file_start";
         public const string VibeLogWorkerResult = "hot_reload_worker_result";
         public const string VibeLogShimCompileFailed = "hot_reload_shim_compile_failed";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -303,6 +303,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string VibeLogWorkerHostShutdown = "hot_reload_worker_shutdown";
         public const string VibeLogWorkerHostLifecycleClosed = "hot_reload_worker_lifecycle_closed";
         public const string VibeLogWorkerHostBrokenConversation = "hot_reload_worker_broken_conversation";
+        public const string VibeLogWorkerHostTempCleanupFailed = "hot_reload_worker_temp_cleanup_failed";
         public const string VibeLogFileStart = "hot_reload_file_start";
         public const string VibeLogWorkerResult = "hot_reload_worker_result";
         public const string VibeLogShimCompileFailed = "hot_reload_shim_compile_failed";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerBootstrap.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerBootstrap.cs
@@ -39,7 +39,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             string workerSourceDirectory = ResolveWorkerSourceDirectory();
-            string[] workerSourcePaths = EnumerateWorkerSourceFiles(workerSourceDirectory);
+            string[] workerSourcePaths = CollectWorkerSourcePaths(workerSourceDirectory);
             if (workerSourcePaths.Length == 0)
             {
                 return TransformWorkerBootstrapResult.Failure(
@@ -94,9 +94,39 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal static string ResolveWorkerSourceDirectory()
         {
+            return Path.Combine(ResolvePackageRoot(), HotReloadConstants.WorkerSourcePackageRelativePath);
+        }
+
+        private static string ResolvePackageRoot()
+        {
             PackageInfo packageInfo = PackageInfo.FindForAssembly(typeof(TransformWorkerBootstrap).Assembly);
             Debug.Assert(packageInfo != null, "PackageInfo must resolve for the HotReload assembly.");
-            return Path.Combine(packageInfo.resolvedPath, HotReloadConstants.WorkerSourcePackageRelativePath);
+            return packageInfo.resolvedPath;
+        }
+
+        /// <summary>
+        /// The tilde-directory sources plus the protocol sources shared with the Editor host.
+        /// The shared files are appended after the sorted directory listing, so the response
+        /// file and the cache key stay deterministic.
+        /// </summary>
+        internal static string[] CollectWorkerSourcePaths(string workerSourceDirectory)
+        {
+            string[] directorySources = EnumerateWorkerSourceFiles(workerSourceDirectory);
+            if (directorySources.Length == 0)
+            {
+                return directorySources;
+            }
+
+            List<string> all = new List<string>(directorySources);
+            string packageRoot = ResolvePackageRoot();
+            foreach (string relativePath in HotReloadConstants.WorkerSharedSourcePackageRelativePaths)
+            {
+                string sharedPath = Path.Combine(packageRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+                Debug.Assert(File.Exists(sharedPath), "Shared worker source missing: " + sharedPath);
+                all.Add(sharedPath);
+            }
+
+            return all.ToArray();
         }
 
         // why: Directory.GetFiles order is unspecified, so ordinal file-name sort keeps the

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerChannel.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerChannel.cs
@@ -1,0 +1,259 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using UnityCliLoopDebug = UnityEngine.Debug;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// One live resident worker as seen by <see cref="TransformWorkerHost"/>: a request writer, a
+    /// response reader, liveness, and termination. Abstracted so host tests can substitute an
+    /// in-process serve loop over pipes for the real dotnet process.
+    /// </summary>
+    internal interface ITransformWorkerChannel : IDisposable
+    {
+        int Id { get; }
+        bool HasExited { get; }
+        TextWriter RequestWriter { get; }
+        TextReader ResponseReader { get; }
+
+        /// <summary>Asks the worker to exit on its own and waits briefly; false when it did not.</summary>
+        bool TryQuitGracefully(int waitMilliseconds);
+
+        /// <summary>Terminates the worker immediately and waits briefly for the exit.</summary>
+        void Kill(int waitMilliseconds);
+
+        /// <summary>The most recent standard-error output, bounded, for failure diagnostics.</summary>
+        string ReadStandardErrorTail();
+    }
+
+    /// <summary>
+    /// Creates a channel for a worker directory and dotnet host. The host owns the returned channel.
+    /// </summary>
+    internal delegate ITransformWorkerChannel TransformWorkerChannelFactory(string workerDirectory, string dotnetHostPath);
+
+    /// <summary>
+    /// The real `dotnet worker.dll --serve` process with stdin/stdout redirected for the protocol
+    /// and stderr drained continuously into a bounded buffer.
+    /// </summary>
+    internal sealed class TransformWorkerProcessChannel : ITransformWorkerChannel
+    {
+        // Why bounded: stderr is only ever shown as the tail of a failure message, and an
+        // unbounded buffer on a chatty worker would grow for the life of the Editor session.
+        private const int StandardErrorTailCapacity = 64 * 1024;
+
+        private readonly Process _process;
+        private readonly StringBuilder _standardErrorTail = new StringBuilder();
+        private readonly object _standardErrorLock = new object();
+
+        private TransformWorkerProcessChannel(Process process)
+        {
+            _process = process;
+            RequestWriter = process.StandardInput;
+            ResponseReader = process.StandardOutput;
+            // Why drain from the start: a worker that writes to stderr while the host is not
+            // reading would block on a full pipe and look like a hang.
+            _ = Task.Run(DrainStandardErrorAsync);
+        }
+
+        public int Id
+        {
+            get { return _process.Id; }
+        }
+
+        public bool HasExited
+        {
+            get { return _process.HasExited; }
+        }
+
+        public TextWriter RequestWriter { get; }
+
+        public TextReader ResponseReader { get; }
+
+        /// <summary>
+        /// Starts the worker in resident mode. Returns null when the process could not be started.
+        /// </summary>
+        public static ITransformWorkerChannel Start(string workerDirectory, string dotnetHostPath)
+        {
+            UnityCliLoopDebug.Assert(!string.IsNullOrEmpty(workerDirectory), "workerDirectory must not be empty.");
+            UnityCliLoopDebug.Assert(!string.IsNullOrEmpty(dotnetHostPath), "dotnetHostPath must not be empty.");
+
+            string workerDllPath = Path.Combine(workerDirectory, HotReloadConstants.WorkerDllFileName);
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                FileName = dotnetHostPath,
+                Arguments = "\"" + workerDllPath + "\" " + TransformWorkerServeProtocol.ServeArgument,
+                WorkingDirectory = workerDirectory,
+                UseShellExecute = false,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                // Pairs with the UTF-8 console encodings the worker sets in resident mode.
+                StandardOutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                StandardErrorEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)
+            };
+
+            Process process;
+            try
+            {
+                process = Process.Start(startInfo);
+            }
+            catch (Win32Exception ex)
+            {
+                UnityCliLoopDebug.LogWarning("Transform worker process could not be started: " + ex.Message);
+                return null;
+            }
+            catch (InvalidOperationException ex)
+            {
+                UnityCliLoopDebug.LogWarning("Transform worker process could not be started: " + ex.Message);
+                return null;
+            }
+
+            if (process == null)
+            {
+                return null;
+            }
+
+            // Why: the request writer must not buffer a line past the WriteLine, or the worker
+            // waits for input while the host waits for a response.
+            process.StandardInput.AutoFlush = true;
+            return new TransformWorkerProcessChannel(process);
+        }
+
+        public bool TryQuitGracefully(int waitMilliseconds)
+        {
+            if (_process.HasExited)
+            {
+                return true;
+            }
+
+            _process.StandardInput.WriteLine(TransformWorkerServeProtocol.QuitCommand);
+            _process.StandardInput.Flush();
+            return _process.WaitForExit(waitMilliseconds);
+        }
+
+        public void Kill(int waitMilliseconds)
+        {
+            if (_process.HasExited)
+            {
+                return;
+            }
+
+            _process.Kill();
+            _process.WaitForExit(waitMilliseconds);
+        }
+
+        public string ReadStandardErrorTail()
+        {
+            lock (_standardErrorLock)
+            {
+                return _standardErrorTail.ToString();
+            }
+        }
+
+        public void Dispose()
+        {
+            _process.Dispose();
+        }
+
+        private async Task DrainStandardErrorAsync()
+        {
+            try
+            {
+                while (true)
+                {
+                    string line = await _process.StandardError.ReadLineAsync().ConfigureAwait(false);
+                    if (line == null)
+                    {
+                        return;
+                    }
+
+                    AppendStandardError(line);
+                }
+            }
+            catch (IOException)
+            {
+                // The pipe closed with the process; nothing further to drain.
+            }
+            catch (ObjectDisposedException)
+            {
+                // Disposed after shutdown; nothing further to drain.
+            }
+        }
+
+        private void AppendStandardError(string line)
+        {
+            lock (_standardErrorLock)
+            {
+                _standardErrorTail.AppendLine(line);
+                if (_standardErrorTail.Length > StandardErrorTailCapacity)
+                {
+                    _standardErrorTail.Remove(0, _standardErrorTail.Length - StandardErrorTailCapacity);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Deadline-bounded line reads for the response frame. On timeout or cancel the in-flight read
+    /// is abandoned; the caller must kill the worker so the pipe closes and the read completes.
+    /// </summary>
+    internal static class TransformWorkerHostLineReader
+    {
+        /// <summary>
+        /// Returns the line, or null when <paramref name="remainingMilliseconds"/> elapsed first.
+        /// Throws <see cref="OperationCanceledException"/> when <paramref name="ct"/> is canceled.
+        /// </summary>
+        public static async Task<string> ReadLineAsync(TextReader reader, int remainingMilliseconds, CancellationToken ct)
+        {
+            UnityCliLoopDebug.Assert(reader != null, "reader must not be null.");
+            ct.ThrowIfCancellationRequested();
+            if (remainingMilliseconds <= 0)
+            {
+                return null;
+            }
+
+            // Why Task.Run: TextReader.ReadLine has no cancellation; isolating it lets the deadline
+            // return while the blocking read continues until the pipe is closed.
+            Task<string> readTask = Task.Run(() => reader.ReadLine(), CancellationToken.None);
+            using CancellationTokenSource delayCancellation = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            Task delayTask = Task.Delay(remainingMilliseconds, delayCancellation.Token);
+            Task completed = await Task.WhenAny(readTask, delayTask).ConfigureAwait(false);
+            if (ReferenceEquals(completed, readTask))
+            {
+                delayCancellation.Cancel();
+                try
+                {
+                    return await readTask.ConfigureAwait(false);
+                }
+                catch (IOException)
+                {
+                    return null;
+                }
+                catch (ObjectDisposedException)
+                {
+                    return null;
+                }
+            }
+
+            ObserveAbandonedRead(readTask);
+            ct.ThrowIfCancellationRequested();
+            return null;
+        }
+
+        private static void ObserveAbandonedRead(Task<string> readTask)
+        {
+            _ = readTask.ContinueWith(
+                static observed => _ = observed.Exception,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerChannel.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerChannel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8fa04c737ac14ccb859408ba8977258
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHost.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHost.cs
@@ -602,48 +602,4 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
     }
-
-    /// <summary>
-    /// Reads and validates a worker output file. Null with a reason when the file is missing,
-    /// unreadable as JSON, or does not carry one per-file row per source.
-    /// </summary>
-    internal static class TransformWorkerOutputReader
-    {
-        public static TransformWorkerOutputDto TryRead(string outputJsonPath, int expectedFileCount, out string error)
-        {
-            error = null;
-            if (!File.Exists(outputJsonPath))
-            {
-                error = "worker exited 0 but produced no output JSON file";
-                return null;
-            }
-
-            string outputJson = File.ReadAllText(outputJsonPath, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-            TransformWorkerOutputDto output;
-            try
-            {
-                output = JsonConvert.DeserializeObject<TransformWorkerOutputDto>(outputJson);
-            }
-            catch (JsonException ex)
-            {
-                error = "worker output JSON could not be parsed: " + ex.Message;
-                return null;
-            }
-
-            if (output == null)
-            {
-                error = "worker output JSON deserialized to null";
-                return null;
-            }
-
-            TransformWorkerClient.CoalesceOutput(output);
-            if (output.parseErrors.Length == 0 && output.files.Length != expectedFileCount)
-            {
-                error = "worker output carried " + output.files.Length + " file rows for " + expectedFileCount + " sources";
-                return null;
-            }
-
-            return output;
-        }
-    }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHost.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHost.cs
@@ -111,6 +111,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(input != null, "input must not be null.");
             Debug.Assert(input.sources != null && input.sources.Length > 0, "sources must not be empty.");
 
+            // Why start the clock before the gate: the caller's wait for an earlier request is
+            // part of this request's latency, so a queued request must not be granted a fresh
+            // response budget once it finally reaches the worker.
+            Stopwatch deadline = Stopwatch.StartNew();
+
             // Why WaitAsync before the try: a cancel while queued must not release a gate this
             // request never acquired.
             await _conversationGate.WaitAsync(ct).ConfigureAwait(false);
@@ -123,7 +128,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return TransformWorkerHostResult.Failure(TransformWorkerHostResultKind.BootstrapFailed, target.ErrorMessage);
                 }
 
-                return await RunConversationsAsync(input, target, generation, ct).ConfigureAwait(false);
+                return await RunConversationsAsync(input, target, generation, deadline, ct).ConfigureAwait(false);
             }
             finally
             {
@@ -167,6 +172,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             TransformWorkerInputDto input,
             TransformWorkerLaunchTarget target,
             int generation,
+            Stopwatch deadline,
             CancellationToken ct)
         {
             string tempDirectory = Path.Combine(Path.GetTempPath(), "uloop-hot-reload-" + Guid.NewGuid().ToString("N"));
@@ -186,8 +192,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         return LifecycleClosed("before starting attempt " + attempt);
                     }
 
+                    // Why give up before touching a process: the budget is already spent, and the
+                    // worker that would serve this attempt is healthy and must not be killed for it.
+                    if (RemainingMilliseconds(deadline) <= 0)
+                    {
+                        return TransformWorkerHostResult.Failure(
+                            TransformWorkerHostResultKind.TimedOut,
+                            "Transform worker request exceeded " + _responseTimeoutMilliseconds
+                            + " ms before attempt " + attempt + " could start.");
+                    }
+
                     ConversationOutcome outcome = await RunOneConversationAsync(
-                        target, requestLine, outputJsonPath, input.sources.Length, generation, ct).ConfigureAwait(false);
+                        target, requestLine, outputJsonPath, input.sources.Length, generation, deadline, ct).ConfigureAwait(false);
                     if (outcome.Result != null)
                     {
                         return outcome.Result;
@@ -227,20 +243,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string outputJsonPath,
             int expectedFileCount,
             int generation,
+            Stopwatch deadline,
             CancellationToken ct)
         {
-            ITransformWorkerChannel channel = EnsureChannel(target, out string startFailure);
+            ITransformWorkerChannel channel = EnsureChannel(target, generation, out string startFailure, out bool lifecycleClosed);
             if (channel == null)
             {
-                return ConversationOutcome.Broken(startFailure);
+                return lifecycleClosed
+                    ? ConversationOutcome.Final(LifecycleClosed("while starting the worker"))
+                    : ConversationOutcome.Broken(startFailure);
             }
 
             if (IsGenerationClosed(generation))
             {
+                // Why discard: a Shutdown that ran while this channel was being handed back saw
+                // the registered channel and may have taken it, but a channel registered after it
+                // read the state would otherwise stay alive with nobody owning it.
+                DiscardChannel(channel);
                 return ConversationOutcome.Final(LifecycleClosed("before sending the request"));
             }
 
-            Stopwatch deadline = Stopwatch.StartNew();
             try
             {
                 channel.RequestWriter.WriteLine(requestLine);
@@ -357,15 +379,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private async Task<string> ReadWithinDeadlineAsync(ITransformWorkerChannel channel, Stopwatch deadline, CancellationToken ct)
         {
-            int remaining = _responseTimeoutMilliseconds - (int)Math.Min(deadline.ElapsedMilliseconds, int.MaxValue);
+            int remaining = RemainingMilliseconds(deadline);
             return await TransformWorkerHostLineReader.ReadLineAsync(channel.ResponseReader, remaining, ct).ConfigureAwait(false);
         }
 
+        // Milliseconds of the request's single response budget that are still unspent.
+        private int RemainingMilliseconds(Stopwatch deadline)
+        {
+            return _responseTimeoutMilliseconds - (int)Math.Min(deadline.ElapsedMilliseconds, int.MaxValue);
+        }
+
         // Returns the live channel for the target directory, starting a new process when none is
-        // alive or the compiled worker moved. Null with a reason when the process could not start.
-        private ITransformWorkerChannel EnsureChannel(TransformWorkerLaunchTarget target, out string startFailure)
+        // alive or the compiled worker moved. Null when the process could not start (with a reason)
+        // or when a shutdown landed while it was starting (lifecycleClosed).
+        private ITransformWorkerChannel EnsureChannel(
+            TransformWorkerLaunchTarget target,
+            int generation,
+            out string startFailure,
+            out bool lifecycleClosed)
         {
             startFailure = null;
+            lifecycleClosed = false;
             ITransformWorkerChannel stale = null;
             lock (_stateLock)
             {
@@ -395,10 +429,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int launchCount;
             lock (_stateLock)
             {
-                _channel = started;
-                _channelWorkerDirectory = target.WorkerDirectory;
-                _launchCount++;
+                if (_generation != generation)
+                {
+                    // Shutdown ran while this process was starting, so it saw no channel to take;
+                    // this request owns the process and must end it instead of registering it.
+                    lifecycleClosed = true;
+                }
+                else
+                {
+                    _channel = started;
+                    _channelWorkerDirectory = target.WorkerDirectory;
+                    _launchCount++;
+                }
+
                 launchCount = _launchCount;
+            }
+
+            if (lifecycleClosed)
+            {
+                TerminateChannel(started);
+                return null;
             }
 
             VibeLogger.LogInfo(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHost.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHost.cs
@@ -228,11 +228,40 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
             finally
             {
-                if (Directory.Exists(tempDirectory))
-                {
-                    Directory.Delete(tempDirectory, recursive: true);
-                }
+                DeleteTempDirectory(tempDirectory);
             }
+        }
+
+        // Why swallow only these two: a worker killed on the timeout path can still hold the
+        // request files open (Windows most of all), and losing a decided result to a cleanup
+        // error would be worse than leaving a temp directory behind for the OS to reap.
+        private static void DeleteTempDirectory(string tempDirectory)
+        {
+            if (!Directory.Exists(tempDirectory))
+            {
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+            catch (IOException ex)
+            {
+                LogTempCleanupFailure(tempDirectory, ex.Message);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                LogTempCleanupFailure(tempDirectory, ex.Message);
+            }
+        }
+
+        private static void LogTempCleanupFailure(string tempDirectory, string reason)
+        {
+            VibeLogger.LogWarning(
+                HotReloadConstants.VibeLogWorkerHostTempCleanupFailed,
+                "Resident transform worker request files could not be deleted.",
+                new { path = tempDirectory, reason });
         }
 
         // One exchange with one process. Returns a final result, or a broken-conversation reason
@@ -482,13 +511,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 if (!channel.TryQuitGracefully(GracefulQuitWaitMilliseconds))
                 {
-                    channel.Kill(KillWaitMilliseconds);
+                    KillQuietly(channel);
                 }
             }
             catch (IOException)
             {
                 // The pipe is already gone; the process is exiting or exited.
-                channel.Kill(KillWaitMilliseconds);
+                KillQuietly(channel);
             }
             catch (InvalidOperationException)
             {
@@ -497,6 +526,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             finally
             {
                 channel.Dispose();
+            }
+        }
+
+        // Why swallow: the process can exit between the liveness check and the kill, and a race
+        // the host lost still leaves it with the outcome it asked for - a dead worker.
+        private static void KillQuietly(ITransformWorkerChannel channel)
+        {
+            try
+            {
+                channel.Kill(KillWaitMilliseconds);
+            }
+            catch (InvalidOperationException)
+            {
+                // The process exited on its own first.
+            }
+            catch (System.ComponentModel.Win32Exception)
+            {
+                // The OS refused the kill because the process is already gone.
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHost.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHost.cs
@@ -1,0 +1,540 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+using Debug = UnityEngine.Debug;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Owns at most one resident transform worker process (`dotnet worker.dll --serve`) and runs
+    /// transform requests through it one at a time, so callers pay the dotnet start-up cost once
+    /// per Editor session instead of once per run.
+    ///
+    /// Concurrency: a single conversation gate serializes bootstrap, process start, and the
+    /// request/response exchange; a separate state lock guards the process reference and the
+    /// lifecycle generation so <see cref="Shutdown"/> never waits behind a running request.
+    ///
+    /// Lifecycle: <see cref="Shutdown"/> bumps the generation and terminates the process. A request
+    /// that observes a generation change ends as <see cref="TransformWorkerHostResultKind.LifecycleClosed"/>
+    /// and never starts a new process. If the Editor itself dies while a request is in flight, the
+    /// worker lives until that RunTransform finishes and remains as an orphan if it hangs; the
+    /// one-shot worker has the same property (a child outlives a dead parent until it completes),
+    /// so this is accepted as equivalent. Between requests the worker exits on its own when its
+    /// stdin closes or after the idle timeout.
+    /// </summary>
+    internal sealed class TransformWorkerHost
+    {
+        private const int MaxConversationAttempts = 2;
+        private const int GracefulQuitWaitMilliseconds = 500;
+        private const int KillWaitMilliseconds = 2000;
+
+        public static readonly TransformWorkerHost Shared = new TransformWorkerHost(
+            TransformWorkerLaunchTargetResolution.ResolveAsync,
+            TransformWorkerProcessChannel.Start,
+            HotReloadConstants.WorkerProcessTimeoutMilliseconds);
+
+        private readonly TransformWorkerLaunchTargetResolver _resolveLaunchTarget;
+        private readonly TransformWorkerChannelFactory _channelFactory;
+        private readonly int _responseTimeoutMilliseconds;
+        private readonly SemaphoreSlim _conversationGate = new SemaphoreSlim(1, 1);
+        private readonly object _stateLock = new object();
+
+        private ITransformWorkerChannel _channel;
+        private string _channelWorkerDirectory;
+        private int _generation;
+        private int _launchCount;
+
+        public TransformWorkerHost(
+            TransformWorkerLaunchTargetResolver resolveLaunchTarget,
+            TransformWorkerChannelFactory channelFactory,
+            int responseTimeoutMilliseconds)
+        {
+            if (resolveLaunchTarget == null)
+            {
+                throw new ArgumentNullException(nameof(resolveLaunchTarget));
+            }
+
+            if (channelFactory == null)
+            {
+                throw new ArgumentNullException(nameof(channelFactory));
+            }
+
+            if (responseTimeoutMilliseconds <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(responseTimeoutMilliseconds));
+            }
+
+            _resolveLaunchTarget = resolveLaunchTarget;
+            _channelFactory = channelFactory;
+            _responseTimeoutMilliseconds = responseTimeoutMilliseconds;
+        }
+
+        /// <summary>Number of worker processes started so far; tests use it to prove reuse.</summary>
+        public int LaunchCount
+        {
+            get
+            {
+                lock (_stateLock)
+                {
+                    return _launchCount;
+                }
+            }
+        }
+
+        /// <summary>Id of the live worker, or null when none is running.</summary>
+        public int? CurrentProcessId
+        {
+            get
+            {
+                lock (_stateLock)
+                {
+                    return _channel == null || _channel.HasExited ? (int?)null : _channel.Id;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Runs one transform request through the resident worker, starting or restarting it as
+        /// needed. Never throws for worker or protocol failures; cancellation propagates as
+        /// <see cref="OperationCanceledException"/> after the in-flight worker has been discarded.
+        /// </summary>
+        public async Task<TransformWorkerHostResult> RunAsync(TransformWorkerInputDto input, CancellationToken ct)
+        {
+            Debug.Assert(input != null, "input must not be null.");
+            Debug.Assert(input.sources != null && input.sources.Length > 0, "sources must not be empty.");
+
+            // Why WaitAsync before the try: a cancel while queued must not release a gate this
+            // request never acquired.
+            await _conversationGate.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                int generation = ReadGeneration();
+                TransformWorkerLaunchTarget target = await _resolveLaunchTarget(ct).ConfigureAwait(false);
+                if (!target.Success)
+                {
+                    return TransformWorkerHostResult.Failure(TransformWorkerHostResultKind.BootstrapFailed, target.ErrorMessage);
+                }
+
+                return await RunConversationsAsync(input, target, generation, ct).ConfigureAwait(false);
+            }
+            finally
+            {
+                _conversationGate.Release();
+            }
+        }
+
+        /// <summary>
+        /// Terminates the resident worker and invalidates every in-flight request. Safe to call
+        /// from lifecycle callbacks while a request is running; it does not wait for the gate.
+        /// </summary>
+        public void Shutdown(string trigger)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(trigger), "trigger must not be empty.");
+
+            ITransformWorkerChannel channel;
+            lock (_stateLock)
+            {
+                _generation++;
+                channel = _channel;
+                _channel = null;
+                _channelWorkerDirectory = null;
+            }
+
+            if (channel == null)
+            {
+                return;
+            }
+
+            TerminateChannel(channel);
+            VibeLogger.LogInfo(
+                HotReloadConstants.VibeLogWorkerHostShutdown,
+                "Resident transform worker stopped.",
+                new { trigger, processId = channel.Id });
+        }
+
+        private async Task<TransformWorkerHostResult> RunConversationsAsync(
+            TransformWorkerInputDto input,
+            TransformWorkerLaunchTarget target,
+            int generation,
+            CancellationToken ct)
+        {
+            string tempDirectory = Path.Combine(Path.GetTempPath(), "uloop-hot-reload-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDirectory);
+            string inputJsonPath = Path.Combine(tempDirectory, "input.json");
+            string outputJsonPath = Path.Combine(tempDirectory, "output.json");
+            try
+            {
+                File.WriteAllText(inputJsonPath, JsonConvert.SerializeObject(input), new UTF8Encoding(false));
+                string requestLine = TransformWorkerServeProtocol.EncodeRequestLine(inputJsonPath, outputJsonPath);
+
+                string lastBrokenReason = string.Empty;
+                for (int attempt = 1; attempt <= MaxConversationAttempts; attempt++)
+                {
+                    if (IsGenerationClosed(generation))
+                    {
+                        return LifecycleClosed("before starting attempt " + attempt);
+                    }
+
+                    ConversationOutcome outcome = await RunOneConversationAsync(
+                        target, requestLine, outputJsonPath, input.sources.Length, generation, ct).ConfigureAwait(false);
+                    if (outcome.Result != null)
+                    {
+                        return outcome.Result;
+                    }
+
+                    lastBrokenReason = outcome.BrokenReason;
+                    VibeLogger.LogWarning(
+                        HotReloadConstants.VibeLogWorkerHostBrokenConversation,
+                        "Resident transform worker conversation broke; the process was discarded.",
+                        new { attempt, reason = lastBrokenReason });
+                }
+
+                if (IsGenerationClosed(generation))
+                {
+                    return LifecycleClosed("after the last attempt broke");
+                }
+
+                return TransformWorkerHostResult.Failure(
+                    TransformWorkerHostResultKind.RetryExhausted,
+                    "Resident transform worker conversation broke " + MaxConversationAttempts
+                    + " times in a row. Last reason: " + lastBrokenReason);
+            }
+            finally
+            {
+                if (Directory.Exists(tempDirectory))
+                {
+                    Directory.Delete(tempDirectory, recursive: true);
+                }
+            }
+        }
+
+        // One exchange with one process. Returns a final result, or a broken-conversation reason
+        // after the process has been discarded so the caller may try once more.
+        private async Task<ConversationOutcome> RunOneConversationAsync(
+            TransformWorkerLaunchTarget target,
+            string requestLine,
+            string outputJsonPath,
+            int expectedFileCount,
+            int generation,
+            CancellationToken ct)
+        {
+            ITransformWorkerChannel channel = EnsureChannel(target, out string startFailure);
+            if (channel == null)
+            {
+                return ConversationOutcome.Broken(startFailure);
+            }
+
+            if (IsGenerationClosed(generation))
+            {
+                return ConversationOutcome.Final(LifecycleClosed("before sending the request"));
+            }
+
+            Stopwatch deadline = Stopwatch.StartNew();
+            try
+            {
+                channel.RequestWriter.WriteLine(requestLine);
+                channel.RequestWriter.Flush();
+
+                string header = await ReadWithinDeadlineAsync(channel, deadline, ct).ConfigureAwait(false);
+                if (header == null)
+                {
+                    return await HandleMissingLineAsync(channel, deadline, "response header").ConfigureAwait(false);
+                }
+
+                if (!TransformWorkerServeProtocol.TryParseResponseHeader(header, out int exitCode, out int diagnosticByteCount))
+                {
+                    DiscardChannel(channel);
+                    return ConversationOutcome.Broken("unrecognized response header: " + header);
+                }
+
+                string diagnosticsLine = await ReadWithinDeadlineAsync(channel, deadline, ct).ConfigureAwait(false);
+                if (diagnosticsLine == null)
+                {
+                    return await HandleMissingLineAsync(channel, deadline, "diagnostics line").ConfigureAwait(false);
+                }
+
+                if (!TransformWorkerServeProtocol.TryDecodeDiagnostics(diagnosticsLine, diagnosticByteCount, out string diagnostics))
+                {
+                    DiscardChannel(channel);
+                    return ConversationOutcome.Broken("diagnostics payload did not match its declared length");
+                }
+
+                // Why check here and not again later: from this point on nothing touches the
+                // process, so a shutdown that lands after this line cannot corrupt the result.
+                if (IsGenerationClosed(generation))
+                {
+                    return ConversationOutcome.Final(LifecycleClosed("after receiving the response"));
+                }
+
+                return InterpretResponse(channel, exitCode, diagnostics, outputJsonPath, expectedFileCount);
+            }
+            catch (IOException ex)
+            {
+                DiscardChannel(channel);
+                return ConversationOutcome.Broken("pipe failure: " + ex.Message);
+            }
+            catch (ObjectDisposedException ex)
+            {
+                DiscardChannel(channel);
+                return ConversationOutcome.Broken("pipe closed: " + ex.Message);
+            }
+            catch (OperationCanceledException)
+            {
+                // Why discard: the worker may still be mid-request; its late response would
+                // desynchronize the next conversation.
+                DiscardChannel(channel);
+                throw;
+            }
+        }
+
+        private ConversationOutcome InterpretResponse(
+            ITransformWorkerChannel channel,
+            int exitCode,
+            string diagnostics,
+            string outputJsonPath,
+            int expectedFileCount)
+        {
+            if (exitCode != 0)
+            {
+                // The request itself failed; the process is healthy and stays for the next one.
+                return ConversationOutcome.Final(TransformWorkerHostResult.Failure(
+                    TransformWorkerHostResultKind.WorkerFailed,
+                    "Transform worker exited with code " + exitCode
+                    + ".\nstdout:\n" + diagnostics
+                    + "\nstderr:\n" + channel.ReadStandardErrorTail()));
+            }
+
+            TransformWorkerOutputDto output = TransformWorkerOutputReader.TryRead(outputJsonPath, expectedFileCount, out string readError);
+            if (output == null)
+            {
+                // Why broken and not WorkerFailed: exit 0 without a usable output file means the
+                // frame and the file system disagree, which only a fresh process can rule out.
+                DiscardChannel(channel);
+                return ConversationOutcome.Broken(readError);
+            }
+
+            if (output.parseErrors.Length > 0)
+            {
+                return ConversationOutcome.Final(TransformWorkerHostResult.Failure(
+                    TransformWorkerHostResultKind.WorkerFailed,
+                    string.Join("\n", output.parseErrors)));
+            }
+
+            return ConversationOutcome.Final(TransformWorkerHostResult.Completed(output));
+        }
+
+        private async Task<ConversationOutcome> HandleMissingLineAsync(
+            ITransformWorkerChannel channel,
+            Stopwatch deadline,
+            string expectedLine)
+        {
+            if (deadline.ElapsedMilliseconds < _responseTimeoutMilliseconds)
+            {
+                DiscardChannel(channel);
+                return ConversationOutcome.Broken("worker closed its output before the " + expectedLine);
+            }
+
+            // Why no retry: a hang is a property of this request as much as of the process, and a
+            // second 120 s wait would double the worst case for callers.
+            int processId = channel.Id;
+            await Task.Run(() => DiscardChannel(channel)).ConfigureAwait(false);
+            return ConversationOutcome.Final(TransformWorkerHostResult.Failure(
+                TransformWorkerHostResultKind.TimedOut,
+                "Transform worker did not answer within " + _responseTimeoutMilliseconds
+                + " ms (waiting for the " + expectedLine + "); process " + processId + " was killed."));
+        }
+
+        private async Task<string> ReadWithinDeadlineAsync(ITransformWorkerChannel channel, Stopwatch deadline, CancellationToken ct)
+        {
+            int remaining = _responseTimeoutMilliseconds - (int)Math.Min(deadline.ElapsedMilliseconds, int.MaxValue);
+            return await TransformWorkerHostLineReader.ReadLineAsync(channel.ResponseReader, remaining, ct).ConfigureAwait(false);
+        }
+
+        // Returns the live channel for the target directory, starting a new process when none is
+        // alive or the compiled worker moved. Null with a reason when the process could not start.
+        private ITransformWorkerChannel EnsureChannel(TransformWorkerLaunchTarget target, out string startFailure)
+        {
+            startFailure = null;
+            ITransformWorkerChannel stale = null;
+            lock (_stateLock)
+            {
+                if (_channel != null && !_channel.HasExited && _channelWorkerDirectory == target.WorkerDirectory)
+                {
+                    return _channel;
+                }
+
+                stale = _channel;
+                _channel = null;
+                _channelWorkerDirectory = null;
+            }
+
+            bool restarted = stale != null;
+            if (stale != null)
+            {
+                TerminateChannel(stale);
+            }
+
+            ITransformWorkerChannel started = _channelFactory(target.WorkerDirectory, target.DotnetHostPath);
+            if (started == null)
+            {
+                startFailure = "worker process could not be started from " + target.WorkerDirectory;
+                return null;
+            }
+
+            int launchCount;
+            lock (_stateLock)
+            {
+                _channel = started;
+                _channelWorkerDirectory = target.WorkerDirectory;
+                _launchCount++;
+                launchCount = _launchCount;
+            }
+
+            VibeLogger.LogInfo(
+                restarted ? HotReloadConstants.VibeLogWorkerHostRestarted : HotReloadConstants.VibeLogWorkerHostStarted,
+                restarted ? "Resident transform worker restarted." : "Resident transform worker started.",
+                new { processId = started.Id, launchCount, workerDirectory = target.WorkerDirectory });
+            return started;
+        }
+
+        // Removes and terminates the channel only if it is still the current one; a concurrent
+        // Shutdown that already took it owns its termination.
+        private void DiscardChannel(ITransformWorkerChannel channel)
+        {
+            lock (_stateLock)
+            {
+                if (!ReferenceEquals(_channel, channel))
+                {
+                    return;
+                }
+
+                _channel = null;
+                _channelWorkerDirectory = null;
+            }
+
+            TerminateChannel(channel);
+        }
+
+        private static void TerminateChannel(ITransformWorkerChannel channel)
+        {
+            try
+            {
+                if (!channel.TryQuitGracefully(GracefulQuitWaitMilliseconds))
+                {
+                    channel.Kill(KillWaitMilliseconds);
+                }
+            }
+            catch (IOException)
+            {
+                // The pipe is already gone; the process is exiting or exited.
+                channel.Kill(KillWaitMilliseconds);
+            }
+            catch (InvalidOperationException)
+            {
+                // The process exited between the liveness check and the write.
+            }
+            finally
+            {
+                channel.Dispose();
+            }
+        }
+
+        private int ReadGeneration()
+        {
+            lock (_stateLock)
+            {
+                return _generation;
+            }
+        }
+
+        private bool IsGenerationClosed(int generation)
+        {
+            return ReadGeneration() != generation;
+        }
+
+        private TransformWorkerHostResult LifecycleClosed(string when)
+        {
+            VibeLogger.LogInfo(
+                HotReloadConstants.VibeLogWorkerHostLifecycleClosed,
+                "Resident transform worker request abandoned because the host was shut down.",
+                new { when });
+            return TransformWorkerHostResult.Failure(
+                TransformWorkerHostResultKind.LifecycleClosed,
+                "The resident transform worker was shut down " + when + ".");
+        }
+
+        private readonly struct ConversationOutcome
+        {
+            public TransformWorkerHostResult Result { get; }
+            public string BrokenReason { get; }
+
+            private ConversationOutcome(TransformWorkerHostResult result, string brokenReason)
+            {
+                Result = result;
+                BrokenReason = brokenReason;
+            }
+
+            public static ConversationOutcome Final(TransformWorkerHostResult result)
+            {
+                return new ConversationOutcome(result, null);
+            }
+
+            public static ConversationOutcome Broken(string reason)
+            {
+                return new ConversationOutcome(null, reason);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads and validates a worker output file. Null with a reason when the file is missing,
+    /// unreadable as JSON, or does not carry one per-file row per source.
+    /// </summary>
+    internal static class TransformWorkerOutputReader
+    {
+        public static TransformWorkerOutputDto TryRead(string outputJsonPath, int expectedFileCount, out string error)
+        {
+            error = null;
+            if (!File.Exists(outputJsonPath))
+            {
+                error = "worker exited 0 but produced no output JSON file";
+                return null;
+            }
+
+            string outputJson = File.ReadAllText(outputJsonPath, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            TransformWorkerOutputDto output;
+            try
+            {
+                output = JsonConvert.DeserializeObject<TransformWorkerOutputDto>(outputJson);
+            }
+            catch (JsonException ex)
+            {
+                error = "worker output JSON could not be parsed: " + ex.Message;
+                return null;
+            }
+
+            if (output == null)
+            {
+                error = "worker output JSON deserialized to null";
+                return null;
+            }
+
+            TransformWorkerClient.CoalesceOutput(output);
+            if (output.parseErrors.Length == 0 && output.files.Length != expectedFileCount)
+            {
+                error = "worker output carried " + output.files.Length + " file rows for " + expectedFileCount + " sources";
+                return null;
+            }
+
+            return output;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHost.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHost.cs
@@ -153,11 +153,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return;
             }
 
+            // Why read the id first: the channel is disposed by TerminateChannel and a disposed
+            // process no longer exposes its id.
+            int processId = channel.Id;
             TerminateChannel(channel);
             VibeLogger.LogInfo(
                 HotReloadConstants.VibeLogWorkerHostShutdown,
                 "Resident transform worker stopped.",
-                new { trigger, processId = channel.Id });
+                new { trigger, processId });
         }
 
         private async Task<TransformWorkerHostResult> RunConversationsAsync(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHost.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHost.cs
@@ -539,11 +539,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
             catch (InvalidOperationException)
             {
-                // The process exited on its own first.
+                // The race was lost to the exit itself, which is the outcome the host wanted.
+                // A live process that still refused the kill is a real problem.
+                if (!channel.HasExited)
+                {
+                    throw;
+                }
             }
             catch (System.ComponentModel.Win32Exception)
             {
-                // The OS refused the kill because the process is already gone.
+                // Same race, reported by the OS instead of the runtime.
+                if (!channel.HasExited)
+                {
+                    throw;
+                }
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHost.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHost.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03f1f0aba303c4f51a8ad1f1b8957195
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHostResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHostResult.cs
@@ -1,0 +1,139 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+using Debug = UnityEngine.Debug;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// How one <see cref="TransformWorkerHost.RunAsync"/> ended. Only <see cref="Completed"/>
+    /// carries output. The other kinds tell the caller whether a one-shot fallback is worthwhile:
+    /// <see cref="RetryExhausted"/> is the sole kind where the request itself is not known to be
+    /// at fault.
+    /// </summary>
+    internal enum TransformWorkerHostResultKind
+    {
+        /// <summary>The worker returned exit code 0 and a valid output file.</summary>
+        Completed,
+
+        /// <summary>The worker reported a non-zero exit code for this request; the request is at fault.</summary>
+        WorkerFailed,
+
+        /// <summary>Two consecutive processes broke the conversation; a fresh one-shot may still succeed.</summary>
+        RetryExhausted,
+
+        /// <summary>The worker did not answer within the response timeout and was killed.</summary>
+        TimedOut,
+
+        /// <summary>The host was shut down (assembly reload or Editor quit) while the request was in flight.</summary>
+        LifecycleClosed,
+
+        /// <summary>The worker could not be compiled or the toolchain could not be resolved.</summary>
+        BootstrapFailed
+    }
+
+    /// <summary>
+    /// Outcome of one resident-worker request.
+    /// </summary>
+    internal sealed class TransformWorkerHostResult
+    {
+        public TransformWorkerHostResultKind Kind { get; }
+        public TransformWorkerOutputDto Output { get; }
+        public string ErrorMessage { get; }
+
+        public bool Success
+        {
+            get { return Kind == TransformWorkerHostResultKind.Completed; }
+        }
+
+        private TransformWorkerHostResult(TransformWorkerHostResultKind kind, TransformWorkerOutputDto output, string errorMessage)
+        {
+            Kind = kind;
+            Output = output;
+            ErrorMessage = errorMessage;
+        }
+
+        public static TransformWorkerHostResult Completed(TransformWorkerOutputDto output)
+        {
+            Debug.Assert(output != null, "output must not be null.");
+            return new TransformWorkerHostResult(TransformWorkerHostResultKind.Completed, output, string.Empty);
+        }
+
+        public static TransformWorkerHostResult Failure(TransformWorkerHostResultKind kind, string errorMessage)
+        {
+            Debug.Assert(kind != TransformWorkerHostResultKind.Completed, "Completed must carry output.");
+            Debug.Assert(!string.IsNullOrEmpty(errorMessage), "errorMessage must not be empty.");
+            return new TransformWorkerHostResult(kind, null, errorMessage);
+        }
+    }
+
+    /// <summary>
+    /// Where the next worker process starts from: the compiled worker directory and the dotnet
+    /// host to run it with. Resolved once per request, before any process is touched, so a
+    /// worker-source change is observed as a directory change and restarts the resident process.
+    /// </summary>
+    internal sealed class TransformWorkerLaunchTarget
+    {
+        public bool Success { get; }
+        public string WorkerDirectory { get; }
+        public string DotnetHostPath { get; }
+        public string ErrorMessage { get; }
+
+        private TransformWorkerLaunchTarget(bool success, string workerDirectory, string dotnetHostPath, string errorMessage)
+        {
+            Success = success;
+            WorkerDirectory = workerDirectory;
+            DotnetHostPath = dotnetHostPath;
+            ErrorMessage = errorMessage;
+        }
+
+        public static TransformWorkerLaunchTarget Resolved(string workerDirectory, string dotnetHostPath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(workerDirectory), "workerDirectory must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(dotnetHostPath), "dotnetHostPath must not be empty.");
+            return new TransformWorkerLaunchTarget(true, workerDirectory, dotnetHostPath, string.Empty);
+        }
+
+        public static TransformWorkerLaunchTarget Failure(string errorMessage)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(errorMessage), "errorMessage must not be empty.");
+            return new TransformWorkerLaunchTarget(false, null, null, errorMessage);
+        }
+    }
+
+    /// <summary>
+    /// Resolves the launch target for the next request. Injected so host tests can run without
+    /// compiling the real worker.
+    /// </summary>
+    internal delegate Task<TransformWorkerLaunchTarget> TransformWorkerLaunchTargetResolver(CancellationToken ct);
+
+    /// <summary>
+    /// The production resolver: compiles the worker on demand and reads the dotnet host path
+    /// from the Unity installation.
+    /// </summary>
+    internal static class TransformWorkerLaunchTargetResolution
+    {
+        public static async Task<TransformWorkerLaunchTarget> ResolveAsync(CancellationToken ct)
+        {
+            TransformWorkerBootstrapResult bootstrapResult =
+                await TransformWorkerBootstrap.EnsureWorkerAsync(ct).ConfigureAwait(false);
+            if (!bootstrapResult.Success)
+            {
+                return TransformWorkerLaunchTarget.Failure(bootstrapResult.ErrorMessage);
+            }
+
+            // ExternalCompilerPathResolver reads EditorApplication.applicationPath.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+            ExternalCompilerPaths paths = ExternalCompilerPathResolver.Resolve();
+            if (paths == null)
+            {
+                return TransformWorkerLaunchTarget.Failure(
+                    "External compiler paths could not be resolved for this Unity installation.");
+            }
+
+            return TransformWorkerLaunchTarget.Resolved(bootstrapResult.WorkerDirectory, paths.DotnetHostPath);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHostResult.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHostResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06d6516acb88948e39463b7a60df8f57
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerOutputReader.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerOutputReader.cs
@@ -15,13 +15,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public static TransformWorkerOutputDto TryRead(string outputJsonPath, int expectedFileCount, out string error)
         {
             error = null;
-            if (!File.Exists(outputJsonPath))
+            // Why Directory.Exists too: a directory sitting at the output path is not a missing file,
+            // and reporting it as one would hide a real path collision behind the "no output" reason.
+            // Letting it fall through turns it into the read failure it actually is.
+            if (!File.Exists(outputJsonPath) && !Directory.Exists(outputJsonPath))
             {
                 error = "worker exited 0 but produced no output JSON file";
                 return null;
             }
 
-            string outputJson = File.ReadAllText(outputJsonPath, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            string outputJson;
+            try
+            {
+                outputJson = File.ReadAllText(outputJsonPath, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            }
+            catch (IOException ex)
+            {
+                error = "worker output JSON could not be read: " + ex.Message;
+                return null;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                // Why here and not at the call sites: without this the exception escapes both the
+                // host and the one-shot client, which have no other place to turn it into a result.
+                error = "worker output JSON could not be read: " + ex.Message;
+                return null;
+            }
+
             TransformWorkerOutputDto output;
             try
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerOutputReader.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerOutputReader.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+using System.Text;
+
+using Newtonsoft.Json;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Reads and validates a worker output file. Null with a reason when the file is missing,
+    /// unreadable as JSON, or does not carry one per-file row per source.
+    /// </summary>
+    internal static class TransformWorkerOutputReader
+    {
+        public static TransformWorkerOutputDto TryRead(string outputJsonPath, int expectedFileCount, out string error)
+        {
+            error = null;
+            if (!File.Exists(outputJsonPath))
+            {
+                error = "worker exited 0 but produced no output JSON file";
+                return null;
+            }
+
+            string outputJson = File.ReadAllText(outputJsonPath, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            TransformWorkerOutputDto output;
+            try
+            {
+                output = JsonConvert.DeserializeObject<TransformWorkerOutputDto>(outputJson);
+            }
+            catch (JsonException ex)
+            {
+                error = "worker output JSON could not be parsed: " + ex.Message;
+                return null;
+            }
+
+            if (output == null)
+            {
+                error = "worker output JSON deserialized to null";
+                return null;
+            }
+
+            TransformWorkerClient.CoalesceOutput(output);
+            if (output.parseErrors.Length == 0 && output.files.Length != expectedFileCount)
+            {
+                error = "worker output carried " + output.files.Length + " file rows for " + expectedFileCount + " sources";
+                return null;
+            }
+
+            return output;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerOutputReader.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerOutputReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f2ba772be517844d38c985e66c33fa9f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerServeProtocol.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerServeProtocol.cs
@@ -162,7 +162,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return false;
             }
 
-            return value.Length > 0;
+            if (value.Length == 0)
+            {
+                value = null;
+                return false;
+            }
+
+            return true;
         }
     }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerServeProtocol.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerServeProtocol.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+// This file is compiled twice: into the Unity editor assembly (host side) and into the
+// out-of-process transform worker (see TransformWorkerBootstrap.CollectWorkerSourcePaths).
+// It must therefore stay free of Unity and Newtonsoft references.
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Line protocol between the Editor and a resident transform worker (`worker.dll --serve`).
+    /// Request: one line, `run &lt;base64 input path&gt; &lt;base64 output path&gt;`. Response: two lines,
+    /// a header `__ULOOP_TRANSFORM_RESULT__ &lt;exitCode&gt; &lt;diagnosticByteCount&gt;` followed by the
+    /// diagnostics as one base64 line. Why length-prefixed instead of an end marker: worker
+    /// diagnostics can contain any text, including a line equal to a marker, and a fixed
+    /// two-line frame cannot be desynchronized by its own payload.
+    /// </summary>
+    internal static class TransformWorkerServeProtocol
+    {
+        public const string ServeArgument = "--serve";
+        public const string RunCommand = "run";
+        public const string QuitCommand = "__ULOOP_TRANSFORM_QUIT__";
+        public const string ResultPrefix = "__ULOOP_TRANSFORM_RESULT__";
+        public const int MalformedRequestExitCode = 2;
+
+        // Why bounded: diagnostics travel as a single line through a pipe the host reads with a
+        // deadline; an unbounded exception dump or a chatty dependency must not stall the frame.
+        public const int MaxDiagnosticBytes = 64 * 1024;
+        public const string DiagnosticsTruncatedSuffix = "\n[diagnostics truncated]";
+
+        public const int DefaultIdleTimeoutMilliseconds = 5 * 60 * 1000;
+
+        public static string EncodeRequestLine(string inputJsonPath, string outputJsonPath)
+        {
+            if (string.IsNullOrEmpty(inputJsonPath))
+            {
+                throw new ArgumentException("inputJsonPath must not be empty.", nameof(inputJsonPath));
+            }
+
+            if (string.IsNullOrEmpty(outputJsonPath))
+            {
+                throw new ArgumentException("outputJsonPath must not be empty.", nameof(outputJsonPath));
+            }
+
+            return RunCommand + " " + ToBase64(inputJsonPath) + " " + ToBase64(outputJsonPath);
+        }
+
+        public static bool TryDecodeRequestLine(string line, out string inputJsonPath, out string outputJsonPath)
+        {
+            inputJsonPath = null;
+            outputJsonPath = null;
+            if (line == null)
+            {
+                return false;
+            }
+
+            string[] parts = line.Split(' ');
+            if (parts.Length != 3 || parts[0] != RunCommand)
+            {
+                return false;
+            }
+
+            return TryFromBase64(parts[1], out inputJsonPath) && TryFromBase64(parts[2], out outputJsonPath);
+        }
+
+        public static string EncodeResponseHeader(int exitCode, int diagnosticByteCount)
+        {
+            if (diagnosticByteCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(diagnosticByteCount));
+            }
+
+            return ResultPrefix + " "
+                + exitCode.ToString(CultureInfo.InvariantCulture) + " "
+                + diagnosticByteCount.ToString(CultureInfo.InvariantCulture);
+        }
+
+        public static bool TryParseResponseHeader(string line, out int exitCode, out int diagnosticByteCount)
+        {
+            exitCode = 0;
+            diagnosticByteCount = 0;
+            if (line == null)
+            {
+                return false;
+            }
+
+            string[] parts = line.Split(' ');
+            if (parts.Length != 3 || parts[0] != ResultPrefix)
+            {
+                return false;
+            }
+
+            return int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out exitCode)
+                && int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out diagnosticByteCount)
+                && diagnosticByteCount >= 0;
+        }
+
+        /// <summary>
+        /// Encodes diagnostics as one base64 line, truncating to <see cref="MaxDiagnosticBytes"/>.
+        /// </summary>
+        public static string EncodeDiagnostics(string diagnostics, out int byteCount)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(diagnostics ?? string.Empty);
+            if (bytes.Length > MaxDiagnosticBytes)
+            {
+                byte[] suffix = Encoding.UTF8.GetBytes(DiagnosticsTruncatedSuffix);
+                byte[] truncated = new byte[MaxDiagnosticBytes];
+                Buffer.BlockCopy(bytes, 0, truncated, 0, MaxDiagnosticBytes - suffix.Length);
+                Buffer.BlockCopy(suffix, 0, truncated, MaxDiagnosticBytes - suffix.Length, suffix.Length);
+                bytes = truncated;
+            }
+
+            byteCount = bytes.Length;
+            return Convert.ToBase64String(bytes);
+        }
+
+        public static bool TryDecodeDiagnostics(string line, int expectedByteCount, out string diagnostics)
+        {
+            diagnostics = null;
+            if (line == null)
+            {
+                return false;
+            }
+
+            byte[] bytes;
+            try
+            {
+                bytes = Convert.FromBase64String(line);
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+
+            if (bytes.Length != expectedByteCount)
+            {
+                return false;
+            }
+
+            // Why not decode strictly: a truncation cut may split a multi-byte sequence; the
+            // replacement character is preferable to failing the whole frame over one glyph.
+            diagnostics = Encoding.UTF8.GetString(bytes);
+            return true;
+        }
+
+        private static string ToBase64(string value)
+        {
+            return Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+        }
+
+        private static bool TryFromBase64(string encoded, out string value)
+        {
+            value = null;
+            try
+            {
+                value = Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+
+            return value.Length > 0;
+        }
+    }
+
+    /// <summary>
+    /// The worker-side request loop of the resident mode. Reads request lines until quit, end of
+    /// input, or an idle timeout while waiting for the next request, runs one transform per
+    /// request with the process stdout captured into the response, and writes one response frame
+    /// per request. Kept free of process concerns so tests can drive it over in-memory pipes.
+    /// </summary>
+    internal static class TransformWorkerServeLoop
+    {
+        public delegate int TransformHandler(string inputJsonPath, string outputJsonPath);
+
+        public const int ExitCodeNormal = 0;
+
+        /// <summary>
+        /// Runs until quit, end of input, or idle. Returns the process exit code.
+        /// </summary>
+        /// <param name="input">Request lines (the process stdin).</param>
+        /// <param name="protocolOutput">Response frames. Must be the original stdout writer, captured
+        /// before this call, because the loop redirects Console.Out while a transform runs.</param>
+        /// <param name="transform">Executes one request and returns its exit code.</param>
+        /// <param name="idleTimeoutMilliseconds">Exit when no request arrives within this time while
+        /// waiting. Never fires while a transform is running.</param>
+        public static int Run(
+            TextReader input,
+            TextWriter protocolOutput,
+            TransformHandler transform,
+            int idleTimeoutMilliseconds)
+        {
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            if (protocolOutput == null)
+            {
+                throw new ArgumentNullException(nameof(protocolOutput));
+            }
+
+            if (transform == null)
+            {
+                throw new ArgumentNullException(nameof(transform));
+            }
+
+            if (idleTimeoutMilliseconds <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(idleTimeoutMilliseconds));
+            }
+
+            while (true)
+            {
+                string line = ReadLineOrIdle(input, idleTimeoutMilliseconds);
+                if (line == null || line == TransformWorkerServeProtocol.QuitCommand)
+                {
+                    return ExitCodeNormal;
+                }
+
+                if (!TransformWorkerServeProtocol.TryDecodeRequestLine(line, out string inputJsonPath, out string outputJsonPath))
+                {
+                    WriteFrame(protocolOutput, TransformWorkerServeProtocol.MalformedRequestExitCode, "malformed request line: " + line);
+                    continue;
+                }
+
+                (int exitCode, string diagnostics) = ExecuteCapturingConsoleOut(transform, inputJsonPath, outputJsonPath);
+                WriteFrame(protocolOutput, exitCode, diagnostics);
+            }
+        }
+
+        // Why race a delay against the read instead of a watchdog thread: the idle exit must only
+        // fire between requests. A watchdog could kill the process right after a request was
+        // accepted but before the transform started.
+        private static string ReadLineOrIdle(TextReader input, int idleTimeoutMilliseconds)
+        {
+            Task<string> readTask = Task.Run(() => input.ReadLine());
+            Task delayTask = Task.Delay(idleTimeoutMilliseconds);
+            Task completed = Task.WhenAny(readTask, delayTask).GetAwaiter().GetResult();
+            if (!ReferenceEquals(completed, readTask))
+            {
+                return null;
+            }
+
+            try
+            {
+                return readTask.GetAwaiter().GetResult();
+            }
+            catch (IOException)
+            {
+                // The host closed the pipe; treat it like end of input.
+                return null;
+            }
+            catch (ObjectDisposedException)
+            {
+                return null;
+            }
+        }
+
+        // Why catch everything here: this is the process boundary of one request. The failure is
+        // reported to the host as exit code 1 with the full exception text, and the process stays
+        // alive for the next request, exactly like a one-shot worker exiting non-zero would.
+        private static (int exitCode, string diagnostics) ExecuteCapturingConsoleOut(
+            TransformHandler transform,
+            string inputJsonPath,
+            string outputJsonPath)
+        {
+            TextWriter originalOut = Console.Out;
+            StringWriter captured = new StringWriter();
+            Console.SetOut(captured);
+            int exitCode;
+            try
+            {
+                exitCode = transform(inputJsonPath, outputJsonPath);
+            }
+            catch (Exception ex)
+            {
+                exitCode = 1;
+                captured.WriteLine(ex.ToString());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+
+            return (exitCode, captured.ToString());
+        }
+
+        private static void WriteFrame(TextWriter protocolOutput, int exitCode, string diagnostics)
+        {
+            string payload = TransformWorkerServeProtocol.EncodeDiagnostics(diagnostics, out int byteCount);
+            protocolOutput.WriteLine(TransformWorkerServeProtocol.EncodeResponseHeader(exitCode, byteCount));
+            protocolOutput.WriteLine(payload);
+            protocolOutput.Flush();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerServeProtocol.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerServeProtocol.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 273927f0793534daeae737434b096995
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -21,6 +21,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 
 public static class TransformWorkerProgram
 {
@@ -39,12 +40,34 @@ public static class TransformWorkerProgram
 
     public static int Main(string[] args)
     {
-        if (args.Length != 2)
+        bool serve = args.Length == 1 && args[0] == TransformWorkerServeProtocol.ServeArgument;
+        if (!serve && args.Length != 2)
         {
-            Console.Error.WriteLine("usage: TransformWorker <input-json-path> <output-json-path>");
+            Console.Error.WriteLine("usage: TransformWorker <input-json-path> <output-json-path> | --serve");
             return 2;
         }
 
+        RegisterRoslynResolver();
+        if (!serve)
+        {
+            return RunTransform(args[0], args[1]);
+        }
+
+        // Resident mode: the host reads the response frames from stdout, so the loop redirects
+        // Console.Out during each transform and writes frames to the original writer captured here.
+        // Both ends declare UTF-8 so diagnostic text survives a non-UTF-8 default codepage on Windows.
+        Console.InputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        Console.OutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        TextWriter protocolOutput = Console.Out;
+        return TransformWorkerServeLoop.Run(
+            Console.In,
+            protocolOutput,
+            RunTransform,
+            TransformWorkerServeProtocol.DefaultIdleTimeoutMilliseconds);
+    }
+
+    private static void RegisterRoslynResolver()
+    {
         string roslynDirectoryPath = ReadRoslynDirectorySidecar();
         AssemblyLoadContext.Default.Resolving += (context, assemblyName) =>
         {
@@ -56,8 +79,6 @@ public static class TransformWorkerProgram
 
             return null;
         };
-
-        return RunTransform(args[0], args[1]);
     }
 
     private static string ReadRoslynDirectorySidecar()


### PR DESCRIPTION
## Summary
- Adds the pieces needed to keep one transform worker process alive across hot reload runs: a `--serve` mode in the worker and a host on the Editor side that owns that process, serializes requests through it, and replaces it when it breaks.
- Nothing is wired into production yet: `TransformWorkerClient.RunAsync` still starts one process per run. The follow-up PR wires the host in (with a one-shot fallback), registers the lifecycle shutdown, and carries the before/after measurement. The dead-code scanner will report `TransformWorkerHost` and its channel as unreferenced until then; that is expected for this PR.

## User Impact
- None yet. This PR is preparation: no runtime path changes for `uloop hot-reload` or for the EditMode suite.
- After the follow-up lands, each hot reload run stops paying a dotnet process start (~0.36 s on this machine, roughly 600 times per full EditMode run) and instead sends one request line to a resident worker.

## Changes
- **Worker (`TransformWorker~`)**: `dotnet worker.dll --serve` reads request lines from stdin and answers each with a two-line frame on stdout: a header `__ULOOP_TRANSFORM_RESULT__ <exitCode> <diagnosticByteCount>` followed by the diagnostics as one base64 line. The frame is length-prefixed rather than end-marked so worker diagnostics can contain any text, including a line equal to the marker. While a request runs, `Console.Out` is captured into the diagnostics so the protocol stream carries frames only. An exception inside one request becomes exit code 1 with the exception text; the process stays for the next request. The loop exits on `__ULOOP_TRANSFORM_QUIT__`, on end of input, or after 5 minutes idle, and the idle timer only runs while waiting for a request. The one-shot `worker.dll <in> <out>` form is unchanged.
- **Shared protocol file**: `TransformWorkerServeProtocol.cs` is compiled into both the Editor assembly and the worker (no Unity or Newtonsoft references). The bootstrap cache key now covers it, so editing the protocol recompiles the worker.
- **`TransformWorkerHost`**: owns at most one process. A conversation gate serializes bootstrap, process start, and the exchange; a separate state lock guards the process reference and a lifecycle generation so `Shutdown` never waits behind a running request. Per request: resolve the launch target (bootstrap + dotnet path), start or reuse the process (restart when it exited or the compiled worker directory changed), send the request, read the frame under a single 120 s monotonic deadline, then read and validate `output.json`.
  - Outcomes: `Completed`; `WorkerFailed` (non-zero exit or run-level parse errors; final, process kept); `RetryExhausted` (two consecutive broken conversations; the only kind where a one-shot fallback is worthwhile); `TimedOut` (process killed, no retry); `LifecycleClosed` (shutdown observed at one of three points: before start, before send, after receive); `BootstrapFailed`.
  - A broken conversation is: process start failure, unrecognized or missing header, diagnostics length mismatch, pipe failure, or exit 0 with a missing, unparsable, or wrong-row-count output file. The process is discarded and the request is retried once on a fresh process.
  - Cancellation while queued releases nothing it did not acquire; cancellation mid-conversation discards the process (its late answer would desynchronize the next request) and rethrows.
  - stderr is redirected and drained continuously into a 64 KB tail that is attached to `WorkerFailed` messages.
  - Editor death: if the Editor dies while a request is in flight, the worker lives until that RunTransform finishes and remains as an orphan if it hangs. The current one-shot worker has the same property (a child outlives a dead parent until it completes), so this is accepted as equivalent. Between requests the worker exits on its own when stdin closes or after the idle timeout.
  - The response budget is one monotonic deadline that starts before the conversation gate wait, so a queued request is not granted a fresh timeout and a retry after a late break gets only the remainder; an attempt whose budget is already spent ends as `TimedOut` without touching the (healthy) worker.
  - A shutdown that lands while a process is starting discards that new process instead of registering it into a closed generation, and `LaunchCount` counts registered launches only.
- **`ITransformWorkerChannel` / `TransformWorkerProcessChannel`**: the process abstraction the host talks to, so host tests can substitute an in-process worker.
- **VibeLogger events**: worker started / restarted / shutdown / lifecycle closed / broken conversation.
- **Tests** (`Assets/Tests/Editor/HotReload/`, 62 new cases):
  - `TransformWorkerServeProtocolTests`: request and header round trips, malformed inputs, marker-like multi-line diagnostics, truncation at the cap, length mismatch.
  - `TransformWorkerServeLoopTests`: over in-process pipes; stdout noise stays inside the frame, exception isolation and `Console.Out` restoration, malformed request, end of input, idle exit firing only between requests.
  - `TransformWorkerHostTests`: scripted channel; reuse, crash → retry, two breaks → `RetryExhausted`, exit ≠ 0 final and kept, run-level parse errors, exit 0 with unusable output → broken, hang → `TimedOut` + kill + relaunch, cancel while queued (no launch), cancel mid-conversation (discard + recover), shutdown during request (`LifecycleClosed`, no relaunch), shutdown with no process, worker-directory change restarts, idle exit between requests relaunches, bootstrap failure, start failure twice.
  - `TransformWorkerHostProcessTests`: the real compiled worker in `--serve` mode on the e2e fixture; same pid across two runs, external kill → new pid, `Shutdown` stops the process, run-level rejection is `WorkerFailed` and keeps the process.
  - `TransformWorkerClientTests` only gains an `internal static BuildE2EFixtureInput()` extracted from its existing input builder, shared with the process tests.

## Verification
- `dist/darwin-arm64/uloop compile` — 0 errors; file-length gate: no files exceeded.
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value 'TransformWorkerServeProtocolTests|TransformWorkerServeLoopTests|TransformWorkerHostTests|TransformWorkerHostProcessTests|TransformWorkerBootstrapSourceEnumerationTests|TransformWorkerClientTests'` — 106/106 passed.
- Review round: the four added cases (shutdown during process start, deadline consumed by the gate wait, retry limited to the remainder, declared-length mismatch through the host) pass with the rest of the group — `--filter-type regex --filter-value 'TransformWorkerServeProtocolTests|TransformWorkerServeLoopTests|TransformWorkerHostTests|TransformWorkerHostProcessTests'` 52/52 passed, file-length gate clean.
- One EditMode deadlock was hit and fixed during development: `Assert.ThrowsAsync` blocks the Unity main thread while the awaited task needs it for its continuation. The cancellation tests await inside try/catch instead.

Part of #2634. The wiring, fallback, lifecycle registration, and measurement follow in the next PR.
