### PR TITLE
fix: uloop update now explains how to recover from a GitHub API rate limit

### DIFF
--- a/cli/dispatcher/internal/dispatcher/update_test.go
+++ b/cli/dispatcher/internal/dispatcher/update_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -13,9 +14,12 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hatayama/unity-cli-loop/common/clicore"
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
 	"github.com/hatayama/unity-cli-loop/dispatcher/dispatchercontract"
+	"github.com/hatayama/unity-cli-loop/dispatcher/internal/githubapi"
 	"github.com/hatayama/unity-cli-loop/dispatcher/internal/update"
 )
 
@@ -400,6 +404,47 @@ func TestTryHandleUpdateRequestSkipsInstallerWhenResolvedTargetIsCurrent(t *test
 	expected := "uloop dispatcher is already up to date (" + dispatcherVersion + ")."
 	if !strings.Contains(stdout.String(), expected) {
 		t.Fatalf("update output mismatch: %s", stdout.String())
+	}
+}
+
+func TestTryHandleUpdateRequestExplainsRateLimit(t *testing.T) {
+	// Verifies a rate-limited release lookup reports the token and reset-time guidance instead of generic advice.
+	previousRunner := updateRunCommand
+	previousResolver := resolveUpdateTargetVersionFunc
+	previousExecutablePath := resolveUpdateExecutablePathFunc
+	defer func() {
+		updateRunCommand = previousRunner
+		resolveUpdateTargetVersionFunc = previousResolver
+		resolveUpdateExecutablePathFunc = previousExecutablePath
+	}()
+	updateRunCommand = func(context.Context, update.Command, io.Writer, io.Writer) error {
+		t.Fatal("updateRunCommand must not run when the release lookup failed")
+		return nil
+	}
+	resetAt := time.Date(2026, 9, 7, 1, 29, 0, 0, time.UTC)
+	resolveUpdateTargetVersionFunc = func(_ context.Context, _ update.Options) (update.Options, error) {
+		return update.Options{}, fmt.Errorf("list releases: %w", githubapi.RateLimitError{ResetAt: resetAt})
+	}
+	resolveUpdateExecutablePathFunc = func() (string, error) {
+		return "/tmp/uloop", nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	handled, code := tryHandleUpdateRequest(context.Background(), []string{clicore.UpdateCommandName}, &stdout, &stderr)
+
+	if !handled || code != 1 {
+		t.Fatalf("update result mismatch: handled=%t code=%d stderr=%s", handled, code, stderr.String())
+	}
+	var envelope clierrors.CLIErrorEnvelope
+	if err := json.Unmarshal(stderr.Bytes(), &envelope); err != nil {
+		t.Fatalf("could not decode error envelope: %v (stderr=%s)", err, stderr.String())
+	}
+	if len(envelope.Error.NextActions) == 0 || !strings.Contains(envelope.Error.NextActions[0], "GH_TOKEN") {
+		t.Fatalf("expected token guidance, got %v", envelope.Error.NextActions)
+	}
+	if envelope.Error.Details["GitHubRateLimitResetAt"] != resetAt.Format(time.RFC3339) {
+		t.Fatalf("reset detail mismatch: got %v", envelope.Error.Details["GitHubRateLimitResetAt"])
 	}
 }
 

--- a/cli/dispatcher/internal/githubapi/ratelimit.go
+++ b/cli/dispatcher/internal/githubapi/ratelimit.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
 )
 
 const (
@@ -64,6 +66,31 @@ func (e RateLimitError) NextActions() []string {
 		return append(actions, "Or: "+secondaryLimitFallbackWait)
 	}
 	return append(actions, "Or retry after "+e.ResetAt.Local().Format(resetTimeLayout)+" when the anonymous quota resets.")
+}
+
+// ToCLIError lets ClassifyError turn a rate-limited GitHub call into an
+// envelope that names the recovery (a token, or the reset time) instead of the
+// generic "fix the local environment" guidance. Every WriteClassifiedError path
+// that wraps this error reaches it through errors.As, so the guidance no longer
+// has to be re-attached at each call site.
+func (e RateLimitError) ToCLIError(context clierrors.ErrorContext) clierrors.CLIError {
+	details := map[string]any{}
+	if !e.ResetAt.IsZero() {
+		details["GitHubRateLimitResetAt"] = e.ResetAt.UTC().Format(time.RFC3339)
+	}
+	return clierrors.CLIError{
+		ErrorCode: clierrors.ErrorCodeInternalError,
+		Phase:     clierrors.ErrorPhaseExecution,
+		Message:   e.Error(),
+		// Why retryable: the refused request was a GET with no side effects, and
+		// the quota recovers on its own once the reset time passes.
+		Retryable:   true,
+		SafeToRetry: true,
+		ProjectRoot: context.ProjectRoot,
+		Command:     context.Command,
+		NextActions: e.NextActions(),
+		Details:     details,
+	}
 }
 
 // DetectRateLimit classifies a non-2xx response. GitHub signals an exhausted

--- a/cli/dispatcher/internal/githubapi/ratelimit_test.go
+++ b/cli/dispatcher/internal/githubapi/ratelimit_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
 )
 
 func responseWith(status int, headers map[string]string) *http.Response {
@@ -186,5 +188,68 @@ func TestRateLimitErrorMessageIncludesResetDate(t *testing.T) {
 	message := RateLimitError{ResetAt: time.Date(2026, 9, 3, 0, 15, 0, 0, time.Local)}.Error()
 	if !strings.Contains(message, "2026-09-03 00:15") {
 		t.Fatalf("expected dated reset time, got: %s", message)
+	}
+}
+
+// Verifies an anonymous exhaustion classifies into an envelope that keeps the token guidance and the reset detail.
+func TestRateLimitErrorToCLIErrorAnonymousExplainsToken(t *testing.T) {
+	resetAt := time.Date(2026, 9, 7, 1, 29, 0, 0, time.UTC)
+	rateLimit := RateLimitError{ResetAt: resetAt}
+
+	cliError := rateLimit.ToCLIError(clierrors.ErrorContext{Command: "update"})
+
+	if cliError.ErrorCode != clierrors.ErrorCodeInternalError {
+		t.Fatalf("error code mismatch: got %q", cliError.ErrorCode)
+	}
+	if cliError.Phase != clierrors.ErrorPhaseExecution {
+		t.Fatalf("phase mismatch: got %q", cliError.Phase)
+	}
+	if cliError.Command != "update" {
+		t.Fatalf("command mismatch: got %q", cliError.Command)
+	}
+	if !cliError.Retryable || !cliError.SafeToRetry {
+		t.Fatalf("a refused GET should be retryable and safe to retry: %+v", cliError)
+	}
+	if !strings.Contains(cliError.Message, "rate limit exhausted") {
+		t.Fatalf("message should name the rate limit, got: %s", cliError.Message)
+	}
+	expectedActions := rateLimit.NextActions()
+	if len(cliError.NextActions) != len(expectedActions) {
+		t.Fatalf("next actions mismatch: got %v want %v", cliError.NextActions, expectedActions)
+	}
+	for index, action := range expectedActions {
+		if cliError.NextActions[index] != action {
+			t.Fatalf("next action %d mismatch: got %q want %q", index, cliError.NextActions[index], action)
+		}
+	}
+	if len(cliError.NextActions) != 2 || !strings.Contains(cliError.NextActions[0], "GH_TOKEN") {
+		t.Fatalf("anonymous guidance should lead with the token hint: %v", cliError.NextActions)
+	}
+	if cliError.Details["GitHubRateLimitResetAt"] != resetAt.Format(time.RFC3339) {
+		t.Fatalf("reset detail mismatch: got %v", cliError.Details["GitHubRateLimitResetAt"])
+	}
+}
+
+// Verifies an authenticated exhaustion classifies without the token hint, since a token is already in use.
+func TestRateLimitErrorToCLIErrorAuthenticatedSkipsTokenHint(t *testing.T) {
+	cliError := RateLimitError{
+		ResetAt:       time.Date(2026, 9, 7, 1, 29, 0, 0, time.UTC),
+		Authenticated: true,
+	}.ToCLIError(clierrors.ErrorContext{Command: "update"})
+
+	if len(cliError.NextActions) != 1 {
+		t.Fatalf("expected a single next action, got %v", cliError.NextActions)
+	}
+	if strings.Contains(cliError.NextActions[0], "GH_TOKEN") {
+		t.Fatalf("authenticated guidance should not suggest a token: %v", cliError.NextActions)
+	}
+}
+
+// Verifies an unknown reset time leaves the reset detail out of the envelope instead of reporting a zero time.
+func TestRateLimitErrorToCLIErrorWithoutResetOmitsDetail(t *testing.T) {
+	cliError := RateLimitError{}.ToCLIError(clierrors.ErrorContext{Command: "update"})
+
+	if _, ok := cliError.Details["GitHubRateLimitResetAt"]; ok {
+		t.Fatalf("reset detail should be absent, got %v", cliError.Details)
 	}
 }


### PR DESCRIPTION
## Summary
- When `uloop update` fails because GitHub refused the API request, the error now tells you how to recover: set a token, or wait until the named reset time.
- The same recovery guidance now reaches every classified error envelope, not just the runner-download path that already had it.

## User Impact

`uloop update` looks up the latest dispatcher release through the GitHub REST API. With no `GITHUB_TOKEN` / `GH_TOKEN` the request is anonymous, and GitHub gives anonymous callers 60 requests per hour **shared by everyone behind the same public IP**. Behind an office NAT that quota is routinely gone, and the command failed with advice that named nothing actionable:

```json
{
  "Success": false,
  "Error": {
    "ErrorCode": "INTERNAL_ERROR",
    "Phase": "execution",
    "Message": "list releases: GitHub API rate limit exhausted (anonymous requests share a per-IP quota); resets at 2026-09-07 10:29 JST",
    "Retryable": false,
    "SafeToRetry": false,
    "Command": "update",
    "NextActions": [
      "Read the message and fix the local environment or command input before retrying."
    ]
  }
}
```

After this change the same failure names both ways out, and reports the reset time as a machine-readable field:

```json
{
  "Success": false,
  "Error": {
    "ErrorCode": "INTERNAL_ERROR",
    "Phase": "execution",
    "Message": "GitHub API rate limit exhausted (anonymous requests share a per-IP quota); resets at 2026-09-07 11:29 JST",
    "Retryable": true,
    "SafeToRetry": true,
    "Command": "update",
    "NextActions": [
      "Set GH_TOKEN (or GITHUB_TOKEN) to a GitHub token so uloop uses your authenticated API quota, then retry.",
      "Or retry after 2026-09-07 11:29 JST when the anonymous quota resets."
    ],
    "Details": {
      "GitHubRateLimitResetAt": "2026-09-07T02:29:52Z"
    }
  }
}
```

The failure is also correctly reported as retryable and safe to retry: the refused request was a side-effect-free GET, and the quota recovers on its own.

## Changes
- `RateLimitError` now self-classifies into an error envelope. The classifier already looks for that capability through `errors.As`, so the guidance is picked up wherever the error is wrapped — the update path and any future caller — instead of being re-attached at each call site.
- Unit tests cover the anonymous case (token hint plus reset detail), the authenticated case (no token hint, since a token is already in use), and an unknown reset time (the reset field is omitted rather than reported as a zero time).
- An integration test drives the update command with a rate-limited release lookup and asserts the recovery guidance and reset time survive into the printed envelope.

## Verification
- `scripts/check-go-cli.sh` — exit 0 (format, vet, lint, all Go module tests, dist rebuild).
- Removed the new classification temporarily and re-ran the integration test to confirm it fails with the old generic advice, then restored it.
- Manual: ran the development binary's `update` with both token variables cleared while the anonymous quota happened to be exhausted, and got the second envelope above verbatim.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

