### PR TITLE
chore: Freeze-prevention guidance now describes uloop single-flight behavior instead of forbidding parallel runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,8 +210,11 @@ not work.
 
 ## Unity Freeze Prevention
 
-Unity EditMode tests can freeze the Editor. Never run multiple `uloop run-tests` commands in
-parallel — Unity Test Runner is single-flight only. Before adding or modifying Unity EditMode
+Unity EditMode tests can freeze the Editor. `uloop` is single-flight per Editor: a command sent
+while another is still running is rejected with a BUSY error after a bounded retry, so two
+`uloop run-tests` runs never overlap in one Editor. When you see BUSY, wait for the running
+command to finish and run yours once — do not retry in a loop. Separate Unity projects run in
+separate Editors and do not block each other. Before adding or modifying Unity EditMode
 tests (especially anything touching async execution, cancellation, threads, or dynamic-code
 runtime paths), read `docs/unity-editmode-test-guardrails.md` and follow its rules. If a new
 test makes `uloop run-tests` stall, remove or disable it instead of retrying the suite. If

--- a/docs/unity-editmode-test-guardrails.md
+++ b/docs/unity-editmode-test-guardrails.md
@@ -6,7 +6,7 @@ async execution, cancellation, threads, or dynamic-code runtime paths.
 
 ## Hard rules
 
-- Never run multiple `uloop run-tests` commands in parallel. Treat Unity Test Runner as single-flight only.
+- `uloop` is single-flight per Editor: a `run-tests` sent while another command runs is rejected with BUSY after a bounded retry, so runs never overlap. On BUSY, wait for the running command and run once; do not retry in a loop.
 - Do not add tests that rely on infinite waits, long-lived `TaskCompletionSource`, background fire-and-forget work, or cancellation handoff across domain reload boundaries.
 - Avoid tests that intentionally cancel linked `CancellationTokenSource` instances while Unity may still dispose them during reload or teardown.
 - Do not add Unity EditMode tests that use `Task.Run`, raw `Thread` work, or cross-thread coordination primitives such as `ManualResetEventSlim` unless the test is explicitly reviewed as unavoidable.


### PR DESCRIPTION
## Summary
- The freeze-prevention guidance no longer tells agents to avoid something the CLI already makes impossible; it describes the single-flight behavior they will actually observe.

## User Impact
- Before, `AGENTS.md` and the EditMode test guardrails said "never run multiple `uloop run-tests` commands in parallel", which read as if overlapping runs could happen and had to be avoided by discipline.
- After, both documents state that `uloop` is single-flight per Editor, that a second command is rejected with BUSY after a bounded retry, what to do on BUSY (wait, then run once), and that separate Unity projects run in separate Editors and do not block each other.

## Changes
- `AGENTS.md` (mirrored by the `CLAUDE.md` symlink): rewrote the opening of "Unity Freeze Prevention".
- `docs/unity-editmode-test-guardrails.md`: rewrote the matching first rule.

## Verification
- Documentation only; no code or generated artifacts changed. `git diff --stat` shows the two files above.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

