### PR TITLE
fix: uloop compile now warns when armed pause points will be dropped in Edit Mode

### DIFF
--- a/.agents/skills/uloop-compile/SKILL.md
+++ b/.agents/skills/uloop-compile/SKILL.md
@@ -47,7 +47,7 @@ Returns JSON:
 - `Success`: boolean or null
 - `ErrorCount`: number or null
 - `WarningCount`: number or null
-- `Warning` (string, optional): set when compile was requested during Play Mode (Play session and pause points are discarded) or while hot-reload changes were active (a successful compile drops every patch; the edited sources are compiled in).
+- `Warning` (string, optional): set when the compile was requested during Play Mode (the Play session is discarded), while pause points were armed in either Play Mode or Edit Mode (the domain reload drops every pause point patch), or while hot-reload changes were active (a successful compile drops every patch; the edited sources are compiled in).
 - `Message`: string
 - `ErrorCode`: string or null. `COMPILE_ALREADY_IN_PROGRESS` when Unity is already compiling, `COMPILE_EDITOR_UPDATING` when the editor is updating, `COMPILE_RESULT_UNKNOWN` after a forced recompile that did not return a definitive result.
 - `NextActions`: string array or null. Corrective steps derived from the errors, e.g. the assembly that declares an unresolved namespace (CS0234), or, for CS0246 in a script under an asmdef, a reminder to check that asmdef's references (the type may instead be a typo — decide from the error).

--- a/.claude/skills/uloop-compile/SKILL.md
+++ b/.claude/skills/uloop-compile/SKILL.md
@@ -47,7 +47,7 @@ Returns JSON:
 - `Success`: boolean or null
 - `ErrorCount`: number or null
 - `WarningCount`: number or null
-- `Warning` (string, optional): set when compile was requested during Play Mode (Play session and pause points are discarded) or while hot-reload changes were active (a successful compile drops every patch; the edited sources are compiled in).
+- `Warning` (string, optional): set when the compile was requested during Play Mode (the Play session is discarded), while pause points were armed in either Play Mode or Edit Mode (the domain reload drops every pause point patch), or while hot-reload changes were active (a successful compile drops every patch; the edited sources are compiled in).
 - `Message`: string
 - `ErrorCode`: string or null. `COMPILE_ALREADY_IN_PROGRESS` when Unity is already compiling, `COMPILE_EDITOR_UPDATING` when the editor is updating, `COMPILE_RESULT_UNKNOWN` after a forced recompile that did not return a definitive result.
 - `NextActions`: string array or null. Corrective steps derived from the errors, e.g. the assembly that declares an unresolved namespace (CS0234), or, for CS0246 in a script under an asmdef, a reminder to check that asmdef's references (the type may instead be a typo — decide from the error).

--- a/Assets/Tests/Editor/CompilePlayModeStopWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/CompilePlayModeStopWarningBuilderTests.cs
@@ -5,24 +5,52 @@ using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
     /// <summary>
-    /// Verifies compile Warning text for each Play-at-request-start branch: none, Play without
-    /// pause points, and Play with enabled pause points.
+    /// Verifies compile Warning text for each Play-at-request-start branch: Edit Mode with and
+    /// without enabled pause points, Play without pause points, and Play with enabled pause points.
     /// </summary>
     [TestFixture]
     public sealed class CompilePlayModeStopWarningBuilderTests
     {
         /// <summary>
-        /// What: no warning when Play Mode was not active, regardless of marker count.
+        /// What: Edit Mode with enabled pause points warns about the drop without claiming Play Mode was active.
         /// </summary>
         [Test]
-        public void BuildWarning_WhenNotPlayingAtRequestStart_ReturnsNull()
+        public void BuildWarning_WhenNotPlayingWithActivePausePoints_ReturnsEditModeDropWarning()
         {
             string warning = CompilePlayModeStopWarningBuilder.BuildWarning(
                 wasPlayingAtRequestStart: false,
-                activePausePointCount: 3,
+                activePausePointCount: 2,
                 activeHotReloadChangeCount: 0);
 
-            Assert.That(warning, Is.Null);
+            Assert.That(warning, Is.Not.Null);
+            Assert.That(warning, Does.Contain("2 enabled pause point(s)"));
+            Assert.That(
+                warning,
+                Does.Not.Contain("Play Mode was active"),
+                "An Edit Mode compile must not claim Play Mode was running.");
+        }
+
+        /// <summary>
+        /// What: Edit Mode with both pause points and hot-reload changes joins the pause point sentence first.
+        /// </summary>
+        [Test]
+        public void BuildWarning_WhenNotPlayingWithPausePointsAndHotReloadChanges_JoinsPausePointSentenceFirst()
+        {
+            string pausePointOnly = CompilePlayModeStopWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart: false,
+                activePausePointCount: 2,
+                activeHotReloadChangeCount: 0);
+            string hotReloadOnly = CompilePlayModeStopWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart: false,
+                activePausePointCount: 0,
+                activeHotReloadChangeCount: 3);
+
+            string warning = CompilePlayModeStopWarningBuilder.BuildWarning(
+                wasPlayingAtRequestStart: false,
+                activePausePointCount: 2,
+                activeHotReloadChangeCount: 3);
+
+            Assert.That(warning, Is.EqualTo(pausePointOnly + " " + hotReloadOnly));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/CompileUseCaseTests.cs
+++ b/Assets/Tests/Editor/CompileUseCaseTests.cs
@@ -267,6 +267,71 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: a validation failure in Edit Mode with enabled pause points returns and stores the drop Warning.
+        /// </summary>
+        [Test]
+        public async Task CompileAsync_WhenValidationFailsInEditModeWithActivePausePoints_SetsPausePointDropWarningOnImmediateAndStoredResponses()
+        {
+            UnityCliLoopCompileResultSessionRepository compileResultSessionRepository =
+                UnityCliLoopEditorSessionStateTestFactory.CreateCompileResultSessionRepository();
+            UnityCliLoopPendingCompileSessionRepository pendingCompileSessionRepository =
+                UnityCliLoopEditorSessionStateTestFactory.CreatePendingCompileSessionRepository();
+            UnityCliLoopCompileSessionLifecycleService compileSessionLifecycleService =
+                new(
+                    UnityCliLoopEditorSessionStateTestFactory.CreateSessionFlagsRepository(),
+                    compileResultSessionRepository,
+                    pendingCompileSessionRepository);
+            UnityCliLoopEditorSessionStateSnapshot originalSnapshot =
+                UnityCliLoopEditorSessionStateTestFactory.CaptureSnapshot();
+            UnityCliLoopEditorSessionStateTestFactory.ClearAll();
+
+            try
+            {
+                CompileUseCase useCase = new(
+                    compileSessionLifecycleService,
+                    compileResultSessionRepository,
+                    pendingCompileSessionRepository);
+                useCase.SetPlayModeStopWarningInputsForTesting(
+                    wasPlayingAtRequestStart: false,
+                    activePausePointCount: 1,
+                    activeHotReloadChangeCount: 0);
+                useCase.SetCompilationStateValidationForTesting(() =>
+                    ValidationResult.FailureWithErrorCode(
+                        "Compilation is already in progress. Please wait for the current compilation to finish.",
+                        CompileStateValidationErrorCodes.AlreadyInProgressErrorCodeText));
+                useCase.SetCompilationExecutionForTesting((compileRequest, playModeStopWarning, ct) =>
+                {
+                    throw new InvalidOperationException("validation failure must not start compilation");
+                });
+
+                CompileResponse response = await useCase.CompileAsync(
+                    new CompileSchema
+                    {
+                        WaitForDomainReload = true,
+                        RequestId = "compile_validation_edit_mode_pause_point_warning",
+                        ForceRecompile = false,
+                        ReloadExternalSceneChanges = true
+                    },
+                    CancellationToken.None);
+
+                UnityCliLoopStoredCompileResult storedResult =
+                    compileResultSessionRepository.GetCompileResult("compile_validation_edit_mode_pause_point_warning");
+                CompileResponse storedResponse = JsonConvert.DeserializeObject<CompileResponse>(
+                    storedResult.ResultJson,
+                    UnityCliLoopJsonResponseSerializerSettings.Settings);
+
+                Assert.That(response.Warning, Does.Contain("1 enabled pause point(s)"));
+                Assert.That(response.Warning, Does.Not.Contain("Play Mode was active"));
+                Assert.That(storedResult.HasResult, Is.True);
+                Assert.That(storedResponse.Warning, Does.Contain("1 enabled pause point(s)"));
+            }
+            finally
+            {
+                originalSnapshot.Restore();
+            }
+        }
+
+        /// <summary>
         /// What: a successful compile with live hot-reload changes passes the drop Warning into compilation execution.
         /// </summary>
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompilePlayModeStopWarningBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompilePlayModeStopWarningBuilder.cs
@@ -1,10 +1,10 @@
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// Builds the compile Warning text when Play Mode was active or hot-reload changes were live
-    /// at the moment compile was requested: the compile stops Play Mode and the following
-    /// domain reload discards the Play session state, every pause-point Harmony patch when any
-    /// are enabled, and every active hot-reload patch.
+    /// Builds the compile Warning text for the state that the compile is about to discard:
+    /// the Play session when Play Mode was active, every pause-point Harmony patch when any are
+    /// enabled (in Play Mode and in Edit Mode alike, because the compile reloads the domain
+    /// either way), and every active hot-reload patch.
     /// </summary>
     internal static class CompilePlayModeStopWarningBuilder
     {
@@ -13,28 +13,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int activePausePointCount,
             int activeHotReloadChangeCount)
         {
-            string playWarning = BuildPlayModeStopWarning(wasPlayingAtRequestStart, activePausePointCount);
+            string primaryWarning = wasPlayingAtRequestStart
+                ? BuildPlayModeStopWarning(activePausePointCount)
+                : BuildEditModePausePointDropWarning(activePausePointCount);
             string hotReloadWarning = BuildHotReloadDropWarning(activeHotReloadChangeCount);
-            if (playWarning == null)
+            return Join(primaryWarning, hotReloadWarning);
+        }
+
+        private static string Join(string primaryWarning, string hotReloadWarning)
+        {
+            if (primaryWarning == null)
             {
                 return hotReloadWarning;
             }
 
             if (hotReloadWarning == null)
             {
-                return playWarning;
+                return primaryWarning;
             }
 
-            return playWarning + " " + hotReloadWarning;
+            return primaryWarning + " " + hotReloadWarning;
         }
 
-        private static string BuildPlayModeStopWarning(bool wasPlayingAtRequestStart, int activePausePointCount)
+        private static string BuildPlayModeStopWarning(int activePausePointCount)
         {
-            if (!wasPlayingAtRequestStart)
-            {
-                return null;
-            }
-
             if (activePausePointCount > 0)
             {
                 return "Play Mode was active with " + activePausePointCount + " enabled pause point(s). "
@@ -43,6 +45,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return "Play Mode was active when this compile was requested. The compile stops Play Mode and the domain reload discards the Play session state — re-establish your runtime state before continuing verification.";
+        }
+
+        /// <summary>
+        /// An Edit Mode compile keeps no Play session to lose, but its domain reload still drops
+        /// every pause point patch, so the caller has to be told the patches are gone.
+        /// </summary>
+        private static string BuildEditModePausePointDropWarning(int activePausePointCount)
+        {
+            if (activePausePointCount <= 0)
+            {
+                return null;
+            }
+
+            return activePausePointCount + " enabled pause point(s) were armed when this compile was requested. "
+                + "A successful compile reloads the domain and drops every pause point patch — "
+                + "re-enable them after the compile completes.";
         }
 
         private static string BuildHotReloadDropWarning(int activeHotReloadChangeCount)

--- a/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
@@ -47,7 +47,7 @@ Returns JSON:
 - `Success`: boolean or null
 - `ErrorCount`: number or null
 - `WarningCount`: number or null
-- `Warning` (string, optional): set when compile was requested during Play Mode (Play session and pause points are discarded) or while hot-reload changes were active (a successful compile drops every patch; the edited sources are compiled in).
+- `Warning` (string, optional): set when the compile was requested during Play Mode (the Play session is discarded), while pause points were armed in either Play Mode or Edit Mode (the domain reload drops every pause point patch), or while hot-reload changes were active (a successful compile drops every patch; the edited sources are compiled in).
 - `Message`: string
 - `ErrorCode`: string or null. `COMPILE_ALREADY_IN_PROGRESS` when Unity is already compiling, `COMPILE_EDITOR_UPDATING` when the editor is updating, `COMPILE_RESULT_UNKNOWN` after a forced recompile that did not return a definitive result.
 - `NextActions`: string array or null. Corrective steps derived from the errors, e.g. the assembly that declares an unresolved namespace (CS0234), or, for CS0246 in a script under an asmdef, a reminder to check that asmdef's references (the type may instead be a typo — decide from the error).


### PR DESCRIPTION
## Problem

`uloop compile` reloads the domain whether or not Play Mode is running, and the reload drops every pause point Harmony patch. `CompilePlayModeStopWarningBuilder` returned early when `wasPlayingAtRequestStart` was false, so an Edit Mode compile discarded armed pause points with no `Warning` at all. The caller only discovered it later, when a pause point that used to fire stopped firing.

Play Mode compiles and Play entry already warn; only the Edit Mode compile path was silent.

## Change

- Split `BuildWarning` into "pick the primary sentence from the Play state" + "hot-reload sentence" + "join", and add `BuildEditModePausePointDropWarning` for the non-Play branch.
- Every existing Play Mode wording is byte-identical — the existing `Is.EqualTo` wording assertions pass unchanged.
- `compile` skill: the `Warning` bullet now lists the three states that set it (Play Mode, armed pause points in either mode, active hot-reload changes) instead of Play Mode only.

`CompileUseCase` needed no change: `CaptureLivePlayModeStopWarningInputs` already reads `UloopPausePointRegistry.GetActiveCount()` in Edit Mode.

## Verification

TDD. The two new builder tests plus the new `CompileUseCase` wiring test were confirmed Red against the pre-change builder before the fix landed:

```
# builder reverted to the base version, same test set
{'Success': False, 'PassedCount': 11, 'FailedCount': 3}
# with the fix
uloop run-tests --filter-type regex --filter-value "CompilePlayModeStopWarningBuilderTests|CompileUseCaseTests|CompileControllerPlayModeStopWarningTests"
{'Success': True, 'PassedCount': 15, 'FailedCount': 0}
```

- `uloop compile` — 0 errors.
- `go run ./cmd/check-skill-size` — no SKILL.md over the byte limit.
- `go run ./cmd/sync-tool-docs --check` — catalog matches the parameter tables (the `Warning` bullet is response text, so the catalog is unchanged).
- `uloop skills install --claude --agents` — generated copies regenerated and included.

https://claude.ai/code/session_019kkGy4ujdjChrkMcimjKfY


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

