### PR TITLE
fix: Keep a newly introduced type bound to the assembly the previous reload loaded it into

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAddedMemberHost.cs
@@ -167,10 +167,33 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     {
         public int Existing;
 
+        public HotReloadAddedFieldNestedStruct Nested;
+
+        public int this[int index]
+        {
+            get { return Existing + index; }
+            set { Existing = value + index; }
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         public int ReadExisting()
         {
             return Existing;
+        }
+    }
+
+    /// <summary>
+    /// Compiled struct nested inside the struct host, so a write reached through more than one
+    /// member step can be tested against a real type.
+    /// </summary>
+    public struct HotReloadAddedFieldNestedStruct
+    {
+        public int Inner;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Bump()
+        {
+            Inner += 1;
         }
     }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompilerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompilerTests.cs
@@ -647,6 +647,95 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
         }
 
+        /// <summary>
+        /// What: a batch whose type derives from a type an earlier artifact already holds compiles
+        /// only when that artifact is among the reference paths, so the retained-artifact
+        /// references a run collects are what makes a continuation batch buildable at all.
+        /// </summary>
+        [Test]
+        public async Task CompileAsync_ContinuationBatch_NeedsTheEarlierArtifactReference()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            HotReloadIntroducedTypeArtifactPaths firstPaths =
+                new HotReloadIntroducedTypeArtifactPathFactory(projectRoot, "compiler-continuation-first").Create();
+            HotReloadIntroducedTypeArtifactPaths withoutReferencePaths =
+                new HotReloadIntroducedTypeArtifactPathFactory(projectRoot, "compiler-continuation-without").Create();
+            HotReloadIntroducedTypeArtifactPaths withReferencePaths =
+                new HotReloadIntroducedTypeArtifactPathFactory(projectRoot, "compiler-continuation-with").Create();
+            HotReloadIntroducedTypeCompiler compiler = new HotReloadIntroducedTypeCompiler(
+                new HotReloadIntroducedTypeCompilerEnvironment());
+
+            try
+            {
+                HotReloadIntroducedTypeCompilerResult first = await compiler.CompileAsync(
+                    CreateContinuationRequest(
+                        firstPaths,
+                        "ContinuationFixture.Base",
+                        "namespace ContinuationFixture { public class Base { } }",
+                        CreateReferencePaths()),
+                    CancellationToken.None);
+                Assert.That(first.Success, Is.True, first.ErrorMessage);
+
+                List<string> referencesWithArtifact = new List<string>(CreateReferencePaths());
+                HotReloadShimReferenceBuilder.AppendIntroducedTypeArtifactReferences(
+                    referencesWithArtifact,
+                    new[]
+                    {
+                        new TransformWorkerIntroducedTypeArtifactDto
+                        {
+                            assemblyFullName = firstPaths.AssemblyFullName,
+                            referencePath = firstPaths.DllPath,
+                            types = Array.Empty<TransformWorkerIntroducedTypeArtifactTypeDto>()
+                        }
+                    });
+
+                HotReloadIntroducedTypeCompilerResult withoutReference = await compiler.CompileAsync(
+                    CreateContinuationRequest(
+                        withoutReferencePaths,
+                        "ContinuationFixture.Derived",
+                        "namespace ContinuationFixture { public class Derived : Base { } }",
+                        CreateReferencePaths()),
+                    CancellationToken.None);
+                HotReloadIntroducedTypeCompilerResult withReference = await compiler.CompileAsync(
+                    CreateContinuationRequest(
+                        withReferencePaths,
+                        "ContinuationFixture.Derived",
+                        "namespace ContinuationFixture { public class Derived : Base { } }",
+                        referencesWithArtifact.ToArray()),
+                    CancellationToken.None);
+
+                Assert.That(withoutReference.Success, Is.False);
+                Assert.That(withReference.Success, Is.True, withReference.ErrorMessage);
+                Assert.That(withReference.Artifact.Assembly.GetType("ContinuationFixture.Derived"), Is.Not.Null);
+            }
+            finally
+            {
+                DeleteArtifactDirectory(firstPaths.DllPath);
+                DeleteArtifactDirectory(withoutReferencePaths.DllPath);
+                DeleteArtifactDirectory(withReferencePaths.DllPath);
+            }
+        }
+
+        private static HotReloadIntroducedTypeCompilationRequest CreateContinuationRequest(
+            HotReloadIntroducedTypeArtifactPaths paths,
+            string metadataName,
+            string source,
+            string[] referencePaths)
+        {
+            HotReloadIntroducedTypeDescriptor descriptor = new HotReloadIntroducedTypeDescriptor(
+                "OriginalAssembly",
+                "original-mvid",
+                metadataName,
+                "Assets/Continuation.cs",
+                "continuation",
+                source);
+            return HotReloadIntroducedTypeCompilationRequest.CreateBatch(
+                paths,
+                new[] { descriptor },
+                referencePaths,
+                Array.Empty<string>());
+        }
+
         // The artifact assembly is loaded from bytes rather than mapped from the file, so its
         // directory can be removed as soon as the assertions have read the emitted DLL and PDB.
         private static void DeleteArtifactDirectory(string dllPath)

--- a/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactFixture.cs
@@ -28,6 +28,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     {
         private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
 
+        // The restricted type has no declaration left in the edited source, so no fingerprint of
+        // it can ever match; the record only has to carry one for the request to be well formed.
+        private const string RestrictedDeclarationFingerprint =
+            "0000000000000000000000000000000000000000000000000000000000000000";
+
         // A second edited file of the same group, so a test can show that a run-level failure
         // takes the whole group down rather than reporting one file's diagnostics.
         private const string SiblingSource =
@@ -148,6 +153,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         originalAssemblyMvid = TargetAssemblyMvid,
                         ownerProjectRelativePath = ProjectRelativePath,
                         declarationFingerprint = declarationFingerprint
+                    },
+                    // The restricted type is part of the verified mapping too, so a test can
+                    // tell a constructor the mapping refuses from a type it never held.
+                    new TransformWorkerIntroducedTypeArtifactTypeDto
+                    {
+                        metadataName = "Example.RetainedRestricted",
+                        originalAssemblyName = TargetAssemblyName,
+                        originalAssemblyMvid = TargetAssemblyMvid,
+                        ownerProjectRelativePath = ProjectRelativePath,
+                        declarationFingerprint = RestrictedDeclarationFingerprint
                     }
                 }
             };
@@ -270,9 +285,81 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     Mono.Cecil.FieldAttributes.Public | Mono.Cecil.FieldAttributes.Static,
                     assembly.MainModule.TypeSystem.Int32);
                 retained.Fields.Add(valueField);
+                AddConstructor(assembly, retained, CecilMethodAttributes.Public);
+                AddInstanceInt32Method(assembly, retained, "Compute");
+                AddInstanceInt32Property(assembly, retained, "Number");
                 assembly.MainModule.Types.Add(retained);
+
+                // A type whose only constructor is private is what a source class with a private
+                // constructor looks like once it is served from the artifact assembly instead.
+                TypeDefinition restricted = new TypeDefinition(
+                    "Example",
+                    "RetainedRestricted",
+                    CecilTypeAttributes.Public | CecilTypeAttributes.Class,
+                    assembly.MainModule.TypeSystem.Object);
+                AddConstructor(assembly, restricted, CecilMethodAttributes.Private);
+                assembly.MainModule.Types.Add(restricted);
                 assembly.Write(path);
             }
+        }
+
+        // The bodies are never executed: the artifact is only ever read as metadata, so a bare
+        // return is enough to give a member the signature the compiler binds against.
+        private static void AddConstructor(
+            AssemblyDefinition assembly,
+            TypeDefinition type,
+            CecilMethodAttributes accessibility)
+        {
+            MethodDefinition constructor = new MethodDefinition(
+                ".ctor",
+                accessibility
+                    | CecilMethodAttributes.HideBySig
+                    | CecilMethodAttributes.SpecialName
+                    | CecilMethodAttributes.RTSpecialName,
+                assembly.MainModule.TypeSystem.Void);
+            ILProcessor processor = constructor.Body.GetILProcessor();
+            processor.Append(processor.Create(OpCodes.Ret));
+            type.Methods.Add(constructor);
+        }
+
+        private static void AddInstanceInt32Method(
+            AssemblyDefinition assembly,
+            TypeDefinition type,
+            string name)
+        {
+            MethodDefinition method = new MethodDefinition(
+                name,
+                CecilMethodAttributes.Public | CecilMethodAttributes.HideBySig,
+                assembly.MainModule.TypeSystem.Int32);
+            ILProcessor processor = method.Body.GetILProcessor();
+            processor.Append(processor.Create(OpCodes.Ldc_I4_0));
+            processor.Append(processor.Create(OpCodes.Ret));
+            type.Methods.Add(method);
+        }
+
+        private static void AddInstanceInt32Property(
+            AssemblyDefinition assembly,
+            TypeDefinition type,
+            string name)
+        {
+            MethodDefinition getter = new MethodDefinition(
+                "get_" + name,
+                CecilMethodAttributes.Public
+                    | CecilMethodAttributes.HideBySig
+                    | CecilMethodAttributes.SpecialName,
+                assembly.MainModule.TypeSystem.Int32);
+            ILProcessor processor = getter.Body.GetILProcessor();
+            processor.Append(processor.Create(OpCodes.Ldc_I4_0));
+            processor.Append(processor.Create(OpCodes.Ret));
+            type.Methods.Add(getter);
+            PropertyDefinition property = new PropertyDefinition(
+                name,
+                Mono.Cecil.PropertyAttributes.None,
+                assembly.MainModule.TypeSystem.Int32)
+            {
+                GetMethod = getter
+            };
+            type.Properties.Add(property);
         }
 
         public static UnityEditor.Compilation.Assembly FindCompilationAssembly()

--- a/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactFixture.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using CecilTypeAttributes = Mono.Cecil.TypeAttributes;
+using CecilMethodAttributes = Mono.Cecil.MethodAttributes;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Builds the edited source, the compiled target assembly and the retained artifact assembly a
+    /// retained-binding test runs against, plus the worker inputs that reference them, so both the
+    /// worker-level and the propagation tests describe the same world.
+    /// </summary>
+    internal sealed class HotReloadRetainedArtifactFixture
+    {
+        private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+
+        private HotReloadRetainedArtifactFixture(
+            string sourcePath,
+            string projectRelativePath,
+            string targetAssemblyPath,
+            string targetAssemblyName,
+            string targetAssemblyMvid,
+            string artifactPath)
+        {
+            SourcePath = sourcePath;
+            ProjectRelativePath = projectRelativePath;
+            TargetAssemblyPath = targetAssemblyPath;
+            TargetAssemblyName = targetAssemblyName;
+            TargetAssemblyMvid = targetAssemblyMvid;
+            ArtifactPath = artifactPath;
+            RetainedFingerprint = string.Empty;
+        }
+
+        public string SourcePath { get; }
+
+        public string ProjectRelativePath { get; }
+
+        public string TargetAssemblyPath { get; }
+
+        public string TargetAssemblyName { get; }
+
+        public string TargetAssemblyMvid { get; }
+
+        public string ArtifactPath { get; }
+
+        public string RetainedFingerprint { get; private set; }
+
+        public static async Task<HotReloadRetainedArtifactFixture> CreateAsync(
+            string name,
+            string editedSource)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(
+                projectRoot,
+                "Library",
+                "UloopHotReload",
+                "TestSources",
+                "RetainedDeclaration",
+                name);
+            Directory.CreateDirectory(directory);
+            string sourcePath = Path.Combine(directory, "Edited.cs");
+            File.WriteAllText(sourcePath, editedSource);
+            string targetAssemblyPath = Path.Combine(directory, "RetainedTarget.dll");
+            string targetAssemblyMvid = CreateTargetAssembly(targetAssemblyPath);
+            string artifactPath = Path.Combine(directory, "RetainedArtifact.dll");
+            CreateArtifactAssembly(artifactPath);
+            HotReloadRetainedArtifactFixture fixture = new HotReloadRetainedArtifactFixture(
+                sourcePath,
+                "Assets/RetainedDeclaration/" + name + "/Edited.cs",
+                targetAssemblyPath,
+                "RetainedTarget",
+                targetAssemblyMvid,
+                artifactPath);
+            // The recorded fingerprint has to be the value planning really produced for this
+            // source, so it is read back from a prepare run rather than restated by the test.
+            fixture.RetainedFingerprint = await fixture.ReadPlannedFingerprintAsync();
+            return fixture;
+        }
+
+        public TransformWorkerInputDto BuildTransformInput(
+            TransformWorkerIntroducedTypeArtifactDto[] artifacts)
+        {
+            return BuildInput(null, artifacts);
+        }
+
+        public TransformWorkerInputDto BuildPrepareInput()
+        {
+            return BuildInput(
+                "prepareIntroducedTypes",
+                Array.Empty<TransformWorkerIntroducedTypeArtifactDto>());
+        }
+
+        public TransformWorkerIntroducedTypeArtifactDto CreateRecordedArtifact(
+            string declarationFingerprint)
+        {
+            return new TransformWorkerIntroducedTypeArtifactDto
+            {
+                assemblyFullName = ReadAssemblyFullName(ArtifactPath),
+                referencePath = ArtifactPath,
+                types = new[]
+                {
+                    new TransformWorkerIntroducedTypeArtifactTypeDto
+                    {
+                        metadataName = "Example.Retained",
+                        originalAssemblyName = TargetAssemblyName,
+                        originalAssemblyMvid = TargetAssemblyMvid,
+                        ownerProjectRelativePath = ProjectRelativePath,
+                        declarationFingerprint = declarationFingerprint
+                    }
+                }
+            };
+        }
+
+        public static string ReadAssemblyFullName(string path)
+        {
+            using (AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(path))
+            {
+                return assembly.Name.FullName;
+            }
+        }
+
+        private TransformWorkerInputDto BuildInput(
+            string operation,
+            TransformWorkerIntroducedTypeArtifactDto[] artifacts)
+        {
+            UnityEditor.Compilation.Assembly compilationAssembly = FindCompilationAssembly();
+            List<string> referencePaths = new List<string>();
+            foreach (string reference in compilationAssembly.allReferences)
+            {
+                if (!string.IsNullOrEmpty(reference) && File.Exists(reference))
+                {
+                    referencePaths.Add(Path.GetFullPath(reference));
+                }
+            }
+
+            referencePaths.Add(Path.GetFullPath(TargetAssemblyPath));
+            return new TransformWorkerInputDto
+            {
+                operation = operation,
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = SourcePath,
+                        projectRelativePath = ProjectRelativePath
+                    }
+                },
+                defines = compilationAssembly.defines ?? Array.Empty<string>(),
+                referencePaths = referencePaths.ToArray(),
+                targetTypesAssemblyPath = TargetAssemblyPath,
+                targetAssemblyName = TargetAssemblyName,
+                targetAssemblyMvid = TargetAssemblyMvid,
+                assemblySourcePaths = Array.Empty<string>(),
+                changedSiblingSourcePaths = Array.Empty<string>(),
+                introducedTypeArtifacts = artifacts
+            };
+        }
+
+        private async Task<string> ReadPlannedFingerprintAsync()
+        {
+            TransformWorkerClientResult prepared =
+                await TransformWorkerClient.RunAsync(BuildPrepareInput(), CancellationToken.None);
+            Assert.That(prepared.Success, Is.True, prepared.ErrorMessage);
+            foreach (TransformWorkerIntroducedTypeDto introducedType in prepared.Output.files[0].introducedTypes)
+            {
+                if (introducedType.metadataName == "Example.Retained")
+                {
+                    return introducedType.declarationFingerprint;
+                }
+            }
+
+            Assert.Fail("Planning did not report the retained type.");
+            return null;
+        }
+
+        private static string CreateTargetAssembly(string path)
+        {
+            AssemblyNameDefinition assemblyName = new AssemblyNameDefinition("RetainedTarget", new Version(1, 0, 0, 0));
+            using (AssemblyDefinition assembly = AssemblyDefinition.CreateAssembly(assemblyName, "RetainedTarget", ModuleKind.Dll))
+            {
+                TypeDefinition caller = new TypeDefinition(
+                    "Example",
+                    "Caller",
+                    CecilTypeAttributes.Public | CecilTypeAttributes.Class,
+                    assembly.MainModule.TypeSystem.Object);
+                MethodDefinition read = new MethodDefinition(
+                    "Read",
+                    CecilMethodAttributes.Public | CecilMethodAttributes.HideBySig,
+                    assembly.MainModule.TypeSystem.Int32);
+                ILProcessor processor = read.Body.GetILProcessor();
+                processor.Append(processor.Create(OpCodes.Ldc_I4_0));
+                processor.Append(processor.Create(OpCodes.Ret));
+                caller.Methods.Add(read);
+                assembly.MainModule.Types.Add(caller);
+                assembly.Write(path);
+            }
+
+            using (ModuleDefinition module = ModuleDefinition.ReadModule(path))
+            {
+                return module.Mvid.ToString();
+            }
+        }
+
+        private static void CreateArtifactAssembly(string path)
+        {
+            AssemblyNameDefinition assemblyName = new AssemblyNameDefinition("RetainedArtifact", new Version(1, 0, 0, 0));
+            using (AssemblyDefinition assembly = AssemblyDefinition.CreateAssembly(assemblyName, "RetainedArtifact", ModuleKind.Dll))
+            {
+                TypeDefinition retained = new TypeDefinition(
+                    "Example",
+                    "Retained",
+                    CecilTypeAttributes.Public | CecilTypeAttributes.Class,
+                    assembly.MainModule.TypeSystem.Object);
+                FieldDefinition valueField = new FieldDefinition(
+                    "Value",
+                    Mono.Cecil.FieldAttributes.Public | Mono.Cecil.FieldAttributes.Static,
+                    assembly.MainModule.TypeSystem.Int32);
+                retained.Fields.Add(valueField);
+                assembly.MainModule.Types.Add(retained);
+                assembly.Write(path);
+            }
+        }
+
+        public static UnityEditor.Compilation.Assembly FindCompilationAssembly()
+        {
+            foreach (UnityEditor.Compilation.Assembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name == TestAssemblyName)
+                {
+                    return assembly;
+                }
+            }
+
+            Assert.Fail("Compilation assembly was not found.");
+            return null;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactFixture.cs
@@ -28,9 +28,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     {
         private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
 
+        // A second edited file of the same group, so a test can show that a run-level failure
+        // takes the whole group down rather than reporting one file's diagnostics.
+        private const string SiblingSource =
+            "namespace Example { public class Sibling { public int Get() { return 3; } } }";
+
         private HotReloadRetainedArtifactFixture(
             string sourcePath,
             string projectRelativePath,
+            string siblingSourcePath,
+            string siblingProjectRelativePath,
             string targetAssemblyPath,
             string targetAssemblyName,
             string targetAssemblyMvid,
@@ -38,6 +45,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             SourcePath = sourcePath;
             ProjectRelativePath = projectRelativePath;
+            SiblingSourcePath = siblingSourcePath;
+            SiblingProjectRelativePath = siblingProjectRelativePath;
             TargetAssemblyPath = targetAssemblyPath;
             TargetAssemblyName = targetAssemblyName;
             TargetAssemblyMvid = targetAssemblyMvid;
@@ -57,6 +66,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         public string ArtifactPath { get; }
 
+        public string SiblingSourcePath { get; }
+
+        public string SiblingProjectRelativePath { get; }
+
         public string RetainedFingerprint { get; private set; }
 
         public static async Task<HotReloadRetainedArtifactFixture> CreateAsync(
@@ -74,6 +87,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Directory.CreateDirectory(directory);
             string sourcePath = Path.Combine(directory, "Edited.cs");
             File.WriteAllText(sourcePath, editedSource);
+            string siblingSourcePath = Path.Combine(directory, "Sibling.cs");
+            File.WriteAllText(siblingSourcePath, SiblingSource);
             string targetAssemblyPath = Path.Combine(directory, "RetainedTarget.dll");
             string targetAssemblyMvid = CreateTargetAssembly(targetAssemblyPath);
             string artifactPath = Path.Combine(directory, "RetainedArtifact.dll");
@@ -81,6 +96,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadRetainedArtifactFixture fixture = new HotReloadRetainedArtifactFixture(
                 sourcePath,
                 "Assets/RetainedDeclaration/" + name + "/Edited.cs",
+                siblingSourcePath,
+                "Assets/RetainedDeclaration/" + name + "/Sibling.cs",
                 targetAssemblyPath,
                 "RetainedTarget",
                 targetAssemblyMvid,
@@ -94,14 +111,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public TransformWorkerInputDto BuildTransformInput(
             TransformWorkerIntroducedTypeArtifactDto[] artifacts)
         {
-            return BuildInput(null, artifacts);
+            return BuildInput(null, artifacts, includeSibling: false);
+        }
+
+        /// <summary>
+        /// Builds a transform input for both edited files of the group, so a test can assert what
+        /// a run-level failure does to a group of more than one file.
+        /// </summary>
+        public TransformWorkerInputDto BuildGroupTransformInput(
+            TransformWorkerIntroducedTypeArtifactDto[] artifacts)
+        {
+            return BuildInput(null, artifacts, includeSibling: true);
         }
 
         public TransformWorkerInputDto BuildPrepareInput()
         {
             return BuildInput(
                 "prepareIntroducedTypes",
-                Array.Empty<TransformWorkerIntroducedTypeArtifactDto>());
+                Array.Empty<TransformWorkerIntroducedTypeArtifactDto>(),
+                includeSibling: false);
         }
 
         public TransformWorkerIntroducedTypeArtifactDto CreateRecordedArtifact(
@@ -135,7 +163,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private TransformWorkerInputDto BuildInput(
             string operation,
-            TransformWorkerIntroducedTypeArtifactDto[] artifacts)
+            TransformWorkerIntroducedTypeArtifactDto[] artifacts,
+            bool includeSibling)
         {
             UnityEditor.Compilation.Assembly compilationAssembly = FindCompilationAssembly();
             List<string> referencePaths = new List<string>();
@@ -148,17 +177,28 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             referencePaths.Add(Path.GetFullPath(TargetAssemblyPath));
+            List<TransformWorkerSourceDto> sources = new List<TransformWorkerSourceDto>
+            {
+                new TransformWorkerSourceDto
+                {
+                    sourcePath = SourcePath,
+                    projectRelativePath = ProjectRelativePath
+                }
+            };
+            if (includeSibling)
+            {
+                sources.Add(
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = SiblingSourcePath,
+                        projectRelativePath = SiblingProjectRelativePath
+                    });
+            }
+
             return new TransformWorkerInputDto
             {
                 operation = operation,
-                sources = new[]
-                {
-                    new TransformWorkerSourceDto
-                    {
-                        sourcePath = SourcePath,
-                        projectRelativePath = ProjectRelativePath
-                    }
-                },
+                sources = sources.ToArray(),
                 defines = compilationAssembly.defines ?? Array.Empty<string>(),
                 referencePaths = referencePaths.ToArray(),
                 targetTypesAssemblyPath = TargetAssemblyPath,

--- a/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactFixture.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 08b475abbdbd24b309932a2d20d2fcb4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactInitializerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactInitializerTests.cs
@@ -1,0 +1,161 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Verifies which initializer of a field added next to a retained declaration can run in the
+    /// shim lambda: only a public constructor of a type the verified artifact mapping holds, and
+    /// nothing else that needs an instance.
+    /// </summary>
+    public sealed class HotReloadRetainedArtifactInitializerTests
+    {
+        private const string SkipReasonFragment = "Added field initializer";
+
+        private const string SourceFormat =
+            "namespace Example\n"
+            + "{\n"
+            + "    public class Retained\n"
+            + "    {\n"
+            + "        public static int Value = 1;\n"
+            + "    }\n"
+            + "\n"
+            + "    public class Caller\n"
+            + "    {\n"
+            + "        public {0} Cache = {1};\n"
+            + "\n"
+            + "        public int Read()\n"
+            + "        {\n"
+            + "            return Retained.Value + ({2});\n"
+            + "        }\n"
+            + "    }\n"
+            + "}\n";
+
+        /// <summary>
+        /// What: a field added next to a retained declaration keeps its initializer when it only
+        /// constructs a type the verified mapping holds, so the method that reads it is patched
+        /// through the added-field store instead of being skipped.
+        /// </summary>
+        [Test]
+        public async Task Initializer_PublicConstructorOfMappedType_IsEmitted()
+        {
+            TransformWorkerClientResult result = await RunAsync(
+                "MappedConstructor",
+                "Retained",
+                "new Retained()",
+                "Cache == null ? 0 : 1");
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(FindSkipReason(result, "Read"), Is.Null);
+            Assert.That(result.Output.hasAddedFieldRewrites, Is.True);
+        }
+
+        /// <summary>
+        /// What: a constructor the artifact assembly does not expose is refused, because the
+        /// shim assembly cannot reach it once the type is served from the artifact.
+        /// </summary>
+        [Test]
+        public async Task Initializer_NonPublicConstructorOfMappedType_IsRefused()
+        {
+            TransformWorkerClientResult result = await RunAsync(
+                "RestrictedConstructor",
+                "RetainedRestricted",
+                "new RetainedRestricted()",
+                "Cache == null ? 0 : 1");
+
+            AssertReadIsRefused(result);
+        }
+
+        /// <summary>
+        /// What: an instance method call on a mapped type is still refused, so the allowance
+        /// covers construction only and not everything the mapped type exposes.
+        /// </summary>
+        [Test]
+        public async Task Initializer_InstanceMethodOnMappedType_IsRefused()
+        {
+            TransformWorkerClientResult result = await RunAsync(
+                "MappedInstanceMethod",
+                "int",
+                "new Retained().Compute()",
+                "Cache");
+
+            AssertReadIsRefused(result);
+        }
+
+        /// <summary>
+        /// What: reading an instance property of a mapped type is refused for the same reason as
+        /// an instance method call.
+        /// </summary>
+        [Test]
+        public async Task Initializer_InstancePropertyOnMappedType_IsRefused()
+        {
+            TransformWorkerClientResult result = await RunAsync(
+                "MappedInstanceProperty",
+                "int",
+                "new Retained().Number",
+                "Cache");
+
+            AssertReadIsRefused(result);
+        }
+
+        /// <summary>
+        /// What: constructing a public type the mapping does not hold stays refused, so the
+        /// allowance is decided by the mapping and not by the constructor alone.
+        /// </summary>
+        [Test]
+        public async Task Initializer_ConstructorOfUnmappedType_IsRefused()
+        {
+            TransformWorkerClientResult result = await RunAsync(
+                "UnmappedConstructor",
+                "System.Text.StringBuilder",
+                "new System.Text.StringBuilder()",
+                "Cache == null ? 0 : 1");
+
+            AssertReadIsRefused(result);
+        }
+
+        private static void AssertReadIsRefused(TransformWorkerClientResult result)
+        {
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            string reason = FindSkipReason(result, "Read");
+            Assert.That(reason, Is.Not.Null, "The method reading the added field must be skipped.");
+            Assert.That(reason, Does.Contain(SkipReasonFragment));
+        }
+
+        private static async Task<TransformWorkerClientResult> RunAsync(
+            string name,
+            string fieldTypeName,
+            string initializer,
+            string readExpression)
+        {
+            string editedSource = SourceFormat
+                .Replace("{0}", fieldTypeName)
+                .Replace("{1}", initializer)
+                .Replace("{2}", readExpression);
+            HotReloadRetainedArtifactFixture fixture =
+                await HotReloadRetainedArtifactFixture.CreateAsync(name, editedSource);
+
+            return await TransformWorkerClient.RunAsync(
+                fixture.BuildTransformInput(
+                    new[] { fixture.CreateRecordedArtifact(fixture.RetainedFingerprint) }),
+                CancellationToken.None);
+        }
+
+        private static string FindSkipReason(TransformWorkerClientResult result, string methodName)
+        {
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                if (skipped.method != null && skipped.method.Contains(methodName))
+                {
+                    return skipped.reason;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactInitializerTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactInitializerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ce49adffb33f24804a1e96986facde3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactPropagationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactPropagationTests.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Verifies that the retained-artifact records and the target assembly identity of the first
+    /// worker run reach the retry run as well. The isolation retry and the signature-change gate
+    /// share one retry entry point, so a retry that lost them would bind the retained types back
+    /// to their source and emit types a loaded assembly already holds.
+    /// </summary>
+    public sealed class HotReloadRetainedArtifactPropagationTests
+    {
+        private const string EditedSource =
+            "namespace Example\n"
+            + "{\n"
+            + "    public class Retained\n"
+            + "    {\n"
+            + "        public static int Value = 1;\n"
+            + "\n"
+            + "        public static int Twice()\n"
+            + "        {\n"
+            + "            return Value * 2;\n"
+            + "        }\n"
+            + "    }\n"
+            + "\n"
+            + "    public class Caller\n"
+            + "    {\n"
+            + "        public int Read()\n"
+            + "        {\n"
+            + "            return Retained.Value + 1;\n"
+            + "        }\n"
+            + "    }\n"
+            + "}\n";
+
+        /// <summary>
+        /// What: a retry inherits the artifact records, so an artifact the worker cannot trust
+        /// fails the retry run instead of letting isolation continue against a guessed binding.
+        /// </summary>
+        [Test]
+        public async Task IsolationRetry_UntrustedArtifactRecord_FailsRetry()
+        {
+            HotReloadRetainedArtifactFixture fixture =
+                await HotReloadRetainedArtifactFixture.CreateAsync("RetryUntrustedArtifact", EditedSource);
+            TransformWorkerIntroducedTypeArtifactDto mismatched =
+                fixture.CreateRecordedArtifact(fixture.RetainedFingerprint);
+            mismatched.assemblyFullName =
+                HotReloadRetainedArtifactFixture.ReadAssemblyFullName(fixture.TargetAssemblyPath);
+
+            HotReloadShimIsolation.IsolationRetryRunResult retry = await RunRetryAsync(
+                fixture.BuildTransformInput(new[] { mismatched }),
+                fixture,
+                BuildExclusions(
+                    new[]
+                    {
+                        BuildMethodKey("Example.Caller", "Read"),
+                        BuildMethodKey("Example.Retained", "Twice")
+                    }));
+
+            Assert.That(retry.Isolation, Is.Null);
+            Assert.That(retry.FailureMessage, Does.Contain("Retry worker failed"));
+        }
+
+        /// <summary>
+        /// What: a retry inherits the artifact records and the target assembly identity, so the
+        /// retained declaration is still recognized and its members produce no retry rows. Without
+        /// the identity the recomputed fingerprint could not match the record.
+        /// </summary>
+        [Test]
+        public async Task IsolationRetry_RetainedRecord_ProducesNoRowsForRetainedType()
+        {
+            HotReloadRetainedArtifactFixture fixture =
+                await HotReloadRetainedArtifactFixture.CreateAsync("RetryRetainedRecord", EditedSource);
+            TransformWorkerInputDto workerInput = fixture.BuildTransformInput(
+                new[] { fixture.CreateRecordedArtifact(fixture.RetainedFingerprint) });
+
+            HotReloadShimIsolation.IsolationRetryRunResult retry = await RunRetryAsync(
+                workerInput,
+                fixture,
+                BuildExclusions(new[] { BuildMethodKey("Example.Caller", "Read") }));
+
+            Assert.That(retry.Isolation, Is.Not.Null, retry.FailureMessage);
+            Assert.That(retry.Isolation.RetryEntries, Is.Empty);
+            AssertNoOutcomeMentions(retry.Isolation.SkippedCallerOutcomes, "Twice");
+        }
+
+        /// <summary>
+        /// What: a retry always runs the transform operation, even when the first run was a
+        /// preparation run, so its per-file rows carry transformed methods and not descriptors.
+        /// </summary>
+        [Test]
+        public async Task IsolationRetry_PreparationInput_StillRetriesAsTransform()
+        {
+            HotReloadRetainedArtifactFixture fixture =
+                await HotReloadRetainedArtifactFixture.CreateAsync("RetryOperation", EditedSource);
+            TransformWorkerInputDto workerInput = fixture.BuildPrepareInput();
+
+            HotReloadShimIsolation.IsolationRetryRunResult retry = await RunRetryAsync(
+                workerInput,
+                fixture,
+                BuildExclusions(
+                    new[]
+                    {
+                        BuildMethodKey("Example.Caller", "Read"),
+                        BuildMethodKey("Example.Retained", "Twice")
+                    }));
+
+            Assert.That(retry.Isolation, Is.Not.Null, retry.FailureMessage);
+            Assert.That(retry.Isolation.RetryFiles.Length, Is.EqualTo(1));
+            Assert.That(retry.Isolation.RetryFiles[0].introducedTypes, Is.Null.Or.Empty);
+        }
+
+        /// <summary>
+        /// What: an artifact whose file the run already references is not added a second time, and
+        /// two records naming the same file collapse to one entry, so every record keeps a single
+        /// reference and the compilation never holds one assembly identity twice.
+        /// </summary>
+        [Test]
+        public async Task ArtifactReferences_PathAlreadyReferenced_IsAddedOnce()
+        {
+            HotReloadRetainedArtifactFixture fixture =
+                await HotReloadRetainedArtifactFixture.CreateAsync("ArtifactReferenceReuse", EditedSource);
+            string artifactDirectory = Path.GetDirectoryName(fixture.ArtifactPath);
+            List<string> references = new List<string> { fixture.ArtifactPath };
+
+            HotReloadShimReferenceBuilder.AppendIntroducedTypeArtifactReferences(
+                references,
+                new[]
+                {
+                    CreateArtifactReference(Path.Combine(artifactDirectory, ".", "RetainedArtifact.dll")),
+                    CreateArtifactReference(fixture.ArtifactPath),
+                    CreateArtifactReference(fixture.TargetAssemblyPath)
+                });
+
+            Assert.That(references.Count, Is.EqualTo(2));
+            Assert.That(references[0], Is.EqualTo(fixture.ArtifactPath));
+            Assert.That(references[1], Is.EqualTo(Path.GetFullPath(fixture.TargetAssemblyPath)));
+        }
+
+        /// <summary>
+        /// What: a record without a reference path contributes nothing, so a malformed record
+        /// cannot put an empty entry into a compilation's reference list.
+        /// </summary>
+        [Test]
+        public void ArtifactReferences_RecordWithoutPath_ContributesNothing()
+        {
+            List<string> collected = HotReloadShimReferenceBuilder.CollectIntroducedTypeArtifactReferencePaths(
+                new[] { CreateArtifactReference(string.Empty), null });
+
+            Assert.That(collected, Is.Empty);
+        }
+
+        private static TransformWorkerIntroducedTypeArtifactDto CreateArtifactReference(string referencePath)
+        {
+            return new TransformWorkerIntroducedTypeArtifactDto
+            {
+                assemblyFullName = "Artifact",
+                referencePath = referencePath,
+                types = Array.Empty<TransformWorkerIntroducedTypeArtifactTypeDto>()
+            };
+        }
+
+        private static async Task<HotReloadShimIsolation.IsolationRetryRunResult> RunRetryAsync(
+            TransformWorkerInputDto workerInput,
+            HotReloadRetainedArtifactFixture fixture,
+            HotReloadShimIsolation.IsolationExclusions exclusions)
+        {
+            return await HotReloadShimIsolation.RunIsolationRetryAsync(
+                workerInput,
+                exclusions,
+                new List<HotReloadMethodOutcome>(),
+                new List<HotReloadMethodOutcome>(),
+                HotReloadRetainedArtifactFixture.FindCompilationAssembly(),
+                fixture.TargetAssemblyPath,
+                workerInput.defines,
+                Array.Empty<TransformWorkerSkippedDto>(),
+                HotReloadGroupFilePaths.ForSingleFile(
+                    fixture.ProjectRelativePath,
+                    fixture.TargetAssemblyPath),
+                HotReloadConstants.VibeLogIsolationTriggerShimCompileFailure,
+                "retained-artifact-propagation",
+                CancellationToken.None);
+        }
+
+        private static HotReloadShimIsolation.IsolationExclusions BuildExclusions(string[] excludedMethodKeys)
+        {
+            return new HotReloadShimIsolation.IsolationExclusions(
+                excludedMethodKeys,
+                Array.Empty<string>(),
+                Array.Empty<TransformWorkerEntryDto>());
+        }
+
+        private static string BuildMethodKey(string typeMetadataName, string methodName)
+        {
+            return HotReloadMethodKeys.BuildMethodKeyParts(
+                typeMetadataName,
+                methodName,
+                Array.Empty<string>(),
+                0);
+        }
+
+        private static void AssertNoOutcomeMentions(
+            IReadOnlyList<HotReloadMethodOutcome> outcomes,
+            string memberName)
+        {
+            foreach (HotReloadMethodOutcome outcome in outcomes)
+            {
+                Assert.That(outcome.Method ?? string.Empty, Does.Not.Contain(memberName));
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactPropagationTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactPropagationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1af2ba549dc14348aad813768950ab5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedFieldTests.cs
@@ -831,6 +831,54 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: incrementing a member of an added value-type field skips, because the increment
+        /// would apply to the copy the store hands back and then be discarded.
+        /// </summary>
+        [Test]
+        public async Task Skip_ValueTypeAddedFieldMemberIncrement_UsesDedicatedReason()
+        {
+            await AssertValueTypeMemberWriteSkipAsync(
+                "AddedFieldValueTypeIncrement.cs",
+                "            AddedValue.Existing++;\n            return value;");
+        }
+
+        /// <summary>
+        /// What: a write reached through more than one member step still skips, because the copy
+        /// the store hands back is the root of that chain.
+        /// </summary>
+        [Test]
+        public async Task Skip_NestedValueTypeAddedFieldMemberWrite_UsesDedicatedReason()
+        {
+            await AssertValueTypeMemberWriteSkipAsync(
+                "AddedFieldNestedValueTypeWrite.cs",
+                "            AddedValue.Nested.Inner = value;\n            return value;");
+        }
+
+        /// <summary>
+        /// What: an indexer assignment on an added value-type field skips, because the indexer
+        /// writes into the copy rather than into the stored value.
+        /// </summary>
+        [Test]
+        public async Task Skip_ValueTypeAddedFieldIndexerWrite_UsesDedicatedReason()
+        {
+            await AssertValueTypeMemberWriteSkipAsync(
+                "AddedFieldValueTypeIndexerWrite.cs",
+                "            AddedValue[0] = value;\n            return value;");
+        }
+
+        /// <summary>
+        /// What: an instance call on a nested value-type member skips, because a mutating method
+        /// on that chain also only reaches the copy.
+        /// </summary>
+        [Test]
+        public async Task Skip_NestedValueTypeAddedFieldMutatingCall_UsesDedicatedReason()
+        {
+            await AssertValueTypeMemberWriteSkipAsync(
+                "AddedFieldNestedValueTypeCall.cs",
+                "            AddedValue.Nested.Bump();\n            return value;");
+        }
+
+        /// <summary>
         /// What: added fields on a compiled struct type skip referencing methods because the
         /// store cannot keep identity without boxing.
         /// </summary>
@@ -1943,6 +1991,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             return paths;
+        }
+
+        /// <summary>
+        /// Runs the worker on a body that reaches an added value-type field through a receiver
+        /// chain and asserts the dedicated skip reason, so each write form is one test.
+        /// </summary>
+        private static async Task AssertValueTypeMemberWriteSkipAsync(
+            string editedFileName,
+            string callerBody)
+        {
+            string onDisk = File.ReadAllText(ResolveHostPath());
+            string edited = WithHostMembers(onDisk, "public HotReloadAddedFieldStructHost AddedValue;");
+            edited = edited.Replace(
+                ExistingCallerOriginal,
+                "        public int ExistingCaller(int value)\n        {\n" + callerBody + "\n        }",
+                StringComparison.Ordinal);
+
+            TransformWorkerClientResult result = await RunWorkerOnSourceAsync(
+                WriteEdited(editedFileName, edited),
+                HostProjectRelativePath,
+                snapshotSource: onDisk);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            AssertHasSkip(result, nameof(HotReloadAddedMemberHost.ExistingCaller), "value-type");
         }
 
         private static string WithHostMembers(string onDisk, string extraMembers)

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -2938,6 +2938,117 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CreatePreparationValidationOutput(assemblyName, assemblyMvid, "Assets/Edited.cs"));
         }
 
+        /// <summary>
+        /// What: a retained-artifact record without the owner and fingerprint the worker needs to
+        /// re-verify it is refused before the worker runs, because such a record still builds a
+        /// valid mapping and would silently bind the retained type back to its source.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_ArtifactTypeWithoutOwner_IsRejectedBeforeTheWorkerRuns()
+        {
+            TransformWorkerInputDto input = CreateArtifactValidationInput();
+            input.introducedTypeArtifacts[0].types[0].ownerProjectRelativePath = string.Empty;
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                input,
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("owner"));
+        }
+
+        /// <summary>
+        /// What: two retained artifacts claiming one assembly identity are refused, because both
+        /// would enter the compilation under that identity and one of them would resolve to
+        /// nothing, turning a sound artifact into an untrusted one.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_TwoArtifactsClaimingOneAssembly_IsRejected()
+        {
+            TransformWorkerInputDto input = CreateArtifactValidationInput();
+            input.introducedTypeArtifacts = new[]
+            {
+                input.introducedTypeArtifacts[0],
+                CreateArtifactValidationInput().introducedTypeArtifacts[0]
+            };
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                input,
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("assembly identity"));
+        }
+
+        /// <summary>
+        /// What: one artifact listing a type twice is refused, so no run depends on which of the
+        /// two records the worker happened to read first.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_ArtifactListingOneTypeTwice_IsRejected()
+        {
+            TransformWorkerInputDto input = CreateArtifactValidationInput();
+            TransformWorkerIntroducedTypeArtifactDto artifact = input.introducedTypeArtifacts[0];
+            artifact.types = new[] { artifact.types[0], artifact.types[0] };
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                input,
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("more than once"));
+        }
+
+        /// <summary>
+        /// What: a run that carries retained artifacts but names no target assembly is refused,
+        /// because the identity the records normalize back to is the one this run targets.
+        /// </summary>
+        [Test]
+        public async Task RunAsync_ArtifactsWithoutTargetIdentity_IsRejected()
+        {
+            TransformWorkerInputDto input = CreateArtifactValidationInput();
+            input.targetAssemblyMvid = string.Empty;
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                input,
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("module version id"));
+        }
+
+        private static TransformWorkerInputDto CreateArtifactValidationInput()
+        {
+            return new TransformWorkerInputDto
+            {
+                targetAssemblyName = "Assembly",
+                targetAssemblyMvid = "mvid",
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto { projectRelativePath = "Assets/Edited.cs" }
+                },
+                introducedTypeArtifacts = new[]
+                {
+                    new TransformWorkerIntroducedTypeArtifactDto
+                    {
+                        assemblyFullName = "Artifact, Version=1.0.0.0",
+                        referencePath = "Artifact.dll",
+                        types = new[]
+                        {
+                            new TransformWorkerIntroducedTypeArtifactTypeDto
+                            {
+                                metadataName = "Example.Retained",
+                                originalAssemblyName = "Assembly",
+                                originalAssemblyMvid = "mvid",
+                                ownerProjectRelativePath = "Assets/Edited.cs",
+                                declarationFingerprint = "fingerprint"
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
         private static TransformWorkerInputDto CreatePreparationValidationInput()
         {
             return new TransformWorkerInputDto

--- a/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeBindingTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeBindingTests.cs
@@ -26,6 +26,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     {
         private const string RetainedProjectRelativePath = "Assets/Retained.cs";
 
+        private const string DependentProjectRelativePath = "Assets/Dependent.cs";
+
         // The records these tests use only have to be well formed; what they assert is the
         // fingerprint of a dependent type, never the removal of the retained declaration.
         private const string PlaceholderDeclarationFingerprint =
@@ -367,6 +369,101 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 FindFingerprint(foreignBound, "Example.Dependent"),
                 Is.Not.EqualTo(FindFingerprint(sourceDeclared, "Example.Dependent")));
+        }
+
+        /// <summary>
+        /// What: a declaration whose own record still matches is taken out of the binding tree
+        /// even though it reads a type that is now served from a retained artifact, because the
+        /// fingerprint is recomputed through the same normalization planning used. A tampered
+        /// fingerprint on the same run keeps the declaration, so the check is not vacuous.
+        /// </summary>
+        [Test]
+        public async Task Transform_DeclarationReadingRetainedType_StillMatchesItsRecord()
+        {
+            BindingFixture fixture = CreateFixture("DeclarationReadingRetainedType", DirectDependentSource);
+            TransformWorkerClientResult planned = await TransformWorkerClient.RunAsync(
+                CreateInput(
+                    fixture,
+                    includeRetainedSource: true,
+                    Array.Empty<TransformWorkerIntroducedTypeArtifactDto>(),
+                    Array.Empty<string>()),
+                CancellationToken.None);
+            Assert.That(planned.Success, Is.True, planned.ErrorMessage);
+            string dependentFingerprint = FindFingerprint(planned, "Example.Dependent");
+
+            TransformWorkerClientResult matched = await RunTransformAsync(fixture, dependentFingerprint);
+            TransformWorkerClientResult tampered = await RunTransformAsync(
+                fixture,
+                new string('0', 64));
+
+            Assert.That(matched.Success, Is.True, matched.ErrorMessage);
+            Assert.That(tampered.Success, Is.True, tampered.ErrorMessage);
+            Assert.That(CountRowsMentioning(tampered, "Read"), Is.GreaterThan(0));
+            Assert.That(CountRowsMentioning(matched, "Read"), Is.EqualTo(0));
+        }
+
+        private static async Task<TransformWorkerClientResult> RunTransformAsync(
+            BindingFixture fixture,
+            string dependentFingerprint)
+        {
+            TransformWorkerInputDto input = CreateInput(
+                fixture,
+                includeRetainedSource: false,
+                new[]
+                {
+                    CreateRetainedArtifact(fixture),
+                    CreateDependentArtifact(fixture, dependentFingerprint)
+                },
+                Array.Empty<string>());
+            // The declaration is only ever removed by a transform run; planning reports it.
+            input.operation = null;
+            return await TransformWorkerClient.RunAsync(input, CancellationToken.None);
+        }
+
+        private static TransformWorkerIntroducedTypeArtifactDto CreateDependentArtifact(
+            BindingFixture fixture,
+            string declarationFingerprint)
+        {
+            string artifactPath = Path.Combine(fixture.Directory, "DependentArtifact.dll");
+            CreateArtifactAssembly(artifactPath, "DependentArtifact", "Example", "Dependent");
+            return new TransformWorkerIntroducedTypeArtifactDto
+            {
+                assemblyFullName = ReadAssemblyFullName(artifactPath),
+                referencePath = artifactPath,
+                types = new[]
+                {
+                    new TransformWorkerIntroducedTypeArtifactTypeDto
+                    {
+                        metadataName = "Example.Dependent",
+                        originalAssemblyName = fixture.TargetAssemblyName,
+                        originalAssemblyMvid = fixture.TargetAssemblyMvid,
+                        ownerProjectRelativePath = DependentProjectRelativePath,
+                        declarationFingerprint = declarationFingerprint
+                    }
+                }
+            };
+        }
+
+        private static int CountRowsMentioning(TransformWorkerClientResult result, string memberName)
+        {
+            int count = 0;
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                if (entry.methodName == memberName)
+                {
+                    count++;
+                }
+            }
+
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                if (skipped.method != null && skipped.method.Contains(memberName))
+                {
+                    count++;
+                }
+            }
+
+            return count;
         }
 
         private static string FindFingerprint(TransformWorkerClientResult result, string metadataName)

--- a/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeBindingTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeBindingTests.cs
@@ -26,6 +26,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     {
         private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
 
+        private const string DirectDependentSource =
+            "namespace Example { public class Dependent { public int Read(Retained retained) { return retained.Value; } } }";
+
+        // Reaches the retained type without naming it: the only occurrence is inside the type
+        // returned by the member the declaration calls. A fingerprint that collapses a bound
+        // symbol to one type records the collection type and loses the retained type.
+        private const string IndirectDependentSource =
+            "using System.Collections.Generic; namespace Example { public static class Holder { public static List<Retained> All() { return null; } } public class Dependent { public int Count() { return Holder.All().Count; } } }";
+
         /// <summary>
         /// Verifies that the fingerprint of a type is unchanged when the type it depends on stops
         /// being a source declaration and is bound from a retained artifact assembly instead.
@@ -33,7 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task PrepareIntroducedTypes_DependencyMovedToArtifact_KeepsFingerprint()
         {
-            BindingFixture fixture = CreateFixture("DependencyMovedToArtifact");
+            BindingFixture fixture = CreateFixture("DependencyMovedToArtifact", DirectDependentSource);
 
             TransformWorkerClientResult beforeSwitch = await TransformWorkerClient.RunAsync(
                 CreateInput(fixture, includeRetainedSource: true, Array.Empty<TransformWorkerIntroducedTypeArtifactDto>(),
@@ -59,7 +68,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task PrepareIntroducedTypes_UnrelatedArtifactAdded_KeepsFingerprint()
         {
-            BindingFixture fixture = CreateFixture("UnrelatedArtifactAdded");
+            BindingFixture fixture = CreateFixture("UnrelatedArtifactAdded", DirectDependentSource);
             string unrelatedPath = Path.Combine(fixture.Directory, "Unrelated.dll");
             CreateArtifactAssembly(unrelatedPath, "UnrelatedArtifact", "Example", "Unrelated");
             TransformWorkerIntroducedTypeArtifactDto unrelatedArtifact = new TransformWorkerIntroducedTypeArtifactDto
@@ -94,27 +103,48 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// Verifies that a type bound from a retained artifact reports the artifact assembly as
-        /// its containing assembly, so the fingerprint match is not produced by the artifact
-        /// reference being ignored altogether.
+        /// Verifies that the retained type really binds against the artifact assembly and that the
+        /// record is what maps its identity back: referencing the same artifact without a record
+        /// leaves the artifact assembly identity in the fingerprint, so it stops matching the run
+        /// in which the type was still a source declaration.
         /// </summary>
         [Test]
-        public async Task PrepareIntroducedTypes_DependencyMovedToArtifact_BindsAgainstArtifactAssembly()
+        public async Task PrepareIntroducedTypes_ArtifactReferencedWithoutRecord_ChangesFingerprint()
         {
-            BindingFixture fixture = CreateFixture("BindsAgainstArtifact");
-            TransformWorkerIntroducedTypeArtifactDto artifact = CreateRetainedArtifact(fixture);
+            BindingFixture fixture = CreateFixture("ArtifactWithoutRecord", DirectDependentSource);
 
-            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
-                CreateInput(fixture, includeRetainedSource: false, new[] { artifact },
+            TransformWorkerClientResult sourceDeclared = await TransformWorkerClient.RunAsync(
+                CreateInput(
+                    fixture,
+                    includeRetainedSource: true,
+                    Array.Empty<TransformWorkerIntroducedTypeArtifactDto>(),
                     Array.Empty<string>()),
                 CancellationToken.None);
+            TransformWorkerClientResult recorded = await TransformWorkerClient.RunAsync(
+                CreateInput(
+                    fixture,
+                    includeRetainedSource: false,
+                    new[] { CreateRetainedArtifact(fixture) },
+                    Array.Empty<string>()),
+                CancellationToken.None);
+            TransformWorkerClientResult unrecorded = await TransformWorkerClient.RunAsync(
+                CreateInput(
+                    fixture,
+                    includeRetainedSource: false,
+                    Array.Empty<TransformWorkerIntroducedTypeArtifactDto>(),
+                    new[] { fixture.RetainedArtifactPath }),
+                CancellationToken.None);
 
-            Assert.That(result.Success, Is.True, result.ErrorMessage);
-            // The dependent type only compiles when the retained member really resolved, so a
-            // source that uses the member proves the binding went through the artifact rather
-            // than through a leftover source declaration.
-            Assert.That(FindFingerprint(result, "Example.Dependent"), Is.Not.Null);
-            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Is.Empty);
+            Assert.That(sourceDeclared.Success, Is.True, sourceDeclared.ErrorMessage);
+            Assert.That(recorded.Success, Is.True, recorded.ErrorMessage);
+            Assert.That(unrecorded.Success, Is.True, unrecorded.ErrorMessage);
+            Assert.That(
+                FindFingerprint(recorded, "Example.Dependent"),
+                Is.EqualTo(FindFingerprint(sourceDeclared, "Example.Dependent")));
+            Assert.That(
+                FindFingerprint(unrecorded, "Example.Dependent"),
+                Is.Not.EqualTo(FindFingerprint(sourceDeclared, "Example.Dependent")),
+                "Without a record the artifact assembly identity must stay in the fingerprint.");
         }
 
         /// <summary>
@@ -125,7 +155,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task PrepareIntroducedTypes_ArtifactOriginalIdentityChanged_ChangesFingerprint()
         {
-            BindingFixture fixture = CreateFixture("ArtifactOriginalIdentityChanged");
+            BindingFixture fixture = CreateFixture("ArtifactOriginalIdentityChanged", DirectDependentSource);
             TransformWorkerIntroducedTypeArtifactDto recorded = CreateRetainedArtifact(fixture);
             TransformWorkerIntroducedTypeArtifactDto reattributed = CreateRetainedArtifact(fixture);
             reattributed.types[0].originalAssemblyMvid = Guid.NewGuid().ToString();
@@ -151,7 +181,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task PrepareIntroducedTypes_SameNameFromUnlistedAssembly_ChangesFingerprint()
         {
-            BindingFixture fixture = CreateFixture("SameNameFromUnlistedAssembly");
+            BindingFixture fixture = CreateFixture("SameNameFromUnlistedAssembly", DirectDependentSource);
             string foreignPath = Path.Combine(fixture.Directory, "ForeignRetained.dll");
             CreateRetainedArtifactAssembly(foreignPath, "ForeignRetained");
 
@@ -185,7 +215,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task PrepareIntroducedTypes_ArtifactIdentityMismatch_ReportsNoIntroducedType()
         {
-            BindingFixture fixture = CreateFixture("ArtifactIdentityMismatch");
+            BindingFixture fixture = CreateFixture("ArtifactIdentityMismatch", DirectDependentSource);
             TransformWorkerIntroducedTypeArtifactDto mismatched = CreateRetainedArtifact(fixture);
             mismatched.assemblyFullName = ReadAssemblyFullName(fixture.TargetAssemblyPath);
 
@@ -199,7 +229,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task PrepareIntroducedTypes_ArtifactMissingMetadataName_ReportsNoIntroducedType()
         {
-            BindingFixture fixture = CreateFixture("ArtifactMissingMetadataName");
+            BindingFixture fixture = CreateFixture("ArtifactMissingMetadataName", DirectDependentSource);
             TransformWorkerIntroducedTypeArtifactDto missing = CreateRetainedArtifact(fixture);
             missing.types[0].metadataName = "Example.Absent";
 
@@ -213,7 +243,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task PrepareIntroducedTypes_TwoArtifactsNormalizeToSameType_ReportsNoIntroducedType()
         {
-            BindingFixture fixture = CreateFixture("TwoArtifactsNormalizeToSameType");
+            BindingFixture fixture = CreateFixture("TwoArtifactsNormalizeToSameType", DirectDependentSource);
             string secondPath = Path.Combine(fixture.Directory, "SecondRetained.dll");
             CreateRetainedArtifactAssembly(secondPath, "SecondRetained");
             TransformWorkerIntroducedTypeArtifactDto duplicate = new TransformWorkerIntroducedTypeArtifactDto
@@ -263,6 +293,71 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
         }
 
+        /// <summary>
+        /// Verifies that a declaration reaching the retained type only through a constructed
+        /// generic and an array keeps its fingerprint when that type moves into an artifact.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_IndirectDependencyMovedToArtifact_KeepsFingerprint()
+        {
+            BindingFixture fixture = CreateFixture("IndirectDependencyMoved", IndirectDependentSource);
+
+            TransformWorkerClientResult beforeSwitch = await TransformWorkerClient.RunAsync(
+                CreateInput(
+                    fixture,
+                    includeRetainedSource: true,
+                    Array.Empty<TransformWorkerIntroducedTypeArtifactDto>(),
+                    Array.Empty<string>()),
+                CancellationToken.None);
+            TransformWorkerClientResult afterSwitch = await TransformWorkerClient.RunAsync(
+                CreateInput(
+                    fixture,
+                    includeRetainedSource: false,
+                    new[] { CreateRetainedArtifact(fixture) },
+                    Array.Empty<string>()),
+                CancellationToken.None);
+
+            Assert.That(beforeSwitch.Success, Is.True, beforeSwitch.ErrorMessage);
+            Assert.That(afterSwitch.Success, Is.True, afterSwitch.ErrorMessage);
+            Assert.That(
+                FindFingerprint(afterSwitch, "Example.Dependent"),
+                Is.EqualTo(FindFingerprint(beforeSwitch, "Example.Dependent")));
+        }
+
+        /// <summary>
+        /// Verifies that swapping the type behind a constructed generic and an array for a
+        /// same-named type in another assembly changes the fingerprint, so a dependency that only
+        /// appears inside a type argument or an element type is really recorded.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_IndirectDependencySwappedForForeignType_ChangesFingerprint()
+        {
+            BindingFixture fixture = CreateFixture("IndirectDependencySwapped", IndirectDependentSource);
+            string foreignPath = Path.Combine(fixture.Directory, "ForeignRetained.dll");
+            CreateRetainedArtifactAssembly(foreignPath, "ForeignRetained");
+
+            TransformWorkerClientResult sourceDeclared = await TransformWorkerClient.RunAsync(
+                CreateInput(
+                    fixture,
+                    includeRetainedSource: true,
+                    Array.Empty<TransformWorkerIntroducedTypeArtifactDto>(),
+                    Array.Empty<string>()),
+                CancellationToken.None);
+            TransformWorkerClientResult foreignBound = await TransformWorkerClient.RunAsync(
+                CreateInput(
+                    fixture,
+                    includeRetainedSource: false,
+                    Array.Empty<TransformWorkerIntroducedTypeArtifactDto>(),
+                    new[] { foreignPath }),
+                CancellationToken.None);
+
+            Assert.That(sourceDeclared.Success, Is.True, sourceDeclared.ErrorMessage);
+            Assert.That(foreignBound.Success, Is.True, foreignBound.ErrorMessage);
+            Assert.That(
+                FindFingerprint(foreignBound, "Example.Dependent"),
+                Is.Not.EqualTo(FindFingerprint(sourceDeclared, "Example.Dependent")));
+        }
+
         private static string FindFingerprint(TransformWorkerClientResult result, string metadataName)
         {
             foreach (TransformWorkerFileOutputDto file in result.Output.files)
@@ -280,7 +375,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return null;
         }
 
-        private static BindingFixture CreateFixture(string name)
+        private static BindingFixture CreateFixture(string name, string dependentSource)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string directory = Path.Combine(
@@ -293,9 +388,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Directory.CreateDirectory(directory);
             string dependentSourcePath = Path.Combine(directory, "Dependent.cs");
             string retainedSourcePath = Path.Combine(directory, "Retained.cs");
-            File.WriteAllText(
-                dependentSourcePath,
-                "namespace Example { public class Dependent { public int Read(Retained retained) { return retained.Value; } } }");
+            File.WriteAllText(dependentSourcePath, dependentSource);
             File.WriteAllText(
                 retainedSourcePath,
                 "namespace Example { public class Retained { public int Value; } }");

--- a/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeBindingTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeBindingTests.cs
@@ -1,0 +1,504 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+using Mono.Cecil;
+using CecilTypeAttributes = Mono.Cecil.TypeAttributes;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Verifies that a reference which moves from a source declaration to a retained artifact
+    /// assembly normalizes back to the same original identity, so the declaration fingerprint
+    /// describes the definition rather than where the definition currently lives.
+    /// </summary>
+    public class TransformWorkerIntroducedTypeBindingTests
+    {
+        private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+
+        /// <summary>
+        /// Verifies that the fingerprint of a type is unchanged when the type it depends on stops
+        /// being a source declaration and is bound from a retained artifact assembly instead.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_DependencyMovedToArtifact_KeepsFingerprint()
+        {
+            BindingFixture fixture = CreateFixture("DependencyMovedToArtifact");
+
+            TransformWorkerClientResult beforeSwitch = await TransformWorkerClient.RunAsync(
+                CreateInput(fixture, includeRetainedSource: true, Array.Empty<TransformWorkerIntroducedTypeArtifactDto>(),
+                    Array.Empty<string>()),
+                CancellationToken.None);
+            TransformWorkerClientResult afterSwitch = await TransformWorkerClient.RunAsync(
+                CreateInput(fixture, includeRetainedSource: false, new[] { CreateRetainedArtifact(fixture) },
+                    Array.Empty<string>()),
+                CancellationToken.None);
+
+            Assert.That(beforeSwitch.Success, Is.True, beforeSwitch.ErrorMessage);
+            Assert.That(afterSwitch.Success, Is.True, afterSwitch.ErrorMessage);
+            Assert.That(
+                FindFingerprint(beforeSwitch, "Example.Dependent"),
+                Is.EqualTo(FindFingerprint(afterSwitch, "Example.Dependent")),
+                "Moving the dependency into a retained artifact must not change the definition.");
+        }
+
+        /// <summary>
+        /// Verifies that adding an artifact the declaration does not depend on leaves the
+        /// fingerprint unchanged, so an unrelated retained type cannot invalidate it.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_UnrelatedArtifactAdded_KeepsFingerprint()
+        {
+            BindingFixture fixture = CreateFixture("UnrelatedArtifactAdded");
+            string unrelatedPath = Path.Combine(fixture.Directory, "Unrelated.dll");
+            CreateArtifactAssembly(unrelatedPath, "UnrelatedArtifact", "Example", "Unrelated");
+            TransformWorkerIntroducedTypeArtifactDto unrelatedArtifact = new TransformWorkerIntroducedTypeArtifactDto
+            {
+                assemblyFullName = ReadAssemblyFullName(unrelatedPath),
+                referencePath = unrelatedPath,
+                types = new[]
+                {
+                    new TransformWorkerIntroducedTypeArtifactTypeDto
+                    {
+                        metadataName = "Example.Unrelated",
+                        originalAssemblyName = fixture.TargetAssemblyName,
+                        originalAssemblyMvid = fixture.TargetAssemblyMvid
+                    }
+                }
+            };
+
+            TransformWorkerClientResult withoutArtifact = await TransformWorkerClient.RunAsync(
+                CreateInput(fixture, includeRetainedSource: true, Array.Empty<TransformWorkerIntroducedTypeArtifactDto>(),
+                    Array.Empty<string>()),
+                CancellationToken.None);
+            TransformWorkerClientResult withArtifact = await TransformWorkerClient.RunAsync(
+                CreateInput(fixture, includeRetainedSource: true, new[] { unrelatedArtifact },
+                    Array.Empty<string>()),
+                CancellationToken.None);
+
+            Assert.That(withoutArtifact.Success, Is.True, withoutArtifact.ErrorMessage);
+            Assert.That(withArtifact.Success, Is.True, withArtifact.ErrorMessage);
+            Assert.That(
+                FindFingerprint(withArtifact, "Example.Dependent"),
+                Is.EqualTo(FindFingerprint(withoutArtifact, "Example.Dependent")));
+        }
+
+        /// <summary>
+        /// Verifies that a type bound from a retained artifact reports the artifact assembly as
+        /// its containing assembly, so the fingerprint match is not produced by the artifact
+        /// reference being ignored altogether.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_DependencyMovedToArtifact_BindsAgainstArtifactAssembly()
+        {
+            BindingFixture fixture = CreateFixture("BindsAgainstArtifact");
+            TransformWorkerIntroducedTypeArtifactDto artifact = CreateRetainedArtifact(fixture);
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                CreateInput(fixture, includeRetainedSource: false, new[] { artifact },
+                    Array.Empty<string>()),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            // The dependent type only compiles when the retained member really resolved, so a
+            // source that uses the member proves the binding went through the artifact rather
+            // than through a leftover source declaration.
+            Assert.That(FindFingerprint(result, "Example.Dependent"), Is.Not.Null);
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Is.Empty);
+        }
+
+        /// <summary>
+        /// Verifies that the fingerprint changes when the artifact record attributes the retained
+        /// type to a different original assembly, so normalization follows the recorded identity
+        /// rather than erasing the dependency.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_ArtifactOriginalIdentityChanged_ChangesFingerprint()
+        {
+            BindingFixture fixture = CreateFixture("ArtifactOriginalIdentityChanged");
+            TransformWorkerIntroducedTypeArtifactDto recorded = CreateRetainedArtifact(fixture);
+            TransformWorkerIntroducedTypeArtifactDto reattributed = CreateRetainedArtifact(fixture);
+            reattributed.types[0].originalAssemblyMvid = Guid.NewGuid().ToString();
+
+            TransformWorkerClientResult first = await TransformWorkerClient.RunAsync(
+                CreateInput(fixture, includeRetainedSource: false, new[] { recorded }, Array.Empty<string>()),
+                CancellationToken.None);
+            TransformWorkerClientResult second = await TransformWorkerClient.RunAsync(
+                CreateInput(fixture, includeRetainedSource: false, new[] { reattributed }, Array.Empty<string>()),
+                CancellationToken.None);
+
+            Assert.That(first.Success, Is.True, first.ErrorMessage);
+            Assert.That(second.Success, Is.True, second.ErrorMessage);
+            Assert.That(
+                FindFingerprint(second, "Example.Dependent"),
+                Is.Not.EqualTo(FindFingerprint(first, "Example.Dependent")));
+        }
+
+        /// <summary>
+        /// Verifies that a type with the same metadata name coming from an assembly no artifact
+        /// record names is not normalized, so the mapping cannot be driven by a metadata name alone.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_SameNameFromUnlistedAssembly_ChangesFingerprint()
+        {
+            BindingFixture fixture = CreateFixture("SameNameFromUnlistedAssembly");
+            string foreignPath = Path.Combine(fixture.Directory, "ForeignRetained.dll");
+            CreateRetainedArtifactAssembly(foreignPath, "ForeignRetained");
+
+            TransformWorkerClientResult sourceDeclared = await TransformWorkerClient.RunAsync(
+                CreateInput(
+                    fixture,
+                    includeRetainedSource: true,
+                    Array.Empty<TransformWorkerIntroducedTypeArtifactDto>(),
+                    Array.Empty<string>()),
+                CancellationToken.None);
+            TransformWorkerClientResult unlisted = await TransformWorkerClient.RunAsync(
+                CreateInput(
+                    fixture,
+                    includeRetainedSource: false,
+                    Array.Empty<TransformWorkerIntroducedTypeArtifactDto>(),
+                    new[] { foreignPath }),
+                CancellationToken.None);
+
+            Assert.That(sourceDeclared.Success, Is.True, sourceDeclared.ErrorMessage);
+            Assert.That(unlisted.Success, Is.True, unlisted.ErrorMessage);
+            Assert.That(
+                FindFingerprint(unlisted, "Example.Dependent"),
+                Is.Not.EqualTo(FindFingerprint(sourceDeclared, "Example.Dependent")),
+                "An unlisted assembly must not be normalized just because the metadata name matches.");
+        }
+
+        /// <summary>
+        /// Verifies that an artifact record claiming an identity the referenced assembly does not
+        /// report produces a diagnostic instead of a descriptor.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_ArtifactIdentityMismatch_ReportsNoIntroducedType()
+        {
+            BindingFixture fixture = CreateFixture("ArtifactIdentityMismatch");
+            TransformWorkerIntroducedTypeArtifactDto mismatched = CreateRetainedArtifact(fixture);
+            mismatched.assemblyFullName = ReadAssemblyFullName(fixture.TargetAssemblyPath);
+
+            await AssertArtifactIsRejected(fixture, mismatched);
+        }
+
+        /// <summary>
+        /// Verifies that an artifact record listing a type the referenced assembly does not hold
+        /// produces a diagnostic instead of a descriptor.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_ArtifactMissingMetadataName_ReportsNoIntroducedType()
+        {
+            BindingFixture fixture = CreateFixture("ArtifactMissingMetadataName");
+            TransformWorkerIntroducedTypeArtifactDto missing = CreateRetainedArtifact(fixture);
+            missing.types[0].metadataName = "Example.Absent";
+
+            await AssertArtifactIsRejected(fixture, missing);
+        }
+
+        /// <summary>
+        /// Verifies that two artifacts normalizing to the same original type are rejected, because
+        /// the fingerprint would otherwise depend on which record was consulted first.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_TwoArtifactsNormalizeToSameType_ReportsNoIntroducedType()
+        {
+            BindingFixture fixture = CreateFixture("TwoArtifactsNormalizeToSameType");
+            string secondPath = Path.Combine(fixture.Directory, "SecondRetained.dll");
+            CreateRetainedArtifactAssembly(secondPath, "SecondRetained");
+            TransformWorkerIntroducedTypeArtifactDto duplicate = new TransformWorkerIntroducedTypeArtifactDto
+            {
+                assemblyFullName = ReadAssemblyFullName(secondPath),
+                referencePath = secondPath,
+                types = new[]
+                {
+                    new TransformWorkerIntroducedTypeArtifactTypeDto
+                    {
+                        metadataName = "Example.Retained",
+                        originalAssemblyName = fixture.TargetAssemblyName,
+                        originalAssemblyMvid = fixture.TargetAssemblyMvid
+                    }
+                }
+            };
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                CreateInput(
+                    fixture,
+                    includeRetainedSource: false,
+                    new[] { CreateRetainedArtifact(fixture), duplicate },
+                    Array.Empty<string>()),
+                CancellationToken.None);
+
+            AssertPreparationWasRefused(result);
+        }
+
+        private static async Task AssertArtifactIsRejected(
+            BindingFixture fixture,
+            TransformWorkerIntroducedTypeArtifactDto artifact)
+        {
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                CreateInput(fixture, includeRetainedSource: true, new[] { artifact }, Array.Empty<string>()),
+                CancellationToken.None);
+
+            AssertPreparationWasRefused(result);
+        }
+
+        private static void AssertPreparationWasRefused(TransformWorkerClientResult result)
+        {
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            foreach (TransformWorkerFileOutputDto file in result.Output.files)
+            {
+                Assert.That(file.introducedTypes, Is.Empty);
+                Assert.That(file.introducedTypeDiagnostics, Is.Not.Empty);
+            }
+        }
+
+        private static string FindFingerprint(TransformWorkerClientResult result, string metadataName)
+        {
+            foreach (TransformWorkerFileOutputDto file in result.Output.files)
+            {
+                foreach (TransformWorkerIntroducedTypeDto introducedType in file.introducedTypes)
+                {
+                    if (introducedType.metadataName == metadataName)
+                    {
+                        return introducedType.declarationFingerprint;
+                    }
+                }
+            }
+
+            Assert.Fail("No introduced type named " + metadataName + " was reported.");
+            return null;
+        }
+
+        private static BindingFixture CreateFixture(string name)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(
+                projectRoot,
+                "Library",
+                "UloopHotReload",
+                "TestSources",
+                "IntroducedTypeBinding",
+                name);
+            Directory.CreateDirectory(directory);
+            string dependentSourcePath = Path.Combine(directory, "Dependent.cs");
+            string retainedSourcePath = Path.Combine(directory, "Retained.cs");
+            File.WriteAllText(
+                dependentSourcePath,
+                "namespace Example { public class Dependent { public int Read(Retained retained) { return retained.Value; } } }");
+            File.WriteAllText(
+                retainedSourcePath,
+                "namespace Example { public class Retained { public int Value; } }");
+            string targetAssemblyPath = Path.Combine(directory, "BindingTarget.dll");
+            string targetAssemblyMvid = CreateArtifactAssembly(
+                targetAssemblyPath,
+                "BindingTarget",
+                "Example",
+                "Unrelated");
+            string retainedArtifactPath = Path.Combine(directory, "RetainedArtifact.dll");
+            CreateRetainedArtifactAssembly(retainedArtifactPath, "RetainedArtifact");
+            return new BindingFixture(
+                directory,
+                dependentSourcePath,
+                retainedSourcePath,
+                targetAssemblyPath,
+                "BindingTarget",
+                targetAssemblyMvid,
+                retainedArtifactPath);
+        }
+
+        private static TransformWorkerIntroducedTypeArtifactDto CreateRetainedArtifact(BindingFixture fixture)
+        {
+            return new TransformWorkerIntroducedTypeArtifactDto
+            {
+                assemblyFullName = ReadAssemblyFullName(fixture.RetainedArtifactPath),
+                referencePath = fixture.RetainedArtifactPath,
+                types = new[]
+                {
+                    new TransformWorkerIntroducedTypeArtifactTypeDto
+                    {
+                        metadataName = "Example.Retained",
+                        originalAssemblyName = fixture.TargetAssemblyName,
+                        originalAssemblyMvid = fixture.TargetAssemblyMvid
+                    }
+                }
+            };
+        }
+
+        private static TransformWorkerInputDto CreateInput(
+            BindingFixture fixture,
+            bool includeRetainedSource,
+            TransformWorkerIntroducedTypeArtifactDto[] artifacts,
+            string[] extraReferencePaths)
+        {
+            UnityEditor.Compilation.Assembly compilationAssembly = FindCompilationAssembly();
+            List<TransformWorkerSourceDto> sources = new List<TransformWorkerSourceDto>
+            {
+                new TransformWorkerSourceDto
+                {
+                    sourcePath = fixture.DependentSourcePath,
+                    projectRelativePath = "Assets/Dependent.cs"
+                }
+            };
+            if (includeRetainedSource)
+            {
+                sources.Add(
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = fixture.RetainedSourcePath,
+                        projectRelativePath = "Assets/Retained.cs"
+                    });
+            }
+
+            List<string> referencePaths = new List<string>();
+            foreach (string reference in compilationAssembly.allReferences)
+            {
+                if (!string.IsNullOrEmpty(reference) && File.Exists(reference))
+                {
+                    referencePaths.Add(Path.GetFullPath(reference));
+                }
+            }
+
+            referencePaths.Add(Path.GetFullPath(fixture.TargetAssemblyPath));
+            foreach (string extraReferencePath in extraReferencePaths)
+            {
+                referencePaths.Add(Path.GetFullPath(extraReferencePath));
+            }
+
+            return new TransformWorkerInputDto
+            {
+                operation = "prepareIntroducedTypes",
+                sources = sources.ToArray(),
+                defines = compilationAssembly.defines ?? Array.Empty<string>(),
+                referencePaths = referencePaths.ToArray(),
+                targetTypesAssemblyPath = fixture.TargetAssemblyPath,
+                targetAssemblyName = fixture.TargetAssemblyName,
+                targetAssemblyMvid = fixture.TargetAssemblyMvid,
+                assemblySourcePaths = Array.Empty<string>(),
+                changedSiblingSourcePaths = Array.Empty<string>(),
+                introducedTypeArtifacts = artifacts
+            };
+        }
+
+        private static string CreateArtifactAssembly(
+            string path,
+            string assemblyName,
+            string typeNamespace,
+            string typeName)
+        {
+            AssemblyNameDefinition assemblyNameDefinition = new AssemblyNameDefinition(
+                assemblyName,
+                new Version(1, 0, 0, 0));
+            using (AssemblyDefinition assembly = AssemblyDefinition.CreateAssembly(
+                assemblyNameDefinition,
+                assemblyName,
+                ModuleKind.Dll))
+            {
+                TypeDefinition type = new TypeDefinition(
+                    typeNamespace,
+                    typeName,
+                    CecilTypeAttributes.Public | CecilTypeAttributes.Class,
+                    assembly.MainModule.TypeSystem.Object);
+                assembly.MainModule.Types.Add(type);
+                assembly.Write(path);
+            }
+
+            using (ModuleDefinition module = ModuleDefinition.ReadModule(path))
+            {
+                return module.Mvid.ToString();
+            }
+        }
+
+        private static void CreateRetainedArtifactAssembly(string path, string assemblyName)
+        {
+            AssemblyNameDefinition assemblyNameDefinition = new AssemblyNameDefinition(
+                assemblyName,
+                new Version(1, 0, 0, 0));
+            using (AssemblyDefinition assembly = AssemblyDefinition.CreateAssembly(
+                assemblyNameDefinition,
+                assemblyName,
+                ModuleKind.Dll))
+            {
+                TypeDefinition retainedType = new TypeDefinition(
+                    "Example",
+                    "Retained",
+                    CecilTypeAttributes.Public | CecilTypeAttributes.Class,
+                    assembly.MainModule.TypeSystem.Object);
+                FieldDefinition valueField = new FieldDefinition(
+                    "Value",
+                    Mono.Cecil.FieldAttributes.Public,
+                    assembly.MainModule.TypeSystem.Int32);
+                retainedType.Fields.Add(valueField);
+                assembly.MainModule.Types.Add(retainedType);
+                assembly.Write(path);
+            }
+        }
+
+        private static string ReadAssemblyFullName(string path)
+        {
+            using (AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(path))
+            {
+                return assembly.Name.FullName;
+            }
+        }
+
+        private static UnityEditor.Compilation.Assembly FindCompilationAssembly()
+        {
+            foreach (UnityEditor.Compilation.Assembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name == TestAssemblyName)
+                {
+                    return assembly;
+                }
+            }
+
+            Assert.Fail("Compilation assembly was not found.");
+            return null;
+        }
+
+        private sealed class BindingFixture
+        {
+            public BindingFixture(
+                string directory,
+                string dependentSourcePath,
+                string retainedSourcePath,
+                string targetAssemblyPath,
+                string targetAssemblyName,
+                string targetAssemblyMvid,
+                string retainedArtifactPath)
+            {
+                Directory = directory;
+                DependentSourcePath = dependentSourcePath;
+                RetainedSourcePath = retainedSourcePath;
+                TargetAssemblyPath = targetAssemblyPath;
+                TargetAssemblyName = targetAssemblyName;
+                TargetAssemblyMvid = targetAssemblyMvid;
+                RetainedArtifactPath = retainedArtifactPath;
+            }
+
+            public string Directory { get; }
+
+            public string DependentSourcePath { get; }
+
+            public string RetainedSourcePath { get; }
+
+            public string TargetAssemblyPath { get; }
+
+            public string TargetAssemblyName { get; }
+
+            public string TargetAssemblyMvid { get; }
+
+            public string RetainedArtifactPath { get; }
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeBindingTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeBindingTests.cs
@@ -24,6 +24,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     /// </summary>
     public class TransformWorkerIntroducedTypeBindingTests
     {
+        private const string RetainedProjectRelativePath = "Assets/Retained.cs";
+
+        // The records these tests use only have to be well formed; what they assert is the
+        // fingerprint of a dependent type, never the removal of the retained declaration.
+        private const string PlaceholderDeclarationFingerprint =
+            "0000000000000000000000000000000000000000000000000000000000000000";
+
         private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
 
         private const string DirectDependentSource =
@@ -81,7 +88,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     {
                         metadataName = "Example.Unrelated",
                         originalAssemblyName = fixture.TargetAssemblyName,
-                        originalAssemblyMvid = fixture.TargetAssemblyMvid
+                        originalAssemblyMvid = fixture.TargetAssemblyMvid,
+                        ownerProjectRelativePath = RetainedProjectRelativePath,
+                        declarationFingerprint = PlaceholderDeclarationFingerprint
                     }
                 }
             };
@@ -256,7 +265,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     {
                         metadataName = "Example.Retained",
                         originalAssemblyName = fixture.TargetAssemblyName,
-                        originalAssemblyMvid = fixture.TargetAssemblyMvid
+                        originalAssemblyMvid = fixture.TargetAssemblyMvid,
+                        ownerProjectRelativePath = RetainedProjectRelativePath,
+                        declarationFingerprint = PlaceholderDeclarationFingerprint
                     }
                 }
             };
@@ -422,7 +433,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     {
                         metadataName = "Example.Retained",
                         originalAssemblyName = fixture.TargetAssemblyName,
-                        originalAssemblyMvid = fixture.TargetAssemblyMvid
+                        originalAssemblyMvid = fixture.TargetAssemblyMvid,
+                        ownerProjectRelativePath = RetainedProjectRelativePath,
+                        declarationFingerprint = PlaceholderDeclarationFingerprint
                     }
                 }
             };

--- a/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeBindingTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeBindingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ded486faa060c4be08cf7af8bc5d88bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
@@ -481,6 +481,39 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that a const changed in another edited file, one this run does not transform,
+        /// still rejects the introduced type that reads it, because planning would otherwise fold
+        /// the value the target assembly was compiled with into the artifact.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_ChangedConstInAnotherFile_IsRejected()
+        {
+            string directory = CreateSourceDirectory("ChangedConstInAnotherFile");
+            string sourcePath = Path.Combine(directory, "Edited.cs");
+            string siblingPath = Path.Combine(directory, "Sibling.cs");
+            string targetAssemblyPath = Path.Combine(directory, "ConstDriftTarget.dll");
+            string targetAssemblyMvid = CreateConstDriftTargetAssembly(targetAssemblyPath, 1);
+            File.WriteAllText(
+                sourcePath,
+                "namespace Example { public class Introduced { public int Get() { return Existing.Value; } } }");
+            File.WriteAllText(
+                siblingPath,
+                "namespace Example { public class Existing { public const int Value = 2; } }");
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                CreateConstDriftInputWithSiblings(
+                    sourcePath,
+                    targetAssemblyPath,
+                    targetAssemblyMvid,
+                    new[] { siblingPath }),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.files[0].introducedTypes, Is.Empty);
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Existing.Value"));
+        }
+
+        /// <summary>
         /// Verifies that a changed const does not reject an introduced type that does not refer to it.
         /// </summary>
         [Test]
@@ -614,7 +647,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     targetAssemblyPath,
                     "ConstDriftTarget",
                     targetAssemblyMvid,
-                    new[] { brokenReferencePath }),
+                    new[] { brokenReferencePath },
+                    Array.Empty<string>()),
                 CancellationToken.None);
 
             Assert.That(result.Success, Is.True, result.ErrorMessage);
@@ -675,7 +709,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     targetAssemblyPath,
                     "SameNameTarget",
                     targetAssemblyMvid,
-                    new[] { otherAssemblyPath }),
+                    new[] { otherAssemblyPath },
+                    Array.Empty<string>()),
                 CancellationToken.None);
 
             Assert.That(result.Success, Is.True, result.ErrorMessage);
@@ -734,7 +769,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 targetAssemblyPath,
                 "ConstDriftTarget",
                 targetAssemblyMvid,
+                Array.Empty<string>(),
                 Array.Empty<string>());
+        }
+
+        private static TransformWorkerInputDto CreateConstDriftInputWithSiblings(
+            string sourcePath,
+            string targetAssemblyPath,
+            string targetAssemblyMvid,
+            string[] changedSiblingSourcePaths)
+        {
+            return CreatePreparationInput(
+                sourcePath,
+                targetAssemblyPath,
+                "ConstDriftTarget",
+                targetAssemblyMvid,
+                Array.Empty<string>(),
+                changedSiblingSourcePaths);
         }
 
         private static TransformWorkerInputDto CreatePreparationInput(
@@ -742,7 +793,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string targetAssemblyPath,
             string targetAssemblyName,
             string targetAssemblyMvid,
-            string[] extraReferencePaths)
+            string[] extraReferencePaths,
+            string[] changedSiblingSourcePaths)
         {
             UnityEditor.Compilation.Assembly compilationAssembly = FindCompilationAssembly();
             List<string> referencePaths = new List<string>(
@@ -769,7 +821,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 targetAssemblyName = targetAssemblyName,
                 targetAssemblyMvid = targetAssemblyMvid,
                 assemblySourcePaths = Array.Empty<string>(),
-                changedSiblingSourcePaths = Array.Empty<string>()
+                changedSiblingSourcePaths = changedSiblingSourcePaths
             };
         }
 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
@@ -456,6 +456,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that an introduced type referencing a changed const from a compiled existing
+        /// type is rejected instead of compiling the artifact with the metadata assembly's old value.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_ChangedReferencedExistingConst_IsRejected()
+        {
+            string directory = CreateSourceDirectory("ChangedExistingConst");
+            string sourcePath = Path.Combine(directory, "Edited.cs");
+            string targetAssemblyPath = Path.Combine(directory, "ConstDriftTarget.dll");
+            string targetAssemblyMvid = CreateConstDriftTargetAssembly(targetAssemblyPath, 1);
+            File.WriteAllText(
+                sourcePath,
+                "namespace Example { public class Existing { public const int Value = 2; } public class Introduced { public int Get() { return Existing.Value; } } public class Safe { } }");
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                CreateConstDriftInput(sourcePath, targetAssemblyPath, targetAssemblyMvid),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.files[0].introducedTypes, Has.Length.EqualTo(1));
+            Assert.That(result.Output.files[0].introducedTypes[0].metadataName, Is.EqualTo("Example.Safe"));
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Existing.Value"));
+        }
+
+        /// <summary>
         /// Verifies that a changed const does not reject an introduced type that does not refer to it.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
@@ -514,6 +514,39 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that a const in another edited file whose value cannot be read at all rejects
+        /// the introduced type that reads it, because the artifact compile does not see that file
+        /// and would succeed against the value still in the target assembly.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_UnreadableConstInAnotherFile_IsRejected()
+        {
+            string directory = CreateSourceDirectory("UnreadableConstInAnotherFile");
+            string sourcePath = Path.Combine(directory, "Edited.cs");
+            string siblingPath = Path.Combine(directory, "Sibling.cs");
+            string targetAssemblyPath = Path.Combine(directory, "ConstDriftTarget.dll");
+            string targetAssemblyMvid = CreateConstDriftTargetAssembly(targetAssemblyPath, 1);
+            File.WriteAllText(
+                sourcePath,
+                "namespace Example { public class Introduced { public int Get() { return Existing.Value; } } }");
+            File.WriteAllText(
+                siblingPath,
+                "namespace Example { public class Existing { public const int Value = ; } }");
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                CreateConstDriftInputWithSiblings(
+                    sourcePath,
+                    targetAssemblyPath,
+                    targetAssemblyMvid,
+                    new[] { siblingPath }),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.files[0].introducedTypes, Is.Empty);
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Has.Some.Contains("Existing.Value"));
+        }
+
+        /// <summary>
         /// Verifies that a changed const does not reject an introduced type that does not refer to it.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
@@ -514,6 +514,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that a const changed in another edited file does not reject an introduced type
+        /// that only names it inside nameof, because nameof yields the identifier and never folds
+        /// the value into the artifact.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_ChangedConstNamedOnlyInNameof_IsNotRejected()
+        {
+            string directory = CreateSourceDirectory("ChangedConstNamedOnlyInNameof");
+            string sourcePath = Path.Combine(directory, "Edited.cs");
+            string siblingPath = Path.Combine(directory, "Sibling.cs");
+            string targetAssemblyPath = Path.Combine(directory, "ConstDriftTarget.dll");
+            string targetAssemblyMvid = CreateConstDriftTargetAssembly(targetAssemblyPath, 1);
+            File.WriteAllText(
+                sourcePath,
+                "namespace Example { public class Introduced { public string Get() { return nameof(Existing.Value); } } }");
+            File.WriteAllText(
+                siblingPath,
+                "namespace Example { public class Existing { public const int Value = 2; } }");
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                CreateConstDriftInputWithSiblings(
+                    sourcePath,
+                    targetAssemblyPath,
+                    targetAssemblyMvid,
+                    new[] { siblingPath }),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
+            Assert.That(result.Output.files[0].introducedTypes, Has.Length.EqualTo(1));
+            Assert.That(result.Output.files[0].introducedTypes[0].metadataName, Is.EqualTo("Example.Introduced"));
+            Assert.That(result.Output.files[0].introducedTypeDiagnostics, Is.Empty);
+        }
+
+        /// <summary>
         /// Verifies that a const in another edited file whose value cannot be read at all rejects
         /// the introduced type that reads it, because the artifact compile does not see that file
         /// and would succeed against the value still in the target assembly.

--- a/Assets/Tests/Editor/HotReload/TransformWorkerRetainedDeclarationTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerRetainedDeclarationTests.cs
@@ -50,6 +50,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             + "    }\n"
             + "}\n";
 
+        // The region opens above the retained declaration and closes inside it, so blanking the
+        // declaration takes the closing directive with it and leaves the text unparseable.
+        private const string UnbalancedRegionSource =
+            "namespace Example\n"
+            + "{\n"
+            + "#if UNITY_EDITOR\n"
+            + "    public class Retained\n"
+            + "    {\n"
+            + "        public static int Value = 1;\n"
+            + "#endif\n"
+            + "\n"
+            + "        public static int Twice()\n"
+            + "        {\n"
+            + "            return Value * 2;\n"
+            + "        }\n"
+            + "    }\n"
+            + "\n"
+            + "    public class Caller\n"
+            + "    {\n"
+            + "        public int Read()\n"
+            + "        {\n"
+            + "            return Retained.Value + 1;\n"
+            + "        }\n"
+            + "    }\n"
+            + "}\n";
+
         /// <summary>
         /// What: the shim reports the line the edited file really has for a method that follows a
         /// removed declaration, so taking the declaration out does not shift the mapping.
@@ -57,7 +83,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task Transform_RetainedDeclarationRemoved_KeepsSourceLineNumbers()
         {
-            RetainedFixture fixture = await CreateFixtureAsync("KeepsSourceLineNumbers");
+            RetainedFixture fixture = await CreateFixtureAsync("KeepsSourceLineNumbers", EditedSource);
 
             TransformWorkerClientResult withoutRecord = await RunAsync(fixture, Array.Empty<TransformWorkerIntroducedTypeArtifactDto>());
             TransformWorkerClientResult withRecord = await RunAsync(fixture, new[] { CreateRecordedArtifact(fixture, fixture.RetainedFingerprint) });
@@ -75,7 +101,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task Transform_RetainedDeclarationRemoved_ReportsNoRowsForRetainedType()
         {
-            RetainedFixture fixture = await CreateFixtureAsync("ReportsNoRows");
+            RetainedFixture fixture = await CreateFixtureAsync("ReportsNoRows", EditedSource);
 
             TransformWorkerClientResult withoutRecord = await RunAsync(fixture, Array.Empty<TransformWorkerIntroducedTypeArtifactDto>());
             TransformWorkerClientResult withRecord = await RunAsync(fixture, new[] { CreateRecordedArtifact(fixture, fixture.RetainedFingerprint) });
@@ -93,7 +119,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task Transform_RecordFingerprintDoesNotMatch_KeepsDeclarationInBinding()
         {
-            RetainedFixture fixture = await CreateFixtureAsync("FingerprintMismatch");
+            RetainedFixture fixture = await CreateFixtureAsync("FingerprintMismatch", EditedSource);
 
             TransformWorkerClientResult tampered = await RunAsync(
                 fixture,
@@ -110,12 +136,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task Transform_ArtifactIdentityMismatch_FailsRun()
         {
-            RetainedFixture fixture = await CreateFixtureAsync("IdentityMismatch");
+            RetainedFixture fixture = await CreateFixtureAsync("IdentityMismatch", EditedSource);
             TransformWorkerIntroducedTypeArtifactDto mismatched =
                 CreateRecordedArtifact(fixture, fixture.RetainedFingerprint);
             mismatched.assemblyFullName = ReadAssemblyFullName(fixture.TargetAssemblyPath);
 
             TransformWorkerClientResult result = await RunAsync(fixture, new[] { mismatched });
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.Output, Is.Null.Or.Property("entries").Empty);
+        }
+
+        /// <summary>
+        /// What: a preprocessor region that closes inside the retained declaration makes the
+        /// blanked text unparseable, and the run fails instead of transforming the file against a
+        /// tree the parser had to guess at.
+        /// </summary>
+        [Test]
+        public async Task Transform_BlankedDeclarationLeavesUnbalancedRegion_FailsRun()
+        {
+            RetainedFixture fixture = await CreateFixtureAsync("UnbalancedRegion", UnbalancedRegionSource);
+
+            TransformWorkerClientResult result = await RunAsync(
+                fixture,
+                new[] { CreateRecordedArtifact(fixture, fixture.RetainedFingerprint) });
 
             Assert.That(result.Success, Is.False);
             Assert.That(result.Output, Is.Null.Or.Property("entries").Empty);
@@ -252,7 +296,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return await TransformWorkerClient.RunAsync(input, CancellationToken.None);
         }
 
-        private static async Task<RetainedFixture> CreateFixtureAsync(string name)
+        private static async Task<RetainedFixture> CreateFixtureAsync(string name, string editedSource)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string directory = Path.Combine(
@@ -264,7 +308,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 name);
             Directory.CreateDirectory(directory);
             string sourcePath = Path.Combine(directory, "Edited.cs");
-            File.WriteAllText(sourcePath, EditedSource);
+            File.WriteAllText(sourcePath, editedSource);
             string targetAssemblyPath = Path.Combine(directory, "RetainedTarget.dll");
             string targetAssemblyMvid = CreateTargetAssembly(targetAssemblyPath);
             string artifactPath = Path.Combine(directory, "RetainedArtifact.dll");

--- a/Assets/Tests/Editor/HotReload/TransformWorkerRetainedDeclarationTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerRetainedDeclarationTests.cs
@@ -148,6 +148,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: an untrusted artifact takes the whole group down, so a run of two edited files
+        /// produces no entries and no shim for either of them instead of reporting the artifact as
+        /// one file's diagnostic while the other file is still transformed and applied.
+        /// </summary>
+        [Test]
+        public async Task Transform_ArtifactIdentityMismatchInGroup_FailsEveryFile()
+        {
+            HotReloadRetainedArtifactFixture fixture =
+                await HotReloadRetainedArtifactFixture.CreateAsync("GroupIdentityMismatch", EditedSource);
+            TransformWorkerIntroducedTypeArtifactDto mismatched =
+                fixture.CreateRecordedArtifact(fixture.RetainedFingerprint);
+            mismatched.assemblyFullName =
+                HotReloadRetainedArtifactFixture.ReadAssemblyFullName(fixture.TargetAssemblyPath);
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                fixture.BuildGroupTransformInput(new[] { mismatched }),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.Output, Is.Null.Or.Property("entries").Empty);
+            Assert.That(result.Output, Is.Null.Or.Property("shimSource").Null.Or.Property("shimSource").Empty);
+        }
+
+        /// <summary>
         /// What: a preprocessor region that closes inside the retained declaration makes the
         /// blanked text unparseable, and the run fails instead of transforming the file against a
         /// tree the parser had to guess at.

--- a/Assets/Tests/Editor/HotReload/TransformWorkerRetainedDeclarationTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerRetainedDeclarationTests.cs
@@ -1,0 +1,405 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using CecilTypeAttributes = Mono.Cecil.TypeAttributes;
+using CecilMethodAttributes = Mono.Cecil.MethodAttributes;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Verifies that a declaration a retained artifact already serves is taken out of the tree the
+    /// transform binds against, only when the artifact record still describes the edited source,
+    /// and that removing it does not move the source lines the shim reports.
+    /// </summary>
+    public sealed class TransformWorkerRetainedDeclarationTests
+    {
+        private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+
+        private const string EditedSource =
+            "namespace Example\n"
+            + "{\n"
+            + "    public class Retained\n"
+            + "    {\n"
+            + "        public static int Value = 1;\n"
+            + "\n"
+            + "        public static int Twice()\n"
+            + "        {\n"
+            + "            return Value * 2;\n"
+            + "        }\n"
+            + "    }\n"
+            + "\n"
+            + "    public class Caller\n"
+            + "    {\n"
+            + "        public int Read()\n"
+            + "        {\n"
+            + "            return Retained.Value + 1;\n"
+            + "        }\n"
+            + "    }\n"
+            + "}\n";
+
+        /// <summary>
+        /// What: the shim reports the line the edited file really has for a method that follows a
+        /// removed declaration, so taking the declaration out does not shift the mapping.
+        /// </summary>
+        [Test]
+        public async Task Transform_RetainedDeclarationRemoved_KeepsSourceLineNumbers()
+        {
+            RetainedFixture fixture = await CreateFixtureAsync("KeepsSourceLineNumbers");
+
+            TransformWorkerClientResult withoutRecord = await RunAsync(fixture, Array.Empty<TransformWorkerIntroducedTypeArtifactDto>());
+            TransformWorkerClientResult withRecord = await RunAsync(fixture, new[] { CreateRecordedArtifact(fixture, fixture.RetainedFingerprint) });
+
+            Assert.That(withoutRecord.Success, Is.True, withoutRecord.ErrorMessage);
+            Assert.That(withRecord.Success, Is.True, withRecord.ErrorMessage);
+            Assert.That(FindReadEntry(withRecord).sourceStartLine, Is.EqualTo(FindReadEntry(withoutRecord).sourceStartLine));
+            Assert.That(withRecord.Output.shimSource, Does.Contain("Retained.Value + 1"));
+        }
+
+        /// <summary>
+        /// What: the retained type stops being transformed as a source declaration once its record
+        /// matches, so the run no longer reports rows for its members.
+        /// </summary>
+        [Test]
+        public async Task Transform_RetainedDeclarationRemoved_ReportsNoRowsForRetainedType()
+        {
+            RetainedFixture fixture = await CreateFixtureAsync("ReportsNoRows");
+
+            TransformWorkerClientResult withoutRecord = await RunAsync(fixture, Array.Empty<TransformWorkerIntroducedTypeArtifactDto>());
+            TransformWorkerClientResult withRecord = await RunAsync(fixture, new[] { CreateRecordedArtifact(fixture, fixture.RetainedFingerprint) });
+
+            Assert.That(withoutRecord.Success, Is.True, withoutRecord.ErrorMessage);
+            Assert.That(withRecord.Success, Is.True, withRecord.ErrorMessage);
+            Assert.That(CountRowsMentioning(withoutRecord, "Twice"), Is.GreaterThan(0));
+            Assert.That(CountRowsMentioning(withRecord, "Twice"), Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: a record whose fingerprint no longer matches the edited source leaves the
+        /// declaration in place, because the source is then newer than the artifact.
+        /// </summary>
+        [Test]
+        public async Task Transform_RecordFingerprintDoesNotMatch_KeepsDeclarationInBinding()
+        {
+            RetainedFixture fixture = await CreateFixtureAsync("FingerprintMismatch");
+
+            TransformWorkerClientResult tampered = await RunAsync(
+                fixture,
+                new[] { CreateRecordedArtifact(fixture, new string('0', 64)) });
+
+            Assert.That(tampered.Success, Is.True, tampered.ErrorMessage);
+            Assert.That(CountRowsMentioning(tampered, "Twice"), Is.GreaterThan(0));
+        }
+
+        /// <summary>
+        /// What: an artifact record the worker cannot trust fails the whole run instead of
+        /// producing a shim, because the caller advances to revert and compile on success.
+        /// </summary>
+        [Test]
+        public async Task Transform_ArtifactIdentityMismatch_FailsRun()
+        {
+            RetainedFixture fixture = await CreateFixtureAsync("IdentityMismatch");
+            TransformWorkerIntroducedTypeArtifactDto mismatched =
+                CreateRecordedArtifact(fixture, fixture.RetainedFingerprint);
+            mismatched.assemblyFullName = ReadAssemblyFullName(fixture.TargetAssemblyPath);
+
+            TransformWorkerClientResult result = await RunAsync(fixture, new[] { mismatched });
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.Output, Is.Null.Or.Property("entries").Empty);
+        }
+
+        private static TransformWorkerEntryDto FindReadEntry(TransformWorkerClientResult result)
+        {
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                if (entry.methodName == "Read")
+                {
+                    return entry;
+                }
+            }
+
+            Assert.Fail("No shim entry was emitted for the caller method.");
+            return null;
+        }
+
+        private static int CountRowsMentioning(TransformWorkerClientResult result, string memberName)
+        {
+            int count = 0;
+            foreach (TransformWorkerEntryDto entry in result.Output.entries)
+            {
+                if (entry.methodName == memberName)
+                {
+                    count++;
+                }
+            }
+
+            foreach (TransformWorkerSkippedDto skipped in result.Output.skipped)
+            {
+                if (skipped.method != null && skipped.method.Contains(memberName))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        private static TransformWorkerIntroducedTypeArtifactDto CreateRecordedArtifact(
+            RetainedFixture fixture,
+            string declarationFingerprint)
+        {
+            return new TransformWorkerIntroducedTypeArtifactDto
+            {
+                assemblyFullName = ReadAssemblyFullName(fixture.ArtifactPath),
+                referencePath = fixture.ArtifactPath,
+                types = new[]
+                {
+                    new TransformWorkerIntroducedTypeArtifactTypeDto
+                    {
+                        metadataName = "Example.Retained",
+                        originalAssemblyName = fixture.TargetAssemblyName,
+                        originalAssemblyMvid = fixture.TargetAssemblyMvid,
+                        ownerProjectRelativePath = fixture.ProjectRelativePath,
+                        declarationFingerprint = declarationFingerprint
+                    }
+                }
+            };
+        }
+
+        private static async Task<TransformWorkerClientResult> RunAsync(
+            RetainedFixture fixture,
+            TransformWorkerIntroducedTypeArtifactDto[] artifacts)
+        {
+            UnityEditor.Compilation.Assembly compilationAssembly = FindCompilationAssembly();
+            List<string> referencePaths = new List<string>();
+            foreach (string reference in compilationAssembly.allReferences)
+            {
+                if (!string.IsNullOrEmpty(reference) && File.Exists(reference))
+                {
+                    referencePaths.Add(Path.GetFullPath(reference));
+                }
+            }
+
+            referencePaths.Add(Path.GetFullPath(fixture.TargetAssemblyPath));
+            TransformWorkerInputDto input = new TransformWorkerInputDto
+            {
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = fixture.SourcePath,
+                        projectRelativePath = fixture.ProjectRelativePath
+                    }
+                },
+                defines = compilationAssembly.defines ?? Array.Empty<string>(),
+                referencePaths = referencePaths.ToArray(),
+                targetTypesAssemblyPath = fixture.TargetAssemblyPath,
+                targetAssemblyName = fixture.TargetAssemblyName,
+                targetAssemblyMvid = fixture.TargetAssemblyMvid,
+                assemblySourcePaths = Array.Empty<string>(),
+                changedSiblingSourcePaths = Array.Empty<string>(),
+                introducedTypeArtifacts = artifacts
+            };
+            return await TransformWorkerClient.RunAsync(input, CancellationToken.None);
+        }
+
+        private static async Task<TransformWorkerClientResult> RunPrepareAsync(RetainedFixture fixture)
+        {
+            UnityEditor.Compilation.Assembly compilationAssembly = FindCompilationAssembly();
+            List<string> referencePaths = new List<string>();
+            foreach (string reference in compilationAssembly.allReferences)
+            {
+                if (!string.IsNullOrEmpty(reference) && File.Exists(reference))
+                {
+                    referencePaths.Add(Path.GetFullPath(reference));
+                }
+            }
+
+            referencePaths.Add(Path.GetFullPath(fixture.TargetAssemblyPath));
+            TransformWorkerInputDto input = new TransformWorkerInputDto
+            {
+                operation = "prepareIntroducedTypes",
+                sources = new[]
+                {
+                    new TransformWorkerSourceDto
+                    {
+                        sourcePath = fixture.SourcePath,
+                        projectRelativePath = fixture.ProjectRelativePath
+                    }
+                },
+                defines = compilationAssembly.defines ?? Array.Empty<string>(),
+                referencePaths = referencePaths.ToArray(),
+                targetTypesAssemblyPath = fixture.TargetAssemblyPath,
+                targetAssemblyName = fixture.TargetAssemblyName,
+                targetAssemblyMvid = fixture.TargetAssemblyMvid,
+                assemblySourcePaths = Array.Empty<string>(),
+                changedSiblingSourcePaths = Array.Empty<string>(),
+                introducedTypeArtifacts = Array.Empty<TransformWorkerIntroducedTypeArtifactDto>()
+            };
+            return await TransformWorkerClient.RunAsync(input, CancellationToken.None);
+        }
+
+        private static async Task<RetainedFixture> CreateFixtureAsync(string name)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string directory = Path.Combine(
+                projectRoot,
+                "Library",
+                "UloopHotReload",
+                "TestSources",
+                "RetainedDeclaration",
+                name);
+            Directory.CreateDirectory(directory);
+            string sourcePath = Path.Combine(directory, "Edited.cs");
+            File.WriteAllText(sourcePath, EditedSource);
+            string targetAssemblyPath = Path.Combine(directory, "RetainedTarget.dll");
+            string targetAssemblyMvid = CreateTargetAssembly(targetAssemblyPath);
+            string artifactPath = Path.Combine(directory, "RetainedArtifact.dll");
+            CreateArtifactAssembly(artifactPath);
+            RetainedFixture fixture = new RetainedFixture(
+                sourcePath,
+                "Assets/RetainedDeclaration/" + name + "/Edited.cs",
+                targetAssemblyPath,
+                "RetainedTarget",
+                targetAssemblyMvid,
+                artifactPath);
+            // The recorded fingerprint has to be the value planning really produced for this
+            // source, so it is read back from a prepare run rather than restated by the test.
+            fixture.RetainedFingerprint = await ReadPlannedFingerprintAsync(fixture);
+            return fixture;
+        }
+
+        private static async Task<string> ReadPlannedFingerprintAsync(RetainedFixture fixture)
+        {
+            TransformWorkerClientResult prepared = await RunPrepareAsync(fixture);
+            Assert.That(prepared.Success, Is.True, prepared.ErrorMessage);
+            foreach (TransformWorkerIntroducedTypeDto introducedType in prepared.Output.files[0].introducedTypes)
+            {
+                if (introducedType.metadataName == "Example.Retained")
+                {
+                    return introducedType.declarationFingerprint;
+                }
+            }
+
+            Assert.Fail("Planning did not report the retained type.");
+            return null;
+        }
+
+        private static string CreateTargetAssembly(string path)
+        {
+            AssemblyNameDefinition assemblyName = new AssemblyNameDefinition("RetainedTarget", new Version(1, 0, 0, 0));
+            using (AssemblyDefinition assembly = AssemblyDefinition.CreateAssembly(assemblyName, "RetainedTarget", ModuleKind.Dll))
+            {
+                TypeDefinition caller = new TypeDefinition(
+                    "Example",
+                    "Caller",
+                    CecilTypeAttributes.Public | CecilTypeAttributes.Class,
+                    assembly.MainModule.TypeSystem.Object);
+                MethodDefinition read = new MethodDefinition(
+                    "Read",
+                    CecilMethodAttributes.Public | CecilMethodAttributes.HideBySig,
+                    assembly.MainModule.TypeSystem.Int32);
+                ILProcessor processor = read.Body.GetILProcessor();
+                processor.Append(processor.Create(OpCodes.Ldc_I4_0));
+                processor.Append(processor.Create(OpCodes.Ret));
+                caller.Methods.Add(read);
+                assembly.MainModule.Types.Add(caller);
+                assembly.Write(path);
+            }
+
+            using (ModuleDefinition module = ModuleDefinition.ReadModule(path))
+            {
+                return module.Mvid.ToString();
+            }
+        }
+
+        private static void CreateArtifactAssembly(string path)
+        {
+            AssemblyNameDefinition assemblyName = new AssemblyNameDefinition("RetainedArtifact", new Version(1, 0, 0, 0));
+            using (AssemblyDefinition assembly = AssemblyDefinition.CreateAssembly(assemblyName, "RetainedArtifact", ModuleKind.Dll))
+            {
+                TypeDefinition retained = new TypeDefinition(
+                    "Example",
+                    "Retained",
+                    CecilTypeAttributes.Public | CecilTypeAttributes.Class,
+                    assembly.MainModule.TypeSystem.Object);
+                FieldDefinition valueField = new FieldDefinition(
+                    "Value",
+                    Mono.Cecil.FieldAttributes.Public | Mono.Cecil.FieldAttributes.Static,
+                    assembly.MainModule.TypeSystem.Int32);
+                retained.Fields.Add(valueField);
+                assembly.MainModule.Types.Add(retained);
+                assembly.Write(path);
+            }
+        }
+
+        private static string ReadAssemblyFullName(string path)
+        {
+            using (AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(path))
+            {
+                return assembly.Name.FullName;
+            }
+        }
+
+        private static UnityEditor.Compilation.Assembly FindCompilationAssembly()
+        {
+            foreach (UnityEditor.Compilation.Assembly assembly in CompilationPipeline.GetAssemblies())
+            {
+                if (assembly.name == TestAssemblyName)
+                {
+                    return assembly;
+                }
+            }
+
+            Assert.Fail("Compilation assembly was not found.");
+            return null;
+        }
+
+        private sealed class RetainedFixture
+        {
+            public RetainedFixture(
+                string sourcePath,
+                string projectRelativePath,
+                string targetAssemblyPath,
+                string targetAssemblyName,
+                string targetAssemblyMvid,
+                string artifactPath)
+            {
+                SourcePath = sourcePath;
+                ProjectRelativePath = projectRelativePath;
+                TargetAssemblyPath = targetAssemblyPath;
+                TargetAssemblyName = targetAssemblyName;
+                TargetAssemblyMvid = targetAssemblyMvid;
+                ArtifactPath = artifactPath;
+                RetainedFingerprint = string.Empty;
+            }
+
+            public string SourcePath { get; }
+
+            public string ProjectRelativePath { get; }
+
+            public string TargetAssemblyPath { get; }
+
+            public string TargetAssemblyName { get; }
+
+            public string TargetAssemblyMvid { get; }
+
+            public string ArtifactPath { get; }
+
+            public string RetainedFingerprint { get; set; }
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/TransformWorkerRetainedDeclarationTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerRetainedDeclarationTests.cs
@@ -1,21 +1,10 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
 using NUnit.Framework;
 
-using UnityEditor.Compilation;
-
-using UnityEngine;
-
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
-
-using Mono.Cecil;
-using Mono.Cecil.Cil;
-using CecilTypeAttributes = Mono.Cecil.TypeAttributes;
-using CecilMethodAttributes = Mono.Cecil.MethodAttributes;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
@@ -26,8 +15,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     /// </summary>
     public sealed class TransformWorkerRetainedDeclarationTests
     {
-        private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
-
         private const string EditedSource =
             "namespace Example\n"
             + "{\n"
@@ -83,10 +70,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task Transform_RetainedDeclarationRemoved_KeepsSourceLineNumbers()
         {
-            RetainedFixture fixture = await CreateFixtureAsync("KeepsSourceLineNumbers", EditedSource);
+            HotReloadRetainedArtifactFixture fixture =
+                await HotReloadRetainedArtifactFixture.CreateAsync("KeepsSourceLineNumbers", EditedSource);
 
-            TransformWorkerClientResult withoutRecord = await RunAsync(fixture, Array.Empty<TransformWorkerIntroducedTypeArtifactDto>());
-            TransformWorkerClientResult withRecord = await RunAsync(fixture, new[] { CreateRecordedArtifact(fixture, fixture.RetainedFingerprint) });
+            TransformWorkerClientResult withoutRecord = await RunAsync(
+                fixture,
+                Array.Empty<TransformWorkerIntroducedTypeArtifactDto>());
+            TransformWorkerClientResult withRecord = await RunAsync(
+                fixture,
+                new[] { fixture.CreateRecordedArtifact(fixture.RetainedFingerprint) });
 
             Assert.That(withoutRecord.Success, Is.True, withoutRecord.ErrorMessage);
             Assert.That(withRecord.Success, Is.True, withRecord.ErrorMessage);
@@ -101,10 +93,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task Transform_RetainedDeclarationRemoved_ReportsNoRowsForRetainedType()
         {
-            RetainedFixture fixture = await CreateFixtureAsync("ReportsNoRows", EditedSource);
+            HotReloadRetainedArtifactFixture fixture =
+                await HotReloadRetainedArtifactFixture.CreateAsync("ReportsNoRows", EditedSource);
 
-            TransformWorkerClientResult withoutRecord = await RunAsync(fixture, Array.Empty<TransformWorkerIntroducedTypeArtifactDto>());
-            TransformWorkerClientResult withRecord = await RunAsync(fixture, new[] { CreateRecordedArtifact(fixture, fixture.RetainedFingerprint) });
+            TransformWorkerClientResult withoutRecord = await RunAsync(
+                fixture,
+                Array.Empty<TransformWorkerIntroducedTypeArtifactDto>());
+            TransformWorkerClientResult withRecord = await RunAsync(
+                fixture,
+                new[] { fixture.CreateRecordedArtifact(fixture.RetainedFingerprint) });
 
             Assert.That(withoutRecord.Success, Is.True, withoutRecord.ErrorMessage);
             Assert.That(withRecord.Success, Is.True, withRecord.ErrorMessage);
@@ -119,11 +116,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task Transform_RecordFingerprintDoesNotMatch_KeepsDeclarationInBinding()
         {
-            RetainedFixture fixture = await CreateFixtureAsync("FingerprintMismatch", EditedSource);
+            HotReloadRetainedArtifactFixture fixture =
+                await HotReloadRetainedArtifactFixture.CreateAsync("FingerprintMismatch", EditedSource);
 
             TransformWorkerClientResult tampered = await RunAsync(
                 fixture,
-                new[] { CreateRecordedArtifact(fixture, new string('0', 64)) });
+                new[] { fixture.CreateRecordedArtifact(new string('0', 64)) });
 
             Assert.That(tampered.Success, Is.True, tampered.ErrorMessage);
             Assert.That(CountRowsMentioning(tampered, "Twice"), Is.GreaterThan(0));
@@ -136,10 +134,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task Transform_ArtifactIdentityMismatch_FailsRun()
         {
-            RetainedFixture fixture = await CreateFixtureAsync("IdentityMismatch", EditedSource);
+            HotReloadRetainedArtifactFixture fixture =
+                await HotReloadRetainedArtifactFixture.CreateAsync("IdentityMismatch", EditedSource);
             TransformWorkerIntroducedTypeArtifactDto mismatched =
-                CreateRecordedArtifact(fixture, fixture.RetainedFingerprint);
-            mismatched.assemblyFullName = ReadAssemblyFullName(fixture.TargetAssemblyPath);
+                fixture.CreateRecordedArtifact(fixture.RetainedFingerprint);
+            mismatched.assemblyFullName =
+                HotReloadRetainedArtifactFixture.ReadAssemblyFullName(fixture.TargetAssemblyPath);
 
             TransformWorkerClientResult result = await RunAsync(fixture, new[] { mismatched });
 
@@ -155,14 +155,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task Transform_BlankedDeclarationLeavesUnbalancedRegion_FailsRun()
         {
-            RetainedFixture fixture = await CreateFixtureAsync("UnbalancedRegion", UnbalancedRegionSource);
+            HotReloadRetainedArtifactFixture fixture =
+                await HotReloadRetainedArtifactFixture.CreateAsync("UnbalancedRegion", UnbalancedRegionSource);
 
             TransformWorkerClientResult result = await RunAsync(
                 fixture,
-                new[] { CreateRecordedArtifact(fixture, fixture.RetainedFingerprint) });
+                new[] { fixture.CreateRecordedArtifact(fixture.RetainedFingerprint) });
 
             Assert.That(result.Success, Is.False);
             Assert.That(result.Output, Is.Null.Or.Property("entries").Empty);
+        }
+
+        private static async Task<TransformWorkerClientResult> RunAsync(
+            HotReloadRetainedArtifactFixture fixture,
+            TransformWorkerIntroducedTypeArtifactDto[] artifacts)
+        {
+            return await TransformWorkerClient.RunAsync(
+                fixture.BuildTransformInput(artifacts),
+                CancellationToken.None);
         }
 
         private static TransformWorkerEntryDto FindReadEntry(TransformWorkerClientResult result)
@@ -199,251 +209,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             return count;
-        }
-
-        private static TransformWorkerIntroducedTypeArtifactDto CreateRecordedArtifact(
-            RetainedFixture fixture,
-            string declarationFingerprint)
-        {
-            return new TransformWorkerIntroducedTypeArtifactDto
-            {
-                assemblyFullName = ReadAssemblyFullName(fixture.ArtifactPath),
-                referencePath = fixture.ArtifactPath,
-                types = new[]
-                {
-                    new TransformWorkerIntroducedTypeArtifactTypeDto
-                    {
-                        metadataName = "Example.Retained",
-                        originalAssemblyName = fixture.TargetAssemblyName,
-                        originalAssemblyMvid = fixture.TargetAssemblyMvid,
-                        ownerProjectRelativePath = fixture.ProjectRelativePath,
-                        declarationFingerprint = declarationFingerprint
-                    }
-                }
-            };
-        }
-
-        private static async Task<TransformWorkerClientResult> RunAsync(
-            RetainedFixture fixture,
-            TransformWorkerIntroducedTypeArtifactDto[] artifacts)
-        {
-            UnityEditor.Compilation.Assembly compilationAssembly = FindCompilationAssembly();
-            List<string> referencePaths = new List<string>();
-            foreach (string reference in compilationAssembly.allReferences)
-            {
-                if (!string.IsNullOrEmpty(reference) && File.Exists(reference))
-                {
-                    referencePaths.Add(Path.GetFullPath(reference));
-                }
-            }
-
-            referencePaths.Add(Path.GetFullPath(fixture.TargetAssemblyPath));
-            TransformWorkerInputDto input = new TransformWorkerInputDto
-            {
-                sources = new[]
-                {
-                    new TransformWorkerSourceDto
-                    {
-                        sourcePath = fixture.SourcePath,
-                        projectRelativePath = fixture.ProjectRelativePath
-                    }
-                },
-                defines = compilationAssembly.defines ?? Array.Empty<string>(),
-                referencePaths = referencePaths.ToArray(),
-                targetTypesAssemblyPath = fixture.TargetAssemblyPath,
-                targetAssemblyName = fixture.TargetAssemblyName,
-                targetAssemblyMvid = fixture.TargetAssemblyMvid,
-                assemblySourcePaths = Array.Empty<string>(),
-                changedSiblingSourcePaths = Array.Empty<string>(),
-                introducedTypeArtifacts = artifacts
-            };
-            return await TransformWorkerClient.RunAsync(input, CancellationToken.None);
-        }
-
-        private static async Task<TransformWorkerClientResult> RunPrepareAsync(RetainedFixture fixture)
-        {
-            UnityEditor.Compilation.Assembly compilationAssembly = FindCompilationAssembly();
-            List<string> referencePaths = new List<string>();
-            foreach (string reference in compilationAssembly.allReferences)
-            {
-                if (!string.IsNullOrEmpty(reference) && File.Exists(reference))
-                {
-                    referencePaths.Add(Path.GetFullPath(reference));
-                }
-            }
-
-            referencePaths.Add(Path.GetFullPath(fixture.TargetAssemblyPath));
-            TransformWorkerInputDto input = new TransformWorkerInputDto
-            {
-                operation = "prepareIntroducedTypes",
-                sources = new[]
-                {
-                    new TransformWorkerSourceDto
-                    {
-                        sourcePath = fixture.SourcePath,
-                        projectRelativePath = fixture.ProjectRelativePath
-                    }
-                },
-                defines = compilationAssembly.defines ?? Array.Empty<string>(),
-                referencePaths = referencePaths.ToArray(),
-                targetTypesAssemblyPath = fixture.TargetAssemblyPath,
-                targetAssemblyName = fixture.TargetAssemblyName,
-                targetAssemblyMvid = fixture.TargetAssemblyMvid,
-                assemblySourcePaths = Array.Empty<string>(),
-                changedSiblingSourcePaths = Array.Empty<string>(),
-                introducedTypeArtifacts = Array.Empty<TransformWorkerIntroducedTypeArtifactDto>()
-            };
-            return await TransformWorkerClient.RunAsync(input, CancellationToken.None);
-        }
-
-        private static async Task<RetainedFixture> CreateFixtureAsync(string name, string editedSource)
-        {
-            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
-            string directory = Path.Combine(
-                projectRoot,
-                "Library",
-                "UloopHotReload",
-                "TestSources",
-                "RetainedDeclaration",
-                name);
-            Directory.CreateDirectory(directory);
-            string sourcePath = Path.Combine(directory, "Edited.cs");
-            File.WriteAllText(sourcePath, editedSource);
-            string targetAssemblyPath = Path.Combine(directory, "RetainedTarget.dll");
-            string targetAssemblyMvid = CreateTargetAssembly(targetAssemblyPath);
-            string artifactPath = Path.Combine(directory, "RetainedArtifact.dll");
-            CreateArtifactAssembly(artifactPath);
-            RetainedFixture fixture = new RetainedFixture(
-                sourcePath,
-                "Assets/RetainedDeclaration/" + name + "/Edited.cs",
-                targetAssemblyPath,
-                "RetainedTarget",
-                targetAssemblyMvid,
-                artifactPath);
-            // The recorded fingerprint has to be the value planning really produced for this
-            // source, so it is read back from a prepare run rather than restated by the test.
-            fixture.RetainedFingerprint = await ReadPlannedFingerprintAsync(fixture);
-            return fixture;
-        }
-
-        private static async Task<string> ReadPlannedFingerprintAsync(RetainedFixture fixture)
-        {
-            TransformWorkerClientResult prepared = await RunPrepareAsync(fixture);
-            Assert.That(prepared.Success, Is.True, prepared.ErrorMessage);
-            foreach (TransformWorkerIntroducedTypeDto introducedType in prepared.Output.files[0].introducedTypes)
-            {
-                if (introducedType.metadataName == "Example.Retained")
-                {
-                    return introducedType.declarationFingerprint;
-                }
-            }
-
-            Assert.Fail("Planning did not report the retained type.");
-            return null;
-        }
-
-        private static string CreateTargetAssembly(string path)
-        {
-            AssemblyNameDefinition assemblyName = new AssemblyNameDefinition("RetainedTarget", new Version(1, 0, 0, 0));
-            using (AssemblyDefinition assembly = AssemblyDefinition.CreateAssembly(assemblyName, "RetainedTarget", ModuleKind.Dll))
-            {
-                TypeDefinition caller = new TypeDefinition(
-                    "Example",
-                    "Caller",
-                    CecilTypeAttributes.Public | CecilTypeAttributes.Class,
-                    assembly.MainModule.TypeSystem.Object);
-                MethodDefinition read = new MethodDefinition(
-                    "Read",
-                    CecilMethodAttributes.Public | CecilMethodAttributes.HideBySig,
-                    assembly.MainModule.TypeSystem.Int32);
-                ILProcessor processor = read.Body.GetILProcessor();
-                processor.Append(processor.Create(OpCodes.Ldc_I4_0));
-                processor.Append(processor.Create(OpCodes.Ret));
-                caller.Methods.Add(read);
-                assembly.MainModule.Types.Add(caller);
-                assembly.Write(path);
-            }
-
-            using (ModuleDefinition module = ModuleDefinition.ReadModule(path))
-            {
-                return module.Mvid.ToString();
-            }
-        }
-
-        private static void CreateArtifactAssembly(string path)
-        {
-            AssemblyNameDefinition assemblyName = new AssemblyNameDefinition("RetainedArtifact", new Version(1, 0, 0, 0));
-            using (AssemblyDefinition assembly = AssemblyDefinition.CreateAssembly(assemblyName, "RetainedArtifact", ModuleKind.Dll))
-            {
-                TypeDefinition retained = new TypeDefinition(
-                    "Example",
-                    "Retained",
-                    CecilTypeAttributes.Public | CecilTypeAttributes.Class,
-                    assembly.MainModule.TypeSystem.Object);
-                FieldDefinition valueField = new FieldDefinition(
-                    "Value",
-                    Mono.Cecil.FieldAttributes.Public | Mono.Cecil.FieldAttributes.Static,
-                    assembly.MainModule.TypeSystem.Int32);
-                retained.Fields.Add(valueField);
-                assembly.MainModule.Types.Add(retained);
-                assembly.Write(path);
-            }
-        }
-
-        private static string ReadAssemblyFullName(string path)
-        {
-            using (AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(path))
-            {
-                return assembly.Name.FullName;
-            }
-        }
-
-        private static UnityEditor.Compilation.Assembly FindCompilationAssembly()
-        {
-            foreach (UnityEditor.Compilation.Assembly assembly in CompilationPipeline.GetAssemblies())
-            {
-                if (assembly.name == TestAssemblyName)
-                {
-                    return assembly;
-                }
-            }
-
-            Assert.Fail("Compilation assembly was not found.");
-            return null;
-        }
-
-        private sealed class RetainedFixture
-        {
-            public RetainedFixture(
-                string sourcePath,
-                string projectRelativePath,
-                string targetAssemblyPath,
-                string targetAssemblyName,
-                string targetAssemblyMvid,
-                string artifactPath)
-            {
-                SourcePath = sourcePath;
-                ProjectRelativePath = projectRelativePath;
-                TargetAssemblyPath = targetAssemblyPath;
-                TargetAssemblyName = targetAssemblyName;
-                TargetAssemblyMvid = targetAssemblyMvid;
-                ArtifactPath = artifactPath;
-                RetainedFingerprint = string.Empty;
-            }
-
-            public string SourcePath { get; }
-
-            public string ProjectRelativePath { get; }
-
-            public string TargetAssemblyPath { get; }
-
-            public string TargetAssemblyName { get; }
-
-            public string TargetAssemblyMvid { get; }
-
-            public string ArtifactPath { get; }
-
-            public string RetainedFingerprint { get; set; }
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/TransformWorkerRetainedDeclarationTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerRetainedDeclarationTests.cs
@@ -172,6 +172,28 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: the worker itself refuses a record whose type names no owning file, so a request
+        /// that did not pass through the client's own check still fails the run instead of
+        /// silently leaving the declaration in the tree and binding the type from source.
+        /// </summary>
+        [Test]
+        public async Task Transform_ArtifactTypeWithoutOwner_FailsRunInsideTheWorker()
+        {
+            HotReloadRetainedArtifactFixture fixture =
+                await HotReloadRetainedArtifactFixture.CreateAsync("WorkerWithoutOwner", EditedSource);
+            TransformWorkerIntroducedTypeArtifactDto ownerless =
+                fixture.CreateRecordedArtifact(fixture.RetainedFingerprint);
+            ownerless.types[0].ownerProjectRelativePath = string.Empty;
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunWorkerAsync(
+                fixture.BuildTransformInput(new[] { ownerless }),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.Output, Is.Null.Or.Property("entries").Empty);
+        }
+
+        /// <summary>
         /// What: a preprocessor region that closes inside the retained declaration makes the
         /// blanked text unparseable, and the run fails instead of transforming the file against a
         /// tree the parser had to guess at.

--- a/Assets/Tests/Editor/HotReload/TransformWorkerRetainedDeclarationTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerRetainedDeclarationTests.cs
@@ -194,6 +194,51 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a record that lists no type fails the run inside the worker, because its
+        /// reference would enter the compilation while no declaration is taken out of the binding
+        /// tree and the type would bind from source again.
+        /// </summary>
+        [Test]
+        public async Task Transform_ArtifactWithoutTypes_FailsRunInsideTheWorker()
+        {
+            HotReloadRetainedArtifactFixture fixture =
+                await HotReloadRetainedArtifactFixture.CreateAsync("WorkerWithoutTypes", EditedSource);
+            TransformWorkerIntroducedTypeArtifactDto typeless =
+                fixture.CreateRecordedArtifact(fixture.RetainedFingerprint);
+            typeless.types = Array.Empty<TransformWorkerIntroducedTypeArtifactTypeDto>();
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunWorkerAsync(
+                fixture.BuildTransformInput(new[] { typeless }),
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.Output, Is.Null.Or.Property("entries").Empty);
+        }
+
+        /// <summary>
+        /// What: a transform that carries records but does not name the assembly generation they
+        /// were planned against fails the run inside the worker, because the recorded identities
+        /// would be rebuilt from an empty identity and no declaration would match its record.
+        /// </summary>
+        [Test]
+        public async Task Transform_ArtifactsWithoutTargetIdentity_FailsRunInsideTheWorker()
+        {
+            HotReloadRetainedArtifactFixture fixture =
+                await HotReloadRetainedArtifactFixture.CreateAsync("WorkerWithoutTargetIdentity", EditedSource);
+            TransformWorkerInputDto input =
+                fixture.BuildTransformInput(new[] { fixture.CreateRecordedArtifact(fixture.RetainedFingerprint) });
+            input.targetAssemblyName = string.Empty;
+            input.targetAssemblyMvid = string.Empty;
+
+            TransformWorkerClientResult result = await TransformWorkerClient.RunWorkerAsync(
+                input,
+                CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.Output, Is.Null.Or.Property("entries").Empty);
+        }
+
+        /// <summary>
         /// What: a preprocessor region that closes inside the retained declaration makes the
         /// blanked text unparseable, and the run fails instead of transforming the file against a
         /// tree the parser had to guess at.

--- a/Assets/Tests/Editor/HotReload/TransformWorkerRetainedDeclarationTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerRetainedDeclarationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28fa2b8deb62641868963aa18146983a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
@@ -83,7 +83,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 context.CompilationAssembly,
                 context.TargetDllPath,
                 includeHarmonyReference,
-                includeAddedFieldStoreReference);
+                includeAddedFieldStoreReference,
+                context.WorkerInput.introducedTypeArtifacts);
             if (shimReferencePaths.ErrorMessage != null)
             {
                 HotReloadGroupOutcomeRouter.AppendGroupFailure(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
@@ -115,6 +115,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 defines = workerInput.defines,
                 referencePaths = workerInput.referencePaths,
                 targetTypesAssemblyPath = workerInput.targetTypesAssemblyPath,
+                // Why copy the identity and the records, and why never the operation: the retry is
+                // still a transform, and it recomputes each retained declaration's fingerprint
+                // through the artifact mapping. Without them the retry binds the retained types
+                // back to their source and emits types a loaded assembly already holds.
+                targetAssemblyName = workerInput.targetAssemblyName,
+                targetAssemblyMvid = workerInput.targetAssemblyMvid,
+                introducedTypeArtifacts = workerInput.introducedTypeArtifacts,
                 excludedMethodKeys = exclusions.ExcludedMethodKeys,
                 excludedAddedMethodKeys = exclusions.ExcludedAddedMethodKeys,
                 assemblySourcePaths = workerInput.assemblySourcePaths,
@@ -182,7 +189,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 compilationAssembly,
                 targetDllPath,
                 includeHarmonyReference,
-                includeAddedFieldStoreReference);
+                includeAddedFieldStoreReference,
+                workerInput.introducedTypeArtifacts);
             if (shimReferencePaths.ErrorMessage != null)
             {
                 // First-pass publicize already succeeded, so a miss here is rare; abandon

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimReferenceBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimReferenceBuilder.cs
@@ -56,6 +56,74 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return paths.ToArray();
         }
 
+        /// <summary>
+        /// Collects the reference paths of the retained introduced-type assemblies a run may bind
+        /// against, one path per record and never the same file twice. One place assembles them so
+        /// every compilation of a run — the shim compile, its retries and the introduced-type
+        /// compile — references exactly the assemblies the worker was told about.
+        /// </summary>
+        internal static List<string> CollectIntroducedTypeArtifactReferencePaths(
+            TransformWorkerIntroducedTypeArtifactDto[] introducedTypeArtifacts)
+        {
+            List<string> paths = new List<string>();
+            if (introducedTypeArtifacts == null)
+            {
+                return paths;
+            }
+
+            foreach (TransformWorkerIntroducedTypeArtifactDto artifact in introducedTypeArtifacts)
+            {
+                if (artifact == null || string.IsNullOrEmpty(artifact.referencePath))
+                {
+                    continue;
+                }
+
+                AppendIfMissingByFullPath(paths, Path.GetFullPath(artifact.referencePath));
+            }
+
+            return paths;
+        }
+
+        /// <summary>
+        /// Adds the retained introduced-type assemblies to a reference list, keeping one entry per
+        /// file so a compilation never holds the same assembly identity twice.
+        /// </summary>
+        internal static void AppendIntroducedTypeArtifactReferences(
+            List<string> references,
+            TransformWorkerIntroducedTypeArtifactDto[] introducedTypeArtifacts)
+        {
+            Debug.Assert(references != null, "references must not be null.");
+
+            foreach (string path in CollectIntroducedTypeArtifactReferencePaths(introducedTypeArtifacts))
+            {
+                AppendIfMissingByFullPath(references, path);
+            }
+        }
+
+        // Why full path (not file name, as the optional shim assemblies use): an artifact assembly
+        // is never publicized, so no second copy of it exists, and two artifacts of one run can
+        // share a file name while being different assemblies.
+        private static void AppendIfMissingByFullPath(List<string> references, string fullPath)
+        {
+            foreach (string reference in references)
+            {
+                if (string.IsNullOrEmpty(reference))
+                {
+                    continue;
+                }
+
+                if (string.Equals(
+                    Path.GetFullPath(reference),
+                    fullPath,
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+            }
+
+            references.Add(fullPath);
+        }
+
         internal static bool NeedsHarmonyReference(TransformWorkerOutputDto output)
         {
             return HasDelegationEntry(output.entries) || output.hasAccessorDelegates;
@@ -155,7 +223,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             UnityCompilationAssembly compilationAssembly,
             string targetDllPath,
             bool includeHarmonyReference,
-            bool includeAddedFieldStoreReference)
+            bool includeAddedFieldStoreReference,
+            TransformWorkerIntroducedTypeArtifactDto[] introducedTypeArtifacts)
         {
             // Why catch only AssemblyResolutionException: publicize fails when Cecil cannot
             // resolve engine/netstandard types during Write; that is a per-file hot-reload
@@ -167,7 +236,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         compilationAssembly,
                         targetDllPath,
                         includeHarmonyReference,
-                        includeAddedFieldStoreReference),
+                        includeAddedFieldStoreReference,
+                        introducedTypeArtifacts),
                     null);
             }
             catch (AssemblyResolutionException resolutionException)
@@ -189,7 +259,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             UnityCompilationAssembly compilationAssembly,
             string targetDllPath,
             bool includeHarmonyReference,
-            bool includeAddedFieldStoreReference)
+            bool includeAddedFieldStoreReference,
+            TransformWorkerIntroducedTypeArtifactDto[] introducedTypeArtifacts)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string scriptAssembliesDirectory = Path.GetFullPath(
@@ -210,6 +281,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 references,
                 includeHarmonyReference,
                 includeAddedFieldStoreReference);
+            // Why here: the shim binds against the retained types the worker bound against, and a
+            // shim that cannot see them fails to compile the bodies that use them.
+            AppendIntroducedTypeArtifactReferences(references, introducedTypeArtifacts);
 
             if (compilationAssembly.allReferences == null)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -28,6 +29,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(input != null, "input must not be null.");
             Debug.Assert(input.sources != null, "sources must not be null.");
             Debug.Assert(input.sources.Length > 0, "sources must not be empty.");
+
+            // Why before the worker runs: a record the worker cannot act on does not always fail
+            // there. A record missing its owner or its fingerprint still builds a valid mapping,
+            // and the run then silently binds the retained type back to its source.
+            if (!TryValidateIntroducedTypeArtifacts(input, out string artifactError))
+            {
+                return TransformWorkerClientResult.Failure(artifactError);
+            }
 
             TransformWorkerBootstrapResult bootstrapResult =
                 await TransformWorkerBootstrap.EnsureWorkerAsync(ct).ConfigureAwait(false);
@@ -91,6 +100,94 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     Directory.Delete(tempDirectory, recursive: true);
                 }
             }
+        }
+
+        /// <summary>
+        /// Rejects retained-artifact records the worker could not act on faithfully: an incomplete
+        /// record, a run that names no target assembly to normalize back to, or two records that
+        /// claim the same assembly identity or the same type inside it.
+        /// </summary>
+        internal static bool TryValidateIntroducedTypeArtifacts(
+            TransformWorkerInputDto input,
+            out string errorMessage)
+        {
+            if (input.introducedTypeArtifacts == null || input.introducedTypeArtifacts.Length == 0)
+            {
+                errorMessage = string.Empty;
+                return true;
+            }
+
+            // The records normalize a retained type back to the assembly its source belongs to,
+            // and that is the assembly this run targets.
+            if (string.IsNullOrWhiteSpace(input.targetAssemblyName)
+                || string.IsNullOrWhiteSpace(input.targetAssemblyMvid))
+            {
+                errorMessage = "A run that carries retained artifacts must name the target assembly and its module version id.";
+                return false;
+            }
+
+            HashSet<string> assemblyFullNames = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<string> typeKeys = new HashSet<string>(StringComparer.Ordinal);
+            foreach (TransformWorkerIntroducedTypeArtifactDto artifact in input.introducedTypeArtifacts)
+            {
+                if (artifact == null
+                    || string.IsNullOrWhiteSpace(artifact.assemblyFullName)
+                    || string.IsNullOrWhiteSpace(artifact.referencePath)
+                    || artifact.types == null
+                    || artifact.types.Length == 0)
+                {
+                    errorMessage = "A retained artifact must name its assembly, its reference path and at least one type.";
+                    return false;
+                }
+
+                // Two records claiming one identity would put the same assembly into the
+                // compilation twice, and the worker would then resolve one of them to nothing.
+                if (!assemblyFullNames.Add(artifact.assemblyFullName))
+                {
+                    errorMessage = "Two retained artifacts claim the assembly identity " + artifact.assemblyFullName + ".";
+                    return false;
+                }
+
+                if (!TryValidateIntroducedTypeArtifactTypes(artifact, typeKeys, out errorMessage))
+                {
+                    return false;
+                }
+            }
+
+            errorMessage = string.Empty;
+            return true;
+        }
+
+        private static bool TryValidateIntroducedTypeArtifactTypes(
+            TransformWorkerIntroducedTypeArtifactDto artifact,
+            HashSet<string> typeKeys,
+            out string errorMessage)
+        {
+            foreach (TransformWorkerIntroducedTypeArtifactTypeDto artifactType in artifact.types)
+            {
+                // Without the owner and the fingerprint the worker cannot tell whether the edited
+                // source still produces the declaration the artifact holds, so it would leave the
+                // declaration in place and bind the type from source after all.
+                if (artifactType == null
+                    || string.IsNullOrWhiteSpace(artifactType.metadataName)
+                    || string.IsNullOrWhiteSpace(artifactType.originalAssemblyName)
+                    || string.IsNullOrWhiteSpace(artifactType.originalAssemblyMvid)
+                    || string.IsNullOrWhiteSpace(artifactType.ownerProjectRelativePath)
+                    || string.IsNullOrWhiteSpace(artifactType.declarationFingerprint))
+                {
+                    errorMessage = "A retained type must carry its metadata name, its original identity, its owner and its fingerprint.";
+                    return false;
+                }
+
+                if (!typeKeys.Add(artifact.assemblyFullName + "|" + artifactType.metadataName))
+                {
+                    errorMessage = "A retained artifact lists " + artifactType.metadataName + " more than once.";
+                    return false;
+                }
+            }
+
+            errorMessage = string.Empty;
+            return true;
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
@@ -38,6 +38,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return TransformWorkerClientResult.Failure(artifactError);
             }
 
+            return await RunWorkerAsync(input, ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Runs the worker on a request that has already been checked, without checking it again.
+        /// </summary>
+        // Why separate from RunAsync: the worker consumes the request JSON as a boundary of its
+        // own and has to refuse a record it cannot act on even when the request did not come from
+        // this client. Its guard can only be shown by handing it a request this client would have
+        // refused first.
+        internal static async Task<TransformWorkerClientResult> RunWorkerAsync(
+            TransformWorkerInputDto input,
+            CancellationToken ct)
+        {
             TransformWorkerBootstrapResult bootstrapResult =
                 await TransformWorkerBootstrap.EnsureWorkerAsync(ct).ConfigureAwait(false);
             if (!bootstrapResult.Success)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -39,6 +39,47 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // The worker scans these for const drift the edited file's syntax tree cannot see.
         // Null/omitted is treated as empty.
         public string[] changedSiblingSourcePaths;
+
+        // Retained introduced-type assemblies the worker may bind against. Each record carries the
+        // complete identity and the reference path together, so the worker can confirm the file it
+        // resolved really is the assembly the record claims before it normalizes anything through
+        // it. Null/omitted is treated as empty.
+        public TransformWorkerIntroducedTypeArtifactDto[] introducedTypeArtifacts;
+    }
+
+    /// <summary>
+    /// One retained introduced-type assembly a worker run may bind against.
+    /// </summary>
+    // Keep in sync with TransformWorker~/WorkerIntroducedTypeArtifact.cs.
+    [Serializable]
+    internal sealed class TransformWorkerIntroducedTypeArtifactDto
+    {
+        // Complete assembly identity display name of the artifact assembly, not a simple name.
+        // The worker rejects the record when the assembly it resolves from referencePath reports
+        // a different identity, so a self-reported name alone can never drive normalization.
+        public string assemblyFullName;
+
+        // Absolute path the artifact assembly is referenced from.
+        public string referencePath;
+
+        // Types this artifact holds, with the original identity each one must normalize back to.
+        public TransformWorkerIntroducedTypeArtifactTypeDto[] types;
+    }
+
+    /// <summary>
+    /// One retained type inside an introduced-type artifact assembly.
+    /// </summary>
+    // Keep in sync with TransformWorker~/WorkerIntroducedTypeArtifactType.cs.
+    [Serializable]
+    internal sealed class TransformWorkerIntroducedTypeArtifactTypeDto
+    {
+        // Metadata name of the type as it exists inside the artifact assembly.
+        public string metadataName;
+
+        // Assembly the type is attributed to once normalized: the assembly its source belongs to.
+        public string originalAssemblyName;
+
+        public string originalAssemblyMvid;
     }
 
     /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -80,6 +80,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string originalAssemblyName;
 
         public string originalAssemblyMvid;
+
+        // Project-relative forward-slash path of the source the retained type was planned from.
+        public string ownerProjectRelativePath;
+
+        // Fingerprint the retained type was planned with. A declaration may only be removed from
+        // the tree the transform binds against when the source still produces this value.
+        public string declarationFingerprint;
     }
 
     /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldBodyScan.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldBodyScan.cs
@@ -289,8 +289,27 @@ internal static class AddedFieldBodyScan
         foreach (AssignmentExpressionSyntax assignment in bodyNode.DescendantNodesAndSelf()
             .OfType<AssignmentExpressionSyntax>())
         {
-            if (assignment.Left is MemberAccessExpressionSyntax memberAccess
-                && IsStoreAddedValueTypeField(semanticModel, memberAccess.Expression, addedFieldCatalog))
+            if (WritesThroughValueTypeAddedField(semanticModel, assignment.Left, addedFieldCatalog))
+            {
+                return true;
+            }
+        }
+
+        foreach (PrefixUnaryExpressionSyntax prefix in bodyNode.DescendantNodesAndSelf()
+            .OfType<PrefixUnaryExpressionSyntax>())
+        {
+            if (IsIncrementOrDecrement(prefix.Kind())
+                && WritesThroughValueTypeAddedField(semanticModel, prefix.Operand, addedFieldCatalog))
+            {
+                return true;
+            }
+        }
+
+        foreach (PostfixUnaryExpressionSyntax postfix in bodyNode.DescendantNodesAndSelf()
+            .OfType<PostfixUnaryExpressionSyntax>())
+        {
+            if (IsIncrementOrDecrement(postfix.Kind())
+                && WritesThroughValueTypeAddedField(semanticModel, postfix.Operand, addedFieldCatalog))
             {
                 return true;
             }
@@ -308,13 +327,62 @@ internal static class AddedFieldBodyScan
             ISymbol invoked = semanticModel.GetSymbolInfo(invocation).Symbol;
             if (invoked is IMethodSymbol methodSymbol
                 && !methodSymbol.IsStatic
-                && IsStoreAddedValueTypeField(semanticModel, memberAccess.Expression, addedFieldCatalog))
+                && ReachesValueTypeAddedFieldRoot(semanticModel, memberAccess.Expression, addedFieldCatalog))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    // A whole-value reassignment of the field itself stays supported, so only a target reached
+    // through at least one member or element step counts as a write into the copy.
+    private static bool WritesThroughValueTypeAddedField(
+        SemanticModel semanticModel,
+        ExpressionSyntax target,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        ExpressionSyntax receiver = TryGetReceiver(target);
+        return receiver != null
+            && ReachesValueTypeAddedFieldRoot(semanticModel, receiver, addedFieldCatalog);
+    }
+
+    // Why walk the whole chain: the store hands back a copy of the field, so a write reached
+    // through any number of further steps is lost, no matter how deep the member or element
+    // access that names it sits.
+    private static bool ReachesValueTypeAddedFieldRoot(
+        SemanticModel semanticModel,
+        ExpressionSyntax expression,
+        AddedFieldCatalog addedFieldCatalog)
+    {
+        ExpressionSyntax current = expression;
+        while (current != null)
+        {
+            if (IsStoreAddedValueTypeField(semanticModel, current, addedFieldCatalog))
+            {
+                return true;
+            }
+
+            current = TryGetReceiver(current);
+        }
+
+        return false;
+    }
+
+    private static ExpressionSyntax TryGetReceiver(ExpressionSyntax expression)
+    {
+        switch (expression)
+        {
+            case MemberAccessExpressionSyntax memberAccess:
+                return memberAccess.Expression;
+            case ElementAccessExpressionSyntax elementAccess:
+                return elementAccess.Expression;
+            case ParenthesizedExpressionSyntax parenthesized:
+                return parenthesized.Expression;
+            default:
+                return null;
+        }
     }
 
     internal static bool IsIncrementOrDecrement(SyntaxKind kind)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
@@ -118,7 +118,8 @@ internal static class AddedFieldClassifier
             semanticModel,
             targetTypesAssemblySymbol,
             fieldSymbol,
-            binding);
+            binding,
+            typeState.SourceUnit.ArtifactMap);
 
         if (binding.UnavailableReason != null)
         {
@@ -140,7 +141,8 @@ internal static class AddedFieldClassifier
         SemanticModel semanticModel,
         IAssemblySymbol targetTypesAssemblySymbol,
         IFieldSymbol fieldSymbol,
-        AddedFieldBinding binding)
+        AddedFieldBinding binding,
+        IntroducedTypeArtifactMap artifactMap)
     {
         if (fieldSymbol.IsConst)
         {
@@ -179,7 +181,8 @@ internal static class AddedFieldClassifier
                 binding.Initializer,
                 semanticModel,
                 hostType,
-                targetTypesAssemblySymbol))
+                targetTypesAssemblySymbol,
+                artifactMap))
         {
             return AddedFieldSkipReasons.InitializerNotLiteralOrExternalStatic;
         }
@@ -367,7 +370,8 @@ internal static class AddedFieldClassifier
         ExpressionSyntax initializer,
         SemanticModel semanticModel,
         INamedTypeSymbol hostType,
-        IAssemblySymbol targetTypesAssemblySymbol)
+        IAssemblySymbol targetTypesAssemblySymbol,
+        IntroducedTypeArtifactMap artifactMap)
     {
         foreach (SyntaxNode node in initializer.DescendantNodesAndSelf())
         {
@@ -381,6 +385,19 @@ internal static class AddedFieldClassifier
                 return true;
             }
 
+            // Why object creation is decided on its own: the constructor of an introduced type
+            // is the one instance member the lambda can call, and an inaccessible constructor
+            // leaves GetSymbolInfo without a symbol, so the general check would let it through.
+            if (node is ObjectCreationExpressionSyntax creation)
+            {
+                if (!IsIntroducedTypeConstruction(creation, semanticModel, artifactMap))
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
             if (HasDisallowedInitializerSymbol(
                 semanticModel.GetSymbolInfo(node).Symbol,
                 hostType,
@@ -392,6 +409,54 @@ internal static class AddedFieldClassifier
         }
 
         return false;
+    }
+
+    // The three conditions a construction has to meet: it names a constructor, the constructor is
+    // public, and the constructed type is exactly the (assembly, metadata name) pair the verified
+    // mapping holds. The shim compilation references that artifact assembly, so such a type is
+    // reachable from the lambda; anything else is not.
+    private static bool IsIntroducedTypeConstruction(
+        ObjectCreationExpressionSyntax creation,
+        SemanticModel semanticModel,
+        IntroducedTypeArtifactMap artifactMap)
+    {
+        if (artifactMap == null)
+        {
+            return false;
+        }
+
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(creation);
+        IMethodSymbol constructor = symbolInfo.Symbol as IMethodSymbol;
+        if (constructor == null)
+        {
+            // A constructor the shim assembly cannot reach is reported as a candidate rather
+            // than as the symbol, and it still has to be refused rather than ignored.
+            foreach (ISymbol candidate in symbolInfo.CandidateSymbols)
+            {
+                constructor = candidate as IMethodSymbol;
+                if (constructor != null)
+                {
+                    break;
+                }
+            }
+        }
+
+        if (constructor == null
+            || constructor.MethodKind != MethodKind.Constructor
+            || constructor.DeclaredAccessibility != Accessibility.Public)
+        {
+            return false;
+        }
+
+        INamedTypeSymbol constructedType = constructor.ContainingType;
+        if (constructedType == null || constructedType.ContainingAssembly == null)
+        {
+            return false;
+        }
+
+        return artifactMap.FindNormalizedIdentity(
+            constructedType.ContainingAssembly,
+            CecilTypeNames.ToMetadataName(constructedType.OriginalDefinition)) != null;
     }
 
     internal static bool HasDisallowedInitializerSymbol(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldSkipReasons.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldSkipReasons.cs
@@ -27,8 +27,8 @@ internal static class AddedFieldSkipReasons
 
     public const string InitializerNotLiteralOrExternalStatic =
         "Added field initializer is not a literal or an externally visible static member "
-        + "(object creation and instance, host-type, or same-file added members cannot run in "
-        + "the shim lambda). Drop the initializer and assign the field inside the patched method "
+        + "(object creation other than an introduced type, and instance, host-type, or same-file "
+        + "added members cannot run in the shim lambda). Drop the initializer and assign the field inside the patched method "
         + "instead - an added field without an initializer applies without compiling and starts "
         + "at default(T); for a reference type, guard the assignment with "
         + "'if (_field == null) { _field = ...; }' ('??=' is not rewritable). "

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ConstDriftCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ConstDriftCollector.cs
@@ -94,7 +94,7 @@ internal static class ConstDriftCollector
                     continue;
                 }
 
-                if (Equals(sourceField.ConstantValue, compiledField.ConstantValue))
+                if (HasSameConstantValue(sourceField.ConstantValue, compiledField.ConstantValue))
                 {
                     continue;
                 }
@@ -110,6 +110,17 @@ internal static class ConstDriftCollector
         }
 
         return warnings;
+    }
+
+    /// <summary>
+    /// Compares an edited-source const value with the value compiled into the target assembly.
+    /// </summary>
+    // Why one helper: the transform warns about a drifted const and planning refuses an
+    // introduced type that reads one. Two comparison rules would let a value count as changed in
+    // one path and unchanged in the other.
+    internal static bool HasSameConstantValue(object sourceValue, object compiledValue)
+    {
+        return Equals(sourceValue, compiledValue);
     }
 
     /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeArtifactMap.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeArtifactMap.cs
@@ -123,6 +123,16 @@ internal sealed class IntroducedTypeArtifactMap
             return false;
         }
 
+        // Without the owning file and the fingerprint, re-verification finds no record to compare
+        // the edited declaration against, silently leaves it in the tree and binds the type from
+        // source while the loaded assembly already holds it.
+        if (string.IsNullOrWhiteSpace(artifactType.OwnerProjectRelativePath)
+            || string.IsNullOrWhiteSpace(artifactType.DeclarationFingerprint))
+        {
+            errorMessage = "Introduced-type artifact entry must carry its owning file and its declaration fingerprint.";
+            return false;
+        }
+
         if (assembly.GetTypeByMetadataName(artifactType.MetadataName) == null)
         {
             errorMessage = "Introduced-type artifact does not contain " + artifactType.MetadataName + ".";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeArtifactMap.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeArtifactMap.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+// Maps a type that is bound from a retained artifact assembly back to the identity its source
+// belongs to. Without it a declaration would fingerprint differently depending on whether the
+// type it depends on is currently a source declaration or already a retained artifact, even
+// though the definition did not change.
+internal sealed class IntroducedTypeArtifactMap
+{
+    private readonly Dictionary<string, string> normalizedIdentities;
+
+    private IntroducedTypeArtifactMap(Dictionary<string, string> normalizedIdentities)
+    {
+        this.normalizedIdentities = normalizedIdentities;
+    }
+
+    internal static IntroducedTypeArtifactMap Empty { get; } =
+        new IntroducedTypeArtifactMap(new Dictionary<string, string>(StringComparer.Ordinal));
+
+    // Builds the mapping, or reports why the records cannot be trusted. A record is only usable
+    // when the assembly resolved from its own reference path reports the identity the record
+    // claims and really holds the types it lists: a self-reported name or a metadata name alone
+    // would let an unrelated assembly of the same simple name drive normalization.
+    internal static bool TryBuild(
+        CSharpCompilation compilation,
+        IReadOnlyList<(WorkerIntroducedTypeArtifact Artifact, MetadataReference Reference)> artifactReferences,
+        out IntroducedTypeArtifactMap map,
+        out string errorMessage)
+    {
+        Dictionary<string, string> identities = new Dictionary<string, string>(StringComparer.Ordinal);
+        HashSet<string> normalizedTargets = new HashSet<string>(StringComparer.Ordinal);
+        foreach ((WorkerIntroducedTypeArtifact artifact, MetadataReference reference) in artifactReferences)
+        {
+            if (!TryResolveArtifactAssembly(compilation, artifact, reference, out IAssemblySymbol assembly, out errorMessage))
+            {
+                map = null;
+                return false;
+            }
+
+            foreach (WorkerIntroducedTypeArtifactType artifactType in artifact.Types)
+            {
+                if (!TryAddArtifactType(assembly, artifactType, identities, normalizedTargets, out errorMessage))
+                {
+                    map = null;
+                    return false;
+                }
+            }
+        }
+
+        map = new IntroducedTypeArtifactMap(identities);
+        errorMessage = null;
+        return true;
+    }
+
+    // The normalized identity of a type bound from an artifact, or null when the type does not
+    // come from one.
+    internal string FindNormalizedIdentity(IAssemblySymbol containingAssembly, string metadataName)
+    {
+        if (containingAssembly == null || metadataName == null)
+        {
+            return null;
+        }
+
+        return normalizedIdentities.TryGetValue(BuildKey(containingAssembly, metadataName), out string identity)
+            ? identity
+            : null;
+    }
+
+    private static bool TryResolveArtifactAssembly(
+        CSharpCompilation compilation,
+        WorkerIntroducedTypeArtifact artifact,
+        MetadataReference reference,
+        out IAssemblySymbol assembly,
+        out string errorMessage)
+    {
+        assembly = compilation.GetAssemblyOrModuleSymbol(reference) as IAssemblySymbol;
+        if (assembly == null)
+        {
+            errorMessage = "Introduced-type artifact could not be resolved as an assembly.";
+            return false;
+        }
+
+        // Parsed rather than string-compared: the record and the compiler may render the same
+        // identity with different display formatting, and a formatting difference is not a
+        // mismatched artifact.
+        if (!AssemblyIdentity.TryParseDisplayName(artifact.AssemblyFullName ?? string.Empty, out AssemblyIdentity claimed)
+            || !claimed.Equals(assembly.Identity))
+        {
+            errorMessage = "Introduced-type artifact identity does not match the assembly it references.";
+            return false;
+        }
+
+        return TrySucceed(out errorMessage);
+    }
+
+    private static bool TryAddArtifactType(
+        IAssemblySymbol assembly,
+        WorkerIntroducedTypeArtifactType artifactType,
+        Dictionary<string, string> identities,
+        HashSet<string> normalizedTargets,
+        out string errorMessage)
+    {
+        if (artifactType == null
+            || string.IsNullOrWhiteSpace(artifactType.MetadataName)
+            || string.IsNullOrWhiteSpace(artifactType.OriginalAssemblyName)
+            || string.IsNullOrWhiteSpace(artifactType.OriginalAssemblyMvid))
+        {
+            errorMessage = "Introduced-type artifact entry must carry a metadata name and a complete original identity.";
+            return false;
+        }
+
+        if (assembly.GetTypeByMetadataName(artifactType.MetadataName) == null)
+        {
+            errorMessage = "Introduced-type artifact does not contain " + artifactType.MetadataName + ".";
+            return false;
+        }
+
+        string normalizedIdentity = artifactType.OriginalAssemblyName
+            + "|" + artifactType.OriginalAssemblyMvid
+            + "|" + artifactType.MetadataName;
+        if (!identities.TryAdd(BuildKey(assembly, artifactType.MetadataName), normalizedIdentity))
+        {
+            errorMessage = "Introduced-type artifact lists " + artifactType.MetadataName + " more than once.";
+            return false;
+        }
+
+        // Two artifacts normalizing to the same original type would leave the fingerprint
+        // depending on which record happened to be consulted first.
+        if (!normalizedTargets.Add(normalizedIdentity))
+        {
+            errorMessage = "Two introduced-type artifacts normalize to " + artifactType.MetadataName + ".";
+            return false;
+        }
+
+        return TrySucceed(out errorMessage);
+    }
+
+    private static bool TrySucceed(out string errorMessage)
+    {
+        errorMessage = null;
+        return true;
+    }
+
+    private static string BuildKey(IAssemblySymbol assembly, string metadataName)
+    {
+        return assembly.Identity.GetDisplayName() + "|" + metadataName;
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeArtifactMap.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeArtifactMap.cs
@@ -51,6 +51,16 @@ internal sealed class IntroducedTypeArtifactMap
                 return false;
             }
 
+            // A record that lists no type puts its reference into the compilation but takes no
+            // declaration out of the binding tree, so the type binds from source while the loaded
+            // assembly already holds it - the same silent fallback an incomplete record produces.
+            if (artifact.Types == null || artifact.Types.Length == 0)
+            {
+                map = null;
+                errorMessage = "Introduced-type artifact must list the types it holds.";
+                return false;
+            }
+
             foreach (WorkerIntroducedTypeArtifactType artifactType in artifact.Types)
             {
                 if (!TryAddArtifactType(assembly, artifactType, identities, normalizedTargets, out errorMessage))

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeArtifactReferences.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeArtifactReferences.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.CodeAnalysis;
+
+// Resolves each retained-artifact record to the metadata reference the compilation will bind it
+// through. Adding a second reference for a file the run already references would give the
+// compilation two references of one assembly identity; it drops one, and the record's own
+// reference then resolves to no symbol, which would report a valid artifact as unreadable.
+internal static class IntroducedTypeArtifactReferences
+{
+    internal static List<(WorkerIntroducedTypeArtifact Artifact, MetadataReference Reference)> Collect(
+        WorkerInput input,
+        List<MetadataReference> references,
+        List<string> parseErrors)
+    {
+        Dictionary<string, MetadataReference> referencesByPath = BuildPathIndex(references);
+        List<(WorkerIntroducedTypeArtifact, MetadataReference)> artifactReferences =
+            new List<(WorkerIntroducedTypeArtifact, MetadataReference)>();
+        foreach (WorkerIntroducedTypeArtifact artifact in input.IntroducedTypeArtifacts)
+        {
+            if (artifact == null || string.IsNullOrEmpty(artifact.ReferencePath))
+            {
+                parseErrors.Add("Introduced-type artifact record must carry a reference path.");
+                continue;
+            }
+
+            if (!File.Exists(artifact.ReferencePath))
+            {
+                parseErrors.Add("Introduced-type artifact not found: " + artifact.ReferencePath);
+                continue;
+            }
+
+            string fullPath = Path.GetFullPath(artifact.ReferencePath);
+            if (!referencesByPath.TryGetValue(fullPath, out MetadataReference reference))
+            {
+                reference = MetadataReference.CreateFromFile(fullPath);
+                references.Add(reference);
+                referencesByPath.Add(fullPath, reference);
+            }
+
+            artifactReferences.Add((artifact, reference));
+        }
+
+        return artifactReferences;
+    }
+
+    private static Dictionary<string, MetadataReference> BuildPathIndex(List<MetadataReference> references)
+    {
+        Dictionary<string, MetadataReference> referencesByPath =
+            new Dictionary<string, MetadataReference>(StringComparer.OrdinalIgnoreCase);
+        foreach (MetadataReference reference in references)
+        {
+            if (string.IsNullOrEmpty(reference.Display))
+            {
+                continue;
+            }
+
+            referencesByPath[Path.GetFullPath(reference.Display)] = reference;
+        }
+
+        return referencesByPath;
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeBindingRewriter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeBindingRewriter.cs
@@ -19,7 +19,8 @@ internal static class IntroducedTypeBindingRewriter
     internal static void RemoveRetainedDeclarations(
         WorkerSourceUnit unit,
         IReadOnlyList<BaseTypeDeclarationSyntax> declarations,
-        CSharpParseOptions parseOptions)
+        CSharpParseOptions parseOptions,
+        List<string> bindingParseErrors)
     {
         if (declarations.Count == 0)
         {
@@ -36,8 +37,11 @@ internal static class IntroducedTypeBindingRewriter
             builder.ToString(),
             parseOptions,
             unit.Input.SourcePath,
-            unit.ParseErrors);
-        if (bindingTree == null)
+            bindingParseErrors);
+        // A preprocessor region that starts outside the declaration and ends inside it leaves the
+        // blanked text unparseable. The run stops rather than transforming a file whose binding
+        // tree is a guess: the caller advances to revert and compile whenever a run succeeds.
+        if (bindingTree == null || bindingParseErrors.Count > 0)
         {
             return;
         }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeBindingRewriter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeBindingRewriter.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+// Produces the tree the transform binds against by taking the declarations a retained artifact
+// already serves out of the source. Leaving them in place would bind every reference to the
+// source declaration, and the transform would emit a type that a loaded assembly already holds.
+internal static class IntroducedTypeBindingRewriter
+{
+    // Why blanked in place instead of removed from the syntax tree: emit reports the line range of
+    // every shim method from the span of its declaration, so deleting text above a method would
+    // move the lines that a shim compile error is attributed to. Overwriting the declaration with
+    // spaces and keeping its newlines leaves every surviving node at exactly the offset and line
+    // it has in the edited file.
+    internal static void RemoveRetainedDeclarations(
+        WorkerSourceUnit unit,
+        IReadOnlyList<BaseTypeDeclarationSyntax> declarations,
+        CSharpParseOptions parseOptions)
+    {
+        if (declarations.Count == 0)
+        {
+            return;
+        }
+
+        StringBuilder builder = new StringBuilder(unit.SyntaxTree.GetText().ToString());
+        foreach (BaseTypeDeclarationSyntax declaration in declarations)
+        {
+            BlankSpan(builder, declaration.Span);
+        }
+
+        (SyntaxTree bindingTree, CompilationUnitSyntax _) = WorkerSourceAnnotator.ParseAndAnnotateSource(
+            builder.ToString(),
+            parseOptions,
+            unit.Input.SourcePath,
+            unit.ParseErrors);
+        if (bindingTree == null)
+        {
+            return;
+        }
+
+        unit.BindingSyntaxTree = bindingTree;
+        unit.BindingRoot = bindingTree.GetCompilationUnitRoot();
+    }
+
+    private static void BlankSpan(StringBuilder builder, TextSpan span)
+    {
+        for (int index = span.Start; index < span.End; index++)
+        {
+            if (builder[index] == '\n' || builder[index] == '\r')
+            {
+                continue;
+            }
+
+            builder[index] = ' ';
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeConstDriftDetector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeConstDriftDetector.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+// Finds const fields an introduced declaration reads whose edited source value no longer matches
+// the value compiled into the target assembly. The artifact is compiled against that assembly, so
+// the reference would silently fold the stale metadata value into the retained type.
+internal static class IntroducedTypeConstDriftDetector
+{
+    // The identifier of the first changed const the declaration reads, or null when every const it
+    // reads still holds the value the target assembly was compiled with.
+    internal static string FindChangedReferencedConst(
+        BaseTypeDeclarationSyntax declaration,
+        SemanticModel semanticModel,
+        IAssemblySymbol targetAssembly)
+    {
+        foreach (SyntaxNode node in declaration.DescendantNodesAndSelf())
+        {
+            IFieldSymbol field = semanticModel.GetSymbolInfo(node).Symbol as IFieldSymbol;
+            if (field == null || !field.IsConst || !field.HasConstantValue)
+            {
+                continue;
+            }
+
+            if (HasDriftedFromCompiledValue(field, targetAssembly))
+            {
+                return CecilTypeNames.ToMetadataName(field.ContainingType) + "." + field.Name;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool HasDriftedFromCompiledValue(IFieldSymbol field, IAssemblySymbol targetAssembly)
+    {
+        INamedTypeSymbol compiledType = CompiledMemberMatcher.FindCompiledType(field.ContainingType, targetAssembly);
+        if (compiledType == null)
+        {
+            return false;
+        }
+
+        // A const that is not in the compiled type at all is an added const, which planning
+        // classifies elsewhere; only a value that exists on both sides can have drifted.
+        foreach (ISymbol member in compiledType.GetMembers(field.Name))
+        {
+            IFieldSymbol compiledField = member as IFieldSymbol;
+            if (compiledField == null || !compiledField.IsConst || !compiledField.HasConstantValue)
+            {
+                continue;
+            }
+
+            return !Equals(compiledField.ConstantValue, field.ConstantValue);
+        }
+
+        return false;
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeConstDriftDetector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeConstDriftDetector.cs
@@ -52,7 +52,7 @@ internal static class IntroducedTypeConstDriftDetector
                 continue;
             }
 
-            return !Equals(compiledField.ConstantValue, field.ConstantValue);
+            return !ConstDriftCollector.HasSameConstantValue(field.ConstantValue, compiledField.ConstantValue);
         }
 
         return false;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeConstDriftDetector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeConstDriftDetector.cs
@@ -23,6 +23,13 @@ internal static class IntroducedTypeConstDriftDetector
     {
         foreach (SyntaxNode node in declaration.DescendantNodesAndSelf())
         {
+            // nameof yields the identifier, never the value, so a const named inside one is not
+            // folded into the artifact and its value cannot go stale there.
+            if (NameofRules.IsInsideNameofArgument(node))
+            {
+                continue;
+            }
+
             IFieldSymbol field = semanticModel.GetSymbolInfo(node).Symbol as IFieldSymbol;
             if (field == null || !field.IsConst)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeConstDriftDetector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeConstDriftDetector.cs
@@ -5,33 +5,51 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-// Finds const fields an introduced declaration reads whose edited source value no longer matches
-// the value compiled into the target assembly. The artifact is compiled against that assembly, so
-// the reference would silently fold the stale metadata value into the retained type.
+// Finds const fields an introduced declaration reads that the artifact cannot be compiled against:
+// the edited source value no longer matches the value compiled into the target assembly, or the
+// edited value cannot be read at all. The artifact is compiled against that assembly, so in either
+// case the reference would silently fold the stale metadata value into the retained type.
 internal static class IntroducedTypeConstDriftDetector
 {
-    // The identifier of the first changed const the declaration reads, or null when every const it
-    // reads still holds the value the target assembly was compiled with.
-    internal static string FindChangedReferencedConst(
+    // True when the declaration reads a const the artifact cannot be compiled against: one whose
+    // edited value no longer matches the compiled one, or one whose edited value cannot be read at
+    // all. Reports which const it was and why.
+    internal static bool TryFindUnusableReferencedConst(
         BaseTypeDeclarationSyntax declaration,
         SemanticModel semanticModel,
-        IAssemblySymbol targetAssembly)
+        IAssemblySymbol targetAssembly,
+        out string identifier,
+        out string reason)
     {
         foreach (SyntaxNode node in declaration.DescendantNodesAndSelf())
         {
             IFieldSymbol field = semanticModel.GetSymbolInfo(node).Symbol as IFieldSymbol;
-            if (field == null || !field.IsConst || !field.HasConstantValue)
+            if (field == null || !field.IsConst)
             {
                 continue;
             }
 
+            // A const whose initializer does not compile carries no value to compare, and the
+            // artifact compile does not see that file at all: it would succeed against the value
+            // still in the target assembly and fold a stale constant into the retained type.
+            if (!field.HasConstantValue)
+            {
+                identifier = CecilTypeNames.ToMetadataName(field.ContainingType) + "." + field.Name;
+                reason = "Const value cannot be verified";
+                return true;
+            }
+
             if (HasDriftedFromCompiledValue(field, targetAssembly))
             {
-                return CecilTypeNames.ToMetadataName(field.ContainingType) + "." + field.Name;
+                identifier = CecilTypeNames.ToMetadataName(field.ContainingType) + "." + field.Name;
+                reason = "Changed const requires a compile";
+                return true;
             }
         }
 
-        return null;
+        identifier = null;
+        reason = null;
+        return false;
     }
 
     private static bool HasDriftedFromCompiledValue(IFieldSymbol field, IAssemblySymbol targetAssembly)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeDeclarationVerifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeDeclarationVerifier.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+// Decides which source declarations may be removed from the tree the transform binds against.
+// A declaration is only removable when the artifact record that claims it still describes the
+// source: same owner file, same metadata name, and the same fingerprint recomputed from the
+// edited text. Otherwise the source is newer than the artifact and the source has to win.
+internal static class IntroducedTypeDeclarationVerifier
+{
+    // The declarations of each unit that a retained artifact already serves, keyed by unit.
+    internal static Dictionary<WorkerSourceUnit, List<BaseTypeDeclarationSyntax>> FindRetainedDeclarations(
+        IReadOnlyList<WorkerSourceUnit> units,
+        CSharpCompilation verificationCompilation,
+        WorkerInput input,
+        IAssemblySymbol targetAssembly,
+        IntroducedTypeArtifactMap artifactMap)
+    {
+        Dictionary<string, WorkerIntroducedTypeArtifactType> recordsByKey = BuildRecordIndex(input);
+        Dictionary<WorkerSourceUnit, List<BaseTypeDeclarationSyntax>> retainedDeclarations =
+            new Dictionary<WorkerSourceUnit, List<BaseTypeDeclarationSyntax>>();
+        if (recordsByKey.Count == 0)
+        {
+            return retainedDeclarations;
+        }
+
+        foreach (WorkerSourceUnit unit in units)
+        {
+            List<BaseTypeDeclarationSyntax> declarations = FindRetainedDeclarationsOfUnit(
+                unit, verificationCompilation, input, targetAssembly, artifactMap, recordsByKey);
+            if (declarations.Count > 0)
+            {
+                retainedDeclarations.Add(unit, declarations);
+            }
+        }
+
+        return retainedDeclarations;
+    }
+
+    private static List<BaseTypeDeclarationSyntax> FindRetainedDeclarationsOfUnit(
+        WorkerSourceUnit unit,
+        CSharpCompilation verificationCompilation,
+        WorkerInput input,
+        IAssemblySymbol targetAssembly,
+        IntroducedTypeArtifactMap artifactMap,
+        Dictionary<string, WorkerIntroducedTypeArtifactType> recordsByKey)
+    {
+        List<BaseTypeDeclarationSyntax> declarations = new List<BaseTypeDeclarationSyntax>();
+        SemanticModel semanticModel = verificationCompilation.GetSemanticModel(unit.SyntaxTree, ignoreAccessibility: false);
+        foreach (BaseTypeDeclarationSyntax declaration in unit.Root.DescendantNodes().OfType<BaseTypeDeclarationSyntax>())
+        {
+            INamedTypeSymbol typeSymbol = semanticModel.GetDeclaredSymbol(declaration);
+            if (typeSymbol == null || typeSymbol.ContainingType != null)
+            {
+                continue;
+            }
+
+            string metadataName = CecilTypeNames.ToMetadataName(typeSymbol);
+            if (!recordsByKey.TryGetValue(
+                    BuildKey(unit.Input.ProjectRelativePath, metadataName),
+                    out WorkerIntroducedTypeArtifactType record))
+            {
+                continue;
+            }
+
+            // Recomputed through the same path the plan used, artifact normalization included:
+            // a retained declaration may itself depend on another retained type, and computing
+            // its fingerprint without the mapping would never reproduce the recorded value.
+            string fingerprint = IntroducedTypeFingerprint.Compute(
+                unit.Root,
+                declaration,
+                input.Defines,
+                typeSymbol,
+                semanticModel,
+                targetAssembly,
+                input.TargetAssemblyName,
+                input.TargetAssemblyMvid,
+                artifactMap);
+            if (string.Equals(fingerprint, record.DeclarationFingerprint, StringComparison.Ordinal))
+            {
+                declarations.Add(declaration);
+            }
+        }
+
+        return declarations;
+    }
+
+    private static Dictionary<string, WorkerIntroducedTypeArtifactType> BuildRecordIndex(WorkerInput input)
+    {
+        Dictionary<string, WorkerIntroducedTypeArtifactType> recordsByKey =
+            new Dictionary<string, WorkerIntroducedTypeArtifactType>(StringComparer.Ordinal);
+        foreach (WorkerIntroducedTypeArtifact artifact in input.IntroducedTypeArtifacts)
+        {
+            if (artifact == null)
+            {
+                continue;
+            }
+
+            foreach (WorkerIntroducedTypeArtifactType artifactType in artifact.Types)
+            {
+                if (artifactType == null
+                    || string.IsNullOrEmpty(artifactType.OwnerProjectRelativePath)
+                    || string.IsNullOrEmpty(artifactType.DeclarationFingerprint))
+                {
+                    continue;
+                }
+
+                recordsByKey[BuildKey(artifactType.OwnerProjectRelativePath, artifactType.MetadataName)] =
+                    artifactType;
+            }
+        }
+
+        return recordsByKey;
+    }
+
+    private static string BuildKey(string ownerProjectRelativePath, string metadataName)
+    {
+        return (ownerProjectRelativePath ?? string.Empty) + "|" + (metadataName ?? string.Empty);
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeDependencyWalker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeDependencyWalker.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+// Turns a bound symbol into the set of type identities a declaration depends on. Collapsing a
+// symbol to a single type would lose the types that only appear inside it: the element type of an
+// array, the type arguments of a constructed generic, and the signature types of a referenced
+// member. A definition that changes only there has to change the fingerprint too.
+internal sealed class IntroducedTypeDependencyWalker
+{
+    private readonly IAssemblySymbol compilationAssembly;
+    private readonly IAssemblySymbol targetAssembly;
+    private readonly string targetAssemblyName;
+    private readonly string targetAssemblyMvid;
+    private readonly IntroducedTypeArtifactMap artifactMap;
+
+    internal IntroducedTypeDependencyWalker(
+        IAssemblySymbol compilationAssembly,
+        IAssemblySymbol targetAssembly,
+        string targetAssemblyName,
+        string targetAssemblyMvid,
+        IntroducedTypeArtifactMap artifactMap)
+    {
+        this.compilationAssembly = compilationAssembly;
+        this.targetAssembly = targetAssembly;
+        this.targetAssemblyName = targetAssemblyName;
+        this.targetAssemblyMvid = targetAssemblyMvid;
+        this.artifactMap = artifactMap;
+    }
+
+    // Adds every type identity reachable from the symbol. The visited set is per call, so the same
+    // type reached through two different symbols is still recorded once per dependency set.
+    internal void AddDependencies(ISymbol symbol, HashSet<string> dependencies)
+    {
+        HashSet<ISymbol> visited = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        Expand(symbol, dependencies, visited);
+    }
+
+    private void Expand(ISymbol symbol, HashSet<string> dependencies, HashSet<ISymbol> visited)
+    {
+        if (symbol == null || !visited.Add(symbol))
+        {
+            return;
+        }
+
+        if (symbol is IArrayTypeSymbol arrayType)
+        {
+            Expand(arrayType.ElementType, dependencies, visited);
+            return;
+        }
+
+        if (symbol is IPointerTypeSymbol pointerType)
+        {
+            Expand(pointerType.PointedAtType, dependencies, visited);
+            return;
+        }
+
+        if (symbol is ITypeParameterSymbol typeParameter)
+        {
+            foreach (ITypeSymbol constraintType in typeParameter.ConstraintTypes)
+            {
+                Expand(constraintType, dependencies, visited);
+            }
+
+            return;
+        }
+
+        if (symbol is INamedTypeSymbol namedType)
+        {
+            ExpandNamedType(namedType, dependencies, visited);
+            return;
+        }
+
+        ExpandMember(symbol, dependencies, visited);
+    }
+
+    private void ExpandNamedType(
+        INamedTypeSymbol namedType,
+        HashSet<string> dependencies,
+        HashSet<ISymbol> visited)
+    {
+        AddIdentity(namedType, dependencies);
+        foreach (ITypeSymbol typeArgument in namedType.TypeArguments)
+        {
+            Expand(typeArgument, dependencies, visited);
+        }
+    }
+
+    private void ExpandMember(ISymbol symbol, HashSet<string> dependencies, HashSet<ISymbol> visited)
+    {
+        Expand(symbol.ContainingType, dependencies, visited);
+        if (symbol is IMethodSymbol method)
+        {
+            ExpandMethod(method, dependencies, visited);
+            return;
+        }
+
+        if (symbol is IPropertySymbol property)
+        {
+            Expand(property.Type, dependencies, visited);
+            foreach (IParameterSymbol parameter in property.Parameters)
+            {
+                Expand(parameter.Type, dependencies, visited);
+            }
+
+            return;
+        }
+
+        if (symbol is IFieldSymbol field)
+        {
+            Expand(field.Type, dependencies, visited);
+            return;
+        }
+
+        if (symbol is IEventSymbol eventSymbol)
+        {
+            Expand(eventSymbol.Type, dependencies, visited);
+        }
+    }
+
+    private void ExpandMethod(IMethodSymbol method, HashSet<string> dependencies, HashSet<ISymbol> visited)
+    {
+        Expand(method.ReturnType, dependencies, visited);
+        foreach (IParameterSymbol parameter in method.Parameters)
+        {
+            Expand(parameter.Type, dependencies, visited);
+        }
+
+        foreach (ITypeSymbol typeArgument in method.TypeArguments)
+        {
+            Expand(typeArgument, dependencies, visited);
+        }
+    }
+
+    private void AddIdentity(INamedTypeSymbol namedType, HashSet<string> dependencies)
+    {
+        IAssemblySymbol containingAssembly = namedType.ContainingAssembly;
+        if (containingAssembly == null)
+        {
+            return;
+        }
+
+        string metadataName = CecilTypeNames.ToMetadataName(namedType.OriginalDefinition);
+
+        // A type that already lives in a retained artifact is the same definition it was when it
+        // was still a source declaration, so it has to fingerprint as the assembly its source
+        // belongs to. Binding through the artifact assembly identity instead would invalidate
+        // every dependent declaration the moment the type it depends on is introduced.
+        string normalizedIdentity = artifactMap.FindNormalizedIdentity(containingAssembly, metadataName);
+        if (normalizedIdentity != null)
+        {
+            dependencies.Add(normalizedIdentity);
+            return;
+        }
+
+        if (SymbolEqualityComparer.Default.Equals(containingAssembly, compilationAssembly)
+            || SymbolEqualityComparer.Default.Equals(containingAssembly, targetAssembly))
+        {
+            dependencies.Add((targetAssemblyName ?? string.Empty)
+                + "|" + (targetAssemblyMvid ?? string.Empty)
+                + "|" + metadataName);
+            return;
+        }
+
+        dependencies.Add(containingAssembly.Identity.GetDisplayName() + "|" + metadataName);
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeFingerprint.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeFingerprint.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+// Turns one declaration into the value that decides whether a retained type still describes the
+// same definition: its tokens, the defines it was parsed with, and the identity of every type it
+// depends on, each recorded against the traversal position that binds it.
+internal static class IntroducedTypeFingerprint
+{
+    internal static string Compute(
+        CompilationUnitSyntax root,
+        BaseTypeDeclarationSyntax declaration,
+        IReadOnlyList<string> defineSymbols,
+        INamedTypeSymbol typeSymbol,
+        SemanticModel semanticModel,
+        IAssemblySymbol targetAssembly,
+        string targetAssemblyName,
+        string targetAssemblyMvid,
+        IntroducedTypeArtifactMap artifactMap)
+    {
+        StringBuilder input = new StringBuilder();
+        AppendTokens(input, declaration.DescendantTokens());
+
+        foreach (string defineSymbol in defineSymbols.OrderBy(symbol => symbol, StringComparer.Ordinal))
+        {
+            AppendValue(input, defineSymbol);
+        }
+
+        foreach (string dependencyIdentity in CollectDependencyIdentities(
+            declaration,
+            typeSymbol,
+            semanticModel,
+            targetAssembly,
+            targetAssemblyName,
+            targetAssemblyMvid,
+            artifactMap))
+        {
+            AppendValue(input, dependencyIdentity);
+        }
+
+        byte[] sourceBytes = Encoding.UTF8.GetBytes(input.ToString());
+        using SHA256 hash = SHA256.Create();
+        byte[] bytes = hash.ComputeHash(sourceBytes);
+        StringBuilder builder = new StringBuilder(bytes.Length * 2);
+        for (int index = 0; index < bytes.Length; index++)
+        {
+            builder.Append(bytes[index].ToString("x2", CultureInfo.InvariantCulture));
+        }
+
+        return builder.ToString();
+    }
+
+    private static void AppendTokens(StringBuilder builder, IEnumerable<SyntaxToken> tokens)
+    {
+        foreach (SyntaxToken token in tokens)
+        {
+            builder.Append(token.RawKind.ToString(CultureInfo.InvariantCulture));
+            builder.Append(':');
+            AppendValue(builder, token.Text);
+        }
+    }
+
+    private static void AppendValue(StringBuilder builder, string value)
+    {
+        string safeValue = value ?? string.Empty;
+        builder.Append(safeValue.Length.ToString(CultureInfo.InvariantCulture));
+        builder.Append(':');
+        builder.Append(safeValue);
+        builder.Append('\n');
+    }
+
+    // Records each dependency against the ordinal position of the declaration node that binds it.
+    // An unordered set cannot tell two aliases apart when they exchange the types they bind to:
+    // the tokens are identical and the set of referenced types is the same, so the fingerprint
+    // would stay equal while the definition changed. The position is a traversal ordinal rather
+    // than an absolute span, so it survives trivia edits and unrelated using directives.
+    private static IReadOnlyList<string> CollectDependencyIdentities(
+        BaseTypeDeclarationSyntax declaration,
+        INamedTypeSymbol typeSymbol,
+        SemanticModel semanticModel,
+        IAssemblySymbol targetAssembly,
+        string targetAssemblyName,
+        string targetAssemblyMvid,
+        IntroducedTypeArtifactMap artifactMap)
+    {
+        IntroducedTypeDependencyWalker walker = new IntroducedTypeDependencyWalker(
+            semanticModel.Compilation.Assembly,
+            targetAssembly,
+            targetAssemblyName,
+            targetAssemblyMvid,
+            artifactMap);
+        List<string> positionedDependencies = new List<string>();
+        HashSet<string> declaringDependency = new HashSet<string>(StringComparer.Ordinal);
+        walker.AddDependencies(typeSymbol, declaringDependency);
+        foreach (string identity in declaringDependency.OrderBy(identity => identity, StringComparer.Ordinal))
+        {
+            positionedDependencies.Add("self|" + identity);
+        }
+
+        int position = 0;
+        foreach (SyntaxNode node in declaration.DescendantNodesAndSelf())
+        {
+            HashSet<string> nodeDependencies = new HashSet<string>(StringComparer.Ordinal);
+            SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(node);
+            walker.AddDependencies(symbolInfo.Symbol, nodeDependencies);
+            foreach (ISymbol candidate in symbolInfo.CandidateSymbols)
+            {
+                walker.AddDependencies(candidate, nodeDependencies);
+            }
+
+            TypeInfo typeInfo = semanticModel.GetTypeInfo(node);
+            walker.AddDependencies(typeInfo.Type, nodeDependencies);
+            walker.AddDependencies(typeInfo.ConvertedType, nodeDependencies);
+            foreach (string identity in nodeDependencies.OrderBy(identity => identity, StringComparer.Ordinal))
+            {
+                positionedDependencies.Add(position.ToString(CultureInfo.InvariantCulture) + "|" + identity);
+            }
+
+            position++;
+        }
+
+        return positionedDependencies;
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
@@ -24,6 +24,7 @@ internal static class IntroducedTypePlanner
         IAssemblySymbol targetAssembly,
         string targetAssemblyName,
         string targetAssemblyMvid,
+        IntroducedTypeArtifactMap artifactMap,
         IReadOnlyList<string> defineSymbols,
         IReadOnlyList<UsingDirectiveSyntax> assemblyGlobalUsings)
     {
@@ -65,6 +66,16 @@ internal static class IntroducedTypePlanner
                 continue;
             }
 
+            string changedConst = IntroducedTypeConstDriftDetector.FindChangedReferencedConst(
+                declaration, unit.SemanticModel, targetAssembly);
+            if (changedConst != null)
+            {
+                unit.IntroducedTypeDiagnostics.Add(
+                    "Changed const requires a compile: " + changedConst
+                    + " referenced by " + CecilTypeNames.ToMetadataName(typeSymbol));
+                continue;
+            }
+
             unit.IntroducedTypes.Add(
                 new WorkerIntroducedType
                 {
@@ -80,7 +91,8 @@ internal static class IntroducedTypePlanner
                         unit.SemanticModel,
                         targetAssembly,
                         targetAssemblyName,
-                        targetAssemblyMvid),
+                        targetAssemblyMvid,
+                        artifactMap),
                     Source = BuildTypeSource(unit.Root, typeSymbol, declaration, assemblyGlobalUsings)
                 });
         }
@@ -331,7 +343,8 @@ internal static class IntroducedTypePlanner
         SemanticModel semanticModel,
         IAssemblySymbol targetAssembly,
         string targetAssemblyName,
-        string targetAssemblyMvid)
+        string targetAssemblyMvid,
+        IntroducedTypeArtifactMap artifactMap)
     {
         StringBuilder input = new StringBuilder();
         AppendTokens(input, declaration.DescendantTokens());
@@ -347,7 +360,8 @@ internal static class IntroducedTypePlanner
             semanticModel,
             targetAssembly,
             targetAssemblyName,
-            targetAssemblyMvid))
+            targetAssemblyMvid,
+            artifactMap))
         {
             AppendValue(input, dependencyIdentity);
         }
@@ -394,11 +408,12 @@ internal static class IntroducedTypePlanner
         SemanticModel semanticModel,
         IAssemblySymbol targetAssembly,
         string targetAssemblyName,
-        string targetAssemblyMvid)
+        string targetAssemblyMvid,
+        IntroducedTypeArtifactMap artifactMap)
     {
         List<string> positionedDependencies = new List<string>();
         HashSet<string> declaringDependency = new HashSet<string>(StringComparer.Ordinal);
-        AddDependency(typeSymbol, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, declaringDependency);
+        AddDependency(typeSymbol, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, artifactMap, declaringDependency);
         foreach (string identity in declaringDependency.OrderBy(identity => identity, StringComparer.Ordinal))
         {
             positionedDependencies.Add("self|" + identity);
@@ -409,15 +424,15 @@ internal static class IntroducedTypePlanner
         {
             HashSet<string> nodeDependencies = new HashSet<string>(StringComparer.Ordinal);
             SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(node);
-            AddDependency(symbolInfo.Symbol, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, nodeDependencies);
+            AddDependency(symbolInfo.Symbol, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, artifactMap, nodeDependencies);
             foreach (ISymbol candidate in symbolInfo.CandidateSymbols)
             {
-                AddDependency(candidate, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, nodeDependencies);
+                AddDependency(candidate, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, artifactMap, nodeDependencies);
             }
 
             TypeInfo typeInfo = semanticModel.GetTypeInfo(node);
-            AddDependency(typeInfo.Type, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, nodeDependencies);
-            AddDependency(typeInfo.ConvertedType, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, nodeDependencies);
+            AddDependency(typeInfo.Type, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, artifactMap, nodeDependencies);
+            AddDependency(typeInfo.ConvertedType, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, artifactMap, nodeDependencies);
             foreach (string identity in nodeDependencies.OrderBy(identity => identity, StringComparer.Ordinal))
             {
                 positionedDependencies.Add(position.ToString(CultureInfo.InvariantCulture) + "|" + identity);
@@ -435,6 +450,7 @@ internal static class IntroducedTypePlanner
         IAssemblySymbol targetAssembly,
         string targetAssemblyName,
         string targetAssemblyMvid,
+        IntroducedTypeArtifactMap artifactMap,
         HashSet<string> dependencies)
     {
         if (symbol == null)
@@ -467,16 +483,28 @@ internal static class IntroducedTypePlanner
             return;
         }
 
+        string metadataName = CecilTypeNames.ToMetadataName(namedType.OriginalDefinition);
+
+        // A type that already lives in a retained artifact is the same definition it was when it
+        // was still a source declaration, so it has to fingerprint as the assembly its source
+        // belongs to. Binding through the artifact assembly identity instead would invalidate
+        // every dependent declaration the moment the type it depends on is introduced.
+        string normalizedIdentity = artifactMap.FindNormalizedIdentity(containingAssembly, metadataName);
+        if (normalizedIdentity != null)
+        {
+            dependencies.Add(normalizedIdentity);
+            return;
+        }
+
         if (SymbolEqualityComparer.Default.Equals(containingAssembly, semanticModel.Compilation.Assembly)
             || SymbolEqualityComparer.Default.Equals(containingAssembly, targetAssembly))
         {
             dependencies.Add((targetAssemblyName ?? string.Empty)
                 + "|" + (targetAssemblyMvid ?? string.Empty)
-                + "|" + CecilTypeNames.ToMetadataName(namedType.OriginalDefinition));
+                + "|" + metadataName);
             return;
         }
 
-        dependencies.Add(containingAssembly.Identity.GetDisplayName()
-            + "|" + CecilTypeNames.ToMetadataName(namedType.OriginalDefinition));
+        dependencies.Add(containingAssembly.Identity.GetDisplayName() + "|" + metadataName);
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
@@ -67,7 +67,7 @@ internal static class IntroducedTypePlanner
             }
 
             string changedConst = IntroducedTypeConstDriftDetector.FindChangedReferencedConst(
-                declaration, unit.SemanticModel, targetAssembly);
+                declaration, unit.ConstDriftSemanticModel ?? unit.SemanticModel, targetAssembly);
             if (changedConst != null)
             {
                 unit.IntroducedTypeDiagnostics.Add(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
@@ -83,7 +83,7 @@ internal static class IntroducedTypePlanner
                     OriginalAssemblyMvid = targetAssemblyMvid ?? string.Empty,
                     MetadataName = CecilTypeNames.ToMetadataName(typeSymbol),
                     OwnerProjectRelativePath = unit.Input.ProjectRelativePath,
-                    DeclarationFingerprint = ComputeFingerprint(
+                    DeclarationFingerprint = IntroducedTypeFingerprint.Compute(
                         unit.Root,
                         declaration,
                         defineSymbols,
@@ -333,120 +333,5 @@ internal static class IntroducedTypePlanner
         }
 
         return false;
-    }
-
-    private static string ComputeFingerprint(
-        CompilationUnitSyntax root,
-        BaseTypeDeclarationSyntax declaration,
-        IReadOnlyList<string> defineSymbols,
-        INamedTypeSymbol typeSymbol,
-        SemanticModel semanticModel,
-        IAssemblySymbol targetAssembly,
-        string targetAssemblyName,
-        string targetAssemblyMvid,
-        IntroducedTypeArtifactMap artifactMap)
-    {
-        StringBuilder input = new StringBuilder();
-        AppendTokens(input, declaration.DescendantTokens());
-
-        foreach (string defineSymbol in defineSymbols.OrderBy(symbol => symbol, StringComparer.Ordinal))
-        {
-            AppendValue(input, defineSymbol);
-        }
-
-        foreach (string dependencyIdentity in CollectDependencyIdentities(
-            declaration,
-            typeSymbol,
-            semanticModel,
-            targetAssembly,
-            targetAssemblyName,
-            targetAssemblyMvid,
-            artifactMap))
-        {
-            AppendValue(input, dependencyIdentity);
-        }
-
-        byte[] sourceBytes = Encoding.UTF8.GetBytes(input.ToString());
-        using SHA256 hash = SHA256.Create();
-        byte[] bytes = hash.ComputeHash(sourceBytes);
-        StringBuilder builder = new StringBuilder(bytes.Length * 2);
-        for (int index = 0; index < bytes.Length; index++)
-        {
-            builder.Append(bytes[index].ToString("x2", CultureInfo.InvariantCulture));
-        }
-
-        return builder.ToString();
-    }
-
-    private static void AppendTokens(StringBuilder builder, IEnumerable<SyntaxToken> tokens)
-    {
-        foreach (SyntaxToken token in tokens)
-        {
-            builder.Append(token.RawKind.ToString(CultureInfo.InvariantCulture));
-            builder.Append(':');
-            AppendValue(builder, token.Text);
-        }
-    }
-
-    private static void AppendValue(StringBuilder builder, string value)
-    {
-        string safeValue = value ?? string.Empty;
-        builder.Append(safeValue.Length.ToString(CultureInfo.InvariantCulture));
-        builder.Append(':');
-        builder.Append(safeValue);
-        builder.Append('\n');
-    }
-
-    // Records each dependency against the ordinal position of the declaration node that binds it.
-    // An unordered set cannot tell two aliases apart when they exchange the types they bind to:
-    // the tokens are identical and the set of referenced types is the same, so the fingerprint
-    // would stay equal while the definition changed. The position is a traversal ordinal rather
-    // than an absolute span, so it survives trivia edits and unrelated using directives.
-    private static IReadOnlyList<string> CollectDependencyIdentities(
-        BaseTypeDeclarationSyntax declaration,
-        INamedTypeSymbol typeSymbol,
-        SemanticModel semanticModel,
-        IAssemblySymbol targetAssembly,
-        string targetAssemblyName,
-        string targetAssemblyMvid,
-        IntroducedTypeArtifactMap artifactMap)
-    {
-        IntroducedTypeDependencyWalker walker = new IntroducedTypeDependencyWalker(
-            semanticModel.Compilation.Assembly,
-            targetAssembly,
-            targetAssemblyName,
-            targetAssemblyMvid,
-            artifactMap);
-        List<string> positionedDependencies = new List<string>();
-        HashSet<string> declaringDependency = new HashSet<string>(StringComparer.Ordinal);
-        walker.AddDependencies(typeSymbol, declaringDependency);
-        foreach (string identity in declaringDependency.OrderBy(identity => identity, StringComparer.Ordinal))
-        {
-            positionedDependencies.Add("self|" + identity);
-        }
-
-        int position = 0;
-        foreach (SyntaxNode node in declaration.DescendantNodesAndSelf())
-        {
-            HashSet<string> nodeDependencies = new HashSet<string>(StringComparer.Ordinal);
-            SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(node);
-            walker.AddDependencies(symbolInfo.Symbol, nodeDependencies);
-            foreach (ISymbol candidate in symbolInfo.CandidateSymbols)
-            {
-                walker.AddDependencies(candidate, nodeDependencies);
-            }
-
-            TypeInfo typeInfo = semanticModel.GetTypeInfo(node);
-            walker.AddDependencies(typeInfo.Type, nodeDependencies);
-            walker.AddDependencies(typeInfo.ConvertedType, nodeDependencies);
-            foreach (string identity in nodeDependencies.OrderBy(identity => identity, StringComparer.Ordinal))
-            {
-                positionedDependencies.Add(position.ToString(CultureInfo.InvariantCulture) + "|" + identity);
-            }
-
-            position++;
-        }
-
-        return positionedDependencies;
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
@@ -411,9 +411,15 @@ internal static class IntroducedTypePlanner
         string targetAssemblyMvid,
         IntroducedTypeArtifactMap artifactMap)
     {
+        IntroducedTypeDependencyWalker walker = new IntroducedTypeDependencyWalker(
+            semanticModel.Compilation.Assembly,
+            targetAssembly,
+            targetAssemblyName,
+            targetAssemblyMvid,
+            artifactMap);
         List<string> positionedDependencies = new List<string>();
         HashSet<string> declaringDependency = new HashSet<string>(StringComparer.Ordinal);
-        AddDependency(typeSymbol, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, artifactMap, declaringDependency);
+        walker.AddDependencies(typeSymbol, declaringDependency);
         foreach (string identity in declaringDependency.OrderBy(identity => identity, StringComparer.Ordinal))
         {
             positionedDependencies.Add("self|" + identity);
@@ -424,15 +430,15 @@ internal static class IntroducedTypePlanner
         {
             HashSet<string> nodeDependencies = new HashSet<string>(StringComparer.Ordinal);
             SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(node);
-            AddDependency(symbolInfo.Symbol, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, artifactMap, nodeDependencies);
+            walker.AddDependencies(symbolInfo.Symbol, nodeDependencies);
             foreach (ISymbol candidate in symbolInfo.CandidateSymbols)
             {
-                AddDependency(candidate, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, artifactMap, nodeDependencies);
+                walker.AddDependencies(candidate, nodeDependencies);
             }
 
             TypeInfo typeInfo = semanticModel.GetTypeInfo(node);
-            AddDependency(typeInfo.Type, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, artifactMap, nodeDependencies);
-            AddDependency(typeInfo.ConvertedType, semanticModel, targetAssembly, targetAssemblyName, targetAssemblyMvid, artifactMap, nodeDependencies);
+            walker.AddDependencies(typeInfo.Type, nodeDependencies);
+            walker.AddDependencies(typeInfo.ConvertedType, nodeDependencies);
             foreach (string identity in nodeDependencies.OrderBy(identity => identity, StringComparer.Ordinal))
             {
                 positionedDependencies.Add(position.ToString(CultureInfo.InvariantCulture) + "|" + identity);
@@ -442,69 +448,5 @@ internal static class IntroducedTypePlanner
         }
 
         return positionedDependencies;
-    }
-
-    private static void AddDependency(
-        ISymbol symbol,
-        SemanticModel semanticModel,
-        IAssemblySymbol targetAssembly,
-        string targetAssemblyName,
-        string targetAssemblyMvid,
-        IntroducedTypeArtifactMap artifactMap,
-        HashSet<string> dependencies)
-    {
-        if (symbol == null)
-        {
-            return;
-        }
-
-        INamedTypeSymbol namedType = symbol as INamedTypeSymbol;
-        if (symbol is IMethodSymbol methodSymbol)
-        {
-            namedType = methodSymbol.ContainingType;
-        }
-        else if (symbol is IPropertySymbol propertySymbol)
-        {
-            namedType = propertySymbol.ContainingType;
-        }
-        else if (symbol is IFieldSymbol fieldSymbol)
-        {
-            namedType = fieldSymbol.ContainingType;
-        }
-
-        if (namedType == null)
-        {
-            return;
-        }
-
-        IAssemblySymbol containingAssembly = namedType.ContainingAssembly;
-        if (containingAssembly == null)
-        {
-            return;
-        }
-
-        string metadataName = CecilTypeNames.ToMetadataName(namedType.OriginalDefinition);
-
-        // A type that already lives in a retained artifact is the same definition it was when it
-        // was still a source declaration, so it has to fingerprint as the assembly its source
-        // belongs to. Binding through the artifact assembly identity instead would invalidate
-        // every dependent declaration the moment the type it depends on is introduced.
-        string normalizedIdentity = artifactMap.FindNormalizedIdentity(containingAssembly, metadataName);
-        if (normalizedIdentity != null)
-        {
-            dependencies.Add(normalizedIdentity);
-            return;
-        }
-
-        if (SymbolEqualityComparer.Default.Equals(containingAssembly, semanticModel.Compilation.Assembly)
-            || SymbolEqualityComparer.Default.Equals(containingAssembly, targetAssembly))
-        {
-            dependencies.Add((targetAssemblyName ?? string.Empty)
-                + "|" + (targetAssemblyMvid ?? string.Empty)
-                + "|" + metadataName);
-            return;
-        }
-
-        dependencies.Add(containingAssembly.Identity.GetDisplayName() + "|" + metadataName);
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
@@ -66,12 +66,15 @@ internal static class IntroducedTypePlanner
                 continue;
             }
 
-            string changedConst = IntroducedTypeConstDriftDetector.FindChangedReferencedConst(
-                declaration, unit.ConstDriftSemanticModel ?? unit.SemanticModel, targetAssembly);
-            if (changedConst != null)
+            if (IntroducedTypeConstDriftDetector.TryFindUnusableReferencedConst(
+                    declaration,
+                    unit.ConstDriftSemanticModel ?? unit.SemanticModel,
+                    targetAssembly,
+                    out string unusableConst,
+                    out string unusableConstReason))
             {
                 unit.IntroducedTypeDiagnostics.Add(
-                    "Changed const requires a compile: " + changedConst
+                    unusableConstReason + ": " + unusableConst
                     + " referenced by " + CecilTypeNames.ToMetadataName(typeSymbol));
                 continue;
             }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePreparation.cs
@@ -42,6 +42,8 @@ internal static class IntroducedTypePreparation
         List<string> referenceParseErrors = new List<string>();
         (List<MetadataReference> references, MetadataReference targetTypesReference) =
             WorkerGroupPipeline.CollectMetadataReferences(input, referenceParseErrors);
+        List<(WorkerIntroducedTypeArtifact Artifact, MetadataReference Reference)> artifactReferences =
+            CollectArtifactReferences(input, references, referenceParseErrors);
         CSharpCompilation compilation = CSharpCompilation.Create(
             assemblyName: "UloopHotReloadIntroducedTypePlanning",
             syntaxTrees: syntaxTrees,
@@ -59,6 +61,12 @@ internal static class IntroducedTypePreparation
             WorkerUsingCollector.CollectAssemblyGlobalUsings(input, parseOptions, analyzableRoots);
         string incompleteInputsDiagnostic =
             DescribeIncompleteCompilationInputs(input, targetAssembly, referenceParseErrors);
+        IntroducedTypeArtifactMap artifactMap = IntroducedTypeArtifactMap.Empty;
+        if (incompleteInputsDiagnostic == null
+            && !IntroducedTypeArtifactMap.TryBuild(compilation, artifactReferences, out artifactMap, out string artifactError))
+        {
+            incompleteInputsDiagnostic = "Introduced types require a compile: " + artifactError;
+        }
         WorkerFileOutput[] files = new WorkerFileOutput[units.Count];
         for (int index = 0; index < units.Count; index++)
         {
@@ -73,6 +81,7 @@ internal static class IntroducedTypePreparation
                         targetAssembly,
                         input.TargetAssemblyName,
                         input.TargetAssemblyMvid,
+                        artifactMap,
                         input.Defines,
                         assemblyGlobalUsings);
                 }
@@ -181,6 +190,40 @@ internal static class IntroducedTypePreparation
         {
             return Guid.Empty;
         }
+    }
+
+    // Adds each artifact assembly to the references the planning compilation binds against, so a
+    // declaration whose dependency now lives in a retained artifact still resolves. The reference
+    // is kept beside its record because normalization may only use a mapping whose file was
+    // confirmed to be the assembly the record claims.
+    private static List<(WorkerIntroducedTypeArtifact Artifact, MetadataReference Reference)>
+        CollectArtifactReferences(
+            WorkerInput input,
+            List<MetadataReference> references,
+            List<string> parseErrors)
+    {
+        List<(WorkerIntroducedTypeArtifact, MetadataReference)> artifactReferences =
+            new List<(WorkerIntroducedTypeArtifact, MetadataReference)>();
+        foreach (WorkerIntroducedTypeArtifact artifact in input.IntroducedTypeArtifacts)
+        {
+            if (artifact == null || string.IsNullOrEmpty(artifact.ReferencePath))
+            {
+                parseErrors.Add("Introduced-type artifact record must carry a reference path.");
+                continue;
+            }
+
+            if (!File.Exists(artifact.ReferencePath))
+            {
+                parseErrors.Add("Introduced-type artifact not found: " + artifact.ReferencePath);
+                continue;
+            }
+
+            MetadataReference reference = MetadataReference.CreateFromFile(artifact.ReferencePath);
+            references.Add(reference);
+            artifactReferences.Add((artifact, reference));
+        }
+
+        return artifactReferences;
     }
 
     // A reference file that exists but is not readable managed metadata never reaches the

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePreparation.cs
@@ -20,6 +20,33 @@ using Microsoft.CodeAnalysis.Text;
 // could not be read or describe a different assembly than the request named.
 internal static class IntroducedTypePreparation
 {
+    // The planning compilation itself when this run has no other edited file to read, so the
+    // common case does not pay for a second compilation.
+    private static CSharpCompilation CreateConstDriftCompilation(
+        WorkerInput input,
+        CSharpParseOptions parseOptions,
+        List<SyntaxTree> syntaxTrees,
+        List<MetadataReference> references,
+        CSharpCompilation planningCompilation)
+    {
+        List<SyntaxTree> siblingTrees = SiblingConstDriftCollector.ParseChangedSiblings(
+            input.ChangedSiblingSourcePaths,
+            parseOptions);
+        if (siblingTrees.Count == 0)
+        {
+            return planningCompilation;
+        }
+
+        List<SyntaxTree> allTrees = new List<SyntaxTree>(syntaxTrees.Count + siblingTrees.Count);
+        allTrees.AddRange(syntaxTrees);
+        allTrees.AddRange(siblingTrees);
+        return CSharpCompilation.Create(
+            assemblyName: "UloopHotReloadIntroducedTypeConstVerification",
+            syntaxTrees: allTrees,
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
     internal static WorkerOutput Prepare(WorkerInput input)
     {
         CSharpParseOptions parseOptions = new CSharpParseOptions(
@@ -67,6 +94,17 @@ internal static class IntroducedTypePreparation
         {
             incompleteInputsDiagnostic = "Introduced types require a compile: " + artifactError;
         }
+        // Why a second compilation: a const declared in a file this run does not transform binds
+        // to the value the target assembly was compiled with, so its edited value is invisible in
+        // the planning compilation and a changed const would pass unnoticed. Planning itself stays
+        // on the compilation of the requested sources only, so which types are introduced does not
+        // depend on which other files happened to be edited.
+        CSharpCompilation constDriftCompilation = CreateConstDriftCompilation(
+            input,
+            parseOptions,
+            syntaxTrees,
+            references,
+            compilation);
         WorkerFileOutput[] files = new WorkerFileOutput[units.Count];
         for (int index = 0; index < units.Count; index++)
         {
@@ -76,6 +114,9 @@ internal static class IntroducedTypePreparation
                 if (incompleteInputsDiagnostic == null)
                 {
                     unit.SemanticModel = compilation.GetSemanticModel(unit.SyntaxTree, ignoreAccessibility: false);
+                    unit.ConstDriftSemanticModel = constDriftCompilation.GetSemanticModel(
+                        unit.SyntaxTree,
+                        ignoreAccessibility: false);
                     IntroducedTypePlanner.Plan(
                         unit,
                         targetAssembly,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePreparation.cs
@@ -43,7 +43,7 @@ internal static class IntroducedTypePreparation
         (List<MetadataReference> references, MetadataReference targetTypesReference) =
             WorkerGroupPipeline.CollectMetadataReferences(input, referenceParseErrors);
         List<(WorkerIntroducedTypeArtifact Artifact, MetadataReference Reference)> artifactReferences =
-            CollectArtifactReferences(input, references, referenceParseErrors);
+            IntroducedTypeArtifactReferences.Collect(input, references, referenceParseErrors);
         CSharpCompilation compilation = CSharpCompilation.Create(
             assemblyName: "UloopHotReloadIntroducedTypePlanning",
             syntaxTrees: syntaxTrees,
@@ -190,40 +190,6 @@ internal static class IntroducedTypePreparation
         {
             return Guid.Empty;
         }
-    }
-
-    // Adds each artifact assembly to the references the planning compilation binds against, so a
-    // declaration whose dependency now lives in a retained artifact still resolves. The reference
-    // is kept beside its record because normalization may only use a mapping whose file was
-    // confirmed to be the assembly the record claims.
-    private static List<(WorkerIntroducedTypeArtifact Artifact, MetadataReference Reference)>
-        CollectArtifactReferences(
-            WorkerInput input,
-            List<MetadataReference> references,
-            List<string> parseErrors)
-    {
-        List<(WorkerIntroducedTypeArtifact, MetadataReference)> artifactReferences =
-            new List<(WorkerIntroducedTypeArtifact, MetadataReference)>();
-        foreach (WorkerIntroducedTypeArtifact artifact in input.IntroducedTypeArtifacts)
-        {
-            if (artifact == null || string.IsNullOrEmpty(artifact.ReferencePath))
-            {
-                parseErrors.Add("Introduced-type artifact record must carry a reference path.");
-                continue;
-            }
-
-            if (!File.Exists(artifact.ReferencePath))
-            {
-                parseErrors.Add("Introduced-type artifact not found: " + artifact.ReferencePath);
-                continue;
-            }
-
-            MetadataReference reference = MetadataReference.CreateFromFile(artifact.ReferencePath);
-            references.Add(reference);
-            artifactReferences.Add((artifact, reference));
-        }
-
-        return artifactReferences;
     }
 
     // A reference file that exists but is not readable managed metadata never reaches the

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePreparation.cs
@@ -181,56 +181,12 @@ internal static class IntroducedTypePreparation
         // for the assembly generation it was planned against. Reading the identity back from the
         // file that was actually analysed is what stops a stale request from producing artifacts
         // that claim an assembly the planning never looked at.
-        if (!TargetAssemblyIdentityMatchesRequest(input, targetAssembly))
+        if (!IntroducedTypeTargetIdentity.MatchesRequest(input, targetAssembly))
         {
             return "Introduced types require a compile: the target assembly identity does not match the request.";
         }
 
         return null;
-    }
-
-    private static bool TargetAssemblyIdentityMatchesRequest(WorkerInput input, IAssemblySymbol targetAssembly)
-    {
-        // Assembly names are compared case-insensitively by the runtime, so a case difference in
-        // the request is the same assembly and must not reject the plan.
-        if (!string.Equals(
-                input.TargetAssemblyName,
-                targetAssembly.Identity.Name,
-                StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        if (!Guid.TryParse(input.TargetAssemblyMvid, out Guid requestedMvid) || requestedMvid == Guid.Empty)
-        {
-            return false;
-        }
-
-        return requestedMvid == ReadModuleVersionId(input.TargetTypesAssemblyPath);
-    }
-
-    private static Guid ReadModuleVersionId(string assemblyPath)
-    {
-        if (string.IsNullOrEmpty(assemblyPath))
-        {
-            return Guid.Empty;
-        }
-
-        try
-        {
-            using (ModuleMetadata metadata = ModuleMetadata.CreateFromFile(assemblyPath))
-            {
-                return metadata.GetModuleVersionId();
-            }
-        }
-        catch (BadImageFormatException)
-        {
-            return Guid.Empty;
-        }
-        catch (IOException)
-        {
-            return Guid.Empty;
-        }
     }
 
     // A reference file that exists but is not readable managed metadata never reaches the

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeTargetIdentity.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeTargetIdentity.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using Microsoft.CodeAnalysis;
+
+// Answers whether the assembly a request was analysed against is the one the request named.
+// Planning and transforming both depend on it: a descriptor is only valid for the assembly
+// generation it was planned against, and a retained record is only valid for that same
+// generation. Keeping one rule is what stops the two paths from accepting different requests.
+internal static class IntroducedTypeTargetIdentity
+{
+    internal static bool MatchesRequest(WorkerInput input, IAssemblySymbol targetAssembly)
+    {
+        if (targetAssembly == null)
+        {
+            return false;
+        }
+
+        // Assembly names are compared case-insensitively by the runtime, so a case difference in
+        // the request is the same assembly and must not reject the plan.
+        if (!string.Equals(
+                input.TargetAssemblyName,
+                targetAssembly.Identity.Name,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!Guid.TryParse(input.TargetAssemblyMvid, out Guid requestedMvid) || requestedMvid == Guid.Empty)
+        {
+            return false;
+        }
+
+        return requestedMvid == ReadModuleVersionId(input.TargetTypesAssemblyPath);
+    }
+
+    private static Guid ReadModuleVersionId(string assemblyPath)
+    {
+        if (string.IsNullOrEmpty(assemblyPath))
+        {
+            return Guid.Empty;
+        }
+
+        try
+        {
+            using (ModuleMetadata metadata = ModuleMetadata.CreateFromFile(assemblyPath))
+            {
+                return metadata.GetModuleVersionId();
+            }
+        }
+        catch (BadImageFormatException)
+        {
+            return Guid.Empty;
+        }
+        catch (IOException)
+        {
+            return Guid.Empty;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
@@ -31,7 +31,7 @@ internal static class PropertyGetterEmitter
         int globalShimMethodCounter)
     {
         SemanticModel semanticModel = typeState.SourceUnit.SemanticModel;
-        CompilationUnitSyntax root = typeState.SourceUnit.Root;
+        CompilationUnitSyntax root = typeState.SourceUnit.BindingRoot;
         BaselineSnapshotState baseline = typeState.SourceUnit.Baseline;
         foreach (PropertyDeclarationSyntax propertyDeclaration in typeState.TypeDeclaration.Members
             .OfType<PropertyDeclarationSyntax>())

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/SiblingConstDriftCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/SiblingConstDriftCollector.cs
@@ -36,13 +36,7 @@ internal static class SiblingConstDriftCollector
                 continue;
             }
 
-            string text = File.ReadAllText(
-                siblingPath,
-                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-            SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(
-                SourceText.From(text, Encoding.UTF8),
-                parseOptions,
-                path: siblingPath);
+            SyntaxTree syntaxTree = ParseSibling(siblingPath, parseOptions);
             CompilationUnitSyntax root = syntaxTree.GetCompilationUnitRoot();
             CSharpCompilation siblingCompilation = CSharpCompilation.Create(
                 assemblyName: "UloopHotReloadSiblingConstDriftCompilation",
@@ -60,5 +54,44 @@ internal static class SiblingConstDriftCollector
         }
 
         return warnings;
+    }
+
+    /// <summary>
+    /// Parses the changed sibling files that exist, so a caller can put them into a compilation
+    /// of its own.
+    /// </summary>
+    internal static List<SyntaxTree> ParseChangedSiblings(
+        string[] changedSiblingSourcePaths,
+        CSharpParseOptions parseOptions)
+    {
+        List<SyntaxTree> trees = new List<SyntaxTree>();
+        if (changedSiblingSourcePaths == null)
+        {
+            return trees;
+        }
+
+        for (int index = 0; index < changedSiblingSourcePaths.Length; index++)
+        {
+            string siblingPath = changedSiblingSourcePaths[index];
+            if (string.IsNullOrEmpty(siblingPath) || !File.Exists(siblingPath))
+            {
+                continue;
+            }
+
+            trees.Add(ParseSibling(siblingPath, parseOptions));
+        }
+
+        return trees;
+    }
+
+    private static SyntaxTree ParseSibling(string siblingPath, CSharpParseOptions parseOptions)
+    {
+        string text = File.ReadAllText(
+            siblingPath,
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        return CSharpSyntaxTree.ParseText(
+            SourceText.From(text, Encoding.UTF8),
+            parseOptions,
+            path: siblingPath);
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TransformWorker.cs
@@ -144,6 +144,15 @@ public static class TransformWorkerProgram
         input.ExcludedAddedMethodKeys ??= Array.Empty<string>();
         input.AssemblySourcePaths ??= Array.Empty<string>();
         input.ChangedSiblingSourcePaths ??= Array.Empty<string>();
+        input.IntroducedTypeArtifacts ??= Array.Empty<WorkerIntroducedTypeArtifact>();
+        foreach (WorkerIntroducedTypeArtifact artifact in input.IntroducedTypeArtifacts)
+        {
+            if (artifact != null)
+            {
+                artifact.Types ??= Array.Empty<WorkerIntroducedTypeArtifactType>();
+            }
+        }
+
         return input;
     }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitPlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitPlanner.cs
@@ -34,7 +34,7 @@ internal static class TypeEmitPlanner
             int shimTypeCounter,
             int globalShimMethodCounter)
     {
-        CompilationUnitSyntax root = sourceUnit.Root;
+        CompilationUnitSyntax root = sourceUnit.BindingRoot;
         SemanticModel semanticModel = sourceUnit.SemanticModel;
         BaselineSnapshotState baseline = sourceUnit.Baseline;
         List<TypeEmitState> typeEmitStates = new List<TypeEmitState>();

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
@@ -244,9 +244,16 @@ internal static class WorkerGroupPipeline
         Dictionary<WorkerSourceUnit, List<BaseTypeDeclarationSyntax>> retainedDeclarations =
             IntroducedTypeDeclarationVerifier.FindRetainedDeclarations(
                 loadedUnits, verificationCompilation, input, targetAssembly, artifactMap);
+        List<string> bindingParseErrors = new List<string>();
         foreach (KeyValuePair<WorkerSourceUnit, List<BaseTypeDeclarationSyntax>> entry in retainedDeclarations)
         {
-            IntroducedTypeBindingRewriter.RemoveRetainedDeclarations(entry.Key, entry.Value, parseOptions);
+            IntroducedTypeBindingRewriter.RemoveRetainedDeclarations(
+                entry.Key, entry.Value, parseOptions, bindingParseErrors);
+        }
+
+        if (bindingParseErrors.Count > 0)
+        {
+            return bindingParseErrors[0];
         }
 
         return null;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
@@ -238,6 +238,11 @@ internal static class WorkerGroupPipeline
             return artifactError;
         }
 
+        foreach (WorkerSourceUnit loadedUnit in loadedUnits)
+        {
+            loadedUnit.ArtifactMap = artifactMap;
+        }
+
         IAssemblySymbol targetAssembly = ResolveTargetTypesAssemblySymbol(
             verificationCompilation,
             targetTypesReference);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
@@ -81,7 +81,7 @@ internal static class WorkerGroupPipeline
             options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
         foreach (WorkerSourceUnit unit in loadedUnits)
         {
-            unit.SemanticModel = compilation.GetSemanticModel(unit.SyntaxTree, ignoreAccessibility: true);
+            unit.SemanticModel = compilation.GetSemanticModel(unit.BindingSyntaxTree, ignoreAccessibility: true);
         }
 
         IAssemblySymbol targetTypesAssemblySymbol = ResolveTargetTypesAssemblySymbol(
@@ -216,14 +216,14 @@ internal static class WorkerGroupPipeline
     {
         unit.DeclarationDriftWarnings.AddRange(
             ConstDriftCollector.CollectConstDriftWarnings(
-                unit.Root,
+                unit.BindingRoot,
                 unit.SemanticModel,
                 targetTypesAssemblySymbol));
         // Why here: a compiled property/event can disappear or change kind with no
         // touched body, so the generic outside-body warning would bury the name.
         unit.KindChangeSyntaxKeys =
             CompiledMemberKindChangeWarnings.AppendCompiledPropertyOrEventKindChangeWarnings(
-                unit.Root,
+                unit.BindingRoot,
                 unit.SemanticModel,
                 targetTypesAssemblySymbol,
                 unit.DeclarationDriftWarnings);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
@@ -50,16 +50,12 @@ internal static class WorkerGroupPipeline
         }
 
         List<WorkerSourceUnit> loadedUnits = new List<WorkerSourceUnit>(units.Count);
-        List<SyntaxTree> syntaxTrees = new List<SyntaxTree>(units.Count);
         foreach (WorkerSourceUnit unit in units)
         {
-            if (unit.SyntaxTree == null)
+            if (unit.SyntaxTree != null)
             {
-                continue;
+                loadedUnits.Add(unit);
             }
-
-            loadedUnits.Add(unit);
-            syntaxTrees.Add(unit.SyntaxTree);
         }
 
         // Why every loaded unit reports it: a missing reference is a problem of the whole assembly,
@@ -74,9 +70,25 @@ internal static class WorkerGroupPipeline
             loadedUnit.ParseErrors.AddRange(referenceParseErrors);
         }
 
+        // Why a run-level failure and not a per-file diagnostic: the orchestrator advances to
+        // revert, gating and compile whenever the run succeeds, so a run that could not trust its
+        // retained artifacts has to stop the whole group rather than transform against a binding
+        // that is missing a type or attributing it to the wrong assembly.
+        string artifactFailure = PrepareBindingTrees(input, loadedUnits, references, targetTypesReference, parseOptions);
+        if (artifactFailure != null)
+        {
+            return CreateRunFailureOutput(artifactFailure);
+        }
+
+        List<SyntaxTree> bindingTrees = new List<SyntaxTree>(loadedUnits.Count);
+        foreach (WorkerSourceUnit loadedUnit in loadedUnits)
+        {
+            bindingTrees.Add(loadedUnit.BindingSyntaxTree);
+        }
+
         CSharpCompilation compilation = CSharpCompilation.Create(
             assemblyName: "UloopHotReloadTransformWorkerCompilation",
-            syntaxTrees: syntaxTrees,
+            syntaxTrees: bindingTrees,
             references: references,
             options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
         foreach (WorkerSourceUnit unit in loadedUnits)
@@ -182,6 +194,62 @@ internal static class WorkerGroupPipeline
             unchangedMethods,
             siblingConstDriftWarnings,
             addedFieldCatalog);
+    }
+
+    // Removes from each unit's binding tree the declarations a retained artifact already serves,
+    // and reports why the artifacts could not be used at all. Returns null when the run has no
+    // artifact to bind against, which is every run until introduced types are in play.
+    private static string PrepareBindingTrees(
+        WorkerInput input,
+        List<WorkerSourceUnit> loadedUnits,
+        List<MetadataReference> references,
+        MetadataReference targetTypesReference,
+        CSharpParseOptions parseOptions)
+    {
+        if (input.IntroducedTypeArtifacts.Length == 0)
+        {
+            return null;
+        }
+
+        List<string> artifactErrors = new List<string>();
+        List<(WorkerIntroducedTypeArtifact Artifact, MetadataReference Reference)> artifactReferences =
+            IntroducedTypeArtifactReferences.Collect(input, references, artifactErrors);
+        if (artifactErrors.Count > 0)
+        {
+            return artifactErrors[0];
+        }
+
+        List<SyntaxTree> editedTrees = new List<SyntaxTree>(loadedUnits.Count);
+        foreach (WorkerSourceUnit loadedUnit in loadedUnits)
+        {
+            editedTrees.Add(loadedUnit.SyntaxTree);
+        }
+
+        // The declarations are verified against the edited text, so this compilation binds the
+        // trees as written; the binding compilation is built from what survives the removal.
+        CSharpCompilation verificationCompilation = CSharpCompilation.Create(
+            assemblyName: "UloopHotReloadRetainedDeclarationVerification",
+            syntaxTrees: editedTrees,
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        if (!IntroducedTypeArtifactMap.TryBuild(
+                verificationCompilation, artifactReferences, out IntroducedTypeArtifactMap artifactMap, out string artifactError))
+        {
+            return artifactError;
+        }
+
+        IAssemblySymbol targetAssembly = ResolveTargetTypesAssemblySymbol(
+            verificationCompilation,
+            targetTypesReference);
+        Dictionary<WorkerSourceUnit, List<BaseTypeDeclarationSyntax>> retainedDeclarations =
+            IntroducedTypeDeclarationVerifier.FindRetainedDeclarations(
+                loadedUnits, verificationCompilation, input, targetAssembly, artifactMap);
+        foreach (KeyValuePair<WorkerSourceUnit, List<BaseTypeDeclarationSyntax>> entry in retainedDeclarations)
+        {
+            IntroducedTypeBindingRewriter.RemoveRetainedDeclarations(entry.Key, entry.Value, parseOptions);
+        }
+
+        return null;
     }
 
     private static WorkerOutput CreateRunFailureOutput(string parseError)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
@@ -232,6 +232,20 @@ internal static class WorkerGroupPipeline
             syntaxTrees: editedTrees,
             references: references,
             options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        IAssemblySymbol targetAssembly = ResolveTargetTypesAssemblySymbol(
+            verificationCompilation,
+            targetTypesReference);
+
+        // A record is only valid for the assembly generation it was planned against, and the
+        // recorded identities are what the fingerprint is rebuilt from. Binding against an
+        // assembly the request cannot name would rebuild them from an empty identity, no
+        // declaration would match its record, and every retained type would quietly bind from
+        // source again.
+        if (!IntroducedTypeTargetIdentity.MatchesRequest(input, targetAssembly))
+        {
+            return "Retained introduced types require the assembly identity the records were planned against.";
+        }
+
         if (!IntroducedTypeArtifactMap.TryBuild(
                 verificationCompilation, artifactReferences, out IntroducedTypeArtifactMap artifactMap, out string artifactError))
         {
@@ -242,10 +256,6 @@ internal static class WorkerGroupPipeline
         {
             loadedUnit.ArtifactMap = artifactMap;
         }
-
-        IAssemblySymbol targetAssembly = ResolveTargetTypesAssemblySymbol(
-            verificationCompilation,
-            targetTypesReference);
         Dictionary<WorkerSourceUnit, List<BaseTypeDeclarationSyntax>> retainedDeclarations =
             IntroducedTypeDeclarationVerifier.FindRetainedDeclarations(
                 loadedUnits, verificationCompilation, input, targetAssembly, artifactMap);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerInput.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerInput.cs
@@ -50,4 +50,8 @@ internal sealed class WorkerInput
     // Absolute paths of snapshot-mismatched sibling sources in the same compilation assembly.
     // Null/omitted is treated as empty (no sibling const-drift scan).
     public string[] ChangedSiblingSourcePaths { get; set; }
+
+    // Retained introduced-type assemblies this run may bind against.
+    // Null/omitted is treated as empty (nothing is normalized through an artifact).
+    public WorkerIntroducedTypeArtifact[] IntroducedTypeArtifacts { get; set; }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerIntroducedTypeArtifact.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerIntroducedTypeArtifact.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+// One retained introduced-type assembly this run may bind against. Identity and reference path
+// travel in the same record so the worker can confirm the file it resolved is the assembly the
+// record claims before normalizing any reference through it.
+// Keep in sync with TransformWorkerDtos.cs TransformWorkerIntroducedTypeArtifactDto.
+internal sealed class WorkerIntroducedTypeArtifact
+{
+    public string AssemblyFullName { get; set; }
+
+    public string ReferencePath { get; set; }
+
+    public WorkerIntroducedTypeArtifactType[] Types { get; set; }
+}
+
+// One retained type inside an artifact assembly, with the original identity it normalizes back to.
+// Keep in sync with TransformWorkerDtos.cs TransformWorkerIntroducedTypeArtifactTypeDto.
+internal sealed class WorkerIntroducedTypeArtifactType
+{
+    public string MetadataName { get; set; }
+
+    public string OriginalAssemblyName { get; set; }
+
+    public string OriginalAssemblyMvid { get; set; }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerIntroducedTypeArtifact.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerIntroducedTypeArtifact.cs
@@ -37,4 +37,8 @@ internal sealed class WorkerIntroducedTypeArtifactType
     public string OriginalAssemblyName { get; set; }
 
     public string OriginalAssemblyMvid { get; set; }
+
+    public string OwnerProjectRelativePath { get; set; }
+
+    public string DeclarationFingerprint { get; set; }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceLoader.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceLoader.cs
@@ -50,6 +50,9 @@ internal static class WorkerSourceLoader
         unit.SyntaxTree = syntaxTree;
         unit.Root = syntaxTree.GetCompilationUnitRoot();
         unit.PlainRoot = plainRoot;
+        // Until a caller removes retained declarations, the binding tree is the loaded tree.
+        unit.BindingSyntaxTree = syntaxTree;
+        unit.BindingRoot = unit.Root;
         return unit;
     }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceUnit.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceUnit.cs
@@ -32,6 +32,15 @@ internal sealed class WorkerSourceUnit
     // Unannotated root. Baseline comparison must use it on both sides.
     public CompilationUnitSyntax PlainRoot { get; set; }
 
+    // The tree the transform compilation binds against: the annotated tree with the declarations
+    // that are already served from a retained artifact removed. Equal to SyntaxTree when the run
+    // has no such declaration. A SemanticModel only answers for nodes of the tree it came from,
+    // so every consumer that uses SemanticModel must read BindingRoot, never Root.
+    public SyntaxTree BindingSyntaxTree { get; set; }
+
+    // Root of BindingSyntaxTree.
+    public CompilationUnitSyntax BindingRoot { get; set; }
+
     public SemanticModel SemanticModel { get; set; }
 
     public BaselineSnapshotState Baseline { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceUnit.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceUnit.cs
@@ -48,6 +48,12 @@ internal sealed class WorkerSourceUnit
     // Empty for every run that has no artifact.
     public IntroducedTypeArtifactMap ArtifactMap { get; set; } = IntroducedTypeArtifactMap.Empty;
 
+    // A model of the same tree from a compilation that also holds the files this run does not
+    // transform but that were edited too. Only const comparison may use it: a const declared in
+    // one of those files binds to the compiled metadata value in every other compilation, so its
+    // edited value would be invisible. Null until planning sets it.
+    public SemanticModel ConstDriftSemanticModel { get; set; }
+
     public BaselineSnapshotState Baseline { get; set; }
 
     public string SourceContentSha256 { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceUnit.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerSourceUnit.cs
@@ -43,6 +43,11 @@ internal sealed class WorkerSourceUnit
 
     public SemanticModel SemanticModel { get; set; }
 
+    // The verified mapping the binding trees were built with, so the emit steps can ask whether a
+    // type is served from a retained artifact without threading it through every signature.
+    // Empty for every run that has no artifact.
+    public IntroducedTypeArtifactMap ArtifactMap { get; set; } = IntroducedTypeArtifactMap.Empty;
+
     public BaselineSnapshotState Baseline { get; set; }
 
     public string SourceContentSha256 { get; set; }


### PR DESCRIPTION
## Summary
- Once a reload has introduced a new type, a later reload can keep that type bound to the assembly the previous reload loaded it into, instead of compiling it a second time from source.
- A reload that cannot be re-verified is refused up front rather than producing a build whose types silently disagree with the ones already loaded.
- Editor-side wiring that feeds retained records into a reload follows in a later pull request; this one delivers the worker contract, the binding-tree separation, the reference propagation and the added-field classification.

## User Impact

Before: once a reload introduced a new type, the following reloads still saw that type's declaration in the edited file and bound to it from source, while the previously loaded assembly already held it. The same type then existed twice with different identities, and code that touched it failed in ways that pointed nowhere near the edit. A const declared in another file edited in the same reload was read at its already-compiled value, so a new type could be built with a stale constant folded in. An added field written through a nested value-type receiver lost the write silently, because the store hands back a copy.

After, once the Editor side is wired: a reload binds an already-introduced type from the retained assembly, so a type has one identity for the life of the session. A declaration whose text is unchanged is taken out of the binding tree; one that was edited is compiled again. A const that changed in any file of the same reload makes the reading type refuse to be introduced, and a write that reaches an added value-type field through any receiver chain is skipped instead of being lost.

## Changes
- Planning normalizes a dependency that resolves into a retained artifact assembly back to its original assembly identity, and records the identities positionally in the declaration fingerprint, so re-verification compares the same thing planning did.
- Retained declarations are blanked in place (their span becomes spaces) so line numbers reported from the binding tree stay the ones in the file.
- A retained record without its owning file or its fingerprint is refused on both boundaries: as a per-file diagnostic while planning, and as a run-level failure inside the worker, which cannot trust a request it did not build.
- Const drift comparison is one shared helper, and planning takes a second compilation that also holds the other changed files of the run when there are any. Which types are introduced still comes from the compilation of the requested sources alone.
- An added field may be initialized with an object creation only when the constructed type resolves to a public constructor of a type present in the verified artifact map; everything else keeps the existing refusal.
- The added-field write scan follows member, element and parenthesized receivers to the root of the chain, and covers assignment, increment/decrement and instance invocation.
- A record that lists no type, and a transform that carries records without naming the assembly generation they were planned against, are both refused: either one would put the artifact reference into the compilation while every declaration still bound from source.
- A const the run cannot read a value for (an initializer that does not compile in another edited file) refuses the type that reads it, instead of being treated as unchanged and compiled against the value still in the target assembly.
- A const named only inside `nameof` no longer refuses the type that names it: nameof yields the identifier, never the value, so nothing about it can go stale in the artifact.

`TransformWorkerIntroducedTypeBindingTests.cs` has grown past 500 SLOC. Test files are excluded from the file-length checker, so it does not fail the build; it is worth splitting the next time it is touched.

## Verification

Local Unity EditMode runs, single flight, filtered by test class. `--no-verify` was not used at any point.

- `TransformWorkerRetainedDeclarationTests`, `TransformWorkerIntroducedTypeTests`, `TransformWorkerIntroducedTypeBindingTests`: 40 passed / 0 failed.
- `HotReloadRetainedArtifactInitializerTests`, `HotReloadRetainedArtifactPropagationTests`, `HotReloadIntroducedTypeCompilerTests`, `TransformWorkerClientTests`: 102 passed / 0 failed.
- `TransformWorkerIntroducedTypeTests` after the `nameof` fix: 21 passed / 0 failed.
- `HotReloadRetainedArtifactInitializerTests`, `TransformWorkerRetainedDeclarationTests`, `TransformWorkerAddedFieldTests`, `TransformWorkerClientTests`: 148 passed / 0 failed.
- `TransformWorkerIntroducedTypeBindingTests`, `HotReloadRetainedArtifactPropagationTests`, `HotReloadIntroducedTypeCompilerTests`: 37 passed / 0 failed.

Repository CI does not run on a pull request targeting an integration branch, so `Build and Test` is not evidence here and is not claimed as such. The full EditMode suite is the scheduled gate and was not run.

### Mutation evidence

Each guard was removed in isolation and the suite re-run, to confirm exactly the intended test fails. Every mutation was reverted afterwards; the tree is clean.

| Mutation | Result |
| --- | --- |
| Remove the owner/fingerprint check in the artifact map | only the worker-side refusal test fails (76 / 77) |
| Stop the receiver-chain walk after one step | only the nested write and nested call tests fail (64 / 66) |
| Drop element access from the receiver walk | only the indexer test fails (65 / 66) |
| Drop the increment/decrement scan | only the increment test fails (65 / 66) |
| Make the artifact map lookup always succeed | only the unmapped-type initializer test fails |
| Remove the static check on initializer symbols | the instance method and instance property tests fail |
| Remove the artifact map assignment in the pipeline | only the positive initializer test fails |
| Make the const drift compilation ignore the other changed files | only the changed-const-in-another-file test fails (18 / 19) |
| Make the const value comparison always report "same" | both const rejection tests fail (17 / 19) |
| Recompute the verification fingerprint without normalization | only the reads-a-retained-type test fails (17 / 18) |
| Remove the "record lists no type" check | only the empty-record test fails (39 / 40) |
| Remove the transform-side target identity check | only the missing-identity test fails (39 / 40) |
| Skip a const whose value cannot be read | only the unverifiable-const test fails (39 / 40) |
| Remove the `nameof` skip in the const scan | only the nameof test fails (20 / 21) |

### Not discriminated by a test

Five points are covered by type or by construction only, and are recorded here rather than claimed as verified.

1. The first-compile and retry call sites that carry retained types through are guaranteed by their signatures, not by an end-to-end test that would fail if a call were dropped.
2. The assembly component of the artifact map key is not mutation-discriminated: producing a discriminating case needs two assemblies exporting the same metadata name, which is itself an ambiguous binding.
3. The group-level fail-closed test shares its guard with the single-file one, so it does not independently prove the group path.
4. In the initializer rule, the "is a constructor" and "is public" conditions are each undiscriminated. An unreachable constructor appears in neither `Symbol` nor `CandidateSymbols`, so the private-constructor test is actually refused one branch earlier; inverting the accessibility condition does fail the positive test, which shows the expression is live. Both conditions stay as the contract for symbols taken from `CandidateSymbols`, where an artifact with `InternalsVisibleTo` could bind a non-public constructor.
5. Propagation is covered from the worker request inward; the first reload that would produce those records is not driven end to end here, because the Editor side does not build them yet. That end-to-end case is the first red test of the follow-up pull request.
