### PR TITLE
fix: skills list no longer reports installed skills as outdated when other tools leave files beside SKILL.md

### DIFF
--- a/cli/dispatcher/internal/dispatcher/skills_display.go
+++ b/cli/dispatcher/internal/dispatcher/skills_display.go
@@ -2,6 +2,7 @@ package dispatcher
 
 import (
 	"io"
+	"path/filepath"
 	"strings"
 
 	"github.com/hatayama/unity-cli-loop/common/clicore"
@@ -16,7 +17,20 @@ func defaultSkillTargets() []skillTarget {
 }
 
 func shouldSkipSkillFile(name string) bool {
-	return name == ".DS_Store" || strings.HasSuffix(name, ".meta")
+	return name == ".DS_Store" || name == ".gitkeep" || strings.HasSuffix(name, ".meta")
+}
+
+// isComparableSkillFile reports whether a file inside a skill directory takes part in the
+// installed-vs-source comparison. Files in subdirectories are always compared because the skill
+// ships them itself; at the directory root only Markdown files are compared, because other
+// tools may place their own metadata files there (a package manager manifest, for example)
+// and those must not make an up-to-date skill report as outdated. The Editor applies the same
+// rule in SkillInstallLayout.IsComparableSkillFile.
+func isComparableSkillFile(relativePath string) bool {
+	if filepath.Dir(relativePath) != "." {
+		return true
+	}
+	return strings.EqualFold(filepath.Ext(relativePath), ".md")
 }
 
 func isSafeSkillName(name string) bool {

--- a/cli/dispatcher/internal/dispatcher/skills_sync.go
+++ b/cli/dispatcher/internal/dispatcher/skills_sync.go
@@ -177,7 +177,7 @@ func collectComparableSkillFiles(root string) map[string][]byte {
 			return nil
 		}
 		relativePath, err := filepath.Rel(root, path)
-		if err != nil || relativePath == skillscan.SkillFileName {
+		if err != nil || relativePath == skillscan.SkillFileName || !isComparableSkillFile(relativePath) {
 			return nil
 		}
 		content, err := os.ReadFile(path)

--- a/cli/dispatcher/internal/dispatcher/skills_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_test.go
@@ -383,6 +383,76 @@ func TestSkillStatusIgnoresCRLFLineEndings(t *testing.T) {
 	}
 }
 
+// Tests that a root-level non-Markdown file placed by another tool does not mark an installed skill outdated.
+func TestSkillStatusIgnoresRootLevelNonMarkdownFiles(t *testing.T) {
+	baseDir, skill, installedDir := setUpInstalledSampleSkill(t)
+	writeSkillDirectoryFile(t, installedDir, "apm.yml", "name: sample\n")
+
+	assertSkillStatus(t, baseDir, skill, "installed")
+}
+
+// Tests that an extra root-level Markdown file still marks the skill outdated, matching the Editor-side rule.
+func TestSkillStatusDetectsExtraRootLevelMarkdownFile(t *testing.T) {
+	baseDir, skill, installedDir := setUpInstalledSampleSkill(t)
+	writeSkillDirectoryFile(t, installedDir, "EXTRA.md", "extra\n")
+
+	assertSkillStatus(t, baseDir, skill, "outdated")
+}
+
+// Tests that a .gitkeep file inside an installed skill directory is ignored, matching the Editor-side exclusion list.
+func TestSkillStatusIgnoresGitkeepFiles(t *testing.T) {
+	baseDir, skill, installedDir := setUpInstalledSampleSkill(t)
+	writeSkillDirectoryFile(t, installedDir, filepath.Join("references", ".gitkeep"), "")
+
+	assertSkillStatus(t, baseDir, skill, "installed")
+}
+
+// setUpInstalledSampleSkill writes a sample skill to a temporary source directory and an
+// identical installed copy, so each caller only has to add the one file under test.
+func setUpInstalledSampleSkill(t *testing.T) (string, skillDefinition, string) {
+	t.Helper()
+	const skillFileContent = "---\nname: uloop-sample\n---\n\n# sample\n"
+	projectRoot := t.TempDir()
+	sourceDir := filepath.Join(projectRoot, "source", "Skill")
+	writeSkillFile(t, sourceDir, skillFileContent)
+	writeSkillDirectoryFile(t, sourceDir, filepath.Join("references", "note.md"), "note\n")
+
+	skill := skillDefinition{
+		name:            "uloop-sample",
+		content:         []byte(skillFileContent),
+		sourceDirectory: sourceDir,
+	}
+	baseDir := filepath.Join(projectRoot, ".claude", "skills")
+	installedDir := getPreferredSkillDir(baseDir, skill.name, true)
+	writeRawSkillFile(t, installedDir, skillFileContent)
+	writeSkillDirectoryFile(t, installedDir, filepath.Join("references", "note.md"), "note\n")
+	return baseDir, skill, installedDir
+}
+
+// writeSkillDirectoryFile writes one file inside a skill directory, creating parent directories.
+func writeSkillDirectoryFile(t *testing.T, skillDir string, relativePath string, content string) {
+	t.Helper()
+	fullPath := filepath.Join(skillDir, relativePath)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		t.Fatalf("failed to create directory for %s: %v", relativePath, err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write %s: %v", relativePath, err)
+	}
+}
+
+// assertSkillStatus fails when the target-mode status of the skill differs from the expected one.
+func assertSkillStatus(t *testing.T, baseDir string, skill skillDefinition, expectedStatus string) {
+	t.Helper()
+	status, err := getSkillStatus(baseDir, skill, true)
+	if err != nil {
+		t.Fatalf("getSkillStatus failed: %v", err)
+	}
+	if status != expectedStatus {
+		t.Fatalf("status mismatch: %s", status)
+	}
+}
+
 // Tests that status checks surface inaccessible installed skill directories.
 func TestSkillStatusReturnsStatErrors(t *testing.T) {
 	projectRoot := t.TempDir()


### PR DESCRIPTION
## Summary
- `uloop skills list` no longer reports an up-to-date skill as `outdated` just because another tool left a file next to its `SKILL.md`.
- The CLI and the Unity Settings window now agree on whether an installed skill is up to date.

## User Impact
- Before: a single non-Markdown file at the root of an installed skill directory (a package manager manifest, for example) made `skills list` report `outdated` even when `SKILL.md` and everything under `references/` were identical to the package source. The Settings window, which applies a narrower comparison rule, kept showing the same skill as installed, so the two disagreed and `skills install` looked permanently necessary.
- After: files placed at the skill directory root by other tools are ignored, and the skill stays `installed`. An extra root-level Markdown file, a changed or missing file under a subdirectory, and a modified `SKILL.md` still report `outdated`.

## Changes
- Introduce the comparable-skill-file rule on the CLI side: files in subdirectories always take part in the installed-vs-source comparison, while at the directory root only Markdown files do. The rule is applied inside the single collection function that both the source side and the installed side go through, so the two sides of the file-count comparison cannot drift apart.
- Exclude `.gitkeep` from skill file collection so the CLI exclusion set matches the Editor one (`.meta`, `.DS_Store`, `.gitkeep`).
- Dir mode (`--output-dir`) is untouched: it walks only source-owned entries and was never affected by this bug.

## Verification
- `cd cli/dispatcher && go test ./internal/dispatcher -count=1` — pass.
- Three new tests were confirmed to fail before the fix and pass after it: a root-level `apm.yml` reports `installed`, an extra root-level `EXTRA.md` still reports `outdated`, and a `.gitkeep` under `references/` reports `installed`.
- `scripts/check-go-cli.sh` — exit 0 (format, vet, lint, tests, binary rebuild).

Closes #2663


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

