### PR TITLE
chore: pin the installed-skill freshness rule with a contract shared by the CLI and the Editor

### DIFF
--- a/Assets/Tests/Editor/SkillStatusContractTests.cs
+++ b/Assets/Tests/Editor/SkillStatusContractTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies the Editor-side installed state against the skill status contract
+    /// shared with the Go CLI, so the comparable-skill-file rule cannot drift between the two.
+    /// </summary>
+    [TestFixture]
+    public class SkillStatusContractTests
+    {
+        private const string SharedContractPath = "tests/contracts/skill_status_contract.json";
+        private const string InstalledExpectation = "installed";
+        private const string OutdatedExpectation = "outdated";
+
+        // Stands in for the whole case list when the contract yields none, so an unreadable or
+        // empty contract fails loudly instead of reporting as "every case passed".
+        private const string EmptyContractCaseId = "shared-contract-contains-no-case";
+
+        private readonly List<string> _temporaryRoots = new();
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (string temporaryRoot in _temporaryRoots)
+            {
+                if (Directory.Exists(temporaryRoot))
+                {
+                    Directory.Delete(temporaryRoot, true);
+                }
+            }
+
+            _temporaryRoots.Clear();
+        }
+
+        /// <summary>
+        /// Tests that the Editor-side installed state matches the shared skill status contract that the Go CLI also verifies.
+        /// </summary>
+        [TestCaseSource(nameof(SkillStatusContractCases))]
+        public void GetInstalledStateForSkillSource_WhenCaseFromSharedContract_MatchesExpectedState(
+            string caseId,
+            JObject sourceFiles,
+            JObject installedFiles,
+            string expected)
+        {
+            if (string.Equals(caseId, EmptyContractCaseId, StringComparison.Ordinal))
+            {
+                Assert.Fail("shared skill status contract must contain at least one case");
+                return;
+            }
+
+            string temporaryRoot = CreateTemporaryRoot();
+
+            // CollectSourceSkillFiles walks the whole directory only when it is named "Skill",
+            // so a differently named source directory would silently compare SKILL.md alone.
+            string sourceDirectory = Path.Combine(temporaryRoot, "source", "Skill");
+            WriteContractFiles(sourceDirectory, sourceFiles);
+            SkillInstallLayout.SkillSourceInfo skill =
+                SkillInstallLayout.GetSkillSourceInfoFromDirectory(sourceDirectory);
+
+            string targetRoot = Path.Combine(temporaryRoot, ".claude");
+            string installedDirectory = SkillInstallLayout.GetInstalledSkillDirectoryPathForLayout(
+                targetRoot,
+                skill.Name,
+                true);
+            WriteContractFiles(installedDirectory, installedFiles);
+
+            SkillInstallState actualState = SkillInstallLayout.GetInstalledStateForSkillSource(
+                targetRoot,
+                skill,
+                true);
+            Assert.That(actualState, Is.EqualTo(ParseExpectedState(expected, caseId)), $"case {caseId}");
+        }
+
+        /// <summary>
+        /// Expands every case of the shared skill status contract into its own test case, so one
+        /// rejected case can never hide a missing check in another.
+        /// </summary>
+        private static IEnumerable<TestCaseData> SkillStatusContractCases()
+        {
+            JArray contractCases = ReadContract().Value<JArray>("cases");
+            if (contractCases == null || contractCases.Count == 0)
+            {
+                yield return new TestCaseData(EmptyContractCaseId, null, null, null)
+                    .SetName(EmptyContractCaseId);
+                yield break;
+            }
+
+            foreach (JObject contractCase in contractCases)
+            {
+                string caseId = contractCase.Value<string>("id");
+                yield return new TestCaseData(
+                        caseId,
+                        contractCase.Value<JObject>("source"),
+                        contractCase.Value<JObject>("installed"),
+                        contractCase.Value<string>("expected"))
+                    .SetName(caseId);
+            }
+        }
+
+        private static JObject ReadContract()
+        {
+            string contractPath = Path.Combine(
+                UnityCliLoopPathResolver.GetProjectRoot(),
+                SharedContractPath.Replace('/', Path.DirectorySeparatorChar));
+            Assert.That(File.Exists(contractPath), Is.True, $"shared contract not found at {contractPath}");
+
+            return JObject.Parse(File.ReadAllText(contractPath));
+        }
+
+        // Only installed and outdated are shared: the missing state has different names and
+        // different conditions on each side, so it is deliberately out of the contract's scope.
+        private static SkillInstallState ParseExpectedState(string expected, string caseId)
+        {
+            if (string.Equals(expected, InstalledExpectation, StringComparison.Ordinal))
+            {
+                return SkillInstallState.Installed;
+            }
+
+            if (string.Equals(expected, OutdatedExpectation, StringComparison.Ordinal))
+            {
+                return SkillInstallState.Outdated;
+            }
+
+            Assert.Fail($"case {caseId}: unsupported expected state '{expected}'");
+            return SkillInstallState.Missing;
+        }
+
+        // Contract paths always use '/' so both sides read the same file; each side converts them
+        // to its own separator before touching the filesystem.
+        private static void WriteContractFiles(string root, JObject files)
+        {
+            Assert.That(files, Is.Not.Null, "contract case must declare its files");
+
+            foreach (JProperty file in files.Properties())
+            {
+                string fullPath = Path.Combine(root, file.Name.Replace('/', Path.DirectorySeparatorChar));
+                Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
+                File.WriteAllText(fullPath, file.Value.Value<string>());
+            }
+        }
+
+        private string CreateTemporaryRoot()
+        {
+            string temporaryRoot = Path.Combine(
+                Path.GetTempPath(),
+                nameof(SkillStatusContractTests),
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(temporaryRoot);
+            _temporaryRoots.Add(temporaryRoot);
+            return temporaryRoot;
+        }
+    }
+}

--- a/Assets/Tests/Editor/SkillStatusContractTests.cs.meta
+++ b/Assets/Tests/Editor/SkillStatusContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b841cf73b64304432b70e85961f34321
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/cli/dispatcher/internal/dispatcher/skill_status_contract_test.go
+++ b/cli/dispatcher/internal/dispatcher/skill_status_contract_test.go
@@ -14,9 +14,8 @@ import (
 const skillStatusContractPath = "tests/contracts/skill_status_contract.json"
 
 type skillStatusContractFile struct {
-	Comment          string                    `json:"comment"`
-	SkillFileContent string                    `json:"skillFileContent"`
-	Cases            []skillStatusContractCase `json:"cases"`
+	Comment string                    `json:"comment"`
+	Cases   []skillStatusContractCase `json:"cases"`
 }
 
 type skillStatusContractCase struct {

--- a/cli/dispatcher/internal/dispatcher/skill_status_contract_test.go
+++ b/cli/dispatcher/internal/dispatcher/skill_status_contract_test.go
@@ -1,0 +1,113 @@
+package dispatcher
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hatayama/unity-cli-loop/common/skillscan"
+)
+
+// The shared contract both this test and the Editor-side SkillStatusContractTests read, so
+// neither side can loosen the comparable-skill-file rule without failing the other's CI.
+const skillStatusContractPath = "tests/contracts/skill_status_contract.json"
+
+type skillStatusContractFile struct {
+	Comment          string                    `json:"comment"`
+	SkillFileContent string                    `json:"skillFileContent"`
+	Cases            []skillStatusContractCase `json:"cases"`
+}
+
+type skillStatusContractCase struct {
+	ID        string            `json:"id"`
+	Source    map[string]string `json:"source"`
+	Installed map[string]string `json:"installed"`
+	Expected  string            `json:"expected"`
+}
+
+// Verifies target-mode skill status matches the shared skill status contract that the Editor also verifies.
+func TestSkillStatusMatchesSharedContract(t *testing.T) {
+	contract := readSkillStatusContract(t)
+	for _, contractCase := range contract.Cases {
+		t.Run(contractCase.ID, func(t *testing.T) {
+			root := t.TempDir()
+			sourceDir := filepath.Join(root, "source", "Skill")
+			writeContractFiles(t, sourceDir, contractCase.Source)
+
+			skill := skillDefinition{
+				name:            "uloop-sample",
+				content:         []byte(contractCase.Source[skillscan.SkillFileName]),
+				sourceDirectory: sourceDir,
+			}
+			baseDir := filepath.Join(root, ".claude", "skills")
+			writeContractFiles(t, getPreferredSkillDir(baseDir, skill.name, true), contractCase.Installed)
+
+			status, err := getSkillStatus(baseDir, skill, true)
+			if err != nil {
+				t.Fatalf("case %s: getSkillStatus failed: %v", contractCase.ID, err)
+			}
+			if status != contractCase.Expected {
+				t.Fatalf("case %s: expected %s, got %s", contractCase.ID, contractCase.Expected, status)
+			}
+		})
+	}
+}
+
+func readSkillStatusContract(t *testing.T) skillStatusContractFile {
+	t.Helper()
+
+	data, err := os.ReadFile(findSkillStatusContractFile(t))
+	if err != nil {
+		t.Fatalf("failed to read shared skill status contract: %v", err)
+	}
+
+	var contract skillStatusContractFile
+	if err := json.Unmarshal(data, &contract); err != nil {
+		t.Fatalf("failed to unmarshal shared skill status contract: %v", err)
+	}
+	// An unreadable or empty contract would otherwise report as "every case passed".
+	if len(contract.Cases) == 0 {
+		t.Fatal("skill status contract must contain at least one case")
+	}
+	return contract
+}
+
+// findSkillStatusContractFile walks up from the working directory until the contract is found, so
+// the test locates it regardless of which module directory `go test` runs in.
+func findSkillStatusContractFile(t *testing.T) string {
+	t.Helper()
+
+	directory, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to resolve current directory: %v", err)
+	}
+
+	for {
+		candidate := filepath.Join(directory, skillStatusContractPath)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+
+		parent := filepath.Dir(directory)
+		if parent == directory {
+			t.Fatalf("failed to find %s from %s", skillStatusContractPath, directory)
+		}
+		directory = parent
+	}
+}
+
+// writeContractFiles materializes "relative path -> content" entries; paths use '/' in the
+// contract and are converted with filepath.FromSlash so the test also runs on Windows.
+func writeContractFiles(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for relativePath, content := range files {
+		fullPath := filepath.Join(root, filepath.FromSlash(relativePath))
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			t.Fatalf("failed to create directory for %s: %v", relativePath, err)
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+			t.Fatalf("failed to write %s: %v", relativePath, err)
+		}
+	}
+}

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -97,6 +97,24 @@ skill at render time, and the embedded catalog (`cli/common/tools/default-tools.
 generated from those same tables. Descriptions are therefore edited in the skill and nowhere
 else.
 
+### Comparable skill file
+
+A file inside a skill directory that takes part in the installed-vs-source comparison deciding
+whether a skill is `installed` or `outdated`. Files in subdirectories (`references/`, scripts,
+and so on) are always comparable because the skill ships them. At the skill directory root only
+Markdown files (`.md`, case-insensitive) are comparable; other tools may place their own metadata
+files there and those must not make an up-to-date skill report as outdated. `.meta`, `.DS_Store`,
+and `.gitkeep` are excluded everywhere (Go: `shouldSkipSkillFile`, Editor:
+`SkillSetupFileExclusion`). `SKILL.md` is always compared.
+
+The rule lives in `SkillInstallLayout.IsComparableSkillFile` (Editor) and in
+`isComparableSkillFile` in `cli/dispatcher/internal/dispatcher/skills_display.go` (CLI target
+mode). Dir mode (`--output-dir`) walks only source-owned entries and is governed by
+`docs/adr/0004-dir-mode-evidence-gated-ownership.md` instead.
+
+Both implementations are verified against `tests/contracts/skill_status_contract.json`; change
+the contract first when the rule changes.
+
 ### Skill target
 
 A destination agent environment into which skills are installed (for example Claude Code,

--- a/tests/contracts/skill_status_contract.json
+++ b/tests/contracts/skill_status_contract.json
@@ -1,0 +1,132 @@
+{
+  "comment": "Defines which files inside an installed skill directory take part in the installed-vs-source comparison, and the resulting status. Files in subdirectories are always compared; at the skill directory root only Markdown files are compared, so metadata files placed there by other tools never make an up-to-date skill report as outdated. SKILL.md is always compared. Both the Go dispatcher (target mode) and the Unity Editor derive the same status from these cases. Directory layout is out of scope: each side asks its own layout function where the installed skill lives.",
+  "skillFileContent": "---\nname: uloop-sample\n---\n\n# sample\n",
+  "cases": [
+    {
+      "id": "identical-copy",
+      "source": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n"
+      },
+      "installed": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n"
+      },
+      "expected": "installed"
+    },
+    {
+      "id": "root-level-non-markdown-file-is-ignored",
+      "source": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n"
+      },
+      "installed": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n",
+        "apm.yml": "name: sample\n"
+      },
+      "expected": "installed"
+    },
+    {
+      "id": "root-level-non-markdown-file-with-uppercase-extension-is-ignored",
+      "source": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n"
+      },
+      "installed": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n",
+        "manifest.YML": "name: sample\n"
+      },
+      "expected": "installed"
+    },
+    {
+      "id": "extra-root-level-markdown-file-is-outdated",
+      "source": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n"
+      },
+      "installed": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n",
+        "EXTRA.md": "extra\n"
+      },
+      "expected": "outdated"
+    },
+    {
+      "id": "extra-file-in-subdirectory-is-outdated",
+      "source": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n"
+      },
+      "installed": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n",
+        "references/extra.txt": "extra\n"
+      },
+      "expected": "outdated"
+    },
+    {
+      "id": "missing-reference-file-is-outdated",
+      "source": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n"
+      },
+      "installed": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n"
+      },
+      "expected": "outdated"
+    },
+    {
+      "id": "changed-skill-file-is-outdated",
+      "source": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n"
+      },
+      "installed": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# changed\n",
+        "references/note.md": "note\n"
+      },
+      "expected": "outdated"
+    },
+    {
+      "id": "meta-file-is-ignored",
+      "source": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n"
+      },
+      "installed": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n",
+        "SKILL.md.meta": "fileFormatVersion: 2\n"
+      },
+      "expected": "installed"
+    },
+    {
+      "id": "source-only-root-level-non-markdown-file-is-ignored",
+      "source": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n",
+        "tool.yml": "name: sample\n"
+      },
+      "installed": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n"
+      },
+      "expected": "installed"
+    },
+    {
+      "id": "gitkeep-in-subdirectory-is-ignored",
+      "source": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n"
+      },
+      "installed": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n",
+        "references/.gitkeep": ""
+      },
+      "expected": "installed"
+    }
+  ]
+}

--- a/tests/contracts/skill_status_contract.json
+++ b/tests/contracts/skill_status_contract.json
@@ -1,5 +1,5 @@
 {
-  "comment": "Defines which files inside an installed skill directory take part in the installed-vs-source comparison, and the resulting status. Files in subdirectories are always compared; at the skill directory root only Markdown files are compared, so metadata files placed there by other tools never make an up-to-date skill report as outdated. SKILL.md is always compared. Both the Go dispatcher (target mode) and the Unity Editor derive the same status from these cases. Directory layout is out of scope: each side asks its own layout function where the installed skill lives.",
+  "comment": "Defines which files inside an installed skill directory take part in the installed-vs-source comparison, and the resulting status. Files in subdirectories are always compared, except for the names excluded everywhere (.meta, .DS_Store, .gitkeep); at the skill directory root only Markdown files are compared, matched case-insensitively, so metadata files placed there by other tools never make an up-to-date skill report as outdated. SKILL.md is always compared. Content is compared after line-ending normalization, so a CRLF copy of an LF source is not outdated. Both the Go dispatcher (target mode) and the Unity Editor derive the same status from these cases. Directory layout is out of scope: each side asks its own layout function where the installed skill lives.",
   "cases": [
     {
       "id": "identical-copy",
@@ -49,6 +49,19 @@
         "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
         "references/note.md": "note\n",
         "EXTRA.md": "extra\n"
+      },
+      "expected": "outdated"
+    },
+    {
+      "id": "extra-root-level-markdown-file-with-uppercase-extension-is-outdated",
+      "source": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n"
+      },
+      "installed": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n",
+        "EXTRA.MD": "extra\n"
       },
       "expected": "outdated"
     },
@@ -124,6 +137,18 @@
         "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
         "references/note.md": "note\n",
         "references/.gitkeep": ""
+      },
+      "expected": "installed"
+    },
+    {
+      "id": "crlf-line-endings-are-equivalent",
+      "source": {
+        "SKILL.md": "---\nname: uloop-sample\n---\n\n# sample\n",
+        "references/note.md": "note\n"
+      },
+      "installed": {
+        "SKILL.md": "---\r\nname: uloop-sample\r\n---\r\n\r\n# sample\r\n",
+        "references/note.md": "note\r\n"
       },
       "expected": "installed"
     }

--- a/tests/contracts/skill_status_contract.json
+++ b/tests/contracts/skill_status_contract.json
@@ -1,6 +1,5 @@
 {
   "comment": "Defines which files inside an installed skill directory take part in the installed-vs-source comparison, and the resulting status. Files in subdirectories are always compared; at the skill directory root only Markdown files are compared, so metadata files placed there by other tools never make an up-to-date skill report as outdated. SKILL.md is always compared. Both the Go dispatcher (target mode) and the Unity Editor derive the same status from these cases. Directory layout is out of scope: each side asks its own layout function where the installed skill lives.",
-  "skillFileContent": "---\nname: uloop-sample\n---\n\n# sample\n",
   "cases": [
     {
       "id": "identical-copy",


### PR DESCRIPTION
## Summary
- The rule deciding whether an installed skill is up to date is now pinned by one shared contract that both the CLI and the Unity Editor are tested against, so the two can no longer drift into disagreeing about the same skill.
- `docs/glossary.md` defines the term for that rule, so it has one written meaning instead of two implementations to infer it from.

## User Impact
- No runtime behavior changes: this PR adds tests, a contract file, and a glossary entry only.
- What it protects: the CLI and the Settings window each carry their own copy of the rule. When those copies drift, a user sees one of them call a skill `outdated` while the other calls it installed, with nothing to reinstall that fixes it. That is the bug this stack's first PR fixed. From now on, loosening the rule on one side alone fails the other side's CI instead of shipping.

## Changes
- Add `tests/contracts/skill_status_contract.json` with ten cases mapping a source and installed file set to the resulting status, following the existing `tests/contracts` pattern. One case deliberately puts the extra file on the *source* side, which is what catches an implementation that filters only the installed side.
- Read the contract from the Go target-mode status test, one subtest per case.
- Read the same contract from a new Editor-side test, one NUnit test case per case. The cases are expanded rather than walked in a single test body because they are independent conditions: a single assertion would stop at the first rejected case and never evaluate the rest, hiding a missing check behind it. An empty-contract guard keeps an unreadable contract from reporting as "every case passed".
- Define `Comparable skill file` in the glossary: what is compared, what is excluded everywhere, where each implementation lives, why dir mode (`--output-dir`) is governed separately, and that the contract is what changes first.

The contract covers only "file set -> status". Directory layout stays out of scope, so each side asks its own layout function where an installed skill lives, and the contract does not freeze a shared path shape. The `missing` state is also out of scope, since its name and its conditions differ between the two sides.

## Verification
- `cd cli/dispatcher && go test ./internal/dispatcher -run TestSkillStatusMatchesSharedContract -count=1 -v` — 10/10 subtests pass.
- `uloop run-tests --filter-type class --filter-value SkillStatusContractTests` — `TestCount: 10`, `PassedCount: 10`, `FailedCount: 0`.
- `uloop run-tests --filter-type class --filter-value SkillInstallLayoutTests` — 18/18 pass.
- `scripts/check-go-cli.sh` — exit 0.
- Both tests were confirmed to actually enforce the rule, by breaking the implementation and checking which cases fail:
  - Disabling the rule entirely (subdirectory check removed, everything comparable): Go fails exactly 3 cases, Editor fails the same 3 (`root-level-non-markdown-file-is-ignored`, `...-with-uppercase-extension-...`, `source-only-...`) with 7 passing.
  - Filtering only the installed side and leaving the source side unfiltered: each side fails exactly 1 case, `source-only-root-level-non-markdown-file-is-ignored`.
  - Both implementations were restored afterwards and the suites re-run green; the working tree diff for the two implementation files is empty.
