### PR TITLE
feat: Hot reload applies a newly introduced type at the moment it applies the reload

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -580,13 +580,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assembly compilationAssembly,
             HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence = null)
         {
+            // Why a real worker source with its hash: the commit boundary verifies each request
+            // source still hashes to what the transform run reported, and refuses a file it
+            // cannot compare.
+            string workerSourcePath = HotReloadTestSourceWriter.WriteEditedSource(
+                Path.GetFileName(path),
+                "// " + path + "\n");
             HotReloadGroupFile file = new HotReloadGroupFile(
-                path, path, path, AssemblyName, compilationAssembly,
+                path, workerSourcePath, path, AssemblyName, compilationAssembly,
                 Path.Combine(projectRoot, "Library", "ScriptAssemblies", AssemblyName + ".dll"),
                 projectRoot, new HotReloadFileSinks(new List<string>(), null), newSourceMembershipEvidence);
             file.FileOutput = new TransformWorkerFileOutputDto
             {
                 projectRelativePath = path,
+                sourceContentSha256 = HotReloadAppliedSourceLedger.ComputeContentHash(
+                    File.ReadAllBytes(workerSourcePath)),
                 removedMethodSignatures = Array.Empty<TransformWorkerRemovedMethodSignatureDto>()
             };
             file.SnapshotLabels = new HashSet<string>();

--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -40,31 +40,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// A two-file coverage loss fails both files before the application continuation runs.
+        /// A two-file coverage loss fails both files before the apply stage runs.
         /// </summary>
         [Test]
-        public async Task CompleteApplyAfterCoverageAsync_DroppedSourceLiveCaller_FailsEveryFileWithoutContinuation()
+        public async Task CompleteApplyAfterCoverageAsync_DroppedSourceLiveCaller_FailsEveryFileWithoutApplying()
         {
             HotReloadApplyContext context = CreateContext();
             TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
             HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult = CreateGateResultWithoutExemptions();
             HotReloadGroupCompileResult compile = CreateCompile(target);
-            int continuationCalls = 0;
+            ApplyRecorder applyRecorder = new ApplyRecorder();
 
             IReadOnlyList<HotReloadFileProcessResult> results =
-                await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                await CompleteApplyWithRecorder(applyRecorder,
                     context,
                     gateResult,
                     compile,
-                    CancellationToken.None,
-                    () =>
-                    {
-                        continuationCalls++;
-                        return Task.FromResult<IReadOnlyList<HotReloadFileProcessResult>>(
-                            Array.Empty<HotReloadFileProcessResult>());
-                    });
+                    CancellationToken.None);
 
-            Assert.That(continuationCalls, Is.EqualTo(0));
+            Assert.That(applyRecorder.Calls, Is.EqualTo(0));
             Assert.That(results, Has.Count.EqualTo(2));
             string[] expectedPaths = { "Assets/CoverageCaller.cs", "Assets/CoverageTarget.cs" };
             for (int index = 0; index < results.Count; index++)
@@ -80,33 +74,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// A final source-live caller permits the continuation and preserves its returned results.
+        /// A final source-live caller permits the apply stage and preserves its returned results.
         /// </summary>
         [Test]
-        public async Task CompleteApplyAfterCoverageAsync_RetainedCaller_InvokesContinuationAndReturnsItsResults()
+        public async Task CompleteApplyAfterCoverageAsync_RetainedCaller_AppliesAndReturnsItsResults()
         {
             HotReloadApplyContext context = CreateContext();
             TransformWorkerEntryDto caller = CreateCallerEntry("Assets/CoverageCaller.cs");
             TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
             HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult = CreateGateResultWithoutExemptions();
             HotReloadGroupCompileResult compile = CreateCompile(caller, target);
-            int continuationCalls = 0;
+            ApplyRecorder applyRecorder = new ApplyRecorder();
             IReadOnlyList<HotReloadFileProcessResult> expected =
                 new[] { new HotReloadFileProcessResult(new List<HotReloadMethodOutcome>(), new List<string>(), 1) };
+            applyRecorder.Results = expected;
 
             IReadOnlyList<HotReloadFileProcessResult> results =
-                await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                await CompleteApplyWithRecorder(applyRecorder,
                     context,
                     gateResult,
                     compile,
-                    CancellationToken.None,
-                    () =>
-                    {
-                        continuationCalls++;
-                        return Task.FromResult(expected);
-                    });
+                    CancellationToken.None);
 
-            Assert.That(continuationCalls, Is.EqualTo(1));
+            Assert.That(applyRecorder.Calls, Is.EqualTo(1));
             Assert.That(results, Is.SameAs(expected));
         }
 
@@ -114,57 +104,47 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// A deletion exemption carried by the gate covers a caller absent from final entries.
         /// </summary>
         [Test]
-        public async Task CompleteApplyAfterCoverageAsync_DeletedCallerExemption_InvokesContinuationAndReturnsItsResults()
+        public async Task CompleteApplyAfterCoverageAsync_DeletedCallerExemption_AppliesAndReturnsItsResults()
         {
             HotReloadApplyContext context = CreateContext();
             TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
             HotReloadGroupCompileResult compile = CreateCompile(target);
-            int continuationCalls = 0;
+            ApplyRecorder applyRecorder = new ApplyRecorder();
             IReadOnlyList<HotReloadFileProcessResult> expected =
                 new[] { new HotReloadFileProcessResult(new List<HotReloadMethodOutcome>(), new List<string>(), 1) };
+            applyRecorder.Results = expected;
 
             IReadOnlyList<HotReloadFileProcessResult> results =
-                await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                await CompleteApplyWithRecorder(applyRecorder,
                     context,
                     CreateGateResultWithDeletedCallerExemption(),
                     compile,
-                    CancellationToken.None,
-                    () =>
-                    {
-                        continuationCalls++;
-                        return Task.FromResult(expected);
-                    });
+                    CancellationToken.None);
 
-            Assert.That(continuationCalls, Is.EqualTo(1));
+            Assert.That(applyRecorder.Calls, Is.EqualTo(1));
             Assert.That(results, Is.SameAs(expected));
         }
 
         /// <summary>
-        /// Membership evidence that changes after the worker prevents the production apply continuation from running.
+        /// Membership evidence that changes after the worker prevents the production apply stage from running.
         /// </summary>
         [Test]
-        public async Task CompleteApplyAfterCoverageAsync_WhenNewSourceMembershipChanges_DoesNotInvokeContinuation()
+        public async Task CompleteApplyAfterCoverageAsync_WhenNewSourceMembershipChanges_DoesNotApply()
         {
             HotReloadApplyContext context = CreateContext(CreateChangedMembershipEvidence());
             TransformWorkerEntryDto caller = CreateCallerEntry("Assets/CoverageCaller.cs");
             TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
             HotReloadGroupCompileResult compile = CreateCompile(caller, target);
-            int continuationCalls = 0;
+            ApplyRecorder applyRecorder = new ApplyRecorder();
 
             IReadOnlyList<HotReloadFileProcessResult> results =
-                await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                await CompleteApplyWithRecorder(applyRecorder,
                     context,
                     CreateGateResultWithoutExemptions(),
                     compile,
-                    CancellationToken.None,
-                    () =>
-                    {
-                        continuationCalls++;
-                        return Task.FromResult<IReadOnlyList<HotReloadFileProcessResult>>(
-                            Array.Empty<HotReloadFileProcessResult>());
-                    });
+                    CancellationToken.None);
 
-            Assert.That(continuationCalls, Is.EqualTo(0));
+            Assert.That(applyRecorder.Calls, Is.EqualTo(0));
             Assert.That(results, Has.Count.EqualTo(2));
             for (int index = 0; index < results.Count; index++)
             {
@@ -175,37 +155,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// A ready Editor state permits the final production continuation after revalidating actual membership evidence.
+        /// A ready Editor state permits the production apply stage after revalidating actual membership evidence.
         /// </summary>
         [Test]
-        public async Task CompleteApplyAfterCoverageAsync_WhenMembershipEvidenceStaysReady_InvokesContinuation()
+        public async Task CompleteApplyAfterCoverageAsync_WhenMembershipEvidenceStaysReady_Applies()
         {
             HotReloadNewSourceMembershipEvidence evidence = CaptureCurrentMembershipEvidence();
             HotReloadApplyContext context = CreateContext(evidence);
             TransformWorkerEntryDto caller = CreateCallerEntry("Assets/CoverageCaller.cs");
             TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
-            int continuationCalls = 0;
+            ApplyRecorder applyRecorder = new ApplyRecorder();
 
-            await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+            await CompleteApplyWithRecorder(applyRecorder,
                 context,
                 CreateGateResultWithoutExemptions(),
                 CreateCompile(caller, target),
-                CancellationToken.None,
-                () =>
-                {
-                    continuationCalls++;
-                    return Task.FromResult<IReadOnlyList<HotReloadFileProcessResult>>(
-                        Array.Empty<HotReloadFileProcessResult>());
-                });
+                CancellationToken.None);
 
-            Assert.That(continuationCalls, Is.EqualTo(1));
+            Assert.That(applyRecorder.Calls, Is.EqualTo(1));
         }
 
         /// <summary>
-        /// An Editor state that becomes unsafe after evidence capture blocks the final production continuation.
+        /// An Editor state that becomes unsafe after evidence capture blocks the production apply stage.
         /// </summary>
         [Test]
-        public async Task CompleteApplyAfterCoverageAsync_WhenEditorBecomesUnsafe_DoesNotInvokeContinuation()
+        public async Task CompleteApplyAfterCoverageAsync_WhenEditorBecomesUnsafe_DoesNotApply()
         {
             HotReloadNewSourceMembershipEvidence evidence = CaptureCurrentMembershipEvidence();
             HotReloadEditorStateSnapshotProvider.CaptureForTesting = () =>
@@ -213,66 +187,54 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadApplyContext context = CreateContext(evidence);
             TransformWorkerEntryDto caller = CreateCallerEntry("Assets/CoverageCaller.cs");
             TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
-            int continuationCalls = 0;
+            ApplyRecorder applyRecorder = new ApplyRecorder();
 
             IReadOnlyList<HotReloadFileProcessResult> results =
-                await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                await CompleteApplyWithRecorder(applyRecorder,
                     context,
                     CreateGateResultWithoutExemptions(),
                     CreateCompile(caller, target),
-                    CancellationToken.None,
-                    () =>
-                    {
-                        continuationCalls++;
-                        return Task.FromResult<IReadOnlyList<HotReloadFileProcessResult>>(
-                            Array.Empty<HotReloadFileProcessResult>());
-                    });
+                    CancellationToken.None);
 
-            Assert.That(continuationCalls, Is.EqualTo(0));
+            Assert.That(applyRecorder.Calls, Is.EqualTo(0));
             Assert.That(results, Has.Count.EqualTo(2));
             Assert.That(results[0].Outcomes[0].Reason, Does.Contain("compiling"));
         }
 
         /// <summary>
-        /// Cancellation before the final main-thread revalidation prevents the production continuation.
+        /// Cancellation before the final main-thread revalidation prevents the production apply stage.
         /// </summary>
         [Test]
-        public void CompleteApplyAfterCoverageAsync_WhenCancelled_DoesNotInvokeContinuation()
+        public void CompleteApplyAfterCoverageAsync_WhenCancelled_DoesNotApply()
         {
             HotReloadApplyContext context = CreateContext();
             TransformWorkerEntryDto caller = CreateCallerEntry("Assets/CoverageCaller.cs");
             TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
-            int continuationCalls = 0;
+            ApplyRecorder applyRecorder = new ApplyRecorder();
             using CancellationTokenSource cancellation = new CancellationTokenSource();
             cancellation.Cancel();
 
             Assert.ThrowsAsync<TaskCanceledException>(async () =>
-                await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                await CompleteApplyWithRecorder(applyRecorder,
                     context,
                     CreateGateResultWithoutExemptions(),
                     CreateCompile(caller, target),
-                    cancellation.Token,
-                    () =>
-                    {
-                        continuationCalls++;
-                        return Task.FromResult<IReadOnlyList<HotReloadFileProcessResult>>(
-                            Array.Empty<HotReloadFileProcessResult>());
-                    }));
+                    cancellation.Token));
 
-            Assert.That(continuationCalls, Is.EqualTo(0));
+            Assert.That(applyRecorder.Calls, Is.EqualTo(0));
         }
 
         /// <summary>
-        /// Cancellation that arrives during synchronous membership revalidation prevents the final continuation.
+        /// Cancellation that arrives during synchronous membership revalidation prevents the apply stage.
         /// </summary>
         [Test]
-        public void CompleteApplyAfterCoverageAsync_WhenCancelledDuringRevalidation_DoesNotInvokeContinuation()
+        public void CompleteApplyAfterCoverageAsync_WhenCancelledDuringRevalidation_DoesNotApply()
         {
             HotReloadNewSourceMembershipEvidence evidence = CaptureCurrentMembershipEvidence();
             HotReloadApplyContext context = CreateContext(evidence);
             TransformWorkerEntryDto caller = CreateCallerEntry("Assets/CoverageCaller.cs");
             TransformWorkerEntryDto target = CreateTargetEntry("Assets/CoverageTarget.cs");
-            int continuationCalls = 0;
+            ApplyRecorder applyRecorder = new ApplyRecorder();
             using CancellationTokenSource cancellation = new CancellationTokenSource();
             HotReloadEditorStateSnapshotProvider.CaptureForTesting = () =>
             {
@@ -281,19 +243,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             };
 
             Assert.ThrowsAsync<TaskCanceledException>(async () =>
-                await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                await CompleteApplyWithRecorder(applyRecorder,
                     context,
                     CreateGateResultWithoutExemptions(),
                     CreateCompile(caller, target),
-                    cancellation.Token,
-                    () =>
-                    {
-                        continuationCalls++;
-                        return Task.FromResult<IReadOnlyList<HotReloadFileProcessResult>>(
-                            Array.Empty<HotReloadFileProcessResult>());
-                    }));
+                    cancellation.Token));
 
-            Assert.That(continuationCalls, Is.EqualTo(0));
+            Assert.That(applyRecorder.Calls, Is.EqualTo(0));
         }
 
         /// <summary>
@@ -433,6 +389,56 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(file.ClearedAddedFieldNames, Is.Not.Null);
         }
 
+        /// <summary>
+        /// Runs the production post-coverage stage with the apply stage of the dependency bundle
+        /// replaced by a recorder, so a test observes whether the group reached its commit
+        /// boundary without patching anything.
+        /// </summary>
+        private static async Task<IReadOnlyList<HotReloadFileProcessResult>> CompleteApplyWithRecorder(
+            ApplyRecorder recorder,
+            HotReloadApplyContext context,
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult,
+            HotReloadGroupCompileResult compile,
+            CancellationToken ct)
+        {
+            using (recorder.Install())
+            {
+                return await HotReloadGroupProcessor.CompleteApplyAfterCoverageAsync(
+                    context,
+                    gateResult,
+                    compile,
+                    ct);
+            }
+        }
+
+        /// <summary>
+        /// Counts the calls of the bundle's apply stage and hands back the results a test expects.
+        /// </summary>
+        private sealed class ApplyRecorder
+        {
+            internal int Calls { get; private set; }
+
+            internal IReadOnlyList<HotReloadFileProcessResult> Results { get; set; } =
+                Array.Empty<HotReloadFileProcessResult>();
+
+            internal IDisposable Install()
+            {
+                return HotReloadGroupProcessorDependencies.BeginReplacement(
+                    HotReloadGroupProcessorDependencies.Create(
+                        HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                        HotReloadIntroducedTypePreparation.PrepareAsync,
+                        TransformWorkerClient.RunAsync,
+                        HotReloadGroupProcessor.GateAndCompileAsync,
+                        (context, compileResult, entriesToPatch) =>
+                            Array.Empty<HotReloadPreparedGroupFile>(),
+                        (context, compileResult, preparedFiles) =>
+                        {
+                            Calls++;
+                            return Results;
+                        }));
+            }
+        }
+
         private static HotReloadSignatureChangeGate.SignatureChangeGateResult CreateGateResultWithoutExemptions()
         {
             return HotReloadSignatureChangeGate.SignatureChangeGateResult.WarningsOnly(
@@ -524,7 +530,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     }
                 },
                 workerOutput,
-                new[] { callerFile, targetFile });
+                new[] { callerFile, targetFile },
+                null);
         }
 
         private static HotReloadApplyContext CreateEmptyEntriesContext(
@@ -549,7 +556,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 context.Defines,
                 context.WorkerInput,
                 emptyWorkerOutput,
-                context.Files);
+                context.Files,
+                null);
         }
 
         private static Assembly FindCompilationAssembly()

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -619,6 +619,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that a run whose target assembly no longer has the module version id the run
+        /// read is stopped at the commit boundary, so a reload never activates a type normalized
+        /// against a generation the domain has replaced.
+        /// </summary>
+        [Test]
+        public async Task Run_TargetAssemblyRebuiltBeforeTheCommitBoundary_ActivatesNothing()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                    CreateDependenciesWithRebuiltTargetAfterWorker()))
+                {
+                    HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                        new[] { hostPath, callerPath },
+                        contentPathOverride: null,
+                        CancellationToken.None,
+                        CreateIntroducedTypeEdits(hostPath, callerPath, "TargetRebuilt"));
+
+                    AssertNothingWasCommitted(result, "was rebuilt");
+                }
+            }
+        }
+
+        /// <summary>
         /// Verifies that an owner rewritten between the preparation run and the transform run
         /// stops the run at the commit boundary, because the artifact assembly no longer describes
         /// the source the transform read.
@@ -891,6 +919,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 prepared.File,
                 prepared.Entries,
                 HotReloadEntryResolution.Result.Failed(failureOutcomes));
+        }
+
+        // The window between the transform run and the commit boundary, in which the target
+        // assembly can be rebuilt.
+        //
+        // Why the run's recorded module version id is changed instead of the file on disk: the
+        // target assembly is loaded into this domain, and overwriting a mapped assembly file
+        // could take the Editor down. The check under test compares the two, so making them
+        // differ from this side observes the same condition. The change is made after the worker
+        // has run, so nothing the worker decided is affected by it.
+        private static HotReloadGroupProcessorDependencies CreateDependenciesWithRebuiltTargetAfterWorker()
+        {
+            return HotReloadGroupProcessorDependencies.Create(
+                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                HotReloadIntroducedTypePreparation.PrepareAsync,
+                async (input, ct) =>
+                {
+                    TransformWorkerClientResult workerResult =
+                        await TransformWorkerClient.RunAsync(input, ct);
+                    input.targetAssemblyMvid = Guid.NewGuid().ToString("N");
+                    return workerResult;
+                },
+                HotReloadGroupProcessor.GateAndCompileAsync,
+                HotReloadGroupEntryPreparation.PrepareGroup,
+                HotReloadEntryApplier.ApplyPreparedEntries);
         }
 
         // The edited caller returns the introduced type's value plus the compiled host's value.

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -499,6 +499,56 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that a reload whose introduced type derives from a type an earlier reload
+        /// introduced compiles its artifact against the active artifact: the base type lives in
+        /// neither the compiled assembly nor this run's sources, so only the record of the
+        /// retained assembly can supply it.
+        /// </summary>
+        [Test]
+        public async Task Run_IntroducedTypeDerivesFromAnActiveOne_CompilesAgainstTheActiveArtifact()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                HotReloadOrchestratorResult baseRun = await HotReloadOrchestrator.RunAsync(
+                    new[] { hostPath },
+                    WriteBaseTypeSource(hostPath),
+                    CancellationToken.None);
+
+                Assert.That(
+                    FindFailureReason(baseRun, string.Empty),
+                    Is.Null,
+                    "Precondition: the base type had to be introduced. " + DescribeOutcomes(baseRun));
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Registry.ActiveCount,
+                    Is.EqualTo(1),
+                    "Precondition: the base type had to become active.");
+
+                HotReloadOrchestratorResult derivedRun = await HotReloadOrchestrator.RunAsync(
+                    new[] { callerPath },
+                    WriteDerivedTypeSource(callerPath),
+                    CancellationToken.None);
+
+                Assert.That(
+                    FindFailureReason(derivedRun, string.Empty),
+                    Is.Null,
+                    "A declaration deriving from an active introduced type must compile. "
+                        + DescribeOutcomes(derivedRun));
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Registry.ActiveCount,
+                    Is.EqualTo(2),
+                    "The derived type must become active alongside the base it was compiled against.");
+                Assert.That(
+                    new HotReloadCrossFileAddedMemberCaller().Call(new HotReloadCrossFileAddedMemberHost()),
+                    Is.EqualTo(IntroducedValueThroughDerivedType),
+                    "The patched caller must read its value through the derived introduced type.");
+            }
+        }
+
+        /// <summary>
         /// Verifies that an Editor that becomes busy after the shim compile stops the run at the
         /// commit boundary, leaving no type active and no patch applied.
         /// </summary>
@@ -794,6 +844,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         // value shifts by one while the type it reads through must stay the one already active.
         private const int IntroducedValueThroughReintroducedCaller = 9;
 
+        // The derived introduced type doubles the base's value, and the edited caller adds
+        // the compiled host's value to it.
+        private const int IntroducedValueThroughDerivedType = 15;
+
         private const string ValidateStage = "validate-membership";
 
         private const string PrepareStage = "prepare-introduced-types";
@@ -1088,6 +1142,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private const string CallerBodyAnchor = "return host.Value();";
 
+        private const string CallerTypeAnchor =
+            "    internal sealed class HotReloadCrossFileAddedMemberCaller";
+
         private static void AssertArtifactRecordReachedTheTransformRun(
             TransformWorkerInputDto transformInput,
             HotReloadIntroducedTypeArtifact preparedArtifact)
@@ -1237,6 +1294,59 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         "return new HotReloadCrossFileIntroducedValue().Read() + host.Value() + 1;",
                         StringComparison.Ordinal))
             };
+        }
+
+        // The base of the two-reload chain: unsealed, so the later reload's declaration can
+        // derive from the assembly this reload retains.
+        private static string WriteBaseTypeSource(string hostPath)
+        {
+            string hostSource = File.ReadAllText(hostPath);
+            Assert.That(hostSource, Does.Contain(HostTypeAnchor), "Precondition: host type anchor must exist.");
+            string introduced =
+                "    public class HotReloadCrossFileIntroducedBase\n"
+                + "    {\n"
+                + "        public int Read()\n"
+                + "        {\n"
+                + "            return 7;\n"
+                + "        }\n"
+                + "    }\n"
+                + "\n";
+            return HotReloadTestSourceWriter.WriteEditedSource(
+                "IntroducedTypeBaseHost.cs",
+                hostSource.Replace(HostTypeAnchor, introduced + HostTypeAnchor, StringComparison.Ordinal));
+        }
+
+        // The later reload's declaration, which names a base only the active artifact assembly
+        // holds, plus the caller body that reads a value through it.
+        private static string WriteDerivedTypeSource(string callerPath)
+        {
+            string callerSource = File.ReadAllText(callerPath);
+            Assert.That(
+                callerSource,
+                Does.Contain(CallerTypeAnchor),
+                "Precondition: caller type anchor must exist.");
+            Assert.That(
+                callerSource,
+                Does.Contain(CallerBodyAnchor),
+                "Precondition: caller body anchor must exist.");
+            string introduced =
+                "    public sealed class HotReloadCrossFileIntroducedDerived"
+                + " : HotReloadCrossFileIntroducedBase\n"
+                + "    {\n"
+                + "        public int Doubled()\n"
+                + "        {\n"
+                + "            return Read() * 2;\n"
+                + "        }\n"
+                + "    }\n"
+                + "\n";
+            return HotReloadTestSourceWriter.WriteEditedSource(
+                "IntroducedTypeDerivedCaller.cs",
+                callerSource
+                    .Replace(CallerTypeAnchor, introduced + CallerTypeAnchor, StringComparison.Ordinal)
+                    .Replace(
+                        CallerBodyAnchor,
+                        "return new HotReloadCrossFileIntroducedDerived().Doubled() + host.Value();",
+                        StringComparison.Ordinal));
         }
 
         private static string CallIntroducedType(string callerSource)

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -293,6 +293,51 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that a reload whose only change is a new type declaration still reaches the
+        /// commit boundary and activates the type, instead of ending unapplied because the run
+        /// has no method to patch.
+        /// </summary>
+        [Test]
+        public async Task Run_OnlyATypeIsIntroduced_ActivatesTheTypeWithoutAnyMethodToPatch()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            HotReloadIntroducedTypeArtifact preparedArtifact = null;
+            HotReloadOrchestratorResult result;
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                    CreateArtifactCapturingDependencies(artifact => preparedArtifact = artifact)))
+                {
+                    result = await HotReloadOrchestrator.RunAsync(
+                        new[] { hostPath },
+                        HotReloadTestSourceWriter.WriteEditedSource(
+                            "IntroducedTypeOnlyHost.cs",
+                            InsertIntroducedType(File.ReadAllText(hostPath))),
+                        CancellationToken.None);
+                }
+
+                Assert.That(preparedArtifact, Is.Not.Null, "The run had to prepare the introduced type.");
+                Assert.That(
+                    FindFailureReason(result, string.Empty),
+                    Is.Null,
+                    "A reload that only introduces a type must not fail any method.");
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Registry.PreparedCount,
+                    Is.EqualTo(0),
+                    "The commit boundary must move the prepared membership, not leave it prepared.");
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Registry.TryFindActive(
+                        preparedArtifact.Descriptors,
+                        out HotReloadIntroducedTypeArtifact activeArtifact),
+                    Is.True,
+                    "A run with no method to patch must still activate the type it introduced.");
+                Assert.That(activeArtifact, Is.SameAs(preparedArtifact));
+            }
+        }
+
+        /// <summary>
         /// Verifies that an Editor that becomes busy after the shim compile stops the run at the
         /// commit boundary, leaving no type active and no patch applied.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -18,9 +18,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     /// </summary>
     public class HotReloadIntroducedTypeActivationTests
     {
+        private Func<HotReloadEditorStateSnapshot> _previousSnapshotProvider;
+
         [SetUp]
         public void SetUp()
         {
+            _previousSnapshotProvider = HotReloadEditorStateSnapshotProvider.CaptureForTesting;
             HotReloadPatcher.RevertAll();
             HotReloadAutoRefreshHold.Sync(HotReloadPatcher.ActiveChangeCount);
         }
@@ -31,6 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [TearDown]
         public void TearDown()
         {
+            HotReloadEditorStateSnapshotProvider.CaptureForTesting = _previousSnapshotProvider;
             HotReloadPatcher.RevertAll();
             HotReloadAutoRefreshHold.Sync(HotReloadPatcher.ActiveChangeCount);
         }
@@ -146,7 +150,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                             ownerAssemblyName = files[0].AssemblyName;
                             HotReloadIntroducedTypePreparationResult preparation =
                                 await HotReloadIntroducedTypePreparation.PrepareAsync(files, input, ct);
-                            preparedArtifact = preparation.Artifact;
+                            preparedArtifact = preparation.Prepared?.Artifact;
                             return preparation;
                         },
                         async (input, ct) =>
@@ -241,6 +245,243 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.Empty,
                 "A run must not be offered an artifact bound to another generation of its assembly.");
         }
+
+        /// <summary>
+        /// Verifies that a run introducing a type commits it: the prepared membership becomes
+        /// active, and the caller patched in the same reload reads a value through the introduced
+        /// type at runtime, which only resolves once the artifact assembly is active.
+        /// </summary>
+        [Test]
+        public async Task Run_TypeIntroducedWithItsCaller_ActivatesTheTypeAndTheCallerReadsThroughIt()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
+            HotReloadIntroducedTypeArtifact preparedArtifact = null;
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                    CreateArtifactCapturingDependencies(artifact => preparedArtifact = artifact)))
+                {
+                    HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                        new[] { hostPath, callerPath },
+                        contentPathOverride: null,
+                        CancellationToken.None,
+                        CreateIntroducedTypeEdits(hostPath, callerPath, "Activation"));
+
+                    AssertCallerIsPatched(result);
+                }
+
+                Assert.That(preparedArtifact, Is.Not.Null, "The run had to prepare the introduced type.");
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Registry.PreparedCount,
+                    Is.EqualTo(0),
+                    "The commit boundary must move the prepared membership, not leave it prepared.");
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Registry.TryFindActive(
+                        preparedArtifact.Descriptors,
+                        out HotReloadIntroducedTypeArtifact activeArtifact),
+                    Is.True,
+                    "The committed run must leave the introduced type active.");
+                Assert.That(activeArtifact, Is.SameAs(preparedArtifact));
+                Assert.That(
+                    new HotReloadCrossFileAddedMemberCaller().Call(new HotReloadCrossFileAddedMemberHost()),
+                    Is.EqualTo(IntroducedValueThroughCaller),
+                    "The patched caller must read its value through the introduced type.");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that an Editor that becomes busy after the shim compile stops the run at the
+        /// commit boundary, leaving no type active and no patch applied.
+        /// </summary>
+        [Test]
+        public async Task Run_EditorBecomesBusyBeforeTheCommitBoundary_ActivatesNothing()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
+            HotReloadOrchestratorResult result;
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                    CreateDependenciesWithAfterGateAction(
+                        () => HotReloadEditorStateSnapshotProvider.CaptureForTesting =
+                            () => new HotReloadEditorStateSnapshot(true, false, false))))
+                {
+                    result = await HotReloadOrchestrator.RunAsync(
+                        new[] { hostPath, callerPath },
+                        contentPathOverride: null,
+                        CancellationToken.None,
+                        CreateIntroducedTypeEdits(hostPath, callerPath, "EditorBusy"));
+                }
+
+                AssertNothingWasCommitted(result, "The Editor became busy");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that an owner rewritten between the preparation run and the transform run
+        /// stops the run at the commit boundary, because the artifact assembly no longer describes
+        /// the source the transform read.
+        /// </summary>
+        [Test]
+        public async Task Run_OwnerRewrittenBetweenPreparationAndTransform_ActivatesNothing()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
+            Dictionary<string, string> edits = CreateIntroducedTypeEdits(hostPath, callerPath, "OwnerDrift");
+            HotReloadOrchestratorResult result;
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                    CreateDependenciesWithBeforeWorkerAction(() => AppendMarkerComment(edits[hostPath]))))
+                {
+                    result = await HotReloadOrchestrator.RunAsync(
+                        new[] { hostPath, callerPath },
+                        contentPathOverride: null,
+                        CancellationToken.None,
+                        edits);
+                }
+
+                AssertNothingWasCommitted(result, "between preparation and transform");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a request source rewritten after the transform run stops the run at the
+        /// commit boundary, so a reload never applies code compiled from bytes that are gone.
+        /// </summary>
+        [Test]
+        public async Task Run_RequestSourceRewrittenAfterTransform_ActivatesNothing()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
+            Dictionary<string, string> edits = CreateIntroducedTypeEdits(hostPath, callerPath, "RequestDrift");
+            HotReloadOrchestratorResult result;
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                    CreateDependenciesWithAfterGateAction(() => AppendMarkerComment(edits[callerPath]))))
+                {
+                    result = await HotReloadOrchestrator.RunAsync(
+                        new[] { hostPath, callerPath },
+                        contentPathOverride: null,
+                        CancellationToken.None,
+                        edits);
+                }
+
+                AssertNothingWasCommitted(result, "changed after it was transformed");
+            }
+        }
+
+        // A comment keeps the file compilable while changing every byte-derived hash of it.
+        private static void AppendMarkerComment(string editedSourcePath)
+        {
+            File.AppendAllText(editedSourcePath, "\n// rewritten before the commit boundary\n");
+        }
+
+        private static void AssertNothingWasCommitted(
+            HotReloadOrchestratorResult result,
+            string reasonFragment)
+        {
+            Assert.That(
+                FindFailureReason(result, reasonFragment),
+                Is.Not.Null,
+                "The run must report why it stopped at the commit boundary.");
+            Assert.That(
+                HotReloadIntroducedTypeHolder.Registry.PreparedCount,
+                Is.EqualTo(0),
+                "A run stopped at the commit boundary must leave no prepared membership.");
+            Assert.That(
+                HotReloadIntroducedTypeHolder.Registry.ActiveCount,
+                Is.EqualTo(0),
+                "A run stopped at the commit boundary must activate no type.");
+            Assert.That(
+                HotReloadPatcher.ActivePatchCount,
+                Is.EqualTo(0),
+                "A run stopped at the commit boundary must apply no patch.");
+        }
+
+        private static string FindFailureReason(HotReloadOrchestratorResult result, string reasonFragment)
+        {
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
+                    && outcome.Reason != null
+                    && outcome.Reason.Contains(reasonFragment, StringComparison.Ordinal))
+                {
+                    return outcome.Reason;
+                }
+            }
+
+            return null;
+        }
+
+        private static HotReloadGroupProcessorDependencies CreateArtifactCapturingDependencies(
+            Action<HotReloadIntroducedTypeArtifact> captureArtifact)
+        {
+            return HotReloadGroupProcessorDependencies.Create(
+                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                async (files, input, ct) =>
+                {
+                    HotReloadIntroducedTypePreparationResult preparation =
+                        await HotReloadIntroducedTypePreparation.PrepareAsync(files, input, ct);
+                    captureArtifact(preparation.Prepared?.Artifact);
+                    return preparation;
+                },
+                TransformWorkerClient.RunAsync,
+                HotReloadGroupProcessor.GateAndCompileAsync,
+                HotReloadGroupEntryPreparation.PrepareGroup,
+                HotReloadEntryApplier.ApplyPreparedEntries);
+        }
+
+        // The window between the preparation run and the transform run, which is where an owner
+        // rewrite makes the prepared artifact stale.
+        private static HotReloadGroupProcessorDependencies CreateDependenciesWithBeforeWorkerAction(
+            Action beforeWorker)
+        {
+            return HotReloadGroupProcessorDependencies.Create(
+                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                HotReloadIntroducedTypePreparation.PrepareAsync,
+                (input, ct) =>
+                {
+                    beforeWorker();
+                    return TransformWorkerClient.RunAsync(input, ct);
+                },
+                HotReloadGroupProcessor.GateAndCompileAsync,
+                HotReloadGroupEntryPreparation.PrepareGroup,
+                HotReloadEntryApplier.ApplyPreparedEntries);
+        }
+
+        // The window between the shim compile and the commit boundary, which is the last instant
+        // an external change can invalidate a run that has mutated nothing yet.
+        private static HotReloadGroupProcessorDependencies CreateDependenciesWithAfterGateAction(
+            Action afterGate)
+        {
+            return HotReloadGroupProcessorDependencies.Create(
+                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                HotReloadIntroducedTypePreparation.PrepareAsync,
+                TransformWorkerClient.RunAsync,
+                async (context, ct) =>
+                {
+                    HotReloadGroupGateAndCompileResult gateAndCompile =
+                        await HotReloadGroupProcessor.GateAndCompileAsync(context, ct);
+                    afterGate();
+                    return gateAndCompile;
+                },
+                HotReloadGroupEntryPreparation.PrepareGroup,
+                HotReloadEntryApplier.ApplyPreparedEntries);
+        }
+
+        // The edited caller returns the introduced type's value plus the compiled host's value.
+        private const int IntroducedValueThroughCaller = 8;
 
         private const string ValidateStage = "validate-membership";
 

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -293,6 +293,139 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that a later reload which declares a type this domain already introduced
+        /// reuses the active type instead of introducing it again: the run succeeds, no second
+        /// artifact becomes active, and the caller it patches still reads through the one type.
+        /// </summary>
+        [Test]
+        public async Task Run_SameTypeDeclaredAgainByALaterReload_ReusesTheActiveTypeWithoutIntroducingItAgain()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
+            HotReloadIntroducedTypeArtifact firstArtifact = null;
+            List<int> preparedDescriptorCounts = new List<int>();
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                    CreatePreparationCountingDependencies(
+                        preparedDescriptorCounts,
+                        artifact =>
+                        {
+                            if (firstArtifact == null)
+                            {
+                                firstArtifact = artifact;
+                            }
+                        })))
+                {
+                    HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                        new[] { hostPath, callerPath },
+                        contentPathOverride: null,
+                        CancellationToken.None,
+                        CreateIntroducedTypeEdits(hostPath, callerPath, "FirstIntroduction"));
+
+                    AssertCallerIsPatched(first);
+                    Assert.That(firstArtifact, Is.Not.Null, "The first run had to prepare the introduced type.");
+
+                    HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                        new[] { hostPath, callerPath },
+                        contentPathOverride: null,
+                        CancellationToken.None,
+                        CreateReintroducingEdits(hostPath, callerPath));
+
+                    Assert.That(
+                        FindFailureReason(second, string.Empty),
+                        Is.Null,
+                        "A reload that declares an already introduced type must not fail.");
+                    AssertCallerIsPatched(second);
+                }
+
+                Assert.That(
+                    preparedDescriptorCounts,
+                    Is.EqualTo(new[] { 1, 0 }),
+                    "The second run must introduce no type, because the one it declares is active.");
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Registry.ActiveCount,
+                    Is.EqualTo(1),
+                    "A re-declared type must not add a second active artifact.");
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Registry.TryFindActive(
+                        firstArtifact.Descriptors,
+                        out HotReloadIntroducedTypeArtifact activeArtifact),
+                    Is.True);
+                Assert.That(activeArtifact, Is.SameAs(firstArtifact));
+                Assert.That(
+                    new HotReloadCrossFileAddedMemberCaller().Call(new HotReloadCrossFileAddedMemberHost()),
+                    Is.EqualTo(IntroducedValueThroughReintroducedCaller),
+                    "The caller the second run patched must read through the active type.");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a later reload which redefines a type this domain already introduced is
+        /// refused instead of binding the caller against the stale retained definition: stage one
+        /// cannot replace an artifact assembly a live type was loaded from.
+        /// </summary>
+        [Test]
+        public async Task Run_ActiveIntroducedTypeRedefined_FailsAndLeavesTheActiveTypeInPlace()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
+            HotReloadIntroducedTypeArtifact firstArtifact = null;
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                    CreateArtifactCapturingDependencies(artifact =>
+                    {
+                        if (artifact != null)
+                        {
+                            firstArtifact = artifact;
+                        }
+                    })))
+                {
+                    HotReloadOrchestratorResult first = await HotReloadOrchestrator.RunAsync(
+                        new[] { hostPath, callerPath },
+                        contentPathOverride: null,
+                        CancellationToken.None,
+                        CreateIntroducedTypeEdits(hostPath, callerPath, "BeforeRedefinition"));
+
+                    AssertCallerIsPatched(first);
+                    Assert.That(firstArtifact, Is.Not.Null, "The first run had to prepare the introduced type.");
+
+                    HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
+                        new[] { hostPath, callerPath },
+                        contentPathOverride: null,
+                        CancellationToken.None,
+                        CreateRedefiningEdits(hostPath, callerPath));
+
+                    Assert.That(
+                        FindFailureReason(second, "requires a compile"),
+                        Is.Not.Null,
+                        "A redefined introduced type must fail the reload with a compile hint.\n"
+                        + DescribeOutcomes(second));
+                }
+
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Registry.ActiveCount,
+                    Is.EqualTo(1),
+                    "A refused redefinition must leave the already active type in place.");
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Registry.PreparedCount,
+                    Is.EqualTo(0),
+                    "A refused redefinition must leave no prepared membership behind.");
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Registry.TryFindActive(
+                        firstArtifact.Descriptors,
+                        out HotReloadIntroducedTypeArtifact activeArtifact),
+                    Is.True);
+                Assert.That(activeArtifact, Is.SameAs(firstArtifact));
+            }
+        }
+
+        /// <summary>
         /// Verifies that a reload whose only change is a new type declaration still reaches the
         /// commit boundary and activates the type, instead of ending unapplied because the run
         /// has no method to patch.
@@ -454,6 +587,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "A run stopped at the commit boundary must apply no patch.");
         }
 
+        private static string DescribeOutcomes(HotReloadOrchestratorResult result)
+        {
+            System.Text.StringBuilder description = new System.Text.StringBuilder();
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                description.Append(outcome.Kind).Append(' ').Append(outcome.Method)
+                    .Append(" :: ").Append(outcome.Reason).Append('\n');
+            }
+
+            return description.ToString();
+        }
+
         private static string FindFailureReason(HotReloadOrchestratorResult result, string reasonFragment)
         {
             foreach (HotReloadMethodOutcome outcome in result.Methods)
@@ -467,6 +612,33 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             return null;
+        }
+
+        // Records how many introduced-type descriptors each run of a scope prepared, which is how
+        // a run that reuses an already active type is told from one that introduces it again.
+        private static HotReloadGroupProcessorDependencies CreatePreparationCountingDependencies(
+            List<int> preparedDescriptorCounts,
+            Action<HotReloadIntroducedTypeArtifact> captureArtifact)
+        {
+            return HotReloadGroupProcessorDependencies.Create(
+                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                async (files, input, ct) =>
+                {
+                    HotReloadIntroducedTypePreparationResult preparation =
+                        await HotReloadIntroducedTypePreparation.PrepareAsync(files, input, ct);
+                    HotReloadIntroducedTypeArtifact artifact = preparation.Prepared?.Artifact;
+                    preparedDescriptorCounts.Add(artifact == null ? 0 : artifact.Descriptors.Count);
+                    if (artifact != null)
+                    {
+                        captureArtifact(artifact);
+                    }
+
+                    return preparation;
+                },
+                TransformWorkerClient.RunAsync,
+                HotReloadGroupProcessor.GateAndCompileAsync,
+                HotReloadGroupEntryPreparation.PrepareGroup,
+                HotReloadEntryApplier.ApplyPreparedEntries);
         }
 
         private static HotReloadGroupProcessorDependencies CreateArtifactCapturingDependencies(
@@ -527,6 +699,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         // The edited caller returns the introduced type's value plus the compiled host's value.
         private const int IntroducedValueThroughCaller = 8;
+
+        // The second reload keeps the same introduced type and edits only the caller, so its
+        // value shifts by one while the type it reads through must stay the one already active.
+        private const int IntroducedValueThroughReintroducedCaller = 9;
 
         private const string ValidateStage = "validate-membership";
 
@@ -935,6 +1111,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + "    }\n"
                 + "\n";
             return hostSource.Replace(HostTypeAnchor, introduced + HostTypeAnchor, StringComparison.Ordinal);
+        }
+
+        // The introduced type redefined with a different body, which is what makes its
+        // declaration fingerprint differ from the one the retained assembly was compiled from.
+        private static Dictionary<string, string> CreateRedefiningEdits(string hostPath, string callerPath)
+        {
+            return new Dictionary<string, string>
+            {
+                [hostPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                    "IntroducedTypeRedefinitionHost.cs",
+                    InsertIntroducedType(File.ReadAllText(hostPath)).Replace(
+                        "            return 7;",
+                        "            return 70;",
+                        StringComparison.Ordinal)),
+                [callerPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                    "IntroducedTypeRedefinitionCaller.cs",
+                    CallIntroducedType(File.ReadAllText(callerPath)))
+            };
+        }
+
+        // The same introduced declaration as the first reload, with a caller edited differently so
+        // the reload is not short-circuited as unchanged.
+        private static Dictionary<string, string> CreateReintroducingEdits(string hostPath, string callerPath)
+        {
+            return new Dictionary<string, string>
+            {
+                [hostPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                    "IntroducedTypeReintroductionHost.cs",
+                    InsertIntroducedType(File.ReadAllText(hostPath))),
+                [callerPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                    "IntroducedTypeReintroductionCaller.cs",
+                    File.ReadAllText(callerPath).Replace(
+                        CallerBodyAnchor,
+                        "return new HotReloadCrossFileIntroducedValue().Read() + host.Value() + 1;",
+                        StringComparison.Ordinal))
+            };
         }
 
         private static string CallIntroducedType(string callerSource)

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -18,6 +18,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     /// </summary>
     public class HotReloadIntroducedTypeActivationTests
     {
+        [SetUp]
+        public void SetUp()
+        {
+            HotReloadPatcher.RevertAll();
+            HotReloadAutoRefreshHold.Sync(HotReloadPatcher.ActiveChangeCount);
+        }
+
+        // Why reverting here as well: a run of this class patches a fixture caller against an
+        // artifact assembly that only lives while the run's prepared scope is open, so leaving
+        // the patch active would fail the first later test that calls the fixture.
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadPatcher.RevertAll();
+            HotReloadAutoRefreshHold.Sync(HotReloadPatcher.ActiveChangeCount);
+        }
+
         /// <summary>
         /// Verifies that the resolver the production holder exposes resolves what the registry it
         /// exposes activated, so both sides of the pair are the same instance.
@@ -138,7 +155,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                             TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(input, ct);
                             transformOutput = result.Output;
                             return result;
-                        })))
+                        },
+                        HotReloadGroupProcessor.GateAndCompileAsync,
+                        HotReloadGroupEntryPreparation.PrepareGroup,
+                        HotReloadEntryApplier.ApplyPreparedEntries)))
                 {
                     HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
                         new[] { hostPath, callerPath },
@@ -198,7 +218,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         {
                             transformInput = input;
                             return TransformWorkerClient.RunAsync(input, ct);
-                        })))
+                        },
+                        HotReloadGroupProcessor.GateAndCompileAsync,
+                        HotReloadGroupEntryPreparation.PrepareGroup,
+                        HotReloadEntryApplier.ApplyPreparedEntries)))
                 {
                     await HotReloadOrchestrator.RunAsync(
                         new[] { callerPath },
@@ -217,6 +240,263 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 transformInput.introducedTypeArtifacts,
                 Is.Empty,
                 "A run must not be offered an artifact bound to another generation of its assembly.");
+        }
+
+        private const string ValidateStage = "validate-membership";
+
+        private const string PrepareStage = "prepare-introduced-types";
+
+        private const string WorkerStage = "run-worker";
+
+        private const string GateStage = "gate-and-compile";
+
+        private const string PreflightStage = "prepare-group-entries";
+
+        private const string ApplyStage = "apply-prepared-entries";
+
+        /// <summary>
+        /// Verifies that a run introducing a type walks its stages in the one order the design
+        /// requires: owner membership validation, type preparation, the transform run, the gate
+        /// and shim compile, the group-wide preflight, and only then the apply that mutates.
+        /// </summary>
+        [Test]
+        public async Task Run_TypeIntroducedWithItsCaller_WalksTheGroupStagesInOrder()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
+            List<string> stages = new List<string>();
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                    CreateRecordingDependencies(stages)))
+                {
+                    HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                        new[] { hostPath, callerPath },
+                        contentPathOverride: null,
+                        CancellationToken.None,
+                        CreateIntroducedTypeEdits(hostPath, callerPath, "StageOrder"));
+
+                    AssertCallerIsPatched(result);
+                }
+
+                // The commit boundary that activates a run is a later stage, so the prepared
+                // membership the run registered must be gone again once the run ends.
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Registry.PreparedCount,
+                    Is.EqualTo(0),
+                    "A finished run must leave no prepared membership behind.");
+            }
+
+            Assert.That(
+                stages,
+                Is.EqualTo(new[]
+                {
+                    ValidateStage,
+                    PrepareStage,
+                    WorkerStage,
+                    GateStage,
+                    PreflightStage,
+                    ApplyStage
+                }),
+                "The group pipeline must reach its commit boundary only through this order.");
+        }
+
+        /// <summary>
+        /// Verifies that a group whose files no longer belong to the assembly they were resolved
+        /// against is dropped before any type is compiled into an artifact.
+        /// </summary>
+        [Test]
+        public async Task Run_OwnerMembershipValidationFails_DoesNotPrepareIntroducedTypes()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
+            List<string> stages = new List<string>();
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                    CreateFailingMembershipDependencies(stages)))
+                {
+                    await HotReloadOrchestrator.RunAsync(
+                        new[] { hostPath, callerPath },
+                        contentPathOverride: null,
+                        CancellationToken.None,
+                        CreateIntroducedTypeEdits(hostPath, callerPath, "MembershipFailure"));
+                }
+
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Registry.PreparedCount,
+                    Is.EqualTo(0),
+                    "A group dropped at owner validation must leave no prepared membership.");
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Registry.ActiveCount,
+                    Is.EqualTo(0),
+                    "A group dropped at owner validation must activate no type.");
+            }
+
+            Assert.That(
+                stages,
+                Is.EqualTo(new[] { ValidateStage }),
+                "Owner validation failure must stop the run before the type preparation.");
+        }
+
+        /// <summary>
+        /// Verifies that a failed type preparation stops the run before the transform worker and
+        /// leaves the patch ledger and the introduced-type ledgers exactly as it found them.
+        /// </summary>
+        [Test]
+        public async Task Run_IntroducedTypePreparationFails_DoesNotRunTheWorkerAndLeavesLedgersUnchanged()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
+            List<string> stages = new List<string>();
+            int patchesBefore = HotReloadPatcher.ActivePatchCount;
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                    CreateFailingPreparationDependencies(stages)))
+                {
+                    await HotReloadOrchestrator.RunAsync(
+                        new[] { hostPath, callerPath },
+                        contentPathOverride: null,
+                        CancellationToken.None,
+                        CreateIntroducedTypeEdits(hostPath, callerPath, "PreparationFailure"));
+                }
+
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Registry.PreparedCount,
+                    Is.EqualTo(0),
+                    "A failed preparation must leave no prepared membership behind.");
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Registry.ActiveCount,
+                    Is.EqualTo(0),
+                    "A failed preparation must activate no type.");
+            }
+
+            Assert.That(
+                stages,
+                Is.EqualTo(new[] { ValidateStage, PrepareStage }),
+                "A failed preparation must stop the run before the transform worker.");
+            Assert.That(
+                HotReloadPatcher.ActivePatchCount,
+                Is.EqualTo(patchesBefore),
+                "A failed preparation must leave the patch ledger unchanged.");
+        }
+
+        private static Dictionary<string, string> CreateIntroducedTypeEdits(
+            string hostPath,
+            string callerPath,
+            string label)
+        {
+            return new Dictionary<string, string>
+            {
+                [hostPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                    "IntroducedType" + label + "Host.cs",
+                    InsertIntroducedType(File.ReadAllText(hostPath))),
+                [callerPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                    "IntroducedType" + label + "Caller.cs",
+                    CallIntroducedType(File.ReadAllText(callerPath)))
+            };
+        }
+
+        // Why every stage delegates to production: the order under test is the production order,
+        // so a recording decorator must not stand in for any stage of it.
+        private static HotReloadGroupProcessorDependencies CreateRecordingDependencies(List<string> stages)
+        {
+            return HotReloadGroupProcessorDependencies.Create(
+                files =>
+                {
+                    stages.Add(ValidateStage);
+                    return HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(files);
+                },
+                (files, input, ct) =>
+                {
+                    stages.Add(PrepareStage);
+                    return HotReloadIntroducedTypePreparation.PrepareAsync(files, input, ct);
+                },
+                (input, ct) =>
+                {
+                    stages.Add(WorkerStage);
+                    return TransformWorkerClient.RunAsync(input, ct);
+                },
+                (context, ct) =>
+                {
+                    stages.Add(GateStage);
+                    return HotReloadGroupProcessor.GateAndCompileAsync(context, ct);
+                },
+                (context, compileResult, entriesToPatch) =>
+                {
+                    stages.Add(PreflightStage);
+                    return HotReloadGroupEntryPreparation.PrepareGroup(context, compileResult, entriesToPatch);
+                },
+                (context, compileResult, preparedFiles) =>
+                {
+                    stages.Add(ApplyStage);
+                    return HotReloadEntryApplier.ApplyPreparedEntries(context, compileResult, preparedFiles);
+                });
+        }
+
+        // Why the failure is injected instead of provoked: a group whose sources left their
+        // assembly cannot be produced from a compiled fixture, and the stage under test is
+        // "nothing runs after the refusal", not how the refusal is decided.
+        private static HotReloadGroupProcessorDependencies CreateFailingMembershipDependencies(List<string> stages)
+        {
+            return HotReloadGroupProcessorDependencies.Create(
+                files =>
+                {
+                    stages.Add(ValidateStage);
+                    HotReloadGroupOutcomeRouter.AppendGroupFailure(
+                        files,
+                        "(file)",
+                        "The compiled assembly changed while the group was being processed.");
+                    return false;
+                },
+                (files, input, ct) =>
+                {
+                    stages.Add(PrepareStage);
+                    return HotReloadIntroducedTypePreparation.PrepareAsync(files, input, ct);
+                },
+                (input, ct) =>
+                {
+                    stages.Add(WorkerStage);
+                    return TransformWorkerClient.RunAsync(input, ct);
+                },
+                HotReloadGroupProcessor.GateAndCompileAsync,
+                HotReloadGroupEntryPreparation.PrepareGroup,
+                HotReloadEntryApplier.ApplyPreparedEntries);
+        }
+
+        // Why the failure is injected: an artifact compile failure cannot be provoked from a
+        // fixture the repository keeps compiling, and the stage under test is that the run stops
+        // before the worker with every ledger untouched.
+        private static HotReloadGroupProcessorDependencies CreateFailingPreparationDependencies(List<string> stages)
+        {
+            return HotReloadGroupProcessorDependencies.Create(
+                files =>
+                {
+                    stages.Add(ValidateStage);
+                    return HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(files);
+                },
+                (files, input, ct) =>
+                {
+                    stages.Add(PrepareStage);
+                    return Task.FromResult(
+                        HotReloadIntroducedTypePreparationResult.Failure(
+                            "The introduced type artifact could not be compiled."));
+                },
+                (input, ct) =>
+                {
+                    stages.Add(WorkerStage);
+                    return TransformWorkerClient.RunAsync(input, ct);
+                },
+                HotReloadGroupProcessor.GateAndCompileAsync,
+                HotReloadGroupEntryPreparation.PrepareGroup,
+                HotReloadEntryApplier.ApplyPreparedEntries);
         }
 
         private static HotReloadIntroducedTypeArtifact CreateArtifactForTarget(

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -426,6 +426,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that a file whose entries the group preflight could not resolve stops the run
+        /// before the commit point, so a group that will patch nothing activates no introduced
+        /// type and leaves the failed file's own resolution failure as the reported outcome.
+        /// </summary>
+        [Test]
+        public async Task Run_OneFileFailsTheGroupPreflight_ActivatesNothing()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                    CreateDependenciesWithFailedResolutionFor(Path.GetFileName(callerPath))))
+                {
+                    HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                        new[] { hostPath, callerPath },
+                        contentPathOverride: null,
+                        CancellationToken.None,
+                        CreateIntroducedTypeEdits(hostPath, callerPath, "PreflightFailure"));
+
+                    AssertNothingWasCommitted(result, UnresolvableEntryReason);
+                }
+            }
+        }
+
+        /// <summary>
         /// Verifies that a reload whose only change is a new type declaration still reaches the
         /// commit boundary and activates the type, instead of ending unapplied because the run
         /// has no method to patch.
@@ -695,6 +723,68 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 },
                 HotReloadGroupEntryPreparation.PrepareGroup,
                 HotReloadEntryApplier.ApplyPreparedEntries);
+        }
+
+        // The reason of the preflight failure this test injects at the PrepareGroupEntries seam.
+        private const string UnresolvableEntryReason = "An entry of this file could not be resolved.";
+
+        // Why the failure is injected: an entry that cannot be resolved against a shim assembly
+        // the same run has just compiled from the same source cannot be produced from a fixture,
+        // and what is under test is that the commit point is not reached, not how resolution
+        // decides a file has failed.
+        private static HotReloadGroupProcessorDependencies CreateDependenciesWithFailedResolutionFor(
+            string failingFileName)
+        {
+            return HotReloadGroupProcessorDependencies.Create(
+                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                HotReloadIntroducedTypePreparation.PrepareAsync,
+                TransformWorkerClient.RunAsync,
+                HotReloadGroupProcessor.GateAndCompileAsync,
+                (context, compileResult, entriesToPatch) =>
+                {
+                    IReadOnlyList<HotReloadPreparedGroupFile> prepared =
+                        HotReloadGroupEntryPreparation.PrepareGroup(context, compileResult, entriesToPatch);
+                    List<HotReloadPreparedGroupFile> replaced =
+                        new List<HotReloadPreparedGroupFile>(prepared.Count);
+                    bool failedOne = false;
+                    foreach (HotReloadPreparedGroupFile preparedFile in prepared)
+                    {
+                        HotReloadPreparedGroupFile candidate =
+                            FailResolutionOfMatchingFile(preparedFile, failingFileName);
+                        failedOne = failedOne || !ReferenceEquals(candidate, preparedFile);
+                        replaced.Add(candidate);
+                    }
+
+                    Assert.That(
+                        failedOne,
+                        Is.True,
+                        "Precondition: the group had to resolve " + failingFileName + " to fail it.");
+                    return replaced;
+                },
+                HotReloadEntryApplier.ApplyPreparedEntries);
+        }
+
+        private static HotReloadPreparedGroupFile FailResolutionOfMatchingFile(
+            HotReloadPreparedGroupFile prepared,
+            string failingFileName)
+        {
+            if (prepared.Kind != HotReloadGroupFilePreparationKind.Resolved
+                || !prepared.File.ProjectRelativePath.EndsWith(failingFileName, StringComparison.Ordinal))
+            {
+                return prepared;
+            }
+
+            List<HotReloadMethodOutcome> failureOutcomes = new List<HotReloadMethodOutcome>
+            {
+                HotReloadMethodOutcome.Failed(
+                    prepared.File.ProjectRelativePath,
+                    UnresolvableEntryReason,
+                    prepared.File.AssemblyResolvePath)
+            };
+            return HotReloadPreparedGroupFile.ResolutionFailed(
+                prepared.File,
+                prepared.Entries,
+                HotReloadEntryResolution.Result.Failed(failureOutcomes));
         }
 
         // The edited caller returns the introduced type's value plus the compiled host's value.

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -2,8 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 
 using NUnit.Framework;
+
+using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 
@@ -95,6 +99,293 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
                 Assert.That(restoredResolver.ResolutionCount, Is.GreaterThan(restoredBefore));
             }
+        }
+
+        /// <summary>
+        /// Verifies that a type introduced in one edited file reaches the transform run of the same
+        /// reload as a prepared artifact record, that the owner file's rows carry no member of the
+        /// introduced declaration, and that the caller edited alongside it is patched against the
+        /// artifact instead of the source that still declares the type.
+        /// </summary>
+        [Test]
+        public async Task Run_TypeIntroducedWithItsCaller_PropagatesThePreparedArtifactToTheTransformRun()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
+            string hostProjectRelativePath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(hostPath);
+            TransformWorkerInputDto transformInput = null;
+            TransformWorkerOutputDto transformOutput = null;
+            HotReloadIntroducedTypeArtifact preparedArtifact = null;
+            string ownerAssemblyName = null;
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                    HotReloadGroupProcessorDependencies.Create(
+                        HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                        async (files, input, ct) =>
+                        {
+                            ownerAssemblyName = files[0].AssemblyName;
+                            HotReloadIntroducedTypePreparationResult preparation =
+                                await HotReloadIntroducedTypePreparation.PrepareAsync(files, input, ct);
+                            preparedArtifact = preparation.Artifact;
+                            return preparation;
+                        },
+                        async (input, ct) =>
+                        {
+                            transformInput = input;
+                            TransformWorkerClientResult result = await TransformWorkerClient.RunAsync(input, ct);
+                            transformOutput = result.Output;
+                            return result;
+                        })))
+                {
+                    HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                        new[] { hostPath, callerPath },
+                        contentPathOverride: null,
+                        CancellationToken.None,
+                        new Dictionary<string, string>
+                        {
+                            [hostPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                                "IntroducedTypePropagationHost.cs",
+                                InsertIntroducedType(File.ReadAllText(hostPath))),
+                            [callerPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                                "IntroducedTypePropagationCaller.cs",
+                                CallIntroducedType(File.ReadAllText(callerPath)))
+                        });
+
+                    AssertCallerIsPatched(result);
+                }
+            }
+
+            Assert.That(preparedArtifact, Is.Not.Null, "The run had to prepare the introduced type.");
+            Assert.That(
+                string.Equals(
+                    FindDescriptor(preparedArtifact, IntroducedTypeMetadataName).OriginalAssemblyName,
+                    ownerAssemblyName,
+                    StringComparison.Ordinal),
+                Is.True,
+                "The descriptor identity the short-circuit branch keys on must be the file's assembly name.");
+            AssertArtifactRecordReachedTheTransformRun(transformInput, preparedArtifact);
+            AssertOwnerRowsCarryNoIntroducedMember(transformOutput, hostProjectRelativePath);
+        }
+
+        /// <summary>
+        /// Verifies that an artifact active for another generation of the same compiled assembly
+        /// is left out of the run's records, because its types were normalized back to an assembly
+        /// this run no longer edits.
+        /// </summary>
+        [Test]
+        public async Task Run_ActiveArtifactOfAnotherGeneration_IsNotOfferedToTheTransformRun()
+        {
+            string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
+            string callerAssemblyName = ResolveAssemblyName(callerPath);
+            TransformWorkerInputDto transformInput = null;
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                HotReloadIntroducedTypeArtifact staleArtifact = CreateArtifactForTarget(
+                    callerAssemblyName,
+                    "0000000000000000000000000000000000000000");
+                HotReloadIntroducedTypeHolder.Registry.RegisterPrepared(staleArtifact);
+                HotReloadIntroducedTypeHolder.Registry.Activate(staleArtifact);
+                using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                    HotReloadGroupProcessorDependencies.Create(
+                        HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                        HotReloadIntroducedTypePreparation.PrepareAsync,
+                        (input, ct) =>
+                        {
+                            transformInput = input;
+                            return TransformWorkerClient.RunAsync(input, ct);
+                        })))
+                {
+                    await HotReloadOrchestrator.RunAsync(
+                        new[] { callerPath },
+                        HotReloadTestSourceWriter.WriteEditedSource(
+                            "IntroducedTypeStaleGenerationCaller.cs",
+                            File.ReadAllText(callerPath).Replace(
+                                "return 7;",
+                                "return 8;",
+                                StringComparison.Ordinal)),
+                        CancellationToken.None);
+                }
+            }
+
+            Assert.That(transformInput, Is.Not.Null, "The transform run had to be reached.");
+            Assert.That(
+                transformInput.introducedTypeArtifacts,
+                Is.Empty,
+                "A run must not be offered an artifact bound to another generation of its assembly.");
+        }
+
+        private static HotReloadIntroducedTypeArtifact CreateArtifactForTarget(
+            string originalAssemblyName,
+            string originalAssemblyMvid)
+        {
+            Assembly assembly = typeof(HotReloadIntroducedTypeActivationTests).Assembly;
+            List<HotReloadIntroducedTypeDescriptor> descriptors =
+                new List<HotReloadIntroducedTypeDescriptor>
+                {
+                    new HotReloadIntroducedTypeDescriptor(
+                        originalAssemblyName,
+                        originalAssemblyMvid,
+                        "Example.StaleGeneration",
+                        "Assets/Example.cs",
+                        "fingerprint",
+                        "public class StaleGeneration { }")
+                };
+            return new HotReloadIntroducedTypeArtifact(
+                assembly,
+                assembly.Location,
+                assembly.Location,
+                descriptors);
+        }
+
+        private static string ResolveAssemblyName(string scriptPath)
+        {
+            string projectRelativePath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(scriptPath);
+            return Path.GetFileNameWithoutExtension(
+                UnityEditor.Compilation.CompilationPipeline.GetAssemblyNameFromScriptPath(projectRelativePath));
+        }
+
+        private const string IntroducedTypeMetadataName =
+            "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadCrossFileIntroducedValue";
+
+        private const string HostTypeAnchor = "    public sealed class HotReloadCrossFileAddedMemberHost";
+
+        private const string CallerBodyAnchor = "return host.Value();";
+
+        private static void AssertArtifactRecordReachedTheTransformRun(
+            TransformWorkerInputDto transformInput,
+            HotReloadIntroducedTypeArtifact preparedArtifact)
+        {
+            Assert.That(transformInput, Is.Not.Null, "The transform run had to be reached.");
+            Assert.That(
+                transformInput.introducedTypeArtifacts,
+                Is.Not.Null.And.Not.Empty,
+                "The transform run must see the artifact this run prepared.");
+            foreach (TransformWorkerIntroducedTypeArtifactDto artifact in transformInput.introducedTypeArtifacts)
+            {
+                if (!string.Equals(artifact.assemblyFullName, preparedArtifact.AssemblyFullName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                Assert.That(
+                    File.Exists(artifact.referencePath),
+                    Is.True,
+                    "The record must point at the artifact assembly the preparation compiled.");
+                return;
+            }
+
+            Assert.Fail("No record named the prepared artifact " + preparedArtifact.AssemblyFullName + ".");
+        }
+
+        private static void AssertOwnerRowsCarryNoIntroducedMember(
+            TransformWorkerOutputDto transformOutput,
+            string ownerProjectRelativePath)
+        {
+            Assert.That(transformOutput, Is.Not.Null, "The transform run had to produce an output.");
+            foreach (TransformWorkerEntryDto entry in transformOutput.entries)
+            {
+                Assert.That(
+                    IsIntroducedRow(entry.sourceProjectRelativePath, ownerProjectRelativePath, entry.typeMetadataName),
+                    Is.False,
+                    "The owner file must not carry an entry for the introduced declaration.");
+            }
+
+            foreach (TransformWorkerUnchangedMethodDto unchanged in transformOutput.unchangedMethods)
+            {
+                Assert.That(
+                    IsIntroducedRow(
+                        unchanged.sourceProjectRelativePath,
+                        ownerProjectRelativePath,
+                        unchanged.typeMetadataName),
+                    Is.False,
+                    "The owner file must not carry an unchanged-method row for the introduced declaration.");
+            }
+
+            foreach (TransformWorkerSkippedDto skipped in transformOutput.skipped)
+            {
+                Assert.That(
+                    IsIntroducedRow(skipped.sourceProjectRelativePath, ownerProjectRelativePath, skipped.method),
+                    Is.False,
+                    "The owner file must not carry a skip row for the introduced declaration.");
+            }
+        }
+
+        private static bool IsIntroducedRow(
+            string rowProjectRelativePath,
+            string ownerProjectRelativePath,
+            string rowIdentity)
+        {
+            return string.Equals(rowProjectRelativePath, ownerProjectRelativePath, StringComparison.Ordinal)
+                && rowIdentity != null
+                && rowIdentity.Contains("HotReloadCrossFileIntroducedValue", StringComparison.Ordinal);
+        }
+
+        private static void AssertCallerIsPatched(HotReloadOrchestratorResult result)
+        {
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Patched
+                    && outcome.Method != null
+                    && outcome.Method.Contains("Call", StringComparison.Ordinal))
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail("The caller edited against the introduced type must be patched.");
+        }
+
+        private static HotReloadIntroducedTypeDescriptor FindDescriptor(
+            HotReloadIntroducedTypeArtifact artifact,
+            string metadataName)
+        {
+            foreach (HotReloadIntroducedTypeDescriptor descriptor in artifact.Descriptors)
+            {
+                if (string.Equals(descriptor.MetadataName, metadataName, StringComparison.Ordinal))
+                {
+                    return descriptor;
+                }
+            }
+
+            Assert.Fail("The prepared artifact must describe " + metadataName + ".");
+            return null;
+        }
+
+        private static string InsertIntroducedType(string hostSource)
+        {
+            Assert.That(hostSource, Does.Contain(HostTypeAnchor), "Precondition: host type anchor must exist.");
+            string introduced =
+                "    public sealed class HotReloadCrossFileIntroducedValue\n"
+                + "    {\n"
+                + "        public int Read()\n"
+                + "        {\n"
+                + "            return 7;\n"
+                + "        }\n"
+                + "    }\n"
+                + "\n";
+            return hostSource.Replace(HostTypeAnchor, introduced + HostTypeAnchor, StringComparison.Ordinal);
+        }
+
+        private static string CallIntroducedType(string callerSource)
+        {
+            Assert.That(callerSource, Does.Contain(CallerBodyAnchor), "Precondition: caller body anchor must exist.");
+            return callerSource.Replace(
+                CallerBodyAnchor,
+                "return new HotReloadCrossFileIntroducedValue().Read() + host.Value();",
+                StringComparison.Ordinal);
+        }
+
+        private static string FixturePath(string fileName)
+        {
+            string path = Path.GetFullPath(
+                Path.Combine(Application.dataPath, "Tests", "Editor", "HotReload", fileName));
+            Assert.That(File.Exists(path), Is.True, "Fixture missing: " + path);
+            return path;
         }
 
         private static void RequestUnknownAssembly()

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -677,6 +677,62 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that an introduced type owner the transform run reported no row for stops the
+        /// run at the commit boundary, because a staleness window that cannot be compared has not
+        /// been shown to be closed.
+        /// </summary>
+        [Test]
+        public async Task Run_OwnerHasNoTransformRow_ActivatesNothing()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                    CreateDependenciesWithUnverifiableOwner()))
+                {
+                    HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                        new[] { hostPath, callerPath },
+                        contentPathOverride: null,
+                        CancellationToken.None,
+                        CreateIntroducedTypeEdits(hostPath, callerPath, "OwnerWithoutRow"));
+
+                    AssertNothingWasCommitted(result, "cannot be verified");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a request source whose transform run reported no source hash stops the
+        /// run at the commit boundary as well, so no file of a group is applied on the strength of
+        /// a comparison that never happened.
+        /// </summary>
+        [Test]
+        public async Task Run_RequestSourceHasNoTransformHash_ActivatesNothing()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                    CreateDependenciesWithBlankedHashFor(Path.GetFileName(callerPath))))
+                {
+                    HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                        new[] { hostPath, callerPath },
+                        contentPathOverride: null,
+                        CancellationToken.None,
+                        CreateIntroducedTypeEdits(hostPath, callerPath, "RequestWithoutHash"));
+
+                    AssertNothingWasCommitted(result, "request source");
+                }
+            }
+        }
+
+        /// <summary>
         /// Verifies that a request source rewritten after the transform run stops the run at the
         /// commit boundary, so a reload never applies code compiled from bytes that are gone.
         /// </summary>
@@ -944,6 +1000,83 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HotReloadGroupProcessor.GateAndCompileAsync,
                 HotReloadGroupEntryPreparation.PrepareGroup,
                 HotReloadEntryApplier.ApplyPreparedEntries);
+        }
+
+        // An artifact whose owner hash is keyed by a path the transform run reported no row for,
+        // which is the shape the boundary cannot compare its two windows across.
+        private static HotReloadGroupProcessorDependencies CreateDependenciesWithUnverifiableOwner()
+        {
+            return HotReloadGroupProcessorDependencies.Create(
+                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                async (files, input, ct) =>
+                {
+                    HotReloadIntroducedTypePreparationResult preparation =
+                        await HotReloadIntroducedTypePreparation.PrepareAsync(files, input, ct);
+                    if (preparation.Prepared == null)
+                    {
+                        return preparation;
+                    }
+
+                    return HotReloadIntroducedTypePreparationResult.WithPrepared(
+                        new HotReloadPreparedIntroducedTypes(
+                            preparation.Prepared.Artifact,
+                            RekeyOwnerHashesToUnreportedPaths(preparation.Prepared.OwnerSourceHashes)));
+                },
+                TransformWorkerClient.RunAsync,
+                HotReloadGroupProcessor.GateAndCompileAsync,
+                HotReloadGroupEntryPreparation.PrepareGroup,
+                HotReloadEntryApplier.ApplyPreparedEntries);
+        }
+
+        private static Dictionary<string, string> RekeyOwnerHashesToUnreportedPaths(
+            IReadOnlyDictionary<string, string> ownerSourceHashes)
+        {
+            Dictionary<string, string> rekeyed = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (KeyValuePair<string, string> ownerHash in ownerSourceHashes)
+            {
+                rekeyed[ownerHash.Key + ".unreported.cs"] = ownerHash.Value;
+            }
+
+            return rekeyed;
+        }
+
+        // A worker output row that carries no source hash, which is what the transform client's
+        // own coalescing leaves behind when the worker omits the field.
+        private static HotReloadGroupProcessorDependencies CreateDependenciesWithBlankedHashFor(
+            string fileName)
+        {
+            return HotReloadGroupProcessorDependencies.Create(
+                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                HotReloadIntroducedTypePreparation.PrepareAsync,
+                async (input, ct) =>
+                {
+                    TransformWorkerClientResult workerResult =
+                        await TransformWorkerClient.RunAsync(input, ct);
+                    BlankSourceHashOf(workerResult.Output, fileName);
+                    return workerResult;
+                },
+                HotReloadGroupProcessor.GateAndCompileAsync,
+                HotReloadGroupEntryPreparation.PrepareGroup,
+                HotReloadEntryApplier.ApplyPreparedEntries);
+        }
+
+        private static void BlankSourceHashOf(TransformWorkerOutputDto output, string fileName)
+        {
+            if (output == null)
+            {
+                return;
+            }
+
+            foreach (TransformWorkerFileOutputDto file in output.files)
+            {
+                if (file.projectRelativePath.EndsWith(fileName, StringComparison.Ordinal))
+                {
+                    file.sourceContentSha256 = string.Empty;
+                    return;
+                }
+            }
+
+            Assert.Fail("The worker output must hold a row for " + fileName + ".");
         }
 
         // The edited caller returns the introduced type's value plus the compiled host's value.

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -549,6 +549,46 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that two files of one group declaring the same introduced type fail the run
+        /// with a reported reason naming the type, instead of letting the artifact batch's
+        /// uniqueness contract throw out of the reload.
+        /// </summary>
+        [Test]
+        public async Task Run_SameTypeDeclaredByTwoFilesOfAGroup_FailsWithoutThrowing()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
+                    new[] { hostPath, callerPath },
+                    contentPathOverride: null,
+                    CancellationToken.None,
+                    CreateDoubleDeclaringEdits(hostPath, callerPath));
+
+                Assert.That(
+                    FindFailureReason(result, "more than one file"),
+                    Is.Not.Null,
+                    "The run must report which type two files of the group declare. "
+                        + DescribeOutcomes(result));
+                Assert.That(
+                    CountFailures(result, "more than one file"),
+                    Is.EqualTo(2),
+                    "Both files of the refused group must report the refusal.");
+                Assert.That(
+                    HotReloadIntroducedTypeHolder.Registry.ActiveCount,
+                    Is.EqualTo(0),
+                    "A refused group must activate no type.");
+                Assert.That(
+                    HotReloadPatcher.ActivePatchCount,
+                    Is.EqualTo(0),
+                    "A refused group must apply no patch.");
+            }
+        }
+
+        /// <summary>
         /// Verifies that an Editor that becomes busy after the shim compile stops the run at the
         /// commit boundary, leaving no type active and no patch applied.
         /// </summary>
@@ -675,6 +715,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
 
             return description.ToString();
+        }
+
+        private static int CountFailures(HotReloadOrchestratorResult result, string reasonFragment)
+        {
+            int count = 0;
+            foreach (HotReloadMethodOutcome outcome in result.Methods)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed
+                    && outcome.Reason != null
+                    && outcome.Reason.Contains(reasonFragment, StringComparison.Ordinal))
+                {
+                    count++;
+                }
+            }
+
+            return count;
         }
 
         private static string FindFailureReason(HotReloadOrchestratorResult result, string reasonFragment)
@@ -1347,6 +1403,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         CallerBodyAnchor,
                         "return new HotReloadCrossFileIntroducedDerived().Doubled() + host.Value();",
                         StringComparison.Ordinal));
+        }
+
+        // Both files of the group declare the same type, which is what makes the group offer the
+        // artifact batch two records of one identity.
+        private static Dictionary<string, string> CreateDoubleDeclaringEdits(
+            string hostPath,
+            string callerPath)
+        {
+            string callerSource = File.ReadAllText(callerPath);
+            Assert.That(
+                callerSource,
+                Does.Contain(CallerTypeAnchor),
+                "Precondition: caller type anchor must exist.");
+            string introduced =
+                "    public sealed class HotReloadCrossFileDoubleDeclared\n"
+                + "    {\n"
+                + "        public int Read()\n"
+                + "        {\n"
+                + "            return 7;\n"
+                + "        }\n"
+                + "    }\n"
+                + "\n";
+            string hostSource = File.ReadAllText(hostPath);
+            Assert.That(hostSource, Does.Contain(HostTypeAnchor), "Precondition: host type anchor must exist.");
+            return new Dictionary<string, string>
+            {
+                [hostPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                    "IntroducedTypeDoubleDeclaredHost.cs",
+                    hostSource.Replace(HostTypeAnchor, introduced + HostTypeAnchor, StringComparison.Ordinal)),
+                [callerPath] = HotReloadTestSourceWriter.WriteEditedSource(
+                    "IntroducedTypeDoubleDeclaredCaller.cs",
+                    callerSource.Replace(
+                        CallerTypeAnchor, introduced + CallerTypeAnchor, StringComparison.Ordinal))
+            };
         }
 
         private static string CallIntroducedType(string callerSource)

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs
@@ -461,6 +461,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that activating the same artifact a second time is rejected and publishes
+        /// nothing again, so a reload that re-introduces a type it already introduced keeps
+        /// resolving through the one active artifact instead of activating a second one.
+        /// </summary>
+        [Test]
+        public void Activate_SameArtifactTwice_RejectsWithoutSecondPublication()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeArtifact artifact = CreateArtifact("already-active");
+            registry.RegisterPrepared(artifact);
+            registry.Activate(artifact);
+
+            Assert.Throws<InvalidOperationException>(() => registry.Activate(artifact));
+
+            Assert.That(registry.ActiveCount, Is.EqualTo(1));
+            Assert.That(registry.PreparedCount, Is.EqualTo(0));
+            Assert.That(
+                registry.TryFindActive(artifact.Descriptors, out HotReloadIntroducedTypeArtifact found),
+                Is.True);
+            Assert.That(found, Is.SameAs(artifact));
+        }
+
+        /// <summary>
         /// Verifies that activating an artifact that was never prepared is rejected before any
         /// mutation and leaves both lifecycle counts and the existing active mapping unchanged.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1988,7 +1988,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         {
                             membershipValidations++;
                             return HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(files);
-                        })))
+                        },
+                        HotReloadIntroducedTypePreparation.PrepareAsync,
+                        TransformWorkerClient.RunAsync)))
                 {
                     await HotReloadOrchestrator.RunAsync(
                         new[] { fixturePath },

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2552,6 +2552,55 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a reload that introduces no type peels the patch an earlier reload left on a
+        /// method that is unchanged again before it compiles its shim, so the peel survives a
+        /// shim-compile failure in a sibling method of the same file.
+        /// </summary>
+        [Test]
+        public async Task Run_NoIntroducedType_PeelsUnchangedPatchBeforeAFailingShimCompile()
+        {
+            string fixturePath = ResolveE2EFixturePath();
+            string patchedPath = WriteEditedSource(
+                "PreCompileRevertPatched.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta + 100;\n        }"));
+
+            HotReloadOrchestratorResult patched = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                patchedPath,
+                CancellationToken.None);
+
+            AssertNoFileLevelFailure(patched);
+            AssertHasPatched(patched, nameof(HotReloadE2EFixture.ComputeWithPrivate));
+            HotReloadE2EFixture fixture = new HotReloadE2EFixture();
+            Assert.That(fixture.ComputeWithPrivate(5), Is.EqualTo(115));
+
+            string failingPath = WriteEditedSource(
+                "PreCompileRevertFailing.cs",
+                BuildFixtureSource(
+                    computeWithPrivateMethod:
+                    "public int ComputeWithPrivate(int delta)\n        {\n            return _secret + delta;\n        }",
+                    callsMissingHelperMethod:
+                    "public int CallsMissingHelper(int value)\n        {\n            return MissingHelperAddedByEdit(value);\n        }"));
+
+            HotReloadOrchestratorResult failed = await HotReloadOrchestrator.RunAsync(
+                new[] { fixturePath },
+                failingPath,
+                CancellationToken.None);
+
+            Assert.That(
+                failed.ActivePatchTotal,
+                Is.EqualTo(0),
+                "A run without introduced types must peel the unchanged method before the shim "
+                + "compile it then fails on.\n" + FormatOutcomes(failed));
+            Assert.That(
+                fixture.ComputeWithPrivate(5),
+                Is.EqualTo(15),
+                "15 means the compiled body runs again; 115 means the peel never happened.");
+        }
+
+        /// <summary>
         /// What: a shim compile error in one method isolates that failure (Failed with its own
         /// compiler error, new-member hint, and original-file line) and skips every survivor
         /// in the file instead of patching them.

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2589,6 +2589,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 failingPath,
                 CancellationToken.None);
 
+            // Why the Failed outcome as well: no active patch alone would also hold for a run
+            // that never reached the shim compile, and the position under test is only pinned by
+            // a run that reached it and failed there.
+            AssertHasFailed(failed, nameof(HotReloadE2EFixture.CallsMissingHelper));
             Assert.That(
                 failed.ActivePatchTotal,
                 Is.EqualTo(0),

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1990,7 +1990,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                             return HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(files);
                         },
                         HotReloadIntroducedTypePreparation.PrepareAsync,
-                        TransformWorkerClient.RunAsync)))
+                        TransformWorkerClient.RunAsync,
+                        HotReloadGroupProcessor.GateAndCompileAsync,
+                        HotReloadGroupEntryPreparation.PrepareGroup,
+                        HotReloadEntryApplier.ApplyPreparedEntries)))
                 {
                     await HotReloadOrchestrator.RunAsync(
                         new[] { fixturePath },
@@ -2709,7 +2712,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             };
 
             HotReloadFileProcessResult fileResult =
-                HotReloadEntryApplier.ApplyGroupAndBuildResults(
+                ApplyGroupForTest(
                     CreateApplyContext(
                         typeof(HotReloadE2EFixture).Assembly.GetName().Name,
                         projectRelativePath,
@@ -2978,7 +2981,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             try
             {
                 IReadOnlyList<HotReloadFileProcessResult> results =
-                    HotReloadEntryApplier.ApplyGroupAndBuildResults(
+                    ApplyGroupForTest(
                         context,
                         HotReloadShimCompileResult.SuccessResult(
                             typeof(HotReloadOrchestratorTests).Assembly,
@@ -3063,7 +3066,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     }
                 }
             };
-            return HotReloadEntryApplier.ApplyGroupAndBuildResults(
+            return ApplyGroupForTest(
                 CreateApplyContext(
                     typeof(HotReloadCoreFixture).Assembly.GetName().Name,
                     projectRelativePath,
@@ -3083,6 +3086,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// assembly name, the group's single file and the worker output; the remaining fields
         /// exist to satisfy the context's own preconditions.
         /// </summary>
+        private static IReadOnlyList<HotReloadFileProcessResult> ApplyGroupForTest(
+            HotReloadApplyContext context,
+            HotReloadShimCompileResult compileResult,
+            TransformWorkerEntryDto[] entriesToPatch)
+        {
+            return HotReloadEntryApplier.ApplyPreparedEntries(
+                context,
+                compileResult,
+                HotReloadGroupEntryPreparation.PrepareGroup(context, compileResult, entriesToPatch));
+        }
+
         private static HotReloadApplyContext CreateApplyContext(
             string assemblyName,
             string projectRelativePath,
@@ -3142,7 +3156,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     }
                 },
                 workerOutput,
-                new[] { file });
+                new[] { file },
+                null);
         }
 
         private static HotReloadOrchestratorResult ToOrchestratorResult(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyContext.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyContext.cs
@@ -27,7 +27,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             TransformWorkerInputDto workerInput,
             TransformWorkerOutputDto workerOutput,
             IReadOnlyList<HotReloadGroupFile> files,
-            HotReloadIntroducedTypeArtifact preparedIntroducedTypeArtifact)
+            HotReloadPreparedIntroducedTypes preparedIntroducedTypes)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be empty.");
             Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be empty.");
@@ -47,7 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             WorkerInput = workerInput;
             WorkerOutput = workerOutput;
             Files = files;
-            PreparedIntroducedTypeArtifact = preparedIntroducedTypeArtifact;
+            PreparedIntroducedTypes = preparedIntroducedTypes;
 
             List<(string ProjectRelativePath, string AssemblyResolvePath)> filePaths =
                 new List<(string ProjectRelativePath, string AssemblyResolvePath)>(files.Count);
@@ -81,10 +81,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal string TargetDllPath { get; }
 
         /// <summary>
-        /// The artifact this run prepared, or null when the run introduced no type. It is prepared
-        /// but not yet active, so a stage that publishes it has to activate it first.
+        /// What this run prepared, or null when the run introduced no type. The artifact is
+        /// prepared but not yet active, so the commit boundary has to activate it first.
         /// </summary>
-        internal HotReloadIntroducedTypeArtifact PreparedIntroducedTypeArtifact { get; }
+        internal HotReloadPreparedIntroducedTypes PreparedIntroducedTypes { get; }
 
         internal string[] Defines { get; }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyContext.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyContext.cs
@@ -26,7 +26,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string[] defines,
             TransformWorkerInputDto workerInput,
             TransformWorkerOutputDto workerOutput,
-            IReadOnlyList<HotReloadGroupFile> files)
+            IReadOnlyList<HotReloadGroupFile> files,
+            HotReloadIntroducedTypeArtifact preparedIntroducedTypeArtifact)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be empty.");
             Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be empty.");
@@ -46,6 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             WorkerInput = workerInput;
             WorkerOutput = workerOutput;
             Files = files;
+            PreparedIntroducedTypeArtifact = preparedIntroducedTypeArtifact;
 
             List<(string ProjectRelativePath, string AssemblyResolvePath)> filePaths =
                 new List<(string ProjectRelativePath, string AssemblyResolvePath)>(files.Count);
@@ -77,6 +79,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal UnityCompilationAssembly CompilationAssembly { get; }
 
         internal string TargetDllPath { get; }
+
+        /// <summary>
+        /// The artifact this run prepared, or null when the run introduced no type. It is prepared
+        /// but not yet active, so a stage that publishes it has to activate it first.
+        /// </summary>
+        internal HotReloadIntroducedTypeArtifact PreparedIntroducedTypeArtifact { get; }
 
         internal string[] Defines { get; }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -66,6 +66,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             + "neither passed to this reload nor already hot-reloaded, still require a real compile "
             + "(uloop compile).";
 
+        // Keep in sync with IntroducedTypePlanner.IsAlreadyIntroduced in the transform worker,
+        // which emits the diagnostic this prefix identifies. The preparation stage turns that one
+        // diagnostic into a run failure, because proceeding would bind callers against the
+        // retained definition the source no longer declares.
+        public const string ChangedIntroducedTypeDiagnosticPrefix =
+            "Changed introduced type requires a compile: ";
+
         public const string ActiveSiblingsRebindWarningFormat =
             "Also re-applied {0} unchanged file(s) with active patches in assembly '{1}' so their "
             + "patches bind to this reload's shim: {2}.";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
@@ -22,7 +22,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <remarks>
         /// Why per file: the shim assembly is shared, but a generation, an added-field ledger and
         /// an apply result all belong to a single file, and a file whose entries cannot be
-        /// resolved must not stop its siblings from being applied.
+        /// resolved must not stop its siblings from being applied. The whole group is prepared
+        /// (bound and resolved) first, so nothing is mutated while a sibling can still fail
+        /// preflight.
         /// </remarks>
         internal static IReadOnlyList<HotReloadFileProcessResult> ApplyGroupAndBuildResults(
             HotReloadApplyContext context,
@@ -33,39 +35,43 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(compileResult != null, "compileResult must not be null.");
             Debug.Assert(entriesToPatch != null, "entriesToPatch must not be null.");
 
-            Dictionary<string, List<TransformWorkerEntryDto>> entriesByFile =
-                HotReloadWorkerRowsByFile.GroupEntriesBySourceFile(entriesToPatch, context.ProjectRelativePaths);
-            // Why once for the group: every shim type of the group lives in this one assembly, so
-            // binding per file would re-run the same binders and hide which file first failed.
-            Dictionary<string, string> bindFailures = BindShimAccessors(compileResult.Assembly);
+            IReadOnlyList<HotReloadPreparedGroupFile> preparedFiles =
+                HotReloadGroupEntryPreparation.PrepareGroup(context, compileResult, entriesToPatch);
             List<HotReloadFileProcessResult> results =
-                new List<HotReloadFileProcessResult>(context.Files.Count);
-            foreach (HotReloadGroupFile file in context.Files)
+                new List<HotReloadFileProcessResult>(preparedFiles.Count);
+            foreach (HotReloadPreparedGroupFile prepared in preparedFiles)
             {
-                if (file.SkipApply)
-                {
-                    results.Add(HotReloadFileEntryApplier.BuildUnappliedResult(file));
-                    continue;
-                }
-
-                List<TransformWorkerEntryDto> fileEntries = entriesByFile[file.ProjectRelativePath];
-                if (fileEntries.Count == 0)
-                {
-                    HotReloadFileEntryApplier.ClearFileGeneration(context, file);
-                    results.Add(HotReloadFileEntryApplier.BuildUnappliedResult(file));
-                    continue;
-                }
-
-                results.Add(
-                    HotReloadFileEntryApplier.ApplyFileAndBuildResult(
-                        context,
-                        file,
-                        compileResult,
-                        fileEntries.ToArray(),
-                        bindFailures));
+                results.Add(ApplyPreparedFile(context, compileResult, prepared));
             }
 
             return results;
+        }
+
+        private static HotReloadFileProcessResult ApplyPreparedFile(
+            HotReloadApplyContext context,
+            HotReloadShimCompileResult compileResult,
+            HotReloadPreparedGroupFile prepared)
+        {
+            HotReloadGroupFile file = prepared.File;
+            if (prepared.Kind == HotReloadGroupFilePreparationKind.SkippedByGroup)
+            {
+                return HotReloadFileEntryApplier.BuildUnappliedResult(file);
+            }
+
+            if (prepared.Kind == HotReloadGroupFilePreparationKind.NoEntriesToApply)
+            {
+                HotReloadFileEntryApplier.ClearFileGeneration(context, file);
+                return HotReloadFileEntryApplier.BuildUnappliedResult(file);
+            }
+
+            if (prepared.Kind == HotReloadGroupFilePreparationKind.ResolutionFailed)
+            {
+                return HotReloadFileEntryApplier.BuildResolutionFailedResult(
+                    context, file, prepared.Resolution);
+            }
+
+            return HotReloadFileEntryApplier.ApplyResolvedFileAndBuildResult(
+                context, file, compileResult, prepared.Entries, prepared.Resolution);
         }
 
         // Why only here and the empty-entries deactivation: a failed worker or shim compile

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
@@ -146,6 +146,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
+        /// Peels every file's leftover patches on the methods the worker reported unchanged, and
+        /// records per file how many patches that removed.
+        /// </summary>
+        internal static void RevertUnchangedPatchesPerFile(
+            IReadOnlyList<HotReloadGroupFile> files,
+            HotReloadWorkerRowsByFile rows)
+        {
+            foreach (HotReloadGroupFile file in files)
+            {
+                IReadOnlyList<TransformWorkerUnchangedMethodDto> fileUnchanged =
+                    rows.UnchangedFor(file.ProjectRelativePath);
+                TransformWorkerUnchangedMethodDto[] unchangedMethods =
+                    new TransformWorkerUnchangedMethodDto[fileUnchanged.Count];
+                for (int index = 0; index < fileUnchanged.Count; index++)
+                {
+                    unchangedMethods[index] = fileUnchanged[index];
+                }
+
+                file.RevertedUnchangedCount = RevertUnchangedPatches(
+                    file.AssemblyName,
+                    unchangedMethods,
+                    file.Sinks.Outcomes,
+                    file.AssemblyResolvePath);
+            }
+        }
+        /// <summary>
         /// Invokes each shim type's binder (emitted when the type carries at least one accessor
         /// delegate) once, before any patch is applied, so no delegation shim or added-method
         /// accessor rewrite can run with unbound accessor delegates. Returns bind failures keyed

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
@@ -16,27 +16,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal static class HotReloadEntryApplier
     {
         /// <summary>
-        /// Applies the group's entries file by file against the one compiled shim assembly, and
-        /// returns one result per file in the order the files were sent to the worker.
+        /// Applies the group's prepared files against the one compiled shim assembly, and returns
+        /// one result per file in the order the files were sent to the worker.
         /// </summary>
         /// <remarks>
         /// Why per file: the shim assembly is shared, but a generation, an added-field ledger and
         /// an apply result all belong to a single file, and a file whose entries cannot be
         /// resolved must not stop its siblings from being applied. The whole group is prepared
-        /// (bound and resolved) first, so nothing is mutated while a sibling can still fail
-        /// preflight.
+        /// (bound and resolved) by an earlier stage, so nothing is mutated while a sibling can
+        /// still fail preflight.
         /// </remarks>
-        internal static IReadOnlyList<HotReloadFileProcessResult> ApplyGroupAndBuildResults(
+        internal static IReadOnlyList<HotReloadFileProcessResult> ApplyPreparedEntries(
             HotReloadApplyContext context,
             HotReloadShimCompileResult compileResult,
-            TransformWorkerEntryDto[] entriesToPatch)
+            IReadOnlyList<HotReloadPreparedGroupFile> preparedFiles)
         {
             Debug.Assert(context != null, "context must not be null.");
             Debug.Assert(compileResult != null, "compileResult must not be null.");
-            Debug.Assert(entriesToPatch != null, "entriesToPatch must not be null.");
+            Debug.Assert(preparedFiles != null, "preparedFiles must not be null.");
 
-            IReadOnlyList<HotReloadPreparedGroupFile> preparedFiles =
-                HotReloadGroupEntryPreparation.PrepareGroup(context, compileResult, entriesToPatch);
             List<HotReloadFileProcessResult> results =
                 new List<HotReloadFileProcessResult>(preparedFiles.Count);
             foreach (HotReloadPreparedGroupFile prepared in preparedFiles)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
@@ -14,31 +14,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class HotReloadFileEntryApplier
     {
-        // Why preflight before BeginFileGeneration: a match/bind/CheckPatchable failure
-        // must not replace this file's shim or added-member generation.
-        internal static HotReloadFileProcessResult ApplyFileAndBuildResult(
+        // Why the resolution is passed in: preflight for the whole group runs before any file
+        // is mutated, so a match/bind/CheckPatchable failure cannot replace this file's shim or
+        // added-member generation.
+        internal static HotReloadFileProcessResult ApplyResolvedFileAndBuildResult(
             HotReloadApplyContext context,
             HotReloadGroupFile file,
             HotReloadShimCompileResult compileResult,
             TransformWorkerEntryDto[] fileEntries,
-            Dictionary<string, string> bindFailures)
+            HotReloadEntryResolution.Result resolution)
         {
             Debug.Assert(context != null, "context must not be null.");
             Debug.Assert(file != null, "file must not be null.");
             Debug.Assert(fileEntries.Length > 0, "An applied file must hold an entry.");
-
-            HotReloadFileSinks sinks = file.Sinks;
-            HotReloadEntryResolution.Result resolution = HotReloadEntryResolution.ResolveEntries(
-                context.AssemblyName,
-                file.AssemblyResolvePath,
-                compileResult.Assembly,
-                fileEntries,
-                bindFailures);
-            if (!resolution.AllResolved)
-            {
-                sinks.Outcomes.AddRange(resolution.FailureOutcomes);
-                return FinishFileResult(context, file, patchedCount: 0, applied: false);
-            }
+            Debug.Assert(resolution != null && resolution.AllResolved, "resolution must be resolved.");
 
             HotReloadFileGenerations.BeginFileGeneration(
                 file.ProjectRelativePath,
@@ -55,6 +44,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 inlineRiskMethodLabels);
 
             return FinishFileResult(context, file, patchedCount, applied: true, inlineRiskMethodLabels);
+        }
+
+        /// <summary>
+        /// The result of a file whose preflight resolution failed: its failure outcomes are
+        /// reported and nothing of this file is applied.
+        /// </summary>
+        internal static HotReloadFileProcessResult BuildResolutionFailedResult(
+            HotReloadApplyContext context,
+            HotReloadGroupFile file,
+            HotReloadEntryResolution.Result resolution)
+        {
+            Debug.Assert(context != null, "context must not be null.");
+            Debug.Assert(file != null, "file must not be null.");
+            Debug.Assert(resolution != null, "resolution must not be null.");
+
+            file.Sinks.Outcomes.AddRange(resolution.FailureOutcomes);
+            return FinishFileResult(context, file, patchedCount: 0, applied: false);
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
@@ -122,6 +122,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 revertedUnchangedCount: file.RevertedUnchangedCount);
         }
 
+        /// <summary>
+        /// The results of a group no file of which was applied, one unapplied result per file.
+        /// </summary>
+        internal static List<HotReloadFileProcessResult> BuildUnappliedGroupResults(
+            IReadOnlyList<HotReloadGroupFile> files)
+        {
+            List<HotReloadFileProcessResult> results =
+                new List<HotReloadFileProcessResult>(files.Count);
+            foreach (HotReloadGroupFile file in files)
+            {
+                results.Add(BuildUnappliedResult(file));
+            }
+
+            return results;
+        }
         private static HotReloadFileProcessResult FinishFileResult(
             HotReloadApplyContext context,
             HotReloadGroupFile file,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitBoundary.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitBoundary.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// The rechecks a group run has to pass in the last instant before it mutates anything, and
+    /// the reason it must not.
+    /// </summary>
+    /// <remarks>
+    /// Why they sit together and after the last await: everything they confirm can change while
+    /// the run awaits the worker, the gate and the shim compile, and the run activates an
+    /// artifact assembly whose types cannot be taken back once a caller has bound them. Each
+    /// check reports an expected external change, so none of them is a <c>Debug.Assert</c>.
+    /// </remarks>
+    internal static class HotReloadGroupCommitBoundary
+    {
+        /// <summary>
+        /// The reason this group must not be committed, or null when every recheck passed.
+        /// </summary>
+        internal static string DescribeStaleReason(HotReloadApplyContext context)
+        {
+            // The Editor may have started compiling or importing while the run awaited its worker.
+            string notReadyReason = HotReloadEditorStateSnapshotProvider.GetNotReadyReason(
+                HotReloadEditorStateSnapshotProvider.CaptureCurrent());
+            if (notReadyReason != null)
+            {
+                return "The Editor became busy before the reload could be applied: " + notReadyReason;
+            }
+
+            string preparationDrift = DescribePreparationDrift(context);
+            if (preparationDrift != null)
+            {
+                return preparationDrift;
+            }
+
+            return DescribeRequestSourceDrift(context.Files);
+        }
+
+        /// <summary>
+        /// The owner whose source changed between the preparation run and the transform run, so
+        /// the artifact assembly no longer describes what the transform saw.
+        /// </summary>
+        private static string DescribePreparationDrift(HotReloadApplyContext context)
+        {
+            HotReloadPreparedIntroducedTypes prepared = context.PreparedIntroducedTypes;
+            if (prepared == null)
+            {
+                return null;
+            }
+
+            Dictionary<string, string> transformHashesByPath = CollectTransformHashes(context.WorkerOutput);
+            foreach (KeyValuePair<string, string> ownerHash in prepared.OwnerSourceHashes)
+            {
+                if (!transformHashesByPath.TryGetValue(ownerHash.Key, out string transformHash))
+                {
+                    continue;
+                }
+
+                if (string.Equals(ownerHash.Value, transformHash, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                return "The introduced type owner '" + ownerHash.Key
+                    + "' changed between preparation and transform, so the prepared assembly no"
+                    + " longer describes the transformed source.";
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// The request source that changed on disk after the transform run read it.
+        /// </summary>
+        private static string DescribeRequestSourceDrift(IReadOnlyList<HotReloadGroupFile> files)
+        {
+            foreach (HotReloadGroupFile file in files)
+            {
+                if (file.FileOutput == null || string.IsNullOrEmpty(file.FileOutput.sourceContentSha256))
+                {
+                    continue;
+                }
+
+                string currentHash = TryComputeCurrentHash(file.WorkerSourcePath);
+                if (currentHash == null)
+                {
+                    return "The request source '" + file.ProjectRelativePath
+                        + "' could not be read again before the reload was applied.";
+                }
+
+                if (string.Equals(currentHash, file.FileOutput.sourceContentSha256, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                return "The request source '" + file.ProjectRelativePath
+                    + "' changed after it was transformed, so the reload would apply stale code.";
+            }
+
+            return null;
+        }
+
+        private static Dictionary<string, string> CollectTransformHashes(TransformWorkerOutputDto workerOutput)
+        {
+            Dictionary<string, string> hashesByPath = new Dictionary<string, string>(StringComparer.Ordinal);
+            if (workerOutput.files == null)
+            {
+                return hashesByPath;
+            }
+
+            foreach (TransformWorkerFileOutputDto file in workerOutput.files)
+            {
+                hashesByPath[file.projectRelativePath] = file.sourceContentSha256;
+            }
+
+            return hashesByPath;
+        }
+
+        // Why a failed read is drift rather than a throw: the file can be deleted or locked by an
+        // external editor between the transform run and this instant, which is the very window
+        // these checks exist for.
+        private static string TryComputeCurrentHash(string sourcePath)
+        {
+            try
+            {
+                return HotReloadAppliedSourceLedger.ComputeContentHash(File.ReadAllBytes(sourcePath));
+            }
+            catch (IOException)
+            {
+                return null;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitBoundary.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitBoundary.cs
@@ -29,6 +29,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return "The Editor became busy before the reload could be applied: " + notReadyReason;
             }
 
+            string targetAssemblyDrift = DescribeTargetAssemblyDrift(context);
+            if (targetAssemblyDrift != null)
+            {
+                return targetAssemblyDrift;
+            }
+
             string preparationDrift = DescribePreparationDrift(context);
             if (preparationDrift != null)
             {
@@ -36,6 +42,65 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return DescribeRequestSourceDrift(context.Files);
+        }
+
+        /// <summary>
+        /// The target assembly that was rebuilt after this run read it, which every introduced
+        /// type of the run was normalized against.
+        /// </summary>
+        /// <remarks>
+        /// Why only for a run that commits types: an ordinary patch of a rebuilt assembly is
+        /// already refused by the guard the patcher applies per method, while an artifact
+        /// assembly carries the module version id of the generation it was compiled for and
+        /// stays active for the rest of the domain's life.
+        /// </remarks>
+        private static string DescribeTargetAssemblyDrift(HotReloadApplyContext context)
+        {
+            if (!HotReloadGroupCommitStage.CommitsIntroducedTypes(
+                    context.PreparedIntroducedTypes,
+                    context.AssemblyName))
+            {
+                return null;
+            }
+
+            string currentMvid = TryReadTargetAssemblyMvid(context.TargetDllPath);
+            if (currentMvid == null)
+            {
+                return "The target assembly could not be read again before the reload was applied.";
+            }
+
+            if (string.Equals(
+                currentMvid,
+                context.WorkerInput.targetAssemblyMvid,
+                StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            return "The target assembly was rebuilt after this run read it, so the types it"
+                + " prepared belong to a generation the domain no longer has.";
+        }
+
+        // Why a failed read is drift rather than a throw: the same rebuild this check exists for
+        // replaces the file, so the read can land while it is half written or locked.
+        private static string TryReadTargetAssemblyMvid(string targetDllPath)
+        {
+            try
+            {
+                return HotReloadSourceSnapshotter.ReadAssemblyMvid(targetDllPath);
+            }
+            catch (IOException)
+            {
+                return null;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return null;
+            }
+            catch (BadImageFormatException)
+            {
+                return null;
+            }
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitBoundary.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitBoundary.cs
@@ -118,9 +118,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Dictionary<string, string> transformHashesByPath = CollectTransformHashes(context.WorkerOutput);
             foreach (KeyValuePair<string, string> ownerHash in prepared.OwnerSourceHashes)
             {
-                if (!transformHashesByPath.TryGetValue(ownerHash.Key, out string transformHash))
+                // Why fail-closed: a comparison this side cannot make is not a window it has
+                // shown to be closed, and the run is about to publish an assembly compiled from
+                // the very source whose staleness is in question.
+                if (!transformHashesByPath.TryGetValue(ownerHash.Key, out string transformHash)
+                    || string.IsNullOrEmpty(transformHash)
+                    || string.IsNullOrEmpty(ownerHash.Value))
                 {
-                    continue;
+                    return "The introduced type owner '" + ownerHash.Key
+                        + "' has no transform hash, so its staleness cannot be verified.";
                 }
 
                 if (string.Equals(ownerHash.Value, transformHash, StringComparison.Ordinal))
@@ -145,7 +151,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 if (file.FileOutput == null || string.IsNullOrEmpty(file.FileOutput.sourceContentSha256))
                 {
-                    continue;
+                    return "The request source '" + file.ProjectRelativePath
+                        + "' has no transform hash, so its staleness cannot be verified.";
                 }
 
                 string currentHash = TryComputeCurrentHash(file.WorkerSourcePath);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitBoundary.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitBoundary.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c2326cf6d7b424472b1c42f4a4b35743
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitStage.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitStage.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// The commit point of a group run: the last refusal a run can still take without having
+    /// changed the domain, and everything the run does once it is past that point.
+    /// </summary>
+    internal static class HotReloadGroupCommitStage
+    {
+        internal static bool HoldsUnresolvedFile(IReadOnlyList<HotReloadPreparedGroupFile> preparedFiles)
+        {
+            foreach (HotReloadPreparedGroupFile prepared in preparedFiles)
+            {
+                if (prepared.Kind == HotReloadGroupFilePreparationKind.ResolutionFailed)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // The group result of a run the preflight refused: the file that failed reports the same
+        // resolution failure the apply step would have reported for it, and every sibling is left
+        // unapplied because the group is atomic on this side of the commit point.
+        internal static List<HotReloadFileProcessResult> BuildResolutionFailedResults(
+            HotReloadApplyContext context,
+            IReadOnlyList<HotReloadPreparedGroupFile> preparedFiles)
+        {
+            List<HotReloadFileProcessResult> results =
+                new List<HotReloadFileProcessResult>(preparedFiles.Count);
+            foreach (HotReloadPreparedGroupFile prepared in preparedFiles)
+            {
+                if (prepared.Kind == HotReloadGroupFilePreparationKind.ResolutionFailed)
+                {
+                    results.Add(HotReloadFileEntryApplier.BuildResolutionFailedResult(
+                        context, prepared.File, prepared.Resolution));
+                    continue;
+                }
+
+                results.Add(HotReloadFileEntryApplier.BuildUnappliedResult(prepared.File));
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// The commit point of a group run and everything that follows it: the introduced types
+        /// become active, the patches this run supersedes are peeled, and the resolved entries are
+        /// applied. A failure after the commit point leaves the types active and fails methods.
+        /// </summary>
+        internal static IReadOnlyList<HotReloadFileProcessResult> Commit(
+            HotReloadApplyContext context,
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult,
+            HotReloadGroupCompileResult compile,
+            IReadOnlyList<HotReloadPreparedGroupFile> preparedFiles)
+        {
+            IReadOnlyList<HotReloadGroupFile> files = context.Files;
+            HotReloadPreparedIntroducedTypes prepared = context.PreparedIntroducedTypes;
+            if (prepared != null)
+            {
+                HotReloadIntroducedTypeHolder.Registry.Activate(prepared.Artifact);
+            }
+
+            bool commitsIntroducedTypes = CommitsIntroducedTypes(prepared, files[0].AssemblyName);
+            if (commitsIntroducedTypes)
+            {
+                HotReloadEntryApplier.RevertUnchangedPatchesPerFile(
+                    files,
+                    HotReloadWorkerRowsByFile.Build(context.WorkerOutput, context.ProjectRelativePaths));
+            }
+
+            if (preparedFiles == null)
+            {
+                // The empty-entries generation clear a run that commits types deferred past the
+                // commit point, because clearing it before the boundary would mutate the domain
+                // a failed recheck can no longer undo. A run without types already cleared.
+                if (commitsIntroducedTypes)
+                {
+                    ClearEmptyFileGenerations(context);
+                }
+
+                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(files);
+            }
+
+            HotReloadGroupProcessorDependencies dependencies = HotReloadGroupProcessorDependencies.Current;
+            IReadOnlyList<HotReloadFileProcessResult> results = dependencies.ApplyPreparedEntries(
+                context,
+                compile.CompileResult,
+                preparedFiles);
+            RecordSupersededSignaturesAfterApply(context, gateResult.GatedReplacementMethodKeys);
+            return results;
+        }
+
+        // A run whose introduced types become active at the commit boundary: the reload either
+        // introduces a type itself, or the assembly it targets already owns one this domain
+        // introduced, in which case its patches resolve through the artifact assemblies too.
+        internal static bool CommitsIntroducedTypes(
+            HotReloadPreparedIntroducedTypes prepared,
+            string targetAssemblyName)
+        {
+            return prepared != null
+                || HotReloadIntroducedTypeHolder.Registry.HasActiveTypesForOriginalAssembly(targetAssemblyName);
+        }
+
+        // Deleting an added method and restoring its callers yields empty entries, so the
+        // post-shim-compile BeginFileGeneration never runs and the previous run's generation would
+        // otherwise stay live.
+        internal static void ClearEmptyFileGenerations(HotReloadApplyContext context)
+        {
+            foreach (HotReloadGroupFile file in context.Files)
+            {
+                HotReloadFileEntryApplier.ClearFileGeneration(context, file);
+            }
+        }
+
+        // Why per file: a group applies file by file, so only the rows that actually reached
+        // Harmony may claim their removed signatures were superseded. A partly applied file
+        // patches some rows and leaves the rest failed or file-atomically skipped.
+        private static void RecordSupersededSignaturesAfterApply(
+            HotReloadApplyContext context,
+            IReadOnlyCollection<string> gatedReplacementMethodKeys)
+        {
+            for (int index = 0; index < context.Files.Count; index++)
+            {
+                HotReloadGroupFile file = context.Files[index];
+                Debug.Assert(file.FileOutput != null, "Every file must carry its worker output row.");
+                HotReloadSupersededSignatureRecorder.RecordFromAppliedEntries(
+                    file.Sinks.AppliedEntries,
+                    file.FileOutput.removedMethodSignatures
+                        ?? Array.Empty<TransformWorkerRemovedMethodSignatureDto>(),
+                    gatedReplacementMethodKeys);
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitStage.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitStage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b78600974538c4fff9f07fecc7c400fe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupEntryPreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupEntryPreparation.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Resolves every file of a group against the one compiled shim assembly before the group
+    /// mutates anything, so the apply step only has to act on decided files.
+    /// </summary>
+    /// <remarks>
+    /// Why ahead of the apply step: binding and resolution touch no registry and apply no patch,
+    /// while starting a generation or patching a method does. Keeping the whole group's
+    /// resolution on this side of that boundary is what lets a later stage decide, per batch,
+    /// whether one file's preflight failure may leave its siblings applied.
+    /// </remarks>
+    internal static class HotReloadGroupEntryPreparation
+    {
+        internal static IReadOnlyList<HotReloadPreparedGroupFile> PrepareGroup(
+            HotReloadApplyContext context,
+            HotReloadShimCompileResult compileResult,
+            TransformWorkerEntryDto[] entriesToPatch)
+        {
+            Debug.Assert(context != null, "context must not be null.");
+            Debug.Assert(compileResult != null, "compileResult must not be null.");
+            Debug.Assert(entriesToPatch != null, "entriesToPatch must not be null.");
+
+            Dictionary<string, List<TransformWorkerEntryDto>> entriesByFile =
+                HotReloadWorkerRowsByFile.GroupEntriesBySourceFile(entriesToPatch, context.ProjectRelativePaths);
+            // Why once for the group: every shim type of the group lives in this one assembly, so
+            // binding per file would re-run the same binders and hide which file first failed.
+            Dictionary<string, string> bindFailures =
+                HotReloadEntryApplier.BindShimAccessors(compileResult.Assembly);
+            List<HotReloadPreparedGroupFile> prepared =
+                new List<HotReloadPreparedGroupFile>(context.Files.Count);
+            foreach (HotReloadGroupFile file in context.Files)
+            {
+                prepared.Add(PrepareFile(context, compileResult, file, entriesByFile, bindFailures));
+            }
+
+            return prepared;
+        }
+
+        private static HotReloadPreparedGroupFile PrepareFile(
+            HotReloadApplyContext context,
+            HotReloadShimCompileResult compileResult,
+            HotReloadGroupFile file,
+            Dictionary<string, List<TransformWorkerEntryDto>> entriesByFile,
+            Dictionary<string, string> bindFailures)
+        {
+            if (file.SkipApply)
+            {
+                return HotReloadPreparedGroupFile.SkippedByGroup(file);
+            }
+
+            List<TransformWorkerEntryDto> fileEntries = entriesByFile[file.ProjectRelativePath];
+            if (fileEntries.Count == 0)
+            {
+                return HotReloadPreparedGroupFile.NoEntriesToApply(file);
+            }
+
+            TransformWorkerEntryDto[] entries = fileEntries.ToArray();
+            HotReloadEntryResolution.Result resolution = HotReloadEntryResolution.ResolveEntries(
+                context.AssemblyName,
+                file.AssemblyResolvePath,
+                compileResult.Assembly,
+                entries,
+                bindFailures);
+            if (!resolution.AllResolved)
+            {
+                return HotReloadPreparedGroupFile.ResolutionFailed(file, entries, resolution);
+            }
+
+            return HotReloadPreparedGroupFile.Resolved(file, entries, resolution);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupEntryPreparation.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupEntryPreparation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e223134cb17a44ed7876889e5c699f56
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupFilePreparationKind.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupFilePreparationKind.cs
@@ -1,0 +1,13 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// What the group preparation decided about one file, before anything is mutated.
+    /// </summary>
+    internal enum HotReloadGroupFilePreparationKind
+    {
+        SkippedByGroup,
+        NoEntriesToApply,
+        ResolutionFailed,
+        Resolved
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupFilePreparationKind.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupFilePreparationKind.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fd312138a0dde4e069228f117dade643
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupGateAndCompileOutcome.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupGateAndCompileOutcome.cs
@@ -1,0 +1,14 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// What the gate and the first shim compile of one group left for the commit boundary: the
+    /// group already reported its own failure, it succeeded with no entry to patch, or it holds
+    /// the entries the apply stage patches.
+    /// </summary>
+    internal enum HotReloadGroupGateAndCompileOutcome
+    {
+        Failed,
+        ReadyWithoutEntries,
+        ReadyWithEntries
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupGateAndCompileOutcome.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupGateAndCompileOutcome.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 519442823e56e45e3a800c45e43d861b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupGateAndCompileResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupGateAndCompileResult.cs
@@ -4,37 +4,60 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
     /// Reports what the signature-change gate and the first shim compile of one group produced,
-    /// so the group pipeline can tell a run that has entries to apply from one that must end
-    /// unapplied without repeating either stage's routing.
+    /// so the group pipeline can tell a run that must end unapplied from one that still has to
+    /// reach the commit boundary, with or without entries to patch.
     /// </summary>
     internal sealed class HotReloadGroupGateAndCompileResult
     {
         private HotReloadGroupGateAndCompileResult(
-            bool hasEntriesToApply,
+            HotReloadGroupGateAndCompileOutcome outcome,
             HotReloadSignatureChangeGate.SignatureChangeGateResult gate,
             HotReloadGroupCompileResult compile)
         {
-            HasEntriesToApply = hasEntriesToApply;
+            Outcome = outcome;
             Gate = gate;
             Compile = compile;
         }
 
-        public bool HasEntriesToApply { get; }
+        public HotReloadGroupGateAndCompileOutcome Outcome { get; }
 
         public HotReloadSignatureChangeGate.SignatureChangeGateResult Gate { get; }
 
         public HotReloadGroupCompileResult Compile { get; }
 
         /// <summary>
-        /// The gate failed the group, or the compile left nothing to apply. Both stages have
-        /// already routed their own outcomes onto the group's files.
+        /// The gate failed the group, or the compile could not produce anything to apply. Both
+        /// stages have already routed their own outcomes onto the group's files.
         /// </summary>
-        public static HotReloadGroupGateAndCompileResult NothingToApply()
+        public static HotReloadGroupGateAndCompileResult Failed()
         {
-            return new HotReloadGroupGateAndCompileResult(false, null, null);
+            return new HotReloadGroupGateAndCompileResult(
+                HotReloadGroupGateAndCompileOutcome.Failed,
+                null,
+                null);
+        }
+
+        /// <summary>
+        /// The group succeeded and simply has no method left to patch. It still reaches the commit
+        /// boundary, because a reload whose only change is a new type declaration has nothing to
+        /// patch and yet must leave that type active.
+        /// </summary>
+        public static HotReloadGroupGateAndCompileResult ReadyWithoutEntries(
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gate,
+            HotReloadGroupCompileResult compile)
+        {
+            return Create(HotReloadGroupGateAndCompileOutcome.ReadyWithoutEntries, gate, compile);
         }
 
         public static HotReloadGroupGateAndCompileResult Ready(
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gate,
+            HotReloadGroupCompileResult compile)
+        {
+            return Create(HotReloadGroupGateAndCompileOutcome.ReadyWithEntries, gate, compile);
+        }
+
+        private static HotReloadGroupGateAndCompileResult Create(
+            HotReloadGroupGateAndCompileOutcome outcome,
             HotReloadSignatureChangeGate.SignatureChangeGateResult gate,
             HotReloadGroupCompileResult compile)
         {
@@ -48,7 +71,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 throw new ArgumentNullException(nameof(compile));
             }
 
-            return new HotReloadGroupGateAndCompileResult(true, gate, compile);
+            return new HotReloadGroupGateAndCompileResult(outcome, gate, compile);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupGateAndCompileResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupGateAndCompileResult.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Reports what the signature-change gate and the first shim compile of one group produced,
+    /// so the group pipeline can tell a run that has entries to apply from one that must end
+    /// unapplied without repeating either stage's routing.
+    /// </summary>
+    internal sealed class HotReloadGroupGateAndCompileResult
+    {
+        private HotReloadGroupGateAndCompileResult(
+            bool hasEntriesToApply,
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gate,
+            HotReloadGroupCompileResult compile)
+        {
+            HasEntriesToApply = hasEntriesToApply;
+            Gate = gate;
+            Compile = compile;
+        }
+
+        public bool HasEntriesToApply { get; }
+
+        public HotReloadSignatureChangeGate.SignatureChangeGateResult Gate { get; }
+
+        public HotReloadGroupCompileResult Compile { get; }
+
+        /// <summary>
+        /// The gate failed the group, or the compile left nothing to apply. Both stages have
+        /// already routed their own outcomes onto the group's files.
+        /// </summary>
+        public static HotReloadGroupGateAndCompileResult NothingToApply()
+        {
+            return new HotReloadGroupGateAndCompileResult(false, null, null);
+        }
+
+        public static HotReloadGroupGateAndCompileResult Ready(
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gate,
+            HotReloadGroupCompileResult compile)
+        {
+            if (gate == null)
+            {
+                throw new ArgumentNullException(nameof(gate));
+            }
+
+            if (compile == null)
+            {
+                throw new ArgumentNullException(nameof(compile));
+            }
+
+            return new HotReloadGroupGateAndCompileResult(true, gate, compile);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupGateAndCompileResult.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupGateAndCompileResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 381184960bdf34e19925acfcdb0b32f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -67,7 +67,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (preparation.Artifact == null)
             {
-                return await TransformAndApplyGroupAsync(files, workerInput, correlationId, ct).ConfigureAwait(false);
+                return await TransformAndApplyGroupAsync(files, workerInput, null, correlationId, ct)
+                    .ConfigureAwait(false);
             }
 
             return await TransformAndApplyPreparedGroupAsync(
@@ -102,7 +103,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 try
                 {
-                    return await TransformAndApplyGroupAsync(files, workerInput, correlationId, ct)
+                    return await TransformAndApplyGroupAsync(files, workerInput, artifact, correlationId, ct)
                         .ConfigureAwait(false);
                 }
                 finally
@@ -118,6 +119,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static async Task<IReadOnlyList<HotReloadFileProcessResult>> TransformAndApplyGroupAsync(
             IReadOnlyList<HotReloadGroupFile> files,
             TransformWorkerInputDto workerInput,
+            HotReloadIntroducedTypeArtifact preparedArtifact,
             string correlationId,
             CancellationToken ct)
         {
@@ -167,13 +169,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 firstFile.CompilationAssembly.defines ?? Array.Empty<string>(),
                 workerInput,
                 workerOutput,
-                files);
-            return await ApplyGroupAsync(context, firstFile, ct).ConfigureAwait(false);
+                files,
+                preparedArtifact);
+            HotReloadGroupGateAndCompileResult gateAndCompile = await HotReloadGroupProcessorDependencies
+                .Current
+                .GateAndCompile(context, ct)
+                .ConfigureAwait(false);
+            if (!gateAndCompile.HasEntriesToApply)
+            {
+                return BuildUnappliedResults(files);
+            }
+
+            return await CompleteApplyAfterCoverageAsync(
+                context,
+                gateAndCompile.Gate,
+                gateAndCompile.Compile,
+                ct).ConfigureAwait(false);
         }
 
-        private static async Task<IReadOnlyList<HotReloadFileProcessResult>> ApplyGroupAsync(
+        /// <summary>
+        /// Runs the signature-change gate and the first shim compile of the group, which together
+        /// decide whether there is anything left to apply.
+        /// </summary>
+        internal static async Task<HotReloadGroupGateAndCompileResult> GateAndCompileAsync(
             HotReloadApplyContext context,
-            HotReloadGroupFile gateWarningSink,
             CancellationToken ct)
         {
             // The worker-bound continuation after the pre-revert check is not guaranteed to
@@ -181,6 +200,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             await MainThreadSwitcher.SwitchToMainThread(ct);
             ct.ThrowIfCancellationRequested();
             IReadOnlyList<HotReloadGroupFile> files = context.Files;
+            HotReloadGroupFile gateWarningSink = files[0];
             HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult = await HotReloadSignatureChangeGate.TryApplySignatureChangeGateAsync(
                 context,
                 ct).ConfigureAwait(false);
@@ -198,7 +218,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     files,
                     "(signature-change-gate)",
                     gateResult.FailureMessage);
-                return BuildUnappliedResults(files);
+                return HotReloadGroupGateAndCompileResult.NothingToApply();
             }
 
             HotReloadGroupOutcomeRouter.AppendByFilePath(files, gateResult.SkippedOutcomes);
@@ -212,33 +232,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ct).ConfigureAwait(false);
             if (!compile.HasEntriesToApply)
             {
-                return BuildUnappliedResults(files);
+                return HotReloadGroupGateAndCompileResult.NothingToApply();
             }
 
-            return await CompleteApplyAfterCoverageAsync(
-                context,
-                gateResult,
-                compile,
-                ct,
-                () =>
-                {
-                    IReadOnlyList<HotReloadFileProcessResult> results = HotReloadEntryApplier.ApplyGroupAndBuildResults(
-                        context,
-                        compile.CompileResult,
-                        compile.EntriesToPatch);
-                    RecordSupersededSignaturesAfterApply(context, gateResult.GatedReplacementMethodKeys);
-                    return Task.FromResult(results);
-                }).ConfigureAwait(false);
+            return HotReloadGroupGateAndCompileResult.Ready(gateResult, compile);
         }
 
-        // Why inject only the post-coverage continuation: coverage failure must use the real
-        // group failure routing, while tests must not invoke Harmony or main-thread work.
+        /// <summary>
+        /// Turns a gated and compiled group into applied patches: coverage, the last membership
+        /// check, the group-wide preflight that resolves every file, and only then the mutation.
+        /// </summary>
         internal static async Task<IReadOnlyList<HotReloadFileProcessResult>> CompleteApplyAfterCoverageAsync(
             HotReloadApplyContext context,
             HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult,
             HotReloadGroupCompileResult compile,
-            CancellationToken ct,
-            Func<Task<IReadOnlyList<HotReloadFileProcessResult>>> continueAfterCoverage)
+            CancellationToken ct)
         {
             if (gateResult.DidScan && !AppendSignatureChangeCoverageNotices(context, gateResult, compile))
             {
@@ -253,7 +261,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             ct.ThrowIfCancellationRequested();
-            return await continueAfterCoverage().ConfigureAwait(false);
+            HotReloadGroupProcessorDependencies dependencies = HotReloadGroupProcessorDependencies.Current;
+            // Why the whole group is resolved before any file is mutated: a file whose entries
+            // cannot be resolved must not leave the files applied before it half patched.
+            IReadOnlyList<HotReloadPreparedGroupFile> preparedFiles = dependencies.PrepareGroupEntries(
+                context,
+                compile.CompileResult,
+                compile.EntriesToPatch);
+            IReadOnlyList<HotReloadFileProcessResult> results = dependencies.ApplyPreparedEntries(
+                context,
+                compile.CompileResult,
+                preparedFiles);
+            RecordSupersededSignaturesAfterApply(context, gateResult.GatedReplacementMethodKeys);
+            return results;
         }
 
         internal static bool TryAppendNewSourceMembershipFailure(IReadOnlyList<HotReloadGroupFile> files)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -179,7 +179,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 .Current
                 .GateAndCompile(context, ct)
                 .ConfigureAwait(false);
-            if (!gateAndCompile.HasEntriesToApply)
+            if (gateAndCompile.Outcome == HotReloadGroupGateAndCompileOutcome.Failed)
             {
                 return BuildUnappliedResults(files);
             }
@@ -222,7 +222,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     files,
                     "(signature-change-gate)",
                     gateResult.FailureMessage);
-                return HotReloadGroupGateAndCompileResult.NothingToApply();
+                return HotReloadGroupGateAndCompileResult.Failed();
             }
 
             HotReloadGroupOutcomeRouter.AppendByFilePath(files, gateResult.SkippedOutcomes);
@@ -234,9 +234,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 context,
                 gateResult,
                 ct).ConfigureAwait(false);
-            if (!compile.HasEntriesToApply)
+            if (compile.Outcome == HotReloadGroupCompileOutcome.Failed)
             {
-                return HotReloadGroupGateAndCompileResult.NothingToApply();
+                return HotReloadGroupGateAndCompileResult.Failed();
+            }
+
+            // Why a run with no entry still goes on: a reload whose only change is a new type
+            // declaration produces no method to patch, and ending here would leave the type it
+            // prepared unactivated — the very case new-file support exists for.
+            if (compile.Outcome == HotReloadGroupCompileOutcome.ReadyWithoutMethods)
+            {
+                return HotReloadGroupGateAndCompileResult.ReadyWithoutEntries(gateResult, compile);
             }
 
             return HotReloadGroupGateAndCompileResult.Ready(gateResult, compile);
@@ -252,7 +260,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadGroupCompileResult compile,
             CancellationToken ct)
         {
-            if (gateResult.DidScan && !AppendSignatureChangeCoverageNotices(context, gateResult, compile))
+            // Why coverage only with entries: it checks that every gated replacement the scan
+            // found has an entry to patch, and a run the compile left no entry for has no
+            // replacement to cover — it reaches the boundary only to commit its types.
+            if (compile.HasEntriesToApply
+                && gateResult.DidScan
+                && !AppendSignatureChangeCoverageNotices(context, gateResult, compile))
             {
                 return BuildUnappliedResults(context.Files);
             }
@@ -272,10 +285,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return BuildUnappliedResults(context.Files);
             }
 
-            HotReloadGroupProcessorDependencies dependencies = HotReloadGroupProcessorDependencies.Current;
             // Why the whole group is resolved before any file is mutated: a file whose entries
             // cannot be resolved must not leave the files applied before it half patched. It is
-            // also the last failure a run can take without having activated anything.
+            // also the last failure a run can take without having activated anything. A run with
+            // no entry has nothing to bind or resolve, so it goes straight to the commit point.
+            if (!compile.HasEntriesToApply)
+            {
+                return CommitPreparedGroup(context, gateResult, compile, null);
+            }
+
+            HotReloadGroupProcessorDependencies dependencies = HotReloadGroupProcessorDependencies.Current;
             IReadOnlyList<HotReloadPreparedGroupFile> preparedFiles = dependencies.PrepareGroupEntries(
                 context,
                 compile.CompileResult,
@@ -301,11 +320,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadIntroducedTypeHolder.Registry.Activate(prepared.Artifact);
             }
 
-            if (CommitsIntroducedTypes(prepared, files[0].AssemblyName))
+            bool commitsIntroducedTypes = CommitsIntroducedTypes(prepared, files[0].AssemblyName);
+            if (commitsIntroducedTypes)
             {
                 RevertUnchangedPatchesPerFile(
                     files,
                     HotReloadWorkerRowsByFile.Build(context.WorkerOutput, context.ProjectRelativePaths));
+            }
+
+            if (preparedFiles == null)
+            {
+                // The empty-entries generation clear a run that commits types deferred past the
+                // commit point, because clearing it before the boundary would mutate the domain
+                // a failed recheck can no longer undo. A run without types already cleared.
+                if (commitsIntroducedTypes)
+                {
+                    ClearEmptyFileGenerations(context);
+                }
+
+                return BuildUnappliedResults(files);
             }
 
             HotReloadGroupProcessorDependencies dependencies = HotReloadGroupProcessorDependencies.Current;
@@ -320,12 +353,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // A run whose introduced types become active at the commit boundary: the reload either
         // introduces a type itself, or the assembly it targets already owns one this domain
         // introduced, in which case its patches resolve through the artifact assemblies too.
-        private static bool CommitsIntroducedTypes(
+        internal static bool CommitsIntroducedTypes(
             HotReloadPreparedIntroducedTypes prepared,
             string targetAssemblyName)
         {
             return prepared != null
                 || HotReloadIntroducedTypeHolder.Registry.HasActiveTypesForOriginalAssembly(targetAssemblyName);
+        }
+
+        // Deleting an added method and restoring its callers yields empty entries, so the
+        // post-shim-compile BeginFileGeneration never runs and the previous run's generation would
+        // otherwise stay live.
+        internal static void ClearEmptyFileGenerations(HotReloadApplyContext context)
+        {
+            foreach (HotReloadGroupFile file in context.Files)
+            {
+                HotReloadFileEntryApplier.ClearFileGeneration(context, file);
+            }
         }
 
         internal static bool TryAppendNewSourceMembershipFailure(IReadOnlyList<HotReloadGroupFile> files)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -92,7 +92,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             HotReloadIntroducedTypeArtifact artifact = prepared.Artifact;
             HotReloadIntroducedTypeRegistry registry = HotReloadIntroducedTypeHolder.Registry;
-            registry.RegisterPrepared(artifact);
             List<TransformWorkerIntroducedTypeArtifactDto> records =
                 new List<TransformWorkerIntroducedTypeArtifactDto>(workerInput.introducedTypeArtifacts);
             records.Add(HotReloadIntroducedTypeArtifactRecords.CreateRecord(artifact));
@@ -104,6 +103,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 try
                 {
+                    // Why inside the scope and first in the try: the finally below is what drops
+                    // the membership again, so registering anywhere the finally does not cover
+                    // would leave the run's membership behind when the scope itself throws.
+                    registry.RegisterPrepared(artifact);
                     return await TransformAndApplyGroupAsync(files, workerInput, prepared, correlationId, ct)
                         .ConfigureAwait(false);
                 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -50,8 +51,81 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             TransformWorkerInputDto workerInput = BuildWorkerInput(files, siblingScan);
-            TransformWorkerClientResult workerResult =
-                await TransformWorkerClient.RunAsync(workerInput, ct).ConfigureAwait(false);
+            workerInput.introducedTypeArtifacts = HotReloadIntroducedTypeArtifactRecords.CollectActive(
+                HotReloadIntroducedTypeHolder.Registry,
+                workerInput.targetAssemblyName,
+                workerInput.targetAssemblyMvid).ToArray();
+            HotReloadIntroducedTypePreparationResult preparation = await HotReloadGroupProcessorDependencies
+                .Current
+                .PrepareIntroducedTypes(files, workerInput, ct)
+                .ConfigureAwait(false);
+            if (!preparation.Success)
+            {
+                HotReloadGroupOutcomeRouter.AppendGroupFailure(files, "(file)", preparation.ErrorMessage);
+                return BuildUnappliedResults(files);
+            }
+
+            if (preparation.Artifact == null)
+            {
+                return await TransformAndApplyGroupAsync(files, workerInput, correlationId, ct).ConfigureAwait(false);
+            }
+
+            return await TransformAndApplyPreparedGroupAsync(
+                files,
+                workerInput,
+                preparation.Artifact,
+                correlationId,
+                ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Runs the group against the artifact this run prepared, so the transform and the shim
+        /// compilation bind the introduced types from the loaded assembly.
+        /// </summary>
+        private static async Task<IReadOnlyList<HotReloadFileProcessResult>> TransformAndApplyPreparedGroupAsync(
+            IReadOnlyList<HotReloadGroupFile> files,
+            TransformWorkerInputDto workerInput,
+            HotReloadIntroducedTypeArtifact artifact,
+            string correlationId,
+            CancellationToken ct)
+        {
+            HotReloadIntroducedTypeRegistry registry = HotReloadIntroducedTypeHolder.Registry;
+            registry.RegisterPrepared(artifact);
+            List<TransformWorkerIntroducedTypeArtifactDto> records =
+                new List<TransformWorkerIntroducedTypeArtifactDto>(workerInput.introducedTypeArtifacts);
+            records.Add(HotReloadIntroducedTypeArtifactRecords.CreateRecord(artifact));
+            workerInput.introducedTypeArtifacts = records.ToArray();
+
+            // The scope answers binds for the prepared assembly while nothing has activated it, so
+            // the shim compilation and the reflection it drives can already reach the new types.
+            using (IDisposable preparedScope = HotReloadIntroducedTypeHolder.Resolver.RegisterPrepared(artifact))
+            {
+                try
+                {
+                    return await TransformAndApplyGroupAsync(files, workerInput, correlationId, ct)
+                        .ConfigureAwait(false);
+                }
+                finally
+                {
+                    // The commit boundary that activates a successful run is a later stage; until
+                    // it exists the prepared membership is dropped here as well. The discard of a
+                    // failed run stays in place once activation replaces the successful path.
+                    registry.DiscardPrepared(artifact);
+                }
+            }
+        }
+
+        private static async Task<IReadOnlyList<HotReloadFileProcessResult>> TransformAndApplyGroupAsync(
+            IReadOnlyList<HotReloadGroupFile> files,
+            TransformWorkerInputDto workerInput,
+            string correlationId,
+            CancellationToken ct)
+        {
+            HotReloadGroupFile firstFile = files[0];
+            TransformWorkerClientResult workerResult = await HotReloadGroupProcessorDependencies
+                .Current
+                .RunWorker(workerInput, ct)
+                .ConfigureAwait(false);
             HotReloadOrchestratorLog.LogHotReloadWorkerResult(workerResult, correlationId);
             if (!workerResult.Success)
             {
@@ -326,6 +400,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     firstFile.CompilationAssembly,
                     firstFile.TargetDllPath),
                 targetTypesAssemblyPath = Path.GetFullPath(firstFile.TargetDllPath),
+                // The retained records normalize an introduced type back to the generation of the
+                // assembly that owns its source, so every run has to name that generation even
+                // before it carries a record of its own.
+                targetAssemblyName = firstFile.AssemblyName,
+                targetAssemblyMvid = HotReloadSourceSnapshotter.ReadAssemblyMvid(firstFile.TargetDllPath),
                 assemblySourcePaths = HotReloadPatchTargetSupport.BuildAssemblySourcePaths(
                     firstFile.ProjectRoot,
                     firstFile.CompilationAssembly.sourceFiles),

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -34,7 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             await MainThreadSwitcher.SwitchToMainThread(ct);
             if (!HotReloadGroupProcessorDependencies.Current.ValidateNewSourceMembership(files))
             {
-                return BuildUnappliedResults(files);
+                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(files);
             }
 
             SnapshotGroupState(files);
@@ -62,7 +62,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (!preparation.Success)
             {
                 HotReloadGroupOutcomeRouter.AppendGroupFailure(files, "(file)", preparation.ErrorMessage);
-                return BuildUnappliedResults(files);
+                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(files);
             }
 
             if (preparation.Prepared == null)
@@ -132,7 +132,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (!workerResult.Success)
             {
                 HotReloadGroupOutcomeRouter.AppendGroupFailure(files, "(file)", workerResult.ErrorMessage);
-                return BuildUnappliedResults(files);
+                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(files);
             }
 
             TransformWorkerOutputDto workerOutput = workerResult.Output;
@@ -155,13 +155,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why a run that commits types skips it: peeling a patch here would mutate the domain
             // before the commit boundary, which a failed recheck could then no longer undo, so
             // such a run reverts at the boundary instead.
-            if (!CommitsIntroducedTypes(prepared, files[0].AssemblyName)
+            if (!HotReloadGroupCommitStage.CommitsIntroducedTypes(prepared, files[0].AssemblyName)
                 && !await RevalidateBeforeRevertAsync(
                     files,
                     ct,
-                    () => RevertUnchangedPatchesPerFile(files, rows)).ConfigureAwait(false))
+                    () => HotReloadEntryApplier.RevertUnchangedPatchesPerFile(files, rows)).ConfigureAwait(false))
             {
-                return BuildUnappliedResults(files);
+                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(files);
             }
 
             HotReloadApplyContext context = new HotReloadApplyContext(
@@ -181,7 +181,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 .ConfigureAwait(false);
             if (gateAndCompile.Outcome == HotReloadGroupGateAndCompileOutcome.Failed)
             {
-                return BuildUnappliedResults(files);
+                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(files);
             }
 
             return await CompleteApplyAfterCoverageAsync(
@@ -267,14 +267,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 && gateResult.DidScan
                 && !AppendSignatureChangeCoverageNotices(context, gateResult, compile))
             {
-                return BuildUnappliedResults(context.Files);
+                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(context.Files);
             }
 
             await MainThreadSwitcher.SwitchToMainThread(ct);
             ct.ThrowIfCancellationRequested();
             if (!TryAppendNewSourceMembershipFailure(context.Files))
             {
-                return BuildUnappliedResults(context.Files);
+                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(context.Files);
             }
 
             ct.ThrowIfCancellationRequested();
@@ -282,7 +282,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (staleReason != null)
             {
                 HotReloadGroupOutcomeRouter.AppendGroupFailure(context.Files, "(file)", staleReason);
-                return BuildUnappliedResults(context.Files);
+                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(context.Files);
             }
 
             // Why the whole group is resolved before any file is mutated: a file whose entries
@@ -291,7 +291,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // no entry has nothing to bind or resolve, so it goes straight to the commit point.
             if (!compile.HasEntriesToApply)
             {
-                return CommitPreparedGroup(context, gateResult, compile, null);
+                return HotReloadGroupCommitStage.Commit(context, gateResult, compile, null);
             }
 
             HotReloadGroupProcessorDependencies dependencies = HotReloadGroupProcessorDependencies.Current;
@@ -299,77 +299,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 context,
                 compile.CompileResult,
                 compile.EntriesToPatch);
-            return CommitPreparedGroup(context, gateResult, compile, preparedFiles);
-        }
-
-        /// <summary>
-        /// The commit point of a group run and everything that follows it: the introduced types
-        /// become active, the patches this run supersedes are peeled, and the resolved entries are
-        /// applied. A failure after the commit point leaves the types active and fails methods.
-        /// </summary>
-        private static IReadOnlyList<HotReloadFileProcessResult> CommitPreparedGroup(
-            HotReloadApplyContext context,
-            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult,
-            HotReloadGroupCompileResult compile,
-            IReadOnlyList<HotReloadPreparedGroupFile> preparedFiles)
-        {
-            IReadOnlyList<HotReloadGroupFile> files = context.Files;
-            HotReloadPreparedIntroducedTypes prepared = context.PreparedIntroducedTypes;
-            if (prepared != null)
+            // Why before the commit point: the preflight decides per file, and a file it could
+            // not resolve is the last failure a run can take without having activated anything.
+            // Committing anyway would publish a type for a group that goes on to patch nothing.
+            if (HotReloadGroupCommitStage.HoldsUnresolvedFile(preparedFiles))
             {
-                HotReloadIntroducedTypeHolder.Registry.Activate(prepared.Artifact);
+                return HotReloadGroupCommitStage.BuildResolutionFailedResults(context, preparedFiles);
             }
 
-            bool commitsIntroducedTypes = CommitsIntroducedTypes(prepared, files[0].AssemblyName);
-            if (commitsIntroducedTypes)
-            {
-                RevertUnchangedPatchesPerFile(
-                    files,
-                    HotReloadWorkerRowsByFile.Build(context.WorkerOutput, context.ProjectRelativePaths));
-            }
-
-            if (preparedFiles == null)
-            {
-                // The empty-entries generation clear a run that commits types deferred past the
-                // commit point, because clearing it before the boundary would mutate the domain
-                // a failed recheck can no longer undo. A run without types already cleared.
-                if (commitsIntroducedTypes)
-                {
-                    ClearEmptyFileGenerations(context);
-                }
-
-                return BuildUnappliedResults(files);
-            }
-
-            HotReloadGroupProcessorDependencies dependencies = HotReloadGroupProcessorDependencies.Current;
-            IReadOnlyList<HotReloadFileProcessResult> results = dependencies.ApplyPreparedEntries(
-                context,
-                compile.CompileResult,
-                preparedFiles);
-            RecordSupersededSignaturesAfterApply(context, gateResult.GatedReplacementMethodKeys);
-            return results;
-        }
-
-        // A run whose introduced types become active at the commit boundary: the reload either
-        // introduces a type itself, or the assembly it targets already owns one this domain
-        // introduced, in which case its patches resolve through the artifact assemblies too.
-        internal static bool CommitsIntroducedTypes(
-            HotReloadPreparedIntroducedTypes prepared,
-            string targetAssemblyName)
-        {
-            return prepared != null
-                || HotReloadIntroducedTypeHolder.Registry.HasActiveTypesForOriginalAssembly(targetAssemblyName);
-        }
-
-        // Deleting an added method and restoring its callers yields empty entries, so the
-        // post-shim-compile BeginFileGeneration never runs and the previous run's generation would
-        // otherwise stay live.
-        internal static void ClearEmptyFileGenerations(HotReloadApplyContext context)
-        {
-            foreach (HotReloadGroupFile file in context.Files)
-            {
-                HotReloadFileEntryApplier.ClearFileGeneration(context, file);
-            }
+            return HotReloadGroupCommitStage.Commit(context, gateResult, compile, preparedFiles);
         }
 
         internal static bool TryAppendNewSourceMembershipFailure(IReadOnlyList<HotReloadGroupFile> files)
@@ -553,48 +491,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        private static void RevertUnchangedPatchesPerFile(
-            IReadOnlyList<HotReloadGroupFile> files,
-            HotReloadWorkerRowsByFile rows)
-        {
-            foreach (HotReloadGroupFile file in files)
-            {
-                IReadOnlyList<TransformWorkerUnchangedMethodDto> fileUnchanged =
-                    rows.UnchangedFor(file.ProjectRelativePath);
-                TransformWorkerUnchangedMethodDto[] unchangedMethods =
-                    new TransformWorkerUnchangedMethodDto[fileUnchanged.Count];
-                for (int index = 0; index < fileUnchanged.Count; index++)
-                {
-                    unchangedMethods[index] = fileUnchanged[index];
-                }
-
-                file.RevertedUnchangedCount = HotReloadEntryApplier.RevertUnchangedPatches(
-                    file.AssemblyName,
-                    unchangedMethods,
-                    file.Sinks.Outcomes,
-                    file.AssemblyResolvePath);
-            }
-        }
-
-        // Why per file: a group applies file by file, so only the rows that actually reached
-        // Harmony may claim their removed signatures were superseded. A partly applied file
-        // patches some rows and leaves the rest failed or file-atomically skipped.
-        private static void RecordSupersededSignaturesAfterApply(
-            HotReloadApplyContext context,
-            IReadOnlyCollection<string> gatedReplacementMethodKeys)
-        {
-            for (int index = 0; index < context.Files.Count; index++)
-            {
-                HotReloadGroupFile file = context.Files[index];
-                Debug.Assert(file.FileOutput != null, "Every file must carry its worker output row.");
-                HotReloadSupersededSignatureRecorder.RecordFromAppliedEntries(
-                    file.Sinks.AppliedEntries,
-                    file.FileOutput.removedMethodSignatures
-                        ?? Array.Empty<TransformWorkerRemovedMethodSignatureDto>(),
-                    gatedReplacementMethodKeys);
-            }
-        }
-
         private static List<string> CollectProjectRelativePaths(IReadOnlyList<HotReloadGroupFile> files)
         {
             List<string> projectRelativePaths = new List<string>(files.Count);
@@ -606,17 +502,5 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return projectRelativePaths;
         }
 
-        private static List<HotReloadFileProcessResult> BuildUnappliedResults(
-            IReadOnlyList<HotReloadGroupFile> files)
-        {
-            List<HotReloadFileProcessResult> results =
-                new List<HotReloadFileProcessResult>(files.Count);
-            foreach (HotReloadGroupFile file in files)
-            {
-                results.Add(HotReloadFileEntryApplier.BuildUnappliedResult(file));
-            }
-
-            return results;
-        }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -65,7 +65,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return BuildUnappliedResults(files);
             }
 
-            if (preparation.Artifact == null)
+            if (preparation.Prepared == null)
             {
                 return await TransformAndApplyGroupAsync(files, workerInput, null, correlationId, ct)
                     .ConfigureAwait(false);
@@ -74,7 +74,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return await TransformAndApplyPreparedGroupAsync(
                 files,
                 workerInput,
-                preparation.Artifact,
+                preparation.Prepared,
                 correlationId,
                 ct).ConfigureAwait(false);
         }
@@ -86,10 +86,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static async Task<IReadOnlyList<HotReloadFileProcessResult>> TransformAndApplyPreparedGroupAsync(
             IReadOnlyList<HotReloadGroupFile> files,
             TransformWorkerInputDto workerInput,
-            HotReloadIntroducedTypeArtifact artifact,
+            HotReloadPreparedIntroducedTypes prepared,
             string correlationId,
             CancellationToken ct)
         {
+            HotReloadIntroducedTypeArtifact artifact = prepared.Artifact;
             HotReloadIntroducedTypeRegistry registry = HotReloadIntroducedTypeHolder.Registry;
             registry.RegisterPrepared(artifact);
             List<TransformWorkerIntroducedTypeArtifactDto> records =
@@ -103,14 +104,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 try
                 {
-                    return await TransformAndApplyGroupAsync(files, workerInput, artifact, correlationId, ct)
+                    return await TransformAndApplyGroupAsync(files, workerInput, prepared, correlationId, ct)
                         .ConfigureAwait(false);
                 }
                 finally
                 {
-                    // The commit boundary that activates a successful run is a later stage; until
-                    // it exists the prepared membership is dropped here as well. The discard of a
-                    // failed run stays in place once activation replaces the successful path.
+                    // A run the commit boundary activated no longer holds a prepared membership,
+                    // so this only drops what a run that never reached activation left behind.
                     registry.DiscardPrepared(artifact);
                 }
             }
@@ -119,7 +119,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static async Task<IReadOnlyList<HotReloadFileProcessResult>> TransformAndApplyGroupAsync(
             IReadOnlyList<HotReloadGroupFile> files,
             TransformWorkerInputDto workerInput,
-            HotReloadIntroducedTypeArtifact preparedArtifact,
+            HotReloadPreparedIntroducedTypes prepared,
             string correlationId,
             CancellationToken ct)
         {
@@ -152,7 +152,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // Why before the empty-entries return: all-unchanged runs exit there, and those are
             // exactly the runs that must peel leftover patches so behavior converges to compiled IL.
-            if (!await RevalidateBeforeRevertAsync(
+            // Why a run that commits types skips it: peeling a patch here would mutate the domain
+            // before the commit boundary, which a failed recheck could then no longer undo, so
+            // such a run reverts at the boundary instead.
+            if (!CommitsIntroducedTypes(prepared, files[0].AssemblyName)
+                && !await RevalidateBeforeRevertAsync(
                     files,
                     ct,
                     () => RevertUnchangedPatchesPerFile(files, rows)).ConfigureAwait(false))
@@ -170,7 +174,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 workerInput,
                 workerOutput,
                 files,
-                preparedArtifact);
+                prepared);
             HotReloadGroupGateAndCompileResult gateAndCompile = await HotReloadGroupProcessorDependencies
                 .Current
                 .GateAndCompile(context, ct)
@@ -261,19 +265,67 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             ct.ThrowIfCancellationRequested();
+            string staleReason = HotReloadGroupCommitBoundary.DescribeStaleReason(context);
+            if (staleReason != null)
+            {
+                HotReloadGroupOutcomeRouter.AppendGroupFailure(context.Files, "(file)", staleReason);
+                return BuildUnappliedResults(context.Files);
+            }
+
             HotReloadGroupProcessorDependencies dependencies = HotReloadGroupProcessorDependencies.Current;
             // Why the whole group is resolved before any file is mutated: a file whose entries
-            // cannot be resolved must not leave the files applied before it half patched.
+            // cannot be resolved must not leave the files applied before it half patched. It is
+            // also the last failure a run can take without having activated anything.
             IReadOnlyList<HotReloadPreparedGroupFile> preparedFiles = dependencies.PrepareGroupEntries(
                 context,
                 compile.CompileResult,
                 compile.EntriesToPatch);
+            return CommitPreparedGroup(context, gateResult, compile, preparedFiles);
+        }
+
+        /// <summary>
+        /// The commit point of a group run and everything that follows it: the introduced types
+        /// become active, the patches this run supersedes are peeled, and the resolved entries are
+        /// applied. A failure after the commit point leaves the types active and fails methods.
+        /// </summary>
+        private static IReadOnlyList<HotReloadFileProcessResult> CommitPreparedGroup(
+            HotReloadApplyContext context,
+            HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult,
+            HotReloadGroupCompileResult compile,
+            IReadOnlyList<HotReloadPreparedGroupFile> preparedFiles)
+        {
+            IReadOnlyList<HotReloadGroupFile> files = context.Files;
+            HotReloadPreparedIntroducedTypes prepared = context.PreparedIntroducedTypes;
+            if (prepared != null)
+            {
+                HotReloadIntroducedTypeHolder.Registry.Activate(prepared.Artifact);
+            }
+
+            if (CommitsIntroducedTypes(prepared, files[0].AssemblyName))
+            {
+                RevertUnchangedPatchesPerFile(
+                    files,
+                    HotReloadWorkerRowsByFile.Build(context.WorkerOutput, context.ProjectRelativePaths));
+            }
+
+            HotReloadGroupProcessorDependencies dependencies = HotReloadGroupProcessorDependencies.Current;
             IReadOnlyList<HotReloadFileProcessResult> results = dependencies.ApplyPreparedEntries(
                 context,
                 compile.CompileResult,
                 preparedFiles);
             RecordSupersededSignaturesAfterApply(context, gateResult.GatedReplacementMethodKeys);
             return results;
+        }
+
+        // A run whose introduced types become active at the commit boundary: the reload either
+        // introduces a type itself, or the assembly it targets already owns one this domain
+        // introduced, in which case its patches resolve through the artifact assemblies too.
+        private static bool CommitsIntroducedTypes(
+            HotReloadPreparedIntroducedTypes prepared,
+            string targetAssemblyName)
+        {
+            return prepared != null
+                || HotReloadIntroducedTypeHolder.Registry.HasActiveTypesForOriginalAssembly(targetAssemblyName);
         }
 
         internal static bool TryAppendNewSourceMembershipFailure(IReadOnlyList<HotReloadGroupFile> files)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessorDependencies.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessorDependencies.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
@@ -12,10 +14,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static HotReloadGroupProcessorDependencies current = CreateProduction();
 
         private HotReloadGroupProcessorDependencies(
-            Func<IReadOnlyList<HotReloadGroupFile>, bool> validateNewSourceMembership)
+            Func<IReadOnlyList<HotReloadGroupFile>, bool> validateNewSourceMembership,
+            Func<IReadOnlyList<HotReloadGroupFile>, TransformWorkerInputDto, CancellationToken,
+                Task<HotReloadIntroducedTypePreparationResult>> prepareIntroducedTypes,
+            Func<TransformWorkerInputDto, CancellationToken, Task<TransformWorkerClientResult>> runWorker)
         {
             ValidateNewSourceMembership = validateNewSourceMembership
                 ?? throw new ArgumentNullException(nameof(validateNewSourceMembership));
+            PrepareIntroducedTypes = prepareIntroducedTypes
+                ?? throw new ArgumentNullException(nameof(prepareIntroducedTypes));
+            RunWorker = runWorker ?? throw new ArgumentNullException(nameof(runWorker));
         }
 
         internal static HotReloadGroupProcessorDependencies Current => current;
@@ -25,15 +33,35 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         internal Func<IReadOnlyList<HotReloadGroupFile>, bool> ValidateNewSourceMembership { get; }
 
+        /// <summary>
+        /// Compiles the types this run introduces into a retained artifact before the transform run.
+        /// </summary>
+        internal Func<IReadOnlyList<HotReloadGroupFile>, TransformWorkerInputDto, CancellationToken,
+            Task<HotReloadIntroducedTypePreparationResult>> PrepareIntroducedTypes { get; }
+
+        /// <summary>
+        /// Runs the transform worker for the group.
+        /// </summary>
+        internal Func<TransformWorkerInputDto, CancellationToken, Task<TransformWorkerClientResult>> RunWorker { get; }
+
         internal static HotReloadGroupProcessorDependencies CreateProduction()
         {
-            return new HotReloadGroupProcessorDependencies(HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure);
+            return new HotReloadGroupProcessorDependencies(
+                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                HotReloadIntroducedTypePreparation.PrepareAsync,
+                TransformWorkerClient.RunAsync);
         }
 
         internal static HotReloadGroupProcessorDependencies Create(
-            Func<IReadOnlyList<HotReloadGroupFile>, bool> validateNewSourceMembership)
+            Func<IReadOnlyList<HotReloadGroupFile>, bool> validateNewSourceMembership,
+            Func<IReadOnlyList<HotReloadGroupFile>, TransformWorkerInputDto, CancellationToken,
+                Task<HotReloadIntroducedTypePreparationResult>> prepareIntroducedTypes,
+            Func<TransformWorkerInputDto, CancellationToken, Task<TransformWorkerClientResult>> runWorker)
         {
-            return new HotReloadGroupProcessorDependencies(validateNewSourceMembership);
+            return new HotReloadGroupProcessorDependencies(
+                validateNewSourceMembership,
+                prepareIntroducedTypes,
+                runWorker);
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessorDependencies.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessorDependencies.cs
@@ -17,13 +17,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Func<IReadOnlyList<HotReloadGroupFile>, bool> validateNewSourceMembership,
             Func<IReadOnlyList<HotReloadGroupFile>, TransformWorkerInputDto, CancellationToken,
                 Task<HotReloadIntroducedTypePreparationResult>> prepareIntroducedTypes,
-            Func<TransformWorkerInputDto, CancellationToken, Task<TransformWorkerClientResult>> runWorker)
+            Func<TransformWorkerInputDto, CancellationToken, Task<TransformWorkerClientResult>> runWorker,
+            Func<HotReloadApplyContext, CancellationToken, Task<HotReloadGroupGateAndCompileResult>> gateAndCompile,
+            Func<HotReloadApplyContext, HotReloadShimCompileResult, TransformWorkerEntryDto[],
+                IReadOnlyList<HotReloadPreparedGroupFile>> prepareGroupEntries,
+            Func<HotReloadApplyContext, HotReloadShimCompileResult, IReadOnlyList<HotReloadPreparedGroupFile>,
+                IReadOnlyList<HotReloadFileProcessResult>> applyPreparedEntries)
         {
             ValidateNewSourceMembership = validateNewSourceMembership
                 ?? throw new ArgumentNullException(nameof(validateNewSourceMembership));
             PrepareIntroducedTypes = prepareIntroducedTypes
                 ?? throw new ArgumentNullException(nameof(prepareIntroducedTypes));
             RunWorker = runWorker ?? throw new ArgumentNullException(nameof(runWorker));
+            GateAndCompile = gateAndCompile ?? throw new ArgumentNullException(nameof(gateAndCompile));
+            PrepareGroupEntries = prepareGroupEntries
+                ?? throw new ArgumentNullException(nameof(prepareGroupEntries));
+            ApplyPreparedEntries = applyPreparedEntries
+                ?? throw new ArgumentNullException(nameof(applyPreparedEntries));
         }
 
         internal static HotReloadGroupProcessorDependencies Current => current;
@@ -44,24 +54,53 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         internal Func<TransformWorkerInputDto, CancellationToken, Task<TransformWorkerClientResult>> RunWorker { get; }
 
+        /// <summary>
+        /// Runs the signature-change gate and the group's shim compile.
+        /// </summary>
+        internal Func<HotReloadApplyContext, CancellationToken, Task<HotReloadGroupGateAndCompileResult>>
+            GateAndCompile { get; }
+
+        /// <summary>
+        /// Resolves every file of the group against the compiled shim before anything is mutated.
+        /// </summary>
+        internal Func<HotReloadApplyContext, HotReloadShimCompileResult, TransformWorkerEntryDto[],
+            IReadOnlyList<HotReloadPreparedGroupFile>> PrepareGroupEntries { get; }
+
+        /// <summary>
+        /// Applies the resolved files: the commit boundary of a group run.
+        /// </summary>
+        internal Func<HotReloadApplyContext, HotReloadShimCompileResult, IReadOnlyList<HotReloadPreparedGroupFile>,
+            IReadOnlyList<HotReloadFileProcessResult>> ApplyPreparedEntries { get; }
+
         internal static HotReloadGroupProcessorDependencies CreateProduction()
         {
             return new HotReloadGroupProcessorDependencies(
                 HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
                 HotReloadIntroducedTypePreparation.PrepareAsync,
-                TransformWorkerClient.RunAsync);
+                TransformWorkerClient.RunAsync,
+                HotReloadGroupProcessor.GateAndCompileAsync,
+                HotReloadGroupEntryPreparation.PrepareGroup,
+                HotReloadEntryApplier.ApplyPreparedEntries);
         }
 
         internal static HotReloadGroupProcessorDependencies Create(
             Func<IReadOnlyList<HotReloadGroupFile>, bool> validateNewSourceMembership,
             Func<IReadOnlyList<HotReloadGroupFile>, TransformWorkerInputDto, CancellationToken,
                 Task<HotReloadIntroducedTypePreparationResult>> prepareIntroducedTypes,
-            Func<TransformWorkerInputDto, CancellationToken, Task<TransformWorkerClientResult>> runWorker)
+            Func<TransformWorkerInputDto, CancellationToken, Task<TransformWorkerClientResult>> runWorker,
+            Func<HotReloadApplyContext, CancellationToken, Task<HotReloadGroupGateAndCompileResult>> gateAndCompile,
+            Func<HotReloadApplyContext, HotReloadShimCompileResult, TransformWorkerEntryDto[],
+                IReadOnlyList<HotReloadPreparedGroupFile>> prepareGroupEntries,
+            Func<HotReloadApplyContext, HotReloadShimCompileResult, IReadOnlyList<HotReloadPreparedGroupFile>,
+                IReadOnlyList<HotReloadFileProcessResult>> applyPreparedEntries)
         {
             return new HotReloadGroupProcessorDependencies(
                 validateNewSourceMembership,
                 prepareIntroducedTypes,
-                runWorker);
+                runWorker,
+                gateAndCompile,
+                prepareGroupEntries,
+                applyPreparedEntries);
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeArtifactRecords.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeArtifactRecords.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Builds the retained-artifact records one worker run may bind against: the artifacts still
+    /// active for the generation this run targets, plus the artifact this run just prepared.
+    /// </summary>
+    internal static class HotReloadIntroducedTypeArtifactRecords
+    {
+        /// <summary>
+        /// Collects the records of the artifacts already active for the run's target generation.
+        /// An artifact of another generation is left out, because its types were normalized back
+        /// to an assembly this run no longer edits.
+        /// </summary>
+        public static List<TransformWorkerIntroducedTypeArtifactDto> CollectActive(
+            HotReloadIntroducedTypeRegistry registry,
+            string targetAssemblyName,
+            string targetAssemblyMvid)
+        {
+            List<TransformWorkerIntroducedTypeArtifactDto> records =
+                new List<TransformWorkerIntroducedTypeArtifactDto>();
+            IReadOnlyList<HotReloadIntroducedTypeArtifact> active = registry.CollectActiveArtifactsForTarget(
+                targetAssemblyName,
+                targetAssemblyMvid);
+            foreach (HotReloadIntroducedTypeArtifact artifact in active)
+            {
+                records.Add(CreateRecord(artifact));
+            }
+
+            return records;
+        }
+
+        public static TransformWorkerIntroducedTypeArtifactDto CreateRecord(
+            HotReloadIntroducedTypeArtifact artifact)
+        {
+            TransformWorkerIntroducedTypeArtifactTypeDto[] types =
+                new TransformWorkerIntroducedTypeArtifactTypeDto[artifact.Descriptors.Count];
+            for (int index = 0; index < artifact.Descriptors.Count; index++)
+            {
+                HotReloadIntroducedTypeDescriptor descriptor = artifact.Descriptors[index];
+                types[index] = new TransformWorkerIntroducedTypeArtifactTypeDto
+                {
+                    metadataName = descriptor.MetadataName,
+                    originalAssemblyName = descriptor.OriginalAssemblyName,
+                    originalAssemblyMvid = descriptor.OriginalAssemblyMvid,
+                    ownerProjectRelativePath = descriptor.OwnerProjectRelativePath,
+                    declarationFingerprint = descriptor.DeclarationFingerprint
+                };
+            }
+
+            return new TransformWorkerIntroducedTypeArtifactDto
+            {
+                assemblyFullName = artifact.AssemblyFullName,
+                referencePath = artifact.DllPath,
+                types = types
+            };
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeArtifactRecords.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeArtifactRecords.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8799ab607cf94c769b4750ce27cf130
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs
@@ -34,6 +34,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     "Introduced-type preparation failed: " + prepareResult.ErrorMessage);
             }
 
+            string refusedDeclaration = FindChangedIntroducedTypeDiagnostic(prepareResult.Output);
+            if (refusedDeclaration != null)
+            {
+                return HotReloadIntroducedTypePreparationResult.Failure(refusedDeclaration);
+            }
+
             List<HotReloadIntroducedTypeDescriptor> descriptors = CollectDescriptors(prepareResult.Output);
             if (descriptors.Count == 0)
             {
@@ -113,6 +119,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 hashesByOwnerPath.Count == ownerPaths.Count,
                 "Every owner of an introduced type must have a row in the preparation output.");
             return hashesByOwnerPath;
+        }
+
+        // Why this one diagnostic fails the run: every other unsupported declaration simply is not
+        // introduced, and the source that declares it stays in the tree. A declaration this domain
+        // already retains an assembly for is taken out of the tree either way, so continuing would
+        // bind callers against the retained definition the edited source no longer declares.
+        private static string FindChangedIntroducedTypeDiagnostic(TransformWorkerOutputDto output)
+        {
+            foreach (TransformWorkerFileOutputDto file in output.files)
+            {
+                foreach (string diagnostic in file.introducedTypeDiagnostics)
+                {
+                    if (diagnostic != null
+                        && diagnostic.StartsWith(
+                            HotReloadConstants.ChangedIntroducedTypeDiagnosticPrefix,
+                            StringComparison.Ordinal))
+                    {
+                        return diagnostic;
+                    }
+                }
+            }
+
+            return null;
         }
 
         private static List<HotReloadIntroducedTypeDescriptor> CollectDescriptors(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs
@@ -58,7 +58,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     "Introduced-type compilation failed: " + compileResult.ErrorMessage);
             }
 
-            return HotReloadIntroducedTypePreparationResult.Prepared(compileResult.Artifact);
+            return HotReloadIntroducedTypePreparationResult.WithPrepared(
+                new HotReloadPreparedIntroducedTypes(
+                    compileResult.Artifact,
+                    CollectOwnerSourceHashes(prepareResult.Output, descriptors)));
         }
 
         // Why the same sources and references: preparation asks the worker which declarations of
@@ -79,6 +82,37 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 changedSiblingSourcePaths = transformInput.changedSiblingSourcePaths,
                 introducedTypeArtifacts = transformInput.introducedTypeArtifacts
             };
+        }
+
+        // Why only the owners: the commit boundary compares what the artifact was compiled from
+        // against what the transform run read, and only the files that declare an introduced type
+        // took part in that compilation.
+        private static Dictionary<string, string> CollectOwnerSourceHashes(
+            TransformWorkerOutputDto output,
+            IReadOnlyList<HotReloadIntroducedTypeDescriptor> descriptors)
+        {
+            HashSet<string> ownerPaths = new HashSet<string>(StringComparer.Ordinal);
+            foreach (HotReloadIntroducedTypeDescriptor descriptor in descriptors)
+            {
+                ownerPaths.Add(descriptor.OwnerProjectRelativePath);
+            }
+
+            Dictionary<string, string> hashesByOwnerPath =
+                new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (TransformWorkerFileOutputDto file in output.files)
+            {
+                if (!ownerPaths.Contains(file.projectRelativePath))
+                {
+                    continue;
+                }
+
+                hashesByOwnerPath[file.projectRelativePath] = file.sourceContentSha256;
+            }
+
+            Debug.Assert(
+                hashesByOwnerPath.Count == ownerPaths.Count,
+                "Every owner of an introduced type must have a row in the preparation output.");
+            return hashesByOwnerPath;
         }
 
         private static List<HotReloadIntroducedTypeDescriptor> CollectDescriptors(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs
@@ -54,7 +54,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         HotReloadIntroducedTypeCompilationRequest.CreateBatch(
                             paths,
                             descriptors,
-                            transformInput.referencePaths,
+                            BuildArtifactReferencePaths(transformInput),
                             transformInput.defines),
                         ct)
                     .ConfigureAwait(false);
@@ -68,6 +68,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 new HotReloadPreparedIntroducedTypes(
                     compileResult.Artifact,
                     CollectOwnerSourceHashes(prepareResult.Output, descriptors)));
+        }
+
+        // Why the active artifacts as well: a declaration this run introduces may name a type an
+        // earlier reload introduced, which lives in neither the compiled assembly nor the sources
+        // of this run. Only the assemblies those reloads retained can supply it.
+        private static List<string> BuildArtifactReferencePaths(TransformWorkerInputDto transformInput)
+        {
+            List<string> referencePaths = new List<string>(transformInput.referencePaths);
+            HotReloadShimReferenceBuilder.AppendIntroducedTypeArtifactReferences(
+                referencePaths,
+                transformInput.introducedTypeArtifacts);
+            return referencePaths;
         }
 
         // Why the same sources and references: preparation asks the worker which declarations of

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Compiles the types one run introduces into a retained artifact before the transform run, so
+    /// the transform and the shim compilation can bind them from a loaded assembly instead of the
+    /// edited source that still declares them.
+    /// </summary>
+    internal static class HotReloadIntroducedTypePreparation
+    {
+        // The artifact directory has to stay unique per domain, or a second reload would emit over
+        // the assembly files a loaded artifact of this domain still maps.
+        private static readonly string SessionId = Guid.NewGuid().ToString("N");
+
+        public static async Task<HotReloadIntroducedTypePreparationResult> PrepareAsync(
+            IReadOnlyList<HotReloadGroupFile> files,
+            TransformWorkerInputDto transformInput,
+            CancellationToken ct)
+        {
+            Debug.Assert(files != null && files.Count > 0, "A group must hold a file.");
+            Debug.Assert(transformInput != null, "The preparation reuses the transform input.");
+
+            TransformWorkerClientResult prepareResult = await TransformWorkerClient.RunAsync(
+                BuildPrepareInput(transformInput),
+                ct).ConfigureAwait(false);
+            if (!prepareResult.Success)
+            {
+                return HotReloadIntroducedTypePreparationResult.Failure(
+                    "Introduced-type preparation failed: " + prepareResult.ErrorMessage);
+            }
+
+            List<HotReloadIntroducedTypeDescriptor> descriptors = CollectDescriptors(prepareResult.Output);
+            if (descriptors.Count == 0)
+            {
+                return HotReloadIntroducedTypePreparationResult.NoIntroducedTypes();
+            }
+
+            HotReloadIntroducedTypeArtifactPaths paths =
+                new HotReloadIntroducedTypeArtifactPathFactory(files[0].ProjectRoot, SessionId).Create();
+            HotReloadIntroducedTypeCompilerResult compileResult =
+                await new HotReloadIntroducedTypeCompiler(new HotReloadIntroducedTypeCompilerEnvironment())
+                    .CompileAsync(
+                        HotReloadIntroducedTypeCompilationRequest.CreateBatch(
+                            paths,
+                            descriptors,
+                            transformInput.referencePaths,
+                            transformInput.defines),
+                        ct)
+                    .ConfigureAwait(false);
+            if (!compileResult.Success)
+            {
+                return HotReloadIntroducedTypePreparationResult.Failure(
+                    "Introduced-type compilation failed: " + compileResult.ErrorMessage);
+            }
+
+            return HotReloadIntroducedTypePreparationResult.Prepared(compileResult.Artifact);
+        }
+
+        // Why the same sources and references: preparation asks the worker which declarations of
+        // this very run are new, so anything that changes what the run compiles against would make
+        // it plan a type the transform run then sees differently.
+        private static TransformWorkerInputDto BuildPrepareInput(TransformWorkerInputDto transformInput)
+        {
+            return new TransformWorkerInputDto
+            {
+                operation = "prepareIntroducedTypes",
+                sources = transformInput.sources,
+                defines = transformInput.defines,
+                referencePaths = transformInput.referencePaths,
+                targetTypesAssemblyPath = transformInput.targetTypesAssemblyPath,
+                targetAssemblyName = transformInput.targetAssemblyName,
+                targetAssemblyMvid = transformInput.targetAssemblyMvid,
+                assemblySourcePaths = transformInput.assemblySourcePaths,
+                changedSiblingSourcePaths = transformInput.changedSiblingSourcePaths,
+                introducedTypeArtifacts = transformInput.introducedTypeArtifacts
+            };
+        }
+
+        private static List<HotReloadIntroducedTypeDescriptor> CollectDescriptors(
+            TransformWorkerOutputDto output)
+        {
+            List<HotReloadIntroducedTypeDescriptor> descriptors =
+                new List<HotReloadIntroducedTypeDescriptor>();
+            foreach (TransformWorkerFileOutputDto file in output.files)
+            {
+                foreach (TransformWorkerIntroducedTypeDto introducedType in file.introducedTypes)
+                {
+                    descriptors.Add(
+                        new HotReloadIntroducedTypeDescriptor(
+                            introducedType.originalAssemblyName,
+                            introducedType.originalAssemblyMvid,
+                            introducedType.metadataName,
+                            introducedType.ownerProjectRelativePath,
+                            introducedType.declarationFingerprint,
+                            introducedType.source));
+                }
+            }
+
+            return descriptors;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs
@@ -46,6 +46,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return HotReloadIntroducedTypePreparationResult.NoIntroducedTypes();
             }
 
+            string doubleDeclaration = FindDoubleDeclaredType(descriptors);
+            if (doubleDeclaration != null)
+            {
+                return HotReloadIntroducedTypePreparationResult.Failure(doubleDeclaration);
+            }
+
             HotReloadIntroducedTypeArtifactPaths paths =
                 new HotReloadIntroducedTypeArtifactPathFactory(files[0].ProjectRoot, SessionId).Create();
             HotReloadIntroducedTypeCompilerResult compileResult =
@@ -151,6 +157,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         return diagnostic;
                     }
                 }
+            }
+
+            return null;
+        }
+
+        // Why refused here and not by the artifact batch: two files of one group declaring the
+        // same type is an editing mistake the reload has to report against both files, while the
+        // batch's uniqueness rule is an internal contract whose violation would throw out of the
+        // run and leave the group with no result at all.
+        private static string FindDoubleDeclaredType(
+            IReadOnlyList<HotReloadIntroducedTypeDescriptor> descriptors)
+        {
+            Dictionary<string, string> ownerPathByIdentity =
+                new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (HotReloadIntroducedTypeDescriptor descriptor in descriptors)
+            {
+                string identity = descriptor.BuildIdentity();
+                if (!ownerPathByIdentity.TryGetValue(identity, out string firstOwnerPath))
+                {
+                    ownerPathByIdentity[identity] = descriptor.OwnerProjectRelativePath;
+                    continue;
+                }
+
+                return "Introduced type " + descriptor.MetadataName
+                    + " is declared in more than one file of the group: "
+                    + firstOwnerPath + " and " + descriptor.OwnerProjectRelativePath + ".";
             }
 
             return null;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0a75d957b47148de9f84dee3c93f8e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparationResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparationResult.cs
@@ -10,20 +10,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         private HotReloadIntroducedTypePreparationResult(
             bool success,
-            HotReloadIntroducedTypeArtifact artifact,
+            HotReloadPreparedIntroducedTypes prepared,
             string errorMessage)
         {
             Success = success;
-            Artifact = artifact;
+            Prepared = prepared;
             ErrorMessage = errorMessage;
         }
 
         public bool Success { get; }
 
         /// <summary>
-        /// The artifact this run prepared, or null when the run introduced no type at all.
+        /// What this run prepared, or null when the run introduced no type at all.
         /// </summary>
-        public HotReloadIntroducedTypeArtifact Artifact { get; }
+        public HotReloadPreparedIntroducedTypes Prepared { get; }
 
         public string ErrorMessage { get; }
 
@@ -32,15 +32,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return new HotReloadIntroducedTypePreparationResult(true, null, string.Empty);
         }
 
-        public static HotReloadIntroducedTypePreparationResult Prepared(
-            HotReloadIntroducedTypeArtifact artifact)
+        public static HotReloadIntroducedTypePreparationResult WithPrepared(
+            HotReloadPreparedIntroducedTypes prepared)
         {
-            if (artifact == null)
+            if (prepared == null)
             {
-                throw new ArgumentNullException(nameof(artifact));
+                throw new ArgumentNullException(nameof(prepared));
             }
 
-            return new HotReloadIntroducedTypePreparationResult(true, artifact, string.Empty);
+            return new HotReloadIntroducedTypePreparationResult(true, prepared, string.Empty);
         }
 
         public static HotReloadIntroducedTypePreparationResult Failure(string errorMessage)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparationResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparationResult.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Reports what one run's introduced-type preparation produced, so the group pipeline can tell
+    /// "nothing to introduce" from a failure that must leave the run unapplied.
+    /// </summary>
+    internal sealed class HotReloadIntroducedTypePreparationResult
+    {
+        private HotReloadIntroducedTypePreparationResult(
+            bool success,
+            HotReloadIntroducedTypeArtifact artifact,
+            string errorMessage)
+        {
+            Success = success;
+            Artifact = artifact;
+            ErrorMessage = errorMessage;
+        }
+
+        public bool Success { get; }
+
+        /// <summary>
+        /// The artifact this run prepared, or null when the run introduced no type at all.
+        /// </summary>
+        public HotReloadIntroducedTypeArtifact Artifact { get; }
+
+        public string ErrorMessage { get; }
+
+        public static HotReloadIntroducedTypePreparationResult NoIntroducedTypes()
+        {
+            return new HotReloadIntroducedTypePreparationResult(true, null, string.Empty);
+        }
+
+        public static HotReloadIntroducedTypePreparationResult Prepared(
+            HotReloadIntroducedTypeArtifact artifact)
+        {
+            if (artifact == null)
+            {
+                throw new ArgumentNullException(nameof(artifact));
+            }
+
+            return new HotReloadIntroducedTypePreparationResult(true, artifact, string.Empty);
+        }
+
+        public static HotReloadIntroducedTypePreparationResult Failure(string errorMessage)
+        {
+            if (string.IsNullOrEmpty(errorMessage))
+            {
+                throw new ArgumentException("A preparation failure must carry a reason.", nameof(errorMessage));
+            }
+
+            return new HotReloadIntroducedTypePreparationResult(false, null, errorMessage);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparationResult.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparationResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aac2d6b2b712944179dc513102c880f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeRegistry.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeRegistry.cs
@@ -192,6 +192,51 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
+        /// <summary>
+        /// Collects the active artifacts whose types belong to one generation of one compiled
+        /// assembly, which is the only generation a run may normalize its declarations back to.
+        /// </summary>
+        public IReadOnlyList<HotReloadIntroducedTypeArtifact> CollectActiveArtifactsForTarget(
+            string originalAssemblyName,
+            string originalAssemblyMvid)
+        {
+            List<HotReloadIntroducedTypeArtifact> matches = new List<HotReloadIntroducedTypeArtifact>();
+            if (string.IsNullOrEmpty(originalAssemblyName) || string.IsNullOrEmpty(originalAssemblyMvid))
+            {
+                return matches;
+            }
+
+            lock (gate)
+            {
+                foreach (HotReloadIntroducedTypeArtifact artifact in activeByAssemblyIdentity.Values)
+                {
+                    if (HasTypeOfTarget(artifact, originalAssemblyName, originalAssemblyMvid))
+                    {
+                        matches.Add(artifact);
+                    }
+                }
+            }
+
+            return matches;
+        }
+
+        private static bool HasTypeOfTarget(
+            HotReloadIntroducedTypeArtifact artifact,
+            string originalAssemblyName,
+            string originalAssemblyMvid)
+        {
+            foreach (HotReloadIntroducedTypeDescriptor descriptor in artifact.Descriptors)
+            {
+                if (string.Equals(descriptor.OriginalAssemblyName, originalAssemblyName, StringComparison.Ordinal)
+                    && string.Equals(descriptor.OriginalAssemblyMvid, originalAssemblyMvid, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public bool TryResolveActiveAssembly(string requestedAssemblyFullName, out HotReloadIntroducedTypeArtifact artifact)
         {
             lock (gate)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPreparedGroupFile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPreparedGroupFile.cs
@@ -1,0 +1,65 @@
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// One file of a group after preparation: which path it takes and, when its entries resolved,
+    /// the entries and the resolution the apply step needs.
+    /// </summary>
+    internal sealed class HotReloadPreparedGroupFile
+    {
+        internal HotReloadGroupFile File { get; }
+        internal HotReloadGroupFilePreparationKind Kind { get; }
+        internal TransformWorkerEntryDto[] Entries { get; }
+        internal HotReloadEntryResolution.Result Resolution { get; }
+
+        private HotReloadPreparedGroupFile(
+            HotReloadGroupFile file,
+            HotReloadGroupFilePreparationKind kind,
+            TransformWorkerEntryDto[] entries,
+            HotReloadEntryResolution.Result resolution)
+        {
+            Debug.Assert(file != null, "file must not be null.");
+
+            File = file;
+            Kind = kind;
+            Entries = entries;
+            Resolution = resolution;
+        }
+
+        internal static HotReloadPreparedGroupFile SkippedByGroup(HotReloadGroupFile file)
+        {
+            return new HotReloadPreparedGroupFile(
+                file, HotReloadGroupFilePreparationKind.SkippedByGroup, null, null);
+        }
+
+        internal static HotReloadPreparedGroupFile NoEntriesToApply(HotReloadGroupFile file)
+        {
+            return new HotReloadPreparedGroupFile(
+                file, HotReloadGroupFilePreparationKind.NoEntriesToApply, null, null);
+        }
+
+        internal static HotReloadPreparedGroupFile ResolutionFailed(
+            HotReloadGroupFile file,
+            TransformWorkerEntryDto[] entries,
+            HotReloadEntryResolution.Result resolution)
+        {
+            Debug.Assert(resolution != null, "resolution must not be null.");
+            return new HotReloadPreparedGroupFile(
+                file, HotReloadGroupFilePreparationKind.ResolutionFailed, entries, resolution);
+        }
+
+        internal static HotReloadPreparedGroupFile Resolved(
+            HotReloadGroupFile file,
+            TransformWorkerEntryDto[] entries,
+            HotReloadEntryResolution.Result resolution)
+        {
+            Debug.Assert(resolution != null, "resolution must not be null.");
+            Debug.Assert(entries != null && entries.Length > 0, "A resolved file must hold an entry.");
+            return new HotReloadPreparedGroupFile(
+                file, HotReloadGroupFilePreparationKind.Resolved, entries, resolution);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPreparedGroupFile.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPreparedGroupFile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e6bbc4e1e823495e9aafb2d75699514
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPreparedIntroducedTypes.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPreparedIntroducedTypes.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// What one run's introduced-type preparation produced: the artifact assembly the run may
+    /// activate, and the source hashes that artifact was compiled from.
+    /// </summary>
+    /// <remarks>
+    /// Why the owner hashes travel with the artifact: the commit boundary has to confirm the
+    /// transform run read the very sources the artifact was compiled from, and the only evidence
+    /// of that is the hash each run reported for the owner file.
+    /// </remarks>
+    internal sealed class HotReloadPreparedIntroducedTypes
+    {
+        internal HotReloadPreparedIntroducedTypes(
+            HotReloadIntroducedTypeArtifact artifact,
+            IReadOnlyDictionary<string, string> ownerSourceHashes)
+        {
+            Artifact = artifact ?? throw new ArgumentNullException(nameof(artifact));
+            OwnerSourceHashes = ownerSourceHashes ?? throw new ArgumentNullException(nameof(ownerSourceHashes));
+        }
+
+        internal HotReloadIntroducedTypeArtifact Artifact { get; }
+
+        /// <summary>
+        /// Owner project-relative path to the source content hash the preparation run read.
+        /// </summary>
+        internal IReadOnlyDictionary<string, string> OwnerSourceHashes { get; }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPreparedIntroducedTypes.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPreparedIntroducedTypes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 489e21f9209da4986921ea7c0d64db3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
@@ -54,11 +54,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Why a run that commits types skips it: clearing a generation here would mutate
                 // the domain before the commit boundary, which a failed recheck could then no
                 // longer undo, so such a run clears at the boundary instead.
-                if (!HotReloadGroupProcessor.CommitsIntroducedTypes(
+                if (!HotReloadGroupCommitStage.CommitsIntroducedTypes(
                         context.PreparedIntroducedTypes,
                         context.AssemblyName))
                 {
-                    HotReloadGroupProcessor.ClearEmptyFileGenerations(context);
+                    HotReloadGroupCommitStage.ClearEmptyFileGenerations(context);
                 }
 
                 return HotReloadGroupCompileResult.ReadyWithoutMethods();

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
@@ -48,14 +48,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 || context.WorkerOutput.entries == null
                 || context.WorkerOutput.entries.Length == 0)
             {
-                // Why only on this success path: deleting an added method and restoring callers
-                // yields empty entries, so the post-shim-compile BeginFileGeneration never runs.
-                // Worker failure and shim-compile failure return earlier or later without
-                // clearing — same as leaving existing Harmony patches in place when apply does
-                // not succeed.
-                foreach (HotReloadGroupFile file in context.Files)
+                // Why only on this success path: worker failure and shim-compile failure return
+                // earlier or later without clearing — same as leaving existing Harmony patches in
+                // place when apply does not succeed.
+                // Why a run that commits types skips it: clearing a generation here would mutate
+                // the domain before the commit boundary, which a failed recheck could then no
+                // longer undo, so such a run clears at the boundary instead.
+                if (!HotReloadGroupProcessor.CommitsIntroducedTypes(
+                        context.PreparedIntroducedTypes,
+                        context.AssemblyName))
                 {
-                    HotReloadFileEntryApplier.ClearFileGeneration(context, file);
+                    HotReloadGroupProcessor.ClearEmptyFileGenerations(context);
                 }
 
                 return HotReloadGroupCompileResult.ReadyWithoutMethods();

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeArtifactMap.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeArtifactMap.cs
@@ -22,14 +22,20 @@ using Microsoft.CodeAnalysis.Text;
 internal sealed class IntroducedTypeArtifactMap
 {
     private readonly Dictionary<string, string> normalizedIdentities;
+    private readonly Dictionary<string, string> fingerprintsByNormalizedIdentity;
 
-    private IntroducedTypeArtifactMap(Dictionary<string, string> normalizedIdentities)
+    private IntroducedTypeArtifactMap(
+        Dictionary<string, string> normalizedIdentities,
+        Dictionary<string, string> fingerprintsByNormalizedIdentity)
     {
         this.normalizedIdentities = normalizedIdentities;
+        this.fingerprintsByNormalizedIdentity = fingerprintsByNormalizedIdentity;
     }
 
     internal static IntroducedTypeArtifactMap Empty { get; } =
-        new IntroducedTypeArtifactMap(new Dictionary<string, string>(StringComparer.Ordinal));
+        new IntroducedTypeArtifactMap(
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.Ordinal));
 
     // Builds the mapping, or reports why the records cannot be trusted. A record is only usable
     // when the assembly resolved from its own reference path reports the identity the record
@@ -42,7 +48,7 @@ internal sealed class IntroducedTypeArtifactMap
         out string errorMessage)
     {
         Dictionary<string, string> identities = new Dictionary<string, string>(StringComparer.Ordinal);
-        HashSet<string> normalizedTargets = new HashSet<string>(StringComparer.Ordinal);
+        Dictionary<string, string> fingerprints = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach ((WorkerIntroducedTypeArtifact artifact, MetadataReference reference) in artifactReferences)
         {
             if (!TryResolveArtifactAssembly(compilation, artifact, reference, out IAssemblySymbol assembly, out errorMessage))
@@ -63,7 +69,7 @@ internal sealed class IntroducedTypeArtifactMap
 
             foreach (WorkerIntroducedTypeArtifactType artifactType in artifact.Types)
             {
-                if (!TryAddArtifactType(assembly, artifactType, identities, normalizedTargets, out errorMessage))
+                if (!TryAddArtifactType(assembly, artifactType, identities, fingerprints, out errorMessage))
                 {
                     map = null;
                     return false;
@@ -71,7 +77,7 @@ internal sealed class IntroducedTypeArtifactMap
             }
         }
 
-        map = new IntroducedTypeArtifactMap(identities);
+        map = new IntroducedTypeArtifactMap(identities, fingerprints);
         errorMessage = null;
         return true;
     }
@@ -87,6 +93,25 @@ internal sealed class IntroducedTypeArtifactMap
 
         return normalizedIdentities.TryGetValue(BuildKey(containingAssembly, metadataName), out string identity)
             ? identity
+            : null;
+    }
+
+    // The fingerprint the retained assembly of this type was compiled from, or null when no
+    // record holds the type. A declaration whose fingerprint matches is already introduced, so
+    // planning it again would produce a second record normalizing to the same original type.
+    internal string FindActiveDeclarationFingerprint(
+        string originalAssemblyName,
+        string originalAssemblyMvid,
+        string metadataName)
+    {
+        if (originalAssemblyName == null || originalAssemblyMvid == null || metadataName == null)
+        {
+            return null;
+        }
+
+        string normalizedIdentity = originalAssemblyName + "|" + originalAssemblyMvid + "|" + metadataName;
+        return fingerprintsByNormalizedIdentity.TryGetValue(normalizedIdentity, out string fingerprint)
+            ? fingerprint
             : null;
     }
 
@@ -121,7 +146,7 @@ internal sealed class IntroducedTypeArtifactMap
         IAssemblySymbol assembly,
         WorkerIntroducedTypeArtifactType artifactType,
         Dictionary<string, string> identities,
-        HashSet<string> normalizedTargets,
+        Dictionary<string, string> fingerprintsByNormalizedIdentity,
         out string errorMessage)
     {
         if (artifactType == null
@@ -160,7 +185,7 @@ internal sealed class IntroducedTypeArtifactMap
 
         // Two artifacts normalizing to the same original type would leave the fingerprint
         // depending on which record happened to be consulted first.
-        if (!normalizedTargets.Add(normalizedIdentity))
+        if (!fingerprintsByNormalizedIdentity.TryAdd(normalizedIdentity, artifactType.DeclarationFingerprint))
         {
             errorMessage = "Two introduced-type artifacts normalize to " + artifactType.MetadataName + ".";
             return false;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
@@ -79,23 +79,36 @@ internal static class IntroducedTypePlanner
                 continue;
             }
 
+            string metadataName = CecilTypeNames.ToMetadataName(typeSymbol);
+            string declarationFingerprint = IntroducedTypeFingerprint.Compute(
+                unit.Root,
+                declaration,
+                defineSymbols,
+                typeSymbol,
+                unit.SemanticModel,
+                targetAssembly,
+                targetAssemblyName,
+                targetAssemblyMvid,
+                artifactMap);
+            if (IsAlreadyIntroduced(
+                    unit,
+                    artifactMap,
+                    targetAssemblyName,
+                    targetAssemblyMvid,
+                    metadataName,
+                    declarationFingerprint))
+            {
+                continue;
+            }
+
             unit.IntroducedTypes.Add(
                 new WorkerIntroducedType
                 {
                     OriginalAssemblyName = targetAssemblyName ?? string.Empty,
                     OriginalAssemblyMvid = targetAssemblyMvid ?? string.Empty,
-                    MetadataName = CecilTypeNames.ToMetadataName(typeSymbol),
+                    MetadataName = metadataName,
                     OwnerProjectRelativePath = unit.Input.ProjectRelativePath,
-                    DeclarationFingerprint = IntroducedTypeFingerprint.Compute(
-                        unit.Root,
-                        declaration,
-                        defineSymbols,
-                        typeSymbol,
-                        unit.SemanticModel,
-                        targetAssembly,
-                        targetAssemblyName,
-                        targetAssemblyMvid,
-                        artifactMap),
+                    DeclarationFingerprint = declarationFingerprint,
                     Source = BuildTypeSource(unit.Root, typeSymbol, declaration, assemblyGlobalUsings)
                 });
         }
@@ -111,6 +124,38 @@ internal static class IntroducedTypePlanner
             unit.IntroducedTypeDiagnostics.Add(
                 "Delegate introduced type requires a compile: " + CecilTypeNames.ToMetadataName(delegateSymbol));
         }
+    }
+
+    // Whether this domain already retains an assembly for the declaration. Introducing it again
+    // would compile a second artifact for the same original type, and the transform run would
+    // then be offered two records normalizing to it, which it refuses. The unchanged declaration
+    // binds from the active record instead, so this run introduces nothing.
+    private static bool IsAlreadyIntroduced(
+        WorkerSourceUnit unit,
+        IntroducedTypeArtifactMap artifactMap,
+        string targetAssemblyName,
+        string targetAssemblyMvid,
+        string metadataName,
+        string declarationFingerprint)
+    {
+        string activeFingerprint = artifactMap.FindActiveDeclarationFingerprint(
+            targetAssemblyName,
+            targetAssemblyMvid,
+            metadataName);
+        if (activeFingerprint == null)
+        {
+            return false;
+        }
+
+        // Replacing the retained assembly a live type was loaded from is outside what a reload
+        // can do, so a redefined introduced type is reported instead of being introduced again.
+        if (!string.Equals(activeFingerprint, declarationFingerprint, StringComparison.Ordinal))
+        {
+            unit.IntroducedTypeDiagnostics.Add(
+                "Changed introduced type requires a compile: " + metadataName);
+        }
+
+        return true;
     }
 
     private static bool TryFindNestedDeclaration(BaseTypeDeclarationSyntax declaration, out string nestedName)


### PR DESCRIPTION
## Summary

- A reload that adds a new type now binds that type from a prepared artifact assembly, and the type becomes usable only at the instant the reload is applied — including a reload whose only change is the new type itself.
- A reload that goes stale between its preparation and that instant now leaves nothing behind: no active type, no patch, no cleared generation.

## User Impact

Before, a reload that introduced a new type had no commit point. The type was compiled into an artifact assembly and dropped again at the end of the run, so a caller edited in the same reload could not bind it. A reload whose only change was the new type produced no method to patch, and the group stage that decides what to apply treated that as "nothing to apply" — the run ended before the commit point and the type was never activated at all, which is exactly the case adding a new file with a new type consists of.

After, one reload prepares the type, applies the caller and activates the type as one step. Anything that goes stale between preparation and that step — the Editor becoming busy, the owner file being rewritten while the transform runs, a request file being rewritten after it was transformed — fails the reload as a whole and leaves the domain exactly as it was. A failure *after* that step keeps the type active and reports only the affected methods as failed, because the type is already published and cannot be withdrawn.

## Changes

Ordered as the run executes them.

- **One group run through named stages.** The group pipeline is now six explicit stages behind one internal dependency bundle: owner-membership validation, introduced-type preparation, the transform worker run, the gate and shim compile, the group-wide preflight that resolves every file, and the apply that mutates. Tests drive the production stages in the production order instead of an ad-hoc continuation seam.
- **The whole group is prepared before any file is mutated.** Accessor binding runs once for the group and each file's entries are resolved ahead of the apply, so one file's preflight failure can no longer leave the files before it half patched.
- **The prepared artifact reaches the transform run.** A run carries the artifact it prepared plus the artifacts still active for the generation it targets, so the transform leaves the new declaration out of the owner file's rows and the caller binds the type from the loaded assembly.
- **The commit boundary.** After the last `await`, the run re-checks cancellation, Editor readiness, owner membership, and two independent staleness windows, then resolves the group, then activates the type, then peels superseded patches, clears empty generations and applies. The deferral of the peel and the clear to that boundary applies only to a run that introduces a type or targets an assembly that already owns one; a run without types keeps peeling before the shim compile.
- **Three states instead of two for the gate-and-compile stage.** Failed, ready-without-entries, ready-with-entries. Only a failure ends the run early. A ready-without-entries run reaches the commit boundary, skips the preflight it has nothing to resolve for, and activates its types. The signature-change coverage scan now runs only for a group that has entries, because it checks that every gated replacement has an entry to patch and a group with no entry has no replacement to cover.
- **A type this domain already introduced is not introduced again.** A reload of the file that declares it re-requests the declaration, and the planner used to decide what to introduce from the compiled assembly alone, so it planned the same type a second time and every later reload of that file failed. The planner now consults the records it is given: a declaration whose fingerprint matches a retained assembly's is bound from that assembly instead. A declaration whose fingerprint differs is a redefinition, which this stage cannot serve, and the run is refused rather than binding callers against the retained definition the edited source no longer declares. A declaration a reload derives from an active introduced type now compiles too, because the artifact compilation sees the active artifacts.
- **A preflight failure stops the group before its types go live.** The preflight that resolves every file reports a file it could not resolve as a returned outcome, so the commit point used to run on regardless and publish a type for a group that then patched nothing. A group holding an unresolvable file now returns before the commit point, and the two files of one group declaring the same type is refused by name instead of throwing out of the run.
- **The continuation batch references the active artifacts.** The artifact compilation of a run now sees the assemblies earlier reloads retained, the same list the transform run and the shim compilation already bind against, so a declaration naming a type this domain holds compiles instead of failing on an unresolved base type.

### The await-free region

`Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs`:

- The last `await` of the apply path is the `MainThreadSwitcher.SwitchToMainThread` at **line 276**, inside `CompleteApplyAfterCoverageAsync`.
- **Lines 277-313** hold the re-checks, the group preflight and the preflight refusal; the commit point itself is `HotReloadGroupCommitStage.Commit`, a separate synchronous unit. There is no `await` anywhere in 277-314 — the next one in the file, line 334, belongs to `RevalidateBeforeRevertAsync`, which this path does not call.
- The stages that region invokes are synchronous by construction: `grep -c "await \|async "` returns 0 for `HotReloadGroupCommitStage.cs`, `HotReloadGroupEntryPreparation.cs`, `HotReloadGroupCommitBoundary.cs`, `HotReloadEntryApplier.cs`, `HotReloadFileEntryApplier.cs` and `HotReloadPatcher.cs`.

### File I/O inside that region

Three sources, all deliberate:

- Owner membership re-validation reads the target assembly's module version id twice per group file (`HotReloadNewSourceMembershipValidator.cs` lines 166 and 200, reached from `TryRevalidateFiles` at line 211). This is pre-existing behavior, not added here.
- The request-source staleness check reads each request file once and hashes it (`HotReloadGroupCommitBoundary.TryComputeCurrentHash`). Separating the two staleness windows is what keeps it to one read per file: the preparation-drift window compares two hashes both stages already produced, with no I/O at all.
- The target-assembly recheck reads the module version id of the target DLL once per group, and only for a group that commits introduced types (`HotReloadGroupCommitBoundary.TryReadTargetAssemblyMvid`).

Every one of these reports a failure through the group outcome router; none of them asserts.

### Where the per-run module version id is read

`HotReloadGroupProcessor.cs:464` reads it once per run while building the worker input, which is before the worker and therefore outside the await-free region. The membership evidence captured at the start of the run reads it once more (`HotReloadNewSourceMembershipValidator.cs:136`). Neither read is on the boundary path; the boundary's own reads are the three listed above.

### Artifact files left on disk

`DiscardPrepared` drops an in-memory membership only. The artifact batch directory — `Library/UloopHotReload/IntroducedTypes/<session>/<batch>/`, holding a `.cs`, a `.dll` and a `.pdb` — stays on disk, and nothing in the repository deletes it: `grep` for `Directory.Delete` or `File.Delete` against the artifact and introduced-type sources returns no match.

Measured in this development project after the verification runs below: 657 batch directories, 19 MB total, about 29 KB per batch. One batch is created per run that prepares a type, whether or not that run activates it.

This is acceptable for now and deliberately not addressed here. The assembly is loaded into the domain, so its files cannot be removed while the domain lives; the cleanup point is a domain-reload-time sweep of the session directory, which needs its own change and its own test.

## Not in this PR

- **Publishing and recording the introduction results.** The registry's activation is itself the record this stage needs, so no placeholder stage was added for it. Exposing the diagnostics on the external response is a later unit.
- **A first-apply failure that must leave the type active with method-level failures.** The contract is implemented, but it has no test: the only existing test seam on the patcher (`UnpatchForTesting`) can induce an *unpatch* failure, not an *apply* failure, and inducing the latter would mean adding a production seam solely for the test. Deferred to the follow-up unit rather than adding that seam.
- **Sweeping the artifact directories** (see above).
- **Redefining an active introduced type.** A declaration whose fingerprint no longer matches the assembly a live type was loaded from would require replacing that assembly, which a reload cannot do. Stage one refuses such a reload and asks for a compile.

## Verification

Run against this checkout's development binary. Repository CI does not fire for a pull request targeting this integration branch, so the checks below are local; the CI gate is the pull request that takes this branch to the default branch. `Build and Test` is not verified here and is not claimed to be.

- `uloop compile` — Success, 0 errors.
- `uloop run-tests --filter-type regex --filter-value 'HotReloadIntroducedTypeActivationTests|HotReloadIntroducedTypeRegistryTests|HotReloadGroupProcessorTests|HotReloadOrchestratorTests|HotReloadCrossFileE2ETests'` — **227 passed / 0 failed / 0 skipped**.
- `uloop run-tests --filter-type regex --filter-value 'TransformWorkerIntroducedTypeTests|TransformWorkerClientTests'` — **91 passed / 0 failed / 0 skipped**.
- `scripts/check-file-length.sh` — no file exceeded the 500 SLOC limit.

The full EditMode suite was not run: it is the scheduled nightly gate, and this change is scoped to the hot-reload group pipeline.

### Failing-first tests and the mutants that kill them

Each test below was written before its production change and observed to fail. Each mutant was applied to the merged code and the suite re-run.

| Behavior | Test | Mutant | Result |
|---|---|---|---|
| The Editor becoming busy before the boundary activates nothing | `Run_EditorBecomesBusyBeforeTheCommitBoundary_ActivatesNothing` | delete the readiness re-check | 1 failed, 11 passed |
| An owner rewritten between preparation and transform activates nothing | `Run_OwnerRewrittenBetweenPreparationAndTransform_ActivatesNothing` | delete the preparation-drift comparison | 1 failed, 11 passed |
| A request file rewritten after transform activates nothing | `Run_RequestSourceRewrittenAfterTransform_ActivatesNothing` | delete the request-source comparison | 1 failed, 11 passed |
| A committed run activates the type and the patched caller reads through it | `Run_TypeIntroducedWithItsCaller_ActivatesTheTypeAndTheCallerReadsThroughIt` | drop the activation at the commit point | 2 failed (this and the no-entry case), 11 passed |
| A run with no method to patch still activates its type | `Run_OnlyATypeIsIntroduced_ActivatesTheTypeWithoutAnyMethodToPatch` | treat ready-without-entries as nothing-to-apply | 1 failed, 12 passed |
| A run without types keeps peeling before the shim compile | `Run_NoIntroducedType_PeelsUnchangedPatchBeforeAFailingShimCompile` | make the deferral condition unconditional | 1 failed, 154 passed |
| Re-activating the same artifact is rejected and publishes nothing again | `Activate_SameArtifactTwice_RejectsWithoutSecondPublication` | return early from activation when the assembly is already active | 2 failed, 18 passed |
| A reload of a file that already introduced a type reuses the active type | `Run_SameTypeDeclaredAgainByALaterReload_ReusesTheActiveTypeWithoutIntroducingItAgain` | introduce even when the fingerprint matches | 1 failed, 14 passed |
| A redefinition of an active introduced type is refused | `Run_ActiveIntroducedTypeRedefined_FailsAndLeavesTheActiveTypeInPlace` | drop the changed-declaration refusal | 1 failed, 14 passed |
| A group whose preflight could not resolve a file activates nothing | `Run_OneFileFailsTheGroupPreflight_ActivatesNothing` | delete the pre-commit resolution check | 1 failed, 183 passed |
| A type deriving from an active introduced type compiles against it | `Run_IntroducedTypeDerivesFromAnActiveOne_CompilesAgainstTheActiveArtifact` | drop the artifact references from the batch | 1 failed, 34 passed |
| Two files of one group declaring one type fail without throwing | `Run_SameTypeDeclaredByTwoFilesOfAGroup_FailsWithoutThrowing` | delete the duplicate-declaration refusal | 1 failed, 39 passed |
| A target assembly rebuilt before the boundary activates nothing | `Run_TargetAssemblyRebuiltBeforeTheCommitBoundary_ActivatesNothing` | delete the module-version-id recheck | 1 failed, 204 passed |
| An owner with no transform row activates nothing | `Run_OwnerHasNoTransformRow_ActivatesNothing` | restore the skip when the hash is missing | 2 failed (this and the request-source case), 205 passed |
| A request source with no transform hash activates nothing | `Run_RequestSourceHasNoTransformHash_ActivatesNothing` | restore the skip when the hash is missing | 2 failed (this and the owner case), 205 passed |

The staleness Reds rewrite real files at real points in a real Editor rather than faking a stage, and the activation Red asserts at runtime that the patched caller returns the value only the active artifact can produce.

The peel-position test earns its place: before it was added, the unconditional-deferral mutant left all 154 existing orchestrator tests passing, so no existing test pinned that position.
