### PR TITLE
chore: keep the hot-reload introduced-type planner under the complexity threshold

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
@@ -42,29 +42,8 @@ internal static class IntroducedTypePlanner
                 continue;
             }
 
-            if (typeSymbol.ContainingType != null)
+            if (IsRefusedForNesting(unit, typeSymbol, declaration, targetAssembly))
             {
-                // Why silent when the outer type is not compiled either: that outer declaration
-                // is refused on its own, and its diagnostic already names this nested one as the
-                // reason. Reporting both turns a single refusal into two lines about one type.
-                if (CompiledMemberMatcher.FindCompiledType(typeSymbol.ContainingType, targetAssembly) == null)
-                {
-                    continue;
-                }
-
-                unit.IntroducedTypeDiagnostics.Add(
-                    "Nested type requires a compile: " + CecilTypeNames.ToMetadataName(typeSymbol));
-                continue;
-            }
-
-            // Nested declarations are excluded unconditionally, so an outer type that contains one
-            // has to be refused as well. Emitting it would either drop the nested implementation
-            // its members rely on or retain a type this stage cannot manage the lifetime of.
-            if (TryFindNestedDeclaration(declaration, out string nestedName))
-            {
-                unit.IntroducedTypeDiagnostics.Add(
-                    "Nested declaration inside an introduced type requires a compile: "
-                    + CecilTypeNames.ToMetadataName(typeSymbol) + "/" + nestedName);
                 continue;
             }
 
@@ -132,6 +111,44 @@ internal static class IntroducedTypePlanner
             unit.IntroducedTypeDiagnostics.Add(
                 "Delegate introduced type requires a compile: " + CecilTypeNames.ToMetadataName(delegateSymbol));
         }
+    }
+
+    // Whether nesting alone settles this declaration, either because it is nested in a type the
+    // assembly already holds or because it declares a nested type of its own. Both cases end the
+    // declaration's planning, so the caller only has to know that it was handled.
+    private static bool IsRefusedForNesting(
+        WorkerSourceUnit unit,
+        INamedTypeSymbol typeSymbol,
+        BaseTypeDeclarationSyntax declaration,
+        IAssemblySymbol targetAssembly)
+    {
+        if (typeSymbol.ContainingType != null)
+        {
+            // Why silent when the outer type is not compiled either: that outer declaration
+            // is refused on its own, and its diagnostic already names this nested one as the
+            // reason. Reporting both turns a single refusal into two lines about one type.
+            if (CompiledMemberMatcher.FindCompiledType(typeSymbol.ContainingType, targetAssembly) == null)
+            {
+                return true;
+            }
+
+            unit.IntroducedTypeDiagnostics.Add(
+                "Nested type requires a compile: " + CecilTypeNames.ToMetadataName(typeSymbol));
+            return true;
+        }
+
+        // Nested declarations are excluded unconditionally, so an outer type that contains one
+        // has to be refused as well. Emitting it would either drop the nested implementation
+        // its members rely on or retain a type this stage cannot manage the lifetime of.
+        if (TryFindNestedDeclaration(declaration, out string nestedName))
+        {
+            unit.IntroducedTypeDiagnostics.Add(
+                "Nested declaration inside an introduced type requires a compile: "
+                + CecilTypeNames.ToMetadataName(typeSymbol) + "/" + nestedName);
+            return true;
+        }
+
+        return false;
     }
 
     // Whether this domain already retains an assembly for the declaration. Introducing it again


### PR DESCRIPTION
## Summary

- The complexity check passes again for the hot-reload introduced-type planner, which had gone one point over the repository limit.

## User Impact

None. The refused declarations, their wording, and the order they are reported in are unchanged; this only moves two decisions out of one method.

## Changes

- `IntroducedTypePlanner.Plan` delegates both nesting decisions — a declaration nested inside a type the target assembly already holds, and a declaration that itself declares a nested type — to a new private `IsRefusedForNesting`. The planning loop keeps the same guard order, and the two diagnostics are produced exactly as before.

## Verification

- `dotnet run --project tools/UnityCliLoop.CodeComplexity -- --root . --max-complexity 15` — `No CA1502 complexity issues found above threshold 15.` (before this change the same check reported `Plan` at 16 on the integration branch head).
- `uloop compile` — `Success: true`, 0 errors.
- `uloop run-tests --filter-type regex --filter-value 'TransformWorkerIntroducedTypeTests|TransformWorkerIntroducedTypeBindingTests'` — 37 tests, 37 passed, 0 failed. These are the classes that cover every diagnostic the moved code produces.
- No test was added: the change is behaviour-preserving, and both nesting refusals already have a test that asserts their exact wording.
- The full EditMode suite was not run (scheduled gate); no shared test infrastructure was touched.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

