### PR TITLE
feat: uloop now uses your GitHub CLI login for GitHub API calls

### DIFF
--- a/cli/dispatcher/attestation/fetcher.go
+++ b/cli/dispatcher/attestation/fetcher.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"time"
 
@@ -27,8 +26,6 @@ func setGithubAPIBase(url string) { githubAPIBaseURL = url }
 
 const (
 	githubReleaseBaseURL   = "https://github.com/%s/releases/download/%s/%s"
-	envAuthTokenPrimary    = "GITHUB_TOKEN"
-	envAuthTokenSecondary  = "GH_TOKEN"
 	acceptHeaderGitHubJSON = "application/vnd.github+json"
 	apiVersionHeaderValue  = "2022-11-28"
 )
@@ -119,7 +116,7 @@ func fetchGitRef(ctx context.Context, apiURL string) (string, string, error) {
 	}
 	req.Header.Set("Accept", acceptHeaderGitHubJSON)
 	req.Header.Set("X-GitHub-Api-Version", apiVersionHeaderValue)
-	authenticated := setAuthorizationIfAvailable(req)
+	authenticated := setAuthorizationIfAvailable(ctx, req)
 	resp, err := DefaultHTTPClient.Do(req)
 	if err != nil {
 		return "", "", fmt.Errorf("%w: %v", ErrTagRefFetch, err)
@@ -148,11 +145,8 @@ func tagRefStatusError(resp *http.Response, apiURL string, authenticated bool) e
 
 // setAuthorizationIfAvailable reports whether a token was attached, so a
 // later rate-limit refusal can skip the "set a token" guidance.
-func setAuthorizationIfAvailable(req *http.Request) bool {
-	token := os.Getenv(envAuthTokenPrimary)
-	if token == "" {
-		token = os.Getenv(envAuthTokenSecondary)
-	}
+func setAuthorizationIfAvailable(ctx context.Context, req *http.Request) bool {
+	token := githubapi.DefaultTokenSource.Resolve(ctx)
 	if token == "" {
 		return false
 	}

--- a/cli/dispatcher/attestation/main_test.go
+++ b/cli/dispatcher/attestation/main_test.go
@@ -1,0 +1,27 @@
+package attestation
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hatayama/unity-cli-loop/dispatcher/internal/githubapi"
+)
+
+// Pins the package default to "no token": GitHub API tests here must not read
+// the developer's GITHUB_TOKEN or consult the gh CLI, or whether a request is
+// reported as authenticated would depend on the machine running the tests.
+func TestMain(m *testing.M) {
+	githubapi.DefaultTokenSource = githubapi.StaticTokenSource("")
+	os.Exit(m.Run())
+}
+
+// useTokenSource pins the token every api.github.com call in this package sees,
+// and restores the previous source when the test ends.
+func useTokenSource(t *testing.T, token string) {
+	t.Helper()
+	previous := githubapi.DefaultTokenSource
+	githubapi.DefaultTokenSource = githubapi.StaticTokenSource(token)
+	t.Cleanup(func() {
+		githubapi.DefaultTokenSource = previous
+	})
+}

--- a/cli/dispatcher/attestation/verifier_test.go
+++ b/cli/dispatcher/attestation/verifier_test.go
@@ -473,9 +473,6 @@ func TestFetchTagCommitSHA_ServerError(t *testing.T) {
 // Verifies FetchTagCommitSHA surfaces an exhausted GitHub quota as a typed
 // rate-limit error while still failing closed under ErrTagRefFetch.
 func TestFetchTagCommitSHA_RateLimited(t *testing.T) {
-	// Why clear both: a token in the developer's shell would turn this into the authenticated case.
-	t.Setenv(envAuthTokenPrimary, "")
-	t.Setenv(envAuthTokenSecondary, "")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-RateLimit-Remaining", "0")
 		w.Header().Set("X-RateLimit-Reset", "1790000000")
@@ -506,7 +503,7 @@ func TestFetchTagCommitSHA_RateLimited(t *testing.T) {
 // Verifies a rate limit hit with a token in the environment is reported as authenticated
 // so the guidance does not ask for a token that is already set.
 func TestFetchTagCommitSHA_RateLimitedWithToken(t *testing.T) {
-	t.Setenv(envAuthTokenPrimary, "test-token")
+	useTokenSource(t, "test-token")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-RateLimit-Remaining", "0")
 		http.Error(w, `{"message":"API rate limit exceeded"}`, http.StatusForbidden)
@@ -524,5 +521,33 @@ func TestFetchTagCommitSHA_RateLimitedWithToken(t *testing.T) {
 	}
 	if !rateLimit.Authenticated {
 		t.Fatalf("expected an authenticated rate limit error, got: %+v", rateLimit)
+	}
+}
+
+// Verifies tag-to-commit resolution authenticates with the token the shared source resolved.
+func TestFetchTagCommitSHASendsResolvedTokenAsBearer(t *testing.T) {
+	useTokenSource(t, "resolved-token")
+	commitSHA := "1234567890abcdef1234567890abcdef12345678"
+	var recorded string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recorded = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"object":{"sha":%q,"type":"commit"}}`, commitSHA)
+	}))
+	defer server.Close()
+
+	original := githubAPIBase()
+	setGithubAPIBase(server.URL)
+	defer setGithubAPIBase(original)
+
+	sha, err := FetchTagCommitSHA(context.Background(), "hatayama/unity-cli-loop", "any")
+	if err != nil {
+		t.Fatalf("FetchTagCommitSHA failed: %v", err)
+	}
+	if sha != commitSHA {
+		t.Fatalf("commit SHA mismatch: got %q", sha)
+	}
+	if recorded != "Bearer resolved-token" {
+		t.Fatalf("authorization header mismatch: got %q", recorded)
 	}
 }

--- a/cli/dispatcher/internal/dispatcher/attestation_release.go
+++ b/cli/dispatcher/internal/dispatcher/attestation_release.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/hatayama/unity-cli-loop/dispatcher/attestation"
@@ -101,7 +100,7 @@ func fetchDispatcherReleasePage(ctx context.Context, page int) ([]githubReleaseL
 	}
 	request.Header.Set("Accept", "application/vnd.github+json")
 	request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	token := lookupGitHubAPIToken()
+	token := githubapi.DefaultTokenSource.Resolve(ctx)
 	if token != "" {
 		request.Header.Set("Authorization", "Bearer "+token)
 	}
@@ -196,16 +195,4 @@ func fetchAttestationSubjectManifest(ctx context.Context, releaseTag string) (st
 		return "", fmt.Errorf("%w: subject manifest was empty after filtering", attestation.ErrVerificationFailed)
 	}
 	return builder.String(), nil
-}
-
-// lookupGitHubAPIToken reads the ambient GitHub token from the environment.
-// GITHUB_TOKEN wins over GH_TOKEN so CI environments that set both behave
-// consistently with attestation.setAuthorizationIfAvailable in fetcher.go.
-func lookupGitHubAPIToken() string {
-	for _, env := range []string{"GITHUB_TOKEN", "GH_TOKEN"} {
-		if value := os.Getenv(env); value != "" {
-			return value
-		}
-	}
-	return ""
 }

--- a/cli/dispatcher/internal/dispatcher/attestation_release_test.go
+++ b/cli/dispatcher/internal/dispatcher/attestation_release_test.go
@@ -148,3 +148,52 @@ func TestFetchDispatcherReleasePageReportsRateLimit(t *testing.T) {
 		t.Fatalf("expected list releases prefix, got: %v", err)
 	}
 }
+
+// installAuthorizationRecordingReleaseServer serves an empty release page and
+// records the Authorization header the request carried.
+func installAuthorizationRecordingReleaseServer(t *testing.T, recorded *string) (*httptest.Server, func()) {
+	t.Helper()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*recorded = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]githubReleaseListEntry{})
+	})
+	server := httptest.NewServer(handler)
+	previousBase := dispatcherAPIBaseURL
+	dispatcherAPIBaseURL = server.URL
+	return server, func() {
+		dispatcherAPIBaseURL = previousBase
+	}
+}
+
+// Verifies the release listing authenticates with the token the shared source resolved.
+func TestFetchDispatcherReleasePageSendsResolvedTokenAsBearer(t *testing.T) {
+	useTokenSource(t, "resolved-token")
+	var recorded string
+	server, restoreBase := installAuthorizationRecordingReleaseServer(t, &recorded)
+	defer server.Close()
+	defer restoreBase()
+
+	if _, err := fetchDispatcherReleasePage(context.Background(), 1); err != nil {
+		t.Fatalf("fetchDispatcherReleasePage failed: %v", err)
+	}
+	if recorded != "Bearer resolved-token" {
+		t.Fatalf("authorization header mismatch: got %q", recorded)
+	}
+}
+
+// Verifies the release listing stays anonymous when no token is available, instead of sending an empty bearer.
+func TestFetchDispatcherReleasePageOmitsAuthorizationWithoutToken(t *testing.T) {
+	useTokenSource(t, "")
+	var recorded string
+	server, restoreBase := installAuthorizationRecordingReleaseServer(t, &recorded)
+	defer server.Close()
+	defer restoreBase()
+
+	if _, err := fetchDispatcherReleasePage(context.Background(), 1); err != nil {
+		t.Fatalf("fetchDispatcherReleasePage failed: %v", err)
+	}
+	if recorded != "" {
+		t.Fatalf("expected no authorization header, got %q", recorded)
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/main_test.go
+++ b/cli/dispatcher/internal/dispatcher/main_test.go
@@ -1,0 +1,27 @@
+package dispatcher
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hatayama/unity-cli-loop/dispatcher/internal/githubapi"
+)
+
+// Pins the package default to "no token": GitHub API tests here must not read
+// the developer's GITHUB_TOKEN or consult the gh CLI, or whether a request
+// carries an Authorization header would depend on the machine running the tests.
+func TestMain(m *testing.M) {
+	githubapi.DefaultTokenSource = githubapi.StaticTokenSource("")
+	os.Exit(m.Run())
+}
+
+// useTokenSource pins the token every api.github.com call in this package sees,
+// and restores the previous source when the test ends.
+func useTokenSource(t *testing.T, token string) {
+	t.Helper()
+	previous := githubapi.DefaultTokenSource
+	githubapi.DefaultTokenSource = githubapi.StaticTokenSource(token)
+	t.Cleanup(func() {
+		githubapi.DefaultTokenSource = previous
+	})
+}

--- a/cli/dispatcher/internal/githubapi/ratelimit.go
+++ b/cli/dispatcher/internal/githubapi/ratelimit.go
@@ -24,7 +24,7 @@ const (
 
 // tokenNextAction tells the user how to move from the shared anonymous quota
 // to their own authenticated one.
-const tokenNextAction = "Set GH_TOKEN (or GITHUB_TOKEN) to a GitHub token so uloop uses your authenticated API quota, then retry."
+const tokenNextAction = "Set GH_TOKEN (or GITHUB_TOKEN) to a GitHub token, or run `gh auth login` so uloop can use the gh CLI's token, then retry."
 
 // RateLimitError reports that GitHub refused a REST API request because the
 // caller's request quota is exhausted. Anonymous quota is shared by every

--- a/cli/dispatcher/internal/githubapi/token.go
+++ b/cli/dispatcher/internal/githubapi/token.go
@@ -92,7 +92,12 @@ func (r *TokenResolver) resolveFromGhCLI(ctx context.Context) string {
 	if err != nil {
 		return ""
 	}
-	ghCtx, cancel := context.WithTimeout(ctx, ghTokenTimeout)
+	// Why the parent's cancellation is dropped: inheriting it would let the first
+	// caller's context decide the result for the whole process. A canceled ctx, or
+	// one with a deadline shorter than ghTokenTimeout, makes the lookup fail, and
+	// once caches that empty token — every later API request would then go out
+	// anonymously. The five-second bound is the real contract here, and it stays.
+	ghCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), ghTokenTimeout)
 	defer cancel()
 	output, err := r.run(ghCtx, ghPath, "auth", "token")
 	if err != nil {

--- a/cli/dispatcher/internal/githubapi/token.go
+++ b/cli/dispatcher/internal/githubapi/token.go
@@ -1,0 +1,108 @@
+package githubapi
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ghTokenTimeout bounds `gh auth token`: a locked keyring makes gh prompt for a
+// password, which would otherwise hang every uloop command that touches the
+// GitHub API.
+const ghTokenTimeout = 5 * time.Second
+
+// ghExecutableName is looked up rather than executed by name so a missing gh
+// install is detected before a process is started.
+const ghExecutableName = "gh"
+
+// TokenSource yields the bearer token for api.github.com calls, or "" for
+// anonymous requests. It is an interface so tests in other packages can pin a
+// fixed value instead of reading the developer's environment.
+type TokenSource interface {
+	Resolve(ctx context.Context) string
+}
+
+// DefaultTokenSource is shared by every api.github.com caller in the dispatcher
+// so the gh CLI is consulted at most once per process, even though a single
+// `uloop update` resolves both the release list and a tag's commit SHA.
+var DefaultTokenSource TokenSource = NewTokenResolver()
+
+// StaticTokenSource returns the same token on every call. Test-only: it lets
+// other packages pin DefaultTokenSource without reaching into this one.
+type StaticTokenSource string
+
+func (s StaticTokenSource) Resolve(context.Context) string {
+	return string(s)
+}
+
+// TokenResolver finds the GitHub token to authenticate API requests with:
+// GITHUB_TOKEN, then GH_TOKEN, then the token the gh CLI is logged in with.
+// GITHUB_TOKEN wins so CI environments that set both behave consistently, and
+// the environment wins over the gh CLI so an explicit setting is never
+// silently overridden by whichever account gh happens to hold.
+type TokenResolver struct {
+	lookPath func(file string) (string, error)
+	run      func(ctx context.Context, name string, args ...string) ([]byte, error)
+	once     sync.Once
+	token    string
+}
+
+func NewTokenResolver() *TokenResolver {
+	return newTokenResolverWithCommands(exec.LookPath, runCommandOutput)
+}
+
+func newTokenResolverWithCommands(
+	lookPath func(file string) (string, error),
+	run func(ctx context.Context, name string, args ...string) ([]byte, error),
+) *TokenResolver {
+	return &TokenResolver{lookPath: lookPath, run: run}
+}
+
+// runCommandOutput leaves stdin unconnected, so a gh subcommand that wants
+// interactive input is cut off by the deadline instead of waiting on a terminal.
+func runCommandOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).Output()
+}
+
+// Resolve returns the token, or "" when none is available. A missing or
+// unauthenticated gh CLI is an expected condition rather than an error: the
+// caller simply falls back to an anonymous request, which is what uloop did
+// before the gh CLI was consulted at all.
+func (r *TokenResolver) Resolve(ctx context.Context) string {
+	r.once.Do(func() {
+		r.token = r.resolve(ctx)
+	})
+	return r.token
+}
+
+func (r *TokenResolver) resolve(ctx context.Context) string {
+	for _, env := range []string{"GITHUB_TOKEN", "GH_TOKEN"} {
+		if value := os.Getenv(env); value != "" {
+			return value
+		}
+	}
+	return r.resolveFromGhCLI(ctx)
+}
+
+func (r *TokenResolver) resolveFromGhCLI(ctx context.Context) string {
+	ghPath, err := r.lookPath(ghExecutableName)
+	if err != nil {
+		return ""
+	}
+	ghCtx, cancel := context.WithTimeout(ctx, ghTokenTimeout)
+	defer cancel()
+	output, err := r.run(ghCtx, ghPath, "auth", "token")
+	if err != nil {
+		return ""
+	}
+	token := strings.TrimSpace(string(output))
+	// Anything but a single word is not a token; sending broken output as a
+	// bearer credential would turn a missing login into a confusing 401.
+	if token == "" || strings.ContainsAny(token, " \t\r\n") {
+		return ""
+	}
+	return token
+}

--- a/cli/dispatcher/internal/githubapi/token_test.go
+++ b/cli/dispatcher/internal/githubapi/token_test.go
@@ -1,0 +1,159 @@
+package githubapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// failingRun fails the test when the gh CLI is consulted, for cases where an
+// environment token must short-circuit the lookup.
+func failingRun(t *testing.T) func(context.Context, string, ...string) ([]byte, error) {
+	t.Helper()
+	return func(context.Context, string, ...string) ([]byte, error) {
+		t.Fatal("the gh CLI must not be consulted when the environment carries a token")
+		return nil, nil
+	}
+}
+
+func foundGhPath(string) (string, error) {
+	return "/usr/local/bin/gh", nil
+}
+
+// Verifies GITHUB_TOKEN wins over GH_TOKEN so environments that set both behave consistently.
+func TestTokenResolverPrefersGitHubTokenEnv(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "env-primary")
+	t.Setenv("GH_TOKEN", "env-secondary")
+	resolver := newTokenResolverWithCommands(foundGhPath, failingRun(t))
+
+	if token := resolver.Resolve(context.Background()); token != "env-primary" {
+		t.Fatalf("token mismatch: got %q", token)
+	}
+}
+
+// Verifies GH_TOKEN is used when GITHUB_TOKEN is empty.
+func TestTokenResolverFallsBackToGHTokenEnv(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "env-secondary")
+	resolver := newTokenResolverWithCommands(foundGhPath, failingRun(t))
+
+	if token := resolver.Resolve(context.Background()); token != "env-secondary" {
+		t.Fatalf("token mismatch: got %q", token)
+	}
+}
+
+// Verifies an empty environment borrows the token the gh CLI is logged in with, invoking `gh auth token`.
+func TestTokenResolverBorrowsGhCliTokenWhenEnvIsEmpty(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+	var invokedName string
+	var invokedArgs []string
+	resolver := newTokenResolverWithCommands(foundGhPath, func(_ context.Context, name string, args ...string) ([]byte, error) {
+		invokedName = name
+		invokedArgs = args
+		return []byte("gho_fake\n"), nil
+	})
+
+	if token := resolver.Resolve(context.Background()); token != "gho_fake" {
+		t.Fatalf("token mismatch: got %q", token)
+	}
+	if invokedName != "/usr/local/bin/gh" {
+		t.Fatalf("expected the resolved gh path, got %q", invokedName)
+	}
+	if len(invokedArgs) != 2 || invokedArgs[0] != "auth" || invokedArgs[1] != "token" {
+		t.Fatalf("argument mismatch: got %v", invokedArgs)
+	}
+}
+
+// Verifies the gh CLI call is bounded by a deadline so a keyring prompt cannot hang the command.
+func TestTokenResolverBoundsGhWithTimeout(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+	resolver := newTokenResolverWithCommands(foundGhPath, func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("the gh CLI call must carry a deadline")
+			return nil, nil
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 || remaining > ghTokenTimeout {
+			t.Fatalf("deadline out of range: %v", remaining)
+		}
+		return []byte("gho_fake\n"), nil
+	})
+
+	if token := resolver.Resolve(context.Background()); token != "gho_fake" {
+		t.Fatalf("token mismatch: got %q", token)
+	}
+}
+
+// Verifies a machine without the gh CLI installed falls back to anonymous requests.
+func TestTokenResolverReturnsEmptyWhenGhIsMissing(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+	resolver := newTokenResolverWithCommands(
+		func(string) (string, error) { return "", errors.New("not found") },
+		failingRun(t),
+	)
+
+	if token := resolver.Resolve(context.Background()); token != "" {
+		t.Fatalf("expected no token, got %q", token)
+	}
+}
+
+// Verifies a failing `gh auth token` (not logged in, locked keyring) is treated as no token rather than an error.
+func TestTokenResolverReturnsEmptyWhenGhFails(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+	resolver := newTokenResolverWithCommands(foundGhPath, func(context.Context, string, ...string) ([]byte, error) {
+		return nil, errors.New("not logged in")
+	})
+
+	if token := resolver.Resolve(context.Background()); token != "" {
+		t.Fatalf("expected no token, got %q", token)
+	}
+}
+
+// Verifies unexpected multi-line gh output is discarded instead of being sent as a bearer token.
+func TestTokenResolverRejectsMultilineGhOutput(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+	resolver := newTokenResolverWithCommands(foundGhPath, func(context.Context, string, ...string) ([]byte, error) {
+		return []byte("a\nb\n"), nil
+	})
+
+	if token := resolver.Resolve(context.Background()); token != "" {
+		t.Fatalf("expected no token, got %q", token)
+	}
+}
+
+// Verifies the gh CLI is consulted once per process even though several API calls ask for the token.
+func TestTokenResolverResolvesOnce(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+	runCount := 0
+	resolver := newTokenResolverWithCommands(foundGhPath, func(context.Context, string, ...string) ([]byte, error) {
+		runCount++
+		return []byte("gho_fake\n"), nil
+	})
+
+	for range 3 {
+		if token := resolver.Resolve(context.Background()); token != "gho_fake" {
+			t.Fatalf("token mismatch: got %q", token)
+		}
+	}
+	if runCount != 1 {
+		t.Fatalf("expected a single gh invocation, got %d", runCount)
+	}
+}
+
+// Verifies the test-only static source returns exactly what it was configured with.
+func TestStaticTokenSourceReturnsConfiguredToken(t *testing.T) {
+	if token := StaticTokenSource("x").Resolve(context.Background()); token != "x" {
+		t.Fatalf("token mismatch: got %q", token)
+	}
+	if token := StaticTokenSource("").Resolve(context.Background()); token != "" {
+		t.Fatalf("expected no token, got %q", token)
+	}
+}

--- a/cli/dispatcher/internal/githubapi/token_test.go
+++ b/cli/dispatcher/internal/githubapi/token_test.go
@@ -157,3 +157,22 @@ func TestStaticTokenSourceReturnsConfiguredToken(t *testing.T) {
 		t.Fatalf("expected no token, got %q", token)
 	}
 }
+
+// Verifies a canceled caller cannot poison the cached token for the rest of the process.
+func TestTokenResolverIgnoresCallerCancellation(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+	resolver := newTokenResolverWithCommands(foundGhPath, func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("the gh CLI context must not be canceled by the caller: %v", err)
+			return nil, nil
+		}
+		return []byte("gho_fake\n"), nil
+	})
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if token := resolver.Resolve(canceled); token != "gho_fake" {
+		t.Fatalf("token mismatch: got %q", token)
+	}
+}


### PR DESCRIPTION
## Summary
- If you have already run `gh auth login`, uloop now uses that token for its GitHub API calls — no extra environment setup needed.
- That moves the release lookup from the anonymous quota (60 requests/hour, shared by everyone behind the same public IP) to your own authenticated quota, so `uloop update` stops failing behind a shared network.

## User Impact

Before: uloop authenticated `api.github.com` calls only from `GITHUB_TOKEN` / `GH_TOKEN`. Anyone who had signed in with the GitHub CLI was still treated as anonymous, so `uloop update` competed for a per-IP quota that an office network exhausts routinely — and failed, even though a perfectly good token was already sitting in the CLI.

After: with neither variable set, uloop asks the GitHub CLI for its token and uses it. An explicit `GITHUB_TOKEN` / `GH_TOKEN` still wins, so CI and deliberate overrides behave exactly as before.

If the GitHub CLI is not installed, not signed in, or its keyring is locked, that is treated as "no token available" and the request falls back to anonymous — the same behavior as today, with no new warning printed on every command.

## Changes
- One shared token source resolves the token once per process: environment first (`GITHUB_TOKEN`, then `GH_TOKEN`), then `gh auth token`. Both API call sites — the dispatcher release listing and tag-to-commit resolution — use it, so a single `uloop update` that walks both paths consults the GitHub CLI at most once.
- The CLI call is bounded by a five-second deadline and is given no stdin, so a keyring password prompt cannot hang the command. Output that is not a single word is discarded rather than sent as a bearer credential.
- That deadline deliberately does not inherit the caller's cancellation or deadline. Because the result is cached once per process, a caller whose context was already canceled (or shorter than five seconds) would otherwise cache the empty token and send every later API request in the command out anonymously.
- The rate-limit guidance now also mentions `gh auth login` as a way out, next to setting a token.
- Test isolation: both packages pin the token source to "no token" in `TestMain`, so whether a request is reported as authenticated no longer depends on the environment of the machine running the tests.

## Verification
- `scripts/check-go-cli.sh` — exit 0 (format, vet, lint, all Go module tests, dist rebuild).
- New unit tests cover: environment precedence, the CLI fallback (including the exact subcommand invoked), the deadline being present and within bounds, a missing CLI, a failing CLI, malformed multi-line output, and resolving only once across repeated calls.
- New tests assert the resolved token reaches the `Authorization` header on **both** API call sites, and that no header is sent when no token is available.
- A test asserts an already-canceled caller still resolves the token, and it fails if the parent's cancellation is inherited again.
- Confirmed the test isolation actually matters: with the `TestMain` pin disabled and a token exported, the anonymous rate-limit test fails; with the pin in place it passes even with tokens exported (`GITHUB_TOKEN=... GH_TOKEN=... go test -count=1 ./internal/dispatcher/... ./attestation/...`).
- Manual, with both variables cleared and the GitHub CLI signed in: the anonymous quota was measured at `x-ratelimit-remaining: 0` both before and after, yet the development binary's `update` resolved the release and reported "already up to date". An anonymous call could not have succeeded, so the CLI's token was used.
