### PR TITLE
fix: Hot reload no longer pays a process start for every worker run

### DIFF
--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientResidentRoutingTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientResidentRoutingTests.cs
@@ -37,7 +37,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a resident run that completes returns success without starting a second process.
+        /// A resident run that completes returns success without starting a second process.
         /// </summary>
         [Test]
         public async Task RunAsync_ResidentCompletes_ReturnsSuccessWithoutOneShot()
@@ -53,7 +53,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a worker-reported failure is final for the caller; no one-shot runs and the resident
+        /// A worker-reported failure is final for the caller; no one-shot runs and the resident
         /// process stays alive for the next request.
         /// </summary>
         [Test]
@@ -71,7 +71,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: two broken conversations in a row fall back to a single one-shot worker process,
+        /// Two broken conversations in a row fall back to a single one-shot worker process,
         /// which serves the request from the real worker.
         /// </summary>
         [Test]
@@ -89,7 +89,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a worker that never answers ends the request as a failure instead of doubling the
+        /// A worker that never answers ends the request as a failure instead of doubling the
         /// wait with a one-shot retry.
         /// </summary>
         [Test]
@@ -107,7 +107,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a bootstrap failure is reported as-is; no process is launched and no one-shot runs.
+        /// A bootstrap failure is reported as-is; no process is launched and no one-shot runs.
         /// </summary>
         [Test]
         public async Task RunAsync_ResidentBootstrapFailed_ReturnsFailureWithoutOneShot()

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientResidentRoutingTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientResidentRoutingTests.cs
@@ -1,0 +1,141 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Routing of <see cref="TransformWorkerClient"/> over the resident worker host: which host
+    /// outcomes are final for the caller and which one falls back to a one-shot worker process.
+    /// </summary>
+    public class TransformWorkerClientResidentRoutingTests
+    {
+        private const int DefaultTimeoutMilliseconds = 30_000;
+        private const int ShortTimeoutMilliseconds = 300;
+
+        private ScriptedChannelFactory _factory;
+        private TransformWorkerHost _host;
+        private bool _bootstrapFails;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _factory = new ScriptedChannelFactory();
+            _bootstrapFails = false;
+            UseHost(DefaultTimeoutMilliseconds);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _host.Shutdown("test teardown");
+            _factory.DisposeAll();
+            TransformWorkerClient.HostOverrideForTests = null;
+        }
+
+        /// <summary>
+        /// What: a resident run that completes returns success without starting a second process.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_ResidentCompletes_ReturnsSuccessWithoutOneShot()
+        {
+            _factory.Enqueue(ScriptStep.Succeed);
+            TransformWorkerInputDto input = TransformWorkerClientTests.BuildE2EFixtureInput();
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(input, CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.files.Length, Is.EqualTo(input.sources.Length));
+            Assert.That(_host.LaunchCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// What: a worker-reported failure is final for the caller; no one-shot runs and the resident
+        /// process stays alive for the next request.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_ResidentReportsWorkerFailure_ReturnsFailureWithoutOneShot()
+        {
+            _factory.Enqueue(ScriptStep.Fail);
+            TransformWorkerInputDto input = TransformWorkerClientTests.BuildE2EFixtureInput();
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(input, CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("exited with code 1"));
+            Assert.That(_host.LaunchCount, Is.EqualTo(1));
+            Assert.That(_factory.Channels[0].HasExited, Is.False);
+        }
+
+        /// <summary>
+        /// What: two broken conversations in a row fall back to a single one-shot worker process,
+        /// which serves the request from the real worker.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_ResidentRetryExhausted_FallsBackToOneShotOnce()
+        {
+            _factory.Enqueue(ScriptStep.Crash);
+            _factory.Enqueue(ScriptStep.Crash);
+            TransformWorkerInputDto input = TransformWorkerClientTests.BuildE2EFixtureInput();
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(input, CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.entries.Length, Is.GreaterThan(0));
+            Assert.That(_host.LaunchCount, Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// What: a worker that never answers ends the request as a failure instead of doubling the
+        /// wait with a one-shot retry.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_ResidentTimedOut_ReturnsFailureWithoutOneShot()
+        {
+            UseHost(ShortTimeoutMilliseconds);
+            _factory.Enqueue(ScriptStep.Hang);
+            TransformWorkerInputDto input = TransformWorkerClientTests.BuildE2EFixtureInput();
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(input, CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("did not answer within"));
+            Assert.That(_host.LaunchCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// What: a bootstrap failure is reported as-is; no process is launched and no one-shot runs.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_ResidentBootstrapFailed_ReturnsFailureWithoutOneShot()
+        {
+            _bootstrapFails = true;
+            TransformWorkerInputDto input = TransformWorkerClientTests.BuildE2EFixtureInput();
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(input, CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("bootstrap failed for test"));
+            Assert.That(_host.LaunchCount, Is.EqualTo(0));
+        }
+
+        private void UseHost(int responseTimeoutMilliseconds)
+        {
+            _host = new TransformWorkerHost(ResolveFakeTargetAsync, _factory.Start, responseTimeoutMilliseconds);
+            TransformWorkerClient.HostOverrideForTests = _host;
+        }
+
+        private Task<TransformWorkerLaunchTarget> ResolveFakeTargetAsync(CancellationToken ct)
+        {
+            if (_bootstrapFails)
+            {
+                return Task.FromResult(TransformWorkerLaunchTarget.Failure("bootstrap failed for test"));
+            }
+
+            return Task.FromResult(TransformWorkerLaunchTarget.Resolved("/worker/fake", "dotnet"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientResidentRoutingTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientResidentRoutingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b6fc654808294393b2cf4d6a322a0b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerHostLifecycleTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerHostLifecycleTests.cs
@@ -14,6 +14,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     public class TransformWorkerHostLifecycleTests
     {
         private const int ProcessExitWaitMilliseconds = 10_000;
+        private const int ExitPollIntervalMilliseconds = 50;
 
         /// <summary>
         /// What: after a real resident run, the reload callback kills the worker process and clears
@@ -34,10 +35,28 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             {
                 TransformWorkerHostLifecycle.ShutdownForReload();
 
-                Assert.That(worker.WaitForExit(ProcessExitWaitMilliseconds), Is.True);
+                Assert.That(await WaitForExitAsync(worker, ProcessExitWaitMilliseconds), Is.True);
             }
 
             Assert.That(TransformWorkerHost.Shared.CurrentProcessId, Is.Null);
+        }
+
+        // Why poll instead of Process.WaitForExit: an EditMode test that blocks the Editor's main
+        // thread on a child process stalls the whole run.
+        private static async Task<bool> WaitForExitAsync(Process process, int timeoutMilliseconds)
+        {
+            Stopwatch waited = Stopwatch.StartNew();
+            while (waited.ElapsedMilliseconds < timeoutMilliseconds)
+            {
+                if (process.HasExited)
+                {
+                    return true;
+                }
+
+                await Task.Delay(ExitPollIntervalMilliseconds);
+            }
+
+            return process.HasExited;
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/TransformWorkerHostLifecycleTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerHostLifecycleTests.cs
@@ -1,0 +1,43 @@
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Domain-reload and quit callbacks stop the shared resident worker process.
+    /// </summary>
+    public class TransformWorkerHostLifecycleTests
+    {
+        private const int ProcessExitWaitMilliseconds = 10_000;
+
+        /// <summary>
+        /// What: after a real resident run, the reload callback kills the worker process and clears
+        /// the host's current process id.
+        /// </summary>
+        [Test]
+        public async Task ShutdownForReload_StopsSharedWorker()
+        {
+            TransformWorkerInputDto input = TransformWorkerClientTests.BuildE2EFixtureInput();
+
+            TransformWorkerHostResult result = await TransformWorkerHost.Shared.RunAsync(input, CancellationToken.None);
+
+            Assert.That(result.Kind, Is.EqualTo(TransformWorkerHostResultKind.Completed), result.ErrorMessage);
+            int? processId = TransformWorkerHost.Shared.CurrentProcessId;
+            Assert.That(processId, Is.Not.Null);
+
+            using (Process worker = Process.GetProcessById(processId.Value))
+            {
+                TransformWorkerHostLifecycle.ShutdownForReload();
+
+                Assert.That(worker.WaitForExit(ProcessExitWaitMilliseconds), Is.True);
+            }
+
+            Assert.That(TransformWorkerHost.Shared.CurrentProcessId, Is.Null);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerHostLifecycleTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerHostLifecycleTests.cs
@@ -17,7 +17,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const int ExitPollIntervalMilliseconds = 50;
 
         /// <summary>
-        /// What: after a real resident run, the reload callback kills the worker process and clears
+        /// After a real resident run, the reload callback kills the worker process and clears
         /// the host's current process id.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/TransformWorkerHostLifecycleTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerHostLifecycleTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b553a4ea9564041aa8e2b36dadf6eb32
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -304,6 +304,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string VibeLogWorkerHostLifecycleClosed = "hot_reload_worker_lifecycle_closed";
         public const string VibeLogWorkerHostBrokenConversation = "hot_reload_worker_broken_conversation";
         public const string VibeLogWorkerHostTempCleanupFailed = "hot_reload_worker_temp_cleanup_failed";
+        public const string VibeLogWorkerHostFallbackOneShot = "hot_reload_worker_fallback_one_shot";
         public const string VibeLogFileStart = "hot_reload_file_start";
         public const string VibeLogWorkerResult = "hot_reload_worker_result";
         public const string VibeLogShimCompileFailed = "hot_reload_shim_compile_failed";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEditorStartup.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEditorStartup.cs
@@ -22,6 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             EditorApplication.update += CaptureOnFirstUpdateTick;
             HotReloadPlayModeEntryDropRecorder.Initialize();
             HotReloadAutoRefreshHold.Initialize();
+            TransformWorkerHostLifecycle.RegisterForEditorStartup();
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
@@ -13,13 +13,18 @@ using Debug = UnityEngine.Debug;
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// Runs the cached transform worker with file-path JSON I/O (UTF-8, no BOM).
+    /// Runs transform requests through the resident worker host, falling back to a single one-shot
+    /// worker process when the resident conversation cannot be held.
     /// </summary>
     internal static class TransformWorkerClient
     {
+        // Why a test seam on a static class: the client has no instance to inject into, and the
+        // resident host must be replaceable so routing tests do not depend on the real worker.
+        internal static TransformWorkerHost HostOverrideForTests;
+
         /// <summary>
-        /// Bootstraps the worker if needed, writes <paramref name="input"/> to a temp JSON file,
-        /// runs <c>dotnet worker.dll &lt;in&gt; &lt;out&gt;</c>, and deserializes the output.
+        /// Transforms <paramref name="input"/> through the resident worker, and only when two fresh
+        /// resident processes broke the conversation, once more through a one-shot worker process.
         /// </summary>
         public static async Task<TransformWorkerClientResult> RunAsync(
             TransformWorkerInputDto input,
@@ -29,6 +34,41 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(input.sources != null, "sources must not be null.");
             Debug.Assert(input.sources.Length > 0, "sources must not be empty.");
 
+            TransformWorkerHost host = HostOverrideForTests ?? TransformWorkerHost.Shared;
+            TransformWorkerHostResult hostResult = await host.RunAsync(input, ct).ConfigureAwait(false);
+            if (hostResult.Kind == TransformWorkerHostResultKind.Completed)
+            {
+                Debug.Assert(
+                    hostResult.Output.files.Length == input.sources.Length,
+                    "A successful worker run must return one per-file output per source.");
+                return TransformWorkerClientResult.SuccessResult(hostResult.Output);
+            }
+
+            // WorkerFailed, TimedOut, BootstrapFailed and LifecycleClosed describe the request or a
+            // deliberate stop, so repeating them on a one-shot process only costs time.
+            if (hostResult.Kind != TransformWorkerHostResultKind.RetryExhausted)
+            {
+                return TransformWorkerClientResult.Failure(hostResult.ErrorMessage);
+            }
+
+            // Why fall back only here: two fresh processes broke the conversation without the worker
+            // reporting anything, so the resident path itself is suspect and a one-shot process is
+            // the only way to still serve this run.
+            VibeLogger.LogWarning(
+                HotReloadConstants.VibeLogWorkerHostFallbackOneShot,
+                "Resident transform worker conversation broke twice; running this request as a one-shot process.",
+                new { reason = hostResult.ErrorMessage });
+            return await RunOneShotAsync(input, ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Bootstraps the worker if needed, writes <paramref name="input"/> to a temp JSON file, runs
+        /// <c>dotnet worker.dll &lt;in&gt; &lt;out&gt;</c> once, and deserializes the output.
+        /// </summary>
+        private static async Task<TransformWorkerClientResult> RunOneShotAsync(
+            TransformWorkerInputDto input,
+            CancellationToken ct)
+        {
             TransformWorkerBootstrapResult bootstrapResult =
                 await TransformWorkerBootstrap.EnsureWorkerAsync(ct).ConfigureAwait(false);
             if (!bootstrapResult.Success)
@@ -73,23 +113,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         + "\nstderr:\n" + standardError);
                 }
 
-                if (!File.Exists(outputJsonPath))
-                {
-                    return TransformWorkerClientResult.Failure(
-                        "Transform worker did not produce an output JSON file.");
-                }
-
-                string outputJson = File.ReadAllText(
+                TransformWorkerOutputDto output = TransformWorkerOutputReader.TryRead(
                     outputJsonPath,
-                    new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                TransformWorkerOutputDto output = JsonConvert.DeserializeObject<TransformWorkerOutputDto>(outputJson);
+                    input.sources.Length,
+                    out string readError);
                 if (output == null)
                 {
-                    return TransformWorkerClientResult.Failure(
-                        "Failed to deserialize transform worker output JSON.");
+                    return TransformWorkerClientResult.Failure(readError);
                 }
-
-                CoalesceOutput(output);
 
                 // Why fail here: run-level parseErrors describe a failure that belongs to no
                 // single source, so there is no per-file row to carry it. Turning it into a
@@ -100,9 +131,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return TransformWorkerClientResult.Failure(string.Join("\n", output.parseErrors));
                 }
 
-                Debug.Assert(
-                    output.files.Length == input.sources.Length,
-                    "A successful worker run must return one per-file output per source.");
                 return TransformWorkerClientResult.SuccessResult(output);
             }
             finally

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHostLifecycle.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHostLifecycle.cs
@@ -1,0 +1,31 @@
+using UnityEditor;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Stops the resident transform worker when the domain is about to reload or the Editor quits,
+    /// so no worker process outlives the Editor session that started it.
+    /// </summary>
+    internal static class TransformWorkerHostLifecycle
+    {
+        public static void RegisterForEditorStartup()
+        {
+            // Why unsubscribe first: Initialize runs once per domain, but a repeated registration
+            // during tests must not stack handlers.
+            AssemblyReloadEvents.beforeAssemblyReload -= ShutdownForReload;
+            AssemblyReloadEvents.beforeAssemblyReload += ShutdownForReload;
+            EditorApplication.quitting -= ShutdownForQuit;
+            EditorApplication.quitting += ShutdownForQuit;
+        }
+
+        internal static void ShutdownForReload()
+        {
+            TransformWorkerHost.Shared.Shutdown("beforeAssemblyReload");
+        }
+
+        internal static void ShutdownForQuit()
+        {
+            TransformWorkerHost.Shared.Shutdown("quitting");
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHostLifecycle.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHostLifecycle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b61f743b7e9804d34ae9dd2334e0606c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Wires `TransformWorkerClient.RunAsync` to the resident worker host added in #2645, so hot reload sends a request line to a worker that is already running instead of starting `dotnet worker.dll` for every run.
- Falls back to the previous one-shot process exactly once, and only when the resident conversation broke twice in a row.
- Stops the resident worker on domain reload and Editor quit.

## User Impact
- `uloop hot-reload` no longer pays a dotnet process start (~0.36 s on this machine) per run. The full EditMode suite starts roughly 600 of those today; after this change the Editor session starts a handful of workers in total.
- Failure behavior is unchanged for everything the worker itself reports: a worker error, a run-level parse error, or a request that never gets answered still surfaces the same `TransformWorkerClientResult.Failure` text as before.

## Changes
- **`TransformWorkerClient.RunAsync`** asks `TransformWorkerHost.Shared` (or `HostOverrideForTests`) for every transform. `Completed` returns success; `WorkerFailed`, `TimedOut`, `BootstrapFailed` and `LifecycleClosed` are final failures, because they describe the request itself or a deliberate stop and a one-shot retry would return the same answer or double the caller's wait.
- **One-shot fallback on `RetryExhausted` only, once.** That kind means two fresh processes broke the conversation without the worker reporting anything, so the resident path itself is suspect. The former `RunAsync` body survives as `RunOneShotAsync` with the same bootstrap, main-thread dotnet path resolution, temp-directory I/O and error text; it now reads `output.json` through the host's `TransformWorkerOutputReader.TryRead` so both paths validate a worker output identically. If the one-shot run fails, that failure is returned — there is no retry loop.
- **`TransformWorkerHostLifecycle`** registers `AssemblyReloadEvents.beforeAssemblyReload` and `EditorApplication.quitting` from `HotReloadEditorStartup.Initialize`, each unsubscribing before subscribing so a repeated initialize cannot stack handlers. The `beforeAssemblyReload` shutdown waits on the worker's graceful quit from the main thread, which costs nothing for a healthy worker (it exits on `quit`) and is bounded at 500 ms before the kill when one hangs.
- **Editor death is unchanged in kind**: if the Editor dies while a request is in flight, the worker lives until that RunTransform finishes and stays as an orphan if it hangs. The one-shot worker has the same property (a child outlives a dead parent until it completes), so this is accepted as equivalent rather than treated as a regression.
- **New VibeLogger event** `hot_reload_worker_fallback_one_shot`, logged as a warning with the resident failure reason before the fallback runs.
- **Tests**: `TransformWorkerClientResidentRoutingTests` covers the five routings (completed, worker failure, retry-exhausted → one real one-shot run, timeout, bootstrap failure) over the scripted channel from the host tests; `TransformWorkerHostLifecycleTests` drives a real resident worker and proves the reload callback kills that process id. `TransformWorkerClientTests` is unchanged and now exercises the real worker through the host.

## Verification
- `dist/darwin-arm64/uloop compile` — 0 errors.
- `run-tests --filter-type regex --filter-value 'TransformWorkerServeProtocolTests|TransformWorkerServeLoopTests|TransformWorkerHostTests|TransformWorkerHostProcessTests|TransformWorkerClientResidentRoutingTests|TransformWorkerHostLifecycleTests'` — 58/58 passed.
- `run-tests --filter-type assembly --filter-value UnityCLILoop.Tests.Editor.HotReload --timeout-seconds 1500` — 864/864 passed.
- `check-file-length --max-length 500` — no files exceeded.

## Measurement
Single-flight `uloop run-tests`, same machine, `--timeout-seconds 1500`, identical command on both sides.

| Run | Before (`main`, `693e11478`) | After (this branch, `10390163f`) |
| --- | --- | --- |
| Full EditMode suite, wall clock | 553 s | 363 s |
| Full EditMode suite, results | 4081 passed / 1 failed / 8 skipped | 4136 passed / 1 failed / 8 skipped |
| HotReload test assembly, wall clock | 385 s | 207 s |
| HotReload test assembly, results | 806 passed | 864 passed |
| `TransformWorkerHost.Shared.LaunchCount` right after the assembly run | n/a (no resident host on `main`) | 3 |

The one failing test is `EditorUnsavedChangesDiscarderTests.DiscardUnsavedEditorChanges_WithDirtyPrefabStage_ReopensWithoutWritingFile`, which fails the same way on `main` and is unrelated to this change.

Notes:
- Both sides were measured with the same locally built project runner via `ULOOP_PROJECT_RUNNER_PATH`, because the runner version pinned on `main` is not published yet; the Go sources are identical between the two branches, so the only variable left is the Unity package diff.
- The measured tip is `10390163f`. Commits pushed after it (the kill-failure rethrow and the unreadable-output-file reason) touch error paths only and do not affect these numbers.

Part of #2634.
