### PR TITLE
fix: find-game-objects retry hint now shows search modes in the documented lowercase spelling

### DIFF
--- a/Assets/Tests/Editor/FindGameObjectsToolTests.cs
+++ b/Assets/Tests/Editor/FindGameObjectsToolTests.cs
@@ -107,7 +107,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.TotalFound, Is.EqualTo(0));
             Assert.That(response.Message, Is.Not.Null);
             Assert.That(response.Message, Does.Contain("Exact match found nothing"));
-            Assert.That(response.Message, Does.Contain("--search-mode Contains"));
+            Assert.That(response.Message, Does.Contain("--search-mode contains"));
         }
 
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/FindGameObjectsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/FindGameObjectsUseCase.cs
@@ -148,7 +148,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return $"Exact match found nothing for name pattern '{parameters.NamePattern}'. " +
-                   "Try --search-mode Contains or Regex for partial matching.";
+                   "Try --search-mode contains or regex for partial matching.";
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- The retry hint printed by a zero-hit `find-game-objects` search now spells the search modes the same way every other place does.

## User Impact
- Before: an exact-mode search that matched nothing answered `Try --search-mode Contains or Regex for partial matching.`, the last remaining PascalCase spelling of this option. An agent reading that hint copied a spelling that disagrees with `--help`, `uloop list`, and the skill file it was following.
- After: the hint says `Try --search-mode contains or regex for partial matching.`, so the caller sees one spelling everywhere.
- Both spellings still parse (case-insensitive on the CLI and on the Unity side), so no command that worked before stops working.

## Changes
- Lowercase the two search-mode values in the zero-hit hint text.
- Update the tool test that asserts on that hint so it checks the lowercase spelling.

## Verification
- `uloop compile` — 0 errors.
- `uloop run-tests --filter-type class --filter-value FindGameObjectsToolTests` — 25 passed, 0 failed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

