### PR TITLE
feat: Hot reload keeps verifying a file while its assembly owns a newly introduced type

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -405,7 +405,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CreateEmptyGateResult(),
                 CancellationToken.None);
 
-            Assert.That(result.HasEntriesToApply, Is.False);
+            Assert.That(result.Outcome, Is.EqualTo(HotReloadGroupCompileOutcome.Failed));
             Assert.That(HotReloadAddedMemberRegistry.HasGeneration(file.ProjectRelativePath), Is.True);
             Assert.That(HotReloadAddedMemberRegistry.IsActiveMember(file.ProjectRelativePath, PersistedAddedMemberKey), Is.True);
             Assert.That(file.ClearedAddedFieldNames, Is.Null);
@@ -427,7 +427,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CreateEmptyGateResult(),
                 CancellationToken.None);
 
-            Assert.That(result.HasEntriesToApply, Is.False);
+            Assert.That(result.Outcome, Is.EqualTo(HotReloadGroupCompileOutcome.ReadyWithoutMethods));
             Assert.That(HotReloadAddedMemberRegistry.HasGeneration(file.ProjectRelativePath), Is.True);
             Assert.That(HotReloadAddedMemberRegistry.IsActiveMember(file.ProjectRelativePath, PersistedAddedMemberKey), Is.False);
             Assert.That(file.ClearedAddedFieldNames, Is.Not.Null);
@@ -486,7 +486,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private static HotReloadGroupCompileResult CreateCompile(params TransformWorkerEntryDto[] entries)
         {
-            return HotReloadGroupCompileResult.Apply(
+            return HotReloadGroupCompileResult.ReadyWithMethods(
                 entries,
                 HotReloadShimCompileResult.SuccessResult(
                     typeof(HotReloadGroupProcessorTests).Assembly,

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Covers the editor-owned introduced type registry and resolver pair that activation runs through.
+    /// </summary>
+    public class HotReloadIntroducedTypeActivationTests
+    {
+        /// <summary>
+        /// Verifies that the resolver the production holder exposes resolves what the registry it
+        /// exposes activated, so both sides of the pair are the same instance.
+        /// </summary>
+        [Test]
+        public void Holder_AfterInitialize_ResolverAndRegistryShareOneInstance()
+        {
+            HotReloadIntroducedTypeArtifact artifact = CreateArtifact();
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                HotReloadIntroducedTypeHolder.Registry.RegisterPrepared(artifact);
+                HotReloadIntroducedTypeHolder.Registry.Activate(artifact);
+
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Resolver.ResolveExact(artifact.AssemblyFullName),
+                    Is.SameAs(artifact.Assembly));
+            }
+        }
+
+        /// <summary>
+        /// Verifies that closing a replacement scope puts the original pair back, so a type
+        /// activated inside the scope is no longer resolvable afterwards.
+        /// </summary>
+        [Test]
+        public void Holder_ReplacementScopeClosed_RestoresTheOriginalPair()
+        {
+            HotReloadIntroducedTypeArtifact artifact = CreateArtifact();
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                HotReloadIntroducedTypeRegistry scoped = HotReloadIntroducedTypeHolder.Registry;
+                scoped.RegisterPrepared(artifact);
+                scoped.Activate(artifact);
+            }
+
+            Assert.That(
+                HotReloadIntroducedTypeHolder.Resolver.ResolveExact(artifact.AssemblyFullName),
+                Is.Null);
+        }
+
+        private static HotReloadIntroducedTypeArtifact CreateArtifact()
+        {
+            Assembly assembly = typeof(HotReloadIntroducedTypeActivationTests).Assembly;
+            List<HotReloadIntroducedTypeDescriptor> descriptors =
+                new List<HotReloadIntroducedTypeDescriptor>
+                {
+                    new HotReloadIntroducedTypeDescriptor(
+                        "OriginalAssembly",
+                        "original-mvid",
+                        "Example.Introduced",
+                        "Assets/Example.cs",
+                        "fingerprint",
+                        "public class Introduced { }")
+                };
+            return new HotReloadIntroducedTypeArtifact(assembly, "artifact.dll", "artifact.pdb", descriptors);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 
 using NUnit.Framework;
@@ -54,6 +55,53 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 HotReloadIntroducedTypeHolder.Resolver.ResolveExact(artifact.AssemblyFullName),
                 Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies that opening a replacement scope stops the resolver it took over from
+        /// answering binds, and that closing the scope makes the original registry resolvable
+        /// again through a live resolver.
+        /// </summary>
+        [Test]
+        public void Holder_ReplacementScopeOpen_OnlyTheReplacementResolverAnswersBinds()
+        {
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                HotReloadIntroducedTypeRegistry outerRegistry = HotReloadIntroducedTypeHolder.Registry;
+                HotReloadIntroducedTypeAssemblyResolver outerResolver = HotReloadIntroducedTypeHolder.Resolver;
+
+                using (HotReloadIntroducedTypeHolder.BeginReplacement())
+                {
+                    HotReloadIntroducedTypeHolder.Initialize();
+                    HotReloadIntroducedTypeAssemblyResolver innerResolver = HotReloadIntroducedTypeHolder.Resolver;
+                    int innerBefore = innerResolver.ResolutionCount;
+                    int outerBefore = outerResolver.ResolutionCount;
+
+                    RequestUnknownAssembly();
+
+                    Assert.That(innerResolver.ResolutionCount, Is.GreaterThan(innerBefore));
+                    Assert.That(
+                        outerResolver.ResolutionCount,
+                        Is.EqualTo(outerBefore),
+                        "The taken-over resolver must be unsubscribed, or two resolvers answer one bind.");
+                }
+
+                Assert.That(HotReloadIntroducedTypeHolder.Registry, Is.SameAs(outerRegistry));
+                HotReloadIntroducedTypeAssemblyResolver restoredResolver = HotReloadIntroducedTypeHolder.Resolver;
+                int restoredBefore = restoredResolver.ResolutionCount;
+
+                RequestUnknownAssembly();
+
+                Assert.That(restoredResolver.ResolutionCount, Is.GreaterThan(restoredBefore));
+            }
+        }
+
+        private static void RequestUnknownAssembly()
+        {
+            Assert.Throws<FileNotFoundException>(() => Assembly.Load(
+                new AssemblyName("MissingIntroducedTypeDependency" + Guid.NewGuid().ToString("N")
+                    + ", Version=1.0.0.0, Culture=neutral, PublicKeyToken=null")));
         }
 
         private static HotReloadIntroducedTypeArtifact CreateArtifact()

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c3586e6a49b924d3086bb641fb31e9d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadNewSourceMembershipTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadNewSourceMembershipTests.cs
@@ -17,6 +17,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             "Assets/Tests/Editor/HotReload/UncompiledNewScript.cs";
         private const string MissingPredefinedScriptPath =
             "Assets/Util/UncompiledNewPredefinedScript.cs";
+        private const string ExistingScriptPath =
+            "Assets/Tests/Editor/HotReload/HotReloadNewSourceMembershipTests.cs";
 
         private Func<HotReloadEditorStateSnapshot> _previousSnapshotProvider;
 
@@ -110,6 +112,83 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(projectRoot, Is.Not.Null.And.Not.Empty);
             Assert.That(unchangedDecision, Is.EqualTo(HotReloadUnchangedSourceDecision.NotUnchanged));
             Assert.That(newSourceMembershipEvidence, Is.Not.Null);
+        }
+
+        /// <summary>
+        /// An assembly that still owns an introduced type keeps its applied-source ledger entry,
+        /// because the unchanged-source short-circuit is not called for it at all.
+        /// </summary>
+        [Test]
+        public void ResolvePatchTarget_WhenAssemblyOwnsAnActiveIntroducedType_KeepsTheLedgerEntry()
+        {
+            string existingScriptPath = ExistingScriptPath;
+            HotReloadAppliedSourceLedger.Clear(existingScriptPath);
+            HotReloadAppliedSourceLedger.Record(existingScriptPath, "stale-hash", true);
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                ActivateIntroducedTypeFor(existingScriptPath);
+
+                ResolveExistingScript("introduced-type-active");
+            }
+
+            Assert.That(HotReloadAppliedSourceLedger.TryGet(existingScriptPath), Is.Not.Null);
+            HotReloadAppliedSourceLedger.Clear(existingScriptPath);
+        }
+
+        /// <summary>
+        /// An assembly without an introduced type still runs the unchanged-source short-circuit,
+        /// which clears a ledger entry that no longer matches the file.
+        /// </summary>
+        [Test]
+        public void ResolvePatchTarget_WhenAssemblyOwnsNoIntroducedType_RunsTheShortCircuit()
+        {
+            string existingScriptPath = ExistingScriptPath;
+            HotReloadAppliedSourceLedger.Clear(existingScriptPath);
+            HotReloadAppliedSourceLedger.Record(existingScriptPath, "stale-hash", true);
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+
+                ResolveExistingScript("introduced-type-absent");
+            }
+
+            Assert.That(HotReloadAppliedSourceLedger.TryGet(existingScriptPath), Is.Null);
+        }
+
+        private static void ResolveExistingScript(string correlationId)
+        {
+            HotReloadEditorStateSnapshotProvider.CaptureForTesting = () =>
+                new HotReloadEditorStateSnapshot(false, false, false);
+            HotReloadPatchTargetSupport.ResolvePatchTarget(
+                ExistingScriptPath,
+                ExistingScriptPath,
+                new List<HotReloadMethodOutcome>(),
+                new List<string>(),
+                correlationId,
+                new List<HotReloadMethodOutcome>());
+        }
+
+        private static void ActivateIntroducedTypeFor(string projectRelativeScriptPath)
+        {
+            string assemblyName = System.IO.Path.GetFileNameWithoutExtension(
+                UnityEditor.Compilation.CompilationPipeline.GetAssemblyNameFromScriptPath(projectRelativeScriptPath));
+            HotReloadIntroducedTypeDescriptor descriptor = new HotReloadIntroducedTypeDescriptor(
+                assemblyName,
+                "original-mvid",
+                "Example.Introduced",
+                projectRelativeScriptPath,
+                "fingerprint",
+                "public class Introduced { }");
+            HotReloadIntroducedTypeArtifact artifact = new HotReloadIntroducedTypeArtifact(
+                typeof(HotReloadNewSourceMembershipTests).Assembly,
+                "artifact.dll",
+                "artifact.pdb",
+                new List<HotReloadIntroducedTypeDescriptor> { descriptor });
+            HotReloadIntroducedTypeHolder.Registry.RegisterPrepared(artifact);
+            HotReloadIntroducedTypeHolder.Registry.Activate(artifact);
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1957,6 +1957,74 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: an unchanged re-request against an assembly that owns an introduced type still
+        /// enters group processing through the production entry instead of short-circuiting.
+        /// </summary>
+        [Test]
+        public async Task Run_UnchangedSourceWithActiveIntroducedType_StillEntersGroupProcessing()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string editedPath = WriteEditedSource(
+                "UnchangedSourceWithActiveIntroducedType.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }"));
+
+            HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                editedPath,
+                CancellationToken.None);
+            AssertNoFileLevelFailure(first);
+            AssertHasPatched(first, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+
+            int membershipValidations = 0;
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                ActivateIntroducedTypeForFixtureAssembly(fixturePath);
+                using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                    HotReloadGroupProcessorDependencies.Create(
+                        files =>
+                        {
+                            membershipValidations++;
+                            return HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(files);
+                        })))
+                {
+                    await HotReloadOrchestrator.RunAsync(
+                        new[] { fixturePath },
+                        editedPath,
+                        CancellationToken.None);
+                }
+            }
+
+            Assert.That(
+                membershipValidations,
+                Is.GreaterThanOrEqualTo(1),
+                "An assembly that owns an introduced type must reach group processing even when its source is unchanged.");
+        }
+
+        private static void ActivateIntroducedTypeForFixtureAssembly(string fixturePath)
+        {
+            string projectRelativePath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(fixturePath);
+            string assemblyName = Path.GetFileNameWithoutExtension(
+                UnityEditor.Compilation.CompilationPipeline.GetAssemblyNameFromScriptPath(projectRelativePath));
+            HotReloadIntroducedTypeDescriptor descriptor = new HotReloadIntroducedTypeDescriptor(
+                assemblyName,
+                "original-mvid",
+                "Example.Introduced",
+                projectRelativePath,
+                "fingerprint",
+                "public class Introduced { }");
+            HotReloadIntroducedTypeArtifact artifact = new HotReloadIntroducedTypeArtifact(
+                typeof(HotReloadOrchestratorTests).Assembly,
+                "artifact.dll",
+                "artifact.pdb",
+                new List<HotReloadIntroducedTypeDescriptor> { descriptor });
+            HotReloadIntroducedTypeHolder.Registry.RegisterPrepared(artifact);
+            HotReloadIntroducedTypeHolder.Registry.Activate(artifact);
+        }
+
+        /// <summary>
         /// What: reloading the same edited source a second time reports AlreadyActive and
         /// leaves the existing Harmony patch in place so InvocationCount is preserved.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -424,6 +425,53 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a Harmony rebuild failure while reverting is contained as that method's failure,
+        /// drops it from the patch ledger anyway, and lets the next revert continue.
+        /// </summary>
+        [Test]
+        public void Revert_WhenHarmonyCannotRebuild_ContainsTheFailureAndKeepsRevertingOthers()
+        {
+            MethodInfo failing = AccessTools.Method(
+                typeof(HotReloadCoreFixture), nameof(HotReloadCoreFixture.ReplaceableCompute));
+            MethodInfo failingShim = AccessTools.Method(
+                typeof(HotReloadHandwrittenShims), nameof(HotReloadHandwrittenShims.ReplaceableCompute__shim0));
+            MethodInfo surviving = AccessTools.Method(
+                typeof(HotReloadCoreFixture), nameof(HotReloadCoreFixture.StaticPing));
+            MethodInfo survivingShim = AccessTools.Method(
+                typeof(HotReloadHandwrittenShims), nameof(HotReloadHandwrittenShims.StaticPing__shim0));
+            Assert.That(
+                HotReloadPatcher.Apply(failing, failingShim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
+                Is.True);
+            Assert.That(
+                HotReloadPatcher.Apply(surviving, survivingShim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
+                Is.True);
+            Assert.That(HotReloadPatcher.ActivePatchCount, Is.EqualTo(2));
+
+            HotReloadRevertOutcome failedOutcome;
+            string failureReason;
+            HotReloadPatcher.UnpatchForTesting = _ => throw new InvalidOperationException("rebuild failed");
+            try
+            {
+                failedOutcome = HotReloadPatcher.Revert(failing, out failureReason);
+            }
+            finally
+            {
+                HotReloadPatcher.UnpatchForTesting = null;
+            }
+
+            Assert.That(failedOutcome, Is.EqualTo(HotReloadRevertOutcome.UnpatchFailed));
+            Assert.That(failureReason, Does.Contain("rebuild failed"));
+            Assert.That(
+                HotReloadPatcher.ActivePatchCount,
+                Is.EqualTo(1),
+                "The ledger entry must be gone even though Harmony could not restore the body.");
+            Assert.That(
+                HotReloadPatcher.Revert(surviving, out string _),
+                Is.EqualTo(HotReloadRevertOutcome.Reverted),
+                "A contained revert failure must not stop the remaining methods from reverting.");
+        }
+
+        /// <summary>
         /// What: Revert(method) clears that method's invocation count (RevertAll is not required).
         /// </summary>
         [Test]
@@ -442,7 +490,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(47));
             Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(1L));
 
-            Assert.That(HotReloadPatcher.Revert(original), Is.True);
+            Assert.That(
+                HotReloadPatcher.Revert(original, out string _),
+                Is.EqualTo(HotReloadRevertOutcome.Reverted));
             Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(0L));
             Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(-5));
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -425,8 +425,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a Harmony rebuild failure while reverting is contained as that method's failure,
-        /// drops it from the patch ledger anyway, and lets the next revert continue.
+        /// What: a Harmony rebuild failure while reverting is contained as that method's failure
+        /// and keeps the still-patched method in the ledger, and a later revert of the same
+        /// method succeeds once the rebuild works again.
         /// </summary>
         [Test]
         public void Revert_WhenHarmonyCannotRebuild_ContainsTheFailureAndKeepsRevertingOthers()
@@ -439,6 +440,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 typeof(HotReloadCoreFixture), nameof(HotReloadCoreFixture.StaticPing));
             MethodInfo survivingShim = AccessTools.Method(
                 typeof(HotReloadHandwrittenShims), nameof(HotReloadHandwrittenShims.StaticPing__shim0));
+            string failingKey = HotReloadMethodKeys.FormatMethodLabel(failing);
             Assert.That(
                 HotReloadPatcher.Apply(failing, failingShim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
                 Is.True);
@@ -463,8 +465,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(failureReason, Does.Contain("rebuild failed"));
             Assert.That(
                 HotReloadPatcher.ActivePatchCount,
-                Is.EqualTo(1),
-                "The ledger entry must be gone even though Harmony could not restore the body.");
+                Is.EqualTo(2),
+                "The transpiler is still live, so the ledger must keep describing it.");
+            Assert.That(
+                HotReloadPatcher.DescribeActivePatches().Select(patch => patch.MethodKey),
+                Does.Contain(failingKey),
+                "Status has to keep reporting a patch Harmony could not remove.");
+            Assert.That(
+                HotReloadPatcher.Revert(failing, out string _),
+                Is.EqualTo(HotReloadRevertOutcome.Reverted),
+                "Once the rebuild works, the retained entry must revert instead of reporting NotPatched.");
+            Assert.That(HotReloadPatcher.ActivePatchCount, Is.EqualTo(1));
             Assert.That(
                 HotReloadPatcher.Revert(surviving, out string _),
                 Is.EqualTo(HotReloadRevertOutcome.Reverted),

--- a/Assets/Tests/Editor/HotReload/HotReloadShimRegistryTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShimRegistryTests.cs
@@ -97,8 +97,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Precondition: Replace of `return _secret + delta;` must patch ComputeWithPrivate " +
                 "plus at least one sibling so revert cannot clear the whole file lookup.");
 
-            bool reverted = HotReloadPatcher.Revert(computeMethod);
-            Assert.That(reverted, Is.True);
+            HotReloadRevertOutcome reverted = HotReloadPatcher.Revert(computeMethod, out string _);
+            Assert.That(reverted, Is.EqualTo(HotReloadRevertOutcome.Reverted));
 
             HotReloadShimFileLookup lookup =
                 HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -349,7 +349,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     nameof(HotReloadCoreFixture.ReplaceableCompute),
                     BindingFlags.Instance | BindingFlags.Public);
                 Assert.That(original, Is.Not.Null);
-                Assert.That(HotReloadPatcher.Revert(original), Is.True);
+                Assert.That(
+                    HotReloadPatcher.Revert(original, out string _),
+                    Is.EqualTo(HotReloadRevertOutcome.Reverted));
 
                 bool found = HotReloadSupersededSignatureRegistry.TryGetReplacement(
                     methodKey,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -295,6 +295,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string VibeLogShimCompileFailed = "hot_reload_shim_compile_failed";
         public const string VibeLogIsolationRetry = "hot_reload_isolation_retry";
         public const string VibeLogEmptyEntriesClear = "hot_reload_empty_entries_clear";
+        public const string VibeLogRevertFailed = "hot_reload_revert_failed";
         public const string VibeLogApplySummary = "hot_reload_apply_summary";
         public const string VibeLogShimCompileStageFirstPass = "first_pass";
         public const string VibeLogShimCompileStageRetry = "retry";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEditorStartup.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEditorStartup.cs
@@ -19,6 +19,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadSourceSnapshotter.CaptureAfterDomainReload();
             }
 
+            // The resolver subscribes to AppDomain.AssemblyResolve when it is built, and that
+            // subscription is lost on every domain reload, so the pair is rebuilt here rather than
+            // on first use.
+            HotReloadIntroducedTypeHolder.Initialize();
             EditorApplication.update += CaptureOnFirstUpdateTick;
             HotReloadPlayModeEntryDropRecorder.Initialize();
             HotReloadAutoRefreshHold.Initialize();

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
@@ -80,13 +80,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         // Peels leftover Harmony patches when the source again matches the verified baseline.
         // Resolve failures are silent: unchanged identities already matched compile-time IL.
+        // A method Harmony could not restore becomes that method's Failed outcome instead of
+        // aborting the peel, so the remaining unchanged methods still get reverted.
         // Returns how many Revert calls actually removed a live patch.
         internal static int RevertUnchangedPatches(
             string assemblyName,
-            TransformWorkerUnchangedMethodDto[] unchangedMethods)
+            TransformWorkerUnchangedMethodDto[] unchangedMethods,
+            List<HotReloadMethodOutcome> outcomes,
+            string assemblyResolvePath)
         {
             Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
             Debug.Assert(unchangedMethods != null, "unchangedMethods must not be null.");
+            Debug.Assert(outcomes != null, "outcomes must not be null.");
 
             int revertedCount = 0;
             for (int index = 0; index < unchangedMethods.Length; index++)
@@ -114,9 +119,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                if (HotReloadPatcher.Revert(matchResult.Method))
+                HotReloadRevertOutcome revertOutcome = HotReloadPatcher.Revert(
+                    matchResult.Method,
+                    out string revertFailureReason);
+                if (revertOutcome == HotReloadRevertOutcome.Reverted)
                 {
                     revertedCount++;
+                    continue;
+                }
+
+                if (revertOutcome == HotReloadRevertOutcome.UnpatchFailed)
+                {
+                    outcomes.Add(
+                        HotReloadMethodOutcome.Failed(
+                            HotReloadMethodKeys.FormatMethodLabel(matchResult.Method),
+                            revertFailureReason,
+                            assemblyResolvePath));
                 }
             }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCompileOutcome.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCompileOutcome.cs
@@ -1,0 +1,13 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// What the group's shim compile stage decided: nothing can be applied because the group
+    /// failed, nothing has to be applied, or entries are ready to patch.
+    /// </summary>
+    internal enum HotReloadGroupCompileOutcome
+    {
+        Failed,
+        ReadyWithoutMethods,
+        ReadyWithMethods
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCompileOutcome.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCompileOutcome.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56ce1a276195f4dfab0746359077c143
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCompileResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCompileResult.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 using UnityEngine;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -11,34 +9,55 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal sealed class HotReloadGroupCompileResult
     {
         private HotReloadGroupCompileResult(
+            HotReloadGroupCompileOutcome outcome,
             TransformWorkerEntryDto[] entriesToPatch,
             HotReloadShimCompileResult compileResult)
         {
+            Outcome = outcome;
             EntriesToPatch = entriesToPatch;
             CompileResult = compileResult;
         }
 
+        internal HotReloadGroupCompileOutcome Outcome { get; }
+
         // False when the outcomes of every file are already in their sinks: the group cleared
         // its generations, failed, or produced no entry to patch.
-        internal bool HasEntriesToApply => EntriesToPatch != null;
+        internal bool HasEntriesToApply => Outcome == HotReloadGroupCompileOutcome.ReadyWithMethods;
 
         internal TransformWorkerEntryDto[] EntriesToPatch { get; }
 
         internal HotReloadShimCompileResult CompileResult { get; }
 
-        internal static HotReloadGroupCompileResult NothingToApply()
+        /// <summary>
+        /// The group cannot apply anything because a failure or a skip already took its entries.
+        /// </summary>
+        internal static HotReloadGroupCompileResult Failed()
         {
-            return new HotReloadGroupCompileResult(null, null);
+            return new HotReloadGroupCompileResult(HotReloadGroupCompileOutcome.Failed, null, null);
         }
 
-        internal static HotReloadGroupCompileResult Apply(
+        /// <summary>
+        /// The group succeeded and simply has no method left to patch.
+        /// </summary>
+        internal static HotReloadGroupCompileResult ReadyWithoutMethods()
+        {
+            return new HotReloadGroupCompileResult(HotReloadGroupCompileOutcome.ReadyWithoutMethods, null, null);
+        }
+
+        /// <summary>
+        /// The group compiled its shim and holds the entries the apply stage patches.
+        /// </summary>
+        internal static HotReloadGroupCompileResult ReadyWithMethods(
             TransformWorkerEntryDto[] entriesToPatch,
             HotReloadShimCompileResult compileResult)
         {
             Debug.Assert(entriesToPatch != null, "entriesToPatch must not be null.");
             Debug.Assert(entriesToPatch.Length > 0, "An apply must hold an entry.");
             Debug.Assert(compileResult != null, "compileResult must not be null.");
-            return new HotReloadGroupCompileResult(entriesToPatch, compileResult);
+            return new HotReloadGroupCompileResult(
+                HotReloadGroupCompileOutcome.ReadyWithMethods,
+                entriesToPatch,
+                compileResult);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -31,7 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadGroupFile firstFile = files[0];
             // Application.dataPath and the ledgers require the Unity main thread.
             await MainThreadSwitcher.SwitchToMainThread(ct);
-            if (!TryAppendNewSourceMembershipFailure(files))
+            if (!HotReloadGroupProcessorDependencies.Current.ValidateNewSourceMembership(files))
             {
                 return BuildUnappliedResults(files);
             }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -375,7 +375,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 file.RevertedUnchangedCount = HotReloadEntryApplier.RevertUnchangedPatches(
                     file.AssemblyName,
-                    unchangedMethods);
+                    unchangedMethods,
+                    file.Sinks.Outcomes,
+                    file.AssemblyResolvePath);
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessorDependencies.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessorDependencies.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// The stages one group run calls out to, so a test can observe the production pipeline's
+    /// order instead of reimplementing it.
+    /// </summary>
+    internal sealed class HotReloadGroupProcessorDependencies
+    {
+        private static HotReloadGroupProcessorDependencies current = CreateProduction();
+
+        private HotReloadGroupProcessorDependencies(
+            Func<IReadOnlyList<HotReloadGroupFile>, bool> validateNewSourceMembership)
+        {
+            ValidateNewSourceMembership = validateNewSourceMembership
+                ?? throw new ArgumentNullException(nameof(validateNewSourceMembership));
+        }
+
+        internal static HotReloadGroupProcessorDependencies Current => current;
+
+        /// <summary>
+        /// Confirms the group's files still belong to the assembly they were resolved against.
+        /// </summary>
+        internal Func<IReadOnlyList<HotReloadGroupFile>, bool> ValidateNewSourceMembership { get; }
+
+        internal static HotReloadGroupProcessorDependencies CreateProduction()
+        {
+            return new HotReloadGroupProcessorDependencies(HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure);
+        }
+
+        internal static HotReloadGroupProcessorDependencies Create(
+            Func<IReadOnlyList<HotReloadGroupFile>, bool> validateNewSourceMembership)
+        {
+            return new HotReloadGroupProcessorDependencies(validateNewSourceMembership);
+        }
+
+        /// <summary>
+        /// Installs a replacement for the duration of the returned scope and puts the previous
+        /// one back when it closes.
+        /// </summary>
+        internal static IDisposable BeginReplacement(HotReloadGroupProcessorDependencies replacement)
+        {
+            if (replacement == null)
+            {
+                throw new ArgumentNullException(nameof(replacement));
+            }
+
+            HotReloadGroupProcessorDependencies previous = current;
+            current = replacement;
+            return new ReplacementScope(previous);
+        }
+
+        private sealed class ReplacementScope : IDisposable
+        {
+            private readonly HotReloadGroupProcessorDependencies previous;
+            private bool restored;
+
+            public ReplacementScope(HotReloadGroupProcessorDependencies previous)
+            {
+                this.previous = previous;
+            }
+
+            public void Dispose()
+            {
+                if (restored)
+                {
+                    return;
+                }
+
+                restored = true;
+                current = previous;
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessorDependencies.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessorDependencies.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ce98dd1a5a974a65bd4a08a702f5693
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeHolder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeHolder.cs
@@ -4,6 +4,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
     /// Owns the single introduced type registry and assembly resolver pair of the current domain.
+    /// A replacement scope disposes the resolver it takes over from and rebuilds one over the
+    /// original registry when it closes.
     /// </summary>
     internal static class HotReloadIntroducedTypeHolder
     {
@@ -29,16 +31,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
-        /// Detaches the current pair and returns a scope that disposes whatever replaced it and
-        /// restores the original one.
+        /// Stops the current resolver from answering binds and returns a scope that restores a
+        /// resolver over the original registry when it closes.
         /// </summary>
+        /// <remarks>
+        /// Why the current resolver is disposed rather than only detached from the fields: its
+        /// AppDomain.AssemblyResolve subscription lives in the resolver itself, so leaving it
+        /// alive would let two resolvers answer the same bind and leak the original registry's
+        /// artifacts into whatever the caller installs.
+        /// </remarks>
         public static IDisposable BeginReplacement()
         {
             HotReloadIntroducedTypeRegistry originalRegistry = registry;
-            HotReloadIntroducedTypeAssemblyResolver originalResolver = resolver;
+            resolver?.Dispose();
             registry = null;
             resolver = null;
-            return new ReplacementScope(originalRegistry, originalResolver);
+            return new ReplacementScope(originalRegistry);
         }
 
         private static T RequireInitialized<T>(T instance)
@@ -58,15 +66,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private sealed class ReplacementScope : IDisposable
         {
             private readonly HotReloadIntroducedTypeRegistry originalRegistry;
-            private readonly HotReloadIntroducedTypeAssemblyResolver originalResolver;
             private bool restored;
 
-            public ReplacementScope(
-                HotReloadIntroducedTypeRegistry originalRegistry,
-                HotReloadIntroducedTypeAssemblyResolver originalResolver)
+            public ReplacementScope(HotReloadIntroducedTypeRegistry originalRegistry)
             {
                 this.originalRegistry = originalRegistry;
-                this.originalResolver = originalResolver;
             }
 
             public void Dispose()
@@ -79,13 +83,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 restored = true;
                 // The replacement resolver stays subscribed to AppDomain.AssemblyResolve until it
                 // is disposed, so leaving it attached would keep answering binds after the scope.
-                if (resolver != null && !ReferenceEquals(resolver, originalResolver))
-                {
-                    resolver.Dispose();
-                }
-
+                resolver?.Dispose();
                 registry = originalRegistry;
-                resolver = originalResolver;
+                // Why a new resolver over the original registry: the original one was disposed
+                // when the scope opened, and a disposed resolver no longer answers binds.
+                resolver = originalRegistry == null
+                    ? null
+                    : new HotReloadIntroducedTypeAssemblyResolver(originalRegistry);
             }
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeHolder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeHolder.cs
@@ -1,0 +1,92 @@
+using System;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Owns the single introduced type registry and assembly resolver pair of the current domain.
+    /// </summary>
+    internal static class HotReloadIntroducedTypeHolder
+    {
+        private static HotReloadIntroducedTypeRegistry registry;
+        private static HotReloadIntroducedTypeAssemblyResolver resolver;
+
+        public static HotReloadIntroducedTypeRegistry Registry => RequireInitialized(registry);
+
+        public static HotReloadIntroducedTypeAssemblyResolver Resolver => RequireInitialized(resolver);
+
+        /// <summary>
+        /// Builds the pair for this domain. Called once per domain reload from editor startup.
+        /// </summary>
+        public static void Initialize()
+        {
+            // Why not a lazy property: the resolver subscribes to AppDomain.AssemblyResolve in its
+            // constructor, and a lazily built one would only subscribe on the first request that
+            // already needs the subscription to succeed. Building it at startup makes the
+            // subscription precede every bind that could reach an artifact assembly.
+            resolver?.Dispose();
+            registry = new HotReloadIntroducedTypeRegistry();
+            resolver = new HotReloadIntroducedTypeAssemblyResolver(registry);
+        }
+
+        /// <summary>
+        /// Detaches the current pair and returns a scope that disposes whatever replaced it and
+        /// restores the original one.
+        /// </summary>
+        public static IDisposable BeginReplacement()
+        {
+            HotReloadIntroducedTypeRegistry originalRegistry = registry;
+            HotReloadIntroducedTypeAssemblyResolver originalResolver = resolver;
+            registry = null;
+            resolver = null;
+            return new ReplacementScope(originalRegistry, originalResolver);
+        }
+
+        private static T RequireInitialized<T>(T instance)
+            where T : class
+        {
+            // A caller reaching the holder before startup wired it would silently work against a
+            // pair no activation ever publishes to, so this is an internal contract violation.
+            if (instance == null)
+            {
+                throw new InvalidOperationException(
+                    "The introduced type holder must be initialized before it is used.");
+            }
+
+            return instance;
+        }
+
+        private sealed class ReplacementScope : IDisposable
+        {
+            private readonly HotReloadIntroducedTypeRegistry originalRegistry;
+            private readonly HotReloadIntroducedTypeAssemblyResolver originalResolver;
+            private bool restored;
+
+            public ReplacementScope(
+                HotReloadIntroducedTypeRegistry originalRegistry,
+                HotReloadIntroducedTypeAssemblyResolver originalResolver)
+            {
+                this.originalRegistry = originalRegistry;
+                this.originalResolver = originalResolver;
+            }
+
+            public void Dispose()
+            {
+                if (restored)
+                {
+                    return;
+                }
+
+                restored = true;
+                // The replacement resolver stays subscribed to AppDomain.AssemblyResolve until it
+                // is disposed, so leaving it attached would keep answering binds after the scope.
+                if (resolver != null && !ReferenceEquals(resolver, originalResolver))
+                {
+                    resolver.Dispose();
+                }
+
+                registry = originalRegistry;
+                resolver = originalResolver;
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeHolder.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeHolder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14c2055aede7c4af6b1099889435e967
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeRegistry.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeRegistry.cs
@@ -165,6 +165,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
+        /// <summary>
+        /// Answers whether a compiled assembly still owns a type this domain introduced.
+        /// </summary>
+        public bool HasActiveTypesForOriginalAssembly(string originalAssemblyName)
+        {
+            if (string.IsNullOrEmpty(originalAssemblyName))
+            {
+                return false;
+            }
+
+            lock (gate)
+            {
+                foreach (HotReloadIntroducedTypeArtifact artifact in activeByAssemblyIdentity.Values)
+                {
+                    foreach (HotReloadIntroducedTypeDescriptor descriptor in artifact.Descriptors)
+                    {
+                        if (string.Equals(descriptor.OriginalAssemblyName, originalAssemblyName, StringComparison.Ordinal))
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
+        }
+
         public bool TryResolveActiveAssembly(string requestedAssemblyFullName, out HotReloadIntroducedTypeArtifact artifact)
         {
             lock (gate)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorLog.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestratorLog.cs
@@ -104,6 +104,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 correlationId);
         }
 
+        internal static void LogHotReloadRevertFailed(string methodKey, Exception exception)
+        {
+            VibeLogger.LogWarning(
+                HotReloadConstants.VibeLogRevertFailed,
+                "Hot reload could not restore a method's original body.",
+                new
+                {
+                    method = methodKey,
+                    error = exception.Message
+                });
+        }
+
         internal static void LogHotReloadApplySummary(
             int patchedCount,
             int failedCount,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
@@ -182,11 +182,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
             }
 
-            HotReloadUnchangedSourceDecision unchangedDecision = HotReloadAppliedSourceLifecycle.TryShortCircuitUnchangedAppliedSource(
-                workerSourcePath,
-                projectRelativePath,
-                assemblyResolvePath,
-                alreadyActiveOutcomes);
+            // Why the call is skipped rather than its result discarded: the short-circuit clears
+            // the applied-source ledger on its miss paths. A type this domain introduced lives in
+            // an artifact assembly whose owner declaration still has to be verified, so an
+            // unchanged source must reach that verification with its ledger entry intact.
+            HotReloadUnchangedSourceDecision unchangedDecision = HotReloadUnchangedSourceDecision.NotUnchanged;
+            if (!HotReloadIntroducedTypeHolder.Registry.HasActiveTypesForOriginalAssembly(assemblyName))
+            {
+                unchangedDecision = HotReloadAppliedSourceLifecycle.TryShortCircuitUnchangedAppliedSource(
+                    workerSourcePath,
+                    projectRelativePath,
+                    assemblyResolvePath,
+                    alreadyActiveOutcomes);
+            }
             HotReloadOrchestratorLog.LogHotReloadFileStart(projectRelativePath, unchangedDecision, correlationId);
             if (unchangedDecision == HotReloadUnchangedSourceDecision.ReapplyNonBaseline)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -253,17 +253,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
+        // Set by tests only. A Harmony rebuild failure cannot be provoked from outside, and the
+        // contained-failure contract of Revert has to be pinned by a test. Production leaves it
+        // null and reverts through Harmony.
+        internal static Action<MethodBase> UnpatchForTesting;
+
         /// <summary>
         /// Removes the hot-reload patch on <paramref name="method"/> when one is recorded.
-        /// Returns false when the method was not patched.
         /// </summary>
-        public static bool Revert(MethodBase method)
+        public static HotReloadRevertOutcome Revert(MethodBase method, out string failureReason)
         {
             Debug.Assert(method != null, "method must not be null.");
 
+            failureReason = null;
             if (!ShimByMethod.Remove(method))
             {
-                return false;
+                return HotReloadRevertOutcome.NotPatched;
             }
 
             // Why Remove before Unpatch: Harmony rebuilds the method during Unpatch, and the
@@ -279,9 +284,35 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why here, not only RevertAll: RevertUnchangedPatches uses this path, and a
             // later apply of the same compiled key must not inherit a stale superseded Reason.
             HotReloadSupersededSignatureRegistry.Remove(methodKey);
-            HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
+            try
+            {
+                Unpatch(method);
+            }
+            catch (Exception exception)
+            {
+                // Same approved exception as the apply path: a Harmony rebuild failure cannot be
+                // pre-validated, and an escaping exception would abort the run while leaving the
+                // other methods of the group unreverted. The ledger entry is already gone, which
+                // is the asymmetry the apply path's failure contract has as well.
+                failureReason = "Reverting '" + methodKey + "' failed: " + exception.Message;
+                HotReloadOrchestratorLog.LogHotReloadRevertFailed(methodKey, exception);
+                HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
+                return HotReloadRevertOutcome.UnpatchFailed;
+            }
+
             HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
-            return true;
+            return HotReloadRevertOutcome.Reverted;
+        }
+
+        private static void Unpatch(MethodBase method)
+        {
+            if (UnpatchForTesting != null)
+            {
+                UnpatchForTesting(method);
+                return;
+            }
+
+            HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -266,10 +266,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(method != null, "method must not be null.");
 
             failureReason = null;
-            if (!ShimByMethod.Remove(method))
+            if (!ShimByMethod.TryGetValue(method, out MethodInfo recordedShim))
             {
                 return HotReloadRevertOutcome.NotPatched;
             }
+
+            // Kept for the failure path: status, the Auto Refresh hold and the next apply's
+            // "unpatch the previous transpiler first" decision all read these two, so a rebuild
+            // failure that leaves the patch live must leave them describing that patch.
+            string recordedFilePath = FilePathByMethod.TryGetValue(method, out string filePathValue)
+                ? filePathValue
+                : null;
+            ShimByMethod.Remove(method);
 
             // Why Remove before Unpatch: Harmony rebuilds the method during Unpatch, and the
             // pause-point guard sees GetActiveShimForMethod == null so surviving markers are
@@ -292,16 +300,46 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 // Same approved exception as the apply path: a Harmony rebuild failure cannot be
                 // pre-validated, and an escaping exception would abort the run while leaving the
-                // other methods of the group unreverted. The ledger entry is already gone, which
-                // is the asymmetry the apply path's failure contract has as well.
+                // other methods of the group unreverted. Unlike the apply path, which converges
+                // on "no ledger entry, no patch" through its own cleanup Unpatch, a failed
+                // rebuild here can leave the transpiler live: restore the ledger entry in that
+                // case only, so status and the next apply still see the patch that is there.
                 failureReason = "Reverting '" + methodKey + "' failed: " + exception.Message;
                 HotReloadOrchestratorLog.LogHotReloadRevertFailed(methodKey, exception);
+                if (HasLiveHotReloadTranspiler(method))
+                {
+                    ShimByMethod[method] = recordedShim;
+                    FilePathByMethod[method] = recordedFilePath ?? string.Empty;
+                    return HotReloadRevertOutcome.UnpatchFailed;
+                }
+
                 HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
                 return HotReloadRevertOutcome.UnpatchFailed;
             }
 
             HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
             return HotReloadRevertOutcome.Reverted;
+        }
+
+        // Whether Harmony still holds this hot-reload transpiler, which decides if a failed
+        // rebuild left the patch live.
+        private static bool HasLiveHotReloadTranspiler(MethodBase method)
+        {
+            Patches patchInfo = Harmony.GetPatchInfo(method);
+            if (patchInfo == null || patchInfo.Transpilers == null)
+            {
+                return false;
+            }
+
+            foreach (Patch transpiler in patchInfo.Transpilers)
+            {
+                if (string.Equals(transpiler.owner, HotReloadConstants.HarmonyId, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static void Unpatch(MethodBase method)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRevertOutcome.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRevertOutcome.cs
@@ -1,0 +1,13 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// What removing one method's hot-reload patch did: the method held no patch, the patch was
+    /// removed, or the ledger entry is gone but Harmony could not restore the original body.
+    /// </summary>
+    internal enum HotReloadRevertOutcome
+    {
+        NotPatched,
+        Reverted,
+        UnpatchFailed
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRevertOutcome.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRevertOutcome.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee5367d3e77674f07834c5ac52ac96eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
@@ -28,7 +28,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             await MainThreadSwitcher.SwitchToMainThread(ct);
             if (!HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(context.Files))
             {
-                return HotReloadGroupCompileResult.NothingToApply();
+                return HotReloadGroupCompileResult.Failed();
             }
 
             if (gateResult.UsedWorkerRetry)
@@ -36,10 +36,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 AdoptRetryAddedMemberNames(context.Files, gateResult.Isolation.RetryFiles);
                 if (gateResult.Isolation.RetryEntries.Length == 0)
                 {
-                    return HotReloadGroupCompileResult.NothingToApply();
+                    return HotReloadGroupCompileResult.Failed();
                 }
 
-                return HotReloadGroupCompileResult.Apply(
+                return HotReloadGroupCompileResult.ReadyWithMethods(
                     gateResult.Isolation.RetryEntries,
                     gateResult.Isolation.RetryCompileResult);
             }
@@ -58,7 +58,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     HotReloadFileEntryApplier.ClearFileGeneration(context, file);
                 }
 
-                return HotReloadGroupCompileResult.NothingToApply();
+                return HotReloadGroupCompileResult.ReadyWithoutMethods();
             }
 
             return await CompileShimForGroupAsync(context, ct).ConfigureAwait(false);
@@ -91,7 +91,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     context.Files,
                     "(file)",
                     shimReferencePaths.ErrorMessage);
-                return HotReloadGroupCompileResult.NothingToApply();
+                return HotReloadGroupCompileResult.Failed();
             }
 
             HotReloadShimCompileResult compileResult = await HotReloadShimCompiler.CompileAndLoadAsync(
@@ -103,7 +103,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (compileResult.Success)
             {
                 AdoptFirstPassAddedMemberNames(context.Files);
-                return HotReloadGroupCompileResult.Apply(workerOutput.entries, compileResult);
+                return HotReloadGroupCompileResult.ReadyWithMethods(workerOutput.entries, compileResult);
             }
 
             HotReloadOrchestratorLog.LogHotReloadShimCompileFailed(
@@ -128,7 +128,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (isolation == null)
             {
                 AppendUnattributableCompileFailure(context, compileResult);
-                return HotReloadGroupCompileResult.NothingToApply();
+                return HotReloadGroupCompileResult.Failed();
             }
 
             context.Files[0].Sinks.SiblingDerivedWarnings.AddRange(isolation.SiblingConstDriftWarnings);
@@ -185,7 +185,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadGroupOutcomeRouter.AppendByFilePath(
                     context.Files,
                     BuildAtomicFileSkipOutcomes(isolation.RetryEntries, context.GroupFilePaths));
-                return HotReloadGroupCompileResult.NothingToApply();
+                return HotReloadGroupCompileResult.Failed();
             }
 
             HotReloadGroupOutcomeRouter.AppendByFilePath(
@@ -203,10 +203,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             AdoptRetryAddedMemberNames(context.Files, isolation.RetryFiles);
             if (isolation.RetryEntries.Length == 0)
             {
-                return HotReloadGroupCompileResult.NothingToApply();
+                return HotReloadGroupCompileResult.Failed();
             }
 
-            return HotReloadGroupCompileResult.Apply(isolation.RetryEntries, isolation.RetryCompileResult);
+            return HotReloadGroupCompileResult.ReadyWithMethods(isolation.RetryEntries, isolation.RetryCompileResult);
         }
 
         private static List<HotReloadMethodOutcome> BuildAtomicFileSkipOutcomes(


### PR DESCRIPTION
## Summary
- Hot reload now has an editor-owned home for the types a reload introduces, so an introduced type can be published for runtime binding at all.
- A file whose content did not change is verified again while its assembly owns such a type, instead of being reported as already active.
- A patch that Harmony cannot remove no longer aborts the whole reload.

## User Impact
Before: nothing in the editor owned the introduced-type registry, so the artifact assemblies a reload produces had no place to become resolvable. A re-request of an unchanged file short-circuited to "already active", which is the wrong answer once the declaration a type came from may have changed or been deleted. Removing a leftover patch called into Harmony unguarded, so one rebuild failure aborted the run and left the remaining methods with their stale patches.

After: the registry and its assembly resolver are built once per domain reload from hot-reload editor startup. An assembly that owns an introduced type keeps verifying its unchanged sources. A failed patch removal is reported as that method's own failure and the remaining methods still get peeled.

## Changes
- Own one registry + resolver pair per domain, built from hot-reload editor startup because the resolver subscribes to `AppDomain.AssemblyResolve` in its constructor. A replacement scope lets a caller install its own pair and put the original back.
- Split the group's shim-compile result into `Failed` / `ReadyWithoutMethods` / `ReadyWithMethods`, so a successful group with no method to patch is distinguishable from a failed one. Pure refactor: the only consumer still branches on whether entries are ready.
- Skip the unchanged-source short-circuit for an assembly that owns an introduced type. The call is skipped rather than its result discarded, because the short-circuit clears the applied-source ledger as a side effect.
- Reach the group's membership validation through one internal dependency bundle, so a test can observe the production pipeline instead of reimplementing it.
- Make patch removal a contained failure. The order stays ledger removal first, then the Harmony rebuild: the pause-point guard has to see no active shim while Harmony rebuilds, so surviving markers are re-instrumented into the restored original body. When the rebuild fails and the transpiler is still live, the ledger entry is restored and no inactive notification is sent, because status, the Auto Refresh hold and the next apply's "remove the previous transpiler first" decision all read that ledger alone.
- Stop a replaced introduced-type resolver from answering binds: the replacement scope disposes the resolver it takes over from (keeping its registry) and builds a fresh resolver over the original registry when it closes. The subscription lives in the resolver itself, so leaving it alive would let two resolvers answer one bind.

## Verification
Editor tests, single flight, class/regex filtered (no full suite):

- `HotReloadIntroducedTypeActivationTests` — 2/2
- `HotReloadGroupProcessorTests` — 13/13
- `HotReloadRetainedArtifactPropagationTests|HotReloadShimErrorAttributionTests|HotReloadSkippedMemberCompileNoteTests` — 20/20
- `HotReloadShimCompilerTests|HotReloadOrchestratorTests` — 159/159
- `HotReloadGroupProcessorTests|HotReloadNewSourceMembershipTests|HotReloadIntroducedTypeActivationTests|HotReloadIntroducedTypeRegistryTests|HotReloadPatcherTests` — 74/74
- `HotReloadToolTests|HotReloadShimRegistryTests|HotReloadCrossFileE2ETests` — 81/81
- `HotReloadOrchestratorTests` — 154/154 (re-run after the patch-removal change)
- `HotReloadPatcherTests|HotReloadIntroducedTypeActivationTests|HotReloadIntroducedTypeRegistryTests` — 39/39 (re-run after the two review fixes)
- `HotReloadOrchestratorTests|HotReloadNewSourceMembershipTests|HotReloadGroupProcessorTests|HotReloadShimRegistryTests|HotReloadToolTests` — 254/254 (re-run after the two review fixes)
- `scripts/check-file-length.sh` — no file exceeds the 500 SLOC limit

Mutation checks (one production edit at a time, restored afterwards, then re-run green):

- Return a new registry/resolver pair on every access → only `Holder_AfterInitialize_ResolverAndRegistryShareOneInstance` fails (1 failed / 1 passed).
- Always call the unchanged-source short-circuit → `ResolvePatchTarget_WhenAssemblyOwnsAnActiveIntroducedType_KeepsTheLedgerEntry` (1 failed / 22 passed) and `Run_UnchangedSourceWithActiveIntroducedType_StillEntersGroupProcessing` (1 failed / 0 passed) fail; the no-type case still passes.
- Call the short-circuit and discard its result → only the ledger-entry test fails (1 failed / 22 passed).
- Remove the catch around the Harmony rebuild in patch removal → only `Revert_WhenHarmonyCannotRebuild_ContainsTheFailureAndKeepsRevertingOthers` fails (1 failed / 16 passed).
- Drop the ledger restore after a failed rebuild → only `Revert_WhenHarmonyCannotRebuild_ContainsTheFailureAndKeepsRevertingOthers` fails (1 failed / 38 passed).
- Do not dispose the taken-over resolver when a replacement scope opens → only `Holder_ReplacementScopeOpen_OnlyTheReplacementResolverAnswersBinds` fails (1 failed / 38 passed).

Not verified in this pull request:

- Repository `Build and Test` CI does not run for pull requests targeting an integration branch, so it is not a gate here. Local verification above stands in for it; the full editor suite runs on the scheduled nightly job.
- The full unfiltered editor suite was not run.
- Nothing wires the introduced-type registry into the group pipeline yet: preparing an artifact, propagating it to the worker input and the shim compile, the commit-boundary re-checks, and the response/status wiring all follow in later pull requests.
- Group entry preparation (one bind plus each file's entry resolution ahead of the commit point) moves to the next stacked pull request: its discriminating test needs the type-introduction batch that does not exist yet.
