### PR TITLE
chore: Keep the unsaved-changes discarder tests from failing on a Scene another test left dirty

### DIFF
--- a/Assets/Tests/Editor/EditorUnsavedChangesDiscarderTests.cs
+++ b/Assets/Tests/Editor/EditorUnsavedChangesDiscarderTests.cs
@@ -25,6 +25,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [SetUp]
         public void SetUp()
         {
+            // Why a fresh Scene: the discarder reports every dirty Scene that has no disk path, so an
+            // untitled Scene left dirty earlier in the run would be read as this fixture's own failure.
+            // Replacing the active Scene drops that dirtiness and starts every test from a known state.
+            EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+
             if (!AssetDatabase.IsValidFolder(TempFolder))
             {
                 AssetDatabase.CreateFolder("Assets", "UloopUnsavedChangesDiscarderTemp");
@@ -77,6 +82,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void DiscardUnsavedEditorChanges_WithDirtyPrefabStage_ReopensWithoutWritingFile()
         {
+            Assert.That(
+                SceneManager.GetActiveScene().isDirty,
+                Is.False,
+                "SetUp must leave a clean Scene so a Scene dirtied earlier in the run is not read as this test's failure");
             PrefabStage stage = OpenDirtyPrefabStage();
             DateTime mtimeBefore = File.GetLastWriteTimeUtc(TempPrefabPath);
 


### PR DESCRIPTION
Fixes #2646.

## Summary
- The scheduled EditMode suite no longer reports a false failure in the unsaved-changes discarder tests when an earlier test leaves the untitled Scene dirty.

## User Impact
- Before: on 2022.3 the scheduled full-suite run failed with `Expected: <empty> But was: < "Scene: Untitled scene" >` in the prefab-stage discard test, while the same test passed when run on its own. The suite was red for a reason unrelated to the code under test, which hides real regressions.
- After: the fixture starts every test from a Scene it controls, so the run stays green and a genuine discard regression is the only thing that can turn it red.

## Cause
The discarder reports every dirty Scene that has no disk path, because such a Scene cannot be reloaded from disk. Somewhere in the full run the untitled Scene ends up dirty; the discard test then collected that Scene as a failure and asserted the discard reported nothing.

Three of the four tests in the fixture already replace the active Scene before acting, so they never saw the leaked state. The prefab-stage test was the only one that inherited whatever Scene the run left behind, and it was the only one that failed.

The test that dirties the Scene could not be identified. Every test class that ran before it in the failing run was reviewed: none marks a Scene dirty, none calls `EditorUtility.SetDirty`, the only `Undo` usage is on `ScriptableObject` instances, and the single class that creates a real Scene object was cleared by running it together with this fixture. Rather than keep hunting, the fixture is made to start from a known state, which also protects it from any future test that leaves a Scene dirty.

## Changes
- `SetUp` replaces the active Scene, dropping any dirtiness inherited from earlier tests.
- The prefab-stage test asserts that precondition, so a future regression points at the leaked Scene instead of at the discarder.

## Verification
- Reproduced the reported failure locally on 2022.3.62f3 by dirtying the active Scene at the start of `SetUp`, which simulates a Scene dirtied after the test runner's own discard gate: with neither the new `NewScene` call nor the new assertion, the run failed with exactly `Expected: <empty> But was: < "Scene: Untitled scene" >` and the other three tests passed.
- With the assertion added and `NewScene` still absent, the assertion fired, proving it is not vacuous.
- With `NewScene` added, all four tests passed even with the simulated dirty Scene in place.
- Final state (no simulation): `--filter-type class --filter-value ...EditorUnsavedChangesDiscarderTests` passes 4/4 on 2022.3.62f3.
- Baseline for the reported failure: run 34041313873, job `EditMode Tests (2022.3.62f3)` (4076/4087, failed 1).
- The full EditMode suite is dispatched on this branch; result reported below.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

