### PR TITLE
fix(asmdef): scope Infrastructure precompiled references to Newtonsoft.Json

### DIFF
--- a/Packages/src/Editor/Infrastructure/UnityCLILoop.Infrastructure.asmdef
+++ b/Packages/src/Editor/Infrastructure/UnityCLILoop.Infrastructure.asmdef
@@ -14,8 +14,10 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "Newtonsoft.Json.dll"
+    ],
     "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],


### PR DESCRIPTION
## Problem

`UnityCLILoop.Infrastructure` has `overrideReferences: false` with an empty
`precompiledReferences`, so Unity adds **every auto-referenced managed plugin in the
consumer project's `Assets` folder** to that assembly's compilation references.

If the consumer project contains a NuGet copy of `System.Security.Principal.Windows`,
the `SecurityIdentifier` usage in `WindowsOwnerOnlyNamedPipeFactory` becomes ambiguous
against Unity's `mscorlib`, and the package fails to compile — on macOS, where that
Windows-only code path is never used:

```
Library/PackageCache/io.github.hatayama.uloopmcp@.../Editor/Infrastructure/WindowsOwnerOnlyNamedPipeFactory.cs(92,24):
error CS0433: The type 'SecurityIdentifier' exists in both
  'System.Security.Principal.Windows, Version=5.0.0.0, PublicKeyToken=b03f5f7f11d50a3a'
  'mscorlib, Version=4.0.0.0, PublicKeyToken=b77a5c561934e089'
```

Because `Editor/Infrastructure` fails to build, the bridge server never starts, so
every `uloop` command against the project returns `UNITY_NOT_REACHABLE` and
`uloop launch` times out waiting for readiness.

### Conditions

All four have to hold, which is why this is easy to miss:

1. `WindowsOwnerOnlyNamedPipeFactory.cs` uses `SecurityIdentifier` (`:92`, `:112`) to
   build the owner-only ACL for the named pipe.
2. That file has no `#if UNITY_EDITOR_WIN` guard and its assembly is
   `includePlatforms: ["Editor"]`, so it is compiled on macOS as well.
3. `UnityCLILoop.Infrastructure.asmdef` has `overrideReferences: false`, so all
   auto-referenced plugins are pulled in.
4. The consumer's DLL is auto-referenced and enabled for the Editor
   (`isExplicitlyReferenced: 0`, `platformData: Any -> enabled: 1`).

This does not reproduce on V2 (2.2.0): that version used `TcpListener` and never
referenced `SecurityIdentifier`. The dependency arrived with the move to
Unix domain sockets / named pipes, and the file is unchanged in 3.4.0 and 3.5.0.

### How the DLL gets there

It is commonly a transitive NuGet dependency rather than a deliberate one. In our
project `System.Security.AccessControl` (6.0.0) declares
`System.Security.Principal.Windows` in its nuspec, and NuGetForUnity restores it into
`Assets/Packages/` — including restoring it again on Editor start when it is removed,
because `slimRestore` is enabled.

## Fix

Declare the precompiled references this assembly actually needs.

`Editor/Infrastructure` uses only `Newtonsoft.Json` / `Newtonsoft.Json.Linq` among
external precompiled assemblies (`Microsoft.Win32.SafeHandles` comes from mscorlib, and
the six remaining namespaces are asmdef-to-asmdef GUID references, which
`overrideReferences` does not affect).

```diff
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "Newtonsoft.Json.dll"
+    ],
```

This keeps unrelated plugins in the consumer project out of the reference set, so a
type collision in any of them can no longer break the package.

## Verification

Unity 6000.3.15f1 on macOS (Apple silicon), package 3.3.0, in a large project that
contains `Assets/Packages/System.Security.Principal.Windows.5.0.0`:

| | Result |
|---|---|
| Before | `CS0433` on every compile; bridge server never starts; `uloop launch` times out after 600s; `uloop get-logs` returns `UNITY_NOT_REACHABLE` |
| After | `uloop compile` → `Success: true`, `ErrorCount: 0`, `WarningCount: 0`; Editor error count 0; `uloop launch` reports `Unity CLI Loop is ready.` |

The consumer DLL was left completely untouched (`Any: enabled: 1`) for the "after"
measurement, so the asmdef change alone is what resolves it.

Additionally verified end to end afterwards: driving two Editors concurrently from the
same `uloop` binary (one project on 2.2.0 in V2 delegation mode, one on 3.3.0), running
an in-game battle scenario in one and a story/exploration regression run in the other
at the same time, both completing.

## Alternative considered

Guarding `WindowsOwnerOnlyNamedPipeFactory.cs` with `#if UNITY_EDITOR_WIN` also removes
the ambiguity, but `BridgeTransportListener.cs:250` and `:258` call
`BuildCurrentUserOnlySddl()` / `CreateServer()` unconditionally and the package branches
at runtime rather than at compile time, so that route needs guards at the call sites too.
The asmdef change is narrower and additionally protects against unrelated plugin
collisions. Happy to switch to whichever you prefer — you have the better view of the
dependency matrix across Unity versions and platforms.

## Note

I have not verified this on Windows or Linux Editors, only macOS.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

