### PR TITLE
fix: find-game-objects and replay-input now document their option values in lowercase like the other single-word options

### DIFF
--- a/.agents/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.agents/skills/uloop-execute-dynamic-code/SKILL.md
@@ -8,7 +8,7 @@ description: "Execute C# with Unity APIs when existing uloop tools cannot inspec
 
 Run focused C# snippets in the active Unity Editor with `uloop execute-dynamic-code`.
 
-For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode Selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
+For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
 
 This tool can inspect reachable Unity state — GameObjects, components, public properties, static values, method results — but it cannot read local variables or intermediate calculations inside an already-running method. When those values matter, follow the `uloop-pause-point` skill: a pause point's `CapturedVariables` carries the locals, parameters, and instance fields at that line with no code edit or recompile, and while Unity stays paused `UloopPausePoint.TryGetCapturedValue(name)` gives this tool live captured references. That skill also covers the reverse combination — registering an `EditorApplication.update` watcher from this tool that freezes Unity on the first frame a runtime condition holds. Never poll or sleep inside a snippet; the body runs synchronously on the main thread.
 

--- a/.agents/skills/uloop-find-game-objects/SKILL.md
+++ b/.agents/skills/uloop-find-game-objects/SKILL.md
@@ -21,7 +21,7 @@ uloop find-game-objects [options]
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--name-pattern` | string | - | Name pattern to search |
-| `--search-mode` | string | `Exact` | Search mode: `Exact`, `Path`, `Regex`, `Contains`, `Selected` |
+| `--search-mode` | string | `exact` | Search mode: `exact`, `path`, `regex`, `contains`, `selected` |
 | `--required-components` | array | - | Required components |
 | `--tag` | string | - | Tag filter |
 | `--layer` | integer | - | Layer filter (layer number) |
@@ -33,11 +33,11 @@ uloop find-game-objects [options]
 
 | Mode | Description |
 |------|-------------|
-| `Exact` | Exact name match (default). **Trap**: `--name-pattern "Camera"` will not match a GameObject named `"Main Camera"` — use `Contains` or `Regex` for partial matching. A zero-hit `Exact` search returns a `Message` hint pointing this out. |
-| `Path` | Hierarchy path search (e.g., `Canvas/Button`) |
-| `Regex` | Regular expression pattern |
-| `Contains` | Partial name match |
-| `Selected` | Get currently selected GameObjects in Unity Editor |
+| `exact` | Exact name match (default). **Trap**: `--name-pattern "Camera"` will not match a GameObject named `"Main Camera"` — use `contains` or `regex` for partial matching. A zero-hit `exact` search returns a `Message` hint pointing this out. |
+| `path` | Hierarchy path search (e.g., `Canvas/Button`) |
+| `regex` | Regular expression pattern |
+| `contains` | Partial name match |
+| `selected` | Get currently selected GameObjects in Unity Editor |
 
 ## Output
 
@@ -56,9 +56,9 @@ Returns JSON with:
 
 ### Multi-selection file export
 
-For `Selected` mode with **multiple** successfully serialized GameObjects, inline `Results` is not populated and the data is written to a file instead. Two extra fields appear:
+For `selected` mode with **multiple** successfully serialized GameObjects, inline `Results` is not populated and the data is written to a file instead. Two extra fields appear:
 
 - `ResultsFilePath` (string): Relative path under `.uloop/outputs/FindGameObjectsResults/`
 - `Message` (string): Human-readable summary (e.g., "5 GameObjects exported")
 
-Single-selection and search-mode calls (`Exact`, `Path`, `Regex`, `Contains`) always return inline. No selection (`Selected` mode with empty selection) returns empty `Results` plus a `Message`.
+Single-selection and search-mode calls (`exact`, `path`, `regex`, `contains`) always return inline. No selection (`selected` mode with empty selection) returns empty `Results` plus a `Message`.

--- a/.agents/skills/uloop-get-hierarchy/SKILL.md
+++ b/.agents/skills/uloop-get-hierarchy/SKILL.md
@@ -8,7 +8,7 @@ description: "Get the Unity scene hierarchy as a structured tree. Use for parent
 
 Get Unity Hierarchy structure from the whole scene, a root path, or selected Hierarchy objects.
 
-Use this for hierarchy structure, especially descendants under the current selection. Use `find-game-objects --search-mode Selected` when you need selected object details or component properties.
+Use this for hierarchy structure, especially descendants under the current selection. Use `find-game-objects --search-mode selected` when you need selected object details or component properties.
 
 ## Usage
 

--- a/.agents/skills/uloop-replay-input/SKILL.md
+++ b/.agents/skills/uloop-replay-input/SKILL.md
@@ -14,26 +14,26 @@ Create recording JSON files in the Unity Editor from **Window > Unity CLI Loop >
 
 ```bash
 # Start replay (auto-detect latest recording)
-uloop replay-input --action Start
+uloop replay-input --action start
 
 # Start replay with specific file
-uloop replay-input --action Start --input-path scripts/my-play.json
+uloop replay-input --action start --input-path scripts/my-play.json
 
 # Start replay with looping
-uloop replay-input --action Start --loop
+uloop replay-input --action start --loop
 
 # Check replay progress
-uloop replay-input --action Status
+uloop replay-input --action status
 
 # Stop replay
-uloop replay-input --action Stop
+uloop replay-input --action stop
 ```
 
 ## Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--action` | enum | `Start` | `Start` - begin replaying, `Stop` - stop mid-way, `Status` - check progress |
+| `--action` | enum | `start` | `start` - begin replaying, `stop` - stop mid-way, `status` - check progress |
 | `--input-path` | string | auto | Path to the recording JSON. When empty, auto-detects the latest recording in `.uloop/outputs/InputRecordings/` |
 | `--no-show-overlay` | flag | - | Hide replay progress overlay |
 | `--loop` | flag | - | Loop continuously |
@@ -53,8 +53,8 @@ Returns JSON with:
 
 - `Success`: Whether the operation succeeded
 - `Message`: Status message
-- `Action`: Echoes which action was executed (`Start`, `Stop`, or `Status`)
-- `InputPath`: Path to recording file (nullable string; populated on `Start` only)
+- `Action`: Echoes which action was executed (`start`, `stop`, or `status`)
+- `InputPath`: Path to recording file (nullable string; populated on `start` only)
 - `CurrentFrame`: Current replay frame index (nullable int)
 - `TotalFrames`: Total frames in the recording (nullable int)
 - `Progress`: Replay progress (nullable float in 0.0 – 1.0)

--- a/.claude/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.claude/skills/uloop-execute-dynamic-code/SKILL.md
@@ -8,7 +8,7 @@ description: "Execute C# with Unity APIs when existing uloop tools cannot inspec
 
 Run focused C# snippets in the active Unity Editor with `uloop execute-dynamic-code`.
 
-For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode Selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
+For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
 
 This tool can inspect reachable Unity state — GameObjects, components, public properties, static values, method results — but it cannot read local variables or intermediate calculations inside an already-running method. When those values matter, follow the `uloop-pause-point` skill: a pause point's `CapturedVariables` carries the locals, parameters, and instance fields at that line with no code edit or recompile, and while Unity stays paused `UloopPausePoint.TryGetCapturedValue(name)` gives this tool live captured references. That skill also covers the reverse combination — registering an `EditorApplication.update` watcher from this tool that freezes Unity on the first frame a runtime condition holds. Never poll or sleep inside a snippet; the body runs synchronously on the main thread.
 

--- a/.claude/skills/uloop-find-game-objects/SKILL.md
+++ b/.claude/skills/uloop-find-game-objects/SKILL.md
@@ -21,7 +21,7 @@ uloop find-game-objects [options]
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--name-pattern` | string | - | Name pattern to search |
-| `--search-mode` | string | `Exact` | Search mode: `Exact`, `Path`, `Regex`, `Contains`, `Selected` |
+| `--search-mode` | string | `exact` | Search mode: `exact`, `path`, `regex`, `contains`, `selected` |
 | `--required-components` | array | - | Required components |
 | `--tag` | string | - | Tag filter |
 | `--layer` | integer | - | Layer filter (layer number) |
@@ -33,11 +33,11 @@ uloop find-game-objects [options]
 
 | Mode | Description |
 |------|-------------|
-| `Exact` | Exact name match (default). **Trap**: `--name-pattern "Camera"` will not match a GameObject named `"Main Camera"` — use `Contains` or `Regex` for partial matching. A zero-hit `Exact` search returns a `Message` hint pointing this out. |
-| `Path` | Hierarchy path search (e.g., `Canvas/Button`) |
-| `Regex` | Regular expression pattern |
-| `Contains` | Partial name match |
-| `Selected` | Get currently selected GameObjects in Unity Editor |
+| `exact` | Exact name match (default). **Trap**: `--name-pattern "Camera"` will not match a GameObject named `"Main Camera"` — use `contains` or `regex` for partial matching. A zero-hit `exact` search returns a `Message` hint pointing this out. |
+| `path` | Hierarchy path search (e.g., `Canvas/Button`) |
+| `regex` | Regular expression pattern |
+| `contains` | Partial name match |
+| `selected` | Get currently selected GameObjects in Unity Editor |
 
 ## Output
 
@@ -56,9 +56,9 @@ Returns JSON with:
 
 ### Multi-selection file export
 
-For `Selected` mode with **multiple** successfully serialized GameObjects, inline `Results` is not populated and the data is written to a file instead. Two extra fields appear:
+For `selected` mode with **multiple** successfully serialized GameObjects, inline `Results` is not populated and the data is written to a file instead. Two extra fields appear:
 
 - `ResultsFilePath` (string): Relative path under `.uloop/outputs/FindGameObjectsResults/`
 - `Message` (string): Human-readable summary (e.g., "5 GameObjects exported")
 
-Single-selection and search-mode calls (`Exact`, `Path`, `Regex`, `Contains`) always return inline. No selection (`Selected` mode with empty selection) returns empty `Results` plus a `Message`.
+Single-selection and search-mode calls (`exact`, `path`, `regex`, `contains`) always return inline. No selection (`selected` mode with empty selection) returns empty `Results` plus a `Message`.

--- a/.claude/skills/uloop-get-hierarchy/SKILL.md
+++ b/.claude/skills/uloop-get-hierarchy/SKILL.md
@@ -8,7 +8,7 @@ description: "Get the Unity scene hierarchy as a structured tree. Use for parent
 
 Get Unity Hierarchy structure from the whole scene, a root path, or selected Hierarchy objects.
 
-Use this for hierarchy structure, especially descendants under the current selection. Use `find-game-objects --search-mode Selected` when you need selected object details or component properties.
+Use this for hierarchy structure, especially descendants under the current selection. Use `find-game-objects --search-mode selected` when you need selected object details or component properties.
 
 ## Usage
 

--- a/.claude/skills/uloop-replay-input/SKILL.md
+++ b/.claude/skills/uloop-replay-input/SKILL.md
@@ -14,26 +14,26 @@ Create recording JSON files in the Unity Editor from **Window > Unity CLI Loop >
 
 ```bash
 # Start replay (auto-detect latest recording)
-uloop replay-input --action Start
+uloop replay-input --action start
 
 # Start replay with specific file
-uloop replay-input --action Start --input-path scripts/my-play.json
+uloop replay-input --action start --input-path scripts/my-play.json
 
 # Start replay with looping
-uloop replay-input --action Start --loop
+uloop replay-input --action start --loop
 
 # Check replay progress
-uloop replay-input --action Status
+uloop replay-input --action status
 
 # Stop replay
-uloop replay-input --action Stop
+uloop replay-input --action stop
 ```
 
 ## Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--action` | enum | `Start` | `Start` - begin replaying, `Stop` - stop mid-way, `Status` - check progress |
+| `--action` | enum | `start` | `start` - begin replaying, `stop` - stop mid-way, `status` - check progress |
 | `--input-path` | string | auto | Path to the recording JSON. When empty, auto-detects the latest recording in `.uloop/outputs/InputRecordings/` |
 | `--no-show-overlay` | flag | - | Hide replay progress overlay |
 | `--loop` | flag | - | Loop continuously |
@@ -53,8 +53,8 @@ Returns JSON with:
 
 - `Success`: Whether the operation succeeded
 - `Message`: Status message
-- `Action`: Echoes which action was executed (`Start`, `Stop`, or `Status`)
-- `InputPath`: Path to recording file (nullable string; populated on `Start` only)
+- `Action`: Echoes which action was executed (`start`, `stop`, or `status`)
+- `InputPath`: Path to recording file (nullable string; populated on `start` only)
 - `CurrentFrame`: Current replay frame index (nullable int)
 - `TotalFrames`: Total frames in the recording (nullable int)
 - `Progress`: Replay progress (nullable float in 0.0 – 1.0)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,12 @@ runner, pin, protocol version, skill, and pause point all have exact meanings th
 internal identifier conflicts with the glossary, rename the identifier; when a public one does,
 keep it and record the mismatch in the glossary instead.
 
+Enum-valued CLI parameters keep the casing of the C# enum member behind them. Members that
+name a Unity concept keep Unity's spelling (`EditMode`, `KeyDown`, `GameView`); an enum whose
+members are all single-word CLI-own values uses lowercase members (`start`, `low`, `exact`);
+an enum with any multi-word or Unity-derived member keeps PascalCase throughout. Go-only
+options use lowercase kebab-case. Rules and rationale: `docs/adr/0006-enum-value-casing.md`.
+
 Comments in the code, commit messages, PR titles, and PR descriptions must all be written in English.
 
 Every test method must have a short comment that states what behavior the test verifies.

--- a/Assets/Editor/FindGameObjects/FindGameObjectsTestMenu.cs
+++ b/Assets/Editor/FindGameObjects/FindGameObjectsTestMenu.cs
@@ -62,7 +62,7 @@ namespace io.github.hatayama.UnityCliLoop.Dev
             // Search for Main Camera by path
             JObject parameters = new()            {
                 ["NamePattern"] = "Main Camera",
-                ["SearchMode"] = "Path",
+                ["SearchMode"] = "path",
                 ["MaxCount"] = 1
             };
             

--- a/Assets/Tests/Demo/scripts/verify-replay-via-cli.sh
+++ b/Assets/Tests/Demo/scripts/verify-replay-via-cli.sh
@@ -197,14 +197,14 @@ wait_for_unity
 echo "[7/8] Activating controller + starting replay via CLI..."
 activate_for_replay
 echo "  Starting replay of the latest Recordings window file..."
-REPLAY_RESULT=$(run_uloop replay-input --action Start 2>&1) || true
+REPLAY_RESULT=$(run_uloop replay-input --action start 2>&1) || true
 echo "  $REPLAY_RESULT"
 
 echo "  Waiting for replay to finish..."
 sleep 2
 waited=0
 while [ $waited -lt 60 ]; do
-    STATUS_RESULT=$(run_uloop replay-input --action Status 2>&1) || true
+    STATUS_RESULT=$(run_uloop replay-input --action status 2>&1) || true
     playing=$(echo "$STATUS_RESULT" | grep -o '"IsReplaying": *[a-z]*' | sed 's/.*: *//')
     if [ "$playing" = "false" ]; then
         echo "  Replay completed."

--- a/Assets/Tests/Editor/CaseInsensitiveStringEnumConverterTests.cs
+++ b/Assets/Tests/Editor/CaseInsensitiveStringEnumConverterTests.cs
@@ -21,6 +21,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(schema.Action, Is.EqualTo(PlayModeAction.Play));
         }
 
+        // Locks the legacy PascalCase spelling for enums whose members are now lowercase, so scripts
+        // written against the old documented form keep working (ADR 0006).
+        [Test]
+        public void Deserialize_SearchMode_AcceptsLegacyPascalCaseValue()
+        {
+            JObject token = JObject.Parse("{\"searchMode\":\"Contains\"}");
+
+            FindGameObjectsSchema schema = token.ToObject<FindGameObjectsSchema>(
+                UnityCliLoopToolParameterSerializer.CamelCaseSerializer);
+
+            Assert.That(schema.SearchMode, Is.EqualTo(SearchMode.contains));
+        }
+
         // Verifies invalid enum values surface the allowed action names in the error.
         [Test]
         public void Deserialize_PlayModeAction_InvalidValue_ListsValidValues()

--- a/Assets/Tests/Editor/FindGameObjectsToolTests.cs
+++ b/Assets/Tests/Editor/FindGameObjectsToolTests.cs
@@ -53,7 +53,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Arrange
             JObject paramsJson = new()            {
                 ["NamePattern"] = "TestObject",
-                ["SearchMode"] = "Contains"
+                ["SearchMode"] = "contains"
             };
             
             // Act
@@ -97,7 +97,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Contains/Regex, since Exact is the default and silently misses partial matches.
             JObject paramsJson = new()            {
                 ["NamePattern"] = "Camera",
-                ["SearchMode"] = "Exact"
+                ["SearchMode"] = "exact"
             };
 
             UnityCliLoopToolResponse baseResponse = await tool.ExecuteAsync(paramsJson, System.Threading.CancellationToken.None);
@@ -117,7 +117,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // already support partial matching and have no equivalent trap to warn about.
             JObject paramsJson = new()            {
                 ["NamePattern"] = "NoSuchObjectNameAtAll",
-                ["SearchMode"] = "Contains"
+                ["SearchMode"] = "contains"
             };
 
             UnityCliLoopToolResponse baseResponse = await tool.ExecuteAsync(paramsJson, System.Threading.CancellationToken.None);
@@ -134,7 +134,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies the hint only appears on a zero-hit result, not alongside real matches.
             JObject paramsJson = new()            {
                 ["NamePattern"] = "TestObject1",
-                ["SearchMode"] = "Exact"
+                ["SearchMode"] = "exact"
             };
 
             UnityCliLoopToolResponse baseResponse = await tool.ExecuteAsync(paramsJson, System.Threading.CancellationToken.None);
@@ -212,7 +212,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             
             JObject paramsJson = new()            {
                 ["NamePattern"] = "TestObject|AnotherObject",
-                ["SearchMode"] = "Regex",
+                ["SearchMode"] = "regex",
                 ["Tag"] = "Untagged"
             };
             
@@ -279,7 +279,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             
             JObject paramsJson = new()            {
                 ["NamePattern"] = "Enemy\\d+",
-                ["SearchMode"] = "Regex"
+                ["SearchMode"] = "regex"
             };
             
             try
@@ -316,7 +316,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             
             JObject paramsJson = new()            {
                 ["NamePattern"] = "Object",
-                ["SearchMode"] = "Contains",
+                ["SearchMode"] = "contains",
                 ["IncludeInactive"] = true
             };
             
@@ -344,7 +344,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             
             JObject paramsJson = new()            {
                 ["NamePattern"] = "Object",
-                ["SearchMode"] = "Contains",
+                ["SearchMode"] = "contains",
                 ["IncludeInactive"] = false
             };
             
@@ -371,7 +371,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             
             JObject paramsJson = new()            {
                 ["NamePattern"] = "Object",
-                ["SearchMode"] = "Contains",
+                ["SearchMode"] = "contains",
                 ["RequiredComponents"] = new JArray { "BoxCollider" },
                 ["Layer"] = 8
             };
@@ -404,7 +404,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             
             JObject paramsJson = new()            {
                 ["NamePattern"] = "ManyObject",
-                ["SearchMode"] = "Contains",
+                ["SearchMode"] = "contains",
                 ["MaxCount"] = 5
             };
             
@@ -447,7 +447,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             
             JObject paramsJson = new()            {
                 ["NamePattern"] = "Parent/Child/Grandchild",
-                ["SearchMode"] = "Path"
+                ["SearchMode"] = "path"
             };
             
             try
@@ -479,7 +479,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             
             JObject paramsJson = new()            {
                 ["NamePattern"] = "ExactName",
-                ["SearchMode"] = "Exact"
+                ["SearchMode"] = "exact"
             };
             
             try
@@ -512,7 +512,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             JObject paramsJson = new()            {
                 ["NamePattern"] = "TestObject",
-                ["SearchMode"] = "Contains"
+                ["SearchMode"] = "contains"
             };
 
             try
@@ -546,7 +546,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Selection.objects = new Object[0];
 
             JObject paramsJson = new()            {
-                ["SearchMode"] = "Selected"
+                ["SearchMode"] = "selected"
             };
 
             // Act
@@ -568,7 +568,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Selection.objects = new Object[] { testObject1 };
 
             JObject paramsJson = new()            {
-                ["SearchMode"] = "Selected"
+                ["SearchMode"] = "selected"
             };
 
             try
@@ -598,7 +598,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Selection.objects = new Object[] { testObject1, testObject2 };
 
             JObject paramsJson = new()            {
-                ["SearchMode"] = "Selected"
+                ["SearchMode"] = "selected"
             };
 
             try
@@ -639,7 +639,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Selection.objects = new Object[] { testObject1, testObject2 };
 
             JObject paramsJson = new()            {
-                ["SearchMode"] = "Selected",
+                ["SearchMode"] = "selected",
                 ["IncludeInactive"] = false
             };
 
@@ -674,7 +674,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             JObject paramsJson = new()            {
                 ["NamePattern"] = "TestObject1",
-                ["SearchMode"] = "Exact"
+                ["SearchMode"] = "exact"
             };
 
             try
@@ -718,7 +718,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             JObject paramsJson = new()            {
                 ["NamePattern"] = "TestObject1",
-                ["SearchMode"] = "Exact"
+                ["SearchMode"] = "exact"
             };
 
             // Act
@@ -764,7 +764,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Selection.objects = new Object[] { testObject1, testObject2 };
 
             JObject paramsJson = new()            {
-                ["SearchMode"] = "Selected",
+                ["SearchMode"] = "selected",
                 ["IncludeInactive"] = true
             };
 

--- a/Assets/Tests/Editor/PausePointPreflightRejectionResponseTests.cs
+++ b/Assets/Tests/Editor/PausePointPreflightRejectionResponseTests.cs
@@ -121,7 +121,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Verifies replay-input's preflight rejection response sets the flag and names the marker.
             ReplayInputResponse response = ReplayInputResponseFactory.PreflightRejectedResult(
-                ReplayInputAction.Start,
+                ReplayInputAction.start,
                 PlayModeToolPreflightResult.FailureRejectedByPausePoint("PlayMode is paused.", "marker"));
 
             Assert.That(response.RejectedBeforeExecution, Is.True);
@@ -178,7 +178,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // ExecuteStart is private, so Start is driven through the public ReplayInputAsync.
             ReplayInputResponse response = RunToCompletion(
                 new ReplayInputUseCase().ReplayInputAsync(
-                    new ReplayInputSchema { Action = ReplayInputAction.Start },
+                    new ReplayInputSchema { Action = ReplayInputAction.start },
                     CancellationToken.None));
 
             Assert.That(response.Success, Is.False);

--- a/Packages/src/Documentation~/tools.md
+++ b/Packages/src/Documentation~/tools.md
@@ -86,7 +86,7 @@ Retrieve objects and examine component parameters. Also retrieve information abo
 → find-game-objects (RequiredComponents: ["Camera"])
 → Investigate Camera component parameters
 
-→ find-game-objects (SearchMode: "Selected")
+→ find-game-objects (SearchMode: "selected")
 → Get detailed information about currently selected GameObjects in Unity Editor (supports multiple selection)
 ```
 
@@ -206,10 +206,10 @@ Supports 3 actions: Press (one-shot tap or timed hold), KeyDown (hold key down),
 Replay recorded keyboard and mouse input during PlayMode. Loads a JSON recording and injects input frame-by-frame via Input System. Supports looping and progress monitoring. This tool is available only when the Input System package is installed. Create recording files first in the Unity Editor from **Window > Unity CLI Loop > Recordings** using **Start Recording** and **Stop Recording**. There is no CLI command for recording input.
 
 ```text
-→ replay-input (Action: Start)
-→ replay-input (Action: Start, InputPath: "scripts/my-play.json", Loop: true)
-→ replay-input (Action: Status)
-→ replay-input (Action: Stop)
+→ replay-input (Action: start)
+→ replay-input (Action: start, InputPath: "scripts/my-play.json", Loop: true)
+→ replay-input (Action: status)
+→ replay-input (Action: stop)
 ```
 
 Terminal-driven E2E coverage is available through one runner per shell family:

--- a/Packages/src/Documentation~/tools_ja.md
+++ b/Packages/src/Documentation~/tools_ja.md
@@ -86,7 +86,7 @@ log検索時、ノイズのとなるlogをクリアする事ができます。
 → find-game-objects (RequiredComponents: ["Camera"])
 → Cameraコンポーネントのパラメータを調査
 
-→ find-game-objects (SearchMode: "Selected")
+→ find-game-objects (SearchMode: "selected")
 → Unity Editorで選択中のGameObjectの詳細情報を取得（複数選択対応）
 ```
 
@@ -206,10 +206,10 @@ Input System経由でPlayMode中のキーボード入力をシミュレーショ
 記録されたキーボード・マウス入力をPlayMode中に再生します。JSON記録を読み込み、Input System経由でフレーム単位で入力を注入します。ループ再生と進捗モニタリングに対応しています。このツールは Input System パッケージ導入時のみ利用可能です。記録ファイルは、まず Unity Editor の **Window > Unity CLI Loop > Recordings** で **Start Recording** と **Stop Recording** を使って作成します。CLI に記録コマンドはありません。
 
 ```text
-→ replay-input (Action: Start)
-→ replay-input (Action: Start, InputPath: "scripts/my-play.json", Loop: true)
-→ replay-input (Action: Status)
-→ replay-input (Action: Stop)
+→ replay-input (Action: start)
+→ replay-input (Action: start, InputPath: "scripts/my-play.json", Loop: true)
+→ replay-input (Action: status)
+→ replay-input (Action: stop)
 ```
 
 terminal から uloop コマンドを実行するE2Eは、shell 系統ごとに1つのrunnerから実行します:

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/ReplayInputAction.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/ReplayInputAction.cs
@@ -3,8 +3,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     public enum ReplayInputAction
     {
-        Start = 0,
-        Stop = 1,
-        Status = 2
+        start = 0,
+        stop = 1,
+        status = 2
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
@@ -8,7 +8,7 @@ description: "Execute C# with Unity APIs when existing uloop tools cannot inspec
 
 Run focused C# snippets in the active Unity Editor with `uloop execute-dynamic-code`.
 
-For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode Selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
+For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
 
 This tool can inspect reachable Unity state — GameObjects, components, public properties, static values, method results — but it cannot read local variables or intermediate calculations inside an already-running method. When those values matter, follow the `uloop-pause-point` skill: a pause point's `CapturedVariables` carries the locals, parameters, and instance fields at that line with no code edit or recompile, and while Unity stays paused `UloopPausePoint.TryGetCapturedValue(name)` gives this tool live captured references. That skill also covers the reverse combination — registering an `EditorApplication.update` watcher from this tool that freezes Unity on the first frame a runtime condition holds. Never poll or sleep inside a snippet; the body runs synchronously on the main thread.
 

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/FindGameObjectsSchema.cs
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/FindGameObjectsSchema.cs
@@ -10,7 +10,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         // Search criteria
         public string NamePattern { get; set; } = "";
-        public SearchMode SearchMode { get; set; } = SearchMode.Exact;
+        public SearchMode SearchMode { get; set; } = SearchMode.exact;
         public string[] RequiredComponents { get; set; } = new string[0];
         public string Tag { get; set; } = "";
         public int? Layer { get; set; } = null;

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/FindGameObjectsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/FindGameObjectsUseCase.cs
@@ -32,7 +32,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             CancellationToken ct)
         {
             // Handle Selected mode separately
-            if (parameters.SearchMode == SearchMode.Selected)
+            if (parameters.SearchMode == SearchMode.selected)
             {
                 return Task.FromResult(ExecuteSelectedMode(parameters, ct));
             }
@@ -141,7 +141,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static string BuildZeroHitExactModeHint(FindGameObjectsSchema parameters, int totalFound)
         {
             if (totalFound != 0 ||
-                parameters.SearchMode != SearchMode.Exact ||
+                parameters.SearchMode != SearchMode.exact ||
                 string.IsNullOrEmpty(parameters.NamePattern))
             {
                 return null;

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/GameObjectFinder/GameObjectFinderService.cs
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/GameObjectFinder/GameObjectFinderService.cs
@@ -32,7 +32,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<GameObjectDetails> results = new();
             
             // Handle hierarchy path search separately
-            if (options.SearchMode == SearchMode.Path && !string.IsNullOrEmpty(options.NamePattern))
+            if (options.SearchMode == SearchMode.path && !string.IsNullOrEmpty(options.NamePattern))
             {
                 GameObject found = FindGameObjectByPath(options.NamePattern);
                 if (found != null)

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/GameObjectFinder/GameObjectSearchFilters.cs
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/GameObjectFinder/GameObjectSearchFilters.cs
@@ -16,17 +16,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 
             switch (searchMode)
             {
-                case SearchMode.Exact:
+                case SearchMode.exact:
                     return gameObject.name == pattern;
                     
-                case SearchMode.Path:
+                case SearchMode.path:
                     // Path search is handled separately in GameObjectFinderService
                     return false;
                     
-                case SearchMode.Regex:
+                case SearchMode.regex:
                     return Regex.IsMatch(gameObject.name, pattern);
                     
-                case SearchMode.Contains:
+                case SearchMode.contains:
                     return gameObject.name.Contains(pattern);
                     
                 default:

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/GameObjectFinder/GameObjectSearchOptions.cs
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/GameObjectFinder/GameObjectSearchOptions.cs
@@ -7,7 +7,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     public class GameObjectSearchOptions
     {
         public string NamePattern { get; set; } = "";
-        public SearchMode SearchMode { get; set; } = SearchMode.Exact;
+        public SearchMode SearchMode { get; set; } = SearchMode.exact;
         public string[] RequiredComponents { get; set; } = new string[0];
         public string Tag { get; set; } = "";
         public int? Layer { get; set; } = null;

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/Skill/SKILL.md
@@ -21,7 +21,7 @@ uloop find-game-objects [options]
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--name-pattern` | string | - | Name pattern to search |
-| `--search-mode` | string | `Exact` | Search mode: `Exact`, `Path`, `Regex`, `Contains`, `Selected` |
+| `--search-mode` | string | `exact` | Search mode: `exact`, `path`, `regex`, `contains`, `selected` |
 | `--required-components` | array | - | Required components |
 | `--tag` | string | - | Tag filter |
 | `--layer` | integer | - | Layer filter (layer number) |
@@ -33,11 +33,11 @@ uloop find-game-objects [options]
 
 | Mode | Description |
 |------|-------------|
-| `Exact` | Exact name match (default). **Trap**: `--name-pattern "Camera"` will not match a GameObject named `"Main Camera"` — use `Contains` or `Regex` for partial matching. A zero-hit `Exact` search returns a `Message` hint pointing this out. |
-| `Path` | Hierarchy path search (e.g., `Canvas/Button`) |
-| `Regex` | Regular expression pattern |
-| `Contains` | Partial name match |
-| `Selected` | Get currently selected GameObjects in Unity Editor |
+| `exact` | Exact name match (default). **Trap**: `--name-pattern "Camera"` will not match a GameObject named `"Main Camera"` — use `contains` or `regex` for partial matching. A zero-hit `exact` search returns a `Message` hint pointing this out. |
+| `path` | Hierarchy path search (e.g., `Canvas/Button`) |
+| `regex` | Regular expression pattern |
+| `contains` | Partial name match |
+| `selected` | Get currently selected GameObjects in Unity Editor |
 
 ## Output
 
@@ -56,9 +56,9 @@ Returns JSON with:
 
 ### Multi-selection file export
 
-For `Selected` mode with **multiple** successfully serialized GameObjects, inline `Results` is not populated and the data is written to a file instead. Two extra fields appear:
+For `selected` mode with **multiple** successfully serialized GameObjects, inline `Results` is not populated and the data is written to a file instead. Two extra fields appear:
 
 - `ResultsFilePath` (string): Relative path under `.uloop/outputs/FindGameObjectsResults/`
 - `Message` (string): Human-readable summary (e.g., "5 GameObjects exported")
 
-Single-selection and search-mode calls (`Exact`, `Path`, `Regex`, `Contains`) always return inline. No selection (`Selected` mode with empty selection) returns empty `Results` plus a `Message`.
+Single-selection and search-mode calls (`exact`, `path`, `regex`, `contains`) always return inline. No selection (`selected` mode with empty selection) returns empty `Results` plus a `Message`.

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/UnityCliLoopGameObjectSearchTypes.cs
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/UnityCliLoopGameObjectSearchTypes.cs
@@ -2,10 +2,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     public enum SearchMode
     {
-        Exact = 0,
-        Path = 1,
-        Regex = 2,
-        Contains = 3,
-        Selected = 4
+        exact = 0,
+        path = 1,
+        regex = 2,
+        contains = 3,
+        selected = 4
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/GetHierarchy/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/GetHierarchy/Skill/SKILL.md
@@ -8,7 +8,7 @@ description: "Get the Unity scene hierarchy as a structured tree. Use for parent
 
 Get Unity Hierarchy structure from the whole scene, a root path, or selected Hierarchy objects.
 
-Use this for hierarchy structure, especially descendants under the current selection. Use `find-game-objects --search-mode Selected` when you need selected object details or component properties.
+Use this for hierarchy structure, especially descendants under the current selection. Use `find-game-objects --search-mode selected` when you need selected object details or component properties.
 
 ## Usage
 

--- a/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputSchema.cs
+++ b/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputSchema.cs
@@ -8,7 +8,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class ReplayInputSchema : UnityCliLoopToolSchema
     {
-        public ReplayInputAction Action { get; set; } = ReplayInputAction.Start;
+        public ReplayInputAction Action { get; set; } = ReplayInputAction.start;
         public string InputPath { get; set; } = "";
         public bool ShowOverlay { get; set; } = true;
         public bool Loop { get; set; } = false;

--- a/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputUseCase.cs
@@ -55,15 +55,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             switch (request.Action)
             {
-                case ReplayInputAction.Start:
+                case ReplayInputAction.start:
                     response = ExecuteStart(request);
                     break;
 
-                case ReplayInputAction.Stop:
+                case ReplayInputAction.stop:
                     response = ExecuteStop();
                     break;
 
-                case ReplayInputAction.Status:
+                case ReplayInputAction.status:
                     response = ExecuteStatus();
                     break;
 
@@ -97,7 +97,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             PlayModeToolPreflightResult preflight = PlayModeToolPreflightService.RequireActiveAndNotPaused(PausedActionDescription);
             if (!preflight.IsValid)
             {
-                return ReplayInputResponseFactory.PreflightRejectedResult(ReplayInputAction.Start, preflight);
+                return ReplayInputResponseFactory.PreflightRejectedResult(ReplayInputAction.start, preflight);
             }
 
             if (InputReplayer.IsReplaying)
@@ -106,7 +106,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     Success = false,
                     Message = "Already replaying. Stop the current replay first.",
-                    Action = ReplayInputAction.Start.ToString()
+                    Action = ReplayInputAction.start.ToString()
                 };
             }
 
@@ -116,7 +116,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     Success = false,
                     Message = "Cannot replay while recording. Stop the recording first.",
-                    Action = ReplayInputAction.Start.ToString()
+                    Action = ReplayInputAction.start.ToString()
                 };
             }
 
@@ -127,7 +127,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     Success = false,
                     Message = $"No recording files found in {RecordInputConstants.DEFAULT_OUTPUT_DIR}/",
-                    Action = ReplayInputAction.Start.ToString()
+                    Action = ReplayInputAction.start.ToString()
                 };
             }
 
@@ -137,7 +137,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     Success = false,
                     Message = $"Recording file not found: {inputPath}",
-                    Action = ReplayInputAction.Start.ToString()
+                    Action = ReplayInputAction.start.ToString()
                 };
             }
 
@@ -149,7 +149,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     Success = false,
                     Message = $"Failed to parse recording file: {inputPath}",
-                    Action = ReplayInputAction.Start.ToString()
+                    Action = ReplayInputAction.start.ToString()
                 };
             }
 
@@ -164,7 +164,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Success = true,
                 Message = $"Replay started: {eventCount} events across {data.Metadata.TotalFrames} frames" +
                           (request.Loop ? " (looping)" : ""),
-                Action = ReplayInputAction.Start.ToString(),
+                Action = ReplayInputAction.start.ToString(),
                 InputPath = inputPath,
                 TotalFrames = data.Metadata.TotalFrames,
                 IsReplaying = true
@@ -179,7 +179,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     Success = false,
                     Message = "Not currently replaying.",
-                    Action = ReplayInputAction.Stop.ToString()
+                    Action = ReplayInputAction.stop.ToString()
                 };
             }
 
@@ -191,7 +191,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 Success = true,
                 Message = $"Replay stopped at frame {stoppedFrame}/{totalFrames}",
-                Action = ReplayInputAction.Stop.ToString(),
+                Action = ReplayInputAction.stop.ToString(),
                 CurrentFrame = stoppedFrame,
                 TotalFrames = totalFrames,
                 IsReplaying = false
@@ -206,7 +206,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     Success = true,
                     Message = "Not replaying.",
-                    Action = ReplayInputAction.Status.ToString(),
+                    Action = ReplayInputAction.status.ToString(),
                     IsReplaying = false
                 };
             }
@@ -215,7 +215,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 Success = true,
                 Message = $"Replaying: frame {InputReplayer.CurrentFrame}/{InputReplayer.TotalFrames} ({InputReplayer.Progress:P0})",
-                Action = ReplayInputAction.Status.ToString(),
+                Action = ReplayInputAction.status.ToString(),
                 CurrentFrame = InputReplayer.CurrentFrame,
                 TotalFrames = InputReplayer.TotalFrames,
                 Progress = InputReplayer.Progress,

--- a/Packages/src/Editor/FirstPartyTools/ReplayInput/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ReplayInput/Skill/SKILL.md
@@ -14,26 +14,26 @@ Create recording JSON files in the Unity Editor from **Window > Unity CLI Loop >
 
 ```bash
 # Start replay (auto-detect latest recording)
-uloop replay-input --action Start
+uloop replay-input --action start
 
 # Start replay with specific file
-uloop replay-input --action Start --input-path scripts/my-play.json
+uloop replay-input --action start --input-path scripts/my-play.json
 
 # Start replay with looping
-uloop replay-input --action Start --loop
+uloop replay-input --action start --loop
 
 # Check replay progress
-uloop replay-input --action Status
+uloop replay-input --action status
 
 # Stop replay
-uloop replay-input --action Stop
+uloop replay-input --action stop
 ```
 
 ## Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--action` | enum | `Start` | `Start` - begin replaying, `Stop` - stop mid-way, `Status` - check progress |
+| `--action` | enum | `start` | `start` - begin replaying, `stop` - stop mid-way, `status` - check progress |
 | `--input-path` | string | auto | Path to the recording JSON. When empty, auto-detects the latest recording in `.uloop/outputs/InputRecordings/` |
 | `--no-show-overlay` | flag | - | Hide replay progress overlay |
 | `--loop` | flag | - | Loop continuously |
@@ -53,8 +53,8 @@ Returns JSON with:
 
 - `Success`: Whether the operation succeeded
 - `Message`: Status message
-- `Action`: Echoes which action was executed (`Start`, `Stop`, or `Status`)
-- `InputPath`: Path to recording file (nullable string; populated on `Start` only)
+- `Action`: Echoes which action was executed (`start`, `stop`, or `status`)
+- `InputPath`: Path to recording file (nullable string; populated on `start` only)
 - `CurrentFrame`: Current replay frame index (nullable int)
 - `TotalFrames`: Total frames in the recording (nullable int)
 - `Progress`: Replay progress (nullable float in 0.0 – 1.0)

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -199,15 +199,15 @@
           },
           "SearchMode": {
             "type": "string",
-            "description": "Search mode: Exact, Path, Regex, Contains, Selected",
+            "description": "Search mode: exact, path, regex, contains, selected",
             "enum": [
-              "Exact",
-              "Path",
-              "Regex",
-              "Contains",
-              "Selected"
+              "exact",
+              "path",
+              "regex",
+              "contains",
+              "selected"
             ],
-            "default": "Exact"
+            "default": "exact"
           },
           "RequiredComponents": {
             "type": "array",
@@ -696,12 +696,12 @@
           "Action": {
             "type": "string",
             "enum": [
-              "Start",
-              "Stop",
-              "Status"
+              "start",
+              "stop",
+              "status"
             ],
-            "description": "Start - begin replaying, Stop - stop mid-way, Status - check progress",
-            "default": "Start"
+            "description": "start - begin replaying, stop - stop mid-way, status - check progress",
+            "default": "start"
           },
           "InputPath": {
             "type": "string",

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "8cac3cf43b9f20986f9583d23cb96aa7c59b8199"
+  "sharedInputsHash": "686f299aad670051a9fb3d5cc6e3c3dbe3d12ce6"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "78133a93e98a0ee341c2f8436ec6e1a545afe597"
+  "sharedInputsHash": "d95cae479447294b46f16e05ddff2b3b344c4f1e"
 }

--- a/docs/adr/0006-enum-value-casing.md
+++ b/docs/adr/0006-enum-value-casing.md
@@ -1,0 +1,68 @@
+# Enum Value Casing on the CLI
+
+Date: 2026-09-07
+
+## Decision
+
+Enum-valued CLI parameters (`--action`, `--log-type`, `--test-mode`, ...) keep the spelling of
+the C# enum member that backs them, and that member is named by the following rules:
+
+1. A value that names a Unity concept keeps Unity's spelling: `EditMode` / `PlayMode`
+   (Test Runner), `Error` / `Warning` / `Log` (`LogType`), `KeyDown` / `KeyUp`
+   (`EventType`), `Play` / `Pause` / `Step` (Editor play controls), `GameView` (window).
+2. An enum whose members are all single-word values the CLI itself defines uses lowercase
+   members: `start` / `stop` / `status`, `low` / `medium` / `high`, `exact` / `prefix` /
+   `contains`, `save` / `fail` / `discard`, `window` / `rendering` / `auto`.
+3. An enum with at least one multi-word member, or at least one Unity-derived member, keeps
+   PascalCase for every member, so one enum never mixes styles: `Click` / `LongPress` /
+   `MoveDelta`, `Press` / `KeyDown` / `ReleaseAll`, `Play` / `Stop` / `Status` / `Resume`.
+4. Options that exist only in the Go CLI, with no C# enum behind them, use lowercase
+   kebab-case: `pre-line` / `post-line`, `single-shot` / `continuous` / `trace`.
+
+Parsing stays case-insensitive on both sides (`CaseInsensitiveStringEnumConverter` in the
+package, `strings.EqualFold` in the project runner), so `--action Status` and
+`--action status` are the same request. The rules govern the documented spelling, which is
+what `--help`, `uloop list`, the tool catalog, and skill files show and what AI agents copy.
+
+We do not add a conversion layer that turns C# member names into kebab-case wire values.
+
+## Context
+
+POSIX-style CLIs almost always spell enum values in lowercase, and issue #2649 proposed
+converting every value to lowercase / kebab-case (`key-down`, `edit-mode`, `game-view`) for
+that reason. Working through the inventory showed that the majority of values here are Unity
+vocabulary rather than CLI vocabulary: `LogType` members, Test Runner modes, `EventType`
+names, Editor play controls, mouse button names, and an Editor window name. Lowercasing those
+makes the CLI disagree with the Unity documentation an agent reads next to it, while a
+"Unity-derived values stay, CLI-own values change" split leaves only a handful of values
+(`Exact` / `Path` / `Regex`, `LongPress` / `MoveDelta`, `DragStart` / `DragEnd`) to convert
+and produces no visible consistency.
+
+A mechanical kebab-case layer would also introduce a second representation of every enum that
+the schema generator, the JSON converter, the response echo fields, the Go validator, and the
+catalog must all agree on, for a benefit that case-insensitive parsing already delivers to
+anyone who prefers typing lowercase.
+
+The rules above describe what the repository already did for every enum except two, so they
+codify practice rather than start a migration. The two exceptions
+(`find-game-objects --search-mode` and `replay-input --action`, both all-single-word CLI-own
+enums spelled in PascalCase) are corrected under rule 2.
+
+## Consequences
+
+- New tools follow the rules when naming their enum members; `record-video`
+  (`start` / `stop` / `status`, `low` / `medium` / `high`) is the reference for rule 2.
+- Renaming an existing enum member under these rules is a documentation-visible change but
+  not a breaking one: the old spelling is still accepted case-insensitively. Response fields
+  that echo the enum (`Action`, `Quality`) change their casing, so tests asserting on them
+  must be updated in the same change.
+- Skill files, the generated catalog, and `Packages/src/Documentation~/tools*.md` must use the
+  member spelling verbatim, so a reader sees one form everywhere.
+
+## Reversal condition
+
+Reopen this decision only if a consumer appears that cannot rely on case-insensitive parsing
+(for example a strict JSON schema validator in front of the tool catalog, or a shell
+completion generator that must emit a single canonical form) and it needs lowercase values
+for Unity-derived terms as well. A preference for lowercase alone is not a reversal
+condition; it is satisfied today by typing lowercase.


### PR DESCRIPTION
## Summary
- Settles how enum-valued CLI options are spelled (ADR 0006) and brings the two options that broke the pattern in line: `find-game-objects --search-mode` and `replay-input --action` now document lowercase values like the other single-word options.

## User Impact
- Before: `--help`, `uloop list`, and the skills showed `Exact, Path, Regex, Contains, Selected` for `--search-mode` while the neighbouring `screenshot --match-mode` showed `exact, prefix, contains`, and `replay-input --action` showed `Start, Stop, Status` while `record-video --action` showed `start, stop, status`. Agents copying the documented form produced two spellings for the same kind of value.
- After: both options show `exact, path, regex, contains, selected` and `start, stop, status`. Parsing stays case-insensitive, so existing scripts that pass `Contains` or `Start` keep working. The echoed `Action` field in the replay-input response now returns `"start"` instead of `"Start"`.
- Unity-derived values (`EditMode`, `KeyDown`, `GameView`, `Error/Warning/Log`, `Play/Pause/Step`) deliberately keep Unity's spelling, and multi-word action enums stay PascalCase. The rationale, including why a repository-wide kebab-case conversion was rejected, is in the ADR.

## Changes
- Add `docs/adr/0006-enum-value-casing.md` and a pointer paragraph in `AGENTS.md` (the target of the `CLAUDE.md` symlink).
- Rename the `SearchMode` and `ReplayInputAction` enum members to lowercase, following the existing `CaptureMode` / `WindowMatchMode` precedent; update callers, test literals, and the demo script.
- Update the affected skills (find-game-objects, replay-input, and the two skills that reference `--search-mode selected`), `Documentation~/tools*.md`, the generated skill copies, and the tool catalog. The catalog enum lists and defaults are a structural change, so the shared-input stamps are refreshed.

## Verification
- `dist/darwin-arm64/uloop compile`: ErrorCount 0
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value "FindGameObjects|GameObjectFinder|GameObjectSearch|ReplayInput|PausePointPreflightRejectionResponse"`: Passed 48, Failed 0
- Live: `find-game-objects --search-mode contains` and the legacy `Contains` both succeed; `replay-input --action status` returns `"Action": "status"`; `--help` lists `exact|path|regex|contains|selected`
- `go run ./cmd/sync-tool-docs --check`, `check-skill-size`, `check-release-triggers`: pass
- `go test ./tools/...` in `cli/common`: pass

Closes #2649


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

