### PR TITLE
chore: Speed up the three slowest EditMode tests without weakening what they verify

### DIFF
--- a/Assets/Tests/Editor/AsmdefGuidNameMap.cs
+++ b/Assets/Tests/Editor/AsmdefGuidNameMap.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json.Linq;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Resolves asmdef "GUID:xxxx" references to assembly names from a map the caller builds once,
+    /// and exposes the project asmdef enumeration that map is built from.
+    /// Why: the asmdef policy tests used to rebuild the map (or rescan the whole project, Library/
+    /// included) for every single reference, which cost several seconds per test.
+    /// </summary>
+    internal static class AsmdefGuidNameMap
+    {
+        private const string GuidReferencePrefix = "GUID:";
+        private const string MetaGuidKey = "guid:";
+
+        /// <summary>
+        /// Builds the guid to assembly name map from every asmdef under Assets/ and Packages/src/.
+        /// Library/ is deliberately never scanned: it holds no project asmdef sources.
+        /// </summary>
+        internal static Dictionary<string, string> Build()
+        {
+            string[] asmdefPaths = ReadProjectAsmdefPaths();
+            Dictionary<string, string> guidToAssemblyNameMap = new();
+
+            foreach (string asmdefPath in asmdefPaths)
+            {
+                string metaPath = asmdefPath + ".meta";
+                if (!File.Exists(metaPath))
+                {
+                    continue;
+                }
+
+                string guid = ReadMetaGuid(metaPath);
+                if (string.IsNullOrEmpty(guid))
+                {
+                    continue;
+                }
+
+                guidToAssemblyNameMap[guid] = ReadAsmdefName(asmdefPath);
+            }
+
+            return guidToAssemblyNameMap;
+        }
+
+        /// <summary>
+        /// Returns the mapped assembly name, or the raw reference when it is a plain name reference
+        /// or an unknown guid.
+        /// </summary>
+        internal static string Resolve(string reference, Dictionary<string, string> guidToAssemblyNameMap)
+        {
+            if (!reference.StartsWith(GuidReferencePrefix, StringComparison.Ordinal))
+            {
+                return reference;
+            }
+
+            string guid = reference.Substring(GuidReferencePrefix.Length);
+            if (!guidToAssemblyNameMap.ContainsKey(guid))
+            {
+                return reference;
+            }
+
+            return guidToAssemblyNameMap[guid];
+        }
+
+        /// <summary>
+        /// Absolute paths of every asmdef under Assets/ and Packages/src/.
+        /// </summary>
+        internal static string[] ReadProjectAsmdefPaths()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            List<string> asmdefPaths = new();
+            string assetsPath = Path.Combine(projectRoot, "Assets");
+            string packagesSrcPath = Path.Combine(projectRoot, "Packages", "src");
+
+            if (Directory.Exists(assetsPath))
+            {
+                asmdefPaths.AddRange(Directory.GetFiles(assetsPath, "*.asmdef", SearchOption.AllDirectories));
+            }
+
+            if (Directory.Exists(packagesSrcPath))
+            {
+                asmdefPaths.AddRange(Directory.GetFiles(packagesSrcPath, "*.asmdef", SearchOption.AllDirectories));
+            }
+
+            return asmdefPaths.ToArray();
+        }
+
+        /// <summary>
+        /// Assembly name declared by an asmdef, or empty when the file declares none.
+        /// </summary>
+        internal static string ReadAsmdefName(string asmdefPath)
+        {
+            JObject asmdef = JObject.Parse(File.ReadAllText(asmdefPath));
+            return asmdef["name"]?.Value<string>() ?? string.Empty;
+        }
+
+        private static string ReadMetaGuid(string metaPath)
+        {
+            string[] lines = File.ReadAllLines(metaPath);
+
+            foreach (string line in lines)
+            {
+                string trimmedLine = line.Trim();
+                if (!trimmedLine.StartsWith(MetaGuidKey, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                return trimmedLine.Substring(MetaGuidKey.Length).Trim();
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/Assets/Tests/Editor/AsmdefGuidNameMap.cs.meta
+++ b/Assets/Tests/Editor/AsmdefGuidNameMap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 625bf9592bce342de9ccf09c1362b8dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -22,7 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     public class TransformWorkerClientTests
     {
         private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
-        private const int SelfSnapshotConcurrency = 4;
+        private const int SelfSnapshotBatchSize = 16;
         private const string ExpectedListEnumeratorFullName =
             "System.Collections.Generic.List`1/Enumerator<System.Int32>";
 
@@ -498,10 +498,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         /// <summary>
         /// What: a self-snapshot of every .cs file under Assets/Tests/Editor/HotReload/ yields
-        /// Success, empty parseErrors/entries/declarationDriftWarnings, and at least one
-        /// unchanged or skipped method (proves the worker recognized the file), except
-        /// global-using-only files and the reviewed method-less allow-list. Permanent guard
-        /// that identical source never false-patches after the unannotated-baseline fix.
+        /// Success, empty parseErrors/entries/declarationDriftWarnings, no duplicate-key baseline
+        /// fallback, and at least one unchanged or skipped method (proves the worker recognized the
+        /// file), except global-using-only files and the reviewed method-less allow-list. Permanent
+        /// guard that identical source never false-patches after the unannotated-baseline fix.
         /// </summary>
         [Test]
         public async Task Run_WithSelfSnapshotOnHotReloadTestSources_TreatsAllMethodsUnchanged()
@@ -516,33 +516,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(sourcePaths.Length, Is.GreaterThan(0), "Expected at least one HotReload test .cs file.");
 
             // Why warm up first: EnsureWorkerAsync compiles into a shared cache directory on a
-            // miss, and concurrent first-time misses would race on the same output files.
+            // miss, and a first-time miss inside the measured loop would charge the first batch.
             TransformWorkerBootstrapResult bootstrap =
                 await TransformWorkerBootstrap.EnsureWorkerAsync(CancellationToken.None);
             Assert.That(bootstrap.Success, Is.True, "Worker bootstrap failed: " + bootstrap.ErrorMessage);
 
-            // Why bounded concurrency: each file costs one ~0.4 s worker process spawn, and with
-            // ~100 files the sequential version alone took 50 s of the suite. Four in flight keeps
-            // the wall time near 1/4 without starving the Editor main thread, which every run
-            // still hops through for CompilationPipeline and compiler-path lookups.
-            using SemaphoreSlim slots = new SemaphoreSlim(SelfSnapshotConcurrency, SelfSnapshotConcurrency);
-            List<Task<string>> fileChecks = new List<Task<string>>(sourcePaths.Length);
-            foreach (string sourcePath in sourcePaths)
-            {
-                fileChecks.Add(CheckSelfSnapshotTreatsFileUnchangedAsync(Path.GetFullPath(sourcePath), slots));
-            }
+            List<SelfSnapshotSource> sources = CollectSelfSnapshotSources(sourcePaths);
 
-            string[] fileOutcomes = await Task.WhenAll(fileChecks);
-
-            // Why keep source order: the report must list files the same way the sequential loop
-            // did, independent of which worker process happened to finish first.
+            // Why batch, and why sequentially: the worker input carries many sources at once as long
+            // as they share one compiled assembly, which every HotReload test source does. The
+            // resident worker host serializes requests, so only cutting the request count speeds the
+            // run up; running the batches in order also keeps the failure report easy to read.
             List<string> failures = new List<string>();
-            foreach (string fileOutcome in fileOutcomes)
+            for (int start = 0; start < sources.Count; start += SelfSnapshotBatchSize)
             {
-                if (fileOutcome != null)
-                {
-                    failures.Add(fileOutcome);
-                }
+                int batchLength = Math.Min(SelfSnapshotBatchSize, sources.Count - start);
+                List<SelfSnapshotSource> batch = sources.GetRange(start, batchLength);
+                TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(
+                    BuildInputForSelfSnapshotSources(batch),
+                    CancellationToken.None);
+                failures.AddRange(DescribeSelfSnapshotBatchFailures(batch, result));
             }
 
             Assert.That(
@@ -553,97 +546,236 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// Runs the worker on one HotReload test source with itself as the snapshot and returns
-        /// the per-file failure line ("path -> reason; reason"), or null when the file passes or
-        /// has no type declaration.
+        /// Reads every candidate self-snapshot source in directory order, dropping the files that
+        /// declare no type. Why drop them: a global-using-only file has no methods to mark
+        /// unchanged, so the worker correctly emits empty entries/skipped/unchanged for it.
         /// </summary>
-        private static async Task<string> CheckSelfSnapshotTreatsFileUnchangedAsync(
-            string fullPath,
-            SemaphoreSlim slots)
+        private static List<SelfSnapshotSource> CollectSelfSnapshotSources(string[] sourcePaths)
         {
-            string projectRelativePath =
-                "Assets/Tests/Editor/HotReload/" + Path.GetFileName(fullPath);
-            string onDisk = File.ReadAllText(fullPath);
-            // Why skip: a global-using-only file has no methods to mark unchanged; the worker
-            // correctly emits empty entries/skipped/unchanged for it.
-            if (!ContainsTypeDeclaration(onDisk))
+            List<SelfSnapshotSource> sources = new List<SelfSnapshotSource>(sourcePaths.Length);
+            foreach (string sourcePath in sourcePaths)
             {
-                return null;
-            }
+                string fullPath = Path.GetFullPath(sourcePath);
+                string onDisk = File.ReadAllText(fullPath);
+                if (!ContainsTypeDeclaration(onDisk))
+                {
+                    continue;
+                }
 
-            bool isMethodlessTypeAllowListed =
-                IsSelfSnapshotMethodlessTypeAllowListed(Path.GetFileName(fullPath));
-
-            await slots.WaitAsync();
-            TransformWorkerClientResult result;
-            try
-            {
-                result = await RunWorkerOnSourceAsync(
+                string fileName = Path.GetFileName(fullPath);
+                sources.Add(new SelfSnapshotSource(
                     fullPath,
-                    projectRelativePath,
-                    snapshotSource: onDisk);
-            }
-            finally
-            {
-                slots.Release();
+                    "Assets/Tests/Editor/HotReload/" + fileName,
+                    onDisk,
+                    IsSelfSnapshotMethodlessTypeAllowListed(fileName)));
             }
 
-            List<string> fileFailures = DescribeSelfSnapshotFailures(result, isMethodlessTypeAllowListed);
-            if (fileFailures.Count == 0)
-            {
-                return null;
-            }
-
-            return projectRelativePath + " -> " + string.Join("; ", fileFailures);
+            return sources;
         }
 
-        private static List<string> DescribeSelfSnapshotFailures(
-            TransformWorkerClientResult result,
-            bool isMethodlessTypeAllowListed)
+        /// <summary>
+        /// Turns one batch result into per-file failure lines ("path -> reason; reason") in source
+        /// order. A failure that cannot be attributed to a single source fails every file in the
+        /// batch, so a broken run is never reported as a clean one.
+        /// </summary>
+        private static List<string> DescribeSelfSnapshotBatchFailures(
+            List<SelfSnapshotSource> batch,
+            TransformWorkerClientResult result)
         {
-            List<string> fileFailures = new List<string>();
+            List<string> failures = new List<string>();
+            string batchFailure = DescribeSelfSnapshotBatchLevelFailure(batch, result);
+            if (batchFailure != null)
+            {
+                foreach (SelfSnapshotSource source in batch)
+                {
+                    failures.Add(source.ProjectRelativePath + " -> " + batchFailure);
+                }
+
+                return failures;
+            }
+
+            for (int index = 0; index < batch.Count; index++)
+            {
+                List<string> fileFailures =
+                    DescribeSelfSnapshotFailures(batch[index], result.Output, index);
+                if (fileFailures.Count == 0)
+                {
+                    continue;
+                }
+
+                failures.Add(batch[index].ProjectRelativePath + " -> " + string.Join("; ", fileFailures));
+            }
+
+            return failures;
+        }
+
+        /// <summary>
+        /// Returns the reason a whole batch failed, or null when the result can be read per file.
+        /// </summary>
+        private static string DescribeSelfSnapshotBatchLevelFailure(
+            List<SelfSnapshotSource> batch,
+            TransformWorkerClientResult result)
+        {
             if (!result.Success)
             {
-                fileFailures.Add("Success=false: " + result.ErrorMessage);
+                return "batch Success=false: " + result.ErrorMessage;
             }
 
             if (result.Output == null)
             {
-                fileFailures.Add("Output is null");
-                return fileFailures;
+                return "batch Output is null";
             }
 
-            if (result.Output.files[0].parseErrors != null && result.Output.files[0].parseErrors.Length > 0)
+            if (result.Output.parseErrors != null && result.Output.parseErrors.Length > 0)
             {
-                fileFailures.Add(
-                    "parseErrors=[" + string.Join(" | ", result.Output.files[0].parseErrors) + "]");
+                return "batch parseErrors=[" + string.Join(" | ", result.Output.parseErrors) + "]";
             }
 
-            if (result.Output.entries != null && result.Output.entries.Length > 0)
+            if (result.Output.files == null || result.Output.files.Length != batch.Count)
             {
-                fileFailures.Add(
-                    "entries=[" + FormatEntryMethodNames(result.Output.entries) + "]");
+                int fileCount = result.Output.files != null ? result.Output.files.Length : 0;
+                return "batch files count mismatch (expected " + batch.Count + ", got " + fileCount + ")";
             }
 
-            int unchangedCount =
-                result.Output.unchangedMethods != null ? result.Output.unchangedMethods.Length : 0;
-            int skippedCount = result.Output.skipped != null ? result.Output.skipped.Length : 0;
-            if (!isMethodlessTypeAllowListed && unchangedCount + skippedCount < 1)
+            return null;
+        }
+
+        private static List<string> DescribeSelfSnapshotFailures(
+            SelfSnapshotSource source,
+            TransformWorkerOutputDto output,
+            int fileIndex)
+        {
+            List<string> fileFailures = new List<string>();
+            TransformWorkerFileOutputDto file = output.files[fileIndex];
+            if (file.parseErrors != null && file.parseErrors.Length > 0)
+            {
+                fileFailures.Add("parseErrors=[" + string.Join(" | ", file.parseErrors) + "]");
+            }
+
+            TransformWorkerEntryDto[] entries = SelectEntriesForSource(output.entries, source);
+            if (entries.Length > 0)
+            {
+                fileFailures.Add("entries=[" + FormatEntryMethodNames(entries) + "]");
+            }
+
+            int unchangedCount = CountUnchangedMethodsForSource(output.unchangedMethods, source);
+            int skippedCount = CountSkippedForSource(output.skipped, source);
+            if (!source.IsMethodlessTypeAllowListed && unchangedCount + skippedCount < 1)
             {
                 fileFailures.Add(
                     "unchangedMethods+skipped < 1 (unchanged="
                     + unchangedCount + ", skipped=" + skippedCount + ")");
             }
 
-            if (result.Output.files[0].declarationDriftWarnings != null
-                && result.Output.files[0].declarationDriftWarnings.Length > 0)
+            if (file.declarationDriftWarnings != null && file.declarationDriftWarnings.Length > 0)
             {
                 fileFailures.Add(
                     "declarationDriftWarnings=["
-                    + string.Join(" | ", result.Output.files[0].declarationDriftWarnings) + "]");
+                    + string.Join(" | ", file.declarationDriftWarnings) + "]");
+            }
+
+            // Why check this here: a duplicate syntax-method key silently disables the baseline and
+            // turns the run into patch-all, which would make an "entries empty" pass meaningless.
+            if (file.baselineDisabledByDuplicateKeys)
+            {
+                fileFailures.Add("baselineDisabledByDuplicateKeys=true");
             }
 
             return fileFailures;
+        }
+
+        private static TransformWorkerEntryDto[] SelectEntriesForSource(
+            TransformWorkerEntryDto[] entries,
+            SelfSnapshotSource source)
+        {
+            if (entries == null || entries.Length == 0)
+            {
+                return Array.Empty<TransformWorkerEntryDto>();
+            }
+
+            List<TransformWorkerEntryDto> selected = new List<TransformWorkerEntryDto>();
+            foreach (TransformWorkerEntryDto entry in entries)
+            {
+                if (IsRowForSource(entry.sourceProjectRelativePath, source))
+                {
+                    selected.Add(entry);
+                }
+            }
+
+            return selected.ToArray();
+        }
+
+        private static int CountUnchangedMethodsForSource(
+            TransformWorkerUnchangedMethodDto[] unchangedMethods,
+            SelfSnapshotSource source)
+        {
+            if (unchangedMethods == null)
+            {
+                return 0;
+            }
+
+            int count = 0;
+            foreach (TransformWorkerUnchangedMethodDto unchanged in unchangedMethods)
+            {
+                if (IsRowForSource(unchanged.sourceProjectRelativePath, source))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        private static int CountSkippedForSource(
+            TransformWorkerSkippedDto[] skipped,
+            SelfSnapshotSource source)
+        {
+            if (skipped == null)
+            {
+                return 0;
+            }
+
+            int count = 0;
+            foreach (TransformWorkerSkippedDto skippedMethod in skipped)
+            {
+                if (IsRowForSource(skippedMethod.sourceProjectRelativePath, source))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        private static bool IsRowForSource(string sourceProjectRelativePath, SelfSnapshotSource source)
+        {
+            return string.Equals(
+                sourceProjectRelativePath,
+                source.ProjectRelativePath,
+                StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// One HotReload test source checked against itself as its own snapshot.
+        /// </summary>
+        private sealed class SelfSnapshotSource
+        {
+            internal SelfSnapshotSource(
+                string fullPath,
+                string projectRelativePath,
+                string onDiskText,
+                bool isMethodlessTypeAllowListed)
+            {
+                FullPath = fullPath;
+                ProjectRelativePath = projectRelativePath;
+                OnDiskText = onDiskText;
+                IsMethodlessTypeAllowListed = isMethodlessTypeAllowListed;
+            }
+
+            internal string FullPath { get; }
+            internal string ProjectRelativePath { get; }
+            internal string OnDiskText { get; }
+            internal bool IsMethodlessTypeAllowListed { get; }
         }
 
         /// <summary>
@@ -2466,6 +2598,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 changedSiblingSourcePaths = changedSiblingSourcePaths
             };
 
+            return input;
+        }
+
+        /// <summary>
+        /// Builds one worker input covering a whole batch of self-snapshot sources. Valid because
+        /// every HotReload test source compiles into the same test assembly, which is what the
+        /// target dll, references and defines are resolved from.
+        /// </summary>
+        private static TransformWorkerInputDto BuildInputForSelfSnapshotSources(
+            List<SelfSnapshotSource> batchSources)
+        {
+            TransformWorkerInputDto input = BuildInputForSource(
+                batchSources[0].FullPath,
+                batchSources[0].ProjectRelativePath,
+                batchSources[0].OnDiskText);
+
+            TransformWorkerSourceDto[] sources = new TransformWorkerSourceDto[batchSources.Count];
+            for (int index = 0; index < batchSources.Count; index++)
+            {
+                sources[index] = new TransformWorkerSourceDto
+                {
+                    sourcePath = batchSources[index].FullPath,
+                    projectRelativePath = batchSources[index].ProjectRelativePath,
+                    snapshotSource = batchSources[index].OnDiskText
+                };
+            }
+
+            input.sources = sources;
             return input;
         }
 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -631,6 +631,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 return "batch parseErrors=[" + string.Join(" | ", result.Output.parseErrors) + "]";
             }
 
+            // Why judge entries for the whole batch rather than per file: every source in the batch
+            // is its own snapshot, so the run must emit no entry at all. Attributing entries by
+            // sourceProjectRelativePath instead would let an entry carrying an unexpected path shape
+            // belong to no file and slip past the "identical source never false-patches" guard.
+            if (result.Output.entries != null && result.Output.entries.Length > 0)
+            {
+                return "batch entries=[" + FormatEntryMethodNames(result.Output.entries) + "]";
+            }
+
             if (result.Output.files == null || result.Output.files.Length != batch.Count)
             {
                 int fileCount = result.Output.files != null ? result.Output.files.Length : 0;
@@ -650,12 +659,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             if (file.parseErrors != null && file.parseErrors.Length > 0)
             {
                 fileFailures.Add("parseErrors=[" + string.Join(" | ", file.parseErrors) + "]");
-            }
-
-            TransformWorkerEntryDto[] entries = SelectEntriesForSource(output.entries, source);
-            if (entries.Length > 0)
-            {
-                fileFailures.Add("entries=[" + FormatEntryMethodNames(entries) + "]");
             }
 
             int unchangedCount = CountUnchangedMethodsForSource(output.unchangedMethods, source);
@@ -682,27 +685,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             return fileFailures;
-        }
-
-        private static TransformWorkerEntryDto[] SelectEntriesForSource(
-            TransformWorkerEntryDto[] entries,
-            SelfSnapshotSource source)
-        {
-            if (entries == null || entries.Length == 0)
-            {
-                return Array.Empty<TransformWorkerEntryDto>();
-            }
-
-            List<TransformWorkerEntryDto> selected = new List<TransformWorkerEntryDto>();
-            foreach (TransformWorkerEntryDto entry in entries)
-            {
-                if (IsRowForSource(entry.sourceProjectRelativePath, source))
-                {
-                    selected.Add(entry);
-                }
-            }
-
-            return selected.ToArray();
         }
 
         private static int CountUnchangedMethodsForSource(

--- a/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
+++ b/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
@@ -111,7 +111,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void ProjectAsmdefFileNames_WhenLoaded_UseUnityCliLoopName()
         {
             // Tests that tracked asmdef asset filenames no longer expose the legacy project name.
-            string[] legacyFileNames = ReadProjectAsmdefPaths()
+            string[] legacyFileNames = AsmdefGuidNameMap.ReadProjectAsmdefPaths()
                 .Select(Path.GetFileName)
                 .Where(fileName => fileName.IndexOf("uLoopMCP", StringComparison.Ordinal) >= 0)
                 .OrderBy(fileName => fileName)
@@ -124,8 +124,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void ProjectAsmdefNames_WhenLoaded_UseUnityCliLoopName()
         {
             // Tests that tracked asmdef assembly names no longer expose the legacy project name.
-            string[] legacyAssemblyNames = ReadProjectAsmdefPaths()
-                .Select(ReadAsmdefName)
+            string[] legacyAssemblyNames = AsmdefGuidNameMap.ReadProjectAsmdefPaths()
+                .Select(AsmdefGuidNameMap.ReadAsmdefName)
                 .Where(assemblyName => assemblyName.IndexOf("uLoopMCP", StringComparison.Ordinal) >= 0)
                 .OrderBy(assemblyName => assemblyName)
                 .ToArray();
@@ -137,9 +137,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void ProjectAsmdefs_WhenLoaded_AutoReferenceOnlyPublicAssemblies()
         {
             // Tests that internal assemblies require explicit asmdef references while public API assemblies stay reachable.
-            string[] offendingAssemblyNames = ReadProjectAsmdefPaths()
+            string[] offendingAssemblyNames = AsmdefGuidNameMap.ReadProjectAsmdefPaths()
                 .Where(ReadAutoReferencedFromAbsolutePath)
-                .Select(ReadAsmdefName)
+                .Select(AsmdefGuidNameMap.ReadAsmdefName)
                 .Where(assemblyName => !IsPublicAutoReferencedAssembly(assemblyName))
                 .OrderBy(assemblyName => assemblyName)
                 .ToArray();
@@ -153,14 +153,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Tests that assemblies depending on package editor code stay out of player builds.
             HashSet<string> editorOnlyPackageAssemblyNames = ReadProductionPackageAsmdefPaths()
                 .Where(IsEditorOnlyAsmdef)
-                .Select(ReadAsmdefName)
+                .Select(AsmdefGuidNameMap.ReadAsmdefName)
                 .ToHashSet(StringComparer.Ordinal);
 
-            string[] offendingAssemblyNames = ReadProjectAsmdefPaths()
+            Dictionary<string, string> guidToAssemblyName = AsmdefGuidNameMap.Build();
+            string[] offendingAssemblyNames = AsmdefGuidNameMap.ReadProjectAsmdefPaths()
                 .Where(path => !IsUnityIncludeTestsAsmdef(path))
                 .Where(path => !IsEditorOnlyAsmdef(path))
-                .Where(path => ReadResolvedReferencesFromAbsolutePath(path).Any(editorOnlyPackageAssemblyNames.Contains))
-                .Select(ReadAsmdefName)
+                .Where(path => ReadResolvedReferencesFromAbsolutePath(path, guidToAssemblyName)
+                    .Any(editorOnlyPackageAssemblyNames.Contains))
+                .Select(AsmdefGuidNameMap.ReadAsmdefName)
                 .OrderBy(assemblyName => assemblyName)
                 .ToArray();
 
@@ -813,10 +815,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void ProductionAsmdefs_WhenLoaded_DoNotReferenceCompositionRootExceptCompositionRootItself()
         {
             // Tests that composition root dependencies do not leak back into production assemblies.
+            Dictionary<string, string> guidToAssemblyName = AsmdefGuidNameMap.Build();
             string[] offendingAssemblyNames = ReadProductionAsmdefPaths()
-                .Where(path => ReadAsmdefName(path) != CompositionRootAssemblyName)
-                .Where(path => ReadResolvedReferencesFromAbsolutePath(path).Contains(CompositionRootAssemblyName))
-                .Select(ReadAsmdefName)
+                .Where(path => AsmdefGuidNameMap.ReadAsmdefName(path) != CompositionRootAssemblyName)
+                .Where(path => ReadResolvedReferencesFromAbsolutePath(path, guidToAssemblyName)
+                    .Contains(CompositionRootAssemblyName))
+                .Select(AsmdefGuidNameMap.ReadAsmdefName)
                 .OrderBy(assemblyName => assemblyName)
                 .ToArray();
 
@@ -937,9 +941,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void ProjectAsmdefs_WhenLoaded_DoNotReferenceRemovedSharedAssemblyGuid()
         {
             // Tests that removed module asmdefs do not leave stale GUID references in dependent asmdefs.
-            string[] offendingReferences = ReadProjectAsmdefPaths()
+            string[] offendingReferences = AsmdefGuidNameMap.ReadProjectAsmdefPaths()
                 .Where(path => ReadRawReferences(path).Contains(RemovedSharedAssemblyGuidReference))
-                .Select(path => $"{ReadAsmdefName(path)} references removed shared assembly")
+                .Select(path => $"{AsmdefGuidNameMap.ReadAsmdefName(path)} references removed shared assembly")
                 .OrderBy(reference => reference)
                 .ToArray();
 
@@ -1232,7 +1236,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private static string[] ReadResolvedReferences(string relativeAsmdefPath)
         {
             string asmdefPath = Path.Combine(UnityCliLoopPathResolver.GetProjectRoot(), relativeAsmdefPath);
-            return ReadResolvedReferencesFromAbsolutePath(asmdefPath);
+            return ReadResolvedReferencesFromAbsolutePath(asmdefPath, AsmdefGuidNameMap.Build());
         }
 
         private static bool IsPublicAutoReferencedAssembly(string assemblyName)
@@ -1244,15 +1248,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                    string.Equals(assemblyName, PausePointsRuntimeAssemblyName, StringComparison.Ordinal);
         }
 
-        private static string[] ReadResolvedReferencesFromAbsolutePath(string asmdefPath)
+        private static string[] ReadResolvedReferencesFromAbsolutePath(
+            string asmdefPath,
+            Dictionary<string, string> guidToAssemblyName)
         {
-            Dictionary<string, string> guidToAssemblyNameMap = BuildGuidToAssemblyNameMap();
             string[] rawReferences = ReadRawReferences(asmdefPath);
             List<string> resolvedReferences = new();
 
             foreach (string rawReference in rawReferences)
             {
-                resolvedReferences.Add(ResolveReference(rawReference, guidToAssemblyNameMap));
+                resolvedReferences.Add(AsmdefGuidNameMap.Resolve(rawReference, guidToAssemblyName));
             }
 
             return resolvedReferences
@@ -1417,92 +1422,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private static string NormalizeRelativePath(string path)
         {
             return path.Replace(Path.DirectorySeparatorChar, '/');
-        }
-
-        private static Dictionary<string, string> BuildGuidToAssemblyNameMap()
-        {
-            string[] asmdefPaths = ReadProjectAsmdefPaths();
-            Dictionary<string, string> guidToAssemblyNameMap = new();
-
-            foreach (string asmdefPath in asmdefPaths)
-            {
-                string metaPath = asmdefPath + ".meta";
-                if (!File.Exists(metaPath))
-                {
-                    continue;
-                }
-
-                string guid = ReadMetaGuid(metaPath);
-                if (string.IsNullOrEmpty(guid))
-                {
-                    continue;
-                }
-
-                guidToAssemblyNameMap[guid] = ReadAsmdefName(asmdefPath);
-            }
-
-            return guidToAssemblyNameMap;
-        }
-
-        private static string[] ReadProjectAsmdefPaths()
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            List<string> asmdefPaths = new();
-            string assetsPath = Path.Combine(projectRoot, "Assets");
-            string packagesSrcPath = Path.Combine(projectRoot, "Packages", "src");
-
-            if (Directory.Exists(assetsPath))
-            {
-                asmdefPaths.AddRange(Directory.GetFiles(assetsPath, "*.asmdef", SearchOption.AllDirectories));
-            }
-
-            if (Directory.Exists(packagesSrcPath))
-            {
-                asmdefPaths.AddRange(Directory.GetFiles(packagesSrcPath, "*.asmdef", SearchOption.AllDirectories));
-            }
-
-            return asmdefPaths.ToArray();
-        }
-
-        private static string ResolveReference(string reference, Dictionary<string, string> guidToAssemblyNameMap)
-        {
-            const string guidReferencePrefix = "GUID:";
-            if (!reference.StartsWith(guidReferencePrefix))
-            {
-                return reference;
-            }
-
-            string guid = reference.Substring(guidReferencePrefix.Length);
-            if (!guidToAssemblyNameMap.ContainsKey(guid))
-            {
-                return reference;
-            }
-
-            return guidToAssemblyNameMap[guid];
-        }
-
-        private static string ReadMetaGuid(string metaPath)
-        {
-            string[] lines = File.ReadAllLines(metaPath);
-
-            foreach (string line in lines)
-            {
-                string trimmedLine = line.Trim();
-                if (!trimmedLine.StartsWith("guid:"))
-                {
-                    continue;
-                }
-
-                return trimmedLine.Substring("guid:".Length).Trim();
-            }
-
-            return string.Empty;
-        }
-
-        private static string ReadAsmdefName(string asmdefPath)
-        {
-            JObject asmdef = JObject.Parse(File.ReadAllText(asmdefPath));
-            return asmdef["name"]?.Value<string>() ?? string.Empty;
         }
     }
 }

--- a/Assets/Tests/Editor/UnityCliLoopToolRegistryTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopToolRegistryTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -600,7 +601,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             JObject asmdef = JObject.Parse(File.ReadAllText(asmdefPath));
             string[] references = asmdef["references"]?.Values<string>().ToArray() ?? new string[0];
-            return references.Select(ResolveAsmdefReference).ToArray();
+            // Why build once here: resolving each reference on its own used to rescan the whole
+            // project tree per reference, which cost seconds on asmdefs with many references.
+            Dictionary<string, string> guidToAssemblyName = AsmdefGuidNameMap.Build();
+            return references
+                .Select(reference => AsmdefGuidNameMap.Resolve(reference, guidToAssemblyName))
+                .ToArray();
         }
 
         private static void AssertThirdPartyTool(System.Type toolType, bool expected)
@@ -608,32 +614,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(toolType, Is.Not.Null);
             string assemblyName = toolType.Assembly.GetName().Name;
             Assert.That(ToolAssemblyClassifier.IsThirdPartyAssembly(assemblyName), Is.EqualTo(expected));
-        }
-
-        private static string ResolveAsmdefReference(string reference)
-        {
-            const string guidPrefix = "GUID:";
-            if (!reference.StartsWith(guidPrefix, System.StringComparison.Ordinal))
-            {
-                return reference;
-            }
-
-            string guid = reference.Substring(guidPrefix.Length);
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            foreach (string metaPath in Directory.GetFiles(projectRoot, "*.asmdef.meta", SearchOption.AllDirectories))
-            {
-                string meta = File.ReadAllText(metaPath);
-                if (!meta.Contains($"guid: {guid}"))
-                {
-                    continue;
-                }
-
-                string resolvedAsmdefPath = metaPath.Substring(0, metaPath.Length - ".meta".Length);
-                JObject asmdef = JObject.Parse(File.ReadAllText(resolvedAsmdefPath));
-                return asmdef["name"]?.Value<string>() ?? reference;
-            }
-
-            return reference;
         }
 
         [Test]


### PR DESCRIPTION
## Summary

Speeds up the three slowest single EditMode tests without touching production code and without weakening a single assertion. Follow-up to #2634 (full-suite 553 s -> 363 s), which left these three as the heaviest individual tests.

## User Impact

None at runtime. The EditMode suite spends roughly 17 s less on these three tests, so local scoped verification and the scheduled full-suite run finish sooner.

## Changes

**Share one asmdef GUID map across the asmdef policy tests** (`dc075c3ec`)

- New `Assets/Tests/Editor/AsmdefGuidNameMap.cs`: builds the guid -> assembly-name map once and resolves `GUID:xxxx` references against it. The map logic is moved out of `OnionAssemblyDependencyTests`, not rewritten.
- `OnionAssemblyDependencyTests` used to rebuild the whole map for every asmdef it inspected. `ReadResolvedReferencesFromAbsolutePath` now takes the map as a parameter (signature change, no overload) and each test builds it once.
- `UnityCliLoopToolRegistryTests.ResolveAsmdefReference` used to scan the entire project tree — `Library/` included — once per reference. It is gone; `ReadResolvedReferences` builds the map once and resolves against it. The scan is now limited to `Assets/` and `Packages/src/`, where every project asmdef lives.

**Batch the hot reload self-snapshot test into 16-source worker runs** (`5f4ae424e`)

- `Run_WithSelfSnapshotOnHotReloadTestSources_TreatsAllMethodsUnchanged` sent one worker request per HotReload test source (116 requests, four in flight). Since the resident worker host serializes requests, the concurrency no longer bought anything.
- A worker input accepts many sources at once as long as they share one compiled assembly, which every HotReload test source does. Sources are now sent 16 at a time, sequentially, and the result is split back per file through the per-file rows the worker already returns (`files[i]`, plus `sourceProjectRelativePath` on `skipped` / `unchangedMethods`).
- `entries` stays a whole-batch check (`5317b587b`), exactly as before batching: every source in a batch is its own snapshot, so the run must emit no entry at all. Attributing entries per file would let one carrying an unexpected path shape match no file and be reported by nobody. `unchangedMethods` and `skipped` keep per-file attribution because an unattributed row there fails the count check rather than escaping it.
- A failure that cannot be attributed to one source (run-level `parseErrors`, `Success=false`, `files` count mismatch) fails every file in its batch, so a broken run is never read as clean.
- Adds one assertion: `files[i].baselineDisabledByDuplicateKeys` must be false. A duplicate method key silently disables the baseline and turns the run into patch-all, which would make the existing "entries empty" check meaningless. Every file passes it today.

## Verification

All commands single-flight; the unfiltered suite was not run.

```
uloop compile                                             # 0 errors
uloop run-tests --skip-compile --filter-type regex \
  --filter-value 'UnityCliLoopToolRegistryTests|OnionAssemblyDependencyTests'   # 117/117 Passed
uloop run-tests --skip-compile --filter-type class \
  --filter-value <...>.HotReload.TransformWorkerClientTests                     # 55/55 Passed (re-run after 5317b587b)
go run ./cmd/check-file-length --root ../.. --max-length 500                    # no files exceeded
```

### Duration

`run-tests` only writes the NUnit result XML when a test fails, so per-test duration is not readable from a green run. Instead each test was run alone with `--filter-type exact` and timed by wall clock, best of two rounds. Those numbers include a fixed runner round-trip of about 9.5-10 s, measured the same way with a trivial test; the `net` columns subtract it.

Two things about the before column: it was measured on the local `main` checkout at `0adfbb2bb`, two commits behind this branch's base, and neither of those commits touches the three tests, which are byte-identical there. And the trivial test used for the runner-overhead row does not exist at `0adfbb2bb` (it arrives with #2487), so the `main` overhead row is the cost of a round trip that ran no test at all — a lower bound on the real fixed cost, which only makes the before column conservative.

| Test | before (full-suite XML, #2634 run) | before (main, solo wall clock / net) | after (branch, solo wall clock / net) |
| --- | --- | --- | --- |
| `TransformWorkerClientTests.Run_WithSelfSnapshotOnHotReloadTestSources_TreatsAllMethodsUnchanged` | 10.83 s | 22.57 s / ~13.0 s | 12.48 s / ~2.5 s |
| `UnityCliLoopToolRegistryTests.FirstPartyToolsAsmdef_DoesNotReferenceImplementationLayers` | 4.15 s | 15.13 s / ~5.6 s | 10.15 s / ~0.2 s |
| `OnionAssemblyDependencyTests.ProductionAsmdefs_WhenLoaded_DoNotReferenceCompositionRootExceptCompositionRootItself` | 2.68 s | 13.20 s / ~3.7 s | 10.06 s / ~0.1 s |
| runner fixed overhead (trivial test, same conditions) | - | 9.54 s (round trip only; test not present) | 9.96 s |

Roughly 17.7 s -> 2.8 s across the three.

Out of scope, as planned: `RunTestsUnfilteredTestListRetrieverTests.RetrieveAsync_WhenEditModeCatalogIsAvailable_IncludesKnownLeafFullName` (4.71 s). Its cost is `TestRunnerApi.RetrieveTestList` enumerating the whole catalog, which the test cannot avoid.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




