### PR TITLE
feat: Hot reload can tell which newly written types it is able to introduce

### DIFF
--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -21,6 +21,81 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     /// </summary>
     public class TransformWorkerClientTests
     {
+        /// <summary>
+        /// A success-shaped worker payload with a missing file row is rejected instead of
+        /// reaching downstream code that assumes one result per input source.
+        /// </summary>
+        [Test]
+        public void TryValidateOutput_MissingFileRow_ReturnsFailure()
+        {
+            TransformWorkerInputDto input = new TransformWorkerInputDto
+            {
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto { projectRelativePath = "Assets/One.cs" },
+                    new TransformWorkerSourceDto { projectRelativePath = "Assets/Two.cs" }
+                }
+            };
+            TransformWorkerOutputDto output = new TransformWorkerOutputDto
+            {
+                files = new[]
+                {
+                    new TransformWorkerFileOutputDto { projectRelativePath = "Assets/One.cs" }
+                }
+            };
+
+            bool valid = TransformWorkerClient.TryValidateOutput(input, output, out string errorMessage);
+
+            Assert.That(valid, Is.False);
+            Assert.That(errorMessage, Does.Contain("same count"));
+        }
+
+        /// <summary>
+        /// Worker output rows must retain source order, so a reordered row is not accepted
+        /// merely because the operation itself reported success.
+        /// </summary>
+        [Test]
+        public void TryValidateOutput_ReorderedFileRows_ReturnsFailure()
+        {
+            TransformWorkerInputDto input = new TransformWorkerInputDto
+            {
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto { projectRelativePath = "Assets/One.cs" },
+                    new TransformWorkerSourceDto { projectRelativePath = "Assets/Two.cs" }
+                }
+            };
+            TransformWorkerOutputDto output = new TransformWorkerOutputDto
+            {
+                files = new[]
+                {
+                    new TransformWorkerFileOutputDto { projectRelativePath = "Assets/Two.cs" },
+                    new TransformWorkerFileOutputDto { projectRelativePath = "Assets/One.cs" }
+                }
+            };
+
+            bool valid = TransformWorkerClient.TryValidateOutput(input, output, out string errorMessage);
+
+            Assert.That(valid, Is.False);
+            Assert.That(errorMessage, Does.Contain("source order"));
+        }
+
+        /// <summary>
+        /// Verifies that a non-empty unknown operation is rejected at the worker/client boundary
+        /// instead of silently running the legacy transform operation.
+        /// </summary>
+        [Test]
+        public async Task RunWorker_UnknownOperation_ReturnsFailure()
+        {
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                ResolveE2EFixturePath(),
+                ResolveE2EFixtureProjectRelativePath(),
+                operation: "unknownOperation");
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("Unknown worker operation"));
+        }
+
         private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
         private const string ExpectedListEnumeratorFullName =
             "System.Collections.Generic.List`1/Enumerator<System.Int32>";
@@ -2296,7 +2371,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string[] additionalAssemblySourcePaths = null,
             string[] changedSiblingSourcePaths = null,
             string secondSourcePath = null,
-            string secondProjectRelativePath = null)
+            string secondProjectRelativePath = null,
+            string operation = null)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string targetDllPath = Path.Combine(
@@ -2358,6 +2434,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             TransformWorkerInputDto input = new TransformWorkerInputDto
             {
+                operation = operation,
                 sources = sources.ToArray(),
                 defines = compilationAssembly.defines ?? System.Array.Empty<string>(),
                 referencePaths = referencePaths,
@@ -2681,6 +2758,210 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             TransformWorkerOutputDto enabled =
                 JsonConvert.DeserializeObject<TransformWorkerOutputDto>(trueJson);
             Assert.That(enabled.hasAddedFieldRewrites, Is.True);
+        }
+
+        /// <summary>
+        /// Verifies that a success-shaped preparation response with omitted mandatory artifacts
+        /// is rejected before optional transform fields are coalesced.
+        /// </summary>
+        [Test]
+        public void TryValidateOutput_PrepareArtifactsOmitted_ReturnsFailure()
+        {
+            TransformWorkerInputDto input = new TransformWorkerInputDto
+            {
+                operation = "prepareIntroducedTypes",
+                targetAssemblyName = "Assembly",
+                targetAssemblyMvid = "mvid",
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto { projectRelativePath = "Assets/Edited.cs" }
+                }
+            };
+            TransformWorkerOutputDto output = new TransformWorkerOutputDto
+            {
+                files = new[]
+                {
+                    new TransformWorkerFileOutputDto { projectRelativePath = "Assets/Edited.cs" }
+                }
+            };
+
+            bool valid = TransformWorkerClient.TryValidateOutput(input, output, out string errorMessage);
+
+            Assert.That(valid, Is.False);
+            Assert.That(errorMessage, Does.Contain("introducedTypes"));
+        }
+
+        /// <summary>
+        /// Verifies that preparation rejects a descriptor whose owner does not match the input
+        /// source even when its compiled identity is otherwise correct.
+        /// </summary>
+        [Test]
+        public void TryValidateOutput_PrepareDescriptorOwnerMismatch_ReturnsFailure()
+        {
+            TransformWorkerInputDto input = new TransformWorkerInputDto
+            {
+                operation = "prepareIntroducedTypes",
+                targetAssemblyName = "Assembly",
+                targetAssemblyMvid = "mvid",
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto { projectRelativePath = "Assets/Edited.cs" }
+                }
+            };
+            TransformWorkerOutputDto output = new TransformWorkerOutputDto
+            {
+                files = new[]
+                {
+                    new TransformWorkerFileOutputDto
+                    {
+                        projectRelativePath = "Assets/Edited.cs",
+                        introducedTypes = new[]
+                        {
+                            new TransformWorkerIntroducedTypeDto
+                            {
+                                originalAssemblyName = "Assembly",
+                                originalAssemblyMvid = "mvid",
+                                metadataName = "Example.Introduced",
+                                ownerProjectRelativePath = "Assets/Other.cs",
+                                declarationFingerprint = "fingerprint",
+                                source = "public class Introduced { }"
+                            }
+                        },
+                        introducedTypeDiagnostics = Array.Empty<string>()
+                    }
+                }
+            };
+
+            bool valid = TransformWorkerClient.TryValidateOutput(input, output, out string errorMessage);
+
+            Assert.That(valid, Is.False);
+            Assert.That(errorMessage, Does.Contain("owner"));
+        }
+
+        /// <summary>
+        /// Verifies that preparation rejects a descriptor with a mismatched assembly name when
+        /// its owner and assembly MVID match the input row.
+        /// </summary>
+        [Test]
+        public void TryValidateOutput_PrepareDescriptorAssemblyNameMismatch_ReturnsFailure()
+        {
+            TransformWorkerInputDto input = CreatePreparationValidationInput();
+            TransformWorkerOutputDto output = CreatePreparationValidationOutput(
+                "OtherAssembly",
+                "mvid",
+                "Assets/Edited.cs");
+
+            bool valid = TransformWorkerClient.TryValidateOutput(input, output, out string errorMessage);
+
+            Assert.That(valid, Is.False);
+            Assert.That(errorMessage, Does.Contain("assembly identity"));
+        }
+
+        /// <summary>
+        /// Verifies that preparation rejects a descriptor with a mismatched assembly MVID when
+        /// its owner and assembly name match the input row.
+        /// </summary>
+        [Test]
+        public void TryValidateOutput_PrepareDescriptorAssemblyMvidMismatch_ReturnsFailure()
+        {
+            TransformWorkerInputDto input = CreatePreparationValidationInput();
+            TransformWorkerOutputDto output = CreatePreparationValidationOutput(
+                "Assembly",
+                "other-mvid",
+                "Assets/Edited.cs");
+
+            bool valid = TransformWorkerClient.TryValidateOutput(input, output, out string errorMessage);
+
+            Assert.That(valid, Is.False);
+            Assert.That(errorMessage, Does.Contain("assembly identity"));
+        }
+
+        /// <summary>
+        /// Verifies that preparation accepts a descriptor when its owner and complete assembly
+        /// identity match the input row.
+        /// </summary>
+        [Test]
+        public void TryValidateOutput_PrepareDescriptorMatchingOwnerAndIdentity_ReturnsSuccess()
+        {
+            TransformWorkerInputDto input = CreatePreparationValidationInput();
+            TransformWorkerOutputDto output = CreatePreparationValidationOutput(
+                "Assembly",
+                "mvid",
+                "Assets/Edited.cs");
+
+            bool valid = TransformWorkerClient.TryValidateOutput(input, output, out string errorMessage);
+
+            Assert.That(valid, Is.True, errorMessage);
+        }
+
+        /// <summary>
+        /// Verifies that JSON containing a null preparation descriptor is rejected before a
+        /// success-shaped response can reach artifact preparation.
+        /// </summary>
+        [Test]
+        public void TryValidateOutput_PrepareNullDescriptorJson_ReturnsFailure()
+        {
+            TransformWorkerInputDto input = new TransformWorkerInputDto
+            {
+                operation = "prepareIntroducedTypes",
+                targetAssemblyName = "Assembly",
+                targetAssemblyMvid = "mvid",
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto { projectRelativePath = "Assets/Edited.cs" }
+                }
+            };
+            TransformWorkerOutputDto output = JsonConvert.DeserializeObject<TransformWorkerOutputDto>(
+                "{\"files\":[{\"projectRelativePath\":\"Assets/Edited.cs\",\"introducedTypes\":[null],\"introducedTypeDiagnostics\":[]}]}");
+
+            bool valid = TransformWorkerClient.TryValidateOutput(input, output, out string errorMessage);
+
+            Assert.That(valid, Is.False);
+            Assert.That(errorMessage, Does.Contain("null introduced type"));
+        }
+
+        private static TransformWorkerInputDto CreatePreparationValidationInput()
+        {
+            return new TransformWorkerInputDto
+            {
+                operation = "prepareIntroducedTypes",
+                targetAssemblyName = "Assembly",
+                targetAssemblyMvid = "mvid",
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto { projectRelativePath = "Assets/Edited.cs" }
+                }
+            };
+        }
+
+        private static TransformWorkerOutputDto CreatePreparationValidationOutput(
+            string assemblyName,
+            string assemblyMvid,
+            string ownerProjectRelativePath)
+        {
+            return new TransformWorkerOutputDto
+            {
+                files = new[]
+                {
+                    new TransformWorkerFileOutputDto
+                    {
+                        projectRelativePath = "Assets/Edited.cs",
+                        introducedTypes = new[]
+                        {
+                            new TransformWorkerIntroducedTypeDto
+                            {
+                                originalAssemblyName = assemblyName,
+                                originalAssemblyMvid = assemblyMvid,
+                                metadataName = "Example.Introduced",
+                                ownerProjectRelativePath = ownerProjectRelativePath,
+                                declarationFingerprint = "fingerprint",
+                                source = "public class Introduced { }"
+                            }
+                        },
+                        introducedTypeDiagnostics = Array.Empty<string>()
+                    }
+                }
+            };
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -26,7 +26,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// reaching downstream code that assumes one result per input source.
         /// </summary>
         [Test]
-        public void TryValidateOutput_MissingFileRow_ReturnsFailure()
+        public void InterpretOutputJson_MissingFileRow_ReturnsFailure()
         {
             TransformWorkerInputDto input = new TransformWorkerInputDto
             {
@@ -36,18 +36,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     new TransformWorkerSourceDto { projectRelativePath = "Assets/Two.cs" }
                 }
             };
-            TransformWorkerOutputDto output = new TransformWorkerOutputDto
-            {
-                files = new[]
-                {
-                    new TransformWorkerFileOutputDto { projectRelativePath = "Assets/One.cs" }
-                }
-            };
 
-            bool valid = TransformWorkerClient.TryValidateOutput(input, output, out string errorMessage);
+            // Goes through the same entry point the worker process path uses, so removing the
+            // check from that path fails here instead of only failing a helper nothing calls.
+            TransformWorkerClientResult result = TransformWorkerClient.InterpretOutputJson(
+                input,
+                "{\"shimSource\":\"\",\"files\":[{\"projectRelativePath\":\"Assets/One.cs\"}]}");
 
-            Assert.That(valid, Is.False);
-            Assert.That(errorMessage, Does.Contain("same count"));
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("same count"));
         }
 
         /// <summary>
@@ -2765,30 +2762,54 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// is rejected before optional transform fields are coalesced.
         /// </summary>
         [Test]
-        public void TryValidateOutput_PrepareArtifactsOmitted_ReturnsFailure()
+        public void InterpretOutputJson_PrepareArtifactsOmitted_ReturnsFailure()
         {
-            TransformWorkerInputDto input = new TransformWorkerInputDto
-            {
-                operation = "prepareIntroducedTypes",
-                targetAssemblyName = "Assembly",
-                targetAssemblyMvid = "mvid",
-                sources = new[]
-                {
-                    new TransformWorkerSourceDto { projectRelativePath = "Assets/Edited.cs" }
-                }
-            };
-            TransformWorkerOutputDto output = new TransformWorkerOutputDto
-            {
-                files = new[]
-                {
-                    new TransformWorkerFileOutputDto { projectRelativePath = "Assets/Edited.cs" }
-                }
-            };
+            TransformWorkerInputDto input = CreatePreparationValidationInput();
 
-            bool valid = TransformWorkerClient.TryValidateOutput(input, output, out string errorMessage);
+            // The omission has to be judged before coalescing turns it into an empty array, so
+            // the payload enters as JSON through the same entry point the process path uses.
+            TransformWorkerClientResult result = TransformWorkerClient.InterpretOutputJson(
+                input,
+                "{\"shimSource\":\"\",\"files\":[{\"projectRelativePath\":\"Assets/Edited.cs\"}]}");
 
-            Assert.That(valid, Is.False);
-            Assert.That(errorMessage, Does.Contain("introducedTypes"));
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("introducedTypes"));
+        }
+
+        /// <summary>
+        /// Verifies that a preparation request without a target assembly name is rejected at the
+        /// client boundary rather than producing descriptors with an unattributable identity.
+        /// </summary>
+        [Test]
+        public void InterpretOutputJson_PrepareInputWithoutAssemblyName_ReturnsFailure()
+        {
+            TransformWorkerInputDto input = CreatePreparationValidationInput();
+            input.targetAssemblyName = string.Empty;
+
+            TransformWorkerClientResult result = TransformWorkerClient.InterpretOutputJson(
+                input,
+                CreateMatchingPreparationOutputJson(string.Empty, "mvid"));
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("target assembly"));
+        }
+
+        /// <summary>
+        /// Verifies that a preparation request without a target module version id is rejected at
+        /// the client boundary, independently of the assembly name being present.
+        /// </summary>
+        [Test]
+        public void InterpretOutputJson_PrepareInputWithoutAssemblyMvid_ReturnsFailure()
+        {
+            TransformWorkerInputDto input = CreatePreparationValidationInput();
+            input.targetAssemblyMvid = string.Empty;
+
+            TransformWorkerClientResult result = TransformWorkerClient.InterpretOutputJson(
+                input,
+                CreateMatchingPreparationOutputJson("Assembly", string.Empty));
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("module version id"));
         }
 
         /// <summary>
@@ -2899,25 +2920,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// success-shaped response can reach artifact preparation.
         /// </summary>
         [Test]
-        public void TryValidateOutput_PrepareNullDescriptorJson_ReturnsFailure()
+        public void InterpretOutputJson_PrepareNullDescriptorJson_ReturnsFailure()
         {
-            TransformWorkerInputDto input = new TransformWorkerInputDto
-            {
-                operation = "prepareIntroducedTypes",
-                targetAssemblyName = "Assembly",
-                targetAssemblyMvid = "mvid",
-                sources = new[]
-                {
-                    new TransformWorkerSourceDto { projectRelativePath = "Assets/Edited.cs" }
-                }
-            };
-            TransformWorkerOutputDto output = JsonConvert.DeserializeObject<TransformWorkerOutputDto>(
+            TransformWorkerInputDto input = CreatePreparationValidationInput();
+
+            TransformWorkerClientResult result = TransformWorkerClient.InterpretOutputJson(
+                input,
                 "{\"files\":[{\"projectRelativePath\":\"Assets/Edited.cs\",\"introducedTypes\":[null],\"introducedTypeDiagnostics\":[]}]}");
 
-            bool valid = TransformWorkerClient.TryValidateOutput(input, output, out string errorMessage);
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("null introduced type"));
+        }
 
-            Assert.That(valid, Is.False);
-            Assert.That(errorMessage, Does.Contain("null introduced type"));
+        private static string CreateMatchingPreparationOutputJson(string assemblyName, string assemblyMvid)
+        {
+            return JsonConvert.SerializeObject(
+                CreatePreparationValidationOutput(assemblyName, assemblyMvid, "Assets/Edited.cs"));
         }
 
         private static TransformWorkerInputDto CreatePreparationValidationInput()

--- a/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
@@ -567,6 +567,102 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Has.Some.Contains("target assembly"));
         }
 
+        /// <summary>
+        /// Verifies that no introduced type is reported when a reference other than the target
+        /// exists but is not readable metadata, because the boundary checks would then answer
+        /// from error types instead of the real base types and attributes.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_UnreadableReference_ReportsNoIntroducedType()
+        {
+            string directory = CreateSourceDirectory("UnreadableReference");
+            string sourcePath = Path.Combine(directory, "Edited.cs");
+            string targetAssemblyPath = Path.Combine(directory, "ConstDriftTarget.dll");
+            string targetAssemblyMvid = CreateConstDriftTargetAssembly(targetAssemblyPath, 1);
+            string brokenReferencePath = Path.Combine(directory, "BrokenReference.dll");
+            File.WriteAllText(brokenReferencePath, "this is not an assembly");
+            File.WriteAllText(sourcePath, "namespace Example { public class Introduced { } }");
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                CreatePreparationInput(
+                    sourcePath,
+                    targetAssemblyPath,
+                    "ConstDriftTarget",
+                    targetAssemblyMvid,
+                    new[] { brokenReferencePath }),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.files[0].introducedTypes, Is.Empty);
+            Assert.That(
+                result.Output.files[0].introducedTypeDiagnostics,
+                Has.Some.Contains("its references"));
+        }
+
+        /// <summary>
+        /// Verifies that no introduced type is reported when the request names a module version
+        /// id the analysed target assembly does not carry, because the descriptors would then
+        /// claim an assembly generation the planning never looked at.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_TargetAssemblyMvidMismatch_ReportsNoIntroducedType()
+        {
+            string directory = CreateSourceDirectory("TargetMvidMismatch");
+            string sourcePath = Path.Combine(directory, "Edited.cs");
+            string targetAssemblyPath = Path.Combine(directory, "ConstDriftTarget.dll");
+            CreateConstDriftTargetAssembly(targetAssemblyPath, 1);
+            File.WriteAllText(sourcePath, "namespace Example { public class Introduced { } }");
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                CreateConstDriftInput(sourcePath, targetAssemblyPath, Guid.NewGuid().ToString()),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.files[0].introducedTypes, Is.Empty);
+            Assert.That(
+                result.Output.files[0].introducedTypeDiagnostics,
+                Has.Some.Contains("identity does not match"));
+        }
+
+        /// <summary>
+        /// Verifies that a declaration whose metadata name already exists in a different
+        /// referenced assembly is still introduced, because only the target assembly decides
+        /// whether the type is already compiled.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_SameMetadataNameInOtherAssembly_IsStillIntroduced()
+        {
+            string directory = CreateSourceDirectory("SameNameOtherAssembly");
+            string sourcePath = Path.Combine(directory, "Edited.cs");
+            string targetAssemblyPath = Path.Combine(directory, "SameNameTarget.dll");
+            string otherAssemblyPath = Path.Combine(directory, "SameNameOther.dll");
+            string targetAssemblyMvid = CreateAssemblyWithType(
+                targetAssemblyPath,
+                "SameNameTarget",
+                "Example",
+                "Unrelated");
+            CreateAssemblyWithType(otherAssemblyPath, "SameNameOther", "Example", "Shared");
+            File.WriteAllText(sourcePath, "namespace Example { public class Shared { } }");
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                CreatePreparationInput(
+                    sourcePath,
+                    targetAssemblyPath,
+                    "SameNameTarget",
+                    targetAssemblyMvid,
+                    new[] { otherAssemblyPath }),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.files[0].introducedTypes, Has.Length.EqualTo(1));
+            Assert.That(
+                result.Output.files[0].introducedTypes[0].metadataName,
+                Is.EqualTo("Example.Shared"));
+            Assert.That(
+                result.Output.files[0].introducedTypes[0].originalAssemblyName,
+                Is.EqualTo("SameNameTarget"));
+        }
+
         private static TransformWorkerInputDto CreateInput(string firstSourcePath, string secondSourcePath)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
@@ -608,7 +704,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string targetAssemblyPath,
             string targetAssemblyMvid)
         {
+            return CreatePreparationInput(
+                sourcePath,
+                targetAssemblyPath,
+                "ConstDriftTarget",
+                targetAssemblyMvid,
+                Array.Empty<string>());
+        }
+
+        private static TransformWorkerInputDto CreatePreparationInput(
+            string sourcePath,
+            string targetAssemblyPath,
+            string targetAssemblyName,
+            string targetAssemblyMvid,
+            string[] extraReferencePaths)
+        {
             UnityEditor.Compilation.Assembly compilationAssembly = FindCompilationAssembly();
+            List<string> referencePaths = new List<string>(
+                BuildAbsoluteReferencePaths(compilationAssembly.allReferences, targetAssemblyPath));
+            foreach (string extraReferencePath in extraReferencePaths)
+            {
+                referencePaths.Add(Path.GetFullPath(extraReferencePath));
+            }
+
             return new TransformWorkerInputDto
             {
                 operation = "prepareIntroducedTypes",
@@ -621,13 +739,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     }
                 },
                 defines = compilationAssembly.defines ?? Array.Empty<string>(),
-                referencePaths = BuildAbsoluteReferencePaths(compilationAssembly.allReferences, targetAssemblyPath),
+                referencePaths = referencePaths.ToArray(),
                 targetTypesAssemblyPath = targetAssemblyPath,
-                targetAssemblyName = "ConstDriftTarget",
+                targetAssemblyName = targetAssemblyName,
                 targetAssemblyMvid = targetAssemblyMvid,
                 assemblySourcePaths = Array.Empty<string>(),
                 changedSiblingSourcePaths = Array.Empty<string>()
             };
+        }
+
+        private static string CreateAssemblyWithType(
+            string path,
+            string assemblyName,
+            string typeNamespace,
+            string typeName)
+        {
+            AssemblyNameDefinition assemblyNameDefinition = new AssemblyNameDefinition(
+                assemblyName,
+                new Version(1, 0, 0, 0));
+            using (AssemblyDefinition assembly = AssemblyDefinition.CreateAssembly(
+                assemblyNameDefinition,
+                assemblyName,
+                ModuleKind.Dll))
+            {
+                TypeDefinition type = new TypeDefinition(
+                    typeNamespace,
+                    typeName,
+                    CecilTypeAttributes.Public | CecilTypeAttributes.Class,
+                    assembly.MainModule.TypeSystem.Object);
+                assembly.MainModule.Types.Add(type);
+                assembly.Write(path);
+            }
+
+            using (ModuleDefinition module = ModuleDefinition.ReadModule(path))
+            {
+                return module.Mvid.ToString();
+            }
         }
 
         private static string CreateConstDriftTargetAssembly(string path, int constantValue)

--- a/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
@@ -1,0 +1,718 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+using Mono.Cecil;
+using CecilFieldAttributes = Mono.Cecil.FieldAttributes;
+using CecilTypeAttributes = Mono.Cecil.TypeAttributes;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Verifies the dedicated worker operation that plans immutable introduced type artifacts.
+    /// </summary>
+    public class TransformWorkerIntroducedTypeTests
+    {
+        private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+
+        /// <summary>
+        /// Verifies that preparation preserves input file order, emits supported top-level types,
+        /// and reports unsupported declarations on their owning file.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_EmitsSupportedTypesAndPerFileDiagnostics()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, "Library", "UloopHotReload", "TestSources", "IntroducedTypes");
+            Directory.CreateDirectory(directory);
+            string firstSourcePath = Path.Combine(directory, "First.cs");
+            string secondSourcePath = Path.Combine(directory, "Second.cs");
+            File.WriteAllText(
+                firstSourcePath,
+                "using Alias = System.IDisposable; namespace Example.Introduced { public class NewClass { public Alias Create() { return null; } } public struct NewStruct { } public enum NewEnum { One } public interface INew { } public static class Helpers { } }");
+            File.WriteAllText(
+                secondSourcePath,
+                "namespace Example.Introduced { internal class Hidden { } public class Generic<T> { } internal class Outer { public class Nested { } } }");
+
+            TransformWorkerInputDto input = CreateInput(firstSourcePath, secondSourcePath);
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                input,
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.files, Has.Length.EqualTo(2));
+            Assert.That(result.Output.files[0].projectRelativePath, Is.EqualTo("Assets/First.cs"));
+            Assert.That(result.Output.files[1].projectRelativePath, Is.EqualTo("Assets/Second.cs"));
+            Assert.That(result.Output.files[0].introducedTypes, Has.Length.EqualTo(5));
+            Assert.That(
+                result.Output.files[0].introducedTypes[0].source,
+                Does.Contain("namespace Example.Introduced"));
+            Assert.That(
+                result.Output.files[0].introducedTypes[0].source,
+                Does.Contain("using Alias"));
+            Assert.That(
+                result.Output.files[1].introducedTypes,
+                Is.Empty);
+            Assert.That(
+                result.Output.files[1].introducedTypeDiagnostics,
+                Has.Some.Contains("Non-public"));
+            Assert.That(
+                result.Output.files[1].introducedTypeDiagnostics,
+                Has.Some.Contains("Generic"));
+            Assert.That(
+                result.Output.files[1].introducedTypeDiagnostics,
+                Has.Some.Contains("Nested"));
+        }
+
+        /// <summary>
+        /// Verifies that a parse-failed row remains isolated from the shared semantic compilation
+        /// while a sibling file still emits its independently valid introduced type.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_ParseFailedSibling_DoesNotEnterSharedAnalysis()
+        {
+            string directory = CreateSourceDirectory("ParseIsolation");
+            string validSourcePath = Path.Combine(directory, "Valid.cs");
+            string invalidSourcePath = Path.Combine(directory, "Invalid.cs");
+            File.WriteAllText(validSourcePath, "namespace Example { public class ValidIntroduced { } }");
+            File.WriteAllText(invalidSourcePath, "namespace Example { public class BrokenIntroduced { ");
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                CreateInput(validSourcePath, invalidSourcePath),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.files[0].introducedTypes, Has.Length.EqualTo(1));
+            Assert.That(result.Output.files[1].introducedTypes, Is.Empty);
+            Assert.That(result.Output.files[1].parseErrors, Is.Not.Empty);
+        }
+
+        /// <summary>
+        /// Verifies that nested namespace alias scopes are retained in emitted source instead of
+        /// being flattened into duplicate aliases at one namespace level.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_NestedAliasScopes_PreservesNamespaceHierarchy()
+        {
+            string directory = CreateSourceDirectory("NamespaceAliases");
+            string firstSourcePath = Path.Combine(directory, "First.cs");
+            string secondSourcePath = Path.Combine(directory, "Second.cs");
+            File.WriteAllText(
+                firstSourcePath,
+                "namespace Outer { using Alias = System.String; namespace Inner { using Alias = System.Int32; public class Aliased { public Alias Value; } } }");
+            File.WriteAllText(secondSourcePath, "namespace Example { public class Other { } }");
+
+            TransformWorkerInputDto input = CreateInput(firstSourcePath, secondSourcePath);
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                input,
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            string source = result.Output.files[0].introducedTypes[0].source;
+            Assert.That(source, Does.Contain("namespace Outer"));
+            Assert.That(source, Does.Contain("namespace Inner"));
+            Assert.That(source, Does.Contain("using Alias = System.String"));
+            Assert.That(source, Does.Contain("using Alias = System.Int32"));
+        }
+
+        /// <summary>
+        /// Verifies that two global-namespace declarations retain their independent alias
+        /// bindings through worker preparation, source composition, and Roslyn compilation.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_GlobalNamespaceSources_CompileWithoutChangingAliasBindings()
+        {
+            string directory = CreateSourceDirectory("GlobalNamespaceSources");
+            string firstSourcePath = Path.Combine(directory, "First.cs");
+            string secondSourcePath = Path.Combine(directory, "Second.cs");
+            File.WriteAllText(
+                firstSourcePath,
+                "using System; using Alias = System.IDisposable; public class GlobalFirst { public Alias Create() { return null; } }");
+            File.WriteAllText(
+                secondSourcePath,
+                "using System; using Alias = System.ICloneable; public class GlobalSecond { public Alias Create() { return null; } }");
+
+            TransformWorkerInputDto input = CreateInput(firstSourcePath, secondSourcePath);
+            TransformWorkerClientResult workerResult = await TransformWorkerClient.RunAsync(
+                input,
+                CancellationToken.None);
+
+            Assert.That(workerResult.Success, Is.True, workerResult.ErrorMessage);
+            Assert.That(workerResult.Output.files[0].introducedTypes, Has.Length.EqualTo(1));
+            Assert.That(workerResult.Output.files[1].introducedTypes, Has.Length.EqualTo(1));
+            List<HotReloadIntroducedTypeDescriptor> descriptors =
+                CreateDescriptors(workerResult.Output.files);
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            HotReloadIntroducedTypeArtifactPathFactory factory =
+                new HotReloadIntroducedTypeArtifactPathFactory(projectRoot, "global-namespace-sources");
+            HotReloadIntroducedTypeCompilationRequest request =
+                HotReloadIntroducedTypeCompilationRequest.CreateBatch(
+                    factory.Create(),
+                    descriptors,
+                    input.referencePaths,
+                    input.defines);
+            HotReloadIntroducedTypeCompiler compiler = new HotReloadIntroducedTypeCompiler(
+                new HotReloadIntroducedTypeCompilerEnvironment());
+
+            HotReloadIntroducedTypeCompilerResult compileResult = await compiler.CompileAsync(
+                request,
+                CancellationToken.None);
+
+            Assert.That(compileResult.Success, Is.True, compileResult.ErrorMessage);
+            Assert.That(compileResult.Artifact.Assembly.GetType("GlobalFirst"), Is.Not.Null);
+            Assert.That(compileResult.Artifact.Assembly.GetType("GlobalSecond"), Is.Not.Null);
+        }
+
+        /// <summary>
+        /// Verifies that one global alias remains valid when worker preparation copies it into
+        /// each independently compiled introduced-type source tree.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_GlobalUsingAlias_CompilesTwoIntroducedTypes()
+        {
+            string directory = CreateSourceDirectory("GlobalUsingAlias");
+            string firstSourcePath = Path.Combine(directory, "First.cs");
+            string secondSourcePath = Path.Combine(directory, "Second.cs");
+            File.WriteAllText(
+                firstSourcePath,
+                "global using Alias = System.IDisposable; namespace GlobalAliasFixture { public class First { public Alias Create() { return null; } } }");
+            File.WriteAllText(
+                secondSourcePath,
+                "namespace GlobalAliasFixture { public class Second { public Alias Create() { return null; } } }");
+
+            TransformWorkerInputDto input = CreateInput(firstSourcePath, secondSourcePath);
+            TransformWorkerClientResult workerResult = await TransformWorkerClient.RunAsync(
+                input,
+                CancellationToken.None);
+
+            List<HotReloadIntroducedTypeDescriptor> descriptors = CreateDescriptors(workerResult.Output.files);
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            HotReloadIntroducedTypeCompilationRequest request =
+                HotReloadIntroducedTypeCompilationRequest.CreateBatch(
+                    new HotReloadIntroducedTypeArtifactPathFactory(projectRoot, "global-using-alias").Create(),
+                    descriptors,
+                    input.referencePaths,
+                    input.defines);
+            HotReloadIntroducedTypeCompilerResult compileResult = await new HotReloadIntroducedTypeCompiler(
+                new HotReloadIntroducedTypeCompilerEnvironment()).CompileAsync(request, CancellationToken.None);
+
+            Assert.That(workerResult.Success, Is.True, workerResult.ErrorMessage);
+            Assert.That(descriptors, Has.Count.EqualTo(2));
+            Assert.That(compileResult.Success, Is.True, compileResult.ErrorMessage);
+            Assert.That(compileResult.Artifact.Assembly.GetType("GlobalAliasFixture.First"), Is.Not.Null);
+            Assert.That(compileResult.Artifact.Assembly.GetType("GlobalAliasFixture.Second"), Is.Not.Null);
+
+            HotReloadIntroducedTypeCompilationRequest subsetRequest =
+                HotReloadIntroducedTypeCompilationRequest.CreateBatch(
+                    new HotReloadIntroducedTypeArtifactPathFactory(projectRoot, "global-using-alias-subset").Create(),
+                    new[] { descriptors[1] },
+                    input.referencePaths,
+                    input.defines);
+            HotReloadIntroducedTypeCompilerResult subsetCompileResult = await new HotReloadIntroducedTypeCompiler(
+                new HotReloadIntroducedTypeCompilerEnvironment()).CompileAsync(subsetRequest, CancellationToken.None);
+
+            Assert.That(subsetCompileResult.Success, Is.True, subsetCompileResult.ErrorMessage);
+            Assert.That(subsetCompileResult.Artifact.Assembly.GetType("GlobalAliasFixture.Second"), Is.Not.Null);
+        }
+
+        /// <summary>
+        /// Verifies that root imports remain in compilation-unit scope when a namespace contains
+        /// a relative namespace with the same name as the imported global namespace.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_RootUsing_KeepsGlobalNamespaceBinding()
+        {
+            string directory = CreateSourceDirectory("RootUsingScope");
+            string firstSourcePath = Path.Combine(directory, "First.cs");
+            string secondSourcePath = Path.Combine(directory, "Second.cs");
+            File.WriteAllText(
+                firstSourcePath,
+                "using ScopeGlobal; using static ScopeStatic.Helpers; using ExtensionGlobal; namespace ScopeGlobal { public class Bound { } } namespace ScopeFixture.ScopeGlobal { public class Bound { } } namespace ScopeStatic { public static class Helpers { public static int Value() { return 7; } } } namespace ScopeFixture.ScopeStatic { public static class Helpers { public static int Value() { return 9; } } } namespace ExtensionGlobal { public static class Extensions { public static int ExtensionValue(this string value) { return 17; } } } namespace ScopeFixture.ExtensionGlobal { public static class Extensions { public static int ExtensionValue(this string value) { return 19; } } } namespace ScopeFixture { public class Consumer { public Bound Create() { return null; } public int GetValue() { return Value(); } public int GetExtensionValue() { return \"test\".ExtensionValue(); } } }");
+            File.WriteAllText(secondSourcePath, "namespace ScopeFixture { public class Other { } }");
+
+            TransformWorkerInputDto input = CreateInput(firstSourcePath, secondSourcePath);
+            TransformWorkerClientResult workerResult = await TransformWorkerClient.RunAsync(
+                input,
+                CancellationToken.None);
+
+            Assert.That(workerResult.Success, Is.True, workerResult.ErrorMessage);
+            Assert.That(workerResult.Output.files[0].introducedTypes, Has.Length.EqualTo(1));
+            Assert.That(workerResult.Output.files[0].introducedTypes[0].metadataName, Is.EqualTo("Example.Safe"));
+            Assert.That(workerResult.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Nested"));
+
+            List<HotReloadIntroducedTypeDescriptor> descriptors = CreateDescriptors(workerResult.Output.files);
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            HotReloadIntroducedTypeCompilationRequest request =
+                HotReloadIntroducedTypeCompilationRequest.CreateBatch(
+                    new HotReloadIntroducedTypeArtifactPathFactory(projectRoot, "root-using-scope").Create(),
+                    descriptors,
+                    input.referencePaths,
+                    input.defines);
+            HotReloadIntroducedTypeCompilerResult compileResult = await new HotReloadIntroducedTypeCompiler(
+                new HotReloadIntroducedTypeCompilerEnvironment()).CompileAsync(request, CancellationToken.None);
+
+            Assert.That(workerResult.Success, Is.True, workerResult.ErrorMessage);
+            Assert.That(compileResult.Success, Is.True, compileResult.ErrorMessage);
+            Type consumer = compileResult.Artifact.Assembly.GetType("ScopeFixture.Consumer");
+            Assert.That(consumer.GetMethod("Create").ReturnType.FullName, Is.EqualTo("ScopeGlobal.Bound"));
+            Assert.That(consumer.GetMethod("GetValue").Invoke(Activator.CreateInstance(consumer), null), Is.EqualTo(7));
+            Assert.That(consumer.GetMethod("GetExtensionValue").Invoke(Activator.CreateInstance(consumer), null), Is.EqualTo(17));
+        }
+
+        /// <summary>
+        /// Verifies that every unsupported declaration category produces an owning-file
+        /// diagnostic and cannot become an introduced artifact descriptor.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_UnsupportedSemanticCategories_ReportDiagnostics()
+        {
+            string directory = CreateSourceDirectory("UnsupportedCategories");
+            string firstSourcePath = Path.Combine(directory, "Unsupported.cs");
+            string secondSourcePath = Path.Combine(directory, "Other.cs");
+            File.WriteAllText(
+                firstSourcePath,
+                "namespace System.Runtime.CompilerServices { internal sealed class ModuleInitializerAttribute : System.Attribute { } } "
+                + "namespace Example { internal class Hidden { } public class Generic<T> { } public partial class Partial { } public ref struct RefLike { } public unsafe class UnsafeType { public int* Value; } public class ObjectType : UnityEngine.Object { } [System.Serializable] public class SerializableType { } public static class InitializerType { [System.Runtime.CompilerServices.ModuleInitializer] public static void Initialize() { } } public delegate void AddedDelegate(); public class Outer { public class Nested { } } }");
+            File.WriteAllText(secondSourcePath, "namespace Example { public class Other { } }");
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                CreateInput(firstSourcePath, secondSourcePath),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.files[0].introducedTypes, Is.Empty);
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Non-public"));
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Generic"));
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Partial"));
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Ref-like"));
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Unsafe"));
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Unity object"));
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Serializable"));
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Module initializer"));
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Delegate"));
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Nested"));
+        }
+
+        /// <summary>
+        /// Verifies that an outer declaration containing an excluded nested declaration is
+        /// rejected so the generated artifact cannot retain the nested implementation.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_OuterContainingNestedDeclaration_IsRejectedBeforeArtifactCompile()
+        {
+            string directory = CreateSourceDirectory("NestedArtifactRejection");
+            string firstSourcePath = Path.Combine(directory, "First.cs");
+            string secondSourcePath = Path.Combine(directory, "Second.cs");
+            File.WriteAllText(
+                firstSourcePath,
+                "namespace System.Runtime.CompilerServices { internal sealed class ModuleInitializerAttribute : System.Attribute { } } "
+                + "namespace Example { public class Outer { public static class Nested { [System.Runtime.CompilerServices.ModuleInitializer] public static void Initialize() { } } } public class Safe { } }");
+            File.WriteAllText(secondSourcePath, "namespace Example { public class Other { } }");
+
+            TransformWorkerInputDto input = CreateInput(firstSourcePath, secondSourcePath);
+            TransformWorkerClientResult workerResult = await TransformWorkerClient.RunAsync(
+                input,
+                CancellationToken.None);
+            List<HotReloadIntroducedTypeDescriptor> descriptors = CreateDescriptors(workerResult.Output.files);
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            HotReloadIntroducedTypeCompilationRequest request =
+                HotReloadIntroducedTypeCompilationRequest.CreateBatch(
+                    new HotReloadIntroducedTypeArtifactPathFactory(projectRoot, "nested-artifact-rejection").Create(),
+                    descriptors,
+                    input.referencePaths,
+                    input.defines);
+            HotReloadIntroducedTypeCompilerResult compileResult = await new HotReloadIntroducedTypeCompiler(
+                new HotReloadIntroducedTypeCompilerEnvironment()).CompileAsync(request, CancellationToken.None);
+
+            Assert.That(compileResult.Success, Is.True, compileResult.ErrorMessage);
+            Assert.That(compileResult.Artifact.Assembly.GetType("Example.Safe"), Is.Not.Null);
+            Assert.That(compileResult.Artifact.Assembly.GetType("Example.Outer"), Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies that fingerprints ignore trivia and unrelated namespace imports while they
+        /// retain token boundaries, defines, and semantically referenced alias identities.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_Fingerprint_TracksOnlyDefinitionInputs()
+        {
+            string directory = CreateSourceDirectory("Fingerprints");
+            string firstSourcePath = Path.Combine(directory, "First.cs");
+            string secondSourcePath = Path.Combine(directory, "Second.cs");
+            File.WriteAllText(
+                firstSourcePath,
+                "using Alias = System.IDisposable; using System.Text; namespace Example { public class Fingerprint { public Alias Create() { return null; } } } namespace Unrelated { using Other = System.Text; class Ignore { } }");
+            File.WriteAllText(secondSourcePath, "namespace Unrelated { using Other = System.String; public class OtherType { } }");
+            TransformWorkerClientResult first = await TransformWorkerClient.RunAsync(
+                CreateInput(firstSourcePath, secondSourcePath),
+                CancellationToken.None);
+
+            File.WriteAllText(
+                firstSourcePath,
+                "using Alias = System.IDisposable; using System.Text; namespace Example { public class Fingerprint { public Alias Create() { return null; } } public class LaterIntroduced { } } namespace Unrelated { using Other = System.Text; class Ignore { } }");
+            TransformWorkerClientResult laterType = await TransformWorkerClient.RunAsync(
+                CreateInput(firstSourcePath, secondSourcePath),
+                CancellationToken.None);
+
+            File.WriteAllText(
+                firstSourcePath,
+                "using Alias = System.IDisposable; using System.Text; namespace Example { public class Fingerprint { public Alias Create() { return null; } } } namespace Unrelated { using Other = System.IO; class Ignore { } }");
+            TransformWorkerClientResult unrelatedUsing = await TransformWorkerClient.RunAsync(
+                CreateInput(firstSourcePath, secondSourcePath),
+                CancellationToken.None);
+
+            File.WriteAllText(
+                firstSourcePath,
+                "using Alias = System.IDisposable; using System.Text; namespace Example { /* trivia */ public class Fingerprint { public Alias Create() { return null; } } } namespace Unrelated { using Other = System.IO; class Ignore { } }");
+            TransformWorkerClientResult trivia = await TransformWorkerClient.RunAsync(
+                CreateInput(firstSourcePath, secondSourcePath),
+                CancellationToken.None);
+
+            File.WriteAllText(
+                firstSourcePath,
+                "using Alias = System.ICloneable; using System.Text; namespace Example { public class Fingerprint { public Alias Create() { return null; } } }");
+            TransformWorkerClientResult aliasChanged = await TransformWorkerClient.RunAsync(
+                CreateInput(firstSourcePath, secondSourcePath),
+                CancellationToken.None);
+
+            File.WriteAllText(
+                firstSourcePath,
+                "using Alias = System.IDisposable; using System.Text; namespace Example { public class Fingerprint { public Alias Create() { return null; } } }");
+            TransformWorkerInputDto definesChangedInput = CreateInput(firstSourcePath, secondSourcePath);
+            definesChangedInput.defines = new[] { "CHANGED_DEFINE" };
+            TransformWorkerClientResult definesChanged = await TransformWorkerClient.RunAsync(
+                definesChangedInput,
+                CancellationToken.None);
+
+            Assert.That(first.Success, Is.True, first.ErrorMessage);
+            Assert.That(laterType.Success, Is.True, laterType.ErrorMessage);
+            Assert.That(unrelatedUsing.Success, Is.True, unrelatedUsing.ErrorMessage);
+            Assert.That(trivia.Success, Is.True, trivia.ErrorMessage);
+            Assert.That(aliasChanged.Success, Is.True, aliasChanged.ErrorMessage);
+            Assert.That(definesChanged.Success, Is.True, definesChanged.ErrorMessage);
+            Assert.That(
+                trivia.Output.files[0].introducedTypes[0].declarationFingerprint,
+                Is.EqualTo(first.Output.files[0].introducedTypes[0].declarationFingerprint));
+            Assert.That(
+                unrelatedUsing.Output.files[0].introducedTypes[0].declarationFingerprint,
+                Is.EqualTo(first.Output.files[0].introducedTypes[0].declarationFingerprint));
+            Assert.That(laterType.Output.files[0].introducedTypes, Has.Length.EqualTo(2));
+            Assert.That(
+                laterType.Output.files[0].introducedTypes[0].declarationFingerprint,
+                Is.EqualTo(first.Output.files[0].introducedTypes[0].declarationFingerprint));
+            Assert.That(
+                aliasChanged.Output.files[0].introducedTypes[0].declarationFingerprint,
+                Is.Not.EqualTo(first.Output.files[0].introducedTypes[0].declarationFingerprint));
+            Assert.That(
+                definesChanged.Output.files[0].introducedTypes[0].declarationFingerprint,
+                Is.Not.EqualTo(first.Output.files[0].introducedTypes[0].declarationFingerprint));
+        }
+
+        /// <summary>
+        /// Verifies that a fingerprint retains each semantic dependency at its stable declaration
+        /// traversal position when aliases exchange their bound types without changing tokens.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_Fingerprint_DistinguishesAliasBindingExchange()
+        {
+            string directory = CreateSourceDirectory("AliasBindingExchange");
+            string firstSourcePath = Path.Combine(directory, "First.cs");
+            string secondSourcePath = Path.Combine(directory, "Second.cs");
+            File.WriteAllText(
+                firstSourcePath,
+                "using Left = System.Int32; using Right = System.String; namespace Example { public class Sample { public Left A; public Right B; } }");
+            File.WriteAllText(secondSourcePath, "namespace Example { public class Other { } }");
+            TransformWorkerClientResult before = await TransformWorkerClient.RunAsync(
+                CreateInput(firstSourcePath, secondSourcePath),
+                CancellationToken.None);
+
+            File.WriteAllText(
+                firstSourcePath,
+                "using Left = System.String; using Right = System.Int32; namespace Example { public class Sample { public Left A; public Right B; } }");
+            TransformWorkerClientResult after = await TransformWorkerClient.RunAsync(
+                CreateInput(firstSourcePath, secondSourcePath),
+                CancellationToken.None);
+
+            Assert.That(before.Success, Is.True, before.ErrorMessage);
+            Assert.That(after.Success, Is.True, after.ErrorMessage);
+            Assert.That(
+                after.Output.files[0].introducedTypes[0].declarationFingerprint,
+                Is.Not.EqualTo(before.Output.files[0].introducedTypes[0].declarationFingerprint));
+        }
+
+        /// <summary>
+        /// Verifies that an introduced type referencing a changed const from a compiled existing
+        /// type is rejected instead of compiling the artifact with the metadata assembly's old value.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_ChangedReferencedExistingConst_IsRejected()
+        {
+            string directory = CreateSourceDirectory("ChangedExistingConst");
+            string sourcePath = Path.Combine(directory, "Edited.cs");
+            string targetAssemblyPath = Path.Combine(directory, "ConstDriftTarget.dll");
+            string targetAssemblyMvid = CreateConstDriftTargetAssembly(targetAssemblyPath, 1);
+            File.WriteAllText(
+                sourcePath,
+                "namespace Example { public class Existing { public const int Value = 2; } public class Introduced { public int Get() { return Existing.Value; } } public class Safe { } }");
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                CreateConstDriftInput(sourcePath, targetAssemblyPath, targetAssemblyMvid),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.files[0].introducedTypes, Has.Length.EqualTo(1));
+            Assert.That(result.Output.files[0].introducedTypes[0].metadataName, Is.EqualTo("Example.Safe"));
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Existing.Value"));
+        }
+
+        /// <summary>
+        /// Verifies that a changed const does not reject an introduced type that does not refer to it.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_UnreferencedChangedExistingConst_DoesNotRejectIntroducedType()
+        {
+            string directory = CreateSourceDirectory("UnreferencedChangedExistingConst");
+            string sourcePath = Path.Combine(directory, "Edited.cs");
+            string targetAssemblyPath = Path.Combine(directory, "ConstDriftTarget.dll");
+            string targetAssemblyMvid = CreateConstDriftTargetAssembly(targetAssemblyPath, 1);
+            File.WriteAllText(
+                sourcePath,
+                "namespace Example { public class Existing { public const int Value = 2; } public class Introduced { public int Get() { return 3; } } }");
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                CreateConstDriftInput(sourcePath, targetAssemblyPath, targetAssemblyMvid),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.files[0].introducedTypes, Has.Length.EqualTo(1));
+            Assert.That(result.Output.files[0].introducedTypes[0].metadataName, Is.EqualTo("Example.Introduced"));
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Is.Empty);
+        }
+
+        /// <summary>
+        /// Verifies that a referenced existing const with the same source and metadata value remains supported.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_UnchangedReferencedExistingConst_RemainsSupported()
+        {
+            string directory = CreateSourceDirectory("UnchangedExistingConst");
+            string sourcePath = Path.Combine(directory, "Edited.cs");
+            string targetAssemblyPath = Path.Combine(directory, "ConstDriftTarget.dll");
+            string targetAssemblyMvid = CreateConstDriftTargetAssembly(targetAssemblyPath, 1);
+            File.WriteAllText(
+                sourcePath,
+                "namespace Example { public class Existing { public const int Value = 1; } public class Introduced { public int Get() { return Existing.Value; } } }");
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                CreateConstDriftInput(sourcePath, targetAssemblyPath, targetAssemblyMvid),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.files[0].introducedTypes, Has.Length.EqualTo(1));
+            Assert.That(result.Output.files[0].introducedTypes[0].metadataName, Is.EqualTo("Example.Introduced"));
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Is.Empty);
+        }
+
+        /// <summary>
+        /// Verifies that the fingerprint serialization retains token boundaries for expressions
+        /// whose unseparated token text would otherwise collide.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_Fingerprint_DistinguishesTokenBoundaries()
+        {
+            string directory = CreateSourceDirectory("TokenBoundaries");
+            string firstSourcePath = Path.Combine(directory, "First.cs");
+            string secondSourcePath = Path.Combine(directory, "Second.cs");
+            File.WriteAllText(
+                firstSourcePath,
+                "namespace Example { public class TokenBoundary { private int a; private int b; public int Value() { return a + ++b; } } }");
+            File.WriteAllText(secondSourcePath, "namespace Example { public class Other { } }");
+            TransformWorkerClientResult before = await TransformWorkerClient.RunAsync(
+                CreateInput(firstSourcePath, secondSourcePath),
+                CancellationToken.None);
+
+            File.WriteAllText(
+                firstSourcePath,
+                "namespace Example { public class TokenBoundary { private int a; private int b; public int Value() { return a++ + b; } } }");
+            TransformWorkerClientResult after = await TransformWorkerClient.RunAsync(
+                CreateInput(firstSourcePath, secondSourcePath),
+                CancellationToken.None);
+
+            Assert.That(before.Success, Is.True, before.ErrorMessage);
+            Assert.That(after.Success, Is.True, after.ErrorMessage);
+            Assert.That(
+                after.Output.files[0].introducedTypes[0].declarationFingerprint,
+                Is.Not.EqualTo(before.Output.files[0].introducedTypes[0].declarationFingerprint));
+        }
+
+        private static string CreateSourceDirectory(string name)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(projectRoot, "Library", "UloopHotReload", "TestSources", "IntroducedTypes", name);
+            Directory.CreateDirectory(directory);
+            return directory;
+        }
+
+        private static TransformWorkerInputDto CreateInput(string firstSourcePath, string secondSourcePath)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string targetDllPath = Path.Combine(
+                projectRoot,
+                "Library",
+                "ScriptAssemblies",
+                TestAssemblyName + ".dll");
+            Assert.That(File.Exists(targetDllPath), Is.True, "Test assembly DLL must exist.");
+            UnityEditor.Compilation.Assembly compilationAssembly = FindCompilationAssembly();
+            return new TransformWorkerInputDto
+            {
+                operation = "prepareIntroducedTypes",
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = firstSourcePath,
+                        projectRelativePath = "Assets/First.cs"
+                    },
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = secondSourcePath,
+                        projectRelativePath = "Assets/Second.cs"
+                    }
+                },
+                defines = compilationAssembly.defines ?? Array.Empty<string>(),
+                referencePaths = BuildAbsoluteReferencePaths(compilationAssembly.allReferences, targetDllPath),
+                targetTypesAssemblyPath = targetDllPath,
+                targetAssemblyName = TestAssemblyName,
+                targetAssemblyMvid = typeof(TransformWorkerIntroducedTypeTests).Assembly.ManifestModule.ModuleVersionId.ToString(),
+                assemblySourcePaths = Array.Empty<string>(),
+                changedSiblingSourcePaths = Array.Empty<string>()
+            };
+        }
+
+        private static TransformWorkerInputDto CreateConstDriftInput(
+            string sourcePath,
+            string targetAssemblyPath,
+            string targetAssemblyMvid)
+        {
+            UnityEditor.Compilation.Assembly compilationAssembly = FindCompilationAssembly();
+            return new TransformWorkerInputDto
+            {
+                operation = "prepareIntroducedTypes",
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = sourcePath,
+                        projectRelativePath = "Assets/Edited.cs"
+                    }
+                },
+                defines = compilationAssembly.defines ?? Array.Empty<string>(),
+                referencePaths = BuildAbsoluteReferencePaths(compilationAssembly.allReferences, targetAssemblyPath),
+                targetTypesAssemblyPath = targetAssemblyPath,
+                targetAssemblyName = "ConstDriftTarget",
+                targetAssemblyMvid = targetAssemblyMvid,
+                assemblySourcePaths = Array.Empty<string>(),
+                changedSiblingSourcePaths = Array.Empty<string>()
+            };
+        }
+
+        private static string CreateConstDriftTargetAssembly(string path, int constantValue)
+        {
+            AssemblyNameDefinition assemblyName = new AssemblyNameDefinition(
+                "ConstDriftTarget",
+                new Version(1, 0, 0, 0));
+            using (AssemblyDefinition assembly = AssemblyDefinition.CreateAssembly(
+                assemblyName,
+                "ConstDriftTarget",
+                ModuleKind.Dll))
+            {
+                TypeDefinition existingType = new TypeDefinition(
+                    "Example",
+                    "Existing",
+                    CecilTypeAttributes.Public | CecilTypeAttributes.Class,
+                    assembly.MainModule.TypeSystem.Object);
+                FieldDefinition valueField = new FieldDefinition(
+                    "Value",
+                    CecilFieldAttributes.Public | CecilFieldAttributes.Static | CecilFieldAttributes.Literal | CecilFieldAttributes.HasDefault,
+                    assembly.MainModule.TypeSystem.Int32)
+                {
+                    Constant = constantValue
+                };
+                existingType.Fields.Add(valueField);
+                assembly.MainModule.Types.Add(existingType);
+                assembly.Write(path);
+            }
+
+            using (ModuleDefinition module = ModuleDefinition.ReadModule(path))
+            {
+                return module.Mvid.ToString();
+            }
+        }
+
+        private static UnityEditor.Compilation.Assembly FindCompilationAssembly()
+        {
+            foreach (UnityEditor.Compilation.Assembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name == TestAssemblyName)
+                {
+                    return assembly;
+                }
+            }
+
+            Assert.Fail("Compilation assembly was not found.");
+            return null;
+        }
+
+        private static List<HotReloadIntroducedTypeDescriptor> CreateDescriptors(
+            TransformWorkerFileOutputDto[] files)
+        {
+            List<HotReloadIntroducedTypeDescriptor> descriptors = new List<HotReloadIntroducedTypeDescriptor>();
+            foreach (TransformWorkerFileOutputDto file in files)
+            {
+                foreach (TransformWorkerIntroducedTypeDto introducedType in file.introducedTypes)
+                {
+                    descriptors.Add(
+                        new HotReloadIntroducedTypeDescriptor(
+                            introducedType.originalAssemblyName,
+                            introducedType.originalAssemblyMvid,
+                            introducedType.metadataName,
+                            introducedType.ownerProjectRelativePath,
+                            introducedType.declarationFingerprint,
+                            introducedType.source));
+                }
+            }
+
+            return descriptors;
+        }
+
+        private static string[] BuildAbsoluteReferencePaths(string[] allReferences, string targetDllPath)
+        {
+            List<string> paths = new List<string>();
+            foreach (string reference in allReferences)
+            {
+                if (!string.IsNullOrEmpty(reference) && File.Exists(reference))
+                {
+                    paths.Add(Path.GetFullPath(reference));
+                }
+            }
+
+            string targetPath = Path.GetFullPath(targetDllPath);
+            if (!paths.Contains(targetPath))
+            {
+                paths.Add(targetPath);
+            }
+
+            return paths.ToArray();
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
@@ -245,11 +245,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 input,
                 CancellationToken.None);
 
-            Assert.That(workerResult.Success, Is.True, workerResult.ErrorMessage);
-            Assert.That(workerResult.Output.files[0].introducedTypes, Has.Length.EqualTo(1));
-            Assert.That(workerResult.Output.files[0].introducedTypes[0].metadataName, Is.EqualTo("Example.Safe"));
-            Assert.That(workerResult.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Nested"));
-
             List<HotReloadIntroducedTypeDescriptor> descriptors = CreateDescriptors(workerResult.Output.files);
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             HotReloadIntroducedTypeCompilationRequest request =
@@ -323,6 +318,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             TransformWorkerClientResult workerResult = await TransformWorkerClient.RunAsync(
                 input,
                 CancellationToken.None);
+
+            // The rejection has to be observable in the worker output before any artifact is
+            // compiled, otherwise a later assertion about the assembly could pass for the wrong
+            // reason - because compilation happened to drop the type rather than because the
+            // outer declaration was refused.
+            Assert.That(workerResult.Success, Is.True, workerResult.ErrorMessage);
+            Assert.That(workerResult.Output.files[0].introducedTypes, Has.Length.EqualTo(1));
+            Assert.That(workerResult.Output.files[0].introducedTypes[0].metadataName, Is.EqualTo("Example.Safe"));
+            Assert.That(workerResult.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Nested"));
+
             List<HotReloadIntroducedTypeDescriptor> descriptors = CreateDescriptors(workerResult.Output.files);
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             HotReloadIntroducedTypeCompilationRequest request =

--- a/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
@@ -456,31 +456,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// Verifies that an introduced type referencing a changed const from a compiled existing
-        /// type is rejected instead of compiling the artifact with the metadata assembly's old value.
-        /// </summary>
-        [Test]
-        public async Task PrepareIntroducedTypes_ChangedReferencedExistingConst_IsRejected()
-        {
-            string directory = CreateSourceDirectory("ChangedExistingConst");
-            string sourcePath = Path.Combine(directory, "Edited.cs");
-            string targetAssemblyPath = Path.Combine(directory, "ConstDriftTarget.dll");
-            string targetAssemblyMvid = CreateConstDriftTargetAssembly(targetAssemblyPath, 1);
-            File.WriteAllText(
-                sourcePath,
-                "namespace Example { public class Existing { public const int Value = 2; } public class Introduced { public int Get() { return Existing.Value; } } public class Safe { } }");
-
-            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
-                CreateConstDriftInput(sourcePath, targetAssemblyPath, targetAssemblyMvid),
-                CancellationToken.None);
-
-            Assert.That(result.Success, Is.True, result.ErrorMessage);
-            Assert.That(result.Output.files[0].introducedTypes, Has.Length.EqualTo(1));
-            Assert.That(result.Output.files[0].introducedTypes[0].metadataName, Is.EqualTo("Example.Safe"));
-            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Existing.Value"));
-        }
-
-        /// <summary>
         /// Verifies that a changed const does not reject an introduced type that does not refer to it.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
@@ -543,6 +543,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return directory;
         }
 
+        /// <summary>
+        /// Verifies that no introduced type is reported when the target assembly cannot be read,
+        /// because every declaration would otherwise look absent from it and be treated as new.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_UnreadableTargetAssembly_ReportsNoIntroducedType()
+        {
+            string directory = CreateSourceDirectory("UnreadableTarget");
+            string sourcePath = Path.Combine(directory, "Edited.cs");
+            string targetAssemblyPath = Path.Combine(directory, "Unreadable.dll");
+            File.WriteAllText(targetAssemblyPath, "this is not an assembly");
+            File.WriteAllText(sourcePath, "namespace Example { public class Introduced { } }");
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                CreateConstDriftInput(sourcePath, targetAssemblyPath, Guid.NewGuid().ToString()),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.files[0].introducedTypes, Is.Empty);
+            Assert.That(
+                result.Output.files[0].introducedTypeDiagnostics,
+                Has.Some.Contains("target assembly"));
+        }
+
         private static TransformWorkerInputDto CreateInput(string firstSourcePath, string secondSourcePath)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));

--- a/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 07dc0363739ad4ace9740e6e01420629
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
@@ -82,35 +82,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 string outputJson = File.ReadAllText(
                     outputJsonPath,
                     new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                TransformWorkerOutputDto output = JsonConvert.DeserializeObject<TransformWorkerOutputDto>(outputJson);
-                if (output == null)
-                {
-                    return TransformWorkerClientResult.Failure(
-                        "Failed to deserialize transform worker output JSON.");
-                }
-
-                if (!TryValidateRequiredPreparationOutput(input, output, out string preparationError))
-                {
-                    return TransformWorkerClientResult.Failure(preparationError);
-                }
-
-                CoalesceOutput(output);
-
-                // Why fail here: run-level parseErrors describe a failure that belongs to no
-                // single source, so there is no per-file row to carry it. Turning it into a
-                // client failure at the process boundary is what makes the per-file row count
-                // an invariant for every caller downstream.
-                if (output.parseErrors.Length > 0)
-                {
-                    return TransformWorkerClientResult.Failure(string.Join("\n", output.parseErrors));
-                }
-
-                if (!TryValidateOutput(input, output, out string validationError))
-                {
-                    return TransformWorkerClientResult.Failure(validationError);
-                }
-
-                return TransformWorkerClientResult.SuccessResult(output);
+                return InterpretOutputJson(input, outputJson);
             }
             finally
             {
@@ -119,6 +91,49 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     Directory.Delete(tempDirectory, recursive: true);
                 }
             }
+        }
+
+        /// <summary>
+        /// Turns one worker output JSON document into the client result, applying the boundary
+        /// checks in the order the process path depends on.
+        /// </summary>
+        // Why internal and separate from RunAsync: the order matters as much as the checks. The
+        // required-output check has to see the omissions before coalescing replaces them with
+        // empty arrays, so a test that calls the checks directly cannot tell whether RunAsync
+        // still performs them at all.
+        internal static TransformWorkerClientResult InterpretOutputJson(
+            TransformWorkerInputDto input,
+            string outputJson)
+        {
+            TransformWorkerOutputDto output = JsonConvert.DeserializeObject<TransformWorkerOutputDto>(outputJson);
+            if (output == null)
+            {
+                return TransformWorkerClientResult.Failure(
+                    "Failed to deserialize transform worker output JSON.");
+            }
+
+            if (!TryValidateRequiredPreparationOutput(input, output, out string preparationError))
+            {
+                return TransformWorkerClientResult.Failure(preparationError);
+            }
+
+            CoalesceOutput(output);
+
+            // Why fail here: run-level parseErrors describe a failure that belongs to no
+            // single source, so there is no per-file row to carry it. Turning it into a
+            // client failure at the process boundary is what makes the per-file row count
+            // an invariant for every caller downstream.
+            if (output.parseErrors.Length > 0)
+            {
+                return TransformWorkerClientResult.Failure(string.Join("\n", output.parseErrors));
+            }
+
+            if (!TryValidateOutput(input, output, out string validationError))
+            {
+                return TransformWorkerClientResult.Failure(validationError);
+            }
+
+            return TransformWorkerClientResult.SuccessResult(output);
         }
 
         // Why internal: tests must exercise this path instead of re-implementing ??=.
@@ -204,6 +219,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 errorMessage = string.Empty;
                 return true;
+            }
+
+            // The descriptors repeat the requested identity, so a request that carries none would
+            // produce descriptors that pass the "matches its input" check with an identity no
+            // retained artifact can be attributed to, and fail far from here when the descriptor
+            // is constructed.
+            if (string.IsNullOrWhiteSpace(input.targetAssemblyName)
+                || string.IsNullOrWhiteSpace(input.targetAssemblyMvid))
+            {
+                errorMessage = "Preparation input must name the target assembly and its module version id.";
+                return false;
             }
 
             if (output.files == null)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
@@ -89,6 +89,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         "Failed to deserialize transform worker output JSON.");
                 }
 
+                if (!TryValidateRequiredPreparationOutput(input, output, out string preparationError))
+                {
+                    return TransformWorkerClientResult.Failure(preparationError);
+                }
+
                 CoalesceOutput(output);
 
                 // Why fail here: run-level parseErrors describe a failure that belongs to no
@@ -100,9 +105,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return TransformWorkerClientResult.Failure(string.Join("\n", output.parseErrors));
                 }
 
-                Debug.Assert(
-                    output.files.Length == input.sources.Length,
-                    "A successful worker run must return one per-file output per source.");
+                if (!TryValidateOutput(input, output, out string validationError))
+                {
+                    return TransformWorkerClientResult.Failure(validationError);
+                }
+
                 return TransformWorkerClientResult.SuccessResult(output);
             }
             finally
@@ -140,6 +147,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 fileOutput.removedMethodSignatures ??= Array.Empty<TransformWorkerRemovedMethodSignatureDto>();
                 fileOutput.addedFieldNames ??= Array.Empty<string>();
                 fileOutput.addedConstNames ??= Array.Empty<string>();
+                fileOutput.introducedTypes ??= Array.Empty<TransformWorkerIntroducedTypeDto>();
+                fileOutput.introducedTypeDiagnostics ??= Array.Empty<string>();
             }
 
             foreach (TransformWorkerEntryDto entry in output.entries)
@@ -153,6 +162,127 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 entry.calledAddedMethodKeys ??= Array.Empty<string>();
                 entry.parameterTypeFullNames ??= Array.Empty<string>();
             }
+        }
+
+        internal static bool TryValidateOutput(
+            TransformWorkerInputDto input,
+            TransformWorkerOutputDto output,
+            out string errorMessage)
+        {
+            if (!TryValidateRequiredPreparationOutput(input, output, out errorMessage))
+            {
+                return false;
+            }
+
+            if (output.files == null || output.files.Length != input.sources.Length)
+            {
+                errorMessage = "Transform worker output files must have the same count as input sources.";
+                return false;
+            }
+
+            for (int index = 0; index < output.files.Length; index++)
+            {
+                TransformWorkerFileOutputDto file = output.files[index];
+                TransformWorkerSourceDto source = input.sources[index];
+                if (file == null || file.projectRelativePath != source.projectRelativePath)
+                {
+                    errorMessage = "Transform worker output files must preserve input source order.";
+                    return false;
+                }
+            }
+
+            errorMessage = string.Empty;
+            return true;
+        }
+
+        private static bool TryValidateRequiredPreparationOutput(
+            TransformWorkerInputDto input,
+            TransformWorkerOutputDto output,
+            out string errorMessage)
+        {
+            if (!string.Equals(input.operation, "prepareIntroducedTypes", StringComparison.Ordinal))
+            {
+                errorMessage = string.Empty;
+                return true;
+            }
+
+            if (output.files == null)
+            {
+                errorMessage = "Preparation output must contain files.";
+                return false;
+            }
+
+            foreach (TransformWorkerFileOutputDto file in output.files)
+            {
+                if (!TryValidatePreparationFile(file, input, out errorMessage))
+                {
+                    return false;
+                }
+            }
+
+            errorMessage = string.Empty;
+            return true;
+        }
+
+        private static bool TryValidatePreparationFile(
+            TransformWorkerFileOutputDto file,
+            TransformWorkerInputDto input,
+            out string errorMessage)
+        {
+            if (file == null || file.introducedTypes == null || file.introducedTypeDiagnostics == null)
+            {
+                errorMessage = "Preparation output must contain introducedTypes and introducedTypeDiagnostics.";
+                return false;
+            }
+
+            foreach (TransformWorkerIntroducedTypeDto introducedType in file.introducedTypes)
+            {
+                if (!TryValidatePreparationDescriptor(introducedType, file, input, out errorMessage))
+                {
+                    return false;
+                }
+            }
+
+            errorMessage = string.Empty;
+            return true;
+        }
+
+        private static bool TryValidatePreparationDescriptor(
+            TransformWorkerIntroducedTypeDto introducedType,
+            TransformWorkerFileOutputDto file,
+            TransformWorkerInputDto input,
+            out string errorMessage)
+        {
+            if (introducedType == null)
+            {
+                errorMessage = "Preparation output must not contain a null introduced type descriptor.";
+                return false;
+            }
+
+            if (introducedType.ownerProjectRelativePath == null
+                || introducedType.ownerProjectRelativePath != file.projectRelativePath)
+            {
+                errorMessage = "Preparation descriptor owner must match its file output.";
+                return false;
+            }
+
+            if (introducedType.originalAssemblyName != input.targetAssemblyName
+                || introducedType.originalAssemblyMvid != input.targetAssemblyMvid)
+            {
+                errorMessage = "Preparation descriptor assembly identity must match its input.";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(introducedType.metadataName)
+                || string.IsNullOrWhiteSpace(introducedType.declarationFingerprint)
+                || string.IsNullOrWhiteSpace(introducedType.source))
+            {
+                errorMessage = "Preparation descriptor metadataName, declarationFingerprint, and source are required.";
+                return false;
+            }
+
+            errorMessage = string.Empty;
+            return true;
         }
 
         private static void WriteUtf8NoBom(string path, string contents)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -8,6 +8,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     [Serializable]
     internal sealed class TransformWorkerInputDto
     {
+        // Null/empty retains the existing transform operation for callers that predate planning.
+        public string operation;
+
         // Edited files this worker run must transform together. One or more; every source must
         // belong to the same compilation assembly so a single shim assembly can host them all.
         // Keep in sync with TransformWorker~/WorkerInput.cs.
@@ -16,6 +19,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string[] defines;
         public string[] referencePaths;
         public string targetTypesAssemblyPath;
+        public string targetAssemblyName;
+        public string targetAssemblyMvid;
 
         // Method keys (see HotReloadMethodKeys.BuildMethodKey) already reported Failed from a
         // first compile round; the retry worker run drops these methods entirely.
@@ -92,6 +97,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Source-level names of added consts folded into edited bodies as literals.
         // Null/omitted deserializes as empty after client coalesce.
         public string[] addedConstNames;
+
+        public TransformWorkerIntroducedTypeDto[] introducedTypes;
+
+        public string[] introducedTypeDiagnostics;
+    }
+
+    /// <summary>
+    /// One top-level type declaration prepared by the transform worker for an artifact assembly.
+    /// </summary>
+    // Keep in sync with TransformWorker~/WorkerIntroducedType.cs.
+    [Serializable]
+    internal sealed class TransformWorkerIntroducedTypeDto
+    {
+        public string originalAssemblyName;
+        public string originalAssemblyMvid;
+        public string metadataName;
+        public string ownerProjectRelativePath;
+        public string declarationFingerprint;
+        public string source;
     }
 
     /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
@@ -48,6 +48,17 @@ internal static class IntroducedTypePlanner
                 continue;
             }
 
+            // Nested declarations are excluded unconditionally, so an outer type that contains one
+            // has to be refused as well. Emitting it would either drop the nested implementation
+            // its members rely on or retain a type this stage cannot manage the lifetime of.
+            if (TryFindNestedDeclaration(declaration, out string nestedName))
+            {
+                unit.IntroducedTypeDiagnostics.Add(
+                    "Nested declaration inside an introduced type requires a compile: "
+                    + CecilTypeNames.ToMetadataName(typeSymbol) + "/" + nestedName);
+                continue;
+            }
+
             if (!IsSupported(typeSymbol, declaration, unit.SemanticModel, out string reason))
             {
                 unit.IntroducedTypeDiagnostics.Add(reason + ": " + CecilTypeNames.ToMetadataName(typeSymbol));
@@ -85,6 +96,27 @@ internal static class IntroducedTypePlanner
             unit.IntroducedTypeDiagnostics.Add(
                 "Delegate introduced type requires a compile: " + CecilTypeNames.ToMetadataName(delegateSymbol));
         }
+    }
+
+    private static bool TryFindNestedDeclaration(BaseTypeDeclarationSyntax declaration, out string nestedName)
+    {
+        foreach (SyntaxNode node in declaration.DescendantNodes())
+        {
+            if (node is BaseTypeDeclarationSyntax nestedType)
+            {
+                nestedName = nestedType.Identifier.Text;
+                return true;
+            }
+
+            if (node is DelegateDeclarationSyntax nestedDelegate)
+            {
+                nestedName = nestedDelegate.Identifier.Text;
+                return true;
+            }
+        }
+
+        nestedName = string.Empty;
+        return false;
     }
 
     private static bool IsSupported(
@@ -351,6 +383,11 @@ internal static class IntroducedTypePlanner
         builder.Append('\n');
     }
 
+    // Records each dependency against the ordinal position of the declaration node that binds it.
+    // An unordered set cannot tell two aliases apart when they exchange the types they bind to:
+    // the tokens are identical and the set of referenced types is the same, so the fingerprint
+    // would stay equal while the definition changed. The position is a traversal ordinal rather
+    // than an absolute span, so it survives trivia edits and unrelated using directives.
     private static IReadOnlyList<string> CollectDependencyIdentities(
         BaseTypeDeclarationSyntax declaration,
         INamedTypeSymbol typeSymbol,
@@ -359,23 +396,37 @@ internal static class IntroducedTypePlanner
         string targetAssemblyName,
         string targetAssemblyMvid)
     {
-        HashSet<string> dependencies = new HashSet<string>(StringComparer.Ordinal);
-        AddDependency(typeSymbol, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, dependencies);
+        List<string> positionedDependencies = new List<string>();
+        HashSet<string> declaringDependency = new HashSet<string>(StringComparer.Ordinal);
+        AddDependency(typeSymbol, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, declaringDependency);
+        foreach (string identity in declaringDependency.OrderBy(identity => identity, StringComparer.Ordinal))
+        {
+            positionedDependencies.Add("self|" + identity);
+        }
+
+        int position = 0;
         foreach (SyntaxNode node in declaration.DescendantNodesAndSelf())
         {
+            HashSet<string> nodeDependencies = new HashSet<string>(StringComparer.Ordinal);
             SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(node);
-            AddDependency(symbolInfo.Symbol, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, dependencies);
+            AddDependency(symbolInfo.Symbol, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, nodeDependencies);
             foreach (ISymbol candidate in symbolInfo.CandidateSymbols)
             {
-                AddDependency(candidate, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, dependencies);
+                AddDependency(candidate, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, nodeDependencies);
             }
 
             TypeInfo typeInfo = semanticModel.GetTypeInfo(node);
-            AddDependency(typeInfo.Type, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, dependencies);
-            AddDependency(typeInfo.ConvertedType, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, dependencies);
+            AddDependency(typeInfo.Type, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, nodeDependencies);
+            AddDependency(typeInfo.ConvertedType, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, nodeDependencies);
+            foreach (string identity in nodeDependencies.OrderBy(identity => identity, StringComparer.Ordinal))
+            {
+                positionedDependencies.Add(position.ToString(CultureInfo.InvariantCulture) + "|" + identity);
+            }
+
+            position++;
         }
 
-        return dependencies.OrderBy(identity => identity, StringComparer.Ordinal).ToArray();
+        return positionedDependencies;
     }
 
     private static void AddDependency(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
@@ -1,0 +1,431 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+// Identifies newly declared top-level type definitions without mixing parse-failed files into
+// semantic analysis. Binding/rewriting callers intentionally remains a later-stage concern.
+internal static class IntroducedTypePlanner
+{
+    internal static void Plan(
+        WorkerSourceUnit unit,
+        IAssemblySymbol targetAssembly,
+        string targetAssemblyName,
+        string targetAssemblyMvid,
+        IReadOnlyList<string> defineSymbols,
+        IReadOnlyList<UsingDirectiveSyntax> assemblyGlobalUsings)
+    {
+        foreach (BaseTypeDeclarationSyntax declaration in unit.Root.DescendantNodes().OfType<BaseTypeDeclarationSyntax>())
+        {
+            INamedTypeSymbol typeSymbol = unit.SemanticModel.GetDeclaredSymbol(declaration);
+            if (typeSymbol == null)
+            {
+                unit.IntroducedTypeDiagnostics.Add("Could not resolve a declared type symbol.");
+                continue;
+            }
+
+            if (CompiledMemberMatcher.FindCompiledType(typeSymbol, targetAssembly) != null)
+            {
+                continue;
+            }
+
+            if (typeSymbol.ContainingType != null)
+            {
+                unit.IntroducedTypeDiagnostics.Add(
+                    "Nested type requires a compile: " + CecilTypeNames.ToMetadataName(typeSymbol));
+                continue;
+            }
+
+            if (!IsSupported(typeSymbol, declaration, unit.SemanticModel, out string reason))
+            {
+                unit.IntroducedTypeDiagnostics.Add(reason + ": " + CecilTypeNames.ToMetadataName(typeSymbol));
+                continue;
+            }
+
+            unit.IntroducedTypes.Add(
+                new WorkerIntroducedType
+                {
+                    OriginalAssemblyName = targetAssemblyName ?? string.Empty,
+                    OriginalAssemblyMvid = targetAssemblyMvid ?? string.Empty,
+                    MetadataName = CecilTypeNames.ToMetadataName(typeSymbol),
+                    OwnerProjectRelativePath = unit.Input.ProjectRelativePath,
+                    DeclarationFingerprint = ComputeFingerprint(
+                        unit.Root,
+                        declaration,
+                        defineSymbols,
+                        typeSymbol,
+                        unit.SemanticModel,
+                        targetAssembly,
+                        targetAssemblyName,
+                        targetAssemblyMvid),
+                    Source = BuildTypeSource(unit.Root, typeSymbol, declaration, assemblyGlobalUsings)
+                });
+        }
+
+        foreach (DelegateDeclarationSyntax declaration in unit.Root.DescendantNodes().OfType<DelegateDeclarationSyntax>())
+        {
+            INamedTypeSymbol delegateSymbol = unit.SemanticModel.GetDeclaredSymbol(declaration);
+            if (delegateSymbol == null || CompiledMemberMatcher.FindCompiledType(delegateSymbol, targetAssembly) != null)
+            {
+                continue;
+            }
+
+            unit.IntroducedTypeDiagnostics.Add(
+                "Delegate introduced type requires a compile: " + CecilTypeNames.ToMetadataName(delegateSymbol));
+        }
+    }
+
+    private static bool IsSupported(
+        INamedTypeSymbol typeSymbol,
+        BaseTypeDeclarationSyntax declaration,
+        SemanticModel semanticModel,
+        out string reason)
+    {
+        if (typeSymbol.Arity != 0)
+        {
+            reason = "Generic introduced type requires a compile";
+            return false;
+        }
+
+        if (declaration.Modifiers.Any(SyntaxKind.PartialKeyword))
+        {
+            reason = "Partial introduced type requires a compile";
+            return false;
+        }
+
+        if (declaration is RecordDeclarationSyntax)
+        {
+            reason = "Record introduced type requires a compile";
+            return false;
+        }
+
+        if (typeSymbol.DeclaredAccessibility != Accessibility.Public)
+        {
+            reason = "Non-public introduced type requires a compile";
+            return false;
+        }
+
+        if (typeSymbol.IsRefLikeType)
+        {
+            reason = "Ref-like introduced type requires a compile";
+            return false;
+        }
+
+        if (ContainsUnsafeCode(declaration))
+        {
+            reason = "Unsafe introduced type requires a compile";
+            return false;
+        }
+
+        if (InheritsUnityObject(typeSymbol))
+        {
+            reason = "Unity object introduced type requires a compile";
+            return false;
+        }
+
+        if (HasSerializableAttribute(typeSymbol))
+        {
+            reason = "Serializable introduced type requires a compile";
+            return false;
+        }
+
+        if (HasModuleInitializer(declaration, semanticModel))
+        {
+            reason = "Module initializer introduced type requires a compile";
+            return false;
+        }
+
+        if (typeSymbol.TypeKind != TypeKind.Class
+            && typeSymbol.TypeKind != TypeKind.Struct
+            && typeSymbol.TypeKind != TypeKind.Enum
+            && typeSymbol.TypeKind != TypeKind.Interface)
+        {
+            reason = "Unsupported introduced type requires a compile";
+            return false;
+        }
+
+        reason = string.Empty;
+        return true;
+    }
+
+    private static string BuildTypeSource(
+        CompilationUnitSyntax root,
+        INamedTypeSymbol typeSymbol,
+        BaseTypeDeclarationSyntax declaration,
+        IReadOnlyList<UsingDirectiveSyntax> assemblyGlobalUsings)
+    {
+        StringBuilder builder = new StringBuilder();
+        foreach (ExternAliasDirectiveSyntax externAlias in root.Externs)
+        {
+            builder.Append(externAlias.ToFullString());
+        }
+
+        List<BaseNamespaceDeclarationSyntax> namespaceDeclarations = declaration.Ancestors()
+            .OfType<BaseNamespaceDeclarationSyntax>()
+            .Reverse()
+            .ToList();
+        if (namespaceDeclarations.Count > 0)
+        {
+            AppendRootUsings(builder, root, assemblyGlobalUsings);
+            foreach (BaseNamespaceDeclarationSyntax namespaceDeclaration in namespaceDeclarations)
+            {
+                builder.Append("namespace ");
+                builder.Append(namespaceDeclaration.Name.ToString());
+                builder.AppendLine();
+                builder.AppendLine("{");
+                foreach (UsingDirectiveSyntax usingDirective in namespaceDeclaration.Usings)
+                {
+                    builder.Append(usingDirective.ToFullString());
+                }
+            }
+
+            builder.Append(declaration.ToFullString());
+            for (int index = 0; index < namespaceDeclarations.Count; index++)
+            {
+                builder.AppendLine("}");
+            }
+            return builder.ToString();
+        }
+
+        AppendRootUsings(builder, root, assemblyGlobalUsings);
+        builder.Append(declaration.ToFullString());
+        return builder.ToString();
+    }
+
+    private static void AppendRootUsings(
+        StringBuilder builder,
+        CompilationUnitSyntax root,
+        IReadOnlyList<UsingDirectiveSyntax> assemblyGlobalUsings)
+    {
+        foreach (UsingDirectiveSyntax usingDirective in root.Usings)
+        {
+            builder.Append(usingDirective.WithGlobalKeyword(default).ToFullString());
+        }
+
+        foreach (UsingDirectiveSyntax assemblyGlobalUsing in assemblyGlobalUsings)
+        {
+            if (WorkerUsingCollector.ContainsEquivalentUsing(root.Usings.ToList(), assemblyGlobalUsing))
+            {
+                continue;
+            }
+
+            builder.Append(assemblyGlobalUsing.ToFullString());
+        }
+    }
+
+    private static bool ContainsUnsafeCode(BaseTypeDeclarationSyntax declaration)
+    {
+        return declaration.DescendantTokens().Any(token => token.IsKind(SyntaxKind.UnsafeKeyword));
+    }
+
+    private static bool InheritsUnityObject(INamedTypeSymbol typeSymbol)
+    {
+        INamedTypeSymbol current = typeSymbol;
+        while (current != null)
+        {
+            if (current.ToDisplayString() == "UnityEngine.Object")
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    private static bool HasSerializableAttribute(INamedTypeSymbol typeSymbol)
+    {
+        foreach (AttributeData attribute in typeSymbol.GetAttributes())
+        {
+            if (attribute.AttributeClass != null
+                && attribute.AttributeClass.ToDisplayString() == "System.SerializableAttribute")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasModuleInitializer(
+        BaseTypeDeclarationSyntax declaration,
+        SemanticModel semanticModel)
+    {
+        if (declaration is not TypeDeclarationSyntax typeDeclaration)
+        {
+            return false;
+        }
+
+        foreach (MethodDeclarationSyntax method in typeDeclaration.Members.OfType<MethodDeclarationSyntax>())
+        {
+            IMethodSymbol methodSymbol = semanticModel.GetDeclaredSymbol(method);
+            if (methodSymbol == null)
+            {
+                continue;
+            }
+
+            foreach (AttributeData attribute in methodSymbol.GetAttributes())
+            {
+                if (attribute.AttributeClass != null
+                    && attribute.AttributeClass.ToDisplayString()
+                        == "System.Runtime.CompilerServices.ModuleInitializerAttribute")
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static string ComputeFingerprint(
+        CompilationUnitSyntax root,
+        BaseTypeDeclarationSyntax declaration,
+        IReadOnlyList<string> defineSymbols,
+        INamedTypeSymbol typeSymbol,
+        SemanticModel semanticModel,
+        IAssemblySymbol targetAssembly,
+        string targetAssemblyName,
+        string targetAssemblyMvid)
+    {
+        StringBuilder input = new StringBuilder();
+        AppendTokens(input, declaration.DescendantTokens());
+
+        foreach (string defineSymbol in defineSymbols.OrderBy(symbol => symbol, StringComparer.Ordinal))
+        {
+            AppendValue(input, defineSymbol);
+        }
+
+        foreach (string dependencyIdentity in CollectDependencyIdentities(
+            declaration,
+            typeSymbol,
+            semanticModel,
+            targetAssembly,
+            targetAssemblyName,
+            targetAssemblyMvid))
+        {
+            AppendValue(input, dependencyIdentity);
+        }
+
+        byte[] sourceBytes = Encoding.UTF8.GetBytes(input.ToString());
+        using SHA256 hash = SHA256.Create();
+        byte[] bytes = hash.ComputeHash(sourceBytes);
+        StringBuilder builder = new StringBuilder(bytes.Length * 2);
+        for (int index = 0; index < bytes.Length; index++)
+        {
+            builder.Append(bytes[index].ToString("x2", CultureInfo.InvariantCulture));
+        }
+
+        return builder.ToString();
+    }
+
+    private static void AppendTokens(StringBuilder builder, IEnumerable<SyntaxToken> tokens)
+    {
+        foreach (SyntaxToken token in tokens)
+        {
+            builder.Append(token.RawKind.ToString(CultureInfo.InvariantCulture));
+            builder.Append(':');
+            AppendValue(builder, token.Text);
+        }
+    }
+
+    private static void AppendValue(StringBuilder builder, string value)
+    {
+        string safeValue = value ?? string.Empty;
+        builder.Append(safeValue.Length.ToString(CultureInfo.InvariantCulture));
+        builder.Append(':');
+        builder.Append(safeValue);
+        builder.Append('\n');
+    }
+
+    private static IReadOnlyList<string> CollectDependencyIdentities(
+        BaseTypeDeclarationSyntax declaration,
+        INamedTypeSymbol typeSymbol,
+        SemanticModel semanticModel,
+        IAssemblySymbol targetAssembly,
+        string targetAssemblyName,
+        string targetAssemblyMvid)
+    {
+        HashSet<string> dependencies = new HashSet<string>(StringComparer.Ordinal);
+        AddDependency(typeSymbol, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, dependencies);
+        foreach (SyntaxNode node in declaration.DescendantNodesAndSelf())
+        {
+            SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(node);
+            AddDependency(symbolInfo.Symbol, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, dependencies);
+            foreach (ISymbol candidate in symbolInfo.CandidateSymbols)
+            {
+                AddDependency(candidate, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, dependencies);
+            }
+
+            TypeInfo typeInfo = semanticModel.GetTypeInfo(node);
+            AddDependency(typeInfo.Type, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, dependencies);
+            AddDependency(typeInfo.ConvertedType, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, dependencies);
+        }
+
+        return dependencies.OrderBy(identity => identity, StringComparer.Ordinal).ToArray();
+    }
+
+    private static void AddDependency(
+        ISymbol symbol,
+        SemanticModel semanticModel,
+        IAssemblySymbol targetAssembly,
+        string targetAssemblyName,
+        string targetAssemblyMvid,
+        HashSet<string> dependencies)
+    {
+        if (symbol == null)
+        {
+            return;
+        }
+
+        INamedTypeSymbol namedType = symbol as INamedTypeSymbol;
+        if (symbol is IMethodSymbol methodSymbol)
+        {
+            namedType = methodSymbol.ContainingType;
+        }
+        else if (symbol is IPropertySymbol propertySymbol)
+        {
+            namedType = propertySymbol.ContainingType;
+        }
+        else if (symbol is IFieldSymbol fieldSymbol)
+        {
+            namedType = fieldSymbol.ContainingType;
+        }
+
+        if (namedType == null)
+        {
+            return;
+        }
+
+        IAssemblySymbol containingAssembly = namedType.ContainingAssembly;
+        if (containingAssembly == null)
+        {
+            return;
+        }
+
+        if (SymbolEqualityComparer.Default.Equals(containingAssembly, semanticModel.Compilation.Assembly)
+            || SymbolEqualityComparer.Default.Equals(containingAssembly, targetAssembly))
+        {
+            dependencies.Add((targetAssemblyName ?? string.Empty)
+                + "|" + (targetAssemblyMvid ?? string.Empty)
+                + "|" + CecilTypeNames.ToMetadataName(namedType.OriginalDefinition));
+            return;
+        }
+
+        dependencies.Add(containingAssembly.Identity.GetDisplayName()
+            + "|" + CecilTypeNames.ToMetadataName(namedType.OriginalDefinition));
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePreparation.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+// Plans which newly written top-level declarations of one compilation assembly could be
+// introduced without a compile, and refuses the run outright when the inputs the plan depends on
+// could not be read or describe a different assembly than the request named.
+internal static class IntroducedTypePreparation
+{
+    internal static WorkerOutput Prepare(WorkerInput input)
+    {
+        CSharpParseOptions parseOptions = new CSharpParseOptions(
+            languageVersion: LanguageVersion.Latest,
+            preprocessorSymbols: input.Defines);
+        List<WorkerSourceUnit> units = new List<WorkerSourceUnit>(input.Sources.Length);
+        List<SyntaxTree> syntaxTrees = new List<SyntaxTree>(input.Sources.Length);
+        List<WorkerSourceUnit> analyzableUnits = new List<WorkerSourceUnit>(input.Sources.Length);
+        foreach (WorkerSourceInput source in input.Sources)
+        {
+            WorkerSourceUnit unit = WorkerSourceLoader.Load(source, parseOptions);
+            units.Add(unit);
+            if (unit.SyntaxTree != null && unit.ParseErrors.Count == 0)
+            {
+                syntaxTrees.Add(unit.SyntaxTree);
+                analyzableUnits.Add(unit);
+            }
+        }
+
+        List<string> referenceParseErrors = new List<string>();
+        (List<MetadataReference> references, MetadataReference targetTypesReference) =
+            WorkerGroupPipeline.CollectMetadataReferences(input, referenceParseErrors);
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName: "UloopHotReloadIntroducedTypePlanning",
+            syntaxTrees: syntaxTrees,
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        AppendUnreadableReferenceErrors(compilation, references, referenceParseErrors);
+        IAssemblySymbol targetAssembly = WorkerGroupPipeline.ResolveTargetTypesAssemblySymbol(compilation, targetTypesReference);
+        List<CompilationUnitSyntax> analyzableRoots = new List<CompilationUnitSyntax>(analyzableUnits.Count);
+        foreach (WorkerSourceUnit analyzableUnit in analyzableUnits)
+        {
+            analyzableRoots.Add(analyzableUnit.Root);
+        }
+
+        List<UsingDirectiveSyntax> assemblyGlobalUsings =
+            WorkerUsingCollector.CollectAssemblyGlobalUsings(input, parseOptions, analyzableRoots);
+        string incompleteInputsDiagnostic =
+            DescribeIncompleteCompilationInputs(input, targetAssembly, referenceParseErrors);
+        WorkerFileOutput[] files = new WorkerFileOutput[units.Count];
+        for (int index = 0; index < units.Count; index++)
+        {
+            WorkerSourceUnit unit = units[index];
+            if (unit.SyntaxTree != null && unit.ParseErrors.Count == 0)
+            {
+                if (incompleteInputsDiagnostic == null)
+                {
+                    unit.SemanticModel = compilation.GetSemanticModel(unit.SyntaxTree, ignoreAccessibility: false);
+                    IntroducedTypePlanner.Plan(
+                        unit,
+                        targetAssembly,
+                        input.TargetAssemblyName,
+                        input.TargetAssemblyMvid,
+                        input.Defines,
+                        assemblyGlobalUsings);
+                }
+                else
+                {
+                    unit.IntroducedTypeDiagnostics.Add(incompleteInputsDiagnostic);
+                }
+            }
+
+            unit.ParseErrors.AddRange(referenceParseErrors);
+            files[index] = new WorkerFileOutput
+            {
+                ProjectRelativePath = unit.Input.ProjectRelativePath,
+                SourceContentSha256 = unit.SourceContentSha256,
+                ParseErrors = unit.ParseErrors.ToArray(),
+                DeclarationDriftWarnings = Array.Empty<string>(),
+                RemovedMembers = Array.Empty<WorkerRemovedMember>(),
+                RemovedMethodSignatures = Array.Empty<WorkerRemovedMethodSignature>(),
+                AddedFieldNames = Array.Empty<string>(),
+                AddedConstNames = Array.Empty<string>(),
+                IntroducedTypes = unit.IntroducedTypes.ToArray(),
+                IntroducedTypeDiagnostics = unit.IntroducedTypeDiagnostics.ToArray()
+            };
+        }
+
+        return new WorkerOutput
+        {
+            ShimSource = string.Empty,
+            Entries = Array.Empty<WorkerEntry>(),
+            Skipped = Array.Empty<WorkerSkipped>(),
+            Files = files,
+            ParseErrors = Array.Empty<string>(),
+            SiblingConstDriftWarnings = Array.Empty<string>(),
+            UnchangedMethods = Array.Empty<WorkerUnchangedMethod>()
+        };
+    }
+
+    // The reason planning cannot run, or null when every input the plan depends on was readable
+    // and describes the assembly the request named.
+    private static string DescribeIncompleteCompilationInputs(
+        WorkerInput input,
+        IAssemblySymbol targetAssembly,
+        List<string> referenceParseErrors)
+    {
+        // Planning decides a declaration is new by failing to find it in the target assembly, so
+        // an unresolved target symbol would make every type already in that assembly look newly
+        // introduced, and a reference that failed to parse would settle the supported-boundary
+        // questions against an incomplete picture. Neither may produce a descriptor; the file
+        // carries the reason instead.
+        if (targetAssembly == null || referenceParseErrors.Count > 0)
+        {
+            return "Introduced types require a compile: the target assembly or its references could not be read.";
+        }
+
+        // Every descriptor carries the requested identity, and a retained artifact is only valid
+        // for the assembly generation it was planned against. Reading the identity back from the
+        // file that was actually analysed is what stops a stale request from producing artifacts
+        // that claim an assembly the planning never looked at.
+        if (!TargetAssemblyIdentityMatchesRequest(input, targetAssembly))
+        {
+            return "Introduced types require a compile: the target assembly identity does not match the request.";
+        }
+
+        return null;
+    }
+
+    private static bool TargetAssemblyIdentityMatchesRequest(WorkerInput input, IAssemblySymbol targetAssembly)
+    {
+        // Assembly names are compared case-insensitively by the runtime, so a case difference in
+        // the request is the same assembly and must not reject the plan.
+        if (!string.Equals(
+                input.TargetAssemblyName,
+                targetAssembly.Identity.Name,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!Guid.TryParse(input.TargetAssemblyMvid, out Guid requestedMvid) || requestedMvid == Guid.Empty)
+        {
+            return false;
+        }
+
+        return requestedMvid == ReadModuleVersionId(input.TargetTypesAssemblyPath);
+    }
+
+    private static Guid ReadModuleVersionId(string assemblyPath)
+    {
+        if (string.IsNullOrEmpty(assemblyPath))
+        {
+            return Guid.Empty;
+        }
+
+        try
+        {
+            using (ModuleMetadata metadata = ModuleMetadata.CreateFromFile(assemblyPath))
+            {
+                return metadata.GetModuleVersionId();
+            }
+        }
+        catch (BadImageFormatException)
+        {
+            return Guid.Empty;
+        }
+        catch (IOException)
+        {
+            return Guid.Empty;
+        }
+    }
+
+    // A reference file that exists but is not readable managed metadata never reaches the
+    // compilation, so the boundary checks would bind against error types and answer "not a Unity
+    // object", "not serializable" and the like for declarations nothing could classify.
+    private static void AppendUnreadableReferenceErrors(
+        CSharpCompilation compilation,
+        List<MetadataReference> references,
+        List<string> parseErrors)
+    {
+        foreach (MetadataReference reference in references)
+        {
+            if (compilation.GetAssemblyOrModuleSymbol(reference) != null)
+            {
+                continue;
+            }
+
+            // A reference the compilation dropped because another reference already supplied the
+            // same assembly identity also answers null here, so the file itself is read before it
+            // is called unreadable.
+            if (CanReadAssemblyMetadata(reference.Display))
+            {
+                continue;
+            }
+
+            parseErrors.Add("Reference could not be read: " + reference.Display);
+        }
+    }
+
+    private static bool CanReadAssemblyMetadata(string assemblyPath)
+    {
+        if (string.IsNullOrEmpty(assemblyPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            using (AssemblyMetadata metadata = AssemblyMetadata.CreateFromFile(assemblyPath))
+            {
+                return metadata.GetModules().Length > 0;
+            }
+        }
+        catch (BadImageFormatException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -83,7 +83,7 @@ public static class TransformWorkerProgram
     {
         WorkerInput input = ReadInput(inputJsonPath);
         WorkerOutput invalidSources = TryCreateInvalidSourcesOutput(input);
-        WorkerOutput output = invalidSources ?? WorkerGroupPipeline.Transform(input);
+        WorkerOutput output = invalidSources ?? WorkerGroupPipeline.Run(input);
         WriteOutput(outputJsonPath, output);
         return 0;
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerFileOutput.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerFileOutput.cs
@@ -38,4 +38,10 @@ internal sealed class WorkerFileOutput
     public string[] AddedFieldNames { get; set; }
 
     public string[] AddedConstNames { get; set; }
+
+    // Keep in sync with TransformWorkerDtos.cs TransformWorkerFileOutputDto.introducedTypes.
+    public WorkerIntroducedType[] IntroducedTypes { get; set; }
+
+    // Keep in sync with TransformWorkerDtos.cs TransformWorkerFileOutputDto.introducedTypeDiagnostics.
+    public string[] IntroducedTypeDiagnostics { get; set; }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
@@ -27,7 +27,7 @@ internal static class WorkerGroupPipeline
     {
         if (string.Equals(input.Operation, PrepareIntroducedTypesOperation, StringComparison.Ordinal))
         {
-            return PrepareIntroducedTypes(input);
+            return IntroducedTypePreparation.Prepare(input);
         }
 
         if (!string.IsNullOrEmpty(input.Operation))
@@ -184,100 +184,6 @@ internal static class WorkerGroupPipeline
             addedFieldCatalog);
     }
 
-    private static WorkerOutput PrepareIntroducedTypes(WorkerInput input)
-    {
-        CSharpParseOptions parseOptions = new CSharpParseOptions(
-            languageVersion: LanguageVersion.Latest,
-            preprocessorSymbols: input.Defines);
-        List<WorkerSourceUnit> units = new List<WorkerSourceUnit>(input.Sources.Length);
-        List<SyntaxTree> syntaxTrees = new List<SyntaxTree>(input.Sources.Length);
-        List<WorkerSourceUnit> analyzableUnits = new List<WorkerSourceUnit>(input.Sources.Length);
-        foreach (WorkerSourceInput source in input.Sources)
-        {
-            WorkerSourceUnit unit = WorkerSourceLoader.Load(source, parseOptions);
-            units.Add(unit);
-            if (unit.SyntaxTree != null && unit.ParseErrors.Count == 0)
-            {
-                syntaxTrees.Add(unit.SyntaxTree);
-                analyzableUnits.Add(unit);
-            }
-        }
-
-        List<string> referenceParseErrors = new List<string>();
-        (List<MetadataReference> references, MetadataReference targetTypesReference) =
-            CollectMetadataReferences(input, referenceParseErrors);
-        CSharpCompilation compilation = CSharpCompilation.Create(
-            assemblyName: "UloopHotReloadIntroducedTypePlanning",
-            syntaxTrees: syntaxTrees,
-            references: references,
-            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
-        IAssemblySymbol targetAssembly = ResolveTargetTypesAssemblySymbol(compilation, targetTypesReference);
-        List<CompilationUnitSyntax> analyzableRoots = new List<CompilationUnitSyntax>(analyzableUnits.Count);
-        foreach (WorkerSourceUnit analyzableUnit in analyzableUnits)
-        {
-            analyzableRoots.Add(analyzableUnit.Root);
-        }
-
-        List<UsingDirectiveSyntax> assemblyGlobalUsings =
-            WorkerUsingCollector.CollectAssemblyGlobalUsings(input, parseOptions, analyzableRoots);
-        // Planning decides a declaration is new by failing to find it in the target assembly, so
-        // an unresolved target symbol would make every type already in that assembly look newly
-        // introduced, and a reference that failed to parse would settle the supported-boundary
-        // questions against an incomplete picture. Neither may produce a descriptor; the file
-        // carries the reason instead.
-        bool hasCompleteCompilationInputs = targetAssembly != null && referenceParseErrors.Count == 0;
-        WorkerFileOutput[] files = new WorkerFileOutput[units.Count];
-        for (int index = 0; index < units.Count; index++)
-        {
-            WorkerSourceUnit unit = units[index];
-            if (unit.SyntaxTree != null && unit.ParseErrors.Count == 0)
-            {
-                if (hasCompleteCompilationInputs)
-                {
-                    unit.SemanticModel = compilation.GetSemanticModel(unit.SyntaxTree, ignoreAccessibility: false);
-                    IntroducedTypePlanner.Plan(
-                        unit,
-                        targetAssembly,
-                        input.TargetAssemblyName,
-                        input.TargetAssemblyMvid,
-                        input.Defines,
-                        assemblyGlobalUsings);
-                }
-                else
-                {
-                    unit.IntroducedTypeDiagnostics.Add(
-                        "Introduced types require a compile: the target assembly or its references could not be read.");
-                }
-            }
-
-            unit.ParseErrors.AddRange(referenceParseErrors);
-            files[index] = new WorkerFileOutput
-            {
-                ProjectRelativePath = unit.Input.ProjectRelativePath,
-                SourceContentSha256 = unit.SourceContentSha256,
-                ParseErrors = unit.ParseErrors.ToArray(),
-                DeclarationDriftWarnings = Array.Empty<string>(),
-                RemovedMembers = Array.Empty<WorkerRemovedMember>(),
-                RemovedMethodSignatures = Array.Empty<WorkerRemovedMethodSignature>(),
-                AddedFieldNames = Array.Empty<string>(),
-                AddedConstNames = Array.Empty<string>(),
-                IntroducedTypes = unit.IntroducedTypes.ToArray(),
-                IntroducedTypeDiagnostics = unit.IntroducedTypeDiagnostics.ToArray()
-            };
-        }
-
-        return new WorkerOutput
-        {
-            ShimSource = string.Empty,
-            Entries = Array.Empty<WorkerEntry>(),
-            Skipped = Array.Empty<WorkerSkipped>(),
-            Files = files,
-            ParseErrors = Array.Empty<string>(),
-            SiblingConstDriftWarnings = Array.Empty<string>(),
-            UnchangedMethods = Array.Empty<WorkerUnchangedMethod>()
-        };
-    }
-
     private static WorkerOutput CreateRunFailureOutput(string parseError)
     {
         return new WorkerOutput
@@ -370,7 +276,7 @@ internal static class WorkerGroupPipeline
             unit.KindChangeSyntaxKeys.EventSyntaxKeys);
     }
 
-    private static (List<MetadataReference> References, MetadataReference TargetTypesReference)
+    internal static (List<MetadataReference> References, MetadataReference TargetTypesReference)
         CollectMetadataReferences(WorkerInput input, List<string> parseErrors)
     {
         string targetTypesFullPath =
@@ -409,8 +315,7 @@ internal static class WorkerGroupPipeline
 
         return (references, targetTypesReference);
     }
-
-    private static IAssemblySymbol ResolveTargetTypesAssemblySymbol(
+    internal static IAssemblySymbol ResolveTargetTypesAssemblySymbol(
         CSharpCompilation compilation,
         MetadataReference targetTypesReference)
     {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
@@ -220,20 +220,34 @@ internal static class WorkerGroupPipeline
 
         List<UsingDirectiveSyntax> assemblyGlobalUsings =
             WorkerUsingCollector.CollectAssemblyGlobalUsings(input, parseOptions, analyzableRoots);
+        // Planning decides a declaration is new by failing to find it in the target assembly, so
+        // an unresolved target symbol would make every type already in that assembly look newly
+        // introduced, and a reference that failed to parse would settle the supported-boundary
+        // questions against an incomplete picture. Neither may produce a descriptor; the file
+        // carries the reason instead.
+        bool hasCompleteCompilationInputs = targetAssembly != null && referenceParseErrors.Count == 0;
         WorkerFileOutput[] files = new WorkerFileOutput[units.Count];
         for (int index = 0; index < units.Count; index++)
         {
             WorkerSourceUnit unit = units[index];
             if (unit.SyntaxTree != null && unit.ParseErrors.Count == 0)
             {
-                unit.SemanticModel = compilation.GetSemanticModel(unit.SyntaxTree, ignoreAccessibility: false);
-                IntroducedTypePlanner.Plan(
-                    unit,
-                    targetAssembly,
-                    input.TargetAssemblyName,
-                    input.TargetAssemblyMvid,
-                    input.Defines,
-                    assemblyGlobalUsings);
+                if (hasCompleteCompilationInputs)
+                {
+                    unit.SemanticModel = compilation.GetSemanticModel(unit.SyntaxTree, ignoreAccessibility: false);
+                    IntroducedTypePlanner.Plan(
+                        unit,
+                        targetAssembly,
+                        input.TargetAssemblyName,
+                        input.TargetAssemblyMvid,
+                        input.Defines,
+                        assemblyGlobalUsings);
+                }
+                else
+                {
+                    unit.IntroducedTypeDiagnostics.Add(
+                        "Introduced types require a compile: the target assembly or its references could not be read.");
+                }
             }
 
             unit.ParseErrors.AddRange(referenceParseErrors);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
@@ -21,6 +21,23 @@ using Microsoft.CodeAnalysis.Text;
 // edited in one file call a member added in another.
 internal static class WorkerGroupPipeline
 {
+    internal const string PrepareIntroducedTypesOperation = "prepareIntroducedTypes";
+
+    internal static WorkerOutput Run(WorkerInput input)
+    {
+        if (string.Equals(input.Operation, PrepareIntroducedTypesOperation, StringComparison.Ordinal))
+        {
+            return PrepareIntroducedTypes(input);
+        }
+
+        if (!string.IsNullOrEmpty(input.Operation))
+        {
+            return CreateRunFailureOutput("Unknown worker operation: " + input.Operation);
+        }
+
+        return Transform(input);
+    }
+
     internal static WorkerOutput Transform(WorkerInput input)
     {
         CSharpParseOptions parseOptions = new CSharpParseOptions(
@@ -165,6 +182,100 @@ internal static class WorkerGroupPipeline
             unchangedMethods,
             siblingConstDriftWarnings,
             addedFieldCatalog);
+    }
+
+    private static WorkerOutput PrepareIntroducedTypes(WorkerInput input)
+    {
+        CSharpParseOptions parseOptions = new CSharpParseOptions(
+            languageVersion: LanguageVersion.Latest,
+            preprocessorSymbols: input.Defines);
+        List<WorkerSourceUnit> units = new List<WorkerSourceUnit>(input.Sources.Length);
+        List<SyntaxTree> syntaxTrees = new List<SyntaxTree>(input.Sources.Length);
+        List<WorkerSourceUnit> analyzableUnits = new List<WorkerSourceUnit>(input.Sources.Length);
+        foreach (WorkerSourceInput source in input.Sources)
+        {
+            WorkerSourceUnit unit = WorkerSourceLoader.Load(source, parseOptions);
+            units.Add(unit);
+            if (unit.SyntaxTree != null && unit.ParseErrors.Count == 0)
+            {
+                syntaxTrees.Add(unit.SyntaxTree);
+                analyzableUnits.Add(unit);
+            }
+        }
+
+        List<string> referenceParseErrors = new List<string>();
+        (List<MetadataReference> references, MetadataReference targetTypesReference) =
+            CollectMetadataReferences(input, referenceParseErrors);
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName: "UloopHotReloadIntroducedTypePlanning",
+            syntaxTrees: syntaxTrees,
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        IAssemblySymbol targetAssembly = ResolveTargetTypesAssemblySymbol(compilation, targetTypesReference);
+        List<CompilationUnitSyntax> analyzableRoots = new List<CompilationUnitSyntax>(analyzableUnits.Count);
+        foreach (WorkerSourceUnit analyzableUnit in analyzableUnits)
+        {
+            analyzableRoots.Add(analyzableUnit.Root);
+        }
+
+        List<UsingDirectiveSyntax> assemblyGlobalUsings =
+            WorkerUsingCollector.CollectAssemblyGlobalUsings(input, parseOptions, analyzableRoots);
+        WorkerFileOutput[] files = new WorkerFileOutput[units.Count];
+        for (int index = 0; index < units.Count; index++)
+        {
+            WorkerSourceUnit unit = units[index];
+            if (unit.SyntaxTree != null && unit.ParseErrors.Count == 0)
+            {
+                unit.SemanticModel = compilation.GetSemanticModel(unit.SyntaxTree, ignoreAccessibility: false);
+                IntroducedTypePlanner.Plan(
+                    unit,
+                    targetAssembly,
+                    input.TargetAssemblyName,
+                    input.TargetAssemblyMvid,
+                    input.Defines,
+                    assemblyGlobalUsings);
+            }
+
+            unit.ParseErrors.AddRange(referenceParseErrors);
+            files[index] = new WorkerFileOutput
+            {
+                ProjectRelativePath = unit.Input.ProjectRelativePath,
+                SourceContentSha256 = unit.SourceContentSha256,
+                ParseErrors = unit.ParseErrors.ToArray(),
+                DeclarationDriftWarnings = Array.Empty<string>(),
+                RemovedMembers = Array.Empty<WorkerRemovedMember>(),
+                RemovedMethodSignatures = Array.Empty<WorkerRemovedMethodSignature>(),
+                AddedFieldNames = Array.Empty<string>(),
+                AddedConstNames = Array.Empty<string>(),
+                IntroducedTypes = unit.IntroducedTypes.ToArray(),
+                IntroducedTypeDiagnostics = unit.IntroducedTypeDiagnostics.ToArray()
+            };
+        }
+
+        return new WorkerOutput
+        {
+            ShimSource = string.Empty,
+            Entries = Array.Empty<WorkerEntry>(),
+            Skipped = Array.Empty<WorkerSkipped>(),
+            Files = files,
+            ParseErrors = Array.Empty<string>(),
+            SiblingConstDriftWarnings = Array.Empty<string>(),
+            UnchangedMethods = Array.Empty<WorkerUnchangedMethod>()
+        };
+    }
+
+    private static WorkerOutput CreateRunFailureOutput(string parseError)
+    {
+        return new WorkerOutput
+        {
+            ShimSource = string.Empty,
+            Entries = Array.Empty<WorkerEntry>(),
+            Skipped = Array.Empty<WorkerSkipped>(),
+            Files = Array.Empty<WorkerFileOutput>(),
+            ParseErrors = new[] { parseError },
+            SiblingConstDriftWarnings = Array.Empty<string>(),
+            UnchangedMethods = Array.Empty<WorkerUnchangedMethod>()
+        };
     }
 
     // Everything one unit contributes before the group-wide guard and emit: its drift warnings,
@@ -358,7 +469,9 @@ internal static class WorkerGroupPipeline
             RemovedMembers = unit.RemovedMembers.ToArray(),
             RemovedMethodSignatures = unit.RemovedMethodSignatures.ToArray(),
             AddedFieldNames = addedFieldCatalog.ListRewrittenAddedFieldDisplayNames(projectRelativePath),
-            AddedConstNames = addedFieldCatalog.ListFoldedConstDisplayNames(projectRelativePath)
+            AddedConstNames = addedFieldCatalog.ListFoldedConstDisplayNames(projectRelativePath),
+            IntroducedTypes = unit.IntroducedTypes.ToArray(),
+            IntroducedTypeDiagnostics = unit.IntroducedTypeDiagnostics.ToArray()
         };
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerInput.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerInput.cs
@@ -17,6 +17,9 @@ using Microsoft.CodeAnalysis.Text;
 
 internal sealed class WorkerInput
 {
+    // Null/empty retains the existing transform operation for older callers.
+    public string Operation { get; set; }
+
     // Edited files this run transforms together; all belong to the same compilation assembly.
     // Keep in sync with TransformWorkerDtos.cs TransformWorkerInputDto.sources.
     public WorkerSourceInput[] Sources { get; set; }
@@ -26,6 +29,10 @@ internal sealed class WorkerInput
     public string[] ReferencePaths { get; set; }
 
     public string TargetTypesAssemblyPath { get; set; }
+
+    public string TargetAssemblyName { get; set; }
+
+    public string TargetAssemblyMvid { get; set; }
 
     // Method keys (see WorkerMethodKeys.BuildMethodKey) that the orchestrator already
     // reported Failed from a first compile round; the retry excludes them so it does not fail

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerIntroducedType.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerIntroducedType.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+// Keep in sync with TransformWorkerDtos.cs TransformWorkerIntroducedTypeDto.
+internal sealed class WorkerIntroducedType
+{
+    public string OriginalAssemblyName { get; set; }
+
+    public string OriginalAssemblyMvid { get; set; }
+
+    public string MetadataName { get; set; }
+
+    public string OwnerProjectRelativePath { get; set; }
+
+    public string DeclarationFingerprint { get; set; }
+
+    public string Source { get; set; }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceUnit.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceUnit.cs
@@ -47,6 +47,10 @@ internal sealed class WorkerSourceUnit
     public List<WorkerRemovedMethodSignature> RemovedMethodSignatures { get; } =
         new List<WorkerRemovedMethodSignature>();
 
+    public List<WorkerIntroducedType> IntroducedTypes { get; } = new List<WorkerIntroducedType>();
+
+    public List<string> IntroducedTypeDiagnostics { get; } = new List<string>();
+
     public CompiledMemberKindChangeWarnings.SyntaxKeys KindChangeSyntaxKeys { get; set; }
 
     public List<TypeEmitState> TypeEmitStates { get; set; } = new List<TypeEmitState>();


### PR DESCRIPTION
## Summary

- Adds the worker side of introduced-type support: the stage that decides which newly written type declarations could be introduced without asking the user to compile, and which ones cannot.
- Nothing is reachable from a tool yet; this change only adds the extraction layer and its tests.

## User Impact

Today a file containing a brand new type is rejected wholesale, and the message says only that a compile is required. This change adds the analysis that tells the difference between a declaration that can be introduced and one that genuinely needs a compile, and records a per-file reason for every refusal — the input the later change needs to explain the refusal to the user instead of stopping at "compile required".

On its own it changes no user-visible behavior: the introduced-type path stays explicitly skipped until the production wiring lands in a later change.

## Changes

- The worker gains a preparation operation alongside the existing transform, which stays the default. It returns one result row per input source, in the input order and with the input count, so a missing or null result is a failure rather than something a success flag can hide.
- The planner lists top-level declarations that the target compiled metadata does not define, checks each one against the supported boundary with semantic symbols instead of syntax alone, keeps results grouped by the file that owns them, and excludes files that failed to parse from the shared analysis.
- Every unsupported category is refused with a diagnostic naming the owning file: non-public, generic, partial, record, ref-like, unsafe, Unity object derived, serializable, delegate, nested, and a type whose module initializer would have to run.
- An outer declaration that contains a nested declaration is refused as well. Nested types are excluded unconditionally, so emitting the outer one would either drop the nested implementation its members rely on or retain a type whose lifetime this stage cannot manage. The refusal is observable in the worker output before any artifact is compiled.
- The declaration fingerprint records each semantic dependency against the ordinal position of the declaration node that binds it. An unordered set cannot tell two aliases apart when they exchange the types they bind to: the tokens are identical and the set of referenced types is the same while the definition is not. The ordinal comes from declaration traversal rather than an absolute span, so trivia edits and unrelated using directives leave the fingerprint unchanged.
- Each emitted type source keeps the using and alias scopes that were in effect at its declaration, including assembly-level global usings, so a type whose namespace shadows an imported one still binds the way it did in its original file.

## Known limitations

- An introduced type that references a const of an existing compiled type whose source value no longer matches the compiled metadata is not detected here; that check belongs to the later change that normalizes references, because it needs the constant read back from the target metadata rather than the declaration analysis this change performs.

## Verification

- `uloop compile`: Success, 0 errors.
- `uloop run-tests` (single-flight, regex filter over the two worker test classes): 77 passed, 0 failed, 0 skipped.
- Guard mutation check: disabling the nested-containing refusal and reverting the fingerprint dependencies to an unordered set makes exactly three tests fail — the nested rejection, the unsupported-category diagnostics, and the alias-exchange fingerprint. Both guards were restored and the suite re-run green.
- `scripts/check-file-length.sh`: no findings. `scripts/check-code-complexity.sh`: 0 Go issues, no CA1502 findings. `check-asmdef-policy`: no violations. `scripts/check-dead-code.sh`: no candidates.
- This pull request targets an integration branch, so the repository pull-request workflows do not fire; the checks above were run locally in their place. Full CI runs on the final pull request from the integration branch, and the full EditMode suite runs on its schedule.
