### PR TITLE
chore: Keep the hot reload call-site cache tests from failing on file systems with sub-microsecond timestamps

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadCompiledCallSiteCacheTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCompiledCallSiteCacheTests.cs
@@ -23,6 +23,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         // Why this assembly: it is always compiled alongside the test assembly and is smaller, so
         // it can be zero-padded to the test assembly's length for the module identity test.
         private const string OtherAssemblyName = "UnityCLILoop.Tests.Editor.HotReload.CallSiteCrossAssembly";
+        // Why a write time the test chooses: SetLastWriteTimeUtc stores microseconds while
+        // GetLastWriteTimeUtc reports 100 ns ticks, so a write time read back from a file cannot be
+        // restored exactly unless it happens to fall on a microsecond. Tests that restore the write
+        // time to isolate another field would otherwise leave it shifted by a few ticks.
+        private static readonly DateTime PinnedWriteTimeUtc = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         private string _tempDirectory;
         private HotReloadCompiledCallSiteCache _cache;
@@ -354,6 +359,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             string destinationPath = Path.Combine(_tempDirectory, fileName);
             File.Copy(sourceDllPath, destinationPath);
+            File.SetLastWriteTimeUtc(destinationPath, PinnedWriteTimeUtc);
+            Assert.That(
+                File.GetLastWriteTimeUtc(destinationPath),
+                Is.EqualTo(PinnedWriteTimeUtc),
+                "The copy's write time must be settable exactly, or restoring it later shifts the fingerprint.");
             return destinationPath;
         }
     }


### PR DESCRIPTION
## Summary
- The scheduled full EditMode suite is green again: the hot reload call-site cache test that failed on every Linux editor now passes.

## User Impact
- Before: the nightly suite failed on all three Linux editors with a single test, `GetOrLoad_RewrittenIdenticalBytesSameWriteTime_ReusesEntry`, while the same test passed on the machine it was written on. A permanently red nightly hides real regressions.
- After: the suite passes on every editor it runs, so a red nightly means something actually broke.

## Cause
The cache treats a dll as unchanged while its length, last write time, and module version id all match. The test copied a dll, remembered its write time, rewrote the same bytes, restored that write time, and expected the cache to serve the same entry.

Restoring is not exact. The last write time is stored with microsecond resolution and read back with 100 ns ticks, so a value that does not fall on a microsecond comes back a few ticks earlier than it was read. The cache then saw a different write time and reloaded. Whether this happens depends on the timestamp the compiler happened to leave on the dll: on the Linux CI images it never fell on a microsecond, so the test failed deterministically there and passed elsewhere.

The cache itself is correct — treating a different write time as a changed file is the intended behaviour, and nothing in the product restores timestamps. The faulty assumption lived in the test.

## Changes
- Each test copy is given a write time the test chooses, on a whole second, and the fixture asserts it was stored exactly. Restoring that value later is then exact on any file system.
- The three tests that restore the write time to isolate the size check, the module identity check, and the retry path now really hold it constant, instead of passing only because the assertion they make happens to survive a shifted timestamp.

## Verification
- Confirmed the cause on CI rather than by inference: a temporary commit asserted length, write time, and module version id separately, and the Linux run named the write time as the only field that differed. That commit is not part of this pull request.
- Full EditMode suite dispatched on this branch: https://github.com/hatayama/unity-cli-loop/actions/runs/34077433572 — all editors pass.
  - 2022.3.62f3: 4206/4216, skipped 10
  - 6000.3.15f1: 876/876
  - 6000.5.8f1: 876/876
  - latest 6000.7: passed on rerun. Its first attempt was killed by the runner during editor startup, before any test ran, and the same job passed on an earlier dispatch of this branch.
- Locally: the affected test class passes 11/11 on 2022.3.62f3.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

